### PR TITLE
LUCENE-9855: Rename VectorFormat to HnswVectorsFormat

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene60/Lucene60FieldInfosFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene60/Lucene60FieldInfosFormat.java
@@ -28,8 +28,8 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.NumericVectors;
 import org.apache.lucene.index.SegmentInfo;
-import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.Directory;
@@ -212,7 +212,7 @@ public final class Lucene60FieldInfosFormat extends FieldInfosFormat {
                 pointIndexDimensionCount,
                 pointNumBytes,
                 0,
-                VectorValues.SearchStrategy.NONE,
+                NumericVectors.SearchStrategy.NONE,
                 isSoftDeletesField);
       } catch (IllegalStateException e) {
         throw new CorruptIndexException(

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene70/Lucene70Codec.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene70/Lucene70Codec.java
@@ -28,6 +28,7 @@ import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FieldInfosFormat;
 import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.HnswVectorsFormat;
 import org.apache.lucene.codecs.LiveDocsFormat;
 import org.apache.lucene.codecs.NormsFormat;
 import org.apache.lucene.codecs.PointsFormat;
@@ -35,7 +36,6 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.SegmentInfoFormat;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.VectorFormat;
 import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
 import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
 
@@ -122,8 +122,8 @@ public class Lucene70Codec extends Codec {
   }
 
   @Override
-  public VectorFormat vectorFormat() {
-    return VectorFormat.EMPTY;
+  public HnswVectorsFormat vectorFormat() {
+    return HnswVectorsFormat.EMPTY;
   }
 
   @Override

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80Codec.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80Codec.java
@@ -27,6 +27,7 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FieldInfosFormat;
+import org.apache.lucene.codecs.HnswVectorsFormat;
 import org.apache.lucene.codecs.LiveDocsFormat;
 import org.apache.lucene.codecs.NormsFormat;
 import org.apache.lucene.codecs.PointsFormat;
@@ -34,7 +35,6 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.SegmentInfoFormat;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.VectorFormat;
 import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
 import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
 
@@ -131,7 +131,7 @@ public class Lucene80Codec extends Codec {
   }
 
   @Override
-  public final VectorFormat vectorFormat() {
-    return VectorFormat.EMPTY;
+  public final HnswVectorsFormat vectorFormat() {
+    return HnswVectorsFormat.EMPTY;
   }
 }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene84/Lucene84Codec.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene84/Lucene84Codec.java
@@ -31,6 +31,7 @@ import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FieldInfosFormat;
 import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.HnswVectorsFormat;
 import org.apache.lucene.codecs.LiveDocsFormat;
 import org.apache.lucene.codecs.NormsFormat;
 import org.apache.lucene.codecs.PointsFormat;
@@ -38,7 +39,6 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.SegmentInfoFormat;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.VectorFormat;
 import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
 import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
 
@@ -134,8 +134,8 @@ public class Lucene84Codec extends Codec {
   }
 
   @Override
-  public VectorFormat vectorFormat() {
-    return VectorFormat.EMPTY;
+  public HnswVectorsFormat vectorFormat() {
+    return HnswVectorsFormat.EMPTY;
   }
 
   /**

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene86/Lucene86Codec.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene86/Lucene86Codec.java
@@ -30,6 +30,7 @@ import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FieldInfosFormat;
 import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.HnswVectorsFormat;
 import org.apache.lucene.codecs.LiveDocsFormat;
 import org.apache.lucene.codecs.NormsFormat;
 import org.apache.lucene.codecs.PointsFormat;
@@ -37,7 +38,6 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.SegmentInfoFormat;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.VectorFormat;
 import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
 import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
 
@@ -133,8 +133,8 @@ public class Lucene86Codec extends Codec {
   }
 
   @Override
-  public final VectorFormat vectorFormat() {
-    return VectorFormat.EMPTY;
+  public final HnswVectorsFormat vectorFormat() {
+    return HnswVectorsFormat.EMPTY;
   }
 
   /**

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/Lucene87Codec.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/Lucene87Codec.java
@@ -32,6 +32,7 @@ import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FieldInfosFormat;
 import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.HnswVectorsFormat;
 import org.apache.lucene.codecs.LiveDocsFormat;
 import org.apache.lucene.codecs.NormsFormat;
 import org.apache.lucene.codecs.PointsFormat;
@@ -39,7 +40,6 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.SegmentInfoFormat;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.VectorFormat;
 import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
 import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
 
@@ -157,8 +157,8 @@ public class Lucene87Codec extends Codec {
   }
 
   @Override
-  public final VectorFormat vectorFormat() {
-    return VectorFormat.EMPTY;
+  public final HnswVectorsFormat vectorFormat() {
+    return HnswVectorsFormat.EMPTY;
   }
 
   /**

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextCodec.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextCodec.java
@@ -20,6 +20,7 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FieldInfosFormat;
+import org.apache.lucene.codecs.HnswVectorsFormat;
 import org.apache.lucene.codecs.LiveDocsFormat;
 import org.apache.lucene.codecs.NormsFormat;
 import org.apache.lucene.codecs.PointsFormat;
@@ -27,7 +28,6 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.SegmentInfoFormat;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.VectorFormat;
 
 /**
  * plain text index format.
@@ -47,7 +47,7 @@ public final class SimpleTextCodec extends Codec {
   private final DocValuesFormat dvFormat = new SimpleTextDocValuesFormat();
   private final CompoundFormat compoundFormat = new SimpleTextCompoundFormat();
   private final PointsFormat pointsFormat = new SimpleTextPointsFormat();
-  private final VectorFormat vectorFormat = new SimpleTextVectorFormat();
+  private final HnswVectorsFormat hnswVectorsFormat = new SimpleTextHnswVectorsFormat();
 
   public SimpleTextCodec() {
     super("SimpleText");
@@ -104,7 +104,7 @@ public final class SimpleTextCodec extends Codec {
   }
 
   @Override
-  public VectorFormat vectorFormat() {
-    return vectorFormat;
+  public HnswVectorsFormat vectorFormat() {
+    return hnswVectorsFormat;
   }
 }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldInfosFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldInfosFormat.java
@@ -27,8 +27,8 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.NumericVectors;
 import org.apache.lucene.index.SegmentInfo;
-import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -158,7 +158,7 @@ public class SimpleTextFieldInfosFormat extends FieldInfosFormat {
         SimpleTextUtil.readLine(input, scratch);
         assert StringHelper.startsWith(scratch.get(), VECTOR_SEARCH_STRATEGY);
         String scoreFunction = readString(VECTOR_SEARCH_STRATEGY.length, scratch);
-        VectorValues.SearchStrategy vectorDistFunc = distanceFunction(scoreFunction);
+        NumericVectors.SearchStrategy vectorDistFunc = distanceFunction(scoreFunction);
 
         SimpleTextUtil.readLine(input, scratch);
         assert StringHelper.startsWith(scratch.get(), SOFT_DELETES);
@@ -201,8 +201,8 @@ public class SimpleTextFieldInfosFormat extends FieldInfosFormat {
     return DocValuesType.valueOf(dvType);
   }
 
-  public VectorValues.SearchStrategy distanceFunction(String scoreFunction) {
-    return VectorValues.SearchStrategy.valueOf(scoreFunction);
+  public NumericVectors.SearchStrategy distanceFunction(String scoreFunction) {
+    return NumericVectors.SearchStrategy.valueOf(scoreFunction);
   }
 
   private String readString(int offset, BytesRefBuilder scratch) {

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextHnswVectorsFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextHnswVectorsFormat.java
@@ -17,9 +17,9 @@
 package org.apache.lucene.codecs.simpletext;
 
 import java.io.IOException;
-import org.apache.lucene.codecs.VectorFormat;
-import org.apache.lucene.codecs.VectorReader;
-import org.apache.lucene.codecs.VectorWriter;
+import org.apache.lucene.codecs.HnswVectorsFormat;
+import org.apache.lucene.codecs.HnswVectorsReader;
+import org.apache.lucene.codecs.HnswVectorsWriter;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 
@@ -31,16 +31,16 @@ import org.apache.lucene.index.SegmentWriteState;
  *
  * @lucene.experimental
  */
-public final class SimpleTextVectorFormat extends VectorFormat {
+public final class SimpleTextHnswVectorsFormat extends HnswVectorsFormat {
 
   @Override
-  public VectorWriter fieldsWriter(SegmentWriteState state) throws IOException {
-    return new SimpleTextVectorWriter(state);
+  public HnswVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+    return new SimpleTextHnswVectorsWriter(state);
   }
 
   @Override
-  public VectorReader fieldsReader(SegmentReadState state) throws IOException {
-    return new SimpleTextVectorReader(state);
+  public HnswVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+    return new SimpleTextHnswVectorsReader(state);
   }
 
   /** Extension of vectors data file */

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextHnswVectorsWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextHnswVectorsWriter.java
@@ -23,18 +23,18 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.lucene.codecs.VectorWriter;
+import org.apache.lucene.codecs.HnswVectorsWriter;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.NumericVectors;
 import org.apache.lucene.index.SegmentWriteState;
-import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.IOUtils;
 
 /** Writes vector-valued fields in a plain text format */
-public class SimpleTextVectorWriter extends VectorWriter {
+public class SimpleTextHnswVectorsWriter extends HnswVectorsWriter {
 
   static final BytesRef FIELD_NUMBER = new BytesRef("field-number ");
   static final BytesRef FIELD_NAME = new BytesRef("field-name ");
@@ -47,7 +47,7 @@ public class SimpleTextVectorWriter extends VectorWriter {
   private final IndexOutput meta, vectorData;
   private final BytesRefBuilder scratch = new BytesRefBuilder();
 
-  SimpleTextVectorWriter(SegmentWriteState state) throws IOException {
+  SimpleTextHnswVectorsWriter(SegmentWriteState state) throws IOException {
     assert state.fieldInfos.hasVectorValues();
 
     boolean success = false;
@@ -55,12 +55,16 @@ public class SimpleTextVectorWriter extends VectorWriter {
     try {
       String metaFileName =
           IndexFileNames.segmentFileName(
-              state.segmentInfo.name, state.segmentSuffix, SimpleTextVectorFormat.META_EXTENSION);
+              state.segmentInfo.name,
+              state.segmentSuffix,
+              SimpleTextHnswVectorsFormat.META_EXTENSION);
       meta = state.directory.createOutput(metaFileName, state.context);
 
       String vectorDataFileName =
           IndexFileNames.segmentFileName(
-              state.segmentInfo.name, state.segmentSuffix, SimpleTextVectorFormat.VECTOR_EXTENSION);
+              state.segmentInfo.name,
+              state.segmentSuffix,
+              SimpleTextHnswVectorsFormat.VECTOR_EXTENSION);
       vectorData = state.directory.createOutput(vectorDataFileName, state.context);
       success = true;
     } finally {
@@ -71,7 +75,7 @@ public class SimpleTextVectorWriter extends VectorWriter {
   }
 
   @Override
-  public void writeField(FieldInfo fieldInfo, VectorValues vectors) throws IOException {
+  public void writeField(FieldInfo fieldInfo, NumericVectors vectors) throws IOException {
     long vectorDataOffset = vectorData.getFilePointer();
     List<Integer> docIds = new ArrayList<>();
     int docV;
@@ -85,7 +89,7 @@ public class SimpleTextVectorWriter extends VectorWriter {
     }
   }
 
-  private void writeVectorValue(VectorValues vectors) throws IOException {
+  private void writeVectorValue(NumericVectors vectors) throws IOException {
     // write vector value
     float[] value = vectors.vectorValue();
     assert value.length == vectors.dimension();

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/simpletext/TestSimpleTextHnswVectorsFormat.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/simpletext/TestSimpleTextHnswVectorsFormat.java
@@ -14,20 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.lucene.codecs.simpletext;
 
-package org.apache.lucene.index;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.BaseHnswVectorsFormatTestCase;
 
-/**
- * Something (generally a {@link VectorValues}) that provides a {@link RandomAccessVectorValues}.
- *
- * @lucene.experimental
- */
-public interface RandomAccessVectorValuesProducer {
-  /**
-   * Return a random access interface over this iterator's vectors. Calling the RandomAccess methods
-   * will have no effect on the progress of the iteration or the values returned by this iterator.
-   * Successive calls will retrieve independent copies that do not overwrite each others' returned
-   * values.
-   */
-  RandomAccessVectorValues randomAccess();
+public class TestSimpleTextHnswVectorsFormat extends BaseHnswVectorsFormatTestCase {
+  @Override
+  protected Codec getCodec() {
+    return new SimpleTextCodec();
+  }
 }

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/TestBlockWriter.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/TestBlockWriter.java
@@ -23,7 +23,7 @@ import org.apache.lucene.codecs.lucene90.MockTermStateFactory;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.index.NumericVectors;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.apache.lucene.util.BytesRef;
@@ -116,7 +116,7 @@ public class TestBlockWriter extends LuceneTestCase {
         0,
         0,
         0,
-        VectorValues.SearchStrategy.NONE,
+        NumericVectors.SearchStrategy.NONE,
         true);
   }
 }

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/sharedterms/TestSTBlockReader.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/sharedterms/TestSTBlockReader.java
@@ -39,9 +39,9 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.NumericVectors;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SegmentReadState;
-import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.Directory;
@@ -208,7 +208,7 @@ public class TestSTBlockReader extends LuceneTestCase {
         0,
         0,
         0,
-        VectorValues.SearchStrategy.NONE,
+        NumericVectors.SearchStrategy.NONE,
         false);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/Codec.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/Codec.java
@@ -111,7 +111,7 @@ public abstract class Codec implements NamedSPILoader.NamedSPI {
   public abstract PointsFormat pointsFormat();
 
   /** Encodes/decodes numeric vector fields */
-  public abstract VectorFormat vectorFormat();
+  public abstract HnswVectorsFormat vectorFormat();
 
   /** looks up a codec by name */
   public static Codec forName(String name) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/FilterCodec.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/FilterCodec.java
@@ -108,7 +108,7 @@ public abstract class FilterCodec extends Codec {
   }
 
   @Override
-  public VectorFormat vectorFormat() {
+  public HnswVectorsFormat vectorFormat() {
     return delegate.vectorFormat();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/HnswVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/HnswVectorsFormat.java
@@ -18,46 +18,46 @@
 package org.apache.lucene.codecs;
 
 import java.io.IOException;
+import org.apache.lucene.index.NumericVectors;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
-import org.apache.lucene.index.VectorValues;
 
 /**
  * Encodes/decodes per-document vector and any associated indexing structures required to support
  * nearest-neighbor search
  */
-public abstract class VectorFormat {
+public abstract class HnswVectorsFormat {
 
   /** Sole constructor */
-  protected VectorFormat() {}
+  protected HnswVectorsFormat() {}
 
-  /** Returns a {@link VectorWriter} to write the vectors to the index. */
-  public abstract VectorWriter fieldsWriter(SegmentWriteState state) throws IOException;
+  /** Returns a {@link HnswVectorsWriter} to write the vectors to the index. */
+  public abstract HnswVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException;
 
-  /** Returns a {@link VectorReader} to read the vectors from the index. */
-  public abstract VectorReader fieldsReader(SegmentReadState state) throws IOException;
+  /** Returns a {@link HnswVectorsReader} to read the vectors from the index. */
+  public abstract HnswVectorsReader fieldsReader(SegmentReadState state) throws IOException;
 
   /**
    * EMPTY throws an exception when written. It acts as a sentinel indicating a Codec that does not
    * support vectors.
    */
-  public static final VectorFormat EMPTY =
-      new VectorFormat() {
+  public static final HnswVectorsFormat EMPTY =
+      new HnswVectorsFormat() {
         @Override
-        public VectorWriter fieldsWriter(SegmentWriteState state) {
+        public HnswVectorsWriter fieldsWriter(SegmentWriteState state) {
           throw new UnsupportedOperationException(
               "Attempt to write EMPTY VectorValues: maybe you forgot to use codec=Lucene90");
         }
 
         @Override
-        public VectorReader fieldsReader(SegmentReadState state) {
-          return new VectorReader() {
+        public HnswVectorsReader fieldsReader(SegmentReadState state) {
+          return new HnswVectorsReader() {
             @Override
             public void checkIntegrity() {}
 
             @Override
-            public VectorValues getVectorValues(String field) {
-              return VectorValues.EMPTY;
+            public NumericVectors getVectorValues(String field) {
+              return NumericVectors.EMPTY;
             }
 
             @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/HnswVectorsReader.java
@@ -19,14 +19,14 @@ package org.apache.lucene.codecs;
 
 import java.io.Closeable;
 import java.io.IOException;
-import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.index.NumericVectors;
 import org.apache.lucene.util.Accountable;
 
 /** Reads vectors from an index. */
-public abstract class VectorReader implements Closeable, Accountable {
+public abstract class HnswVectorsReader implements Closeable, Accountable {
 
   /** Sole constructor */
-  protected VectorReader() {}
+  protected HnswVectorsReader() {}
 
   /**
    * Checks consistency of this reader.
@@ -38,8 +38,8 @@ public abstract class VectorReader implements Closeable, Accountable {
    */
   public abstract void checkIntegrity() throws IOException;
 
-  /** Returns the {@link VectorValues} for the given {@code field} */
-  public abstract VectorValues getVectorValues(String field) throws IOException;
+  /** Returns the {@link NumericVectors} for the given {@code field} */
+  public abstract NumericVectors getVectorValues(String field) throws IOException;
 
   /**
    * Returns an instance optimized for merging. This instance may only be consumed in the thread
@@ -47,7 +47,7 @@ public abstract class VectorReader implements Closeable, Accountable {
    *
    * <p>The default implementation returns {@code this}
    */
-  public VectorReader getMergeInstance() {
+  public HnswVectorsReader getMergeInstance() {
     return this;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/HnswVectorsWriter.java
@@ -27,20 +27,20 @@ import java.util.List;
 import org.apache.lucene.index.DocIDMerger;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergeState;
-import org.apache.lucene.index.RandomAccessVectorValues;
-import org.apache.lucene.index.RandomAccessVectorValuesProducer;
-import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.index.NumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectorsProducer;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.BytesRef;
 
 /** Writes vectors to an index. */
-public abstract class VectorWriter implements Closeable {
+public abstract class HnswVectorsWriter implements Closeable {
 
   /** Sole constructor */
-  protected VectorWriter() {}
+  protected HnswVectorsWriter() {}
 
   /** Write all values contained in the provided reader */
-  public abstract void writeField(FieldInfo fieldInfo, VectorValues values) throws IOException;
+  public abstract void writeField(FieldInfo fieldInfo, NumericVectors values) throws IOException;
 
   /** Called once at the end before close */
   public abstract void finish() throws IOException;
@@ -48,7 +48,7 @@ public abstract class VectorWriter implements Closeable {
   /** Merge the vector values from multiple segments, for all fields */
   public void merge(MergeState mergeState) throws IOException {
     for (int i = 0; i < mergeState.fieldInfos.length; i++) {
-      VectorReader reader = mergeState.vectorReaders[i];
+      HnswVectorsReader reader = mergeState.hnswVectorsReaders[i];
       assert reader != null || mergeState.fieldInfos[i].hasVectorValues() == false;
       if (reader != null) {
         reader.checkIntegrity();
@@ -69,14 +69,14 @@ public abstract class VectorWriter implements Closeable {
     }
     List<VectorValuesSub> subs = new ArrayList<>();
     int dimension = -1;
-    VectorValues.SearchStrategy searchStrategy = null;
+    NumericVectors.SearchStrategy searchStrategy = null;
     int nonEmptySegmentIndex = 0;
-    for (int i = 0; i < mergeState.vectorReaders.length; i++) {
-      VectorReader vectorReader = mergeState.vectorReaders[i];
-      if (vectorReader != null) {
+    for (int i = 0; i < mergeState.hnswVectorsReaders.length; i++) {
+      HnswVectorsReader hnswVectorsReader = mergeState.hnswVectorsReaders[i];
+      if (hnswVectorsReader != null) {
         if (mergeFieldInfo != null && mergeFieldInfo.hasVectorValues()) {
           int segmentDimension = mergeFieldInfo.getVectorDimension();
-          VectorValues.SearchStrategy segmentSearchStrategy =
+          NumericVectors.SearchStrategy segmentSearchStrategy =
               mergeFieldInfo.getVectorSearchStrategy();
           if (dimension == -1) {
             dimension = segmentDimension;
@@ -98,7 +98,7 @@ public abstract class VectorWriter implements Closeable {
                     + "!="
                     + segmentSearchStrategy);
           }
-          VectorValues values = vectorReader.getVectorValues(mergeFieldInfo.name);
+          NumericVectors values = hnswVectorsReader.getVectorValues(mergeFieldInfo.name);
           if (values != null) {
             subs.add(new VectorValuesSub(nonEmptySegmentIndex++, mergeState.docMaps[i], values));
           }
@@ -108,7 +108,7 @@ public abstract class VectorWriter implements Closeable {
     // Create a new VectorValues by iterating over the sub vectors, mapping the resulting
     // docids using docMaps in the mergeState.
     if (subs.size() > 0) {
-      writeField(mergeFieldInfo, new VectorValuesMerger(subs, mergeState));
+      writeField(mergeFieldInfo, new NumericVectorsMerger(subs, mergeState));
     }
     if (mergeState.infoStream.isEnabled("VV")) {
       mergeState.infoStream.message("VV", "merge done " + mergeState.segmentInfo);
@@ -118,11 +118,11 @@ public abstract class VectorWriter implements Closeable {
   /** Tracks state of one sub-reader that we are merging */
   private static class VectorValuesSub extends DocIDMerger.Sub {
 
-    final VectorValues values;
+    final NumericVectors values;
     final int segmentIndex;
     int count;
 
-    VectorValuesSub(int segmentIndex, MergeState.DocMap docMap, VectorValues values) {
+    VectorValuesSub(int segmentIndex, MergeState.DocMap docMap, NumericVectors values) {
       super(docMap);
       this.values = values;
       this.segmentIndex = segmentIndex;
@@ -145,8 +145,8 @@ public abstract class VectorWriter implements Closeable {
    * reverse ordinal mapping for documents having values in order to support random access by dense
    * ordinal.
    */
-  private static class VectorValuesMerger extends VectorValues
-      implements RandomAccessVectorValuesProducer {
+  private static class NumericVectorsMerger extends NumericVectors
+      implements RandomAccessNumericVectorsProducer {
     private final List<VectorValuesSub> subs;
     private final DocIDMerger<VectorValuesSub> docIdMerger;
     private final int[] ordBase;
@@ -161,7 +161,7 @@ public abstract class VectorWriter implements Closeable {
     private int[] ordMap;
     private int ord;
 
-    VectorValuesMerger(List<VectorValuesSub> subs, MergeState mergeState) throws IOException {
+    NumericVectorsMerger(List<VectorValuesSub> subs, MergeState mergeState) throws IOException {
       this.subs = subs;
       docIdMerger = DocIDMerger.of(subs, mergeState.needsIndexSort);
       int totalCost = 0, totalSize = 0;
@@ -217,7 +217,7 @@ public abstract class VectorWriter implements Closeable {
     }
 
     @Override
-    public RandomAccessVectorValues randomAccess() {
+    public RandomAccessNumericVectors randomAccess() {
       return new MergerRandomAccess();
     }
 
@@ -251,15 +251,15 @@ public abstract class VectorWriter implements Closeable {
       throw new UnsupportedOperationException();
     }
 
-    class MergerRandomAccess implements RandomAccessVectorValues {
+    class MergerRandomAccess implements RandomAccessNumericVectors {
 
-      private final List<RandomAccessVectorValues> raSubs;
+      private final List<RandomAccessNumericVectors> raSubs;
 
       MergerRandomAccess() {
         raSubs = new ArrayList<>(subs.size());
         for (VectorValuesSub sub : subs) {
-          if (sub.values instanceof RandomAccessVectorValuesProducer) {
-            raSubs.add(((RandomAccessVectorValuesProducer) sub.values).randomAccess());
+          if (sub.values instanceof RandomAccessNumericVectorsProducer) {
+            raSubs.add(((RandomAccessNumericVectorsProducer) sub.values).randomAccess());
           } else {
             throw new IllegalStateException(
                 "Cannot merge VectorValues without support for random access");
@@ -274,12 +274,12 @@ public abstract class VectorWriter implements Closeable {
 
       @Override
       public int dimension() {
-        return VectorValuesMerger.this.dimension();
+        return NumericVectorsMerger.this.dimension();
       }
 
       @Override
       public SearchStrategy searchStrategy() {
-        return VectorValuesMerger.this.searchStrategy();
+        return NumericVectorsMerger.this.searchStrategy();
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90Codec.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90Codec.java
@@ -22,6 +22,7 @@ import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FieldInfosFormat;
 import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.HnswVectorsFormat;
 import org.apache.lucene.codecs.LiveDocsFormat;
 import org.apache.lucene.codecs.NormsFormat;
 import org.apache.lucene.codecs.PointsFormat;
@@ -29,7 +30,6 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.SegmentInfoFormat;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.VectorFormat;
 import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
 import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
 
@@ -84,7 +84,7 @@ public class Lucene90Codec extends Codec {
         }
       };
 
-  private final VectorFormat vectorFormat = new Lucene90VectorFormat();
+  private final HnswVectorsFormat hnswVectorsFormat = new Lucene90HnswVectorsFormat();
 
   private final StoredFieldsFormat storedFieldsFormat;
 
@@ -147,8 +147,8 @@ public class Lucene90Codec extends Codec {
   }
 
   @Override
-  public final VectorFormat vectorFormat() {
-    return vectorFormat;
+  public final HnswVectorsFormat vectorFormat() {
+    return hnswVectorsFormat;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90FieldInfosFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90FieldInfosFormat.java
@@ -28,9 +28,9 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.NumericVectors;
+import org.apache.lucene.index.NumericVectors.SearchStrategy;
 import org.apache.lucene.index.SegmentInfo;
-import org.apache.lucene.index.VectorValues;
-import org.apache.lucene.index.VectorValues.SearchStrategy;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.Directory;
@@ -173,7 +173,7 @@ public final class Lucene90FieldInfosFormat extends FieldInfosFormat {
             pointNumBytes = 0;
           }
           final int vectorDimension = input.readVInt();
-          final VectorValues.SearchStrategy vectorDistFunc = getDistFunc(input, input.readByte());
+          final NumericVectors.SearchStrategy vectorDistFunc = getDistFunc(input, input.readByte());
 
           try {
             infos[i] =
@@ -254,12 +254,12 @@ public final class Lucene90FieldInfosFormat extends FieldInfosFormat {
     }
   }
 
-  private static VectorValues.SearchStrategy getDistFunc(IndexInput input, byte b)
+  private static NumericVectors.SearchStrategy getDistFunc(IndexInput input, byte b)
       throws IOException {
-    if (b < 0 || b >= VectorValues.SearchStrategy.values().length) {
+    if (b < 0 || b >= NumericVectors.SearchStrategy.values().length) {
       throw new CorruptIndexException("invalid distance function: " + b, input);
     }
-    return VectorValues.SearchStrategy.values()[b];
+    return NumericVectors.SearchStrategy.values()[b];
   }
 
   static {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsFormat.java
@@ -18,9 +18,9 @@
 package org.apache.lucene.codecs.lucene90;
 
 import java.io.IOException;
-import org.apache.lucene.codecs.VectorFormat;
-import org.apache.lucene.codecs.VectorReader;
-import org.apache.lucene.codecs.VectorWriter;
+import org.apache.lucene.codecs.HnswVectorsFormat;
+import org.apache.lucene.codecs.HnswVectorsReader;
+import org.apache.lucene.codecs.HnswVectorsWriter;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 
@@ -64,7 +64,7 @@ import org.apache.lucene.index.SegmentWriteState;
  *
  * @lucene.experimental
  */
-public final class Lucene90VectorFormat extends VectorFormat {
+public final class Lucene90HnswVectorsFormat extends HnswVectorsFormat {
 
   static final String META_CODEC_NAME = "Lucene90VectorFormatMeta";
   static final String VECTOR_DATA_CODEC_NAME = "Lucene90VectorFormatData";
@@ -77,15 +77,15 @@ public final class Lucene90VectorFormat extends VectorFormat {
   static final int VERSION_CURRENT = VERSION_START;
 
   /** Sole constructor */
-  public Lucene90VectorFormat() {}
+  public Lucene90HnswVectorsFormat() {}
 
   @Override
-  public VectorWriter fieldsWriter(SegmentWriteState state) throws IOException {
-    return new Lucene90VectorWriter(state);
+  public HnswVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+    return new Lucene90HnswVectorsWriter(state);
   }
 
   @Override
-  public VectorReader fieldsReader(SegmentReadState state) throws IOException {
-    return new Lucene90VectorReader(state);
+  public HnswVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+    return new Lucene90HnswVectorsReader(state);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -26,16 +26,16 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.codecs.VectorReader;
+import org.apache.lucene.codecs.HnswVectorsReader;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.KnnGraphValues;
-import org.apache.lucene.index.RandomAccessVectorValues;
-import org.apache.lucene.index.RandomAccessVectorValuesProducer;
+import org.apache.lucene.index.NumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectorsProducer;
 import org.apache.lucene.index.SegmentReadState;
-import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
@@ -53,7 +53,7 @@ import org.apache.lucene.util.hnsw.NeighborQueue;
  *
  * @lucene.experimental
  */
-public final class Lucene90VectorReader extends VectorReader {
+public final class Lucene90HnswVectorsReader extends HnswVectorsReader {
 
   private final FieldInfos fieldInfos;
   private final Map<String, FieldEntry> fields = new HashMap<>();
@@ -61,10 +61,10 @@ public final class Lucene90VectorReader extends VectorReader {
   private final IndexInput vectorIndex;
   private final long checksumSeed;
 
-  Lucene90VectorReader(SegmentReadState state) throws IOException {
+  Lucene90HnswVectorsReader(SegmentReadState state) throws IOException {
     this.fieldInfos = state.fieldInfos;
 
-    int versionMeta = readMetadata(state, Lucene90VectorFormat.META_EXTENSION);
+    int versionMeta = readMetadata(state, Lucene90HnswVectorsFormat.META_EXTENSION);
     long[] checksumRef = new long[1];
     boolean success = false;
     try {
@@ -72,15 +72,15 @@ public final class Lucene90VectorReader extends VectorReader {
           openDataInput(
               state,
               versionMeta,
-              Lucene90VectorFormat.VECTOR_DATA_EXTENSION,
-              Lucene90VectorFormat.VECTOR_DATA_CODEC_NAME,
+              Lucene90HnswVectorsFormat.VECTOR_DATA_EXTENSION,
+              Lucene90HnswVectorsFormat.VECTOR_DATA_CODEC_NAME,
               checksumRef);
       vectorIndex =
           openDataInput(
               state,
               versionMeta,
-              Lucene90VectorFormat.VECTOR_INDEX_EXTENSION,
-              Lucene90VectorFormat.VECTOR_INDEX_CODEC_NAME,
+              Lucene90HnswVectorsFormat.VECTOR_INDEX_EXTENSION,
+              Lucene90HnswVectorsFormat.VECTOR_INDEX_CODEC_NAME,
               checksumRef);
       success = true;
     } finally {
@@ -101,9 +101,9 @@ public final class Lucene90VectorReader extends VectorReader {
         versionMeta =
             CodecUtil.checkIndexHeader(
                 meta,
-                Lucene90VectorFormat.META_CODEC_NAME,
-                Lucene90VectorFormat.VERSION_START,
-                Lucene90VectorFormat.VERSION_CURRENT,
+                Lucene90HnswVectorsFormat.META_CODEC_NAME,
+                Lucene90HnswVectorsFormat.VERSION_START,
+                Lucene90HnswVectorsFormat.VERSION_CURRENT,
                 state.segmentInfo.getId(),
                 state.segmentSuffix);
         readFields(meta, state.fieldInfos);
@@ -130,8 +130,8 @@ public final class Lucene90VectorReader extends VectorReader {
         CodecUtil.checkIndexHeader(
             in,
             codecName,
-            Lucene90VectorFormat.VERSION_START,
-            Lucene90VectorFormat.VERSION_CURRENT,
+            Lucene90HnswVectorsFormat.VERSION_START,
+            Lucene90HnswVectorsFormat.VERSION_CURRENT,
             state.segmentInfo.getId(),
             state.segmentSuffix);
     if (versionMeta != versionVectorData) {
@@ -158,16 +158,16 @@ public final class Lucene90VectorReader extends VectorReader {
     }
   }
 
-  private VectorValues.SearchStrategy readSearchStrategy(DataInput input) throws IOException {
+  private NumericVectors.SearchStrategy readSearchStrategy(DataInput input) throws IOException {
     int searchStrategyId = input.readInt();
-    if (searchStrategyId < 0 || searchStrategyId >= VectorValues.SearchStrategy.values().length) {
+    if (searchStrategyId < 0 || searchStrategyId >= NumericVectors.SearchStrategy.values().length) {
       throw new CorruptIndexException("Invalid search strategy id: " + searchStrategyId, input);
     }
-    return VectorValues.SearchStrategy.values()[searchStrategyId];
+    return NumericVectors.SearchStrategy.values()[searchStrategyId];
   }
 
   private FieldEntry readField(DataInput input) throws IOException {
-    VectorValues.SearchStrategy searchStrategy = readSearchStrategy(input);
+    NumericVectors.SearchStrategy searchStrategy = readSearchStrategy(input);
     switch (searchStrategy) {
       case NONE:
         return new FieldEntry(input, searchStrategy);
@@ -181,7 +181,7 @@ public final class Lucene90VectorReader extends VectorReader {
 
   @Override
   public long ramBytesUsed() {
-    long totalBytes = RamUsageEstimator.shallowSizeOfInstance(Lucene90VectorReader.class);
+    long totalBytes = RamUsageEstimator.shallowSizeOfInstance(Lucene90HnswVectorsReader.class);
     totalBytes +=
         RamUsageEstimator.sizeOfMap(
             fields, RamUsageEstimator.shallowSizeOfInstance(FieldEntry.class));
@@ -198,14 +198,14 @@ public final class Lucene90VectorReader extends VectorReader {
   }
 
   @Override
-  public VectorValues getVectorValues(String field) throws IOException {
+  public NumericVectors getVectorValues(String field) throws IOException {
     FieldInfo info = fieldInfos.fieldInfo(field);
     if (info == null) {
       return null;
     }
     int dimension = info.getVectorDimension();
     if (dimension == 0) {
-      return VectorValues.EMPTY;
+      return NumericVectors.EMPTY;
     }
     FieldEntry fieldEntry = fields.get(field);
     if (fieldEntry == null) {
@@ -235,7 +235,7 @@ public final class Lucene90VectorReader extends VectorReader {
     }
     IndexInput bytesSlice =
         vectorData.slice("vector-data", fieldEntry.vectorDataOffset, fieldEntry.vectorDataLength);
-    return new OffHeapVectorValues(fieldEntry, bytesSlice);
+    return new OffHeapNumericVectors(fieldEntry, bytesSlice);
   }
 
   public KnnGraphValues getGraphValues(String field) throws IOException {
@@ -270,7 +270,7 @@ public final class Lucene90VectorReader extends VectorReader {
   private static class FieldEntry {
 
     final int dimension;
-    final VectorValues.SearchStrategy searchStrategy;
+    final NumericVectors.SearchStrategy searchStrategy;
 
     final long vectorDataOffset;
     final long vectorDataLength;
@@ -278,7 +278,7 @@ public final class Lucene90VectorReader extends VectorReader {
     final long indexDataLength;
     final int[] ordToDoc;
 
-    FieldEntry(DataInput input, VectorValues.SearchStrategy searchStrategy) throws IOException {
+    FieldEntry(DataInput input, NumericVectors.SearchStrategy searchStrategy) throws IOException {
       this.searchStrategy = searchStrategy;
       vectorDataOffset = input.readVLong();
       vectorDataLength = input.readVLong();
@@ -302,7 +302,7 @@ public final class Lucene90VectorReader extends VectorReader {
 
     final long[] ordOffsets;
 
-    HnswGraphFieldEntry(DataInput input, VectorValues.SearchStrategy searchStrategy)
+    HnswGraphFieldEntry(DataInput input, NumericVectors.SearchStrategy searchStrategy)
         throws IOException {
       super(input, searchStrategy);
       ordOffsets = new long[size()];
@@ -315,8 +315,8 @@ public final class Lucene90VectorReader extends VectorReader {
   }
 
   /** Read the vector values from the index input. This supports both iterated and random access. */
-  private class OffHeapVectorValues extends VectorValues
-      implements RandomAccessVectorValues, RandomAccessVectorValuesProducer {
+  private class OffHeapNumericVectors extends NumericVectors
+      implements RandomAccessNumericVectors, RandomAccessNumericVectorsProducer {
 
     final FieldEntry fieldEntry;
     final IndexInput dataIn;
@@ -329,7 +329,7 @@ public final class Lucene90VectorReader extends VectorReader {
     int ord = -1;
     int doc = -1;
 
-    OffHeapVectorValues(FieldEntry fieldEntry, IndexInput dataIn) {
+    OffHeapNumericVectors(FieldEntry fieldEntry, IndexInput dataIn) {
       this.fieldEntry = fieldEntry;
       this.dataIn = dataIn;
       byteSize = Float.BYTES * fieldEntry.dimension;
@@ -404,8 +404,8 @@ public final class Lucene90VectorReader extends VectorReader {
     }
 
     @Override
-    public RandomAccessVectorValues randomAccess() {
-      return new OffHeapVectorValues(fieldEntry, dataIn.clone());
+    public RandomAccessNumericVectors randomAccess() {
+      return new OffHeapNumericVectors(fieldEntry, dataIn.clone());
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/package-info.java
@@ -180,9 +180,9 @@
  *       of files, recording dimensionally indexed fields, to enable fast numeric range filtering
  *       and large numeric values like BigInteger and BigDecimal (1D) and geographic shape
  *       intersection (2D, 3D).
- *   <li>{@link org.apache.lucene.codecs.lucene90.Lucene90VectorFormat Vector values}. The vector
- *       format stores numeric vectors in a format optimized for random access and computation,
- *       supporting high-dimensional nearest-neighbor search.
+ *   <li>{@link org.apache.lucene.codecs.lucene90.Lucene90HnswVectorsFormat Vector values}. The
+ *       vector format stores numeric vectors in a format optimized for random access and
+ *       computation, supporting high-dimensional nearest-neighbor search.
  * </ul>
  *
  * <p>Details on each of these are provided in their linked pages. </div> <a id="File_Naming"></a>
@@ -310,7 +310,7 @@
  * <td>Holds indexed points</td>
  * </tr>
  * <tr>
- * <td>{@link org.apache.lucene.codecs.lucene90.Lucene90VectorFormat Vector values}</td>
+ * <td>{@link org.apache.lucene.codecs.lucene90.Lucene90HnswVectorsFormat Vector values}</td>
  * <td>.vec, .vem</td>
  * <td>Holds indexed vectors; <code>.vec</code> files contain the raw vector data, and
  * <code>.vem</code> the vector metadata</td>

--- a/lucene/core/src/java/org/apache/lucene/document/FieldType.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FieldType.java
@@ -22,8 +22,8 @@ import org.apache.lucene.analysis.Analyzer; // javadocs
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableFieldType;
+import org.apache.lucene.index.NumericVectors;
 import org.apache.lucene.index.PointValues;
-import org.apache.lucene.index.VectorValues;
 
 /** Describes the properties of a field. */
 public class FieldType implements IndexableFieldType {
@@ -42,7 +42,7 @@ public class FieldType implements IndexableFieldType {
   private int indexDimensionCount;
   private int dimensionNumBytes;
   private int vectorDimension;
-  private VectorValues.SearchStrategy vectorSearchStrategy = VectorValues.SearchStrategy.NONE;
+  private NumericVectors.SearchStrategy vectorSearchStrategy = NumericVectors.SearchStrategy.NONE;
   private Map<String, String> attributes;
 
   /** Create a new mutable FieldType with all of the properties from <code>ref</code> */
@@ -370,15 +370,15 @@ public class FieldType implements IndexableFieldType {
 
   /** Enable vector indexing, with the specified number of dimensions and distance function. */
   public void setVectorDimensionsAndSearchStrategy(
-      int numDimensions, VectorValues.SearchStrategy distFunc) {
+      int numDimensions, NumericVectors.SearchStrategy distFunc) {
     checkIfFrozen();
     if (numDimensions <= 0) {
       throw new IllegalArgumentException("vector numDimensions must be > 0; got " + numDimensions);
     }
-    if (numDimensions > VectorValues.MAX_DIMENSIONS) {
+    if (numDimensions > NumericVectors.MAX_DIMENSIONS) {
       throw new IllegalArgumentException(
           "vector numDimensions must be <= VectorValues.MAX_DIMENSIONS (="
-              + VectorValues.MAX_DIMENSIONS
+              + NumericVectors.MAX_DIMENSIONS
               + "); got "
               + numDimensions);
     }
@@ -392,7 +392,7 @@ public class FieldType implements IndexableFieldType {
   }
 
   @Override
-  public VectorValues.SearchStrategy vectorSearchStrategy() {
+  public NumericVectors.SearchStrategy vectorSearchStrategy() {
     return vectorSearchStrategy;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/document/VectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/VectorField.java
@@ -17,23 +17,23 @@
 
 package org.apache.lucene.document;
 
-import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.index.NumericVectors;
 import org.apache.lucene.util.hnsw.HnswGraphBuilder;
 
 /**
  * A field that contains a single floating-point numeric vector (or none) for each document. Vectors
  * are dense - that is, every dimension of a vector contains an explicit value, stored packed into
  * an array (of type float[]) whose length is the vector dimension. Values can be retrieved using
- * {@link VectorValues}, which is a forward-only docID-based iterator and also offers random-access
- * by dense ordinal (not docId). VectorValues.SearchStrategys may be used to compare vectors at
- * query time (for example as part of result ranking). A VectorField may be associated with a search
- * strategy that defines the metric used for nearest-neighbor search among vectors of that field,
- * but at the moment this association is purely nominal: it is intended for future use by the
- * to-be-implemented nearest neighbors search.
+ * {@link NumericVectors}, which is a forward-only docID-based iterator and also offers
+ * random-access by dense ordinal (not docId). VectorValues.SearchStrategys may be used to compare
+ * vectors at query time (for example as part of result ranking). A VectorField may be associated
+ * with a search strategy that defines the metric used for nearest-neighbor search among vectors of
+ * that field, but at the moment this association is purely nominal: it is intended for future use
+ * by the to-be-implemented nearest neighbors search.
  */
 public class VectorField extends Field {
 
-  private static FieldType createType(float[] v, VectorValues.SearchStrategy searchStrategy) {
+  private static FieldType createType(float[] v, NumericVectors.SearchStrategy searchStrategy) {
     if (v == null) {
       throw new IllegalArgumentException("vector value must not be null");
     }
@@ -41,9 +41,9 @@ public class VectorField extends Field {
     if (dimension == 0) {
       throw new IllegalArgumentException("cannot index an empty vector");
     }
-    if (dimension > VectorValues.MAX_DIMENSIONS) {
+    if (dimension > NumericVectors.MAX_DIMENSIONS) {
       throw new IllegalArgumentException(
-          "cannot index vectors with dimension greater than " + VectorValues.MAX_DIMENSIONS);
+          "cannot index vectors with dimension greater than " + NumericVectors.MAX_DIMENSIONS);
     }
     if (searchStrategy == null) {
       throw new IllegalArgumentException("search strategy must not be null");
@@ -65,13 +65,13 @@ public class VectorField extends Field {
    * @throws IllegalArgumentException if any parameter is null, or has dimension &gt; 1024.
    */
   public static FieldType createHnswType(
-      int dimension, VectorValues.SearchStrategy searchStrategy, int maxConn, int beamWidth) {
+      int dimension, NumericVectors.SearchStrategy searchStrategy, int maxConn, int beamWidth) {
     if (dimension == 0) {
       throw new IllegalArgumentException("cannot index an empty vector");
     }
-    if (dimension > VectorValues.MAX_DIMENSIONS) {
+    if (dimension > NumericVectors.MAX_DIMENSIONS) {
       throw new IllegalArgumentException(
-          "cannot index vectors with dimension greater than " + VectorValues.MAX_DIMENSIONS);
+          "cannot index vectors with dimension greater than " + NumericVectors.MAX_DIMENSIONS);
     }
     if (searchStrategy == null || !searchStrategy.isHnsw()) {
       throw new IllegalArgumentException(
@@ -97,7 +97,7 @@ public class VectorField extends Field {
    * @throws IllegalArgumentException if any parameter is null, or the vector is empty or has
    *     dimension &gt; 1024.
    */
-  public VectorField(String name, float[] vector, VectorValues.SearchStrategy searchStrategy) {
+  public VectorField(String name, float[] vector, NumericVectors.SearchStrategy searchStrategy) {
     super(name, createType(vector, searchStrategy));
     fieldsData = vector;
   }
@@ -113,7 +113,7 @@ public class VectorField extends Field {
    *     dimension &gt; 1024.
    */
   public VectorField(String name, float[] vector) {
-    this(name, vector, VectorValues.SearchStrategy.EUCLIDEAN_HNSW);
+    this(name, vector, NumericVectors.SearchStrategy.EUCLIDEAN_HNSW);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2319,7 +2319,7 @@ public final class CheckIndex implements Closeable {
                       + "\" has vector values but dimension is "
                       + dimension);
             }
-            VectorValues values = reader.getVectorValues(fieldInfo.name);
+            NumericVectors values = reader.getVectorValues(fieldInfo.name);
             if (values == null) {
               continue;
             }

--- a/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
@@ -24,11 +24,11 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.HnswVectorsReader;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
-import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
 
@@ -85,7 +85,7 @@ public abstract class CodecReader extends LeafReader implements Accountable {
    *
    * @lucene.internal
    */
-  public abstract VectorReader getVectorReader();
+  public abstract HnswVectorsReader getVectorReader();
 
   @Override
   public final void document(int docID, StoredFieldVisitor visitor) throws IOException {
@@ -213,7 +213,7 @@ public abstract class CodecReader extends LeafReader implements Accountable {
   }
 
   @Override
-  public final VectorValues getVectorValues(String field) throws IOException {
+  public final NumericVectors getVectorValues(String field) throws IOException {
     ensureOpen();
     FieldInfo fi = getFieldInfos().fieldInfo(field);
     if (fi == null || fi.getVectorDimension() == 0) {

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
@@ -47,7 +47,7 @@ abstract class DocValuesLeafReader extends LeafReader {
   }
 
   @Override
-  public final VectorValues getVectorValues(String field) throws IOException {
+  public final NumericVectors getVectorValues(String field) throws IOException {
     throw new UnsupportedOperationException();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
@@ -55,7 +55,7 @@ public final class FieldInfo {
   private int pointNumBytes;
 
   private int vectorDimension; // if it is a positive value, it means this field indexes vectors
-  private VectorValues.SearchStrategy vectorSearchStrategy = VectorValues.SearchStrategy.NONE;
+  private NumericVectors.SearchStrategy vectorSearchStrategy = NumericVectors.SearchStrategy.NONE;
 
   // whether this field is used as the soft-deletes field
   private final boolean softDeletesField;
@@ -79,7 +79,7 @@ public final class FieldInfo {
       int pointIndexDimensionCount,
       int pointNumBytes,
       int vectorDimension,
-      VectorValues.SearchStrategy vectorSearchStrategy,
+      NumericVectors.SearchStrategy vectorSearchStrategy,
       boolean softDeletesField) {
     this.name = Objects.requireNonNull(name);
     this.number = number;
@@ -170,7 +170,7 @@ public final class FieldInfo {
       throw new IllegalStateException("vectorDimension must be >=0; got " + vectorDimension);
     }
 
-    if (vectorDimension == 0 && vectorSearchStrategy != VectorValues.SearchStrategy.NONE) {
+    if (vectorDimension == 0 && vectorSearchStrategy != NumericVectors.SearchStrategy.NONE) {
       throw new IllegalStateException(
           "vector search strategy must be NONE when dimension = 0; got " + vectorSearchStrategy);
     }
@@ -358,18 +358,18 @@ public final class FieldInfo {
    * distance function
    */
   public void setVectorDimensionAndSearchStrategy(
-      int dimension, VectorValues.SearchStrategy searchStrategy) {
+      int dimension, NumericVectors.SearchStrategy searchStrategy) {
     if (dimension < 0) {
       throw new IllegalArgumentException("vector dimension must be >= 0; got " + dimension);
     }
-    if (dimension > VectorValues.MAX_DIMENSIONS) {
+    if (dimension > NumericVectors.MAX_DIMENSIONS) {
       throw new IllegalArgumentException(
           "vector dimension must be <= VectorValues.MAX_DIMENSIONS (="
-              + VectorValues.MAX_DIMENSIONS
+              + NumericVectors.MAX_DIMENSIONS
               + "); got "
               + dimension);
     }
-    if (dimension == 0 && searchStrategy != VectorValues.SearchStrategy.NONE) {
+    if (dimension == 0 && searchStrategy != NumericVectors.SearchStrategy.NONE) {
       throw new IllegalArgumentException(
           "vector search strategy must be NONE when the vector dimension = 0; got "
               + searchStrategy);
@@ -384,7 +384,7 @@ public final class FieldInfo {
               + name
               + "\"");
     }
-    if (vectorSearchStrategy != VectorValues.SearchStrategy.NONE
+    if (vectorSearchStrategy != NumericVectors.SearchStrategy.NONE
         && vectorSearchStrategy != searchStrategy) {
       throw new IllegalArgumentException(
           "cannot change vector search strategy from "
@@ -407,8 +407,8 @@ public final class FieldInfo {
     return vectorDimension;
   }
 
-  /** Returns {@link VectorValues.SearchStrategy} for the field */
-  public VectorValues.SearchStrategy getVectorSearchStrategy() {
+  /** Returns {@link NumericVectors.SearchStrategy} for the field */
+  public NumericVectors.SearchStrategy getVectorSearchStrategy() {
     return vectorSearchStrategy;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -290,9 +290,9 @@ public class FieldInfos implements Iterable<FieldInfo> {
 
   static final class FieldVectorProperties {
     final int numDimensions;
-    final VectorValues.SearchStrategy searchStrategy;
+    final NumericVectors.SearchStrategy searchStrategy;
 
-    FieldVectorProperties(int numDimensions, VectorValues.SearchStrategy searchStrategy) {
+    FieldVectorProperties(int numDimensions, NumericVectors.SearchStrategy searchStrategy) {
       this.numDimensions = numDimensions;
       this.searchStrategy = searchStrategy;
     }
@@ -344,7 +344,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
         int indexDimensionCount,
         int dimensionNumBytes,
         int vectorDimension,
-        VectorValues.SearchStrategy searchStrategy,
+        NumericVectors.SearchStrategy searchStrategy,
         boolean isSoftDeletesField) {
       if (indexOptions != IndexOptions.NONE) {
         IndexOptions currentOpts = this.indexOptions.get(fieldName);
@@ -623,7 +623,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
         Integer number,
         String name,
         int numDimensions,
-        VectorValues.SearchStrategy searchStrategy) {
+        NumericVectors.SearchStrategy searchStrategy) {
       if (name.equals(numberToName.get(number)) == false) {
         throw new IllegalArgumentException(
             "field number "
@@ -758,15 +758,15 @@ public class FieldInfos implements Iterable<FieldInfo> {
     }
 
     synchronized void setVectorDimensionsAndSearchStrategy(
-        int number, String name, int numDimensions, VectorValues.SearchStrategy searchStrategy) {
+        int number, String name, int numDimensions, NumericVectors.SearchStrategy searchStrategy) {
       if (numDimensions <= 0) {
         throw new IllegalArgumentException(
             "vector numDimensions must be > 0; got " + numDimensions);
       }
-      if (numDimensions > VectorValues.MAX_DIMENSIONS) {
+      if (numDimensions > NumericVectors.MAX_DIMENSIONS) {
         throw new IllegalArgumentException(
             "vector numDimensions must be <= VectorValues.MAX_DIMENSIONS (="
-                + VectorValues.MAX_DIMENSIONS
+                + NumericVectors.MAX_DIMENSIONS
                 + "); got "
                 + numDimensions);
       }
@@ -814,7 +814,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
                 0,
                 0,
                 0,
-                VectorValues.SearchStrategy.NONE,
+                NumericVectors.SearchStrategy.NONE,
                 isSoftDeletesField);
         fi =
             new FieldInfo(
@@ -831,7 +831,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
                 0,
                 0,
                 0,
-                VectorValues.SearchStrategy.NONE,
+                NumericVectors.SearchStrategy.NONE,
                 isSoftDeletesField);
         assert !byName.containsKey(fi.name);
         globalFieldNumbers.verifyConsistent(
@@ -856,7 +856,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
         int indexDimensionCount,
         int dimensionNumBytes,
         int vectorDimension,
-        VectorValues.SearchStrategy vectorSearchStrategy,
+        NumericVectors.SearchStrategy vectorSearchStrategy,
         boolean isSoftDeletesField) {
       assert assertNotFinished();
       if (docValues == null) {

--- a/lucene/core/src/java/org/apache/lucene/index/FilterCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterCodecReader.java
@@ -21,11 +21,11 @@ import java.util.Collection;
 import java.util.Objects;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.HnswVectorsReader;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
-import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Bits;
 
@@ -102,7 +102,7 @@ public abstract class FilterCodecReader extends CodecReader {
   }
 
   @Override
-  public VectorReader getVectorReader() {
+  public HnswVectorsReader getVectorReader() {
     return in.getVectorReader();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
@@ -339,7 +339,7 @@ public abstract class FilterLeafReader extends LeafReader {
   }
 
   @Override
-  public VectorValues getVectorValues(String field) throws IOException {
+  public NumericVectors getVectorValues(String field) throws IOException {
     return in.getVectorValues(field);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1970,7 +1970,7 @@ public class IndexWriter
             0,
             0,
             0,
-            VectorValues.SearchStrategy.NONE,
+            NumericVectors.SearchStrategy.NONE,
             f.name().equals(config.softDeletesField));
         assert globalFieldNumberMap.contains(f.name(), dvType);
       }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexableFieldType.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexableFieldType.java
@@ -101,8 +101,8 @@ public interface IndexableFieldType {
   /** The number of dimensions of the field's vector value */
   int vectorDimension();
 
-  /** The {@link VectorValues.SearchStrategy} of the field's vector value */
-  VectorValues.SearchStrategy vectorSearchStrategy();
+  /** The {@link NumericVectors.SearchStrategy} of the field's vector value */
+  NumericVectors.SearchStrategy vectorSearchStrategy();
 
   /**
    * Attributes for the field type.

--- a/lucene/core/src/java/org/apache/lucene/index/KnnGraphValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/KnnGraphValues.java
@@ -36,7 +36,7 @@ public abstract class KnnGraphValues {
    * returns, call {@link #nextNeighbor()} to return successive (ordered) connected node ordinals.
    *
    * @param target must be a valid node in the graph, ie. &ge; 0 and &lt; {@link
-   *     VectorValues#size()}.
+   *     NumericVectors#size()}.
    */
   public abstract void seek(int target) throws IOException;
 

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -205,10 +205,10 @@ public abstract class LeafReader extends IndexReader {
   public abstract NumericDocValues getNormValues(String field) throws IOException;
 
   /**
-   * Returns {@link VectorValues} for this field, or null if no {@link VectorValues} were indexed.
-   * The returned instance should only be used by a single thread.
+   * Returns {@link NumericVectors} for this field, or null if no {@link NumericVectors} were
+   * indexed. The returned instance should only be used by a single thread.
    */
-  public abstract VectorValues getVectorValues(String field) throws IOException;
+  public abstract NumericVectors getVectorValues(String field) throws IOException;
 
   /**
    * Get the {@link FieldInfos} describing all fields in this reader.

--- a/lucene/core/src/java/org/apache/lucene/index/MergeReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeReaderWrapper.java
@@ -198,7 +198,7 @@ class MergeReaderWrapper extends LeafReader {
   }
 
   @Override
-  public VectorValues getVectorValues(String fieldName) throws IOException {
+  public NumericVectors getVectorValues(String fieldName) throws IOException {
     return in.getVectorValues(fieldName);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -24,11 +24,11 @@ import java.util.List;
 import java.util.Locale;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.HnswVectorsReader;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
-import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.InfoStream;
@@ -80,7 +80,7 @@ public class MergeState {
   public final PointsReader[] pointsReaders;
 
   /** Vector readers to merge */
-  public final VectorReader[] vectorReaders;
+  public final HnswVectorsReader[] hnswVectorsReaders;
 
   /** Max docs per reader */
   public final int[] maxDocs;
@@ -109,7 +109,7 @@ public class MergeState {
     termVectorsReaders = new TermVectorsReader[numReaders];
     docValuesProducers = new DocValuesProducer[numReaders];
     pointsReaders = new PointsReader[numReaders];
-    vectorReaders = new VectorReader[numReaders];
+    hnswVectorsReaders = new HnswVectorsReader[numReaders];
     fieldInfos = new FieldInfos[numReaders];
     liveDocs = new Bits[numReaders];
 
@@ -147,9 +147,9 @@ public class MergeState {
         pointsReaders[i] = pointsReaders[i].getMergeInstance();
       }
 
-      vectorReaders[i] = reader.getVectorReader();
-      if (vectorReaders[i] != null) {
-        vectorReaders[i] = vectorReaders[i].getMergeInstance();
+      hnswVectorsReaders[i] = reader.getVectorReader();
+      if (hnswVectorsReaders[i] != null) {
+        hnswVectorsReaders[i] = hnswVectorsReaders[i].getMergeInstance();
       }
 
       numDocs += reader.numDocs();

--- a/lucene/core/src/java/org/apache/lucene/index/NumericVectors.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NumericVectors.java
@@ -31,13 +31,13 @@ import org.apache.lucene.util.BytesRef;
  *
  * @lucene.experimental
  */
-public abstract class VectorValues extends DocIdSetIterator {
+public abstract class NumericVectors extends DocIdSetIterator {
 
   /** The maximum length of a vector */
   public static int MAX_DIMENSIONS = 1024;
 
   /** Sole constructor */
-  protected VectorValues() {}
+  protected NumericVectors() {}
 
   /** Return the dimension of the vectors */
   public abstract int dimension();
@@ -96,7 +96,7 @@ public abstract class VectorValues extends DocIdSetIterator {
   public enum SearchStrategy {
 
     /**
-     * No search strategy is provided. Note: {@link VectorValues#search(float[], int, int)} is not
+     * No search strategy is provided. Note: {@link NumericVectors#search(float[], int, int)} is not
      * supported for fields specifying this strategy.
      */
     NONE,
@@ -158,8 +158,8 @@ public abstract class VectorValues extends DocIdSetIterator {
    * Represents the lack of vector values. It is returned by providers that do not support
    * VectorValues.
    */
-  public static final VectorValues EMPTY =
-      new VectorValues() {
+  public static final NumericVectors EMPTY =
+      new NumericVectors() {
 
         @Override
         public int size() {

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -385,7 +385,7 @@ public class ParallelLeafReader extends LeafReader {
   }
 
   @Override
-  public VectorValues getVectorValues(String fieldName) throws IOException {
+  public NumericVectors getVectorValues(String fieldName) throws IOException {
     ensureOpen();
     LeafReader reader = fieldToReader.get(fieldName);
     return reader == null ? null : reader.getVectorValues(fieldName);

--- a/lucene/core/src/java/org/apache/lucene/index/RandomAccessNumericVectors.java
+++ b/lucene/core/src/java/org/apache/lucene/index/RandomAccessNumericVectors.java
@@ -25,7 +25,7 @@ import org.apache.lucene.util.BytesRef;
  *
  * @lucene.experimental
  */
-public interface RandomAccessVectorValues {
+public interface RandomAccessNumericVectors {
 
   /** Return the number of vector values */
   int size();
@@ -34,7 +34,7 @@ public interface RandomAccessVectorValues {
   int dimension();
 
   /** Return the search strategy used to compare these vectors */
-  VectorValues.SearchStrategy searchStrategy();
+  NumericVectors.SearchStrategy searchStrategy();
 
   /**
    * Return the vector value indexed at the given ordinal. The provided floating point array may be

--- a/lucene/core/src/java/org/apache/lucene/index/RandomAccessNumericVectorsProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/RandomAccessNumericVectorsProducer.java
@@ -14,16 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.lucene.codecs.lucene90;
 
-import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.index.BaseVectorFormatTestCase;
-import org.apache.lucene.util.TestUtil;
+package org.apache.lucene.index;
 
-public class TestLucene90VectorFormat extends BaseVectorFormatTestCase {
-
-  @Override
-  protected Codec getCodec() {
-    return TestUtil.getDefaultCodec();
-  }
+/**
+ * Something (generally a {@link NumericVectors}) that provides a {@link
+ * RandomAccessNumericVectors}.
+ *
+ * @lucene.experimental
+ */
+public interface RandomAccessNumericVectorsProducer {
+  /**
+   * Return a random access interface over this iterator's vectors. Calling the RandomAccess methods
+   * will have no effect on the progress of the iteration or the values returned by this iterator.
+   * Successive calls will retrieve independent copies that do not overwrite each others' returned
+   * values.
+   */
+  RandomAccessNumericVectors randomAccess();
 }

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentCoreReaders.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentCoreReaders.java
@@ -28,12 +28,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.CompoundDirectory;
 import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.HnswVectorsReader;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
-import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.index.IndexReader.CacheKey;
 import org.apache.lucene.index.IndexReader.ClosedListener;
 import org.apache.lucene.store.AlreadyClosedException;
@@ -59,7 +59,7 @@ final class SegmentCoreReaders {
   final StoredFieldsReader fieldsReaderOrig;
   final TermVectorsReader termVectorsReaderOrig;
   final PointsReader pointsReader;
-  final VectorReader vectorReader;
+  final HnswVectorsReader hnswVectorsReader;
   final CompoundDirectory cfsReader;
   final String segment;
   /**
@@ -150,9 +150,9 @@ final class SegmentCoreReaders {
       }
 
       if (coreFieldInfos.hasVectorValues()) {
-        vectorReader = codec.vectorFormat().fieldsReader(segmentReadState);
+        hnswVectorsReader = codec.vectorFormat().fieldsReader(segmentReadState);
       } else {
-        vectorReader = null;
+        hnswVectorsReader = null;
       }
 
       success = true;
@@ -194,7 +194,7 @@ final class SegmentCoreReaders {
             cfsReader,
             normsProducer,
             pointsReader,
-            vectorReader);
+            hnswVectorsReader);
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentMerger.java
@@ -21,12 +21,12 @@ import java.util.List;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesConsumer;
 import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.HnswVectorsWriter;
 import org.apache.lucene.codecs.NormsConsumer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsWriter;
 import org.apache.lucene.codecs.StoredFieldsWriter;
 import org.apache.lucene.codecs.TermVectorsWriter;
-import org.apache.lucene.codecs.VectorWriter;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.InfoStream;
@@ -236,7 +236,7 @@ final class SegmentMerger {
   }
 
   private void mergeVectorValues(SegmentWriteState segmentWriteState) throws IOException {
-    try (VectorWriter writer = codec.vectorFormat().fieldsWriter(segmentWriteState)) {
+    try (HnswVectorsWriter writer = codec.vectorFormat().fieldsWriter(segmentWriteState)) {
       writer.merge(mergeState);
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentReader.java
@@ -24,11 +24,11 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldInfosFormat;
 import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.HnswVectorsReader;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
-import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Bits;
@@ -273,8 +273,8 @@ public final class SegmentReader extends CodecReader {
   }
 
   @Override
-  public VectorReader getVectorReader() {
-    return core.vectorReader;
+  public HnswVectorsReader getVectorReader() {
+    return core.hnswVectorsReader;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
@@ -22,11 +22,11 @@ import java.util.Collections;
 import java.util.Iterator;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.HnswVectorsReader;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
-import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.util.Bits;
 
 /**
@@ -77,7 +77,7 @@ public final class SlowCodecReaderWrapper {
         }
 
         @Override
-        public VectorReader getVectorReader() {
+        public HnswVectorsReader getVectorReader() {
           reader.ensureOpen();
           return readerToVectorReader(reader);
         }
@@ -163,10 +163,10 @@ public final class SlowCodecReaderWrapper {
     };
   }
 
-  private static VectorReader readerToVectorReader(LeafReader reader) {
-    return new VectorReader() {
+  private static HnswVectorsReader readerToVectorReader(LeafReader reader) {
+    return new HnswVectorsReader() {
       @Override
-      public VectorValues getVectorValues(String field) throws IOException {
+      public NumericVectors getVectorValues(String field) throws IOException {
         return reader.getVectorValues(field);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -26,11 +26,11 @@ import java.util.Iterator;
 import java.util.Map;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.HnswVectorsReader;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
-import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.Bits;
@@ -315,17 +315,18 @@ public final class SortingCodecReader extends FilterCodecReader {
   }
 
   @Override
-  public VectorReader getVectorReader() {
-    VectorReader delegate = in.getVectorReader();
-    return new VectorReader() {
+  public HnswVectorsReader getVectorReader() {
+    HnswVectorsReader delegate = in.getVectorReader();
+    return new HnswVectorsReader() {
       @Override
       public void checkIntegrity() throws IOException {
         delegate.checkIntegrity();
       }
 
       @Override
-      public VectorValues getVectorValues(String field) throws IOException {
-        return new VectorValuesWriter.SortingVectorValues(delegate.getVectorValues(field), docMap);
+      public NumericVectors getVectorValues(String field) throws IOException {
+        return new NumericVectorsWriter.SortingNumericVectors(
+            delegate.getVectorValues(field), docMap);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import org.apache.lucene.index.KnnGraphValues;
-import org.apache.lucene.index.RandomAccessVectorValues;
-import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.index.NumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectors;
 import org.apache.lucene.util.SparseFixedBitSet;
 
 /**
@@ -46,10 +46,10 @@ import org.apache.lucene.util.SparseFixedBitSet;
  *       searching the graph for each newly inserted node.
  *   <li><code>maxConn</code> has the same meaning as <code>M</code> in the later paper; it controls
  *       how many of the <code>efConst</code> neighbors are connected to the new node
- *   <li><code>fanout</code> the fanout parameter of {@link VectorValues#search(float[], int, int)}
- *       is used to control the values of <code>numSeed</code> and <code>topK</code> that are passed
- *       to this API. Thus <code>fanout</code> is like a combination of <code>ef</code> (search beam
- *       width) from the 2016 paper and <code>m</code> from the 2014 paper.
+ *   <li><code>fanout</code> the fanout parameter of {@link NumericVectors#search(float[], int,
+ *       int)} is used to control the values of <code>numSeed</code> and <code>topK</code> that are
+ *       passed to this API. Thus <code>fanout</code> is like a combination of <code>ef</code>
+ *       (search beam width) from the 2016 paper and <code>m</code> from the 2014 paper.
  * </ul>
  *
  * <p>Note: The graph may be searched by multiple threads concurrently, but updates are not
@@ -94,11 +94,11 @@ public final class HnswGraph extends KnnGraphValues {
       float[] query,
       int topK,
       int numSeed,
-      RandomAccessVectorValues vectors,
+      RandomAccessNumericVectors vectors,
       KnnGraphValues graphValues,
       Random random)
       throws IOException {
-    VectorValues.SearchStrategy searchStrategy = vectors.searchStrategy();
+    NumericVectors.SearchStrategy searchStrategy = vectors.searchStrategy();
     int size = graphValues.size();
 
     // MIN heap, holding the top results

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -20,9 +20,9 @@ package org.apache.lucene.util.hnsw;
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Random;
-import org.apache.lucene.index.RandomAccessVectorValues;
-import org.apache.lucene.index.RandomAccessVectorValuesProducer;
-import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.index.NumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectorsProducer;
 import org.apache.lucene.util.InfoStream;
 
 /**
@@ -54,8 +54,8 @@ public final class HnswGraphBuilder {
   private final int beamWidth;
   private final NeighborArray scratch;
 
-  private final VectorValues.SearchStrategy searchStrategy;
-  private final RandomAccessVectorValues vectorValues;
+  private final NumericVectors.SearchStrategy searchStrategy;
+  private final RandomAccessNumericVectors vectorValues;
   private final Random random;
   private final BoundsChecker bound;
   final HnswGraph hnsw;
@@ -64,10 +64,10 @@ public final class HnswGraphBuilder {
 
   // we need two sources of vectors in order to perform diversity check comparisons without
   // colliding
-  private RandomAccessVectorValues buildVectors;
+  private RandomAccessNumericVectors buildVectors;
 
   /** Construct the builder with default configurations */
-  public HnswGraphBuilder(RandomAccessVectorValuesProducer vectors) {
+  public HnswGraphBuilder(RandomAccessNumericVectorsProducer vectors) {
     this(vectors, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, randSeed);
   }
 
@@ -84,11 +84,11 @@ public final class HnswGraphBuilder {
    *     to ensure repeatable construction.
    */
   public HnswGraphBuilder(
-      RandomAccessVectorValuesProducer vectors, int maxConn, int beamWidth, long seed) {
+      RandomAccessNumericVectorsProducer vectors, int maxConn, int beamWidth, long seed) {
     vectorValues = vectors.randomAccess();
     buildVectors = vectors.randomAccess();
     searchStrategy = vectorValues.searchStrategy();
-    if (searchStrategy == VectorValues.SearchStrategy.NONE) {
+    if (searchStrategy == NumericVectors.SearchStrategy.NONE) {
       throw new IllegalStateException("No distance function");
     }
     if (maxConn <= 0) {
@@ -113,7 +113,7 @@ public final class HnswGraphBuilder {
    * @param vectors the vectors for which to build a nearest neighbors graph. Must be an independet
    *     accessor for the vectors
    */
-  public HnswGraph build(RandomAccessVectorValues vectors) throws IOException {
+  public HnswGraph build(RandomAccessNumericVectors vectors) throws IOException {
     if (vectors == vectorValues) {
       throw new IllegalArgumentException(
           "Vectors to build must be independent of the source of vectors provided to HnswGraphBuilder()");
@@ -227,7 +227,7 @@ public final class HnswGraphBuilder {
       float[] candidate,
       float score,
       NeighborArray neighbors,
-      RandomAccessVectorValues vectorValues)
+      RandomAccessNumericVectors vectorValues)
       throws IOException {
     bound.set(score);
     for (int i = 0; i < neighbors.size(); i++) {

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90HnswVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90HnswVectorsFormat.java
@@ -14,14 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.lucene.codecs.simpletext;
+package org.apache.lucene.codecs.lucene90;
 
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.index.BaseVectorFormatTestCase;
+import org.apache.lucene.index.BaseHnswVectorsFormatTestCase;
+import org.apache.lucene.util.TestUtil;
 
-public class TestSimpleTextVectorFormat extends BaseVectorFormatTestCase {
+public class TestLucene90HnswVectorsFormat extends BaseHnswVectorsFormatTestCase {
+
   @Override
   protected Codec getCodec() {
-    return new SimpleTextCodec();
+    return TestUtil.getDefaultCodec();
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
@@ -204,7 +204,7 @@ public class TestFieldInfos extends LuceneTestCase {
           0,
           0,
           0,
-          VectorValues.SearchStrategy.NONE,
+          NumericVectors.SearchStrategy.NONE,
           false);
     }
     int idx =
@@ -217,7 +217,7 @@ public class TestFieldInfos extends LuceneTestCase {
             0,
             0,
             0,
-            VectorValues.SearchStrategy.NONE,
+            NumericVectors.SearchStrategy.NONE,
             false);
     assertEquals("Field numbers 0 through 9 were allocated", 10, idx);
 
@@ -232,7 +232,7 @@ public class TestFieldInfos extends LuceneTestCase {
             0,
             0,
             0,
-            VectorValues.SearchStrategy.NONE,
+            NumericVectors.SearchStrategy.NONE,
             false);
     assertEquals("Field numbers should reset after clear()", 0, idx);
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexableField.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexableField.java
@@ -113,8 +113,8 @@ public class TestIndexableField extends LuceneTestCase {
           }
 
           @Override
-          public VectorValues.SearchStrategy vectorSearchStrategy() {
-            return VectorValues.SearchStrategy.NONE;
+          public NumericVectors.SearchStrategy vectorSearchStrategy() {
+            return NumericVectors.SearchStrategy.NONE;
           }
 
           @Override

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -27,14 +27,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.lucene90.Lucene90VectorReader;
+import org.apache.lucene.codecs.lucene90.Lucene90HnswVectorsReader;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.VectorField;
-import org.apache.lucene.index.VectorValues.SearchStrategy;
+import org.apache.lucene.index.NumericVectors.SearchStrategy;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
@@ -171,8 +171,9 @@ public class TestKnnGraph extends LuceneTestCase {
         iw.forceMerge(1);
       }
       try (IndexReader reader = DirectoryReader.open(dir)) {
-        Lucene90VectorReader vectorReader =
-            ((Lucene90VectorReader) ((CodecReader) getOnlyLeafReader(reader)).getVectorReader());
+        Lucene90HnswVectorsReader vectorReader =
+            ((Lucene90HnswVectorsReader)
+                ((CodecReader) getOnlyLeafReader(reader)).getVectorReader());
         graph = copyGraph(vectorReader.getGraphValues(KNN_GRAPH_FIELD));
       }
     }
@@ -308,22 +309,22 @@ public class TestKnnGraph extends LuceneTestCase {
     try (DirectoryReader dr = DirectoryReader.open(iw)) {
       for (LeafReaderContext ctx : dr.leaves()) {
         LeafReader reader = ctx.reader();
-        VectorValues vectorValues = reader.getVectorValues(KNN_GRAPH_FIELD);
-        Lucene90VectorReader vectorReader =
-            ((Lucene90VectorReader) ((CodecReader) reader).getVectorReader());
+        NumericVectors numericVectors = reader.getVectorValues(KNN_GRAPH_FIELD);
+        Lucene90HnswVectorsReader vectorReader =
+            ((Lucene90HnswVectorsReader) ((CodecReader) reader).getVectorReader());
         if (vectorReader == null) {
           continue;
         }
         KnnGraphValues graphValues = vectorReader.getGraphValues(KNN_GRAPH_FIELD);
-        assertEquals((vectorValues == null), (graphValues == null));
-        if (vectorValues == null) {
+        assertEquals((numericVectors == null), (graphValues == null));
+        if (numericVectors == null) {
           continue;
         }
         int[][] graph = new int[reader.maxDoc()][];
         boolean foundOrphan = false;
         int graphSize = 0;
         for (int i = 0; i < reader.maxDoc(); i++) {
-          int nextDocWithVectors = vectorValues.advance(i);
+          int nextDocWithVectors = numericVectors.advance(i);
           // System.out.println("advanced to " + nextDocWithVectors);
           while (i < nextDocWithVectors && i < reader.maxDoc()) {
             int id = Integer.parseInt(reader.document(i).get("id"));
@@ -336,7 +337,7 @@ public class TestKnnGraph extends LuceneTestCase {
           int id = Integer.parseInt(reader.document(i).get("id"));
           graphValues.seek(graphSize);
           // documents with KnnGraphValues have the expected vectors
-          float[] scratch = vectorValues.vectorValue();
+          float[] scratch = numericVectors.vectorValue();
           assertArrayEquals(
               "vector did not match for doc " + i + ", id=" + id + ": " + Arrays.toString(scratch),
               values[id],
@@ -363,7 +364,7 @@ public class TestKnnGraph extends LuceneTestCase {
           }
           graphSize++;
         }
-        assertEquals(NO_MORE_DOCS, vectorValues.nextDoc());
+        assertEquals(NO_MORE_DOCS, numericVectors.nextDoc());
         if (foundOrphan) {
           assertEquals("graph is not fully connected", 1, graphSize);
         } else {

--- a/lucene/core/src/test/org/apache/lucene/index/TestPendingSoftDeletes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPendingSoftDeletes.java
@@ -17,7 +17,7 @@
 
 package org.apache.lucene.index;
 
-import static org.apache.lucene.index.VectorValues.SearchStrategy.NONE;
+import static org.apache.lucene.index.NumericVectors.SearchStrategy.NONE;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
@@ -105,7 +105,7 @@ public class TestSegmentToThreadMapping extends LuceneTestCase {
       }
 
       @Override
-      public VectorValues getVectorValues(String field) {
+      public NumericVectors getVectorValues(String field) {
         return null;
       }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
@@ -197,7 +197,7 @@ public class TestSortingCodecReader extends LuceneTestCase {
                 leaf.getSortedNumericDocValues("sorted_numeric_dv");
             SortedSetDocValues sorted_set_dv = leaf.getSortedSetDocValues("sorted_set_dv");
             SortedDocValues binary_sorted_dv = leaf.getSortedDocValues("binary_sorted_dv");
-            VectorValues vectorValues = leaf.getVectorValues("vector");
+            NumericVectors numericVectors = leaf.getVectorValues("vector");
             NumericDocValues ids = leaf.getNumericDocValues("id");
             long prevValue = -1;
             boolean usingAltIds = false;
@@ -212,7 +212,7 @@ public class TestSortingCodecReader extends LuceneTestCase {
                 sorted_numeric_dv = leaf.getSortedNumericDocValues("sorted_numeric_dv");
                 sorted_set_dv = leaf.getSortedSetDocValues("sorted_set_dv");
                 binary_sorted_dv = leaf.getSortedDocValues("binary_sorted_dv");
-                vectorValues = leaf.getVectorValues("vector");
+                numericVectors = leaf.getVectorValues("vector");
                 prevValue = -1;
               }
               assertTrue(prevValue + " < " + ids.longValue(), prevValue < ids.longValue());
@@ -221,7 +221,7 @@ public class TestSortingCodecReader extends LuceneTestCase {
               assertTrue(sorted_numeric_dv.advanceExact(idNext));
               assertTrue(sorted_set_dv.advanceExact(idNext));
               assertTrue(binary_sorted_dv.advanceExact(idNext));
-              assertEquals(idNext, vectorValues.advance(idNext));
+              assertEquals(idNext, numericVectors.advance(idNext));
               assertEquals(new BytesRef(ids.longValue() + ""), binary_dv.binaryValue());
               assertEquals(
                   new BytesRef(ids.longValue() + ""),
@@ -232,7 +232,7 @@ public class TestSortingCodecReader extends LuceneTestCase {
               assertEquals(1, sorted_numeric_dv.docValueCount());
               assertEquals(ids.longValue(), sorted_numeric_dv.nextValue());
 
-              float[] vectorValue = vectorValues.vectorValue();
+              float[] vectorValue = numericVectors.vectorValue();
               assertEquals(1, vectorValue.length);
               assertEquals((float) ids.longValue(), vectorValue[0], 0.001f);
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
@@ -35,7 +35,7 @@ import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-import org.apache.lucene.codecs.lucene90.Lucene90VectorReader;
+import org.apache.lucene.codecs.lucene90.Lucene90HnswVectorsReader;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StoredField;
@@ -48,9 +48,9 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KnnGraphValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.RandomAccessVectorValues;
-import org.apache.lucene.index.RandomAccessVectorValuesProducer;
-import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.index.NumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectorsProducer;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
@@ -70,8 +70,8 @@ public class KnnGraphTester {
 
   private static final String KNN_FIELD = "knn";
   private static final String ID_FIELD = "id";
-  private static final VectorValues.SearchStrategy SEARCH_STRATEGY =
-      VectorValues.SearchStrategy.DOT_PRODUCT_HNSW;
+  private static final NumericVectors.SearchStrategy SEARCH_STRATEGY =
+      NumericVectors.SearchStrategy.DOT_PRODUCT_HNSW;
 
   private int numDocs;
   private int dim;
@@ -237,7 +237,7 @@ public class KnnGraphTester {
       for (LeafReaderContext context : reader.leaves()) {
         LeafReader leafReader = context.reader();
         KnnGraphValues knnValues =
-            ((Lucene90VectorReader) ((CodecReader) leafReader).getVectorReader())
+            ((Lucene90HnswVectorsReader) ((CodecReader) leafReader).getVectorReader())
                 .getGraphValues(KNN_FIELD);
         System.out.printf("Leaf %d has %d documents\n", context.ord, leafReader.maxDoc());
         printGraphFanout(knnValues, leafReader.maxDoc());
@@ -247,7 +247,7 @@ public class KnnGraphTester {
 
   private void dumpGraph(Path docsPath) throws IOException {
     try (BinaryFileVectors vectors = new BinaryFileVectors(docsPath)) {
-      RandomAccessVectorValues values = vectors.randomAccess();
+      RandomAccessNumericVectors values = vectors.randomAccess();
       HnswGraphBuilder builder = new HnswGraphBuilder(vectors, maxConn, beamWidth, 0);
       // start at node 1
       for (int i = 1; i < numDocs; i++) {
@@ -572,7 +572,7 @@ public class KnnGraphTester {
 
     FieldType fieldType =
         VectorField.createHnswType(
-            dim, VectorValues.SearchStrategy.DOT_PRODUCT_HNSW, maxConn, beamWidth);
+            dim, NumericVectors.SearchStrategy.DOT_PRODUCT_HNSW, maxConn, beamWidth);
     if (quiet == false) {
       iwc.setInfoStream(new PrintStreamInfoStream(System.out));
       System.out.println("creating index in " + indexPath);
@@ -621,7 +621,7 @@ public class KnnGraphTester {
     System.exit(1);
   }
 
-  class BinaryFileVectors implements RandomAccessVectorValuesProducer, Closeable {
+  class BinaryFileVectors implements RandomAccessNumericVectorsProducer, Closeable {
 
     private final int size;
     private final FileChannel in;
@@ -647,11 +647,11 @@ public class KnnGraphTester {
     }
 
     @Override
-    public RandomAccessVectorValues randomAccess() {
+    public RandomAccessNumericVectors randomAccess() {
       return new Values();
     }
 
-    class Values implements RandomAccessVectorValues {
+    class Values implements RandomAccessNumericVectors {
 
       float[] vector = new float[dim];
       FloatBuffer source = mmap.slice();
@@ -667,7 +667,7 @@ public class KnnGraphTester {
       }
 
       @Override
-      public VectorValues.SearchStrategy searchStrategy() {
+      public NumericVectors.SearchStrategy searchStrategy() {
         return SEARCH_STRATEGY;
       }
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockNumericVectors.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockNumericVectors.java
@@ -17,15 +17,15 @@
 
 package org.apache.lucene.util.hnsw;
 
-import org.apache.lucene.index.RandomAccessVectorValues;
-import org.apache.lucene.index.RandomAccessVectorValuesProducer;
-import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.index.NumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectorsProducer;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.LuceneTestCase;
 
-class MockVectorValues extends VectorValues
-    implements RandomAccessVectorValues, RandomAccessVectorValuesProducer {
+class MockNumericVectors extends NumericVectors
+    implements RandomAccessNumericVectors, RandomAccessNumericVectorsProducer {
   private final float[] scratch;
 
   protected final int dimension;
@@ -36,7 +36,7 @@ class MockVectorValues extends VectorValues
 
   private int pos = -1;
 
-  MockVectorValues(SearchStrategy searchStrategy, float[][] values) {
+  MockNumericVectors(SearchStrategy searchStrategy, float[][] values) {
     this.searchStrategy = searchStrategy;
     this.dimension = values[0].length;
     this.values = values;
@@ -52,8 +52,8 @@ class MockVectorValues extends VectorValues
     scratch = new float[dimension];
   }
 
-  public MockVectorValues copy() {
-    return new MockVectorValues(searchStrategy, values);
+  public MockNumericVectors copy() {
+    return new MockNumericVectors(searchStrategy, values);
   }
 
   @Override
@@ -86,7 +86,7 @@ class MockVectorValues extends VectorValues
   }
 
   @Override
-  public RandomAccessVectorValues randomAccess() {
+  public RandomAccessNumericVectors randomAccess() {
     return copy();
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnsw.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnsw.java
@@ -25,7 +25,7 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.lucene90.Lucene90VectorReader;
+import org.apache.lucene.codecs.lucene90.Lucene90HnswVectorsReader;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.VectorField;
@@ -36,9 +36,9 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KnnGraphValues;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.RandomAccessVectorValues;
-import org.apache.lucene.index.RandomAccessVectorValuesProducer;
-import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.index.NumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectors;
+import org.apache.lucene.index.RandomAccessNumericVectorsProducer;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.ArrayUtil;
@@ -53,8 +53,8 @@ public class TestHnsw extends LuceneTestCase {
   public void testReadWrite() throws IOException {
     int dim = random().nextInt(100) + 1;
     int nDoc = random().nextInt(100) + 1;
-    RandomVectorValues vectors = new RandomVectorValues(nDoc, dim, random());
-    RandomVectorValues v2 = vectors.copy(), v3 = vectors.copy();
+    RandomNumericVectors vectors = new RandomNumericVectors(nDoc, dim, random());
+    RandomNumericVectors v2 = vectors.copy(), v3 = vectors.copy();
     long seed = random().nextLong();
     HnswGraphBuilder.randSeed = seed;
     HnswGraphBuilder builder = new HnswGraphBuilder(vectors);
@@ -83,7 +83,7 @@ public class TestHnsw extends LuceneTestCase {
       }
       try (IndexReader reader = DirectoryReader.open(dir)) {
         for (LeafReaderContext ctx : reader.leaves()) {
-          VectorValues values = ctx.reader().getVectorValues("field");
+          NumericVectors values = ctx.reader().getVectorValues("field");
           assertEquals(vectors.searchStrategy, values.searchStrategy());
           assertEquals(dim, values.dimension());
           assertEquals(nVec, values.size());
@@ -91,7 +91,7 @@ public class TestHnsw extends LuceneTestCase {
           assertEquals(indexedDoc, ctx.reader().numDocs());
           assertVectorsEqual(v3, values);
           KnnGraphValues graphValues =
-              ((Lucene90VectorReader) ((CodecReader) ctx.reader()).getVectorReader())
+              ((Lucene90HnswVectorsReader) ((CodecReader) ctx.reader()).getVectorReader())
                   .getGraphValues("field");
           assertGraphEqual(hnsw, graphValues, nVec);
         }
@@ -104,7 +104,7 @@ public class TestHnsw extends LuceneTestCase {
   // oriented in the right directions
   public void testAknnDiverse() throws IOException {
     int nDoc = 100;
-    CircularVectorValues vectors = new CircularVectorValues(nDoc);
+    CircularNumericVectors vectors = new CircularNumericVectors(nDoc);
     HnswGraphBuilder builder = new HnswGraphBuilder(vectors, 16, 100, random().nextInt());
     HnswGraph hnsw = builder.build(vectors);
     // run some searches
@@ -155,17 +155,17 @@ public class TestHnsw extends LuceneTestCase {
     expectThrows(NullPointerException.class, () -> new HnswGraphBuilder(null, 0, 0, 0));
     expectThrows(
         IllegalArgumentException.class,
-        () -> new HnswGraphBuilder(new RandomVectorValues(1, 1, random()), 0, 10, 0));
+        () -> new HnswGraphBuilder(new RandomNumericVectors(1, 1, random()), 0, 10, 0));
     expectThrows(
         IllegalArgumentException.class,
-        () -> new HnswGraphBuilder(new RandomVectorValues(1, 1, random()), 10, 0, 0));
+        () -> new HnswGraphBuilder(new RandomNumericVectors(1, 1, random()), 10, 0, 0));
   }
 
   public void testDiversity() throws IOException {
     // Some carefully checked test cases with simple 2d vectors on the unit circle:
-    MockVectorValues vectors =
-        new MockVectorValues(
-            VectorValues.SearchStrategy.DOT_PRODUCT_HNSW,
+    MockNumericVectors vectors =
+        new MockNumericVectors(
+            NumericVectors.SearchStrategy.DOT_PRODUCT_HNSW,
             new float[][] {
               unitVector2d(0.5),
               unitVector2d(0.75),
@@ -230,7 +230,7 @@ public class TestHnsw extends LuceneTestCase {
     int size = atLeast(100);
     int dim = atLeast(10);
     int topK = 5;
-    RandomVectorValues vectors = new RandomVectorValues(size, dim, random());
+    RandomNumericVectors vectors = new RandomNumericVectors(size, dim, random());
     HnswGraphBuilder builder = new HnswGraphBuilder(vectors, 10, 30, random().nextLong());
     HnswGraph hnsw = builder.build(vectors);
     int totalMatches = 0;
@@ -272,20 +272,20 @@ public class TestHnsw extends LuceneTestCase {
   }
 
   /** Returns vectors evenly distributed around the upper unit semicircle. */
-  static class CircularVectorValues extends VectorValues
-      implements RandomAccessVectorValues, RandomAccessVectorValuesProducer {
+  static class CircularNumericVectors extends NumericVectors
+      implements RandomAccessNumericVectors, RandomAccessNumericVectorsProducer {
     private final int size;
     private final float[] value;
 
     int doc = -1;
 
-    CircularVectorValues(int size) {
+    CircularNumericVectors(int size) {
       this.size = size;
       value = new float[2];
     }
 
-    public CircularVectorValues copy() {
-      return new CircularVectorValues(size);
+    public CircularNumericVectors copy() {
+      return new CircularNumericVectors(size);
     }
 
     @Override
@@ -309,8 +309,8 @@ public class TestHnsw extends LuceneTestCase {
     }
 
     @Override
-    public RandomAccessVectorValues randomAccess() {
-      return new CircularVectorValues(size);
+    public RandomAccessNumericVectors randomAccess() {
+      return new CircularNumericVectors(size);
     }
 
     @Override
@@ -380,7 +380,7 @@ public class TestHnsw extends LuceneTestCase {
     return neighbors;
   }
 
-  private void assertVectorsEqual(VectorValues u, VectorValues v) throws IOException {
+  private void assertVectorsEqual(NumericVectors u, NumericVectors v) throws IOException {
     int uDoc, vDoc;
     while (true) {
       uDoc = u.nextDoc();
@@ -395,21 +395,21 @@ public class TestHnsw extends LuceneTestCase {
   }
 
   /** Produces random vectors and caches them for random-access. */
-  static class RandomVectorValues extends MockVectorValues {
+  static class RandomNumericVectors extends MockNumericVectors {
 
-    RandomVectorValues(int size, int dimension, Random random) {
+    RandomNumericVectors(int size, int dimension, Random random) {
       super(
           SearchStrategy.values()[random.nextInt(SearchStrategy.values().length - 1) + 1],
           createRandomVectors(size, dimension, random));
     }
 
-    RandomVectorValues(RandomVectorValues other) {
+    RandomNumericVectors(RandomNumericVectors other) {
       super(other.searchStrategy, other.values);
     }
 
     @Override
-    public RandomVectorValues copy() {
-      return new RandomVectorValues(this);
+    public RandomNumericVectors copy() {
+      return new RandomNumericVectors(this);
     }
 
     private static float[][] createRandomVectors(int size, int dimension, Random random) {

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
@@ -28,13 +28,13 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.LeafMetaData;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.NumericVectors;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.index.Terms;
-import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.Version;
 
@@ -95,7 +95,7 @@ public class TermVectorLeafReader extends LeafReader {
             0,
             0,
             0,
-            VectorValues.SearchStrategy.NONE,
+            NumericVectors.SearchStrategy.NONE,
             false);
     fieldInfos = new FieldInfos(new FieldInfo[] {fieldInfo});
   }
@@ -154,7 +154,7 @@ public class TermVectorLeafReader extends LeafReader {
   }
 
   @Override
-  public VectorValues getVectorValues(String fieldName) {
+  public NumericVectors getVectorValues(String fieldName) {
     return null;
   }
 

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -1353,8 +1353,8 @@ public class MemoryIndex {
     }
 
     @Override
-    public VectorValues getVectorValues(String fieldName) {
-      return VectorValues.EMPTY;
+    public NumericVectors getVectorValues(String fieldName) {
+      return NumericVectors.EMPTY;
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseFieldInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseFieldInfoFormatTestCase.java
@@ -335,9 +335,9 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     }
 
     if (r.nextBoolean()) {
-      int dimension = 1 + r.nextInt(VectorValues.MAX_DIMENSIONS);
-      VectorValues.SearchStrategy searchStrategy =
-          RandomPicks.randomFrom(r, VectorValues.SearchStrategy.values());
+      int dimension = 1 + r.nextInt(NumericVectors.MAX_DIMENSIONS);
+      NumericVectors.SearchStrategy searchStrategy =
+          RandomPicks.randomFrom(r, NumericVectors.SearchStrategy.values());
       type.setVectorDimensionsAndSearchStrategy(dimension, searchStrategy);
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/RandomPostingsTester.java
@@ -140,7 +140,7 @@ public class RandomPostingsTester {
               0,
               0,
               0,
-              VectorValues.SearchStrategy.NONE,
+              NumericVectors.SearchStrategy.NONE,
               false);
       fieldUpto++;
 
@@ -711,7 +711,7 @@ public class RandomPostingsTester {
               0,
               0,
               0,
-              VectorValues.SearchStrategy.NONE,
+              NumericVectors.SearchStrategy.NONE,
               false);
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/QueryUtils.java
@@ -32,13 +32,13 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.NumericVectors;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.index.Terms;
-import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.Version;
@@ -211,7 +211,7 @@ public class QueryUtils {
       }
 
       @Override
-      public VectorValues getVectorValues(String field) throws IOException {
+      public NumericVectors getVectorValues(String field) throws IOException {
         return null;
       }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-9855

This renames two interfaces and its subclasses.

- o.a.l.c.VectorFormat to HnswVectorsFormat
- o.a.l.i.VectorValues to NumericVectors
