### PR TITLE
LUCENE-9907: Remove unused method PackedInts.Mutable#save

### DIFF
--- a/gradle/generation/moman/gen_Packed64SingleBlock.py
+++ b/gradle/generation/moman/gen_Packed64SingleBlock.py
@@ -216,12 +216,6 @@ abstract class Packed64SingleBlock extends PackedInts.MutableImpl {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
-  protected PackedInts.Format getFormat() {
-    return PackedInts.Format.PACKED_SINGLE_BLOCK;
-  }
-
-  @Override
   public String toString() {
     return getClass().getSimpleName() + "(bitsPerValue=" + bitsPerValue
         + ",size=" + size() + ",blocks=" + blocks.length + ")";

--- a/lucene/core/src/generated/checksums/utilGenPacked.json
+++ b/lucene/core/src/generated/checksums/utilGenPacked.json
@@ -26,6 +26,6 @@
     "lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPacked8.java": "bc5124047b26fc0be147db5bc855be038d306f65",
     "lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPacked9.java": "1121f69ea6d830ab6f4bd2f51d017b792c17d1b1",
     "lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPackedSingleBlock.java": "36984601502fcc812eb9d9a845fa10774e575653",
-    "lucene/core/src/java/org/apache/lucene/util/packed/Packed64SingleBlock.java": "18c97614f29045519a8d440a35c685c50a5e9a34",
+    "lucene/core/src/java/org/apache/lucene/util/packed/Packed64SingleBlock.java": "2703943d7980188a3da355490e7b72918910b369",
     "property:source": "https://github.com/jpbarrette/moman/archive/497c90e34e412b6494db6dabf0d95db8034bd325.zip"
 }

--- a/lucene/core/src/java/org/apache/lucene/util/packed/GrowableWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/GrowableWriter.java
@@ -16,8 +16,6 @@
  */
 package org.apache.lucene.util.packed;
 
-import java.io.IOException;
-import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.RamUsageEstimator;
 
 /**
@@ -134,10 +132,5 @@ public class GrowableWriter extends PackedInts.Mutable {
                 + Long.BYTES
                 + Float.BYTES)
         + current.ramBytesUsed();
-  }
-
-  @Override
-  public void save(DataOutput out) throws IOException {
-    current.save(out);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/packed/Packed64SingleBlock.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/Packed64SingleBlock.java
@@ -198,12 +198,6 @@ abstract class Packed64SingleBlock extends PackedInts.MutableImpl {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
-  protected PackedInts.Format getFormat() {
-    return PackedInts.Format.PACKED_SINGLE_BLOCK;
-  }
-
-  @Override
   public String toString() {
     return getClass().getSimpleName()
         + "(bitsPerValue="

--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
@@ -502,25 +502,6 @@ public class PackedInts {
     public void clear() {
       fill(0, size(), 0);
     }
-
-    /**
-     * Save this mutable into <code>out</code>. This method does not write any metadata to the
-     * stream, meaning that it is your responsibility to store it somewhere else in order to be able
-     * to recover data from the stream later on.
-     */
-    public void save(DataOutput out) throws IOException {
-      Writer writer =
-          getWriterNoHeader(out, getFormat(), size(), getBitsPerValue(), DEFAULT_BUFFER_SIZE);
-      for (int i = 0; i < size(); ++i) {
-        writer.add(get(i));
-      }
-      writer.finish();
-    }
-
-    /** The underlying format. */
-    Format getFormat() {
-      return Format.PACKED;
-    }
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/packed/gen_Packed64SingleBlock.py
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/gen_Packed64SingleBlock.py
@@ -216,12 +216,6 @@ abstract class Packed64SingleBlock extends PackedInts.MutableImpl {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
-  protected PackedInts.Format getFormat() {
-    return PackedInts.Format.PACKED_SINGLE_BLOCK;
-  }
-
-  @Override
   public String toString() {
     return getClass().getSimpleName() + "(bitsPerValue=" + bitsPerValue
         + ",size=" + size() + ",blocks=" + blocks.length + ")";

--- a/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import org.apache.lucene.store.ByteArrayDataInput;
-import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -862,48 +861,6 @@ public class TestPackedInts extends LuceneTestCase {
       } else {
         assertEquals(0, writer.get(idx));
       }
-    }
-  }
-
-  public void testSave() throws IOException {
-    final int valueCount = TestUtil.nextInt(random(), 1, 2048);
-    for (int bpv = 1; bpv <= 64; ++bpv) {
-      final int maxValue = (int) Math.min(PackedInts.maxValue(31), PackedInts.maxValue(bpv));
-      final Directory directory = new ByteBuffersDirectory();
-      List<PackedInts.Mutable> packedInts = createPackedInts(valueCount, bpv);
-      for (PackedInts.Mutable mutable : packedInts) {
-        for (int i = 0; i < mutable.size(); ++i) {
-          mutable.set(i, random().nextInt(maxValue));
-        }
-
-        IndexOutput out = directory.createOutput("packed-ints.bin", IOContext.DEFAULT);
-        mutable.save(out);
-        out.close();
-
-        IndexInput in = directory.openInput("packed-ints.bin", IOContext.DEFAULT);
-        PackedInts.Reader reader =
-            PackedInts.getReaderNoHeader(
-                in,
-                mutable.getFormat(),
-                PackedInts.VERSION_CURRENT,
-                mutable.size(),
-                mutable.getBitsPerValue());
-        assertEquals(valueCount, reader.size());
-        if (mutable instanceof Packed64SingleBlock) {
-          // make sure that we used the right format so that the reader has
-          // the same performance characteristics as the mutable that has been
-          // serialized
-          assertTrue(reader instanceof Packed64SingleBlock);
-        } else {
-          assertFalse(reader instanceof Packed64SingleBlock);
-        }
-        for (int i = 0; i < valueCount; ++i) {
-          assertEquals(mutable.get(i), reader.get(i));
-        }
-        in.close();
-        directory.deleteFile("packed-ints.bin");
-      }
-      directory.close();
     }
   }
 


### PR DESCRIPTION
The method in PackedInts.Mutable#save is never used. Let 's remove it. 

The PR removes as well the method PackedInts.Mutable#getFormat() which seems to be only used by the method above. This changes `Packed64SingleBlock` so I need to update the generation script and the hash of the generated file.