### PR TITLE
LUCENE-9907: Move PackedInts#getReaderNoHeader() to backwards codec

### DIFF
--- a/gradle/generation/moman/gen_Packed64SingleBlock.py
+++ b/gradle/generation/moman/gen_Packed64SingleBlock.py
@@ -37,10 +37,7 @@ HEADER = """// This file has been automatically generated, DO NOT EDIT
  */
 package org.apache.lucene.util.packed;
 
-import java.io.IOException;
 import java.util.Arrays;
-
-import org.apache.lucene.store.DataInput;
 import org.apache.lucene.util.RamUsageEstimator;
 
 /**
@@ -219,15 +216,6 @@ abstract class Packed64SingleBlock extends PackedInts.MutableImpl {
   public String toString() {
     return getClass().getSimpleName() + "(bitsPerValue=" + bitsPerValue
         + ",size=" + size() + ",blocks=" + blocks.length + ")";
-  }
-
-  public static Packed64SingleBlock create(DataInput in,
-      int valueCount, int bitsPerValue) throws IOException {
-    Packed64SingleBlock reader = create(valueCount, bitsPerValue);
-    for (int i = 0; i < reader.blocks.length; ++i) {
-      reader.blocks[i] = in.readLong();
-    }
-    return reader;
   }
 
 """ % (SUPPORTED_BITS_PER_VALUE[-1], ", ".join(map(str, SUPPORTED_BITS_PER_VALUE)))

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -299,6 +299,9 @@ Other
  
 * LUCENE-9705: Make new versions of all index formats for the Lucene90 codec and move 
   the existing ones to the backwards codecs. (Julie Tibshirani, Ignacio Vera)  
+  
+* LUCENE-9907: Remove dependency on PackedInts#getReader() from the current codecs and move the
+  method to backwards codec. (Ignacio Vera)   
 
 ======================= Lucene 8.9.0 =======================
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/LegacyFieldsIndexReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/LegacyFieldsIndexReader.java
@@ -19,6 +19,7 @@ package org.apache.lucene.backward_codecs.lucene50.compressing;
 import static org.apache.lucene.util.BitUtil.zigZagDecode;
 
 import java.io.IOException;
+import org.apache.lucene.backward_codecs.packed.LegacyPackedInts;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.store.IndexInput;
@@ -74,7 +75,7 @@ final class LegacyFieldsIndexReader extends FieldsIndex {
             "Corrupted bitsPerDocBase: " + bitsPerDocBase, fieldsIndexIn);
       }
       docBasesDeltas[blockCount] =
