### PR TITLE
LUCENE-9634: Fix highlighting of extended intervals matched using offset

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMatchesIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMatchesIterator.java
@@ -250,6 +250,10 @@ final class DisjunctionMatchesIterator implements MatchesIterator {
 
   @Override
   public Query getQuery() {
-    return queue.top().getQuery();
+    if (queue.size() > 0) {
+      return queue.top().getQuery();
+    } else {
+      return null;
+    }
   }
 }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchRegionRetriever.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchRegionRetriever.java
@@ -262,7 +262,7 @@ public class MatchRegionRetriever {
 
       switch (fieldInfo.getIndexOptions()) {
         case DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS:
-          return new OffsetsFromMatchIterator(field);
+          return new OffsetsFromMatchIterator(field, analyzer);
 
         case DOCS_AND_FREQS_AND_POSITIONS:
           return new OffsetsFromPositions(field, analyzer);

--- a/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/OffsetsFromMatchIterator.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/OffsetsFromMatchIterator.java
@@ -18,15 +18,27 @@ package org.apache.lucene.search.matchhighlight;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.queries.intervals.ExtendedIntervalsSource;
+import org.apache.lucene.queries.intervals.IntervalQuery;
+import org.apache.lucene.queries.intervals.IntervalsSource;
 import org.apache.lucene.search.MatchesIterator;
+import org.apache.lucene.search.Query;
 
 /** This strategy retrieves offsets directly from {@link MatchesIterator}. */
 public final class OffsetsFromMatchIterator implements OffsetsRetrievalStrategy {
   private final String field;
+  private final Analyzer analyzer;
 
-  OffsetsFromMatchIterator(String field) {
+  OffsetsFromMatchIterator(String field, Analyzer analyzer) {
     this.field = field;
+    this.analyzer = analyzer;
   }
 
   @Override
@@ -42,6 +54,120 @@ public final class OffsetsFromMatchIterator implements OffsetsRetrievalStrategy 
       }
       ranges.add(new OffsetRange(from, to));
     }
+
+    // nocommit seems too many type checking & casting?
+    Query query = matchesIterator.getQuery();
+    if (query != null && query instanceof IntervalQuery) {
+      IntervalsSource intervalsSource = ((IntervalQuery) query).getIntervalsSource();
+      if (intervalsSource instanceof ExtendedIntervalsSource) {
+        ExtendedIntervalsSource extendedIntervalsSource = (ExtendedIntervalsSource) intervalsSource;
+        // nocommit is there better way to get before / after values from ExtendedIntervalsSource ?
+        int before = extendedIntervalsSource.getBefore();
+        int after = extendedIntervalsSource.getAfter();
+
+        if (before > 0 || after > 0) {
+          return adjustOffsetRange(doc, ranges, before, after);
+        }
+      }
+    }
+
     return ranges;
+  }
+
+  private List<OffsetRange> adjustOffsetRange(
+      MatchRegionRetriever.FieldValueProvider doc,
+      ArrayList<OffsetRange> ranges,
+      int before,
+      int after)
+      throws IOException {
+    int position = -1;
+    int valueOffset = 0;
+
+    Map<Integer, OffsetsPair> positionToOffsets = new HashMap<>();
+    Map<Integer, Integer> startOffsetToPosition = new HashMap<>();
+    Map<Integer, Integer> endOffsetToPosition = new HashMap<>();
+
+    List<CharSequence> values = doc.getValues(field);
+    for (CharSequence charSequence : values) {
+      final String value = charSequence.toString();
+
+      TokenStream ts = analyzer.tokenStream(field, value);
+      OffsetAttribute offsetAttr = ts.getAttribute(OffsetAttribute.class);
+      PositionIncrementAttribute posAttr = ts.getAttribute(PositionIncrementAttribute.class);
+      ts.reset();
+
+      // go through all tokens to collect position from / to offset mappings
+      while (ts.incrementToken()) {
+        position += posAttr.getPositionIncrement();
+        int startOffset = valueOffset + offsetAttr.startOffset();
+        int endOffset = valueOffset + offsetAttr.endOffset();
+
+        positionToOffsets.put(position, new OffsetsPair(startOffset, endOffset));
+        startOffsetToPosition.put(startOffset, position);
+        endOffsetToPosition.put(endOffset, position);
+      }
+      ts.end();
+      position += posAttr.getPositionIncrement() + analyzer.getPositionIncrementGap(field);
+      valueOffset += offsetAttr.endOffset() + analyzer.getOffsetGap(field);
+      ts.close();
+    }
+
+    int maxPosition = position - analyzer.getPositionIncrementGap(field);
+
+    ArrayList<OffsetRange> extendedRanges = new ArrayList<>();
+    for (OffsetRange original : ranges) {
+      int originalStartOffset = original.from;
+      int originalEndOffset = original.to;
+      int originalStartPosition = startOffsetToPosition.get(originalStartOffset);
+      int originalEndPosition = endOffsetToPosition.get(originalEndOffset);
+
+      int extendedStartPosition = Math.max(0, originalStartPosition - before);
+      // nocommit needs to handle overflow
+      int extendedEndPosition = Math.min(maxPosition, originalEndPosition + after);
+
+      assert extendedStartPosition >= 0;
+      assert extendedEndPosition >= 0;
+
+      // nocommit is the following correct handling of highlighting when there's also token
+      // filtering such as stopword?
+      // if extendedStartPosition is not available due to stopword filtered out etc, find the
+      // next possible extendedStartPosition
+      // it's very likely that the next available extendedStartPosition requires only once or
+      // twice increment, hence "brute-force" scan is used here
+      while (!positionToOffsets.containsKey(extendedStartPosition)) {
+        extendedStartPosition++;
+      }
+
+      // nocommit is the following correct handling of highlighting when there's also token
+      // filtering such as stopword?
+      // if extendedEndPosition is not available due to stopword filtered out etc, find the
+      // next possible extendedEndPosition
+      // it's very likely that the next available extendedEndPosition requires only once or
+      // twice decrement, hence "brute-force" scan is used here
+      while (!positionToOffsets.containsKey(extendedEndPosition)) {
+        extendedEndPosition--;
+      }
+
+      int extendedStartOffset = positionToOffsets.get(extendedStartPosition).startOffset;
+      int extendedEndOffset = positionToOffsets.get(extendedEndPosition).endOffset;
+
+      extendedRanges.add(new OffsetRange(extendedStartOffset, extendedEndOffset));
+    }
+    return extendedRanges;
+  }
+
+  @Override
+  public boolean requiresDocument() {
+    return true;
+  }
+
+  private class OffsetsPair {
+    int startOffset;
+    int endOffset;
+
+    public OffsetsPair(int startOffset, int endOffset) {
+      this.startOffset = startOffset;
+      this.endOffset = endOffset;
+    }
   }
 }

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/ExtendedIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/ExtendedIntervalsSource.java
@@ -25,7 +25,8 @@ import java.util.stream.Collectors;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.QueryVisitor;
 
