### PR TITLE
LUCENE-9869 allow for configuring a custom cache purge scheduler in Monitor (aka Luwak)

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/MonitorConfiguration.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/MonitorConfiguration.java
@@ -34,6 +34,7 @@ public class MonitorConfiguration {
   private int queryUpdateBufferSize = 5000;
   private long purgeFrequency = 5;
   private TimeUnit purgeFrequencyUnits = TimeUnit.MINUTES;
+  private PurgeScheduler purgeScheduler = new SimplePurgeScheduler();
   private QueryDecomposer queryDecomposer = new QueryDecomposer();
   private Path indexPath = null;
   private MonitorQuerySerializer serializer;
@@ -104,6 +105,22 @@ public class MonitorConfiguration {
   /** @return Get the units of the Monitor's querycache garbage-collection frequency */
   public TimeUnit getPurgeFrequencyUnits() {
     return purgeFrequencyUnits;
+  }
+
+  /**
+   * Set the PurgeScheduler to be used by the Monitor
+   *
+   * @param purgeScheduler the PurgeScheduler to be used by the Monitor
+   * @return the current configuration
+   */
+  public MonitorConfiguration setPurgeScheduler(PurgeScheduler purgeScheduler) {
+    this.purgeScheduler = purgeScheduler;
+    return this;
+  }
+
+  /** @return the PurgeScheduler used by the Monitor */
+  public PurgeScheduler getPurgeScheduler() {
+    return purgeScheduler;
   }
 
   /**

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/PurgeScheduledTask.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/PurgeScheduledTask.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.monitor;
+
+/**
+ * PurgeScheduledTask is a handle to a scheduled task that is returned by {@link
+ * org.apache.lucene.monitor.PurgeScheduler#schedule(Runnable, long,
+ * java.util.concurrent.TimeUnit)}. It can be used to cancel scheduled task by calling {@link
+ * org.apache.lucene.monitor.PurgeScheduledTask#stop()} once that task is no longer needed.
+ */
+public interface PurgeScheduledTask {
+  /** Stop periodic execution of task that this instance of PurgeScheduledTask points to */
+  void stop();
+}

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/PurgeScheduler.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/PurgeScheduler.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.monitor;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An interface that is used by Monitor to schedule a periodic cache purge task. Implement this
+ * interface to provide a custom mechanism for scheduling tasks.
+ *
+ * <p>Monitor will run {@link PurgeScheduler#schedule(Runnable, long,
+ * java.util.concurrent.TimeUnit)} to schedule a periodic task and than will call {@link
+ * org.apache.lucene.monitor.PurgeScheduledTask#stop()} once that task is no longer needed.
+ */
+public interface PurgeScheduler {
+
+  /**
+   * Schedule a task for periodic execution.
+   *
+   * @param task a task to be executed periodically
+   * @param purgeFrequency a frequency with which task should be executed
+   * @param purgeFrequencyUnits a time unit used to represent frequency
+   * @return an instance of PurgeScheduledTask that can be used to cancel scheduled task
+   */
+  PurgeScheduledTask schedule(Runnable task, long purgeFrequency, TimeUnit purgeFrequencyUnits);
+}

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/SimplePurgeScheduler.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/SimplePurgeScheduler.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.monitor;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.util.NamedThreadFactory;
+
+final class SimplePurgeScheduler implements PurgeScheduler {
+  @Override
+  public PurgeScheduledTask schedule(
+      Runnable task, long purgeFrequency, TimeUnit purgeFrequencyUnits) {
+    final NamedThreadFactory threadFactory = new NamedThreadFactory("cache-purge");
+    final ScheduledExecutorService purgeExecutor =
+        Executors.newSingleThreadScheduledExecutor(threadFactory);
+    purgeExecutor.scheduleAtFixedRate(task, purgeFrequency, purgeFrequency, purgeFrequencyUnits);
+    return purgeExecutor::shutdown;
+  }
+}


### PR DESCRIPTION
# Description

By default org.apache.lucene.monitor.Monitor will create a new thread per instance
in order to schedule its cache purge periodic task. This is not always the desired
behaviour as for example one could create a large number of Monitor instances in a
single JVM to separate business domains. In such case it would be counterproductive
to create a new thread for each instance of Monitor. Instead through introduction
of PurgeScheduler interface one can now implement its own scheduling strategy.

#10908

# Solution

Introduced a new method to MonitorConfiguration that allows to provide a custom
implementation of PurgeScheduler.

# Tests

Used this new API in an external codebase to confirm its proper behaviour and usefulness.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