-          PackedInts.getReaderNoHeader(
+          LegacyPackedInts.getReaderNoHeader(
               fieldsIndexIn,
               PackedInts.Format.PACKED,
               packedIntsVersion,
@@ -90,7 +91,7 @@ final class LegacyFieldsIndexReader extends FieldsIndex {
             "Corrupted bitsPerStartPointer: " + bitsPerStartPointer, fieldsIndexIn);
       }
       startPointersDeltas[blockCount] =
-          PackedInts.getReaderNoHeader(
+          LegacyPackedInts.getReaderNoHeader(
               fieldsIndexIn,
               PackedInts.Format.PACKED,
               packedIntsVersion,

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsReader.java
@@ -19,6 +19,7 @@ package org.apache.lucene.backward_codecs.lucene50.compressing;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import org.apache.lucene.backward_codecs.packed.LegacyPackedInts;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.TermVectorsReader;
 import org.apache.lucene.codecs.compressing.CompressionMode;
@@ -403,12 +404,12 @@ public final class Lucene50CompressingTermVectorsReader extends TermVectorsReade
     {
       final int bitsPerOff = PackedInts.bitsRequired(fieldNums.length - 1);
       final PackedInts.Reader allFieldNumOffs =
-          PackedInts.getReaderNoHeader(
+          LegacyPackedInts.getReaderNoHeader(
               vectorsStream, PackedInts.Format.PACKED, packedIntsVersion, totalFields, bitsPerOff);
       switch (vectorsStream.readVInt()) {
         case 0:
           final PackedInts.Reader fieldFlags =
-              PackedInts.getReaderNoHeader(
+              LegacyPackedInts.getReaderNoHeader(
                   vectorsStream,
                   PackedInts.Format.PACKED,
                   packedIntsVersion,
@@ -425,7 +426,7 @@ public final class Lucene50CompressingTermVectorsReader extends TermVectorsReade
           break;
         case 1:
           flags =
-              PackedInts.getReaderNoHeader(
+              LegacyPackedInts.getReaderNoHeader(
                   vectorsStream,
                   PackedInts.Format.PACKED,
                   packedIntsVersion,
@@ -446,7 +447,7 @@ public final class Lucene50CompressingTermVectorsReader extends TermVectorsReade
     {
       final int bitsRequired = vectorsStream.readVInt();
       numTerms =
-          PackedInts.getReaderNoHeader(
+          LegacyPackedInts.getReaderNoHeader(
               vectorsStream,
               PackedInts.Format.PACKED,
               packedIntsVersion,

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/packed/LegacyPacked64.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/packed/LegacyPacked64.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.backward_codecs.packed;
+
+import java.io.IOException;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.packed.PackedInts;
+
+/**
+ * Immutable version of {@code Packed64} which is constructed from am existing {@link DataInput}.
+ */
+class LegacyPacked64 extends PackedInts.Reader {
+  static final int BLOCK_SIZE = 64; // 32 = int, 64 = long
+  static final int BLOCK_BITS = 6; // The #bits representing BLOCK_SIZE
+  static final int MOD_MASK = BLOCK_SIZE - 1; // x % BLOCK_SIZE
+
+  /** Values are stores contiguously in the blocks array. */
+  private final long[] blocks;
+  /** A right-aligned mask of width BitsPerValue used by {@link #get(int)}. */
+  private final long maskRight;
+  /** Optimization: Saves one lookup in {@link #get(int)}. */
+  private final int bpvMinusBlockSize;
+  /** number of values */
+  protected final int valueCount;
+  /** bits per value. */
+  protected final int bitsPerValue;
+
+  /**
+   * Creates an array with content retrieved from the given DataInput.
+   *
+   * @param in a DataInput, positioned at the start of Packed64-content.
+   * @param valueCount the number of elements.
+   * @param bitsPerValue the number of bits available for any given value.
+   * @throws IOException if the values for the backing array could not be retrieved.
+   */
+  public LegacyPacked64(int packedIntsVersion, DataInput in, int valueCount, int bitsPerValue)
+      throws IOException {
+    this.valueCount = valueCount;
+    this.bitsPerValue = bitsPerValue;
+    final PackedInts.Format format = PackedInts.Format.PACKED;
+    final long byteCount =
+        format.byteCount(packedIntsVersion, valueCount, bitsPerValue); // to know how much to read
+    final int longCount =
+        format.longCount(PackedInts.VERSION_CURRENT, valueCount, bitsPerValue); // to size the array
+    blocks = new long[longCount];
+    // read as many longs as we can
+    for (int i = 0; i < byteCount / 8; ++i) {
+      blocks[i] = in.readLong();
+    }
+    final int remaining = (int) (byteCount % 8);
+    if (remaining != 0) {
+      // read the last bytes
+      long lastLong = 0;
+      for (int i = 0; i < remaining; ++i) {
+        lastLong |= (in.readByte() & 0xFFL) << (56 - i * 8);
+      }
+      blocks[blocks.length - 1] = lastLong;
+    }
+    maskRight = ~0L << (BLOCK_SIZE - bitsPerValue) >>> (BLOCK_SIZE - bitsPerValue);
+    bpvMinusBlockSize = bitsPerValue - BLOCK_SIZE;
+  }
+
+  @Override
+  public final int size() {
+    return valueCount;
+  }
+
+  @Override
+  public long get(final int index) {
+    // The abstract index in a bit stream
+    final long majorBitPos = (long) index * bitsPerValue;
+    // The index in the backing long-array
+    final int elementPos = (int) (majorBitPos >>> BLOCK_BITS);
+    // The number of value-bits in the second long
+    final long endBits = (majorBitPos & MOD_MASK) + bpvMinusBlockSize;
+
+    if (endBits <= 0) { // Single block
+      return (blocks[elementPos] >>> -endBits) & maskRight;
+    }
+    // Two blocks
+    return ((blocks[elementPos] << endBits) | (blocks[elementPos + 1] >>> (BLOCK_SIZE - endBits)))
+        & maskRight;
+  }
+
+  @Override
+  public int get(int index, long[] arr, int off, int len) {
+    assert len > 0 : "len must be > 0 (got " + len + ")";
+    assert index >= 0 && index < valueCount;
+    len = Math.min(len, valueCount - index);
+    assert off + len <= arr.length;
+
+    final int originalIndex = index;
+    final PackedInts.Decoder decoder =
+        PackedInts.getDecoder(PackedInts.Format.PACKED, PackedInts.VERSION_CURRENT, bitsPerValue);
+
+    // go to the next block where the value does not span across two blocks
+    final int offsetInBlocks = index % decoder.longValueCount();
+    if (offsetInBlocks != 0) {
+      for (int i = offsetInBlocks; i < decoder.longValueCount() && len > 0; ++i) {
+        arr[off++] = get(index++);
+        --len;
+      }
+      if (len == 0) {
+        return index - originalIndex;
+      }
+    }
+
+    // bulk get
+    assert index % decoder.longValueCount() == 0;
+    int blockIndex = (int) (((long) index * bitsPerValue) >>> BLOCK_BITS);
+    assert (((long) index * bitsPerValue) & MOD_MASK) == 0;
+    final int iterations = len / decoder.longValueCount();
+    decoder.decode(blocks, blockIndex, arr, off, iterations);
+    final int gotValues = iterations * decoder.longValueCount();
+    index += gotValues;
+    len -= gotValues;
+    assert len >= 0;
+
+    if (index > originalIndex) {
+      // stay at the block boundary
+      return index - originalIndex;
+    } else {
+      // no progress so far => already at a block boundary but no full block to get
+      assert index == originalIndex;
+      return super.get(index, arr, off, len);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "LegacyPacked64(bitsPerValue="
+        + bitsPerValue
+        + ",size="
+        + size()
+        + ",blocks="
+        + blocks.length
+        + ")";
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return RamUsageEstimator.alignObjectSize(
+            RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
+                + 3 * Integer.BYTES // bpvMinusBlockSize,valueCount,bitsPerValue
+                + Long.BYTES // maskRight
+                + RamUsageEstimator.NUM_BYTES_OBJECT_REF) // blocks ref
+        + RamUsageEstimator.sizeOf(blocks);
+  }
+}

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/packed/LegacyPackedInts.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/packed/LegacyPackedInts.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.backward_codecs.packed;
+
+import java.io.IOException;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.packed.PackedInts;
+
+/**
+ * Legacy PackedInts operations.
+ *
+ * @lucene.internal
+ */
+public class LegacyPackedInts {
+
+  private LegacyPackedInts() {
+    // no instances
+  }
+
+  /**
+   * Expert: Restore a {@code PackedInts.Reader} from a stream without reading metadata at the
+   * beginning of the stream. This method is useful to restore data from streams which have been
+   * created using {@link PackedInts#getWriterNoHeader(DataOutput, PackedInts.Format, int, int,
+   * int)}.
+   *
+   * @param in the stream to read data from, positioned at the beginning of the packed values
+   * @param format the format used to serialize
+   * @param version the version used to serialize the data
+   * @param valueCount how many values the stream holds
+   * @param bitsPerValue the number of bits per value
+   * @return a Reader
+   * @throws IOException If there is a low-level I/O error
+   * @see PackedInts#getWriterNoHeader(DataOutput, PackedInts.Format, int, int, int)
+   * @lucene.internal
+   */
+  public static PackedInts.Reader getReaderNoHeader(
+      DataInput in, PackedInts.Format format, int version, int valueCount, int bitsPerValue)
+      throws IOException {
+    PackedInts.checkVersion(version);
+    switch (format) {
+      case PACKED_SINGLE_BLOCK:
+        return LegacyPacked64SingleBlock.create(in, valueCount, bitsPerValue);
+      case PACKED:
+        return new LegacyPacked64(version, in, valueCount, bitsPerValue);
+      default:
+        throw new AssertionError("Unknown Writer format: " + format);
+    }
+  }
+}

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/packed/package-info.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/packed/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** Legacy PackedInts methods */
+package org.apache.lucene.backward_codecs.packed;

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/packed/TestLegacyPackedInts.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/packed/TestLegacyPackedInts.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.backward_codecs.packed;
+
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import java.io.IOException;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.RamUsageTester;
+import org.apache.lucene.util.TestUtil;
+import org.apache.lucene.util.packed.PackedInts;
+import org.apache.lucene.util.packed.PackedInts.Reader;
+
+public class TestLegacyPackedInts extends LuceneTestCase {
+
+  public void testPackedInts() throws IOException {
+    int num = atLeast(3);
+    for (int iter = 0; iter < num; iter++) {
+      for (int nbits = 1; nbits <= 64; nbits++) {
+        final long maxValue = PackedInts.maxValue(nbits);
+        final int valueCount = TestUtil.nextInt(random(), 1, 600);
+        final Directory d = newDirectory();
+
+        IndexOutput out = d.createOutput("out.bin", newIOContext(random()));
+        final int mem = random().nextInt(2 * PackedInts.DEFAULT_BUFFER_SIZE);
+        PackedInts.Writer w =
+            PackedInts.getWriterNoHeader(out, PackedInts.Format.PACKED, valueCount, nbits, mem);
+        final long startFp = out.getFilePointer();
+
+        final int actualValueCount =
+            random().nextBoolean() ? valueCount : TestUtil.nextInt(random(), 0, valueCount);
+        final long[] values = new long[valueCount];
+        for (int i = 0; i < actualValueCount; i++) {
+          if (nbits == 64) {
+            values[i] = random().nextLong();
+          } else {
+            values[i] = TestUtil.nextLong(random(), 0, maxValue);
+          }
+          w.add(values[i]);
+        }
+        w.finish();
+        final long fp = out.getFilePointer();
+        out.close();
+
+        // ensure that finish() added the (valueCount-actualValueCount) missing values
+        final long bytes =
+            PackedInts.Format.PACKED.byteCount(
+                PackedInts.VERSION_CURRENT, valueCount, w.bitsPerValue());
+        assertEquals(bytes, fp - startFp);
+
+        { // test reader
+          IndexInput in = d.openInput("out.bin", newIOContext(random()));
+          PackedInts.Reader r =
+              LegacyPackedInts.getReaderNoHeader(
+                  in, PackedInts.Format.PACKED, PackedInts.VERSION_CURRENT, valueCount, nbits);
+          assertEquals(fp, in.getFilePointer());
+          for (int i = 0; i < valueCount; i++) {
+            assertEquals(
+                "index="
+                    + i
+                    + " valueCount="
+                    + valueCount
+                    + " nbits="
+                    + nbits
+                    + " for "
+                    + r.getClass().getSimpleName(),
+                values[i],
+                r.get(i));
+          }
+          in.close();
+          final long expectedBytesUsed = RamUsageTester.sizeOf(r);
+          final long computedBytesUsed = r.ramBytesUsed();
+          assertEquals(
+              r.getClass() + "expected " + expectedBytesUsed + ", got: " + computedBytesUsed,
+              expectedBytesUsed,
+              computedBytesUsed);
+        }
+        d.close();
+      }
+    }
+  }
+
+  public void testEndPointer() throws IOException {
+    final Directory dir = newDirectory();
+    final int valueCount = RandomNumbers.randomIntBetween(random(), 1, 1000);
+    final IndexOutput out = dir.createOutput("tests.bin", newIOContext(random()));
+    for (int i = 0; i < valueCount; ++i) {
+      out.writeLong(0);
+    }
+    out.close();
+    final IndexInput in = dir.openInput("tests.bin", newIOContext(random()));
+    for (int version = PackedInts.VERSION_START; version <= PackedInts.VERSION_CURRENT; ++version) {
+      for (int bpv = 1; bpv <= 64; ++bpv) {
+        for (PackedInts.Format format : PackedInts.Format.values()) {
+          if (!format.isSupported(bpv)) {
+            continue;
+          }
+          final long byteCount = format.byteCount(version, valueCount, bpv);
+          String msg =
+              "format="
+                  + format
+                  + ",version="
+                  + version
+                  + ",valueCount="
+                  + valueCount
+                  + ",bpv="
+                  + bpv;
+          // test reader
+          in.seek(0L);
+          LegacyPackedInts.getReaderNoHeader(in, format, version, valueCount, bpv);
+          assertEquals(msg, byteCount, in.getFilePointer());
+        }
+      }
+    }
+    in.close();
+    dir.close();
+  }
+
+  public void testSingleValue() throws Exception {
+    for (int bitsPerValue = 1; bitsPerValue <= 64; ++bitsPerValue) {
+      Directory dir = newDirectory();
+      IndexOutput out = dir.createOutput("out", newIOContext(random()));
+      PackedInts.Writer w =
+          PackedInts.getWriterNoHeader(
+              out, PackedInts.Format.PACKED, 1, bitsPerValue, PackedInts.DEFAULT_BUFFER_SIZE);
+      long value = 17L & PackedInts.maxValue(bitsPerValue);
+      w.add(value);
+      w.finish();
+      final long end = out.getFilePointer();
+      out.close();
+
+      IndexInput in = dir.openInput("out", newIOContext(random()));
+      Reader reader =
+          LegacyPackedInts.getReaderNoHeader(
+              in, PackedInts.Format.PACKED, PackedInts.VERSION_CURRENT, 1, bitsPerValue);
+      String msg = "Impl=" + w.getClass().getSimpleName() + ", bitsPerValue=" + bitsPerValue;
+      assertEquals(msg, 1, reader.size());
+      assertEquals(msg, value, reader.get(0));
+      assertEquals(msg, end, in.getFilePointer());
+      in.close();
+
+      dir.close();
+    }
+  }
+}

--- a/lucene/core/src/generated/checksums/utilGenPacked.json
+++ b/lucene/core/src/generated/checksums/utilGenPacked.json
@@ -26,6 +26,6 @@
     "lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPacked8.java": "bc5124047b26fc0be147db5bc855be038d306f65",
     "lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPacked9.java": "1121f69ea6d830ab6f4bd2f51d017b792c17d1b1",
     "lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPackedSingleBlock.java": "36984601502fcc812eb9d9a845fa10774e575653",
-    "lucene/core/src/java/org/apache/lucene/util/packed/Packed64SingleBlock.java": "2703943d7980188a3da355490e7b72918910b369",
+    "lucene/core/src/java/org/apache/lucene/util/packed/Packed64SingleBlock.java": "2680e0a7c7207ddf615f50fd22465c809904ac42",
     "property:source": "https://github.com/jpbarrette/moman/archive/497c90e34e412b6494db6dabf0d95db8034bd325.zip"
 }

--- a/lucene/core/src/java/org/apache/lucene/util/packed/Packed64.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/Packed64.java
@@ -16,9 +16,7 @@
  */
 package org.apache.lucene.util.packed;
 
-import java.io.IOException;
 import java.util.Arrays;
-import org.apache.lucene.store.DataInput;
 import org.apache.lucene.util.RamUsageEstimator;
 
 /**
@@ -59,40 +57,6 @@ class Packed64 extends PackedInts.MutableImpl {
     final PackedInts.Format format = PackedInts.Format.PACKED;
     final int longCount = format.longCount(PackedInts.VERSION_CURRENT, valueCount, bitsPerValue);
     this.blocks = new long[longCount];
-    maskRight = ~0L << (BLOCK_SIZE - bitsPerValue) >>> (BLOCK_SIZE - bitsPerValue);
-    bpvMinusBlockSize = bitsPerValue - BLOCK_SIZE;
-  }
-
-  /**
-   * Creates an array with content retrieved from the given DataInput.
-   *
-   * @param in a DataInput, positioned at the start of Packed64-content.
-   * @param valueCount the number of elements.
-   * @param bitsPerValue the number of bits available for any given value.
-   * @throws java.io.IOException if the values for the backing array could not be retrieved.
-   */
-  public Packed64(int packedIntsVersion, DataInput in, int valueCount, int bitsPerValue)
-      throws IOException {
-    super(valueCount, bitsPerValue);
-    final PackedInts.Format format = PackedInts.Format.PACKED;
-    final long byteCount =
-        format.byteCount(packedIntsVersion, valueCount, bitsPerValue); // to know how much to read
-    final int longCount =
-        format.longCount(PackedInts.VERSION_CURRENT, valueCount, bitsPerValue); // to size the array
-    blocks = new long[longCount];
-    // read as many longs as we can
-    for (int i = 0; i < byteCount / 8; ++i) {
-      blocks[i] = in.readLong();
-    }
-    final int remaining = (int) (byteCount % 8);
-    if (remaining != 0) {
-      // read the last bytes
-      long lastLong = 0;
-      for (int i = 0; i < remaining; ++i) {
-        lastLong |= (in.readByte() & 0xFFL) << (56 - i * 8);
-      }
-      blocks[blocks.length - 1] = lastLong;
-    }
     maskRight = ~0L << (BLOCK_SIZE - bitsPerValue) >>> (BLOCK_SIZE - bitsPerValue);
     bpvMinusBlockSize = bitsPerValue - BLOCK_SIZE;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
@@ -659,35 +659,6 @@ public class PackedInts {
   }
 
   /**
-   * Expert: Restore a {@link Reader} from a stream without reading metadata at the beginning of the
-   * stream. This method is useful to restore data from streams which have been created using {@link
-   * PackedInts#getWriterNoHeader(DataOutput, Format, int, int, int)}.
-   *
-   * @param in the stream to read data from, positioned at the beginning of the packed values
-   * @param format the format used to serialize
-   * @param version the version used to serialize the data
-   * @param valueCount how many values the stream holds
-   * @param bitsPerValue the number of bits per value
-   * @return a Reader
-   * @throws IOException If there is a low-level I/O error
-   * @see PackedInts#getWriterNoHeader(DataOutput, Format, int, int, int)
-   * @lucene.internal
-   */
-  public static Reader getReaderNoHeader(
-      DataInput in, Format format, int version, int valueCount, int bitsPerValue)
-      throws IOException {
-    checkVersion(version);
-    switch (format) {
-      case PACKED_SINGLE_BLOCK:
-        return Packed64SingleBlock.create(in, valueCount, bitsPerValue);
-      case PACKED:
-        return new Packed64(version, in, valueCount, bitsPerValue);
-      default:
-        throw new AssertionError("Unknown Writer format: " + format);
-    }
-  }
-
-  /**
    * Expert: Restore a {@link ReaderIterator} from a stream without reading metadata at the
    * beginning of the stream. This method is useful to restore data from streams which have been
    * created using {@link PackedInts#getWriterNoHeader(DataOutput, Format, int, int, int)}.
@@ -788,7 +759,6 @@ public class PackedInts {
    * @param mem how much memory (in bytes) can be used to speed up serialization
    * @return a Writer
    * @see PackedInts#getReaderIteratorNoHeader(DataInput, Format, int, int, int, int)
-   * @see PackedInts#getReaderNoHeader(DataInput, Format, int, int, int)
    * @lucene.internal
    */
   public static Writer getWriterNoHeader(

--- a/lucene/core/src/java/org/apache/lucene/util/packed/gen_Packed64SingleBlock.py
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/gen_Packed64SingleBlock.py
@@ -37,10 +37,7 @@ HEADER = """// This file has been automatically generated, DO NOT EDIT
  */
 package org.apache.lucene.util.packed;
 
-import java.io.IOException;
 import java.util.Arrays;
-
-import org.apache.lucene.store.DataInput;
 import org.apache.lucene.util.RamUsageEstimator;
 
 /**
@@ -219,15 +216,6 @@ abstract class Packed64SingleBlock extends PackedInts.MutableImpl {
   public String toString() {
     return getClass().getSimpleName() + "(bitsPerValue=" + bitsPerValue
         + ",size=" + size() + ",blocks=" + blocks.length + ")";
-  }
-
-  public static Packed64SingleBlock create(DataInput in,
-      int valueCount, int bitsPerValue) throws IOException {
-    Packed64SingleBlock reader = create(valueCount, bitsPerValue);
-    for (int i = 0; i < reader.blocks.length; ++i) {
-      reader.blocks[i] = in.readLong();
-    }
-    return reader;
   }
 
 """ % (SUPPORTED_BITS_PER_VALUE[-1], ", ".join(map(str, SUPPORTED_BITS_PER_VALUE)))


### PR DESCRIPTION
The method PackedInts#getReaderNoHeader() is only used from codecs in backwards-codec, therefore we can move the actual method to that package.

In order to do that we create read only versions of Packed64 and Packed64SingleBlock. Those versions are always created from an existing `DataInput`.

In addition the current versions of `Packed64` and `Packed64SingleBlock` have removed the ability of reading from a `DataInput`.

With this change LUCENE-9907 can be closed.

