### PR TITLE
LUCENE-9705: Correct the format names in Lucene90StoredFieldsFormat

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90StoredFieldsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90StoredFieldsFormat.java
@@ -31,7 +31,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.packed.DirectMonotonicWriter;
 
 /**
- * Lucene 8.7 stored fields format.
+ * Lucene 9.0 stored fields format.
  *
  * <p><b>Principle</b>
  *
@@ -158,10 +158,10 @@ public class Lucene90StoredFieldsFormat extends StoredFieldsFormat {
     switch (mode) {
       case BEST_SPEED:
         return new Lucene90CompressingStoredFieldsFormat(
-            "Lucene87StoredFieldsFastData", BEST_SPEED_MODE, BEST_SPEED_BLOCK_LENGTH, 1024, 10);
+            "Lucene90StoredFieldsFastData", BEST_SPEED_MODE, BEST_SPEED_BLOCK_LENGTH, 1024, 10);
       case BEST_COMPRESSION:
         return new Lucene90CompressingStoredFieldsFormat(
-            "Lucene87StoredFieldsHighData",
+            "Lucene90StoredFieldsHighData",
             BEST_COMPRESSION_MODE,
             BEST_COMPRESSION_BLOCK_LENGTH,
             4096,


### PR DESCRIPTION
We accidentally kept the old names when creating the new format.