### PR TITLE
LUCENE-9857: Skip cache building if IndexOrDocValuesQuery choose the dvQuery

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
@@ -185,10 +185,9 @@ public final class IndexOrDocValuesQuery extends Query {
   }
 
   /**
-   * At equal costs, doc values tend to be worse than points since they
-   * still need to perform one comparison per document while points can
-   * do much better than that given how values are organized. So we give
-   * an arbitrary 8x penalty to doc values.
+   * At equal costs, doc values tend to be worse than points since they still need to perform one
+   * comparison per document while points can do much better than that given how values are
+   * organized. So we give an arbitrary 8x penalty to doc values.
    */
   boolean chooseIndexQuery(long leadCost, long cost) {
     final long threshold = cost >>> 3;


### PR DESCRIPTION
`IndexOrDocValuesQuery` can automatically choose dvQueries when the `cost > 8 * leadcost`, And the `LRUQueryCache` skips cache building when `cost > 250(by default) * leadcost`. There is a gap between 8 and 250, which means if the factor is just between 8 and 250 (e.g. `cost = 10 * leadcost`), the `IndexOrDocValueQuery` will choose the dvQueries but `LRUQueryCache` still build cache for it.

`IndexOrDocValuesQuery` aims to using docvalue to speed up queries when the leadcost is small, but building cache by dvScorers can make it meaningless because it needs to scan all the docvalues. This can be rather slow for big segments, so maybe we should skip the cache building for `IndexOrDocValuesQuery` when it chooses dvQueries.
