### PR TITLE
LUCENE-9830: Hunspell: store word length for faster dictionary lookup/enumeration

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/GeneratingSuggester.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/GeneratingSuggester.java
@@ -65,6 +65,7 @@ class GeneratingSuggester {
     TrigramAutomaton automaton = new TrigramAutomaton(word);
 
     dictionary.words.processAllWords(
+        Math.max(1, word.length() - 4),
         word.length() + 4,
         (rootChars, forms) -> {
           speller.checkCanceled.run();

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestDictionary.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestDictionary.java
@@ -77,20 +77,26 @@ public class TestDictionary extends LuceneTestCase {
           reader.lines().skip(1).map(s -> s.split("/")[0]).collect(Collectors.toSet());
       int maxLength = allWords.stream().mapToInt(String::length).max().orElseThrow();
 
-      for (int i = 1; i <= maxLength + 1; i++) {
-        checkProcessWords(dictionary, allWords, i);
+      for (int min = 1; min <= maxLength + 1; min++) {
+        for (int max = min; max <= maxLength + 1; max++) {
+          checkProcessWords(dictionary, allWords, min, max);
+        }
       }
     }
   }
 
-  private void checkProcessWords(Dictionary dictionary, Set<String> allWords, int maxLength) {
+  private void checkProcessWords(
+      Dictionary dictionary, Set<String> allWords, int minLength, int maxLength) {
     Set<String> processed = new HashSet<>();
-    dictionary.words.processAllWords(maxLength, (word, __) -> processed.add(word.toString()));
+    dictionary.words.processAllWords(
+        minLength, maxLength, (word, __) -> processed.add(word.toString()));
 
     Set<String> filtered =
-        allWords.stream().filter(s -> s.length() <= maxLength).collect(Collectors.toSet());
+        allWords.stream()
+            .filter(s -> minLength <= s.length() && s.length() <= maxLength)
+            .collect(Collectors.toSet());
 
-    assertEquals("For length " + maxLength, filtered, processed);
+    assertEquals("For lengths [" + minLength + "," + maxLength + "]", filtered, processed);
   }
 
   public void testCompressedDictionary() throws Exception {


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Word length could be checked before more materializing the whole word

# Solution

Use the spare bits in the hash table `int` and collision `byte` to encode word length, if it's short enough (almost always).

# Tests

No new tests, 10-15% speedup in `TestPerformance.de_suggest`.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
