### PR TITLE
LUCENE-9853: Use CJKWidthCharFilter as the default character width normalizer in JapaneseAnalyzer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -95,6 +95,9 @@ API Changes
 * LUCENE-9796: SortedDocValues no longer extends BinaryDocValues, as binaryValue() was not performant.
   See MIGRATE.md for details. (Robert Muir)
 
+* LUCENE-9853: JapaneseAnalyzer should use CJKWidthCharFilter for full-width and half-width character normalization.
+  (Tomoko Uchida)
+
 Improvements
 
 * LUCENE-9687: Hunspell support improvements: add API for spell-checking and suggestions, support compound words,

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseAnalyzer.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseAnalyzer.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.analysis.ja;
 
 import java.io.IOException;
+import java.io.Reader;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.lucene.analysis.CharArraySet;
@@ -25,6 +26,7 @@ import org.apache.lucene.analysis.StopFilter;
 import org.apache.lucene.analysis.StopwordAnalyzerBase;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.cjk.CJKWidthCharFilter;
 import org.apache.lucene.analysis.cjk.CJKWidthFilter;
 import org.apache.lucene.analysis.ja.JapaneseTokenizer.Mode;
 import org.apache.lucene.analysis.ja.dict.UserDictionary;
@@ -39,21 +41,28 @@ public class JapaneseAnalyzer extends StopwordAnalyzerBase {
   private final Mode mode;
   private final Set<String> stoptags;
   private final UserDictionary userDict;
+  private final boolean charNormalization;
 
   public JapaneseAnalyzer() {
     this(
         null,
         JapaneseTokenizer.DEFAULT_MODE,
         DefaultSetHolder.DEFAULT_STOP_SET,
-        DefaultSetHolder.DEFAULT_STOP_TAGS);
+        DefaultSetHolder.DEFAULT_STOP_TAGS,
+        true);
   }
 
   public JapaneseAnalyzer(
-      UserDictionary userDict, Mode mode, CharArraySet stopwords, Set<String> stoptags) {
+      UserDictionary userDict,
+      Mode mode,
+      CharArraySet stopwords,
+      Set<String> stoptags,
+      boolean charNormalization) {
     super(stopwords);
     this.userDict = userDict;
     this.mode = mode;
     this.stoptags = stoptags;
+    this.charNormalization = charNormalization;
   }
 
   public static CharArraySet getDefaultStopSet() {
@@ -95,7 +104,10 @@ public class JapaneseAnalyzer extends StopwordAnalyzerBase {
     Tokenizer tokenizer = new JapaneseTokenizer(userDict, true, true, mode);
     TokenStream stream = new JapaneseBaseFormFilter(tokenizer);
     stream = new JapanesePartOfSpeechStopFilter(stream, stoptags);
-    stream = new CJKWidthFilter(stream);
+    if (!charNormalization) {
+      // apply width normalization only when character level normalization is not applied.
+      stream = new CJKWidthFilter(stream);
+    }
     stream = new StopFilter(stream, stopwords);
     stream = new JapaneseKatakanaStemFilter(stream);
     stream = new LowerCaseFilter(stream);
@@ -104,8 +116,27 @@ public class JapaneseAnalyzer extends StopwordAnalyzerBase {
 
   @Override
   protected TokenStream normalize(String fieldName, TokenStream in) {
-    TokenStream result = new CJKWidthFilter(in);
+    TokenStream result = charNormalization ? in : new CJKWidthFilter(in);
     result = new LowerCaseFilter(result);
     return result;
+  }
+
+  @Override
+  protected Reader initReader(String fieldName, Reader reader) {
+    if (charNormalization) {
+      // apply character level width normalizetion (LUCENE-9853)
+      return new CJKWidthCharFilter(reader);
+    } else {
+      return reader;
+    }
+  }
+
+  @Override
+  protected Reader initReaderForNormalization(String fieldName, Reader reader) {
+    if (charNormalization) {
+      return new CJKWidthCharFilter(reader);
+    } else {
+      return reader;
+    }
   }
 }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseAnalyzer.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseAnalyzer.java
@@ -53,7 +53,8 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags());
+            JapaneseAnalyzer.getDefaultStopTags(),
+            true);
 
     // Senior software engineer:
     assertAnalyzesToPositions(
@@ -109,7 +110,8 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags());
+            JapaneseAnalyzer.getDefaultStopTags(),
+            true);
     checkRandomData(random, a, atLeast(100));
     a.close();
   }
@@ -122,7 +124,8 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags());
+            JapaneseAnalyzer.getDefaultStopTags(),
+            true);
     checkRandomData(random, a, 2 * RANDOM_MULTIPLIER, 8192);
     a.close();
   }
@@ -136,7 +139,8 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             TestJapaneseTokenizer.readDict(),
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags());
+            JapaneseAnalyzer.getDefaultStopTags(),
+            true);
     assertTokenStreamContents(
         a.tokenStream("foo", "abcd"),
         new String[] {"a", "b", "cd"},
@@ -144,6 +148,41 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
         new int[] {1, 2, 4},
         4);
     a.close();