-class ExtendedIntervalsSource extends IntervalsSource {
+/** IntervalSource that supports before and after extension around current intervals */
+public class ExtendedIntervalsSource extends IntervalsSource {
 
   final IntervalsSource source;
   private final int before;
@@ -99,5 +100,13 @@ class ExtendedIntervalsSource extends IntervalsSource {
   @Override
   public String toString() {
     return "EXTEND(" + source + "," + before + "," + after + ")";
+  }
+
+  public int getBefore() {
+    return before;
+  }
+
+  public int getAfter() {
+    return after;
   }
 }

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/IntervalQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/IntervalQuery.java
@@ -145,6 +145,11 @@ public final class IntervalQuery extends Query {
     return Objects.hash(field, intervalsSource);
   }
 
+  public IntervalsSource getIntervalsSource() {
+    // nocommit clone?
+    return intervalsSource;
+  }
+
   private class IntervalWeight extends Weight {
 
     final ScoreMode scoreMode;


### PR DESCRIPTION
**This PR is currently in draft state**

# Description

Fix highlighting of extended intervals matched using offset

# Proposed Solution

In `OffsetsFromMatchIterator`, retrieves `ExtendedIntervalsSource` and its `before` / `after` position values, and use them to adjust highlight offset range matched by offset

# Tests
* gradle precommit currently failing for nocommit comment
* passed previously failed test
* passed new tests

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
