### PR TITLE
LUCENE-9910: maximize javac lint

### DIFF
--- a/gradle/java/javac.gradle
+++ b/gradle/java/javac.gradle
@@ -33,26 +33,50 @@ allprojects {
       options.compilerArgs += [
         "-Xlint:-deprecation",
         "-Xlint:-serial",
+        "-Xlint:auxiliaryclass",
         "-Xlint:cast",
         "-Xlint:classfile",
         "-Xlint:dep-ann",
         "-Xlint:divzero",
         "-Xlint:empty",
+        "-Xlint:exports",
         "-Xlint:fallthrough",
         "-Xlint:finally",
+        "-Xlint:opens",
         "-Xlint:options",
+        "-Xlint:overloads",
         "-Xlint:overrides",
+        // TODO: some tests seem to have bad classpaths?
+        // this check seems to be a good sanity check for gradle?
+        // "-Xlint:path",
         "-Xlint:processing",
         "-Xlint:rawtypes",
+        "-Xlint:removal",
         "-Xlint:static",
+        "-Xlint:requires-automatic",
+        "-Xlint:requires-transitive-automatic",
         "-Xlint:try",
         "-Xlint:unchecked",
         "-Xlint:varargs",
+        "-Xlint:preview",
         "-Xdoclint:all/protected",
         "-Xdoclint:-missing",
         "-Xdoclint:-accessibility",
         "-proc:none",  // proc:none was added because of LOG4J2-1925 / JDK-8186647
       ]
+
+      // enable some warnings only relevant to newer language features
+      if (rootProject.runtimeJavaVersion >= JavaVersion.VERSION_15) {
+        options.compilerArgs += [
+          "-Xlint:text-blocks",
+        ]
+      }
+
+      if (rootProject.runtimeJavaVersion >= JavaVersion.VERSION_16) {
+        options.compilerArgs += [
+          "-Xlint:synchronization",
+        ]
+      }
 
       if (propertyOrDefault("javac.failOnWarnings", true).toBoolean()) {
         options.compilerArgs += "-Werror"


### PR DESCRIPTION
This enables quite a few javac warnings from java11+ that weren't
enabled for some reason. None of them fail, so lock them in.

Additionally some newer checks are only recognized for newer JDK
versions, so they are only enabled based on the javac version used. They
will cause no annoyance because they relate to newer language features.
