### PR TITLE
Ignore sdkmanrc file on Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ __pycache__
 
 # Emacs backup
 *~
+
+# SDKMAN
+.sdkmanrc


### PR DESCRIPTION
I'm using SDKMAN to switch multiple JDK versions. I think it would not hurt to exclude its settings from the vcs.
https://sdkman.io/usage#env