### PR TITLE
Point jdk.java.net instead of OracleJDK page from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ comprehensive documentation, visit:
 ### Step 0) Set up your development environment (OpenJDK 11 or greater)
 
 We'll assume that you know how to get and set up the JDK - if you
-don't, then we suggest starting at https://www.oracle.com/java/ and learning
+don't, then we suggest starting at https://jdk.java.net/ and learning
 more about Java, before returning to this README. Lucene runs with
 Java 11 or later.
 


### PR DESCRIPTION
It would be better to point jdk.java.net to download JDK instead of OracleJDK page (because it now requires commercial license for production use)?