### PR TITLE
LUCENE-9837: try to improve performance of VectorUtil.dotProduct

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -42,25 +42,55 @@ public final class VectorUtil {
     if (a.length < 8) {
       return res;
     }
-    float s0 = 0f;
-    float s1 = 0f;
-    float s2 = 0f;
-    float s3 = 0f;
-    float s4 = 0f;
-    float s5 = 0f;
-    float s6 = 0f;
-    float s7 = 0f;
-    for (; i + 7 < a.length; i += 8) {
-      s0 += b[i] * a[i];
-      s1 += b[i + 1] * a[i + 1];
-      s2 += b[i + 2] * a[i + 2];
-      s3 += b[i + 3] * a[i + 3];
-      s4 += b[i + 4] * a[i + 4];
-      s5 += b[i + 5] * a[i + 5];
-      s6 += b[i + 6] * a[i + 6];
-      s7 += b[i + 7] * a[i + 7];
+    for (; i + 31 < a.length; i += 32) {
+      res +=
+          b[i + 0] * a[i + 0]
+              + b[i + 1] * a[i + 1]
+              + b[i + 2] * a[i + 2]
+              + b[i + 3] * a[i + 3]
+              + b[i + 4] * a[i + 4]
+              + b[i + 5] * a[i + 5]
+              + b[i + 6] * a[i + 6]
+              + b[i + 7] * a[i + 7];
+      res +=
+          b[i + 8] * a[i + 8]
+              + b[i + 9] * a[i + 9]
+              + b[i + 10] * a[i + 10]
+              + b[i + 11] * a[i + 11]
+              + b[i + 12] * a[i + 12]
+              + b[i + 13] * a[i + 13]
+              + b[i + 14] * a[i + 14]
+              + b[i + 15] * a[i + 15];
+      res +=
+          b[i + 16] * a[i + 16]
+              + b[i + 17] * a[i + 17]
+              + b[i + 18] * a[i + 18]
+              + b[i + 19] * a[i + 19]
+              + b[i + 20] * a[i + 20]
+              + b[i + 21] * a[i + 21]
+              + b[i + 22] * a[i + 22]
+              + b[i + 23] * a[i + 23];
+      res +=
+          b[i + 24] * a[i + 24]
+              + b[i + 25] * a[i + 25]
+              + b[i + 26] * a[i + 26]
+              + b[i + 27] * a[i + 27]
+              + b[i + 28] * a[i + 28]
+              + b[i + 29] * a[i + 29]
+              + b[i + 30] * a[i + 30]
+              + b[i + 31] * a[i + 31];
     }
-    res += s0 + s1 + s2 + s3 + s4 + s5 + s6 + s7;
+    for (; i + 7 < a.length; i += 8) {
+      res +=
+          b[i + 0] * a[i + 0]
+              + b[i + 1] * a[i + 1]
+              + b[i + 2] * a[i + 2]
+              + b[i + 3] * a[i + 3]
+              + b[i + 4] * a[i + 4]
+              + b[i + 5] * a[i + 5]
+              + b[i + 6] * a[i + 6]
+              + b[i + 7] * a[i + 7];
+    }
     return res;
   }
 


### PR DESCRIPTION
Here's my stab at it. It gives ~ 25% improvement for big vectors and doesn't cause regressions. I tested sizes of 1,4,6,8,13,16,25,32,64,100,128,207,256,300,512,702,1024. It starts to give good speedups for sizes bigger than 32.

<details>
 <summary>Benchmarks</summary>

DotProduct.dotProductOld       1  thrpt   45  184.487 ± 0.364  ops/us
DotProduct.dotProductNew       1  thrpt   45  184.675 ± 0.308  ops/us

DotProduct.dotProductOld       4  thrpt   45  132.525 ± 1.124  ops/us
DotProduct.dotProductNew       4  thrpt   45  133.688 ± 0.383  ops/us

DotProduct.dotProductOld       6  thrpt   45  127.527 ± 0.437  ops/us
DotProduct.dotProductNew       6  thrpt   45  122.776 ± 3.605  ops/us

DotProduct.dotProductOld       8  thrpt   45   95.154 ± 0.209  ops/us
DotProduct.dotProductNew       8  thrpt   45  109.312 ± 0.282  ops/us

DotProduct.dotProductOld      13  thrpt   45   73.528 ± 0.179  ops/us
DotProduct.dotProductNew      13  thrpt   45   75.585 ± 0.149  ops/us

DotProduct.dotProductOld      16  thrpt   45   67.102 ± 0.165  ops/us
DotProduct.dotProductNew      16  thrpt   45   71.895 ± 0.207  ops/us

DotProduct.dotProductOld      25  thrpt   45   46.128 ± 0.068  ops/us
DotProduct.dotProductNew      25  thrpt   45   49.999 ± 0.106  ops/us

DotProduct.dotProductOld      32  thrpt   45   40.341 ± 0.136  ops/us
DotProduct.dotProductNew      32  thrpt   45   46.885 ± 0.101  ops/us (+16%)

DotProduct.dotProductOld      64  thrpt   45   23.086 ± 0.039  ops/us
DotProduct.dotProductNew      64  thrpt   45   27.729 ± 0.046  ops/us (+20%)

DotProduct.dotProductOld     100  thrpt   45   14.183 ± 0.041  ops/us
DotProduct.dotProductNew     100  thrpt   45   17.707 ± 0.095  ops/us (+25%)

DotProduct.dotProductOld     128  thrpt   45   12.307 ± 0.022  ops/us
DotProduct.dotProductNew     128  thrpt   45   14.998 ± 0.099  ops/us (+21%)

DotProduct.dotProductOld     207  thrpt   45    7.749 ± 0.047  ops/us
DotProduct.dotProductNew     207  thrpt   45    9.069 ± 0.082  ops/us (+17%)

DotProduct.dotProductOld     256  thrpt   45    6.365 ± 0.012  ops/us
DotProduct.dotProductNew     256  thrpt   45    7.992 ± 0.016  ops/us (+26%)

DotProduct.dotProductOld     300  thrpt   45    5.066 ± 0.009  ops/us
DotProduct.dotProductNew     300  thrpt   45    6.381 ± 0.016  ops/us (+26%)

DotProduct.dotProductOld     512  thrpt   45    3.216 ± 0.017  ops/us
DotProduct.dotProductNew     512  thrpt   45    4.089 ± 0.009  ops/us (+27%)

DotProduct.dotProductOld     702  thrpt   45    2.370 ± 0.004  ops/us
DotProduct.dotProductNew     702  thrpt   45    2.809 ± 0.007  ops/us (+19%)

DotProduct.dotProductOld    1024  thrpt   45    1.611 ± 0.003  ops/us
DotProduct.dotProductNew    1024  thrpt   45    2.049 ± 0.004  ops/us (+27%)

</details>