### PR TITLE
LUCENE-9870: Fix Circle2D intersectsLine t-value (distance) range clamp

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -221,7 +221,9 @@ Bug fixes
   (Mark Harwood, Mike Drob)
 
 * LUCENE-9580: Fix bug in the polygon tessellator when introducing collinear edges during polygon 
-  splitting. (Ignacio Vera)  
+  splitting. (Ignacio Vera)
+
+* LUCENE-9870: Fix Circle2D intersectsLine t-value (distance) range clamp (Jørgen Nystad)
 
 Changes in Backwards Compatibility Policy
 

--- a/lucene/core/src/java/org/apache/lucene/geo/Circle2D.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Circle2D.java
@@ -234,7 +234,7 @@ class Circle2D implements Component2D {
 
     final double distance = dotProduct / magnitudeAB;
 
-    if (distance < 0 || distance > dotProduct) {
+    if (distance < 0 || distance > 1) {
       return false;
     }
 

--- a/lucene/core/src/test/org/apache/lucene/geo/TestCircle2D.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestCircle2D.java
@@ -183,7 +183,7 @@ public class TestCircle2D extends LuceneTestCase {
   public void testLineIntersects() {
     Component2D circle2D;
     if (random().nextBoolean()) {
-      Circle circle = new Circle(0, 0, 0.3f);
+      Circle circle = new Circle(0, 0, 35000);
       circle2D = LatLonGeometry.create(circle);
     } else {
       XYCircle xyCircle = new XYCircle(0, 0, 0.3f);

--- a/lucene/core/src/test/org/apache/lucene/geo/TestCircle2D.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestCircle2D.java
@@ -179,4 +179,28 @@ public class TestCircle2D extends LuceneTestCase {
       }
     }
   }
+
+  public void testLineIntersects() {
+    Component2D circle2D;
+    if (random().nextBoolean()) {
+      Circle circle = new Circle(0, 0, 0.3f);
+      circle2D = LatLonGeometry.create(circle);
+    } else {
+      XYCircle xyCircle = new XYCircle(0, 0, 0.3f);
+      circle2D = XYGeometry.create(xyCircle);
+    }
+
+    double ax = -0.25;
+    double ay = 0.25;
+    double bx = 0.25;
+    double by = 0.25;
+    double cx = 0.2;
+    double cy = 0.25;
+    // Test A->B, circle touches center of line, line is less than 1 unit long
+    assertTrue(circle2D.intersectsLine(ax, ay, bx, by));
+    // Test B->C, circle doesn't touch line itself, but touches extended line at t > 1
+    assertFalse(circle2D.intersectsLine(bx, by, cx, cy));
+    // Test C->B, circle doesn't touch line itself, but touches extended line at t < 0
+    assertFalse(circle2D.intersectsLine(cx, cy, bx, by));
+  }
 }


### PR DESCRIPTION
# Description

t-value (distance) should be between 0 and 1, not 0 and dotProduct.

Fixes missing matches when line magnitudeAB < 1.

Affects indexed line and polygon edges.

# Solution

Changed range check to be between 0 and 1. While clamping may be more correct, edge points are checked separately, so this shortcut should be valid.

# Tests

None.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [x] I have added tests for my changes.

Note: I have built 8.8.0 with this change to ensure proper behaviour in an elasticsearch 7.12 instance.