### PR TITLE
Fix test that modifies schema

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
@@ -987,7 +987,6 @@ public class TestDemoParallelLeafReader extends LuceneTestCase {
             w.addDocument(newDoc);
           }
         } else {
-          // Just carry over doc values from previous field:
           NumericDocValues oldValues = reader.getNumericDocValues("number");
           assertNotNull("oldSchemaGen=" + oldSchemaGen, oldValues);
           for (int i = 0; i < maxDoc; i++) {
@@ -995,9 +994,9 @@ public class TestDemoParallelLeafReader extends LuceneTestCase {
             reader.document(i);
             Document newDoc = new Document();
             assertEquals(i, oldValues.nextDoc());
-            newDoc.add(
-                new NumericDocValuesField(
-                    "number", newSchemaGen * (oldValues.longValue() / oldSchemaGen)));
+            long value = newSchemaGen * (oldValues.longValue() / oldSchemaGen);
+            newDoc.add(new NumericDocValuesField("number", value));
+            newDoc.add(new LongPoint("number", value));
             w.addDocument(newDoc);
           }
         }


### PR DESCRIPTION
LUCENE-9334 requires that docs have the same schema
across the whole schema.
This fixes the test TestDemoParallelLeafReader.testRandomMultipleSchemaGensSameField 
that attempts to modify schema of "number" field
from DocValues and Points to just DocValues.

Relates to #11