### PR TITLE
LUCENE-9911: enable ecjLint unusedExceptionParameter

### DIFF
--- a/gradle/validation/ecj-lint/ecj.javadocs.prefs
+++ b/gradle/validation/ecj-lint/ecj.javadocs.prefs
@@ -86,8 +86,7 @@ org.eclipse.jdt.core.compiler.problem.pessimisticNullAnalysisForFreeTypeVariable
 org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=ignore
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.potentiallyUnclosedCloseable=ignore
-# TODO: generics-related warning that is normally enabled by default
-org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
+org.eclipse.jdt.core.compiler.problem.rawTypeReference=error
 org.eclipse.jdt.core.compiler.problem.redundantNullAnnotation=error
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=error
 org.eclipse.jdt.core.compiler.problem.redundantSpecificationOfTypeArguments=ignore
@@ -106,7 +105,7 @@ org.eclipse.jdt.core.compiler.problem.terminalDeprecation=error
 org.eclipse.jdt.core.compiler.problem.typeParameterHiding=error
 org.eclipse.jdt.core.compiler.problem.unavoidableGenericTypeProblems=enabled
 org.eclipse.jdt.core.compiler.problem.uncheckedTypeOperation=error
-# TODO: resource-related warning that is normally disabled by default
+# TODO: resource-related warning that is normally enabled by default
 # this analysis gets confused by some IOUtils method, maybe there is an improvement possible?
 org.eclipse.jdt.core.compiler.problem.unclosedCloseable=ignore
 org.eclipse.jdt.core.compiler.problem.undocumentedEmptyBlock=ignore
@@ -124,7 +123,7 @@ org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownException=ignore
 org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionExemptExceptionAndThrowable=enabled
 org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionIncludeDocCommentReference=enabled
 org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionWhenOverriding=disabled
-org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter=ignore
+org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter=error
 org.eclipse.jdt.core.compiler.problem.unusedImport=error
 org.eclipse.jdt.core.compiler.problem.unusedLabel=error
 org.eclipse.jdt.core.compiler.problem.unusedLocal=error
@@ -134,7 +133,7 @@ org.eclipse.jdt.core.compiler.problem.unusedParameterIncludeDocCommentReference=
 org.eclipse.jdt.core.compiler.problem.unusedParameterWhenImplementingAbstract=disabled
 org.eclipse.jdt.core.compiler.problem.unusedParameterWhenOverridingConcrete=disabled
 org.eclipse.jdt.core.compiler.problem.unusedPrivateMember=error
-org.eclipse.jdt.core.compiler.problem.unusedTypeParameter=ignore
+org.eclipse.jdt.core.compiler.problem.unusedTypeParameter=error
 # TODO: normally enabled by default: warns of unnecessary SuppressedWarnings token
 # some SuppressWarnings are used for other tools
 org.eclipse.jdt.core.compiler.problem.unusedWarningToken=ignore

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ar/ArabicAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ar/ArabicAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.ar;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
@@ -77,7 +78,7 @@ public final class ArabicAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/bg/BulgarianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/bg/BulgarianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.bg;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
@@ -69,7 +70,7 @@ public final class BulgarianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/bn/BengaliAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/bn/BengaliAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.bn;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
 import org.apache.lucene.analysis.StopFilter;
@@ -68,7 +69,7 @@ public final class BengaliAnalyzer extends StopwordAnalyzerBase {
         DEFAULT_STOP_SET =
             loadStopwordSet(false, BengaliAnalyzer.class, DEFAULT_STOPWORD_FILE, STOPWORDS_COMMENT);
       } catch (IOException ex) {
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/br/BrazilianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/br/BrazilianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.br;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -69,7 +70,7 @@ public final class BrazilianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ca/CatalanAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ca/CatalanAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.ca;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -70,7 +71,7 @@ public final class CatalanAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/cjk/CJKAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/cjk/CJKAnalyzer.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.analysis.cjk;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
@@ -61,7 +62,7 @@ public final class CJKAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ckb/SoraniAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ckb/SoraniAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.ckb;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -68,7 +69,7 @@ public final class SoraniAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/cz/CzechAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/cz/CzechAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.cz;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -65,7 +66,7 @@ public final class CzechAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/da/DanishAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/da/DanishAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.da;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -69,7 +70,7 @@ public final class DanishAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanAnalyzer.java
@@ -19,6 +19,7 @@ package org.apache.lucene.analysis.de;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -72,7 +73,7 @@ public final class GermanAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/el/GreekAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/el/GreekAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.el;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.StopFilter;
@@ -60,7 +61,7 @@ public final class GreekAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.es;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -68,7 +69,7 @@ public final class SpanishAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/et/EstonianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/et/EstonianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.et;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
@@ -60,7 +61,7 @@ public final class EstonianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/eu/BasqueAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/eu/BasqueAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.eu;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
@@ -63,7 +64,7 @@ public final class BasqueAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/fa/PersianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/fa/PersianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.fa;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
@@ -74,7 +75,7 @@ public final class PersianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/fi/FinnishAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/fi/FinnishAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.fi;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -69,7 +70,7 @@ public final class FinnishAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/fr/FrenchAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/fr/FrenchAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.fr;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.apache.lucene.analysis.Analyzer;
@@ -85,7 +86,7 @@ public final class FrenchAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ga/IrishAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ga/IrishAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.ga;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -75,7 +76,7 @@ public final class IrishAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hi/HindiAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hi/HindiAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.hi;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
 import org.apache.lucene.analysis.StopFilter;
@@ -70,7 +71,7 @@ public final class HindiAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hu/HungarianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hu/HungarianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.hu;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -69,7 +70,7 @@ public final class HungarianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/AffixCondition.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/AffixCondition.java
@@ -98,7 +98,9 @@ interface AffixCondition {
         return ALWAYS_FALSE;
       }
       return regexpCondition(kind, condition.substring(0, split), conditionChars - strip.length());
-    } catch (PatternSyntaxException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        PatternSyntaxException e) {
       return ALWAYS_FALSE;
     } catch (Throwable e) {
       throw new IllegalArgumentException("On line: " + line, e);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
@@ -668,7 +668,9 @@ public class Dictionary {
     int numLines;
     try {
       numLines = Integer.parseInt(args[3]);
-    } catch (NumberFormatException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        NumberFormatException e) {
       return;
     }
     affixData = ArrayUtil.grow(affixData, currentAffix * 4 + numLines * 4);
@@ -1296,7 +1298,9 @@ public class Dictionary {
       try {
         int alias = Integer.parseInt(morphData.trim());
         morphData = morphAliases[alias - 1];
-      } catch (NumberFormatException ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          NumberFormatException ignored) {
       }
     }
     if (morphData.isBlank()) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hy/ArmenianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hy/ArmenianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.hy;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
@@ -64,7 +65,7 @@ public final class ArmenianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/id/IndonesianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/id/IndonesianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.id;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
 import org.apache.lucene.analysis.StopFilter;
@@ -59,7 +60,7 @@ public final class IndonesianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/it/ItalianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/it/ItalianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.it;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.apache.lucene.analysis.Analyzer;
@@ -78,7 +79,7 @@ public final class ItalianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/lt/LithuanianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/lt/LithuanianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.lt;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
@@ -64,7 +65,7 @@ public final class LithuanianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/lv/LatvianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/lv/LatvianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.lv;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -67,7 +68,7 @@ public final class LatvianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/DateRecognizerFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/DateRecognizerFilter.java
@@ -53,7 +53,9 @@ public class DateRecognizerFilter extends FilteringTokenFilter {
       // We don't care about the date, just that the term can be parsed to one.
       dateFormat.parse(termAtt.toString());
       return true;
-    } catch (ParseException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        ParseException e) {
       // This term is not a date.
     }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/nl/DutchAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/nl/DutchAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.nl;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArrayMap;
@@ -73,7 +74,7 @@ public final class DutchAnalyzer extends Analyzer {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
 
       DEFAULT_STEM_DICT = new CharArrayMap<>(4, false);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/no/NorwegianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/no/NorwegianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.no;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -69,7 +70,7 @@ public final class NorwegianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pt/PortugueseAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pt/PortugueseAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.pt;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -68,7 +69,7 @@ public final class PortugueseAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ro/RomanianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ro/RomanianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.ro;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
@@ -67,7 +68,7 @@ public final class RomanianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/sr/SerbianAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/sr/SerbianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.sr;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.*;
 import org.apache.lucene.analysis.miscellaneous.SetKeywordMarkerFilter;
 import org.apache.lucene.analysis.snowball.SnowballFilter;
@@ -61,7 +62,7 @@ public class SerbianAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/sv/SwedishAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/sv/SwedishAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.sv;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -69,7 +70,7 @@ public final class SwedishAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/th/ThaiAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/th/ThaiAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.th;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.LowerCaseFilter;
@@ -62,7 +63,7 @@ public final class ThaiAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/TurkishAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/TurkishAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.tr;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.StopFilter;
@@ -65,7 +66,7 @@ public final class TurkishAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/CharArrayIterator.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/CharArrayIterator.java
@@ -192,7 +192,9 @@ public abstract class CharArrayIterator implements CharacterIterator {
       bi.setText("\udb40\udc53");
       bi.next();
       v = false;
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
       v = true;
     }
     HAS_BUGGY_BREAKITERATORS = v;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/FilesystemResourceLoader.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/FilesystemResourceLoader.java
@@ -85,7 +85,7 @@ public final class FilesystemResourceLoader implements ResourceLoader {
   public InputStream openResource(String resource) throws IOException {
     try {
       return Files.newInputStream(baseDirectory.resolve(resource));
-    } catch (FileNotFoundException | NoSuchFileException fnfe) {
+    } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException fnfe) {
       return delegate.openResource(resource);
     }
   }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/classic/TestClassicAnalyzer.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/classic/TestClassicAnalyzer.java
@@ -125,15 +125,12 @@ public class TestClassicAnalyzer extends BaseTokenStreamTestCase {
     assertAnalyzesTo(a, "Excite@Home", new String[] {"excite@home"});
   }
 
+  // should not throw NPE
   public void testLucene1140() throws Exception {
-    try {
-      ClassicAnalyzer analyzer = new ClassicAnalyzer();
-      assertAnalyzesTo(
-          analyzer, "www.nutch.org.", new String[] {"www.nutch.org"}, new String[] {"<HOST>"});
-      analyzer.close();
-    } catch (NullPointerException e) {
-      fail("Should not throw an NPE and it did");
-    }
+    ClassicAnalyzer analyzer = new ClassicAnalyzer();
+    assertAnalyzesTo(
+        analyzer, "www.nutch.org.", new String[] {"www.nutch.org"}, new String[] {"<HOST>"});
+    analyzer.close();
   }
 
   public void testDomainNames() throws Exception {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestAllAnalyzersHaveFactories.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestAllAnalyzersHaveFactories.java
@@ -169,7 +169,9 @@ public class TestAllAnalyzersHaveFactories extends LuceneTestCase {
             ((ResourceLoaderAware) instance).inform(loader);
           }
           assertSame(c, instance.create().getClass());
-        } catch (IllegalArgumentException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            IllegalArgumentException e) {
           // TODO: For now pass because some factories have not yet a default config that always
           // works
         }
@@ -193,7 +195,9 @@ public class TestAllAnalyzersHaveFactories extends LuceneTestCase {
           if (KeywordTokenizer.class != createdClazz) {
             assertSame(c, createdClazz);
           }
-        } catch (IllegalArgumentException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            IllegalArgumentException e) {
           // TODO: For now pass because some factories have not yet a default config that always
           // works
         }
@@ -214,7 +218,9 @@ public class TestAllAnalyzersHaveFactories extends LuceneTestCase {
           if (StringReader.class != createdClazz) {
             assertSame(c, createdClazz);
           }
-        } catch (IllegalArgumentException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            IllegalArgumentException e) {
           // TODO: For now pass because some factories have not yet a default config that always
           // works
         }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestFactories.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestFactories.java
@@ -128,7 +128,7 @@ public class TestFactories extends BaseTokenStreamTestCase {
     try {
       ctor = factoryClazz.getConstructor(Map.class);
     } catch (Exception e) {
-      throw new RuntimeException("factory '" + factoryClazz + "' does not have a proper ctor!");
+      throw new RuntimeException("factory '" + factoryClazz + "' does not have a proper ctor!", e);
     }
 
     AbstractAnalysisFactory factory = null;
@@ -146,9 +146,13 @@ public class TestFactories extends BaseTokenStreamTestCase {
     if (factory instanceof ResourceLoaderAware) {
       try {
         ((ResourceLoaderAware) factory).inform(new StringMockResourceLoader(""));
-      } catch (IOException ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException ignored) {
         // it's ok if the right files arent available or whatever to throw this
-      } catch (IllegalArgumentException ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException ignored) {
         // is this ok? I guess so
       }
     }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestPerformance.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestPerformance.java
@@ -187,7 +187,9 @@ public class TestPerformance extends LuceneTestCase {
     long start = System.nanoTime();
     try {
       speller.suggest(word);
-    } catch (SuggestionTimeoutException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        SuggestionTimeoutException e) {
       System.out.println("Timeout happened for " + word + ", skipping");
       return false;
     }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/TestSynonymGraphFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/TestSynonymGraphFilter.java
@@ -1467,7 +1467,9 @@ public class TestSynonymGraphFilter extends BaseTokenStreamTestCase {
       // output token that also happens to be in the input:
       try {
         actual = Operations.determinize(actual, 50000);
-      } catch (TooComplexToDeterminizeException tctde) {
+      } catch (
+          @SuppressWarnings("unused")
+          TooComplexToDeterminizeException tctde) {
         // Unfortunately the syns can easily create difficult-to-determinize graphs:
         assertTrue(approxEquals(actual, expected));
         continue;
@@ -1475,7 +1477,9 @@ public class TestSynonymGraphFilter extends BaseTokenStreamTestCase {
 
       try {
         expected = Operations.determinize(expected, 50000);
-      } catch (TooComplexToDeterminizeException tctde) {
+      } catch (
+          @SuppressWarnings("unused")
+          TooComplexToDeterminizeException tctde) {
         // Unfortunately the syns can easily create difficult-to-determinize graphs:
         assertTrue(approxEquals(actual, expected));
         continue;

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseAnalyzer.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.ja;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.lucene.analysis.CharArraySet;
@@ -86,7 +87,7 @@ public class JapaneseAnalyzer extends StopwordAnalyzerBase {
         }
       } catch (IOException ex) {
         // default set should always be present as it is part of the distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword or stoptag set");
+        throw new UncheckedIOException("Unable to load default stopword or stoptag set", ex);
       }
     }
   }

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseNumberFilter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseNumberFilter.java
@@ -251,7 +251,7 @@ public class JapaneseNumberFilter extends TokenFilter {
         return number;
       }
       return normalizedNumber.stripTrailingZeros().toPlainString();
-    } catch (NumberFormatException | ArithmeticException e) {
+    } catch (@SuppressWarnings("unused") NumberFormatException | ArithmeticException e) {
       // Return the source number in case of error, i.e. malformed input
       return number;
     }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestFactories.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestFactories.java
@@ -125,7 +125,7 @@ public class TestFactories extends BaseTokenStreamTestCase {
     try {
       ctor = factoryClazz.getConstructor(Map.class);
     } catch (Exception e) {
-      throw new RuntimeException("factory '" + factoryClazz + "' does not have a proper ctor!");
+      throw new RuntimeException("factory '" + factoryClazz + "' does not have a proper ctor!", e);
     }
 
     AbstractAnalysisFactory factory = null;
@@ -143,9 +143,13 @@ public class TestFactories extends BaseTokenStreamTestCase {
     if (factory instanceof ResourceLoaderAware) {
       try {
         ((ResourceLoaderAware) factory).inform(new StringMockResourceLoader(""));
-      } catch (IOException ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException ignored) {
         // it's ok if the right files arent available or whatever to throw this
-      } catch (IllegalArgumentException ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException ignored) {
         // is this ok? I guess so
       }
     }

--- a/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
+++ b/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.uk;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import morfologik.stemming.Dictionary;
 import org.apache.lucene.analysis.Analyzer;
@@ -73,7 +74,7 @@ public final class UkrainianMorfologikAnalyzer extends StopwordAnalyzerBase {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
   }

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanNumberFilter.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanNumberFilter.java
@@ -237,7 +237,7 @@ public class KoreanNumberFilter extends TokenFilter {
         return number;
       }
       return normalizedNumber.stripTrailingZeros().toPlainString();
-    } catch (NumberFormatException | ArithmeticException e) {
+    } catch (@SuppressWarnings("unused") NumberFormatException | ArithmeticException e) {
       // Return the source number in case of error, i.e. malformed input
       return number;
     }

--- a/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/PhoneticFilter.java
+++ b/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/PhoneticFilter.java
@@ -70,7 +70,9 @@ public final class PhoneticFilter extends TokenFilter {
     try {
       String v = encoder.encode(value).toString();
       if (v.length() > 0 && !value.equals(v)) phonetic = v;
-    } catch (Exception ignored) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception ignored) {
     } // just use the direct text
 
     if (phonetic == null) return true;

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/AnalyzerProfile.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/AnalyzerProfile.java
@@ -80,7 +80,9 @@ public class AnalyzerProfile {
     try (BufferedReader reader = Files.newBufferedReader(propFile, StandardCharsets.UTF_8)) {
       prop.load(reader);
       return prop.getProperty("analysis.data.dir", "");
-    } catch (IOException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        IOException e) {
       return "";
     }
   }

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/SmartChineseAnalyzer.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/SmartChineseAnalyzer.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.analysis.cn.smart;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import org.apache.lucene.analysis.Analyzer;
@@ -77,7 +78,7 @@ public final class SmartChineseAnalyzer extends Analyzer {
       } catch (IOException ex) {
         // default set should always be present as it is part of the
         // distribution (JAR)
-        throw new RuntimeException("Unable to load default stopword set");
+        throw new UncheckedIOException("Unable to load default stopword set", ex);
       }
     }
 

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/AbstractDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/AbstractDictionary.java
@@ -86,7 +86,9 @@ abstract class AbstractDictionary {
     try {
       String cchar = new String(buffer, "GB2312");
       return cchar;
-    } catch (UnsupportedEncodingException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        UnsupportedEncodingException e) {
       return "";
     }
   }

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BigramDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BigramDictionary.java
@@ -65,7 +65,9 @@ class BigramDictionary extends AbstractDictionary {
         try {
           singleInstance.load(dictRoot);
         } catch (IOException ioe) {
-          throw new RuntimeException(ioe);
+          RuntimeException ex = new RuntimeException(ioe);
+          ex.addSuppressed(e);
+          throw ex;
         }
       } catch (ClassNotFoundException e) {
         throw new RuntimeException(e);

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
@@ -78,7 +78,9 @@ class WordDictionary extends AbstractDictionary {
       singleInstance = new WordDictionary();
       try {
         singleInstance.load();
-      } catch (IOException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException e) {
         String wordDictRoot = AnalyzerProfile.ANALYSIS_DATA_DIR;
         singleInstance.load(wordDictRoot);
       } catch (ClassNotFoundException e) {
@@ -165,7 +167,9 @@ class WordDictionary extends AbstractDictionary {
       output.writeObject(wordItem_charArrayTable);
       output.writeObject(wordItem_frequencyTable);
       // log.info("serialize core dict.");
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
       // log.warn(e.getMessage());
     }
   }

--- a/lucene/analysis/stempel/src/java/org/egothor/stemmer/Compile.java
+++ b/lucene/analysis/stempel/src/java/org/egothor/stemmer/Compile.java
@@ -136,7 +136,9 @@ public class Compile {
                 trie.add(token, diff.exec(token, stem));
               }
             }
-          } catch (java.util.NoSuchElementException x) {
+          } catch (
+              @SuppressWarnings("unused")
+              java.util.NoSuchElementException x) {
             // no base token (stem) on a line
           }
         }

--- a/lucene/analysis/stempel/src/java/org/egothor/stemmer/Diff.java
+++ b/lucene/analysis/stempel/src/java/org/egothor/stemmer/Diff.java
@@ -140,9 +140,13 @@ public class Diff {
         }
         pos--;
       }
-    } catch (StringIndexOutOfBoundsException x) {
+    } catch (
+        @SuppressWarnings("unused")
+        StringIndexOutOfBoundsException x) {
       // x.printStackTrace();
-    } catch (ArrayIndexOutOfBoundsException x) {
+    } catch (
+        @SuppressWarnings("unused")
+        ArrayIndexOutOfBoundsException x) {
       // x.printStackTrace();
     }
   }

--- a/lucene/analysis/stempel/src/java/org/egothor/stemmer/DiffIt.java
+++ b/lucene/analysis/stempel/src/java/org/egothor/stemmer/DiffIt.java
@@ -71,7 +71,9 @@ public class DiffIt {
   static int get(int i, String s) {
     try {
       return Integer.parseInt(s.substring(i, i + 1));
-    } catch (Throwable x) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception x) {
       return 1;
     }
   }
@@ -111,7 +113,9 @@ public class DiffIt {
                 System.out.println(stem + " " + diff.exec(token, stem));
               }
             }
-          } catch (java.util.NoSuchElementException x) {
+          } catch (
+              @SuppressWarnings("unused")
+              java.util.NoSuchElementException x) {
             // no base token (stem) on a line
           }
         }

