### PR TITLE
LUCENE-9898 Remove no longer used scorePayload method from BM25Similarity

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -205,13 +205,16 @@ Improvements
 * LUCENE-9827: Speed up merging of stored fields and term vectors for smaller segments.
   (Daniel Mitterdorfer, Dimitrios Liapis, Adrien Grand, Robert Muir)
 
+* LUCENE-9898: Removes no longer used scorePayload method from BM25Similarity
+  (Pieter van Boxtel)
+
 Bug fixes
 
 
-* LUCENE-9686: Fix read past EOF handling in DirectIODirectory. (Zach Chen, 
+* LUCENE-9686: Fix read past EOF handling in DirectIODirectory. (Zach Chen,
   Julie Tibshirani)
 
-* LUCENE-8663: NRTCachingDirectory.slowFileExists may open a file while 
+* LUCENE-8663: NRTCachingDirectory.slowFileExists may open a file while
   it's inaccessible. (Dawid Weiss)
 
 * LUCENE-9117: RamUsageEstimator hangs with AOT compilation. Removed any attempt to
@@ -226,7 +229,7 @@ Bug fixes
 * LUCENE-9365: FuzzyQuery was missing matches when prefix length was equal to the term length
   (Mark Harwood, Mike Drob)
 
-* LUCENE-9580: Fix bug in the polygon tessellator when introducing collinear edges during polygon 
+* LUCENE-9580: Fix bug in the polygon tessellator when introducing collinear edges during polygon
   splitting. (Ignacio Vera)
 
 Changes in Backwards Compatibility Policy
@@ -235,8 +238,8 @@ Changes in Backwards Compatibility Policy
   older than N-1. Lucene now can open indices created with a major version of N-2 in read-only mode.
   Opening an index created with a major version of N-2 with an IndexWriter is not supported.
   Further does lucene only support file-format compatibilty which enables reading of old indices while
-  semantic changes like analysis or certain encoding on top of the file format are only supported on 
-  a best effort basis. (Simon Willnauer)  
+  semantic changes like analysis or certain encoding on top of the file format are only supported on
+  a best effort basis. (Simon Willnauer)
 
 Other
 
@@ -289,16 +292,16 @@ API Changes
 New Features
 ---------------------
 
-* LUCENE-9537:  Added smoothingScore method and default implementation to 
-  Scorable abstract class.  The smoothing score allows scorers to calculate a 
-  score for a document where the search term or subquery is not present.  The 
-  smoothing score acts like an idf so that documents that do not have terms or 
-  subqueries that are more frequent in the index are not penalized as much as 
-  documents that do not have less frequent terms or subqueries and prevents 
-  scores which are the product or terms or subqueries from going to zero. Added 
-  the implementation of the Indri AND and the IndriDirichletSimilarity from the 
-  academic Indri search engine: http://www.lemurproject.org/indri.php. 
-  (Cameron VandenBerg)   
+* LUCENE-9537:  Added smoothingScore method and default implementation to
+  Scorable abstract class.  The smoothing score allows scorers to calculate a
+  score for a document where the search term or subquery is not present.  The
+  smoothing score acts like an idf so that documents that do not have terms or
+  subqueries that are more frequent in the index are not penalized as much as
+  documents that do not have less frequent terms or subqueries and prevents
+  scores which are the product or terms or subqueries from going to zero. Added
+  the implementation of the Indri AND and the IndriDirichletSimilarity from the
+  academic Indri search engine: http://www.lemurproject.org/indri.php.
+  (Cameron VandenBerg)
 
 * LUCENE-9694: New tool for creating a deterministic index to enable benchmarking changes
   on a consistent multi-segment index even when they require re-indexing. (Haoyu Zhai)
@@ -357,7 +360,7 @@ Bug Fixes
 ---------------------
 
 * LUCENE-9870: Fix Circle2D intersectsLine t-value (distance) range clamp (Jørgen Nystad)
-  
+
 ======================= Lucene 8.8.1 =======================
 
 Bug Fixes
@@ -375,9 +378,9 @@ New Features
   the generated synonyms to copy some or all flags from the original token (Gus Heck).
 
 
-* LUCENE-9552: New LatLonPoint query that accepts an array of LatLonGeometries. (Ignacio Vera) 
+* LUCENE-9552: New LatLonPoint query that accepts an array of LatLonGeometries. (Ignacio Vera)
 
-* LUCENE-9641: LatLonPoint query support for spatial relationships. (Ignacio Vera) 
+* LUCENE-9641: LatLonPoint query support for spatial relationships. (Ignacio Vera)
 
 * LUCENE-9553: New XYPoint query that accepts an array of XYGeometries. (Ignacio Vera)
 

--- a/lucene/core/src/java/org/apache/lucene/search/similarities/BM25Similarity.java
+++ b/lucene/core/src/java/org/apache/lucene/search/similarities/BM25Similarity.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.CollectionStatistics;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.TermStatistics;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.SmallFloat;
 
 /**
@@ -104,11 +103,6 @@ public class BM25Similarity extends Similarity {
   /** Implemented as <code>log(1 + (docCount - docFreq + 0.5)/(docFreq + 0.5))</code>. */
   protected float idf(long docFreq, long docCount) {
     return (float) Math.log(1 + (docCount - docFreq + 0.5D) / (docFreq + 0.5D));
-  }
-
-  /** The default implementation returns <code>1</code> */
-  protected float scorePayload(int doc, int start, int end, BytesRef payload) {
-    return 1;
   }
 
   /** The default implementation computes the average as <code>sumTotalTermFreq / docCount</code> */


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/projects/LUCENE

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>

LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

After the Lucene 7.2 payload refactoring an unused method was left in BM25Similarity

# Solution

I removed the method

# Tests

All existing tests succeeded. I did another verification scan to make sure there is no reference to the deleted method in Lucene and Solr code.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [n.a.] I have added tests for my changes.