+  }
+
+  public void testCharWidthNormalization() throws Exception {
+    // See LUCENE-9853
+    // with CJKWidthCharFilter (normalize half-width / full-width chars before tokenization)
+    final Analyzer a1 =
+        new JapaneseAnalyzer(
+            TestJapaneseTokenizer.readDict(),
+            Mode.SEARCH,
+            JapaneseAnalyzer.getDefaultStopSet(),
+            JapaneseAnalyzer.getDefaultStopTags(),
+            true);
+    assertTokenStreamContents(
+        a1.tokenStream("foo", "新橋６－２０－１"),
+        new String[] {"新橋", "6", "20", "1"},
+        new int[] {0, 2, 4, 7},
+        new int[] {2, 3, 6, 8},
+        8);
+    a1.close();
+
+    // with CJKWidthFilter (normalize half-width / full-width chars after tokenization)
+    final Analyzer a2 =
+        new JapaneseAnalyzer(
+            TestJapaneseTokenizer.readDict(),
+            Mode.SEARCH,
+            JapaneseAnalyzer.getDefaultStopSet(),
+            JapaneseAnalyzer.getDefaultStopTags(),
+            false);
+    assertTokenStreamContents(
+        a2.tokenStream("foo", "新橋６－２０－１"),
+        new String[] {"新橋", "6", "2", "0", "1"},
+        new int[] {0, 2, 4, 5, 7},
+        new int[] {2, 3, 5, 6, 8},
+        8);
+    a2.close();
   }
 
   // LUCENE-3897: this string (found by running all jawiki
@@ -157,7 +196,8 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags());
+            JapaneseAnalyzer.getDefaultStopTags(),
+            true);
     checkAnalysisConsistency(random, a, random.nextBoolean(), s);
     a.close();
   }
@@ -173,7 +213,8 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags());
+            JapaneseAnalyzer.getDefaultStopTags(),
+            true);
     checkAnalysisConsistency(random, a, random.nextBoolean(), s);
     a.close();
   }
@@ -189,7 +230,8 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags());
+            JapaneseAnalyzer.getDefaultStopTags(),
+            true);
     checkAnalysisConsistency(random, a, random.nextBoolean(), s);
     a.close();
   }
@@ -202,7 +244,8 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags());
+            JapaneseAnalyzer.getDefaultStopTags(),
+            true);
     checkAnalysisConsistency(random(), a, true, s);
     a.close();
   }
@@ -215,7 +258,8 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags());
+            JapaneseAnalyzer.getDefaultStopTags(),
+            true);
     checkAnalysisConsistency(random(), a, false, s);
     a.close();
   }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseAnalyzer.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseAnalyzer.java
@@ -53,8 +53,7 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags(),
-            true);
+            JapaneseAnalyzer.getDefaultStopTags());
 
     // Senior software engineer:
     assertAnalyzesToPositions(
@@ -110,8 +109,7 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags(),
-            true);
+            JapaneseAnalyzer.getDefaultStopTags());
     checkRandomData(random, a, atLeast(100));
     a.close();
   }
@@ -124,8 +122,7 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags(),
-            true);
+            JapaneseAnalyzer.getDefaultStopTags());
     checkRandomData(random, a, 2 * RANDOM_MULTIPLIER, 8192);
     a.close();
   }
@@ -139,8 +136,7 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             TestJapaneseTokenizer.readDict(),
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags(),
-            true);
+            JapaneseAnalyzer.getDefaultStopTags());
     assertTokenStreamContents(
         a.tokenStream("foo", "abcd"),
         new String[] {"a", "b", "cd"},
@@ -151,38 +147,19 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
   }
 
   public void testCharWidthNormalization() throws Exception {
-    // See LUCENE-9853
-    // with CJKWidthCharFilter (normalize half-width / full-width chars before tokenization)
-    final Analyzer a1 =
+    final Analyzer a =
         new JapaneseAnalyzer(
             TestJapaneseTokenizer.readDict(),
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags(),
-            true);
+            JapaneseAnalyzer.getDefaultStopTags());
     assertTokenStreamContents(
-        a1.tokenStream("foo", "新橋６－２０－１"),
+        a.tokenStream("foo", "新橋６－２０－１"),
         new String[] {"新橋", "6", "20", "1"},
         new int[] {0, 2, 4, 7},
         new int[] {2, 3, 6, 8},
         8);
-    a1.close();
-
-    // with CJKWidthFilter (normalize half-width / full-width chars after tokenization)
-    final Analyzer a2 =
-        new JapaneseAnalyzer(
-            TestJapaneseTokenizer.readDict(),
-            Mode.SEARCH,
-            JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags(),
-            false);
-    assertTokenStreamContents(
-        a2.tokenStream("foo", "新橋６－２０－１"),
-        new String[] {"新橋", "6", "2", "0", "1"},
-        new int[] {0, 2, 4, 5, 7},
-        new int[] {2, 3, 5, 6, 8},
-        8);
-    a2.close();
+    a.close();
   }
 
   // LUCENE-3897: this string (found by running all jawiki
@@ -196,8 +173,7 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags(),
-            true);
+            JapaneseAnalyzer.getDefaultStopTags());
     checkAnalysisConsistency(random, a, random.nextBoolean(), s);
     a.close();
   }
@@ -213,8 +189,7 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags(),
-            true);
+            JapaneseAnalyzer.getDefaultStopTags());
     checkAnalysisConsistency(random, a, random.nextBoolean(), s);
     a.close();
   }
@@ -230,8 +205,7 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags(),
-            true);
+            JapaneseAnalyzer.getDefaultStopTags());
     checkAnalysisConsistency(random, a, random.nextBoolean(), s);
     a.close();
   }
@@ -244,8 +218,7 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags(),
-            true);
+            JapaneseAnalyzer.getDefaultStopTags());
     checkAnalysisConsistency(random(), a, true, s);
     a.close();
   }
@@ -258,8 +231,7 @@ public class TestJapaneseAnalyzer extends BaseTokenStreamTestCase {
             null,
             Mode.SEARCH,
             JapaneseAnalyzer.getDefaultStopSet(),
-            JapaneseAnalyzer.getDefaultStopTags(),
-            true);
+            JapaneseAnalyzer.getDefaultStopTags());
     checkAnalysisConsistency(random(), a, false, s);
     a.close();
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-9853