--- a/lucene/analysis/stempel/src/java/org/egothor/stemmer/MultiTrie2.java
+++ b/lucene/analysis/stempel/src/java/org/egothor/stemmer/MultiTrie2.java
@@ -124,7 +124,9 @@ public class MultiTrie2 extends MultiTrie {
           lastkey = key;
         }
       }
-    } catch (IndexOutOfBoundsException x) {
+    } catch (
+        @SuppressWarnings("unused")
+        IndexOutOfBoundsException x) {
     }
     return result;
   }
@@ -167,7 +169,9 @@ public class MultiTrie2 extends MultiTrie {
           lastkey = key;
         }
       }
-    } catch (IndexOutOfBoundsException x) {
+    } catch (
+        @SuppressWarnings("unused")
+        IndexOutOfBoundsException x) {
     }
     return result;
   }

--- a/lucene/analysis/stempel/src/test/org/egothor/stemmer/TestCompile.java
+++ b/lucene/analysis/stempel/src/test/org/egothor/stemmer/TestCompile.java
@@ -150,7 +150,9 @@ public class TestCompile extends LuceneTestCase {
           Diff.apply(stm, cmd);
           assertEquals(stem.toLowerCase(Locale.ROOT), stm.toString().toLowerCase(Locale.ROOT));
         }
-      } catch (java.util.NoSuchElementException x) {
+      } catch (
+          @SuppressWarnings("unused")
+          java.util.NoSuchElementException x) {
         // no base token (stem) on a line
       }
     }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene40/blocktree/IntersectTermsEnum.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene40/blocktree/IntersectTermsEnum.java
@@ -370,7 +370,9 @@ final class IntersectTermsEnum extends BaseTermsEnum {
   public BytesRef next() throws IOException {
     try {
       return _next();
-    } catch (NoMoreTermsException eoi) {
+    } catch (
+        @SuppressWarnings("unused")
+        NoMoreTermsException eoi) {
       // Provoke NPE if we are (illegally!) called again:
       currentFrame = null;
       return null;

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene40/blocktree/Lucene40BlockTreeTermsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene40/blocktree/Lucene40BlockTreeTermsReader.java
@@ -362,7 +362,9 @@ public final class Lucene40BlockTreeTermsReader extends FieldsProducer {
     } else {
       try {
         return b.utf8ToString() + " " + b;
-      } catch (Throwable t) {
+      } catch (
+          @SuppressWarnings("unused")
+          Throwable t) {
         // If BytesRef isn't actually UTF8, or it's eg a
         // prefix of UTF8 that ends mid-unicode-char, we
         // fallback to hex:

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/BugfixDeflater_JDK8252739.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/BugfixDeflater_JDK8252739.java
@@ -91,9 +91,13 @@ interface BugfixDeflater_JDK8252739 {
       if (restoredLength != testData.length) {
         return true;
       }
-    } catch (DataFormatException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        DataFormatException e) {
       return true;
-    } catch (RuntimeException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        RuntimeException e) {
       return true;
     } finally {
       inflater.end();

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsWriter.java
@@ -508,7 +508,9 @@ public final class Lucene50CompressingStoredFieldsWriter extends StoredFieldsWri
     boolean v = true;
     try {
       v = Boolean.parseBoolean(System.getProperty(BULK_MERGE_ENABLED_SYSPROP, "true"));
-    } catch (SecurityException ignored) {
+    } catch (
+        @SuppressWarnings("unused")
+        SecurityException ignored) {
     }
     BULK_MERGE_ENABLED = v;
   }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsWriter.java
@@ -791,7 +791,9 @@ public final class Lucene50CompressingTermVectorsWriter extends TermVectorsWrite
     boolean v = true;
     try {
       v = Boolean.parseBoolean(System.getProperty(BULK_MERGE_ENABLED_SYSPROP, "true"));
-    } catch (SecurityException ignored) {
+    } catch (
+        @SuppressWarnings("unused")
+        SecurityException ignored) {
     }
     BULK_MERGE_ENABLED = v;
   }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/TestIndexedDISI.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/TestIndexedDISI.java
@@ -396,26 +396,19 @@ public class TestIndexedDISI extends LuceneTestCase {
 
     // Illegal values
     for (byte denseRankPower : new byte[] {-2, 0, 1, 6, 16}) {
-      try {
-        createAndOpenDISI(
-            denseRankPower, (byte) 8); // Illegal write, legal read (should not reach read)
-        fail(
-            "Trying to create an IndexedDISI data stream with denseRankPower-read "
-                + denseRankPower
-                + " and denseRankPower-write 8 should fail");
-      } catch (IllegalArgumentException e) {
-        // Expected
-      }
-      try {
-        createAndOpenDISI(
-            (byte) 8, denseRankPower); // Legal write, illegal read (should reach read)
-        fail(
-            "Trying to create an IndexedDISI data stream with denseRankPower-write 8 and denseRankPower-read "
-                + denseRankPower
-                + " should fail");
-      } catch (IllegalArgumentException e) {
-        // Expected
-      }
+      expectThrows(
+          IllegalArgumentException.class,
+          () -> {
+            createAndOpenDISI(
+                denseRankPower, (byte) 8); // Illegal write, legal read (should not reach read)
+          });
+
+      expectThrows(
+          IllegalArgumentException.class,
+          () -> {
+            createAndOpenDISI(
+                (byte) 8, denseRankPower); // Legal write, illegal read (should reach read)
+          });
     }
   }
 

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/SpatialFileQueryMaker.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/SpatialFileQueryMaker.java
@@ -82,7 +82,9 @@ public class SpatialFileQueryMaker extends AbstractQueryMaker {
           i--; // skip
         }
       }
-    } catch (NoMoreDataException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        NoMoreDataException e) {
       // all-done
     } finally {
       src.close();

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/AnalyzerFactoryTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/AnalyzerFactoryTask.java
@@ -279,12 +279,16 @@ public class AnalyzerFactoryTask extends PerfTask {
                     createAnalysisPipelineComponent(stok, clazz);
                     expectedArgType = ArgType.TOKENFILTER;
                   } catch (IllegalArgumentException e2) {
-                    throw new RuntimeException(
-                        "Line #"
-                            + lineno(stok)
-                            + ": Can't find class '"
-                            + argName
-                            + "' as CharFilterFactory or TokenizerFactory");
+                    RuntimeException ex =
+                        new RuntimeException(
+                            "Line #"
+                                + lineno(stok)
+                                + ": Can't find class '"
+                                + argName
+                                + "' as CharFilterFactory or TokenizerFactory",
+                            e2);
+                    ex.addSuppressed(e);
+                    throw ex;
                   }
                 }
               } else { // expectedArgType = ArgType.TOKENFILTER
@@ -298,7 +302,8 @@ public class AnalyzerFactoryTask extends PerfTask {
                           + lineno(stok)
                           + ": Can't find class '"
                           + className
-                          + "' as TokenFilterFactory");
+                          + "' as TokenFilterFactory",
+                      e);
                 }
                 createAnalysisPipelineComponent(stok, clazz);
               }
@@ -483,13 +488,17 @@ public class AnalyzerFactoryTask extends PerfTask {
           // Second, retry lookup after prepending the Lucene analysis package prefix
           return Class.forName(LUCENE_ANALYSIS_PACKAGE_PREFIX + className).asSubclass(expectedType);
         } catch (ClassNotFoundException e1) {
-          throw new ClassNotFoundException(
-              "Can't find class '"
-                  + className
-                  + "' or '"
-                  + LUCENE_ANALYSIS_PACKAGE_PREFIX
-                  + className
-                  + "'");
+          ClassNotFoundException ex =
+              new ClassNotFoundException(
+                  "Can't find class '"
+                      + className
+                      + "' or '"
+                      + LUCENE_ANALYSIS_PACKAGE_PREFIX
+                      + className
+                      + "'",
+                  e1);
+          ex.addSuppressed(e);
+          throw ex;
         }
       }
     }

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/NewAnalyzerTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/NewAnalyzerTask.java
@@ -46,7 +46,9 @@ public class NewAnalyzerTask extends PerfTask {
       // default one anymore
       Constructor<? extends Analyzer> cnstr = clazz.getConstructor(Version.class);
       return cnstr.newInstance(Version.LATEST);
-    } catch (NoSuchMethodException nsme) {
+    } catch (
+        @SuppressWarnings("unused")
+        NoSuchMethodException nsme) {
       // otherwise use default ctor
       return clazz.getConstructor().newInstance();
     }
@@ -80,7 +82,9 @@ public class NewAnalyzerTask extends PerfTask {
             String coreClassName = "org.apache.lucene.analysis.core." + analyzerName;
             analyzer = createAnalyzer(coreClassName);
             analyzerName = coreClassName;
-          } catch (ClassNotFoundException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              ClassNotFoundException e) {
             // If not a core analyzer, try the base analysis package
             analyzerName = "org.apache.lucene.analysis." + analyzerName;
             analyzer = createAnalyzer(analyzerName);

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/TaskSequence.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/TaskSequence.java
@@ -195,7 +195,9 @@ public class TaskSequence extends PerfTask {
               countsByTime[slot] += inc;
             }
             if (anyExhaustibleTasks) updateExhausted(task);
-          } catch (NoMoreDataException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              NoMoreDataException e) {
             exhausted = true;
           }
         }
@@ -262,7 +264,9 @@ public class TaskSequence extends PerfTask {
           }
 
           if (anyExhaustibleTasks) updateExhausted(task);
-        } catch (NoMoreDataException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            NoMoreDataException e) {
           exhausted = true;
         }
       }
@@ -305,7 +309,9 @@ public class TaskSequence extends PerfTask {
           updateExhausted(task);
         }
         count += n;
-      } catch (NoMoreDataException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          NoMoreDataException e) {
         exhausted = true;
       } catch (Exception e) {
         throw new RuntimeException(e);

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Algorithm.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Algorithm.java
@@ -309,7 +309,9 @@ public class Algorithm implements AutoCloseable {
     for (String pkg : taskPackages) {
       try {
         return Class.forName(pkg + '.' + taskName + "Task");
-      } catch (ClassNotFoundException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          ClassNotFoundException e) {
         // failed in this package, might succeed in the next one...
       }
     }

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/quality/QualityQuery.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/quality/QualityQuery.java
@@ -74,7 +74,9 @@ public class QualityQuery implements Comparable<QualityQuery> {
       int n = Integer.parseInt(queryID);
       int nOther = Integer.parseInt(other.queryID);
       return n - nOther;
-    } catch (NumberFormatException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        NumberFormatException e) {
       // fall back to string comparison
       return queryID.compareTo(other.queryID);
     }

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/utils/ExtractWikipedia.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/utils/ExtractWikipedia.java
@@ -96,7 +96,9 @@ public class ExtractWikipedia {
             doc.get(DocMaker.DATE_FIELD),
             doc.get(DocMaker.BODY_FIELD));
       }
-    } catch (NoMoreDataException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        NoMoreDataException e) {
       // continue
     }
     long finish = System.currentTimeMillis();

--- a/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/feeds/TestTrecContentSource.java
+++ b/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/feeds/TestTrecContentSource.java
@@ -424,7 +424,9 @@ public class TestTrecContentSource extends LuceneTestCase {
             assertTrue("Should never get here!", false);
         }
       }
-    } catch (NoMoreDataException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        NoMoreDataException e) {
       gotExpectedException = true;
     }
     assertTrue("Should have gotten NoMoreDataException!", gotExpectedException);

--- a/lucene/classification/src/java/org/apache/lucene/classification/utils/ConfusionMatrixGenerator.java
+++ b/lucene/classification/src/java/org/apache/lucene/classification/utils/ConfusionMatrixGenerator.java
@@ -135,7 +135,9 @@ public class ConfusionMatrixGenerator {
                   }
                 }
               }
-            } catch (TimeoutException timeoutException) {
+            } catch (
+                @SuppressWarnings("unused")
+                TimeoutException timeoutException) {
               // add classification timeout
               time += 5000;
             } catch (ExecutionException | InterruptedException executionException) {

--- a/lucene/classification/src/test/org/apache/lucene/classification/Test20NewsgroupsClassification.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/Test20NewsgroupsClassification.java
@@ -86,7 +86,9 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
     if (indexProperty != null) {
       try {
         index = Boolean.valueOf(indexProperty);
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         // ignore
       }
     }
@@ -95,7 +97,9 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
     if (splitProperty != null) {
       try {
         split = Boolean.valueOf(splitProperty);
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         // ignore
       }
     }
@@ -438,7 +442,9 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
         }
       }
       return new NewsPost(body.toString(), subject, groupName);
-    } catch (Throwable e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Throwable e) {
       return null;
     }
   }

--- a/lucene/classification/src/test/org/apache/lucene/classification/utils/TestDataSplitter.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/utils/TestDataSplitter.java
@@ -155,7 +155,9 @@ public class TestDataSplitter extends LuceneTestCase {
   private static void closeQuietly(IndexReader reader) throws IOException {
     try {
       if (reader != null) reader.close();
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
       // do nothing
     }
   }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/OrdsBlockTreeTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/OrdsBlockTreeTermsReader.java
@@ -242,7 +242,9 @@ public final class OrdsBlockTreeTermsReader extends FieldsProducer {
     } else {
       try {
         return b.utf8ToString() + " " + b;
-      } catch (Throwable t) {
+      } catch (
+          @SuppressWarnings("unused")
+          Throwable t) {
         // If BytesRef isn't actually UTF8, or it's eg a
         // prefix of UTF8 that ends mid-unicode-char, we
         // fallback to hex:

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectPostingsFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectPostingsFormat.java
@@ -1932,7 +1932,9 @@ public final class DirectPostingsFormat extends PostingsFormat {
       upto++;
       try {
         return docID = docIDs[upto];
-      } catch (ArrayIndexOutOfBoundsException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          ArrayIndexOutOfBoundsException e) {
       }
       return docID = NO_MORE_DOCS;
     }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextCompoundFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextCompoundFormat.java
@@ -71,7 +71,7 @@ public class SimpleTextCompoundFormat extends CompoundFormat {
       tablePos = df.parse(stripPrefix(scratch, TABLEPOS)).longValue();
     } catch (ParseException e) {
       throw new CorruptIndexException(
-          "can't parse CFS trailer, got: " + scratch.get().utf8ToString(), in);
+          "can't parse CFS trailer, got: " + scratch.get().utf8ToString(), in, e);
     }
 
     // seek to TOC and read it

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextStoredFieldsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextStoredFieldsReader.java
@@ -77,7 +77,9 @@ public class SimpleTextStoredFieldsReader extends StoredFieldsReader {
       if (!success) {
         try {
           close();
-        } catch (Throwable t) {
+        } catch (
+            @SuppressWarnings("unused")
+            Throwable t) {
         } // ensure we throw our original exception
       }
     }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
@@ -80,7 +80,9 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
       if (!success) {
         try {
           close();
-        } catch (Throwable t) {
+        } catch (
+            @SuppressWarnings("unused")
+            Throwable t) {
         } // ensure we throw our original exception
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/analysis/TokenStream.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/TokenStream.java
@@ -111,7 +111,9 @@ public abstract class TokenStream extends AttributeSource implements Closeable {
               || Modifier.isFinal(clazz.getMethod("incrementToken").getModifiers())
           : "TokenStream implementation classes or at least their incrementToken() implementation must be final";
       return true;
-    } catch (NoSuchMethodException nsme) {
+    } catch (
+        @SuppressWarnings("unused")
+        NoSuchMethodException nsme) {
       return false;
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BugfixDeflater_JDK8252739.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BugfixDeflater_JDK8252739.java
@@ -91,9 +91,13 @@ interface BugfixDeflater_JDK8252739 {
       if (restoredLength != testData.length) {
         return true;
       }
-    } catch (DataFormatException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        DataFormatException e) {
       return true;
-    } catch (RuntimeException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        RuntimeException e) {
       return true;
     } finally {
       inflater.end();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorWriter.java
@@ -205,7 +205,9 @@ public final class Lucene90VectorWriter extends VectorWriter {
     } else {
       try {
         maxConn = Integer.parseInt(maxConnStr);
-      } catch (NumberFormatException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          NumberFormatException e) {
         throw new NumberFormatException(
             "Received non integer value for max-connections parameter of HnswGraphBuilder, value: "
                 + maxConnStr);
@@ -216,7 +218,9 @@ public final class Lucene90VectorWriter extends VectorWriter {
     } else {
       try {
         beamWidth = Integer.parseInt(beamWidthStr);
-      } catch (NumberFormatException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          NumberFormatException e) {
         throw new NumberFormatException(
             "Received non integer value for beam-width parameter of HnswGraphBuilder, value: "
                 + beamWidthStr);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnum.java
@@ -370,7 +370,9 @@ final class IntersectTermsEnum extends BaseTermsEnum {
   public BytesRef next() throws IOException {
     try {
       return _next();
-    } catch (NoMoreTermsException eoi) {
+    } catch (
+        @SuppressWarnings("unused")
+        NoMoreTermsException eoi) {
       // Provoke NPE if we are (illegally!) called again:
       currentFrame = null;
       return null;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
@@ -310,7 +310,9 @@ public final class Lucene90BlockTreeTermsReader extends FieldsProducer {
     } else {
       try {
         return b.utf8ToString() + " " + b;
-      } catch (Throwable t) {
+      } catch (
+          @SuppressWarnings("unused")
+          Throwable t) {
         // If BytesRef isn't actually UTF8, or it's eg a
         // prefix of UTF8 that ends mid-unicode-char, we
         // fallback to hex:

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
@@ -520,7 +520,9 @@ public final class Lucene90CompressingStoredFieldsWriter extends StoredFieldsWri
     boolean v = true;
     try {
       v = Boolean.parseBoolean(System.getProperty(BULK_MERGE_ENABLED_SYSPROP, "true"));
-    } catch (SecurityException ignored) {
+    } catch (
+        @SuppressWarnings("unused")
+        SecurityException ignored) {
     }
     BULK_MERGE_ENABLED = v;
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsWriter.java
@@ -797,7 +797,9 @@ public final class Lucene90CompressingTermVectorsWriter extends TermVectorsWrite
     boolean v = true;
     try {
       v = Boolean.parseBoolean(System.getProperty(BULK_MERGE_ENABLED_SYSPROP, "true"));
-    } catch (SecurityException ignored) {
+    } catch (
+        @SuppressWarnings("unused")
+        SecurityException ignored) {
     }
     BULK_MERGE_ENABLED = v;
   }

--- a/lucene/core/src/java/org/apache/lucene/document/DateTools.java
+++ b/lucene/core/src/java/org/apache/lucene/document/DateTools.java
@@ -116,7 +116,9 @@ public class DateTools {
     try {
       return TL_FORMATS.get()[dateString.length()].parse(dateString);
     } catch (Exception e) {
-      throw new ParseException("Input is not a valid date string: " + dateString, 0);
+      ParseException ex = new ParseException("Input is not a valid date string: " + dateString, 0);
+      ex.initCause(e);
+      throw ex;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
@@ -714,7 +714,9 @@ abstract class SpatialQuery extends Query {
               return rel;
             }
           });
-    } catch (CollectionTerminatedException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        CollectionTerminatedException e) {
       return true;
     }
     return false;

--- a/lucene/core/src/java/org/apache/lucene/geo/SimpleGeoJSONPolygonParser.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/SimpleGeoJSONPolygonParser.java
@@ -342,7 +342,9 @@ class SimpleGeoJSONPolygonParser {
     // we only handle doubles
     try {
       return Double.parseDouble(b.toString());
-    } catch (NumberFormatException nfe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NumberFormatException nfe) {
       upto = uptoStart;
       throw newParseException("could not parse number as double");
     }

--- a/lucene/core/src/java/org/apache/lucene/geo/SimpleWKTShapeParser.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/SimpleWKTShapeParser.java
@@ -301,7 +301,9 @@ public class SimpleWKTShapeParser {
       } else {
         try {
           return Double.parseDouble(stream.sval);
-        } catch (NumberFormatException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            NumberFormatException e) {
           throw new ParseException("invalid number found: " + stream.sval, stream.lineno());
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -1334,7 +1334,9 @@ public final class CheckIndex implements Closeable {
           long ord = -1;
           try {
             ord = termsEnum.ord();
-          } catch (UnsupportedOperationException uoe) {
+          } catch (
+              @SuppressWarnings("unused")
+              UnsupportedOperationException uoe) {
             hasOrd = false;
           }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -167,7 +167,9 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
         if (value != null) {
           coreCount = Integer.parseInt(value);
         }
-      } catch (Throwable ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          Throwable ignored) {
       }
 
       maxThreadCount = Math.max(1, Math.min(4, coreCount / 2));
@@ -466,7 +468,9 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
         if (toSync != null) {
           try {
             toSync.join();
-          } catch (InterruptedException ie) {
+          } catch (
+              @SuppressWarnings("unused")
+              InterruptedException ie) {
             // ignore this Exception, we will retry until all threads are dead
             interrupted = true;
           }
@@ -649,7 +653,9 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     // Let CMS run new merges if necessary:
     try {
       merge(mergeSource, MergeTrigger.MERGE_FINISHED);
-    } catch (AlreadyClosedException ace) {
+    } catch (
+        @SuppressWarnings("unused")
+        AlreadyClosedException ace) {
       // OK
     } catch (IOException ioe) {
       throw new UncheckedIOException(ioe);

--- a/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
@@ -274,7 +274,7 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
           // IOException allowed to throw there, in case
           // segments_N is corrupt
           sis = SegmentInfos.readCommit(dir, fileName, 0);
-        } catch (FileNotFoundException | NoSuchFileException fnfe) {
+        } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException fnfe) {
           // LUCENE-948: on NFS (and maybe others), if
           // you have writers switching back and forth
           // between machines, it's very likely that the

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -665,7 +665,9 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
         try {
           documentsWriter.subtractFlushedNumDocs(dwpt.getNumDocsInRAM());
           dwpt.abort();
-        } catch (Exception ex) {
+        } catch (
+            @SuppressWarnings("unused")
+            Exception ex) {
           // that's fine we just abort everything here this is best effort
         } finally {
           doAfterFlush(dwpt);
@@ -677,7 +679,9 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
               blockedFlush); // add the blockedFlushes for correct accounting in doAfterFlush
           documentsWriter.subtractFlushedNumDocs(blockedFlush.getNumDocsInRAM());
           blockedFlush.abort();
-        } catch (Exception ex) {
+        } catch (
+            @SuppressWarnings("unused")
+            Exception ex) {
           // that's fine we just abort everything here this is best effort
         } finally {
           doAfterFlush(blockedFlush);

--- a/lucene/core/src/java/org/apache/lucene/index/IndexFileDeleter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexFileDeleter.java
@@ -284,7 +284,9 @@ final class IndexFileDeleter implements Closeable {
         try {
           maxSegmentGen =
               Math.max(SegmentInfos.generationFromSegmentsFileName(fileName), maxSegmentGen);
-        } catch (NumberFormatException ignore) {
+        } catch (
+            @SuppressWarnings("unused")
+            NumberFormatException ignore) {
           // trash file: we have to handle this since we allow anything starting with 'segments'
           // here
         }
@@ -294,7 +296,9 @@ final class IndexFileDeleter implements Closeable {
               Math.max(
                   SegmentInfos.generationFromSegmentsFileName(fileName.substring(8)),
                   maxSegmentGen);
-        } catch (NumberFormatException ignore) {
+        } catch (
+            @SuppressWarnings("unused")
+            NumberFormatException ignore) {
           // trash file: we have to handle this since we allow anything starting with
           // 'pending_segments' here
         }
@@ -317,7 +321,9 @@ final class IndexFileDeleter implements Closeable {
 
         try {
           curGen = Math.max(curGen, IndexFileNames.parseGeneration(fileName));
-        } catch (NumberFormatException ignore) {
+        } catch (
+            @SuppressWarnings("unused")
+            NumberFormatException ignore) {
           // trash file: we have to handle this since codec regex is only so good
         }
         maxPerSegmentGen.put(segmentName, curGen);
@@ -400,7 +406,9 @@ final class IndexFileDeleter implements Closeable {
     try {
       ensureOpen();
       return false;
-    } catch (AlreadyClosedException ace) {
+    } catch (
+        @SuppressWarnings("unused")
+        AlreadyClosedException ace) {
       return true;
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1049,7 +1049,8 @@ public class IndexWriter
           throw new IllegalArgumentException(
               "the provided reader is stale: its prior commit file \""
                   + segmentInfos.getSegmentsFileName()
-                  + "\" is missing from index");
+                  + "\" is missing from index",
+              ioe);
         }
 
         if (reader.writer != null) {
@@ -5628,7 +5629,9 @@ public class IndexWriter
     Collection<String> files;
     try {
       files = info.files();
-    } catch (IllegalStateException ise) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalStateException ise) {
       // OK
       files = null;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -1218,7 +1218,7 @@ final class IndexingChain implements Accountable {
                 Math.addExact(invertState.length, invertState.termFreqAttribute.getTermFrequency());
           } catch (ArithmeticException ae) {
             throw new IllegalArgumentException(
-                "too many tokens for field \"" + field.name() + "\"");
+                "too many tokens for field \"" + field.name() + "\"", ae);
           }
 
           // System.out.println("  term=" + invertState.termAttribute);

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -380,7 +380,7 @@ public abstract class MergePolicy {
         return true;
       } catch (InterruptedException e) {
         throw new ThreadInterruptedException(e);
-      } catch (ExecutionException | TimeoutException e) {
+      } catch (@SuppressWarnings("unused") ExecutionException | TimeoutException e) {
         return false;
       }
     }
@@ -471,7 +471,7 @@ public abstract class MergePolicy {
         return true;
       } catch (InterruptedException e) {
         throw new ThreadInterruptedException(e);
-      } catch (ExecutionException | TimeoutException e) {
+      } catch (@SuppressWarnings("unused") ExecutionException | TimeoutException e) {
         return false;
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/PersistentSnapshotDeletionPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PersistentSnapshotDeletionPolicy.java
@@ -120,7 +120,9 @@ public class PersistentSnapshotDeletionPolicy extends SnapshotDeletionPolicy {
       if (!success) {
         try {
           super.release(ic);
-        } catch (Exception e) {
+        } catch (
+            @SuppressWarnings("unused")
+            Exception e) {
           // Suppress so we keep throwing original exception
         }
       }
@@ -145,7 +147,9 @@ public class PersistentSnapshotDeletionPolicy extends SnapshotDeletionPolicy {
       if (!success) {
         try {
           incRef(commit);
-        } catch (Exception e) {
+        } catch (
+            @SuppressWarnings("unused")
+            Exception e) {
           // Suppress so we keep throwing original exception
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -310,7 +310,9 @@ public final class StandardDirectoryReader extends DirectoryReader {
       if (reader != null) {
         try {
           reader.decRef();
-        } catch (Throwable t) {
+        } catch (
+            @SuppressWarnings("unused")
+            Throwable t) {
           // Ignore so we keep throwing original exception
         }
       }
@@ -461,7 +463,9 @@ public final class StandardDirectoryReader extends DirectoryReader {
           if (writer != null) {
             try {
               writer.decRefDeleter(segmentInfos);
-            } catch (AlreadyClosedException ex) {
+            } catch (
+                @SuppressWarnings("unused")
+                AlreadyClosedException ex) {
               // This is OK, it just means our original writer was
               // closed before we were, and this may leave some
               // un-referenced files in the index, which is

--- a/lucene/core/src/java/org/apache/lucene/index/Term.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Term.java
@@ -116,7 +116,9 @@ public final class Term implements Comparable<Term>, Accountable {
       return decoder
           .decode(ByteBuffer.wrap(termText.bytes, termText.offset, termText.length))
           .toString();
-    } catch (CharacterCodingException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        CharacterCodingException e) {
       return termText.toString();
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/index/Terms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Terms.java
@@ -151,7 +151,9 @@ public abstract class Terms {
         TermsEnum iterator = iterator();
         iterator.seekExact(size - 1);
         return iterator.term();
-      } catch (UnsupportedOperationException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          UnsupportedOperationException ignored) {
         // ok
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/TwoPhaseCommitTool.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TwoPhaseCommitTool.java
@@ -61,7 +61,9 @@ public final class TwoPhaseCommitTool {
       if (tpc != null) {
         try {
           tpc.rollback();
-        } catch (Throwable t) {
+        } catch (
+            @SuppressWarnings("unused")
+            Throwable t) {
         }
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/search/ControlledRealTimeReopenThread.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ControlledRealTimeReopenThread.java
@@ -212,7 +212,9 @@ public class ControlledRealTimeReopenThread<T> extends Thread implements Closeab
           } else {
             break;
           }
-        } catch (InterruptedException ie) {
+        } catch (
+            @SuppressWarnings("unused")
+            InterruptedException ie) {
           Thread.currentThread().interrupt();
           return;
         } finally {

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -735,7 +735,9 @@ public class IndexSearcher {
       final LeafCollector leafCollector;
       try {
         leafCollector = collector.getLeafCollector(ctx);
-      } catch (CollectionTerminatedException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          CollectionTerminatedException e) {
         // there is no doc of interest in this reader context
         // continue with the following leaf
         continue;
@@ -744,7 +746,9 @@ public class IndexSearcher {
       if (scorer != null) {
         try {
           scorer.score(leafCollector, ctx.reader().getLiveDocs());
-        } catch (CollectionTerminatedException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            CollectionTerminatedException e) {
           // collection was terminated prematurely
           // continue with the following leaf
         }

--- a/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
@@ -116,7 +116,9 @@ public class MultiCollector implements Collector {
       final LeafCollector leafCollector;
       try {
         leafCollector = collector.getLeafCollector(context);
-      } catch (CollectionTerminatedException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          CollectionTerminatedException e) {
         // this leaf collector does not need this segment
         continue;
       }
@@ -186,7 +188,9 @@ public class MultiCollector implements Collector {
         if (collector != null) {
           try {
             collector.collect(doc);
-          } catch (CollectionTerminatedException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              CollectionTerminatedException e) {
             collectors[i] = null;
             if (allCollectorsTerminated()) {
               throw new CollectionTerminatedException();

--- a/lucene/core/src/java/org/apache/lucene/search/SliceExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SliceExecutor.java
@@ -69,7 +69,9 @@ class SliceExecutor {
         executor.execute(task);
 
         return;
-      } catch (RejectedExecutionException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          RejectedExecutionException e) {
         // Execute on caller thread
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/search/SortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortField.java
@@ -211,7 +211,7 @@ public class SortField {
     try {
       return Type.valueOf(type);
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("Can't deserialize SortField - unknown type " + type);
+      throw new IllegalArgumentException("Can't deserialize SortField - unknown type " + type, e);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/spans/SpanMultiTermQueryWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/spans/SpanMultiTermQueryWrapper.java
@@ -70,7 +70,7 @@ public class SpanMultiTermQueryWrapper<Q extends MultiTermQuery> extends SpanQue
   private static SpanRewriteMethod selectRewriteMethod(MultiTermQuery query) {
     MultiTermQuery.RewriteMethod method = query.getRewriteMethod();
     if (method instanceof TopTermsRewrite) {
-      final int pqsize = ((TopTermsRewrite) method).getSize();
+      final int pqsize = ((TopTermsRewrite<?>) method).getSize();
       return new TopTermsSpanBooleanQueryRewrite(pqsize);
     } else {
       return SCORING_SPAN_QUERY_REWRITE;

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -89,7 +89,9 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
   public final byte readByte() throws IOException {
     try {
       return guard.getByte(curBuf);
-    } catch (BufferUnderflowException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        BufferUnderflowException e) {
       do {
         curBufIndex++;
         if (curBufIndex >= buffers.length) {
@@ -99,7 +101,9 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
         curBuf.position(0);
       } while (!curBuf.hasRemaining());
       return guard.getByte(curBuf);
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -108,7 +112,9 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
   public final void readBytes(byte[] b, int offset, int len) throws IOException {
     try {
       guard.getBytes(curBuf, b, offset, len);
-    } catch (BufferUnderflowException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        BufferUnderflowException e) {
       int curAvail = curBuf.remaining();
       while (len > curAvail) {
         guard.getBytes(curBuf, b, offset, curAvail);
@@ -123,7 +129,9 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
         curAvail = curBuf.remaining();
       }
       guard.getBytes(curBuf, b, offset, len);
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -157,9 +165,13 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
           curLongBufferViews[position & 0x07].position(position >>> 3), dst, offset, length);
       // if the above call succeeded, then we know the below sum cannot overflow
       curBuf.position(position + (length << 3));
-    } catch (BufferUnderflowException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        BufferUnderflowException e) {
       super.readLELongs(dst, offset, length);
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -187,9 +199,13 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
       guard.getFloats(floatBuffer, floats, offset, len);
       // if the above call succeeded, then we know the below sum cannot overflow
       curBuf.position(position + (len << 2));
-    } catch (BufferUnderflowException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        BufferUnderflowException e) {
       super.readLEFloats(floats, offset, len);
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -198,9 +214,13 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
   public final short readShort() throws IOException {
     try {
       return guard.getShort(curBuf);
-    } catch (BufferUnderflowException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        BufferUnderflowException e) {
       return super.readShort();
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -209,9 +229,13 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
   public final int readInt() throws IOException {
     try {
       return guard.getInt(curBuf);
-    } catch (BufferUnderflowException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        BufferUnderflowException e) {
       return super.readInt();
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -220,9 +244,13 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
   public final long readLong() throws IOException {
     try {
       return guard.getLong(curBuf);
-    } catch (BufferUnderflowException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        BufferUnderflowException e) {
       return super.readLong();
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -231,7 +259,9 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
   public long getFilePointer() {
     try {
       return (((long) curBufIndex) << chunkSizePower) + curBuf.position();
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -251,9 +281,13 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
         this.curBufIndex = bi;
         setCurBuf(b);
       }
-    } catch (ArrayIndexOutOfBoundsException | IllegalArgumentException e) {
+    } catch (@SuppressWarnings("unused")
+        ArrayIndexOutOfBoundsException
+        | IllegalArgumentException e) {
       throw new EOFException("seek past EOF: " + this);
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -263,9 +297,13 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     try {
       final int bi = (int) (pos >> chunkSizePower);
       return guard.getByte(buffers[bi], (int) (pos & chunkSizeMask));
-    } catch (IndexOutOfBoundsException ioobe) {
+    } catch (
+        @SuppressWarnings("unused")
+        IndexOutOfBoundsException ioobe) {
       throw new EOFException("seek past EOF: " + this);
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -277,9 +315,13 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
       b.position((int) (pos & chunkSizeMask));
       this.curBufIndex = bi;
       setCurBuf(b);
-    } catch (ArrayIndexOutOfBoundsException | IllegalArgumentException aioobe) {
+    } catch (@SuppressWarnings("unused")
+        ArrayIndexOutOfBoundsException
+        | IllegalArgumentException aioobe) {
       throw new EOFException("seek past EOF: " + this);
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -289,11 +331,15 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     final int bi = (int) (pos >> chunkSizePower);
     try {
       return guard.getShort(buffers[bi], (int) (pos & chunkSizeMask));
-    } catch (IndexOutOfBoundsException ioobe) {
+    } catch (
+        @SuppressWarnings("unused")
+        IndexOutOfBoundsException ioobe) {
       // either it's a boundary, or read past EOF, fall back:
       setPos(pos, bi);
       return readShort();
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -303,11 +349,15 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     final int bi = (int) (pos >> chunkSizePower);
     try {
       return guard.getInt(buffers[bi], (int) (pos & chunkSizeMask));
-    } catch (IndexOutOfBoundsException ioobe) {
+    } catch (
+        @SuppressWarnings("unused")
+        IndexOutOfBoundsException ioobe) {
       // either it's a boundary, or read past EOF, fall back:
       setPos(pos, bi);
       return readInt();
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -317,11 +367,15 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     final int bi = (int) (pos >> chunkSizePower);
     try {
       return guard.getLong(buffers[bi], (int) (pos & chunkSizeMask));
-    } catch (IndexOutOfBoundsException ioobe) {
+    } catch (
+        @SuppressWarnings("unused")
+        IndexOutOfBoundsException ioobe) {
       // either it's a boundary, or read past EOF, fall back:
       setPos(pos, bi);
       return readLong();
-    } catch (NullPointerException npe) {
+    } catch (
+        @SuppressWarnings("unused")
+        NullPointerException npe) {
       throw new AlreadyClosedException("Already closed: " + this);
     }
   }
@@ -474,7 +528,9 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
         } else {
           throw new EOFException("seek past EOF: " + this);
         }
-      } catch (NullPointerException npe) {
+      } catch (
+          @SuppressWarnings("unused")
+          NullPointerException npe) {
         throw new AlreadyClosedException("Already closed: " + this);
       }
     }
@@ -483,7 +539,9 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     public long getFilePointer() {
       try {
         return curBuf.position();
-      } catch (NullPointerException npe) {
+      } catch (
+          @SuppressWarnings("unused")
+          NullPointerException npe) {
         throw new AlreadyClosedException("Already closed: " + this);
       }
     }
@@ -498,7 +556,9 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
         } else {
           throw new EOFException("seek past EOF: " + this);
         }
-      } catch (NullPointerException npe) {
+      } catch (
+          @SuppressWarnings("unused")
+          NullPointerException npe) {
         throw new AlreadyClosedException("Already closed: " + this);
       }
     }
@@ -513,7 +573,9 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
         } else {
           throw new EOFException("seek past EOF: " + this);
         }
-      } catch (NullPointerException npe) {
+      } catch (
+          @SuppressWarnings("unused")
+          NullPointerException npe) {
         throw new AlreadyClosedException("Already closed: " + this);
       }
     }
@@ -528,7 +590,9 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
         } else {
           throw new EOFException("seek past EOF: " + this);
         }
-      } catch (NullPointerException npe) {
+      } catch (
+          @SuppressWarnings("unused")
+          NullPointerException npe) {
         throw new AlreadyClosedException("Already closed: " + this);
       }
     }
@@ -543,7 +607,9 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
         } else {
           throw new EOFException("seek past EOF: " + this);
         }
-      } catch (NullPointerException npe) {
+      } catch (
+          @SuppressWarnings("unused")
+          NullPointerException npe) {
         throw new AlreadyClosedException("Already closed: " + this);
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/store/DataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataInput.java
@@ -297,7 +297,7 @@ public abstract class DataInput implements Cloneable {
     try {
       return (DataInput) super.clone();
     } catch (CloneNotSupportedException e) {
-      throw new Error("This cannot happen: Failing to clone DataInput");
+      throw new Error("This cannot happen: Failing to clone DataInput", e);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/FSDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/FSDirectory.java
@@ -232,7 +232,9 @@ public abstract class FSDirectory extends BaseDirectory {
           continue;
         }
         return new FSIndexOutput(name, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
-      } catch (FileAlreadyExistsException faee) {
+      } catch (
+          @SuppressWarnings("unused")
+          FileAlreadyExistsException faee) {
         // Retry with next incremented name
       }
     }
@@ -355,7 +357,9 @@ public abstract class FSDirectory extends BaseDirectory {
       } else {
         throw e;
       }
-    } catch (IOException ioe) {
+    } catch (
+        @SuppressWarnings("unused")
+        IOException ioe) {
       // On windows, a file delete can fail because there's still an open
       // file handle against it.  We record this in pendingDeletes and
       // try again later.

--- a/lucene/core/src/java/org/apache/lucene/store/LockStressTest.java
+++ b/lucene/core/src/java/org/apache/lucene/store/LockStressTest.java
@@ -126,12 +126,16 @@ public class LockStressTest {
             }
             try (final Lock secondLock = verifyLF.obtainLock(lockDir, LOCK_FILE_NAME)) {
               throw new IOException("Double obtain");
-            } catch (LockObtainFailedException loe) {
+            } catch (
+                @SuppressWarnings("unused")
+                LockObtainFailedException loe) {
               // pass
             }
           }
           Thread.sleep(sleepTimeMS);
-        } catch (LockObtainFailedException loe) {
+        } catch (
+            @SuppressWarnings("unused")
+            LockObtainFailedException loe) {
           // obtain failed
         }
 
@@ -151,7 +155,9 @@ public class LockStressTest {
     // try to get static INSTANCE field of class
     try {
       return (FSLockFactory) Class.forName(lockFactoryClassName).getField("INSTANCE").get(null);
-    } catch (ReflectiveOperationException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        ReflectiveOperationException e) {
       // fall-through
     }
 
@@ -161,7 +167,7 @@ public class LockStressTest {
           .asSubclass(FSLockFactory.class)
           .getConstructor()
           .newInstance();
-    } catch (ReflectiveOperationException | ClassCastException e) {
+    } catch (@SuppressWarnings("unused") ReflectiveOperationException | ClassCastException e) {
       // fall-through
     }
 

--- a/lucene/core/src/java/org/apache/lucene/store/NRTCachingDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NRTCachingDirectory.java
@@ -295,7 +295,7 @@ public class NRTCachingDirectory extends FilterDirectory implements Accountable 
     try {
       dir.fileLength(fileName);
       return true;
-    } catch (NoSuchFileException | FileNotFoundException e) {
+    } catch (@SuppressWarnings("unused") NoSuchFileException | FileNotFoundException e) {
       return false;
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/util/AttributeFactory.java
+++ b/lucene/core/src/java/org/apache/lucene/util/AttributeFactory.java
@@ -83,7 +83,7 @@ public abstract class AttributeFactory {
             .asSubclass(AttributeImpl.class);
       } catch (ClassNotFoundException cnfe) {
         throw new IllegalArgumentException(
-            "Cannot find implementing class for: " + attClass.getName());
+            "Cannot find implementing class for: " + attClass.getName(), cnfe);
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/util/ClassLoaderUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ClassLoaderUtils.java
@@ -42,7 +42,9 @@ public interface ClassLoaderUtils {
         cl = cl.getParent();
       }
       return false;
-    } catch (SecurityException se) {
+    } catch (
+        @SuppressWarnings("unused")
+        SecurityException se) {
       return false;
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/util/Constants.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Constants.java
@@ -70,7 +70,9 @@ public final class Constants {
       if (datamodel != null) {
         is64Bit = datamodel.contains("64");
       }
-    } catch (SecurityException ex) {
+    } catch (
+        @SuppressWarnings("unused")
+        SecurityException ex) {
     }
     if (datamodel == null) {
       if (OS_ARCH != null && OS_ARCH.contains("64")) {

--- a/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
@@ -194,7 +194,9 @@ public final class IOUtils {
     for (String name : files) {
       try {
         dir.deleteFile(name);
-      } catch (Throwable ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          Throwable ignored) {
         // ignore
       }
     }
@@ -248,7 +250,9 @@ public final class IOUtils {
       if (name != null) {
         try {
           Files.delete(name);
-        } catch (Throwable ignored) {
+        } catch (
+            @SuppressWarnings("unused")
+            Throwable ignored) {
           // ignore
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
@@ -139,7 +139,7 @@ public final class RamUsageEstimator {
             compressedOops =
                 Boolean.parseBoolean(
                     vmOption.getClass().getMethod("getValue").invoke(vmOption).toString());
-          } catch (ReflectiveOperationException | RuntimeException e) {
+          } catch (@SuppressWarnings("unused") ReflectiveOperationException | RuntimeException e) {
             isHotspot = false;
           }
           try {
@@ -147,11 +147,11 @@ public final class RamUsageEstimator {
             objectAlignment =
                 Integer.parseInt(
                     vmOption.getClass().getMethod("getValue").invoke(vmOption).toString());
-          } catch (ReflectiveOperationException | RuntimeException e) {
+          } catch (@SuppressWarnings("unused") ReflectiveOperationException | RuntimeException e) {
             isHotspot = false;
           }
         }
-      } catch (ReflectiveOperationException | RuntimeException e) {
+      } catch (@SuppressWarnings("unused") ReflectiveOperationException | RuntimeException e) {
         isHotspot = false;
       }
       JVM_IS_HOTSPOT_64BIT = isHotspot;
@@ -453,9 +453,9 @@ public final class RamUsageEstimator {
     } else if (o instanceof Query) {
       size = sizeOf((Query) o, defSize);
     } else if (o instanceof Map) {
-      size = sizeOfMap((Map) o, ++depth, defSize);
+      size = sizeOfMap((Map<?, ?>) o, ++depth, defSize);
     } else if (o instanceof Collection) {
-      size = sizeOfCollection((Collection) o, ++depth, defSize);
+      size = sizeOfCollection((Collection<?>) o, ++depth, defSize);
     } else {
       if (defSize > 0) {
         size = defSize;

--- a/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
@@ -244,7 +244,9 @@ public abstract class StringHelper {
           new DataInputStream(Files.newInputStream(Paths.get("/dev/urandom")))) {
         x0 = is.readLong();
         x1 = is.readLong();
-      } catch (Exception unavailable) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception unavailable) {
         // may not be available on this platform
         // fall back to lower quality randomness from 3 different sources:
         x0 = System.nanoTime();
@@ -259,7 +261,9 @@ public abstract class StringHelper {
             sb.append(p.getProperty(s));
           }
           x1 |= sb.toString().hashCode();
-        } catch (SecurityException notallowed) {
+        } catch (
+            @SuppressWarnings("unused")
+            SecurityException notallowed) {
           // getting Properties requires wildcard read-write: may not be allowed
           x1 |= StringBuffer.class.hashCode();
         }

--- a/lucene/core/src/java/org/apache/lucene/util/UnicodeUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/UnicodeUtil.java
@@ -557,7 +557,9 @@ public final class UnicodeUtil {
             w += 2;
           }
           break;
-        } catch (IndexOutOfBoundsException ex) {
+        } catch (
+            @SuppressWarnings("unused")
+            IndexOutOfBoundsException ex) {
           int newlen = (int) (Math.ceil((double) codePoints.length * (w + 2) / (r - offset + 1)));
           char[] temp = new char[newlen];
           System.arraycopy(chars, 0, temp, 0, w);

--- a/lucene/core/src/java/org/apache/lucene/util/VirtualMethod.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VirtualMethod.java
@@ -138,7 +138,9 @@ public final class VirtualMethod<C> {
         try {
           clazz.getDeclaredMethod(method, parameters);
           overridden = true;
-        } catch (NoSuchMethodException nsme) {
+        } catch (
+            @SuppressWarnings("unused")
+            NoSuchMethodException nsme) {
         }
       }
 

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -1328,7 +1328,7 @@ public class RegExp {
           }
           return makeInterval(flags, imin, imax, digits);
         } catch (NumberFormatException e) {
-          throw new IllegalArgumentException("interval syntax error at position " + (pos - 1));
+          throw new IllegalArgumentException("interval syntax error at position " + (pos - 1), e);
         }
       }
     } else {

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
@@ -89,7 +89,7 @@ class DocIdsWriter {
     }
   }
 
-  static <T> void readInts32(IndexInput in, int count, int[] docIDs) throws IOException {
+  private static void readInts32(IndexInput in, int count, int[] docIDs) throws IOException {
     for (int i = 0; i < count; i++) {
       docIDs[i] = in.readInt();
     }

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointReader.java
@@ -121,7 +121,9 @@ public final class OfflinePointReader implements PointReader {
           countLeft = 0;
         }
         this.offset = 0;
-      } catch (EOFException eofe) {
+      } catch (
+          @SuppressWarnings("unused")
+          EOFException eofe) {
         assert countLeft == -1;
         return false;
       }

--- a/lucene/core/src/test/org/apache/lucene/TestAssertions.java
+++ b/lucene/core/src/test/org/apache/lucene/TestAssertions.java
@@ -51,7 +51,9 @@ public class TestAssertions extends LuceneTestCase {
       if (assertsAreEnabled) {
         fail("TestTokenStream3 should fail assertion");
       }
-    } catch (AssertionError e) {
+    } catch (
+        @SuppressWarnings("unused")
+        AssertionError e) {
       // expected
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
+++ b/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
@@ -135,7 +135,9 @@ public class TestMergeSchedulerExternal extends LuceneTestCase {
 
     try {
       ((MyMergeScheduler) writer.getConfig().getMergeScheduler()).sync();
-    } catch (IllegalStateException ise) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalStateException ise) {
       // OK
     }
     writer.rollback();

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestIndexedDISI.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestIndexedDISI.java
@@ -397,26 +397,19 @@ public class TestIndexedDISI extends LuceneTestCase {
 
     // Illegal values
     for (byte denseRankPower : new byte[] {-2, 0, 1, 6, 16}) {
-      try {
-        createAndOpenDISI(
-            denseRankPower, (byte) 8); // Illegal write, legal read (should not reach read)
-        fail(
-            "Trying to create an IndexedDISI data stream with denseRankPower-read "
-                + denseRankPower
-                + " and denseRankPower-write 8 should fail");
-      } catch (IllegalArgumentException e) {
-        // Expected
-      }
-      try {
-        createAndOpenDISI(
-            (byte) 8, denseRankPower); // Legal write, illegal read (should reach read)
-        fail(
-            "Trying to create an IndexedDISI data stream with denseRankPower-write 8 and denseRankPower-read "
-                + denseRankPower
-                + " should fail");
-      } catch (IllegalArgumentException e) {
-        // Expected
-      }
+      expectThrows(
+          IllegalArgumentException.class,
+          () -> {
+            createAndOpenDISI(
+                denseRankPower, (byte) 8); // Illegal write, legal read (should not reach read)
+          });
+
+      expectThrows(
+          IllegalArgumentException.class,
+          () -> {
+            createAndOpenDISI(
+                (byte) 8, denseRankPower); // Legal write, illegal read (should reach read)
+          });
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/document/BaseLatLonSpatialTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/document/BaseLatLonSpatialTestCase.java
@@ -202,7 +202,9 @@ public abstract class BaseLatLonSpatialTestCase extends BaseSpatialTestCase {
           try {
             Tessellator.tessellate(p);
             return p;
-          } catch (IllegalArgumentException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              IllegalArgumentException e) {
             // if we can't tessellate; then random polygon generator created a malformed shape
           }
         }

--- a/lucene/core/src/test/org/apache/lucene/document/BaseXYShapeTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/document/BaseXYShapeTestCase.java
@@ -228,7 +228,9 @@ public abstract class BaseXYShapeTestCase extends BaseSpatialTestCase {
           try {
             Tessellator.tessellate(p);
             return p;
-          } catch (IllegalArgumentException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              IllegalArgumentException e) {
             // if we can't tessellate; then random polygon generator created a malformed shape
           }
         }

--- a/lucene/core/src/test/org/apache/lucene/document/TestLatLonShape.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLatLonShape.java
@@ -797,7 +797,9 @@ public class TestLatLonShape extends LuceneTestCase {
         polygon = new Polygon(lats, lons);
         Tessellator.tessellate(polygon);
         break;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         // invalid polygon, try a new one
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/document/TestXYShape.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestXYShape.java
@@ -135,7 +135,9 @@ public class TestXYShape extends LuceneTestCase {
         try {
           Tessellator.tessellate(p);
           break;
-        } catch (Exception e) {
+        } catch (
+            @SuppressWarnings("unused")
+            Exception e) {
           // ignore, try other combination
         }
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestAllFilesDetectBitFlips.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAllFilesDetectBitFlips.java
@@ -123,7 +123,9 @@ public class TestAllFilesDetectBitFlips extends LuceneTestCase {
               System.out.println(
                   "TEST: changing a byte in " + victim + " did not update the checksum)");
               return;
-            } catch (CorruptIndexException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                CorruptIndexException e) {
               // ok
             }
           }

--- a/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
@@ -436,7 +436,9 @@ public class TestCodecs extends LuceneTestCase {
         try {
           termsEnum.seekExact(idx);
           success = true;
-        } catch (UnsupportedOperationException uoe) {
+        } catch (
+            @SuppressWarnings("unused")
+            UnsupportedOperationException uoe) {
           // ok -- skip it
         }
         if (success) {
@@ -488,7 +490,9 @@ public class TestCodecs extends LuceneTestCase {
             termsEnum.seekExact(i);
             assertEquals(field.terms[i].docs.length, termsEnum.docFreq());
             assertTrue(termsEnum.term().bytesEquals(new BytesRef(field.terms[i].text2)));
-          } catch (UnsupportedOperationException uoe) {
+          } catch (
+              @SuppressWarnings("unused")
+              UnsupportedOperationException uoe) {
           }
         }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDeletionPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDeletionPolicy.java
@@ -299,7 +299,9 @@ public class TestDeletionPolicy extends LuceneTestCase {
                 + (lastDeleteTime - modTime)
                 + " msec) but did not get deleted ",
             lastDeleteTime - modTime <= leeway);
-      } catch (IOException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException e) {
         // OK
         break;
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocInverterPerFieldErrorInfo.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocInverterPerFieldErrorInfo.java
@@ -98,11 +98,8 @@ public class TestDocInverterPerFieldErrorInfo extends LuceneTestCase {
     writer = new IndexWriter(dir, c);
     Document doc = new Document();
     doc.add(newField("boringFieldName", "aaa ", storedTextType));
-    try {
-      writer.addDocument(doc);
-    } catch (BadNews badNews) {
-      fail("Unwanted exception");
-    }
+    // should not throw BadNews
+    writer.addDocument(doc);
     infoPrintStream.flush();
     String infoStream = new String(infoBytes.toByteArray(), IOUtils.UTF_8);
     assertFalse(infoStream.contains("boringFieldName"));

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocValuesIndexing.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocValuesIndexing.java
@@ -566,7 +566,9 @@ public class TestDocValuesIndexing extends LuceneTestCase {
               try {
                 startingGun.await();
                 w.addDocument(doc);
-              } catch (IllegalArgumentException iae) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  IllegalArgumentException iae) {
                 // expected
                 hitExc.set(true);
               } catch (Exception e) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterPerThreadPool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterPerThreadPool.java
@@ -93,7 +93,9 @@ public class TestDocumentsWriterPerThreadPool extends LuceneTestCase {
                   latch.countDown();
                   pool.getAndLock();
                   fail();
-                } catch (AlreadyClosedException e) {
+                } catch (
+                    @SuppressWarnings("unused")
+                    AlreadyClosedException e) {
                   // fine
                 }
               });

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -58,7 +58,9 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
         try {
           // Sleep for 100ms before each .next() call.
           Thread.sleep(100);
-        } catch (InterruptedException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            InterruptedException e) {
         }
         return in.next();
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldsReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldsReader.java
@@ -202,13 +202,17 @@ public class TestFieldsReader extends LuceneTestCase {
     for (int i = 0; i < 2; i++) {
       try {
         reader.document(i);
-      } catch (IOException ioe) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException ioe) {
         // expected
         exc = true;
       }
       try {
         reader.document(i);
-      } catch (IOException ioe) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException ioe) {
         // expected
         exc = true;
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFilterCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFilterCodecReader.java
@@ -60,7 +60,9 @@ public class TestFilterCodecReader extends LuceneTestCase {
             "getReturnType() difference",
             superClassMethod.getReturnType(),
             subClassMethod.getReturnType());
-      } catch (NoSuchMethodException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          NoSuchMethodException e) {
         fail(subClass + " needs to override '" + superClassMethod + "'");
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFilterMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFilterMergePolicy.java
@@ -27,7 +27,9 @@ public class TestFilterMergePolicy extends LuceneTestCase {
       if (Modifier.isFinal(m.getModifiers()) || Modifier.isPrivate(m.getModifiers())) continue;
       try {
         FilterMergePolicy.class.getDeclaredMethod(m.getName(), m.getParameterTypes());
-      } catch (NoSuchMethodException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          NoSuchMethodException e) {
         fail("FilterMergePolicy needs to override '" + m + "'");
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFlex.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFlex.java
@@ -80,7 +80,9 @@ public class TestFlex extends LuceneTestCase {
     assertTrue(terms.next() != null);
     try {
       assertEquals(0, terms.ord());
-    } catch (UnsupportedOperationException uoe) {
+    } catch (
+        @SuppressWarnings("unused")
+        UnsupportedOperationException uoe) {
       // ok -- codec is not required to support this op
     }
     r.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -950,7 +950,9 @@ public class TestIndexWriter extends LuceneTestCase {
               // w.rollback();
               try {
                 w.close();
-              } catch (AlreadyClosedException ace) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  AlreadyClosedException ace) {
                 // OK
               }
               w = null;
@@ -2567,7 +2569,9 @@ public class TestIndexWriter extends LuceneTestCase {
     startCommit.await();
     try {
       iw.close();
-    } catch (IllegalStateException ise) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalStateException ise) {
       // OK, but not required (depends on thread scheduling)
     }
     finishCommit.await();
@@ -3005,7 +3009,7 @@ public class TestIndexWriter extends LuceneTestCase {
     try {
       dir.openInput(tempName, IOContext.DEFAULT);
       fail("did not hit exception");
-    } catch (FileNotFoundException | NoSuchFileException e) {
+    } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException e) {
       // expected
     }
     w.close();
@@ -4017,7 +4021,9 @@ public class TestIndexWriter extends LuceneTestCase {
                   indexedDocs.release(1);
                 } catch (IOException e) {
                   throw new AssertionError(e);
-                } catch (AlreadyClosedException ignored) {
+                } catch (
+                    @SuppressWarnings("unused")
+                    AlreadyClosedException ignored) {
                   return;
                 }
               }
@@ -4032,7 +4038,9 @@ public class TestIndexWriter extends LuceneTestCase {
                   sm.maybeRefreshBlocking();
                 } catch (IOException e) {
                   throw new AssertionError(e);
-                } catch (AlreadyClosedException ignored) {
+                } catch (
+                    @SuppressWarnings("unused")
+                    AlreadyClosedException ignored) {
                   return;
                 }
               }
@@ -4105,8 +4113,10 @@ public class TestIndexWriter extends LuceneTestCase {
                 try {
                   queue.processEvents();
                 } catch (IOException e) {
-                  throw new AssertionError();
-                } catch (AlreadyClosedException ex) {
+                  throw new AssertionError(e);
+                } catch (
+                    @SuppressWarnings("unused")
+                    AlreadyClosedException ex) {
                   // possible
                 }
               });

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
@@ -945,7 +945,9 @@ public class TestIndexWriterDelete extends LuceneTestCase {
     try {
       modifier.commit();
       writerClosed = false;
-    } catch (IllegalStateException ise) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalStateException ise) {
       // The above exc struck during merge, and closed the writer
       writerClosed = true;
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
@@ -477,14 +477,18 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
     for (int i = 0; i < 10; i++) {
       try {
         w.addDocument(doc);
-      } catch (RuntimeException re) {
+      } catch (
+          @SuppressWarnings("unused")
+          RuntimeException re) {
         break;
       }
     }
 
     try {
       ((ConcurrentMergeScheduler) w.getConfig().getMergeScheduler()).sync();
-    } catch (IllegalStateException ise) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalStateException ise) {
       // OK: merge exc causes tragedy
     }
     assertTrue(testPoint.failed);
@@ -955,7 +959,9 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
       if ((i - 1) % 2 == 0) {
         try {
           writer.commit();
-        } catch (IOException ioe) {
+        } catch (
+            @SuppressWarnings("unused")
+            IOException ioe) {
           // expected
         }
       }
@@ -1088,7 +1094,9 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
       dir.setRandomIOExceptionRate(0.5);
       try {
         w.forceMerge(1);
-      } catch (IllegalStateException ise) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalStateException ise) {
         // expected
       } catch (IOException ioe) {
         if (ioe.getCause() == null) {
@@ -1099,7 +1107,9 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
       // System.out.println("TEST: now close IW");
       try {
         w.close();
-      } catch (IllegalStateException ise) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalStateException ise) {
         // ok
       }
       dir.close();
@@ -1183,7 +1193,9 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
 
     try {
       writer.close();
-    } catch (IllegalArgumentException ok) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalArgumentException ok) {
       // ok
     }
 
@@ -1881,10 +1893,12 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
       } catch (AssertionError ex) {
         // This is fine: we tripped IW's assert that all files it's about to fsync do exist:
         assertTrue(ex.getMessage().matches("file .* does not exist; files=\\[.*\\]"));
-      } catch (CorruptIndexException ex) {
+      } catch (
+          @SuppressWarnings("unused")
+          CorruptIndexException ex) {
         // Exceptions are fine - we are running out of file handlers here
         continue;
-      } catch (FileNotFoundException | NoSuchFileException ex) {
+      } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException ex) {
         continue;
       }
       failure.clearDoFail();
@@ -2070,7 +2084,9 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
 
       try {
         iw.rollback();
-      } catch (FakeIOException expected) {
+      } catch (
+          @SuppressWarnings("unused")
+          FakeIOException expected) {
         // ok, we randomly hit exc here
       }
 
@@ -2142,10 +2158,14 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           // Flush new segment:
           DirectoryReader.open(w).close();
         }
-      } catch (AlreadyClosedException ace) {
+      } catch (
+          @SuppressWarnings("unused")
+          AlreadyClosedException ace) {
         // OK: e.g. CMS hit the exc in BG thread and closed the writer
         break;
-      } catch (FakeIOException fioe) {
+      } catch (
+          @SuppressWarnings("unused")
+          FakeIOException fioe) {
         // OK: e.g. SMS hit the exception
         break;
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions2.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions2.java
@@ -148,7 +148,9 @@ public class TestIndexWriterExceptions2 extends LuceneTestCase {
                   "dv2",
                   new BytesRef(Integer.toString(i + 1)));
             }
-          } catch (AlreadyClosedException ace) {
+          } catch (
+              @SuppressWarnings("unused")
+              AlreadyClosedException ace) {
             // OK: writer was closed by abort; we just reopen now:
             assertTrue(iw.isDeleterClosed());
             assertTrue(allowAlreadyClosed);
@@ -185,7 +187,9 @@ public class TestIndexWriterExceptions2 extends LuceneTestCase {
               iw.deleteDocuments(
                   new Term("id", Integer.toString(i)), new Term("id", Integer.toString(-i)));
             }
-          } catch (AlreadyClosedException ace) {
+          } catch (
+              @SuppressWarnings("unused")
+              AlreadyClosedException ace) {
             // OK: writer was closed by abort; we just reopen now:
             assertTrue(iw.isDeleterClosed());
             assertTrue(allowAlreadyClosed);
@@ -223,7 +227,9 @@ public class TestIndexWriterExceptions2 extends LuceneTestCase {
             if (DirectoryReader.indexExists(dir)) {
               TestUtil.checkIndex(dir);
             }
-          } catch (AlreadyClosedException ace) {
+          } catch (
+              @SuppressWarnings("unused")
+              AlreadyClosedException ace) {
             // OK: writer was closed by abort; we just reopen now:
             assertTrue(iw.isDeleterClosed());
             assertTrue(allowAlreadyClosed);
@@ -253,7 +259,9 @@ public class TestIndexWriterExceptions2 extends LuceneTestCase {
           e.printStackTrace(exceptionStream);
           try {
             iw.rollback();
-          } catch (Throwable t) {
+          } catch (
+              @SuppressWarnings("unused")
+              Throwable t) {
           }
         } else {
           Rethrow.rethrow(e);

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterLockRelease.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterLockRelease.java
@@ -35,11 +35,11 @@ public class TestIndexWriterLockRelease extends LuceneTestCase {
     try {
       new IndexWriter(
           dir, new IndexWriterConfig(new MockAnalyzer(random())).setOpenMode(OpenMode.APPEND));
-    } catch (FileNotFoundException | NoSuchFileException e) {
+    } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException e) {
       try {
         new IndexWriter(
             dir, new IndexWriterConfig(new MockAnalyzer(random())).setOpenMode(OpenMode.APPEND));
-      } catch (FileNotFoundException | NoSuchFileException e1) {
+      } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException e1) {
       }
     } finally {
       dir.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
@@ -409,7 +409,9 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     try {
       w.addIndexes(dirs);
       fail("didn't get expected exception");
-    } catch (IllegalArgumentException expected) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalArgumentException expected) {
       // pass
     } catch (IOException fakeDiskFull) {
       final Exception e;
@@ -459,7 +461,9 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     try {
       w.addIndexes(readers);
       fail("didn't get expected exception");
-    } catch (IllegalArgumentException expected) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalArgumentException expected) {
       // pass
     } catch (IOException fakeDiskFull) {
       final Exception e;

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
@@ -416,10 +416,14 @@ public class TestIndexWriterMerging extends LuceneTestCase {
                   for (int i = 0; i < 100; i++) {
                     try {
                       finalWriter.addDocument(doc);
-                    } catch (AlreadyClosedException e) {
+                    } catch (
+                        @SuppressWarnings("unused")
+                        AlreadyClosedException e) {
                       done = true;
                       break;
-                    } catch (NullPointerException e) {
+                    } catch (
+                        @SuppressWarnings("unused")
+                        NullPointerException e) {
                       done = true;
                       break;
                     } catch (Throwable e) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterNRTIsCurrent.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterNRTIsCurrent.java
@@ -132,7 +132,9 @@ public class TestIndexWriterNRTIsCurrent extends LuceneTestCase {
         if (currentReader != null) {
           try {
             currentReader.decRef();
-          } catch (IOException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              IOException e) {
           }
         }
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
@@ -107,7 +107,9 @@ public class TestIndexWriterOnDiskFull extends LuceneTestCase {
               dir.setMaxSizeInBytes(0);
               try {
                 writer.close();
-              } catch (AlreadyClosedException ace) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  AlreadyClosedException ace) {
                 // OK
               }
             }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnJRECrash.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnJRECrash.java
@@ -76,7 +76,9 @@ public class TestIndexWriterOnJRECrash extends TestNRTThreads {
             public void run() {
               try {
                 Thread.sleep(crashTime);
-              } catch (InterruptedException e) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  InterruptedException e) {
               }
               crashJRE();
             }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
@@ -1224,7 +1224,9 @@ public class TestIndexWriterReader extends LuceneTestCase {
                       ASC_SORT ? points.getMinPackedValue() : points.getMaxPackedValue();
                   return LongPoint.decodeDimension(sortValue, 0);
                 }
-              } catch (IOException e) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  IOException e) {
               }
               return MISSING_VALUE;
             });

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterThreadsToSegments.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterThreadsToSegments.java
@@ -274,7 +274,9 @@ public class TestIndexWriterThreadsToSegments extends LuceneTestCase {
                 for (int j = 0; j < 1000; j++) {
                   w.addDocument(doc);
                 }
-              } catch (AlreadyClosedException ace) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  AlreadyClosedException ace) {
                 // ok
               } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -289,7 +291,9 @@ public class TestIndexWriterThreadsToSegments extends LuceneTestCase {
     Thread.sleep(100);
     try {
       w.close();
-    } catch (IllegalStateException ise) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalStateException ise) {
       // OK but not required
     }
     for (Thread t : threads) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
@@ -114,7 +114,9 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
             }
             break;
           }
-        } catch (AlreadyClosedException ace) {
+        } catch (
+            @SuppressWarnings("unused")
+            AlreadyClosedException ace) {
           // OK: abort closes the writer
           break;
         } catch (Throwable t) {
@@ -172,7 +174,9 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
       dir.setMaxSizeInBytes(0);
       try {
         writer.commit();
-      } catch (AlreadyClosedException ace) {
+      } catch (
+          @SuppressWarnings("unused")
+          AlreadyClosedException ace) {
         // OK: abort closes the writer
         assertTrue(writer.isDeleterClosed());
       } finally {
@@ -302,10 +306,14 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
         writer.commit();
         writer.close();
         success = true;
-      } catch (AlreadyClosedException ace) {
+      } catch (
+          @SuppressWarnings("unused")
+          AlreadyClosedException ace) {
         // OK: abort closes the writer
         assertTrue(writer.isDeleterClosed());
-      } catch (IOException ioe) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException ioe) {
         writer.rollback();
         failure.clearDoFail();
       }
@@ -602,7 +610,9 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
                           writerRef.get().prepareCommit();
                         }
                         writerRef.get().commit();
-                      } catch (AlreadyClosedException | NullPointerException ace) {
+                      } catch (@SuppressWarnings("unused")
+                          AlreadyClosedException
+                          | NullPointerException ace) {
                         // ok
                       } finally {
                         commitLock.unlock();
@@ -615,7 +625,10 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
                       }
                       try {
                         writerRef.get().addDocument(docs.nextDoc());
-                      } catch (AlreadyClosedException | NullPointerException | AssertionError ace) {
+                      } catch (@SuppressWarnings("unused")
+                          AlreadyClosedException
+                          | NullPointerException
+                          | AssertionError ace) {
                         // ok
                       }
                       break;

--- a/lucene/core/src/test/org/apache/lucene/index/TestOrdinalMap.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestOrdinalMap.java
@@ -38,7 +38,7 @@ public class TestOrdinalMap extends LuceneTestCase {
     try {
       ORDINAL_MAP_OWNER_FIELD = OrdinalMap.class.getDeclaredField("owner");
     } catch (Exception e) {
-      throw new Error();
+      throw new Error(e);
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestReaderClosed.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestReaderClosed.java
@@ -67,9 +67,13 @@ public class TestReaderClosed extends LuceneTestCase {
     reader.close();
     try {
       searcher.search(query, 5);
-    } catch (AlreadyClosedException ace) {
+    } catch (
+        @SuppressWarnings("unused")
+        AlreadyClosedException ace) {
       // expected
-    } catch (RejectedExecutionException ree) {
+    } catch (
+        @SuppressWarnings("unused")
+        RejectedExecutionException ree) {
       // expected if the searcher has been created with threads since LuceneTestCase
       // closes the thread-pool in a reader close listener
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
@@ -371,7 +371,9 @@ public class TestSegmentInfos extends LuceneTestCase {
             System.out.println("TEST: Altering the file did not update the checksum, aborting...");
           }
           return;
-        } catch (CorruptIndexException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            CorruptIndexException e) {
           // ok
         }
         corrupt = true;

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentTermEnum.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentTermEnum.java
@@ -87,7 +87,9 @@ public class TestSegmentTermEnum extends LuceneTestCase {
     long ordB;
     try {
       ordB = terms.ord();
-    } catch (UnsupportedOperationException uoe) {
+    } catch (
+        @SuppressWarnings("unused")
+        UnsupportedOperationException uoe) {
       // ok -- codec is not required to support ord
       reader.close();
       return;

--- a/lucene/core/src/test/org/apache/lucene/index/TestTragicIndexWriterDeadlock.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTragicIndexWriterDeadlock.java
@@ -52,7 +52,9 @@ public class TestTragicIndexWriterDeadlock extends LuceneTestCase {
                 w.addDocument(new Document());
                 w.commit();
               }
-            } catch (Throwable t) {
+            } catch (
+                @SuppressWarnings("unused")
+                Throwable t) {
               done.set(true);
               // System.out.println("commit exc:");
               // t.printStackTrace(System.out);
@@ -80,7 +82,9 @@ public class TestTragicIndexWriterDeadlock extends LuceneTestCase {
               } finally {
                 r.close();
               }
-            } catch (Throwable t) {
+            } catch (
+                @SuppressWarnings("unused")
+                Throwable t) {
               done.set(true);
               // System.out.println("nrt exc:");
               // t.printStackTrace(System.out);

--- a/lucene/core/src/test/org/apache/lucene/index/TestTransactions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTransactions.java
@@ -124,29 +124,41 @@ public class TestTransactions extends LuceneTestCase {
         synchronized (lock) {
           try {
             writer1.prepareCommit();
-          } catch (Throwable t) {
+          } catch (
+              @SuppressWarnings("unused")
+              Throwable t) {
             // release resources
             try {
               writer1.rollback();
-            } catch (Throwable ignore) {
+            } catch (
+                @SuppressWarnings("unused")
+                Throwable ignore) {
             }
             try {
               writer2.rollback();
-            } catch (Throwable ignore) {
+            } catch (
+                @SuppressWarnings("unused")
+                Throwable ignore) {
             }
             return;
           }
           try {
             writer2.prepareCommit();
-          } catch (Throwable t) {
+          } catch (
+              @SuppressWarnings("unused")
+              Throwable t) {
             // release resources
             try {
               writer1.rollback();
-            } catch (Throwable ignore) {
+            } catch (
+                @SuppressWarnings("unused")
+                Throwable ignore) {
             }
             try {
               writer2.rollback();
-            } catch (Throwable ignore) {
+            } catch (
+                @SuppressWarnings("unused")
+                Throwable ignore) {
             }
             return;
           }

--- a/lucene/core/src/test/org/apache/lucene/index/TestTwoPhaseCommitTool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTwoPhaseCommitTool.java
@@ -102,7 +102,9 @@ public class TestTwoPhaseCommitTool extends LuceneTestCase {
     boolean anyFailure = false;
     try {
       TwoPhaseCommitTool.execute(objects);
-    } catch (Throwable t) {
+    } catch (
+        @SuppressWarnings("unused")
+        Throwable t) {
       anyFailure = true;
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreQuery.java
@@ -95,7 +95,9 @@ public class TestConstantScoreQuery extends LuceneTestCase {
         Collection<Scorable.ChildScorable> children = s.getChildren();
         if (children.size() == 0) return s;
         s = children.stream().findFirst().get().child;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         // If FakeScorer returns UnsupportedOperationException
         // We catch Exception here to deal with the (impossible) IOException too
         return s;

--- a/lucene/core/src/test/org/apache/lucene/search/TestFilterWeight.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFilterWeight.java
@@ -49,7 +49,9 @@ public class TestFilterWeight extends LuceneTestCase {
                   + " but it does override\n'"
                   + subClassMethod
                   + "'");
-        } catch (NoSuchMethodException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            NoSuchMethodException e) {
           /* FilterWeight must not override the bulkScorer method
            * since as of July 2016 not all deriving classes use the
            * {code}return in.bulkScorer(content);{code}
@@ -66,7 +68,9 @@ public class TestFilterWeight extends LuceneTestCase {
             "getReturnType() difference",
             superClassMethod.getReturnType(),
             subClassMethod.getReturnType());
-      } catch (NoSuchMethodException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          NoSuchMethodException e) {
         fail(subClass + " needs to override '" + superClassMethod + "'");
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -1122,7 +1122,9 @@ public class TestLRUQueryCache extends LuceneTestCase {
       // trigger an eviction
       searcher.search(new MatchAllDocsQuery(), new TotalHitCountCollector());
       fail();
-    } catch (ConcurrentModificationException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        ConcurrentModificationException e) {
       // expected
     } catch (RuntimeException e) {
       // expected: wrapped when executor is in use

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -235,7 +235,9 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
                 awaitEnterWarm.countDown();
                 awaitClose.await();
               }
-            } catch (InterruptedException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                InterruptedException e) {
               //
             }
             return new IndexSearcher(r, es);
@@ -270,7 +272,9 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
                   }
                   searcherManager.maybeRefresh();
                   success.set(true);
-                } catch (AlreadyClosedException e) {
+                } catch (
+                    @SuppressWarnings("unused")
+                    AlreadyClosedException e) {
                   // expected
                 } catch (Throwable e) {
                   if (VERBOSE) {
@@ -642,7 +646,9 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
                   IndexSearcher searcher;
                   try {
                     searcher = mgr.acquire();
-                  } catch (AlreadyClosedException ace) {
+                  } catch (
+                      @SuppressWarnings("unused")
+                      AlreadyClosedException ace) {
                     // ok
                     continue;
                   }
@@ -672,7 +678,9 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
                   refreshCount++;
                   try {
                     mgr.maybeRefreshBlocking();
-                  } catch (AlreadyClosedException ace) {
+                  } catch (
+                      @SuppressWarnings("unused")
+                      AlreadyClosedException ace) {
                     // ok
                     aceCount++;
                     continue;
@@ -704,7 +712,9 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
                   try {
                     mgrRef.set(new SearcherManager(writerRef.get(), null));
                     break;
-                  } catch (AlreadyClosedException ace) {
+                  } catch (
+                      @SuppressWarnings("unused")
+                      AlreadyClosedException ace) {
                     // ok
                     aceCount++;
                   }

--- a/lucene/core/src/test/org/apache/lucene/store/TestMmapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMmapDirectory.java
@@ -64,7 +64,7 @@ public class TestMmapDirectory extends BaseDirectoryTestCase {
                     clone.seek(0);
                     clone.readBytes(accum, 0, accum.length);
                   }
-                } catch (IOException | AlreadyClosedException ok) {
+                } catch (@SuppressWarnings("unused") IOException | AlreadyClosedException ok) {
                   // OK
                 } catch (InterruptedException e) {
                   throw new RuntimeException(e);

--- a/lucene/core/src/test/org/apache/lucene/util/TestSetOnce.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSetOnce.java
@@ -37,9 +37,13 @@ public class TestSetOnce extends LuceneTestCase {
         sleep(RAND.nextInt(10)); // sleep for a short time
         set.set(Integer.valueOf(getName().substring(2)));
         success = true;
-      } catch (InterruptedException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          InterruptedException e) {
         // ignore
-      } catch (RuntimeException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          RuntimeException e) {
         // TODO: change exception type
         // expected.
         success = false;

--- a/lucene/core/src/test/org/apache/lucene/util/TestStressRamUsageEstimator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestStressRamUsageEstimator.java
@@ -92,7 +92,9 @@ public class TestStressRamUsageEstimator extends LuceneTestCase {
           seg[i] = new byte[random().nextInt(7)];
         }
       }
-    } catch (OutOfMemoryError e) {
+    } catch (
+        @SuppressWarnings("unused")
+        OutOfMemoryError e) {
       // Release and quit.
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/util/TestUnicodeUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestUnicodeUtil.java
@@ -206,7 +206,9 @@ public class TestUnicodeUtil extends LuceneTestCase {
         assertFalse(rc == -1);
         assertEquals(cpString.substring(rs, rs + rc), str);
         continue;
-      } catch (IndexOutOfBoundsException | IllegalArgumentException e1) {
+      } catch (@SuppressWarnings("unused")
+          IndexOutOfBoundsException
+          | IllegalArgumentException e1) {
         // Ignored.
       }
       assertTrue(rc == -1);

--- a/lucene/core/src/test/org/apache/lucene/util/TestWeakIdentityMap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestWeakIdentityMap.java
@@ -133,7 +133,9 @@ public class TestWeakIdentityMap extends LuceneTestCase {
         assertTrue("previousSize(" + size + ")>=iteratorSize(" + c + ")", size >= c);
         assertTrue("iteratorSize(" + c + ")>=newSize(" + newSize + ")", c >= newSize);
         size = newSize;
-      } catch (InterruptedException ie) {
+      } catch (
+          @SuppressWarnings("unused")
+          InterruptedException ie) {
       }
 
     map.clear();
@@ -244,7 +246,9 @@ public class TestWeakIdentityMap extends LuceneTestCase {
         assertTrue("previousSize(" + size + ")>=iteratorSize(" + c + ")", size >= c);
         assertTrue("iteratorSize(" + c + ")>=newSize(" + newSize + ")", c >= newSize);
         size = newSize;
-      } catch (InterruptedException ie) {
+      } catch (
+          @SuppressWarnings("unused")
+          InterruptedException ie) {
       }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestLimitedFiniteStringsIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestLimitedFiniteStringsIterator.java
@@ -40,7 +40,9 @@ public class TestLimitedFiniteStringsIterator extends LuceneTestCase {
         // NOTE: cannot do this, because the method is not
         // guaranteed to detect cycles when you have a limit
         // assertTrue(Operations.isFinite(a));
-      } catch (IllegalArgumentException iae) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException iae) {
         assertFalse(Operations.isFinite(a));
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
@@ -367,7 +367,9 @@ public class TestFSTs extends LuceneTestCase {
         if (ord == 0) {
           try {
             termsEnum.ord();
-          } catch (UnsupportedOperationException uoe) {
+          } catch (
+              @SuppressWarnings("unused")
+              UnsupportedOperationException uoe) {
             if (VERBOSE) {
               System.out.println("TEST: codec doesn't support ord; FST stores docFreq");
             }
@@ -1766,7 +1768,9 @@ public class TestFSTs extends LuceneTestCase {
     fst.getFirstArc(arc);
     try {
       arc = fst.findTargetArc((int) 'm', arc, arc, reader);
-    } catch (AssertionError ae) {
+    } catch (
+        @SuppressWarnings("unused")
+        AssertionError ae) {
       // expected
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
@@ -521,7 +521,9 @@ public class TestPackedInts extends LuceneTestCase {
     Packed64 p64 = null;
     try {
       p64 = new Packed64(INDEX, BITS);
-    } catch (OutOfMemoryError oome) {
+    } catch (
+        @SuppressWarnings("unused")
+        OutOfMemoryError oome) {
       // This can easily happen: we're allocating a
       // long[] that needs 256-273 MB.  Heap is 512 MB,
       // but not all of that is available for large
@@ -540,7 +542,9 @@ public class TestPackedInts extends LuceneTestCase {
     Packed64SingleBlock p64sb = null;
     try {
       p64sb = Packed64SingleBlock.create(INDEX, BITS);
-    } catch (OutOfMemoryError oome) {
+    } catch (
+        @SuppressWarnings("unused")
+        OutOfMemoryError oome) {
       // Ignore: see comment above
     }
     if (p64sb != null) {

--- a/lucene/demo/src/java/org/apache/lucene/demo/IndexFiles.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/IndexFiles.java
@@ -157,7 +157,9 @@ public class IndexFiles {
                 throws IOException {
               try {
                 indexDoc(writer, file, attrs.lastModifiedTime().toMillis());
-              } catch (IOException ignore) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  IOException ignore) {
                 // don't index files that can't be read.
               }
               return FileVisitResult.CONTINUE;

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/js/JavascriptCompiler.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/js/JavascriptCompiler.java
@@ -766,7 +766,7 @@ public final class JavascriptCompiler {
       type = MethodHandles.publicLookup().unreflect(method).type();
     } catch (IllegalAccessException iae) {
       throw new IllegalArgumentException(
-          method + " is not accessible (declaring class or method not public).");
+          method + " is not accessible (declaring class or method not public).", iae);
     }
     // do some checks if the signature is "compatible":
     if (!Modifier.isStatic(method.getModifiers())) {
@@ -791,7 +791,9 @@ public final class JavascriptCompiler {
     try {
       final Class<?> clazz = method.getDeclaringClass();
       ok = Class.forName(clazz.getName(), false, parent) == clazz;
-    } catch (ClassNotFoundException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        ClassNotFoundException e) {
       ok = false;
     }
     if (!ok) {

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyCombined.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyCombined.java
@@ -905,7 +905,9 @@ public class TestTaxonomyCombined extends FacetTestCase {
     try {
       assertEquals(TaxonomyReader.ROOT_ORDINAL, tr.getParallelTaxonomyArrays().parents()[author]);
       // ok
-    } catch (ArrayIndexOutOfBoundsException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        ArrayIndexOutOfBoundsException e) {
       fail(
           "After category addition, commit() and refresh(), getParent for "
               + author

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/writercache/Test2GBCharBlockArray.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/writercache/Test2GBCharBlockArray.java
@@ -35,7 +35,9 @@ public class Test2GBCharBlockArray extends LuceneTestCase {
       count++;
       try {
         array.append(chars, 0, size);
-      } catch (IllegalStateException ise) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalStateException ise) {
         assertTrue(count * (long) size + blockSize > Integer.MAX_VALUE);
         break;
       }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/Highlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/Highlighter.java
@@ -310,7 +310,9 @@ public class Highlighter {
         try {
           tokenStream.end();
           tokenStream.close();
-        } catch (Exception e) {
+        } catch (
+            @SuppressWarnings("unused")
+            Exception e) {
         }
       }
     }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/QueryTermExtractor.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/QueryTermExtractor.java
@@ -78,7 +78,9 @@ public final class QueryTermExtractor {
         // IDF algorithm taken from ClassicSimilarity class
         float idf = (float) (Math.log(totalNumDocs / (double) (docFreq + 1)) + 1.0);
         terms[i].weight *= idf;
-      } catch (IOException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException e) {
         // ignore
       }
     }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/OffsetsEnum.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/OffsetsEnum.java
@@ -103,12 +103,16 @@ public abstract class OffsetsEnum implements Comparable<OffsetsEnum>, Closeable 
     String offset = "";
     try {
       offset = ",[" + startOffset() + "-" + endOffset() + "]";
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
       // ignore; for debugging only
     }
     try {
       return name + "(term:" + getTerm().utf8ToString() + offset + ")";
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
       return name;
     }
   }

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CreateIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CreateIndexDialogFactory.java
@@ -332,7 +332,9 @@ public class CreateIndexDialogFactory implements DialogOpener.DialogFactory {
                           }
                         });
                     Files.deleteIfExists(path);
-                  } catch (IOException ex2) {
+                  } catch (
+                      @SuppressWarnings("unused")
+                      IOException ex2) {
                   }
 
                   log.error("Cannot create index", ex);

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/NumericUtils.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/NumericUtils.java
@@ -95,7 +95,9 @@ public class NumericUtils {
     try {
       // try parse to long
       return Long.parseLong(value.trim());
-    } catch (NumberFormatException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        NumberFormatException e) {
       // try parse to double
       double dvalue = Double.parseDouble(value.trim());
       return org.apache.lucene.util.NumericUtils.doubleToSortableLong(dvalue);

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
@@ -93,7 +93,9 @@ public final class AnalysisImpl implements Analysis {
           // add to presets if no args constructor is available
           clazz.getConstructor();
           types.add(clazz);
-        } catch (NoSuchMethodException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            NoSuchMethodException e) {
         }
       }
       presetAnalyzerTypes = List.copyOf(types);
@@ -281,14 +283,18 @@ public final class AnalysisImpl implements Analysis {
             new NamedTokens(TokenFilterFactory.findSPIName(tokenFilterFactory.getClass()), tokens));
         try {
           listBasedTokenStream.close();
-        } catch (IOException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            IOException e) {
           // do nothing;
         }
         listBasedTokenStream = new ListBasedTokenStream(listBasedTokenStream, attributeSources);
       }
       try {
         listBasedTokenStream.close();
-      } catch (IOException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException e) {
         // do nothing.
       } finally {
         reader.close();

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/commits/Commit.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/commits/Commit.java
@@ -39,7 +39,9 @@ public final class Commit {
     commit.segCount = ic.getSegmentCount();
     try {
       commit.userData = IndexUtils.getCommitUserData(ic);
-    } catch (IOException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        IOException e) {
     }
     return commit;
   }

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/commits/File.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/commits/File.java
@@ -31,7 +31,9 @@ public final class File {
     file.fileName = name;
     try {
       file.displaySize = CommitsImpl.toDisplaySize(Files.size(Paths.get(indexPath, name)));
-    } catch (IOException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        IOException e) {
       file.displaySize = "unknown";
     }
     return file;

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/commits/Segment.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/commits/Segment.java
@@ -49,7 +49,9 @@ public final class Segment {
     segment.codecName = segInfo.info.getCodec().getName();
     try {
       segment.displaySize = CommitsImpl.toDisplaySize(segInfo.sizeInBytes());
-    } catch (IOException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        IOException e) {
     }
     segment.useCompoundFile = segInfo.info.getUseCompoundFile();
     return segment;

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/overview/OverviewImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/overview/OverviewImpl.java
@@ -51,7 +51,7 @@ public final class OverviewImpl extends LukeModel implements Overview {
     try {
       this.termCounts = new TermCounts(reader);
     } catch (IOException e) {
-      throw new LukeException("An error occurred when collecting term statistics.");
+      throw new LukeException("An error occurred when collecting term statistics.", e);
     }
     this.topTerms = new TopTerms(reader);
   }

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/search/SearchImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/search/SearchImpl.java
@@ -261,7 +261,7 @@ public final class SearchImpl extends LukeModel implements Search {
     try {
       return mlt.like(docid);
     } catch (IOException e) {
-      throw new LukeException("Failed to create MLT query for doc: " + docid);
+      throw new LukeException("Failed to create MLT query for doc: " + docid, e);
     }
   }
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/tools/IndexToolsImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/tools/IndexToolsImpl.java
@@ -190,7 +190,9 @@ public final class IndexToolsImpl extends LukeModel implements IndexTools {
       if (writer != null) {
         try {
           writer.close();
-        } catch (IOException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            IOException e) {
         }
       }
     }

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/util/twentynewsgroups/MessageFilesParser.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/util/twentynewsgroups/MessageFilesParser.java
@@ -56,7 +56,9 @@ public class MessageFilesParser extends SimpleFileVisitor<Path> {
           messages.add(parse(file));
         }
       }
-    } catch (IOException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        IOException e) {
       log.warn("Invalid file? {}", file);
     }
     return FileVisitResult.CONTINUE;
@@ -97,7 +99,9 @@ public class MessageFilesParser extends SimpleFileVisitor<Path> {
           case "Lines":
             try {
               message.setLines(Integer.parseInt(ary[1].trim()));
-            } catch (NumberFormatException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                NumberFormatException e) {
             }
             break;
           default:

--- a/lucene/luke/src/java/org/apache/lucene/luke/util/BytesRefUtils.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/util/BytesRefUtils.java
@@ -25,7 +25,9 @@ public final class BytesRefUtils {
   public static String decode(BytesRef ref) {
     try {
       return ref.utf8ToString();
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
       return ref.toString();
     }
   }

--- a/lucene/luke/src/java/org/apache/lucene/luke/util/reflection/ClassScanner.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/util/reflection/ClassScanner.java
@@ -69,7 +69,9 @@ public class ClassScanner {
       try {
         executorService.shutdown();
         executorService.awaitTermination(10, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          InterruptedException e) {
       } finally {
         executorService.shutdownNow();
       }

--- a/lucene/luke/src/java/org/apache/lucene/luke/util/reflection/SubtypeCollector.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/util/reflection/SubtypeCollector.java
@@ -79,7 +79,9 @@ final class SubtypeCollector<T> implements Runnable {
                   types.add(clazz.asSubclass(superType));
                 }
                 break;
-              } catch (Throwable e) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  Throwable e) {
               }
             }
           }

--- a/lucene/misc/src/java/org/apache/lucene/misc/HighFreqTerms.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/HighFreqTerms.java
@@ -65,7 +65,9 @@ public class HighFreqTerms {
       } else {
         try {
           numTerms = Integer.parseInt(args[i]);
-        } catch (NumberFormatException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            NumberFormatException e) {
           field = args[i];
         }
       }

--- a/lucene/misc/src/java/org/apache/lucene/misc/index/MultiPassIndexSplitter.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/index/MultiPassIndexSplitter.java
@@ -150,7 +150,9 @@ public class MultiPassIndexSplitter {
             System.err.println("Invalid input index - skipping: " + file);
             continue;
           }
-        } catch (Exception e) {
+        } catch (
+            @SuppressWarnings("unused")
+            Exception e) {
           System.err.println("Invalid input index - skipping: " + file);
           continue;
         }

--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -95,7 +95,9 @@ public class DirectIODirectory extends FilterDirectory {
               .filter(e -> e.toString().equalsIgnoreCase("DIRECT"))
               .findFirst()
               .orElse(null);
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
       option = null;
     }
     ExtendedOpenOption_DIRECT = option;

--- a/lucene/misc/src/test/org/apache/lucene/misc/document/TestLazyDocument.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/document/TestLazyDocument.java
@@ -50,7 +50,9 @@ public class TestLazyDocument extends LuceneTestCase {
       try {
         dir.close();
         dir = null;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         /* NOOP */
       }
     }

--- a/lucene/misc/src/test/org/apache/lucene/misc/store/TestHardLinkCopyDirectoryWrapper.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/store/TestHardLinkCopyDirectoryWrapper.java
@@ -81,7 +81,9 @@ public class TestHardLinkCopyDirectoryWrapper extends BaseDirectoryTestCase {
         assumeTrue(
             "hardlinks are not supported",
             destAttr.fileKey() != null && destAttr.fileKey().equals(sourceAttr.fileKey()));
-      } catch (UnsupportedOperationException ex) {
+      } catch (
+          @SuppressWarnings("unused")
+          UnsupportedOperationException ex) {
         assumeFalse("hardlinks are not supported", true);
       }
 

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/ConcurrentQueryLoader.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/ConcurrentQueryLoader.java
@@ -109,7 +109,9 @@ public class ConcurrentQueryLoader implements Closeable {
     this.executor.shutdown();
     try {
       this.shutdownLatch.await();
-    } catch (InterruptedException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        InterruptedException e) {
       // fine
     }
     if (errors.size() > 0) {
@@ -143,7 +145,9 @@ public class ConcurrentQueryLoader implements Closeable {
         }
       } catch (IOException e) {
         errors.add(e);
-      } catch (InterruptedException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          InterruptedException e) {
         Thread.currentThread().interrupt();
       } finally {
         shutdownLatch.countDown();

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/EnumFieldSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/EnumFieldSource.java
@@ -52,7 +52,9 @@ public class EnumFieldSource extends FieldCacheSource {
     Integer intValue = null;
     try {
       intValue = Integer.parseInt(valueStr);
-    } catch (NumberFormatException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        NumberFormatException e) {
     }
     return intValue;
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
@@ -606,7 +606,9 @@ public final class MoreLikeThis {
 
       try {
         query.add(tq, BooleanClause.Occur.SHOULD);
-      } catch (IndexSearcher.TooManyClauses ignore) {
+      } catch (
+          @SuppressWarnings("unused")
+          IndexSearcher.TooManyClauses ignore) {
         break;
       }
     }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
@@ -496,7 +496,9 @@ public abstract class QueryParserBase extends QueryBuilder
 
     try {
       part1 = DateTools.dateToString(df.parse(part1), resolution);
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
     }
 
     try {
@@ -514,7 +516,9 @@ public abstract class QueryParserBase extends QueryBuilder
         d2 = cal.getTime();
       }
       part2 = DateTools.dateToString(d2, resolution);
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
     }
 
     return newRangeQuery(field, part1, part2, startInclusive, endInclusive);
@@ -812,7 +816,9 @@ public abstract class QueryParserBase extends QueryBuilder
     float fms = fuzzyMinSim;
     try {
       fms = Float.parseFloat(fuzzySlop.image.substring(1));
-    } catch (Exception ignored) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception ignored) {
     }
     if (fms < 0.0f) {
       throw new ParseException(
@@ -830,7 +836,9 @@ public abstract class QueryParserBase extends QueryBuilder
     if (fuzzySlop != null) {
       try {
         s = (int) Float.parseFloat(fuzzySlop.image.substring(1));
-      } catch (Exception ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception ignored) {
       }
     }
     return getFieldQuery(
@@ -843,7 +851,9 @@ public abstract class QueryParserBase extends QueryBuilder
       float f = (float) 1.0;
       try {
         f = Float.parseFloat(boost.image);
-      } catch (Exception ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception ignored) {
         /* Should this be handled somehow? (defaults to "no boost", if
          * boost number is invalid)
          */

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/config/ConfigurationKey.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/config/ConfigurationKey.java
@@ -18,8 +18,9 @@ package org.apache.lucene.queryparser.flexible.core.config;
 
 /**
  * An instance of this class represents a key that is used to retrieve a value from {@link
- * AbstractQueryConfig}. It also holds the value's type, which is defined in the generic argument.
+ * AbstractQueryConfig}.
  *
+ * @param <T> holds the value's type, which is defined in the generic argument.
  * @see AbstractQueryConfig
  */
 public final class ConfigurationKey<T> {

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/PathQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/PathQueryNode.java
@@ -143,7 +143,9 @@ public class PathQueryNode extends QueryNodeImpl {
     for (int i = startIndex; i < this.values.size(); i++) {
       try {
         rValues.add(this.values.get(i).clone());
-      } catch (CloneNotSupportedException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          CloneNotSupportedException e) {
         // this will not happen
       }
     }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/messages/NLS.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/messages/NLS.java
@@ -84,7 +84,9 @@ public class NLS {
     try {
       load(clazz);
       if (!bundles.containsKey(bundleName)) bundles.put(bundleName, clazz);
-    } catch (Throwable e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Throwable e) {
       // ignore all errors and exceptions
       // because this function is supposed to be called at class load time.
     }
@@ -101,7 +103,9 @@ public class NLS {
         try {
           Object obj = resourceBundle.getObject(messageKey);
           if (obj != null) return obj;
-        } catch (MissingResourceException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            MissingResourceException e) {
           // just continue it might be on the next resource bundle
         }
       }
@@ -131,7 +135,7 @@ public class NLS {
     try {
       field.set(null, field.getName());
       validateMessage(field.getName(), clazz);
-    } catch (IllegalArgumentException | IllegalAccessException e) {
+    } catch (@SuppressWarnings("unused") IllegalArgumentException | IllegalAccessException e) {
       // should not happen
     }
   }
@@ -145,10 +149,14 @@ public class NLS {
       if (resourceBundle != null) {
         resourceBundle.getObject(key);
       }
-    } catch (MissingResourceException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        MissingResourceException e) {
       // System.err.println("WARN: Message with key:" + key + " and locale: "
       //    + Locale.getDefault() + " not found.");
-    } catch (Throwable e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Throwable e) {
       // ignore all other errors and exceptions
       // since this code is just a test to see if the message is present on the
       // system

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/AnalyzerQueryNodeProcessor.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/AnalyzerQueryNodeProcessor.java
@@ -145,7 +145,9 @@ public class AnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
               }
             }
 
-          } catch (IOException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              IOException e) {
             // ignore
           }
 
@@ -172,7 +174,9 @@ public class AnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
             assert hasNext == true;
             term = termAtt.toString();
 
-          } catch (IOException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              IOException e) {
             // safe to ignore, because we know the number of tokens
           }
 
@@ -195,7 +199,9 @@ public class AnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
                   assert hasNext == true;
                   term = termAtt.toString();
 
-                } catch (IOException e) {
+                } catch (
+                    @SuppressWarnings("unused")
+                    IOException e) {
                   // safe to ignore, because we know the number of tokens
                 }
 
@@ -212,7 +218,9 @@ public class AnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
                   boolean hasNext = buffer.incrementToken();
                   assert hasNext == true;
                   term = termAtt.toString();
-                } catch (IOException e) {
+                } catch (
+                    @SuppressWarnings("unused")
+                    IOException e) {
                   // safe to ignore, because we know the number of tokens
                 }
                 if (posIncrAtt != null && posIncrAtt.getPositionIncrement() == 0) {
@@ -263,7 +271,9 @@ public class AnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
                   positionIncrement = posIncrAtt.getPositionIncrement();
                 }
 
-              } catch (IOException e) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  IOException e) {
                 // safe to ignore, because we know the number of tokens
               }
 
@@ -325,7 +335,9 @@ public class AnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
                 positionIncrement = posIncrAtt.getPositionIncrement();
               }
 
-            } catch (IOException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                IOException e) {
               // safe to ignore, because we know the number of tokens
             }
 
@@ -348,7 +360,9 @@ public class AnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
         if (buffer != null) {
           try {
             buffer.close();
-          } catch (IOException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              IOException e) {
             // safe to ignore
           }
         }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/TermRangeQueryNodeProcessor.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/TermRangeQueryNodeProcessor.java
@@ -128,7 +128,9 @@ public class TermRangeQueryNodeProcessor extends QueryNodeProcessorImpl {
           upper.setText(part2);
         }
 
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         // not a date
         Analyzer analyzer = getQueryConfigHandler().get(ConfigurationKeys.ANALYZER);
         if (analyzer != null) {

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/simple/SimpleQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/simple/SimpleQueryParser.java
@@ -510,7 +510,9 @@ public class SimpleQueryParser extends QueryBuilder {
         } else {
           fuzziness = Integer.parseInt(fuzzyString);
         }
-      } catch (NumberFormatException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          NumberFormatException e) {
         // swallow number format exceptions parsing fuzziness
       }
       // negative -> 0

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/CoreParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/CoreParser.java
@@ -166,7 +166,9 @@ public class CoreParser implements SpanQueryBuilder {
     dbf.setValidating(false);
     try {
       dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-    } catch (ParserConfigurationException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        ParserConfigurationException e) {
       // ignore since all implementations are required to support the
       // {@link javax.xml.XMLConstants#FEATURE_SECURE_PROCESSING} feature
     }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/SpanOrTermsBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/SpanOrTermsBuilder.java
@@ -61,7 +61,7 @@ public class SpanOrTermsBuilder extends SpanBuilderBase {
       float boost = DOMUtils.getAttribute(e, "boost", 1.0f);
       return new SpanBoostQuery(soq, boost);
     } catch (IOException ioe) {
-      throw new ParserException("IOException parsing value:" + value);
+      throw new ParserException("IOException parsing value:" + value, ioe);
     }
   }
 }

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestQueryParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestQueryParser.java
@@ -178,7 +178,9 @@ public class TestQueryParser extends QueryParserTestBase {
               float fms = fuzzyMinSim;
               try {
                 fms = Float.parseFloat(fuzzySlop.image.substring(1, fuzzySlop.image.length() - 1));
-              } catch (Exception ignored) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  Exception ignored) {
               }
               float value = Float.parseFloat(termImage);
               return getRangeQuery(

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/IndexReplicationHandler.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/IndexReplicationHandler.java
@@ -79,7 +79,9 @@ public class IndexReplicationHandler implements ReplicationHandler {
         // IndexNotFoundException which we handle below
         return commits.get(commits.size() - 1);
       }
-    } catch (IndexNotFoundException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        IndexNotFoundException e) {
       // ignore the exception and return null
     }
     return null;

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/http/HttpClientBase.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/http/HttpClientBase.java
@@ -234,7 +234,9 @@ public abstract class HttpClientBase implements Closeable {
         if (!consumed && minusOne == -1) {
           try {
             EntityUtils.consume(entity);
-          } catch (Exception e) {
+          } catch (
+              @SuppressWarnings("unused")
+              Exception e) {
             // ignored on purpose
           }
           consumed = true;

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/http/ReplicationService.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/http/ReplicationService.java
@@ -145,7 +145,7 @@ public class ReplicationService {
     try {
       action = ReplicationAction.valueOf(pathElements[ACTION_IDX].toUpperCase(Locale.ENGLISH));
     } catch (IllegalArgumentException e) {
-      throw new ServletException("Unsupported action provided: " + pathElements[ACTION_IDX]);
+      throw new ServletException("Unsupported action provided: " + pathElements[ACTION_IDX], e);
     }
 
     final Replicator replicator = replicators.get(pathElements[SHARD_IDX]);

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/Node.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/Node.java
@@ -218,7 +218,7 @@ public abstract class Node implements Closeable {
           header = CodecUtil.readIndexHeader(in);
           footer = CodecUtil.readFooter(in);
           checksum = CodecUtil.retrieveChecksum(in);
-        } catch (EOFException | CorruptIndexException cie) {
+        } catch (@SuppressWarnings("unused") EOFException | CorruptIndexException cie) {
           // File exists but is busted: we must copy it.  This happens when node had crashed,
           // corrupting an un-fsync'd file.  On init we try
           // to delete such unreferenced files, but virus checker can block that, leaving this bad
@@ -231,7 +231,7 @@ public abstract class Node implements Closeable {
         if (VERBOSE_FILES) {
           message("file " + fileName + " has length=" + bytesToString(length));
         }
-      } catch (FileNotFoundException | NoSuchFileException e) {
+      } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException e) {
         if (VERBOSE_FILES) {
           message("file " + fileName + ": will copy [file does not exist]");
         }

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/ReplicaFileDeleter.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/ReplicaFileDeleter.java
@@ -49,7 +49,7 @@ class ReplicaFileDeleter {
     try {
       dir.openInput(fileName, IOContext.DEFAULT).close();
       return true;
-    } catch (NoSuchFileException | FileNotFoundException e) {
+    } catch (@SuppressWarnings("unused") NoSuchFileException | FileNotFoundException e) {
       return false;
     }
   }

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/TestIndexAndTaxonomyReplicationClient.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/TestIndexAndTaxonomyReplicationClient.java
@@ -165,7 +165,9 @@ public class TestIndexAndTaxonomyReplicationClient extends ReplicatorTestCase {
         } finally {
           reader.close();
         }
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         // we can hit IndexNotFoundException or e.g. EOFException (on
         // segments_N) because it is being copied at the same time it is read by
         // DirectoryReader.open().
@@ -425,7 +427,7 @@ public class TestIndexAndTaxonomyReplicationClient extends ReplicatorTestCase {
                   checker.setInfoStream(new PrintStream(bos, false, IOUtils.UTF_8), false);
                   try {
                     checker.checkIndex(null);
-                  } catch (IOException | RuntimeException ioe) {
+                  } catch (@SuppressWarnings("unused") IOException | RuntimeException ioe) {
                     // ok: we fallback below
                   }
                 }

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/TestIndexReplicationClient.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/TestIndexReplicationClient.java
@@ -121,7 +121,9 @@ public class TestIndexReplicationClient extends ReplicatorTestCase {
         } finally {
           reader.close();
         }
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         // we can hit IndexNotFoundException or e.g. EOFException (on
         // segments_N) because it is being copied at the same time it is read by
         // DirectoryReader.open().

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimplePrimaryNode.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimplePrimaryNode.java
@@ -533,7 +533,9 @@ class SimplePrimaryNode extends PrimaryNode {
       byte cmd;
       try {
         cmd = in.readByte();
-      } catch (EOFException eofe) {
+      } catch (
+          @SuppressWarnings("unused")
+          EOFException eofe) {
         // done
         return;
       }
@@ -675,7 +677,9 @@ class SimplePrimaryNode extends PrimaryNode {
 
       try {
         cmd = in.readByte();
-      } catch (EOFException eofe) {
+      } catch (
+          @SuppressWarnings("unused")
+          EOFException eofe) {
         break;
       }
 

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleReplicaNode.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleReplicaNode.java
@@ -194,7 +194,9 @@ class SimpleReplicaNode extends ReplicaNode {
 
       try {
         cmd = in.readByte();
-      } catch (EOFException eofe) {
+      } catch (
+          @SuppressWarnings("unused")
+          EOFException eofe) {
         break;
       }
 

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleServer.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleServer.java
@@ -326,7 +326,9 @@ public class SimpleServer extends LuceneTestCase {
                 while (System.nanoTime() < endTime) {
                   try {
                     Thread.sleep(10);
-                  } catch (InterruptedException e) {
+                  } catch (
+                      @SuppressWarnings("unused")
+                      InterruptedException e) {
                   }
                   if (stop.get()) {
                     break;
@@ -372,7 +374,9 @@ public class SimpleServer extends LuceneTestCase {
         Socket socket;
         try {
           socket = ss.accept();
-        } catch (SocketException se) {
+        } catch (
+            @SuppressWarnings("unused")
+            SocketException se) {
           // when ClientHandler closes our ss we will hit this
           node.message("top: server socket exc; now exit");
           break;

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestStressNRTReplication.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestStressNRTReplication.java
@@ -1109,7 +1109,9 @@ public class TestStressNRTReplication extends LuceneTestCase {
                         + hitCount);
               }
             }
-          } catch (IOException ioe) {
+          } catch (
+              @SuppressWarnings("unused")
+              IOException ioe) {
             // message("top: searcher: ignore exc talking to node " + node + ": " + ioe);
             // ioe.printStackTrace(System.out);
             IOUtils.closeWhileHandlingException(c);
@@ -1173,7 +1175,9 @@ public class TestStressNRTReplication extends LuceneTestCase {
                 stop.set(true);
                 fail(failMessage);
               }
-            } catch (IOException ioe) {
+            } catch (
+                @SuppressWarnings("unused")
+                IOException ioe) {
               // message("top: searcher: ignore exc talking to node " + node + ": " + ioe);
               // throw new RuntimeException(ioe);
               // ioe.printStackTrace(System.out);
@@ -1274,14 +1278,18 @@ public class TestStressNRTReplication extends LuceneTestCase {
               curPrimary.addOrUpdateDocument(c, doc, false);
               transLog.addDocument(idString, doc);
             }
-          } catch (IOException se) {
+          } catch (
+              @SuppressWarnings("unused")
+              IOException se) {
             // Assume primary crashed
             if (c != null) {
               message("top: indexer lost connection to primary");
             }
             try {
               c.close();
-            } catch (Throwable t) {
+            } catch (
+                @SuppressWarnings("unused")
+                Throwable t) {
             }
             curPrimary = null;
             c = null;
@@ -1303,12 +1311,16 @@ public class TestStressNRTReplication extends LuceneTestCase {
             c.out.writeByte(SimplePrimaryNode.CMD_INDEXING_DONE);
             c.flush();
             c.in.readByte();
-          } catch (IOException se) {
+          } catch (
+              @SuppressWarnings("unused")
+              IOException se) {
             // Assume primary crashed
             message("top: indexer lost connection to primary");
             try {
               c.close();
-            } catch (Throwable t) {
+            } catch (
+                @SuppressWarnings("unused")
+                Throwable t) {
             }
             curPrimary = null;
             c = null;

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/idversion/VersionBlockTreeTermsReader.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/idversion/VersionBlockTreeTermsReader.java
@@ -249,7 +249,9 @@ public final class VersionBlockTreeTermsReader extends FieldsProducer {
     } else {
       try {
         return b.utf8ToString() + " " + b;
-      } catch (Throwable t) {
+      } catch (
+          @SuppressWarnings("unused")
+          Throwable t) {
         // If BytesRef isn't actually UTF8, or it's eg a
         // prefix of UTF8 that ends mid-unicode-char, we
         // fallback to hex:

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/codecs/idversion/TestIDVersionPostingsFormat.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/codecs/idversion/TestIDVersionPostingsFormat.java
@@ -421,7 +421,9 @@ public class TestIDVersionPostingsFormat extends LuceneTestCase {
       w.commit();
       w.forceMerge(1);
       fail("didn't hit exception");
-    } catch (IllegalArgumentException iae) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalArgumentException iae) {
       // expected: SMS will hit this
     } catch (IOException | IllegalStateException exc) {
       // expected

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestQueryEqualsHashCode.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestQueryEqualsHashCode.java
@@ -100,7 +100,9 @@ public class TestQueryEqualsHashCode extends LuceneTestCase {
     Object first;
     try {
       first = generator.gen(args1);
-    } catch (UnsupportedOperationException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        UnsupportedOperationException e) {
       return;
     }
     if (first == null) return; // unsupported op?

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/RandomizedShapeTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/RandomizedShapeTestCase.java
@@ -33,12 +33,16 @@ public abstract class RandomizedShapeTestCase extends LuceneTestCase {
     for (Class<?> clazz : classes) {
       try {
         clazz.getDeclaredMethod("equals", Object.class);
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         fail("Shape needs to define 'equals' : " + clazz.getName());
       }
       try {
         clazz.getDeclaredMethod("hashCode");
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         fail("Shape needs to define 'hashCode' : " + clazz.getName());
       }
     }

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/ShapeRectRelationTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/ShapeRectRelationTestCase.java
@@ -141,7 +141,9 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
           }
           try {
             return builder.build();
-          } catch (IllegalArgumentException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              IllegalArgumentException e) {
             // This is what happens when we create a shape that is invalid.  Although it is
             // conceivable that there are cases where
             // the exception is thrown incorrectly, we aren't going to be able to do that in this
@@ -184,7 +186,9 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
           builder.buffer(width);
           try {
             return builder.build();
-          } catch (IllegalArgumentException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              IllegalArgumentException e) {
             // This is what happens when we create a shape that is invalid.  Although it is
             // conceivable that there are cases where
             // the exception is thrown incorrectly, we aren't going to be able to do that in this

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoComplexPolygon.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoComplexPolygon.java
@@ -748,7 +748,9 @@ class GeoComplexPolygon extends GeoBasePolygon {
       for (final TraversalStrategy ts : traversalStrategies) {
         try {
           return ts.apply(testPoint, testPointInSet, x, y, z);
-        } catch (IllegalArgumentException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            IllegalArgumentException e) {
           // Continue
         }
       }
@@ -895,7 +897,9 @@ class GeoComplexPolygon extends GeoBasePolygon {
       // System.out.println(" creating sector linear crossing edge iterator");
       return new SectorLinearCrossingEdgeIterator(
           testPoint, plane, abovePlane, belowPlane, thePointX, thePointY, thePointZ);
-    } catch (IllegalArgumentException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalArgumentException e) {
       // Assume we failed because we could not construct bounding planes, so do it another way.
       // System.out.println(" create full linear crossing edge iterator");
       return new FullLinearCrossingEdgeIterator(
@@ -1057,7 +1061,9 @@ class GeoComplexPolygon extends GeoBasePolygon {
 
         // System.out.println(" Check point in set? " + rval);
         return rval;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         // Intersection point apparently was on edge, so try another strategy
         // System.out.println(" Trying dual crossing edge iterator");
         final CountingEdgeIterator edgeIterator =

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoPolygonFactory.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoPolygonFactory.java
@@ -234,7 +234,9 @@ public class GeoPolygonFactory {
         }
         throw new IllegalArgumentException(
             "cannot find a point that is inside the polygon " + filteredPointList);
-      } catch (TileException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          TileException e) {
         // Couldn't tile the polygon; use GeoComplexPolygon instead, if we can.
       }
     }
@@ -515,7 +517,9 @@ public class GeoPolygonFactory {
                 new GeoPoint(-testPoint.x, -testPoint.y, -testPoint.z),
                 !isTestPointInside);
           }
-        } catch (IllegalArgumentException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            IllegalArgumentException e) {
           // Probably bad choice of test point.
           return null;
         }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/SidedPlane.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/SidedPlane.java
@@ -220,7 +220,9 @@ public class SidedPlane extends Plane implements Membership {
       // To construct the plane, we now just need D, which is simply the negative of the evaluation
       // of the circle normal vector at one of the points.
       return new SidedPlane(insidePoint, newNormalVector, -newNormalVector.dotProduct(point1));
-    } catch (IllegalArgumentException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalArgumentException e) {
       return null;
     }
   }
@@ -240,7 +242,9 @@ public class SidedPlane extends Plane implements Membership {
               point2.y - point3.y,
               point2.z - point3.z);
       rval = new SidedPlane(insidePoint, planeNormal, -planeNormal.dotProduct(point2));
-    } catch (IllegalArgumentException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalArgumentException e) {
     }
 
     if (rval == null) {
@@ -254,7 +258,9 @@ public class SidedPlane extends Plane implements Membership {
                 point3.y - point2.y,
                 point3.z - point2.z);
         rval = new SidedPlane(insidePoint, planeNormal, -planeNormal.dotProduct(point3));
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
       }
     }
 
@@ -269,7 +275,9 @@ public class SidedPlane extends Plane implements Membership {
                 point1.y - point2.y,
                 point1.z - point2.z);
         rval = new SidedPlane(insidePoint, planeNormal, -planeNormal.dotProduct(point1));
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
       }
     }
 

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/TestGeo3DPoint.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/TestGeo3DPoint.java
@@ -752,7 +752,9 @@ public class TestGeo3DPoint extends LuceneTestCase {
               // System.err.println("Generated: "+q);
               // assertTrue(false);
               return q;
-            } catch (IllegalArgumentException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                IllegalArgumentException e) {
               continue;
             }
           }
@@ -777,7 +779,9 @@ public class TestGeo3DPoint extends LuceneTestCase {
               // System.err.println("Generated: "+q);
               // assertTrue(false);
               return q;
-            } catch (IllegalArgumentException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                IllegalArgumentException e) {
               continue;
             }
           }
@@ -794,7 +798,9 @@ public class TestGeo3DPoint extends LuceneTestCase {
                   GeoTestUtil.nextLatitude(),
                   GeoTestUtil.nextLongitude(),
                   widthMeters);
-            } catch (IllegalArgumentException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                IllegalArgumentException e) {
               continue;
             }
           }
@@ -806,7 +812,9 @@ public class TestGeo3DPoint extends LuceneTestCase {
             try {
               return Geo3DPoint.newBoxQuery(
                   field, planetModel, r.minLat, r.maxLat, r.minLon, r.maxLon);
-            } catch (IllegalArgumentException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                IllegalArgumentException e) {
               continue;
             }
           }
@@ -826,7 +834,9 @@ public class TestGeo3DPoint extends LuceneTestCase {
             }
             try {
               return Geo3DPoint.newPathQuery(field, latitudes, longitudes, width, planetModel);
-            } catch (IllegalArgumentException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                IllegalArgumentException e) {
               // This is what happens when we create a shape that is invalid.  Although it is
               // conceivable that there are cases where
               // the exception is thrown incorrectly, we aren't going to be able to do that in this
@@ -866,7 +876,9 @@ public class TestGeo3DPoint extends LuceneTestCase {
                 continue;
               }
               return rval;
-            } catch (IllegalArgumentException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                IllegalArgumentException e) {
               // This is what happens when we create a shape that is invalid.  Although it is
               // conceivable that there are cases where
               // the exception is thrown incorrectly, we aren't going to be able to do that in this
@@ -886,7 +898,9 @@ public class TestGeo3DPoint extends LuceneTestCase {
 
             try {
               return GeoCircleFactory.makeGeoCircle(planetModel, lat, lon, angle);
-            } catch (IllegalArgumentException iae) {
+            } catch (
+                @SuppressWarnings("unused")
+                IllegalArgumentException iae) {
               // angle is too small; try again:
               continue;
             }
@@ -928,7 +942,9 @@ public class TestGeo3DPoint extends LuceneTestCase {
             }
             try {
               return GeoPathFactory.makeGeoPath(planetModel, width, points);
-            } catch (IllegalArgumentException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                IllegalArgumentException e) {
               // This is what happens when we create a shape that is invalid.  Although it is
               // conceivable that there are cases where
               // the exception is thrown incorrectly, we aren't going to be able to do that in this

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoExactCircle.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoExactCircle.java
@@ -146,34 +146,30 @@ public class TestGeoExactCircle extends LuceneTestCase {
 
   @Test
   public void exactCircleLargeTest() {
-    boolean success = true;
-    try {
-      GeoCircleFactory.makeExactGeoCircle(
-          new PlanetModel(0.99, 1.05), 0.25 * Math.PI, 0, 0.35 * Math.PI, 1e-12);
-    } catch (IllegalArgumentException e) {
-      success = false;
-    }
-    assertTrue(success);
-    success = false;
-    try {
-      GeoCircleFactory.makeExactGeoCircle(
-          PlanetModel.WGS84, 0.25 * Math.PI, 0, 0.9996 * Math.PI, 1e-12);
-    } catch (IllegalArgumentException e) {
-      success = true;
-    }
-    assertTrue(success);
+    // should not throw exception
+    GeoCircleFactory.makeExactGeoCircle(
+        new PlanetModel(0.99, 1.05), 0.25 * Math.PI, 0, 0.35 * Math.PI, 1e-12);
+    // should throw exception
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          GeoCircleFactory.makeExactGeoCircle(
+              PlanetModel.WGS84, 0.25 * Math.PI, 0, 0.9996 * Math.PI, 1e-12);
+        });
   }
 
   @Test
   public void testExactCircleDoesNotFit() {
-    boolean exception = false;
-    try {
-      GeoCircleFactory.makeExactGeoCircle(
-          PlanetModel.WGS84, 1.5633796542562415, -1.0387149580695152, 3.1409865861032844, 1e-12);
-    } catch (IllegalArgumentException e) {
-      exception = true;
-    }
-    assertTrue(exception);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          GeoCircleFactory.makeExactGeoCircle(
+              PlanetModel.WGS84,
+              1.5633796542562415,
+              -1.0387149580695152,
+              3.1409865861032844,
+              1e-12);
+        });
   }
 
   public void testBigCircleInSphere() {
@@ -309,13 +305,11 @@ public class TestGeoExactCircle extends LuceneTestCase {
 
   public void testLUCENE8080() {
     PlanetModel planetModel = new PlanetModel(1.6304230055804751, 1.0199671157571204);
-    boolean fail = false;
-    try {
-      GeoCircleFactory.makeExactGeoCircle(
-          planetModel, 0.8853814403571284, 0.9784990176851283, 0.9071033527030907, 1e-11);
-    } catch (IllegalArgumentException e) {
-      fail = true;
-    }
-    assertTrue(fail);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          GeoCircleFactory.makeExactGeoCircle(
+              planetModel, 0.8853814403571284, 0.9784990176851283, 0.9071033527030907, 1e-11);
+        });
   }
 }

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPath.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPath.java
@@ -308,7 +308,9 @@ public class TestGeoPath extends LuceneTestCase {
     final GeoPath path;
     try {
       path = GeoPathFactory.makeGeoPath(PlanetModel.WGS84, 1.117010721276371, points);
-    } catch (IllegalArgumentException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalArgumentException e) {
       return;
     }
     assertTrue(false);

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPolygon.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPolygon.java
@@ -659,13 +659,11 @@ public class TestGeoPolygon extends LuceneTestCase {
     points.add(new GeoPoint(-0.1699323603224724, 0.8516746480592872, 0.4963385521664198));
     points.add(new GeoPoint(0.2654788898359613, 0.7380222309164597, 0.6200740473100581));
 
-    boolean illegalArgumentException = false;
-    try {
-      GeoPolygonFactory.makeGeoPolygon(PlanetModel.WGS84, points, null);
-    } catch (IllegalArgumentException e) {
-      illegalArgumentException = true;
-    }
-    assertTrue(illegalArgumentException);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          GeoPolygonFactory.makeGeoPolygon(PlanetModel.WGS84, points, null);
+        });
   }
 
   @Test
@@ -692,13 +690,11 @@ public class TestGeoPolygon extends LuceneTestCase {
     points.add(new GeoPoint(PlanetModel.WGS84, 0.4654236264787552, 1.3013260557429494));
     points.add(new GeoPoint(PlanetModel.WGS84, -1.2964641581620537, -1.487600369139357));
 
-    boolean illegalArgumentException = false;
-    try {
-      GeoPolygonFactory.makeGeoPolygon(PlanetModel.WGS84, points, null);
-    } catch (IllegalArgumentException e) {
-      illegalArgumentException = true;
-    }
-    assertTrue(illegalArgumentException);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          GeoPolygonFactory.makeGeoPolygon(PlanetModel.WGS84, points, null);
+        });
   }
 
   @Test
@@ -1030,15 +1026,11 @@ public class TestGeoPolygon extends LuceneTestCase {
     final BitSet poly2Bitset = new BitSet();
     poly2Bitset.set(1);
 
-    boolean result;
-    try {
-      new GeoConvexPolygon(PlanetModel.WGS84, poly2List);
-      result = true;
-    } catch (IllegalArgumentException e) {
-      result = false;
-    }
-
-    assertTrue(!result);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new GeoConvexPolygon(PlanetModel.WGS84, poly2List);
+        });
   }
 
   @Test

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestRandomGeoPolygon.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestRandomGeoPolygon.java
@@ -47,7 +47,9 @@ public class TestRandomGeoPolygon extends LuceneTestCase {
     try {
       GeoPolygon polygon = GeoPolygonFactory.makeGeoPolygon(planetModel, points);
       assertTrue(polygon != null);
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
       fail(points.toString());
     }
   }
@@ -64,7 +66,9 @@ public class TestRandomGeoPolygon extends LuceneTestCase {
     points.add(point4);
     try {
       GeoPolygonFactory.makeGeoPolygon(PlanetModel.SPHERE, points);
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
       fail(points.toString());
     }
   }

--- a/lucene/spatial3d/src/testFixtures/java/org/apache/lucene/spatial3d/geom/RandomGeo3dShapeGenerator.java
+++ b/lucene/spatial3d/src/testFixtures/java/org/apache/lucene/spatial3d/geom/RandomGeo3dShapeGenerator.java
@@ -338,7 +338,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return pointShape;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -371,7 +373,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return circle;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -405,7 +409,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return circle;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -445,7 +451,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return bbox;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -477,7 +485,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return path;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -510,7 +520,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return path;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -570,7 +582,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -627,7 +641,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -677,7 +693,9 @@ public final class RandomGeo3dShapeGenerator {
           return holes;
         }
         pointConstraints.put(hole, GeoArea.DISJOINT);
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -710,7 +728,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -767,7 +787,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -803,7 +825,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -834,7 +858,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }
@@ -866,7 +892,9 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (IllegalArgumentException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IllegalArgumentException e) {
         continue;
       }
     }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/FileDictionary.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/FileDictionary.java
@@ -205,7 +205,9 @@ public class FileDictionary implements Dictionary {
       // keep reading floats for bw compat
       try {
         curWeight = Long.parseLong(weight);
-      } catch (NumberFormatException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          NumberFormatException e) {
         curWeight = (long) Double.parseDouble(weight);
       }
     }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionQuery.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionQuery.java
@@ -93,7 +93,9 @@ public abstract class CompletionQuery extends Query {
         if ((terms = leafReader.terms(getField())) == null) {
           continue;
         }
-      } catch (IOException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException e) {
         continue;
       }
       if (terms instanceof CompletionTerms) {

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/SuggestIndexSearcher.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/SuggestIndexSearcher.java
@@ -69,7 +69,9 @@ public class SuggestIndexSearcher extends IndexSearcher {
       if (scorer != null) {
         try {
           scorer.score(collector.getLeafCollector(context), context.reader().getLiveDocs());
-        } catch (CollectionTerminatedException e) {
+        } catch (
+            @SuppressWarnings("unused")
+            CollectionTerminatedException e) {
           // collection was terminated prematurely
           // continue with the following leaf
         }

--- a/lucene/suggest/src/test/org/apache/lucene/search/spell/TestSpellChecker.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/spell/TestSpellChecker.java
@@ -514,7 +514,9 @@ public class TestSpellChecker extends LuceneTestCase {
         while (true) {
           try {
             checkCommonSuggestions(reader);
-          } catch (AlreadyClosedException e) {
+          } catch (
+              @SuppressWarnings("unused")
+              AlreadyClosedException e) {
 
             return;
           } catch (Throwable e) {

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestLookupBenchmark.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestLookupBenchmark.java
@@ -156,7 +156,7 @@ public class TestLookupBenchmark extends LuceneTestCase {
     } else {
       try {
         lookup = cls.getConstructor().newInstance();
-      } catch (InstantiationException | NoSuchMethodException e) {
+      } catch (@SuppressWarnings("unused") InstantiationException | NoSuchMethodException e) {
         Analyzer a = new MockAnalyzer(random, MockTokenizer.KEYWORD, false);
         if (cls == AnalyzingInfixSuggester.class || cls == BlendedInfixSuggester.class) {
           Constructor<? extends Lookup> ctor = cls.getConstructor(Directory.class, Analyzer.class);

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestAnalyzingInfixSuggester.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestAnalyzingInfixSuggester.java
@@ -18,6 +18,7 @@ package org.apache.lucene.search.suggest.analyzing;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -999,7 +1000,7 @@ public class TestAnalyzingInfixSuggester extends LuceneTestCase {
       try {
         suggester.add(new BytesRef(key), null, 10, null);
       } catch (IOException e) {
-        fail("Could not build suggest dictionary correctly");
+        throw new UncheckedIOException("Could not build suggest dictionary correctly", e);
       }
     }
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/analysis/BaseTokenStreamTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/analysis/BaseTokenStreamTestCase.java
@@ -751,7 +751,9 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
         // System.out.println(ts.reflectAsString(false));
         fail("didn't get expected exception when reset() not called");
       }
-    } catch (IllegalStateException expected) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalStateException expected) {
       // ok
     } catch (Exception unexpected) {
       unexpected.printStackTrace(System.err);
@@ -772,7 +774,9 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
     try {
       ts = a.tokenStream("bogus", input);
       fail("didn't get expected exception when close() not called");
-    } catch (IllegalStateException expected) {
+    } catch (
+        @SuppressWarnings("unused")
+        IllegalStateException expected) {
       // ok
     } finally {
       ts.close();

--- a/lucene/test-framework/src/java/org/apache/lucene/geo/GeoTestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/geo/GeoTestUtil.java
@@ -451,7 +451,9 @@ public class GeoTestUtil {
             random().nextDouble() * GeoUtils.EARTH_MEAN_RADIUS_METERS * Math.PI / 2.0 + 1.0;
         try {
           return createRegularPolygon(nextLatitude(), nextLongitude(), radiusMeters, gons);
-        } catch (IllegalArgumentException iae) {
+        } catch (
+            @SuppressWarnings("unused")
+            IllegalArgumentException iae) {
           // we tried to cross dateline or pole ... try again
         }
       }

--- a/lucene/test-framework/src/java/org/apache/lucene/geo/ShapeTestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/geo/ShapeTestUtil.java
@@ -39,7 +39,9 @@ public class ShapeTestUtil {
         double radius = random.nextDouble() * 0.5 * Float.MAX_VALUE + 1.0;
         try {
           return createRegularPolygon(nextFloat(random), nextFloat(random), radius, gons);
-        } catch (IllegalArgumentException iae) {
+        } catch (
+            @SuppressWarnings("unused")
+            IllegalArgumentException iae) {
           // something went wrong, try again
         }
       }

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
@@ -677,7 +677,9 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
           iw.addDocument(doc);
           // we made it, sometimes delete our doc
           iw.deleteDocuments(new Term("id", Integer.toString(i)));
-        } catch (AlreadyClosedException ace) {
+        } catch (
+            @SuppressWarnings("unused")
+            AlreadyClosedException ace) {
           // OK: writer was closed by abort; we just reopen now:
           dir.setRandomIOExceptionRateOnOpen(
               0.0); // disable exceptions on openInput until next iteration
@@ -716,7 +718,9 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
             if (DirectoryReader.indexExists(dir)) {
               TestUtil.checkIndex(dir);
             }
-          } catch (AlreadyClosedException ace) {
+          } catch (
+              @SuppressWarnings("unused")
+              AlreadyClosedException ace) {
             // OK: writer was closed by abort; we just reopen now:
             dir.setRandomIOExceptionRateOnOpen(
                 0.0); // disable exceptions on openInput until next iteration
@@ -744,7 +748,9 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
         handleFakeIOException(e, exceptionStream);
         try {
           iw.rollback();
-        } catch (Throwable t) {
+        } catch (
+            @SuppressWarnings("unused")
+            Throwable t) {
         }
       }
       dir.close();

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BasePostingsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BasePostingsFormatTestCase.java
@@ -615,7 +615,9 @@ public abstract class BasePostingsFormatTestCase extends BaseIndexFileFormatTest
         long ord;
         try {
           ord = termsEnum.ord();
-        } catch (UnsupportedOperationException uoe) {
+        } catch (
+            @SuppressWarnings("unused")
+            UnsupportedOperationException uoe) {
           supportsOrds = false;
           ord = -1;
         }

--- a/lucene/test-framework/src/java/org/apache/lucene/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/RandomPostingsTester.java
@@ -1492,7 +1492,9 @@ public class RandomPostingsTester {
           // Try seek by ord sometimes:
           try {
             termsEnum.seekExact(fieldAndTerm.ord);
-          } catch (UnsupportedOperationException uoe) {
+          } catch (
+              @SuppressWarnings("unused")
+              UnsupportedOperationException uoe) {
             supportsOrds = false;
             assertTrue(termsEnum.seekExact(fieldAndTerm.term));
           }
@@ -1510,7 +1512,9 @@ public class RandomPostingsTester {
       if (supportsOrds) {
         try {
           termOrd = termsEnum.ord();
-        } catch (UnsupportedOperationException uoe) {
+        } catch (
+            @SuppressWarnings("unused")
+            UnsupportedOperationException uoe) {
           supportsOrds = false;
           termOrd = -1;
         }
@@ -1650,7 +1654,9 @@ public class RandomPostingsTester {
       try {
         iterator.remove();
         throw new AssertionError("Fields.iterator() allows for removal");
-      } catch (UnsupportedOperationException expected) {
+      } catch (
+          @SuppressWarnings("unused")
+          UnsupportedOperationException expected) {
         // expected;
       }
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/mockfile/ExtrasFS.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/mockfile/ExtrasFS.java
@@ -66,7 +66,9 @@ public class ExtrasFS extends FilterFileSystemProvider {
         } else {
           Files.createFile(target);
         }
-      } catch (Exception ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception ignored) {
         // best effort
       }
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/mockfile/WindowsFS.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/mockfile/WindowsFS.java
@@ -96,7 +96,9 @@ public class WindowsFS extends HandleTrackingFS {
   private Object getKeyOrNull(Path path) {
     try {
       return getKey(path);
-    } catch (Exception ignore) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception ignore) {
       // we don't care if the file doesn't exist
     }
     return null;

--- a/lucene/test-framework/src/java/org/apache/lucene/search/AssertingBulkScorer.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/AssertingBulkScorer.java
@@ -62,7 +62,9 @@ final class AssertingBulkScorer extends BulkScorer {
       try {
         final int next = score(collector, acceptDocs, 0, PostingsEnum.NO_MORE_DOCS);
         assert next == DocIdSetIterator.NO_MORE_DOCS;
-      } catch (UnsupportedOperationException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          UnsupportedOperationException e) {
         in.score(collector, acceptDocs);
       }
     } else {

--- a/lucene/test-framework/src/java/org/apache/lucene/search/CheckHits.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/CheckHits.java
@@ -327,7 +327,9 @@ public class CheckHits {
     // TODO: clean this up if we use junit 5 (the assert message is costly)
     try {
       assertEquals(score, value, 0d);
-    } catch (Exception e) {
+    } catch (
+        @SuppressWarnings("unused")
+        Exception e) {
       fail(
           q
               + ": score(doc="
@@ -384,7 +386,9 @@ public class CheckHits {
               if (descr.substring(k2).trim().equals("times others of:")) {
                 maxTimesOthers = true;
               }
-            } catch (NumberFormatException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                NumberFormatException e) {
             }
           }
         }
@@ -434,7 +438,9 @@ public class CheckHits {
         // TODO: clean this up if we use junit 5 (the assert message is costly)
         try {
           assertEquals(combined, value, maxError);
-        } catch (Exception e) {
+        } catch (
+            @SuppressWarnings("unused")
+            Exception e) {
           fail(
               q
                   + ": actual subDetails combined=="

--- a/lucene/test-framework/src/java/org/apache/lucene/search/similarities/BaseSimilarityTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/similarities/BaseSimilarityTestCase.java
@@ -135,7 +135,9 @@ public abstract class BaseSimilarityTestCase extends LuceneTestCase {
     long upperBound;
     try {
       upperBound = Math.min(MAXTOKENS_FORTESTING, Math.multiplyExact(docCount, Integer.MAX_VALUE));
-    } catch (ArithmeticException overflow) {
+    } catch (
+        @SuppressWarnings("unused")
+        ArithmeticException overflow) {
       upperBound = MAXTOKENS_FORTESTING;
     }
     final long sumDocFreq;
@@ -201,7 +203,9 @@ public abstract class BaseSimilarityTestCase extends LuceneTestCase {
     try {
       upperBound =
           Math.min(corpus.sumTotalTermFreq(), Math.multiplyExact(docFreq, Integer.MAX_VALUE));
-    } catch (ArithmeticException overflow) {
+    } catch (
+        @SuppressWarnings("unused")
+        ArithmeticException overflow) {
       upperBound = corpus.sumTotalTermFreq();
     }
     if (corpus.sumTotalTermFreq() == corpus.sumDocFreq()) {

--- a/lucene/test-framework/src/java/org/apache/lucene/store/BaseDirectoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/store/BaseDirectoryTestCase.java
@@ -571,7 +571,9 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
                         try (IndexInput input = dir.openInput(file, newIOContext(random()))) {
                           // Just open, nothing else.
                           assert input != null;
-                        } catch (AccessDeniedException e) {
+                        } catch (
+                            @SuppressWarnings("unused")
+                            AccessDeniedException e) {
                           // Access denied is allowed for files for which the output is still open
                           // (MockDirectoryWriter enforces
                           // this, for example). Since we don't synchronize with the writer thread,

--- a/lucene/test-framework/src/java/org/apache/lucene/store/BaseLockFactoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/store/BaseLockFactoryTestCase.java
@@ -141,7 +141,9 @@ public abstract class BaseLockFactoryTestCase extends LuceneTestCase {
                     fail();
                   }
                   assert lock != null; // stupid compiler
-                } catch (IOException ex) {
+                } catch (
+                    @SuppressWarnings("unused")
+                    IOException ex) {
                   //
                 }
                 if (atomicCounter.incrementAndGet() > runs) {

--- a/lucene/test-framework/src/java/org/apache/lucene/store/MockDirectoryWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/store/MockDirectoryWrapper.java
@@ -512,7 +512,9 @@ public class MockDirectoryWrapper extends BaseDirectoryWrapper {
     for (Closeable f : m.keySet()) {
       try {
         f.close();
-      } catch (Exception ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception ignored) {
       }
     }
     corruptFiles(unSyncedFiles);

--- a/lucene/test-framework/src/java/org/apache/lucene/store/SlowOpeningMockIndexInputWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/store/SlowOpeningMockIndexInputWrapper.java
@@ -33,7 +33,9 @@ class SlowOpeningMockIndexInputWrapper extends MockIndexInputWrapper {
     } catch (InterruptedException ie) {
       try {
         super.close();
-      } catch (Throwable ignore) {
+      } catch (
+          @SuppressWarnings("unused")
+          Throwable ignore) {
         // we didnt open successfully
       }
       throw new ThreadInterruptedException(ie);

--- a/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
@@ -1444,7 +1444,9 @@ public abstract class LuceneTestCase extends Assert {
     try {
       try {
         clazz = CommandLineUtil.loadFSDirectoryClass(fsdirClass);
-      } catch (ClassCastException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          ClassCastException e) {
         // TEST_DIRECTORY is not a sub-class of FSDirectory, so draw one at random
         fsdirClass = RandomPicks.randomFrom(random(), FS_DIRECTORIES);
         clazz = CommandLineUtil.loadFSDirectoryClass(fsdirClass);
@@ -1738,7 +1740,9 @@ public abstract class LuceneTestCase extends Assert {
             clazz.getConstructor(Path.class, LockFactory.class);
         final Path dir = createTempDir("index");
         return pathCtor.newInstance(dir, lf);
-      } catch (NoSuchMethodException nsme) {
+      } catch (
+          @SuppressWarnings("unused")
+          NoSuchMethodException nsme) {
         // Ignore
       }
 
@@ -1748,7 +1752,9 @@ public abstract class LuceneTestCase extends Assert {
         // try ctor with only LockFactory
         try {
           return clazz.getConstructor(LockFactory.class).newInstance(lf);
-        } catch (NoSuchMethodException nsme) {
+        } catch (
+            @SuppressWarnings("unused")
+            NoSuchMethodException nsme) {
           // Ignore
         }
       }
@@ -2071,7 +2077,7 @@ public abstract class LuceneTestCase extends Assert {
     try {
       return Paths.get(this.getClass().getResource(name).toURI());
     } catch (Exception e) {
-      throw new IOException("Cannot find resource: " + name);
+      throw new IOException("Cannot find resource: " + name, e);
     }
   }
 
@@ -3060,7 +3066,7 @@ public abstract class LuceneTestCase extends Assert {
     try {
       dir.openInput(fileName, IOContext.DEFAULT).close();
       return true;
-    } catch (NoSuchFileException | FileNotFoundException e) {
+    } catch (@SuppressWarnings("unused") NoSuchFileException | FileNotFoundException e) {
       return false;
     }
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/util/TestRuleAssertionsRequired.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/TestRuleAssertionsRequired.java
@@ -44,7 +44,9 @@ public class TestRuleAssertionsRequired implements TestRule {
             System.err.println(msg);
             throw new Exception(msg);
           }
-        } catch (AssertionError e) {
+        } catch (
+            @SuppressWarnings("unused")
+            AssertionError e) {
           // Ok, enabled.
         }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/util/TestRuleTemporaryFilesCleanup.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/TestRuleTemporaryFilesCleanup.java
@@ -254,7 +254,9 @@ final class TestRuleTemporaryFilesCleanup extends TestRuleAdapter {
         try {
           Files.createDirectory(f);
           success = true;
-        } catch (IOException ignore) {
+        } catch (
+            @SuppressWarnings("unused")
+            IOException ignore) {
         }
       } while (!success);
 
@@ -281,7 +283,9 @@ final class TestRuleTemporaryFilesCleanup extends TestRuleAdapter {
       try {
         Files.createDirectory(f);
         success = true;
-      } catch (IOException ignore) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException ignore) {
       }
     } while (!success);
 
@@ -306,7 +310,9 @@ final class TestRuleTemporaryFilesCleanup extends TestRuleAdapter {
       try {
         Files.createFile(f);
         success = true;
-      } catch (IOException ignore) {
+      } catch (
+          @SuppressWarnings("unused")
+          IOException ignore) {
       }
     } while (!success);
 

--- a/lucene/test-framework/src/java/org/apache/lucene/util/TestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/TestUtil.java
@@ -181,7 +181,9 @@ public final class TestUtil {
         try {
           iterator.remove();
           throw new AssertionError("broken iterator (supports remove): " + iterator);
-        } catch (UnsupportedOperationException expected) {
+        } catch (
+            @SuppressWarnings("unused")
+            UnsupportedOperationException expected) {
           // ok
         }
       }
@@ -190,7 +192,9 @@ public final class TestUtil {
     try {
       iterator.next();
       throw new AssertionError("broken iterator (allows next() when hasNext==false) " + iterator);
-    } catch (NoSuchElementException expected) {
+    } catch (
+        @SuppressWarnings("unused")
+        NoSuchElementException expected) {
       // ok
     }
   }
@@ -212,14 +216,18 @@ public final class TestUtil {
       try {
         iterator.remove();
         throw new AssertionError("broken iterator (supports remove): " + iterator);
-      } catch (UnsupportedOperationException expected) {
+      } catch (
+          @SuppressWarnings("unused")
+          UnsupportedOperationException expected) {
         // ok
       }
     }
     try {
       iterator.next();
       throw new AssertionError("broken iterator (allows next() when hasNext==false) " + iterator);
-    } catch (NoSuchElementException expected) {
+    } catch (
+        @SuppressWarnings("unused")
+        NoSuchElementException expected) {
       // ok
     }
   }
@@ -249,7 +257,9 @@ public final class TestUtil {
       try {
         coll.remove(coll.iterator().next());
         throw new AssertionError("broken collection (supports remove): " + coll);
-      } catch (UnsupportedOperationException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          UnsupportedOperationException e) {
         // ok
       }
     }
@@ -257,14 +267,18 @@ public final class TestUtil {
     try {
       coll.add(null);
       throw new AssertionError("broken collection (supports add): " + coll);
-    } catch (UnsupportedOperationException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        UnsupportedOperationException e) {
       // ok
     }
 
     try {
       coll.addAll(Collections.singleton(null));
       throw new AssertionError("broken collection (supports addAll): " + coll);
-    } catch (UnsupportedOperationException e) {
+    } catch (
+        @SuppressWarnings("unused")
+        UnsupportedOperationException e) {
       // ok
     }
 
@@ -1515,7 +1529,9 @@ public final class TestUtil {
         // ignore bugs in Sun's regex impl
         try {
           replacement = p.matcher(nonBmpString).replaceAll("_");
-        } catch (StringIndexOutOfBoundsException jdkBug) {
+        } catch (
+            @SuppressWarnings("unused")
+            StringIndexOutOfBoundsException jdkBug) {
           System.out.println("WARNING: your jdk is buggy!");
           System.out.println(
               "Pattern.compile(\""
@@ -1527,7 +1543,9 @@ public final class TestUtil {
         if (replacement != null && UnicodeUtil.validUTF16String(replacement)) {
           return p;
         }
-      } catch (PatternSyntaxException ignored) {
+      } catch (
+          @SuppressWarnings("unused")
+          PatternSyntaxException ignored) {
         // Loop trying until we hit something that compiles.
       }
     }
@@ -1617,7 +1635,7 @@ public final class TestUtil {
     } else {
       try {
         return br.utf8ToString() + " " + br.toString();
-      } catch (AssertionError | IllegalArgumentException t) {
+      } catch (@SuppressWarnings("unused") AssertionError | IllegalArgumentException t) {
         // If BytesRef isn't actually UTF8, or it's eg a
         // prefix of UTF8 that ends mid-unicode-char, we
         // fallback to hex:

--- a/lucene/test-framework/src/java/org/apache/lucene/util/automaton/AutomatonTestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/automaton/AutomatonTestUtil.java
@@ -49,7 +49,9 @@ public class AutomatonTestUtil {
       try {
         new RegExp(regexp, RegExp.NONE);
         return regexp;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
       }
     }
   }
@@ -263,7 +265,9 @@ public class AutomatonTestUtil {
           a1 = Operations.complement(a1, DEFAULT_MAX_DETERMINIZED_STATES);
         }
         return a1;
-      } catch (TooComplexToDeterminizeException tctde) {
+      } catch (
+          @SuppressWarnings("unused")
+          TooComplexToDeterminizeException tctde) {
         // This can (rarely) happen if the random regexp is too hard; just try again...
       }
     }

--- a/lucene/test-framework/src/test/org/apache/lucene/mockfile/TestWindowsFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/mockfile/TestWindowsFS.java
@@ -122,7 +122,9 @@ public class TestWindowsFS extends MockFileSystemTestCase {
                   Files.move(file, target);
                   Files.delete(target);
                 }
-              } catch (IOException ex) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  IOException ignored) {
                 // continue
               }
             }
@@ -138,7 +140,7 @@ public class TestWindowsFS extends MockFileSystemTestCase {
           opened = true;
           stream.write(0);
           // just create
-        } catch (FileNotFoundException | NoSuchFileException ex) {
+        } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException ex) {
           assertEquals(
               "File handle leaked - file is closed but still registered",
               0,

--- a/lucene/test-framework/src/test/org/apache/lucene/store/TestMockDirectoryWrapper.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/store/TestMockDirectoryWrapper.java
@@ -141,7 +141,7 @@ public class TestMockDirectoryWrapper extends BaseDirectoryTestCase {
     IndexInput in = null;
     try {
       in = dir.openInput("foo", IOContext.DEFAULT);
-    } catch (NoSuchFileException | FileNotFoundException fnfe) {
+    } catch (@SuppressWarnings("unused") NoSuchFileException | FileNotFoundException fnfe) {
       // ok
       changed = true;
     }
@@ -150,7 +150,9 @@ public class TestMockDirectoryWrapper extends BaseDirectoryTestCase {
         int x;
         try {
           x = in.readInt();
-        } catch (EOFException eofe) {
+        } catch (
+            @SuppressWarnings("unused")
+            EOFException eofe) {
           changed = true;
           break;
         }

--- a/lucene/test-framework/src/test/org/apache/lucene/util/TestMaxFailuresRule.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/util/TestMaxFailuresRule.java
@@ -126,7 +126,9 @@ public class TestMaxFailuresRule extends WithNestedTests {
                   try {
                     die.await();
                     return;
-                  } catch (Exception e) {
+                  } catch (
+                      @SuppressWarnings("unused")
+                      Exception ignored) {
                     /* ignore */
                   }
                 }

--- a/lucene/test-framework/src/test/org/apache/lucene/util/TestRamUsageTesterOnWildAnimals.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/util/TestRamUsageTesterOnWildAnimals.java
@@ -39,7 +39,9 @@ public class TestRamUsageTesterOnWildAnimals extends LuceneTestCase {
         }
         RamUsageTester.sizeOf(first); // cause SOE or pass.
         lower = mid;
-      } catch (StackOverflowError e) {
+      } catch (
+          @SuppressWarnings("unused")
+          StackOverflowError e) {
         upper = mid;
       }
     }

--- a/lucene/test-framework/src/test/org/apache/lucene/util/TestWorstCaseTestBehavior.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/util/TestWorstCaseTestBehavior.java
@@ -29,7 +29,9 @@ public class TestWorstCaseTestBehavior extends LuceneTestCase {
           public void run() {
             try {
               Thread.sleep(10000);
-            } catch (InterruptedException e) {
+            } catch (
+                @SuppressWarnings("unused")
+                InterruptedException ignored) {
               // Ignore.
             }
           }
@@ -91,7 +93,9 @@ public class TestWorstCaseTestBehavior extends LuceneTestCase {
     while (true) {
       try {
         Thread.sleep(1000);
-      } catch (InterruptedException e) {
+      } catch (
+          @SuppressWarnings("unused")
+          InterruptedException ignored) {
       }
     }
   }


### PR DESCRIPTION
unusedExceptionParameter is a very useful check, as it detects if you catch an exception and do nothing with it at all (swallowed).

As a library, its important to preserve exceptions (e.g. chain the root cause, .addSuppressed, etc). This check helps prevent exceptions from getting swallowed inadvertently.

If this is intentional for some reason, the exception can simply by annotated with `@SuppressWarnings("unused")`.
In general, lucene is good about this today, and in most cases such intentional swallowing is already being "annotated" adhoc with comments to explain why it is ok to swallow the exception. This just requires it to be done in a standardized way.

There were a lot of cases in tests, especially old tests. Still finding various ad-hoc formulations of `expectThrows`, and I fixed some of the obvious ones rather than just suppressing them.