### PR TITLE
LUCENE-9908: Move VectorValues#search to LeafReader

### DIFF
--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
@@ -142,6 +142,12 @@ public class SimpleTextVectorReader extends VectorReader {
   }
 
   @Override
+  public TopDocs search(String field, float[] target, int k, int fanout) throws IOException {
+    VectorValues vectorValues = getVectorValues(field);
+    return vectorValues.search(target, k, fanout);
+  }
+
+  @Override
   public void checkIntegrity() throws IOException {
     IndexInput clone = dataIn.clone();
     clone.seek(0);

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
@@ -143,8 +143,7 @@ public class SimpleTextVectorReader extends VectorReader {
 
   @Override
   public TopDocs search(String field, float[] target, int k, int fanout) throws IOException {
-    VectorValues vectorValues = getVectorValues(field);
-    return vectorValues.search(target, k, fanout);
+    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -338,11 +337,6 @@ public class SimpleTextVectorReader extends VectorReader {
 
     @Override
     public BytesRef binaryValue(int targetOrd) throws IOException {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public TopDocs search(float[] target, int k, int fanout) throws IOException {
       throw new UnsupportedOperationException();
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/VectorFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/VectorFormat.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopDocsCollector;
 
 /**
  * Encodes/decodes per-document vector and any associated indexing structures required to support
@@ -61,7 +63,12 @@ public abstract class VectorFormat {
             }
 
             @Override
-            public void close() throws IOException {}
+            public TopDocs search(String field, float[] target, int k, int fanout) {
+              return TopDocsCollector.EMPTY_TOPDOCS;
+            }
+
+            @Override
+            public void close() {}
 
             @Override
             public long ramBytesUsed() {

--- a/lucene/core/src/java/org/apache/lucene/codecs/VectorReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/VectorReader.java
@@ -20,6 +20,7 @@ package org.apache.lucene.codecs;
 import java.io.Closeable;
 import java.io.IOException;
 import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Accountable;
 
 /** Reads vectors from an index. */
@@ -40,6 +41,22 @@ public abstract class VectorReader implements Closeable, Accountable {
 
   /** Returns the {@link VectorValues} for the given {@code field} */
   public abstract VectorValues getVectorValues(String field) throws IOException;
+
+  /**
+   * Return the k nearest neighbor documents as determined by comparison of their vector values for
+   * this field, to the given vector, by the field's search strategy. If the search strategy is
+   * reversed, lower values indicate nearer vectors, otherwise higher scores indicate nearer
+   * vectors. Unlike relevance scores, vector scores may be negative.
+   *
+   * @param field the vector field to search
+   * @param target the vector-valued query
+   * @param k the number of docs to return
+   * @param fanout control the accuracy/speed tradeoff - larger values give better recall at higher
+   *     cost
+   * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
+   */
+  public abstract TopDocs search(String field, float[] target, int k, int fanout)
+      throws IOException;
 
   /**
    * Returns an instance optimized for merging. This instance may only be consumed in the thread

--- a/lucene/core/src/java/org/apache/lucene/codecs/VectorWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/VectorWriter.java
@@ -30,7 +30,6 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.RandomAccessVectorValues;
 import org.apache.lucene.index.RandomAccessVectorValuesProducer;
 import org.apache.lucene.index.VectorValues;
-import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.BytesRef;
 
 /** Writes vectors to an index. */
@@ -244,11 +243,6 @@ public abstract class VectorWriter implements Closeable {
     @Override
     public SearchStrategy searchStrategy() {
       return subs.get(0).values.searchStrategy();
-    }
-
-    @Override
-    public TopDocs search(float[] target, int k, int fanout) throws IOException {
-      throw new UnsupportedOperationException();
     }
 
     class MergerRandomAccess implements RandomAccessVectorValues {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorReader.java
@@ -38,7 +38,6 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
@@ -230,11 +229,8 @@ public final class Lucene90VectorReader extends VectorReader {
   @Override
   public VectorValues getVectorValues(String field) throws IOException {
     FieldEntry fieldEntry = fields.get(field);
-    if (fieldEntry == null) {
+    if (fieldEntry == null || fieldEntry.dimension == 0) {
       return null;
-    }
-    if (fieldEntry.dimension == 0) {
-      return VectorValues.EMPTY;
     }
 
     return getOffHeapVectorValues(fieldEntry);
@@ -243,11 +239,8 @@ public final class Lucene90VectorReader extends VectorReader {
   @Override
   public TopDocs search(String field, float[] target, int k, int fanout) throws IOException {
     FieldEntry fieldEntry = fields.get(field);
-    if (fieldEntry == null) {
+    if (fieldEntry == null || fieldEntry.dimension == 0) {
       return null;
-    }
-    if (fieldEntry.dimension == 0) {
-      return TopDocsCollector.EMPTY_TOPDOCS;
     }
 
     OffHeapVectorValues vectorValues = getOffHeapVectorValues(fieldEntry);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorReader.java
@@ -38,6 +38,7 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
@@ -236,6 +237,15 @@ public final class Lucene90VectorReader extends VectorReader {
     IndexInput bytesSlice =
         vectorData.slice("vector-data", fieldEntry.vectorDataOffset, fieldEntry.vectorDataLength);
     return new OffHeapVectorValues(fieldEntry, bytesSlice);
+  }
+
+  @Override
+  public TopDocs search(String field, float[] target, int k, int fanout) throws IOException {
+    VectorValues vectorValues = getVectorValues(field);
+    if (vectorValues == null) {
+      return TopDocsCollector.EMPTY_TOPDOCS;
+    }
+    return vectorValues.search(target, k, fanout);
   }
 
   public KnnGraphValues getGraphValues(String field) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
@@ -25,6 +25,7 @@ import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
 import org.apache.lucene.codecs.VectorReader;
+import org.apache.lucene.search.TopDocs;
 
 /** LeafReader implemented by codec APIs. */
 public abstract class CodecReader extends LeafReader {
@@ -216,6 +217,19 @@ public abstract class CodecReader extends LeafReader {
     }
 
     return getVectorReader().getVectorValues(field);
+  }
+
+  @Override
+  public final TopDocs searchNearestVectors(String field, float[] target, int k, int fanout)
+      throws IOException {
+    ensureOpen();
+    FieldInfo fi = getFieldInfos().fieldInfo(field);
+    if (fi == null || fi.getVectorDimension() == 0) {
+      // Field does not exist or does not index vectors
+      return null;
+    }
+
+    return getVectorReader().search(field, target, k, fanout);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
@@ -18,6 +18,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
 
 abstract class DocValuesLeafReader extends LeafReader {
@@ -48,6 +49,12 @@ abstract class DocValuesLeafReader extends LeafReader {
 
   @Override
   public final VectorValues getVectorValues(String field) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public TopDocs searchNearestVectors(String field, float[] target, int k, int fanout)
+      throws IOException {
     throw new UnsupportedOperationException();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Iterator;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
@@ -341,6 +342,12 @@ public abstract class FilterLeafReader extends LeafReader {
   @Override
   public VectorValues getVectorValues(String field) throws IOException {
     return in.getVectorValues(field);
+  }
+
+  @Override
+  public TopDocs searchNearestVectors(String field, float[] target, int k, int fanout)
+      throws IOException {
+    return in.searchNearestVectors(field, target, k, fanout);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -208,6 +208,8 @@ public abstract class LeafReader extends IndexReader {
   /**
    * Returns {@link VectorValues} for this field, or null if no {@link VectorValues} were indexed.
    * The returned instance should only be used by a single thread.
+   *
+   * @lucene.experimental
    */
   public abstract VectorValues getVectorValues(String field) throws IOException;
 
@@ -223,6 +225,8 @@ public abstract class LeafReader extends IndexReader {
    * @param fanout control the accuracy/speed tradeoff - larger values give better recall at higher
    *     cost
    * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
+   *
+   * @lucene.experimental
    */
   public abstract TopDocs searchNearestVectors(String field, float[] target, int k, int fanout)
       throws IOException;

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
 
 /**
@@ -209,6 +210,22 @@ public abstract class LeafReader extends IndexReader {
    * The returned instance should only be used by a single thread.
    */
   public abstract VectorValues getVectorValues(String field) throws IOException;
+
+  /**
+   * Return the k nearest neighbor documents as determined by comparison of their vector values for
+   * this field, to the given vector, by the field's search strategy. If the search strategy is
+   * reversed, lower values indicate nearer vectors, otherwise higher scores indicate nearer
+   * vectors. Unlike relevance scores, vector scores may be negative.
+   *
+   * @param field the vector field to search
+   * @param target the vector-valued query
+   * @param k the number of docs to return
+   * @param fanout control the accuracy/speed tradeoff - larger values give better recall at higher
+   *     cost
+   * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
+   */
+  public abstract TopDocs searchNearestVectors(String field, float[] target, int k, int fanout)
+      throws IOException;
 
   /**
    * Get the {@link FieldInfos} describing all fields in this reader.

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -225,7 +225,6 @@ public abstract class LeafReader extends IndexReader {
    * @param fanout control the accuracy/speed tradeoff - larger values give better recall at higher
    *     cost
    * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
-   *
    * @lucene.experimental
    */
   public abstract TopDocs searchNearestVectors(String field, float[] target, int k, int fanout)

--- a/lucene/core/src/java/org/apache/lucene/index/MergeReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeReaderWrapper.java
@@ -24,6 +24,7 @@ import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
 
 /**
@@ -200,6 +201,12 @@ class MergeReaderWrapper extends LeafReader {
   @Override
   public VectorValues getVectorValues(String fieldName) throws IOException {
     return in.getVectorValues(fieldName);
+  }
+
+  @Override
+  public TopDocs searchNearestVectors(String field, float[] target, int k, int fanout)
+      throws IOException {
+    return in.searchNearestVectors(field, target, k, fanout);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.Version;
 
@@ -389,6 +390,14 @@ public class ParallelLeafReader extends LeafReader {
     ensureOpen();
     LeafReader reader = fieldToReader.get(fieldName);
     return reader == null ? null : reader.getVectorValues(fieldName);
+  }
+
+  @Override
+  public TopDocs searchNearestVectors(String fieldName, float[] target, int k, int fanout)
+      throws IOException {
+    ensureOpen();
+    LeafReader reader = fieldToReader.get(fieldName);
+    return reader == null ? null : reader.searchNearestVectors(fieldName, target, k, fanout);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
@@ -27,6 +27,7 @@ import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
 import org.apache.lucene.codecs.VectorReader;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
 
 /**
@@ -163,6 +164,11 @@ public final class SlowCodecReaderWrapper {
       @Override
       public VectorValues getVectorValues(String field) throws IOException {
         return reader.getVectorValues(field);
+      }
+
+      @Override
+      public TopDocs search(String field, float[] target, int k, int fanout) throws IOException {
+        return reader.searchNearestVectors(field, target, k, fanout);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -33,6 +33,7 @@ import org.apache.lucene.codecs.TermVectorsReader;
 import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOSupplier;
@@ -311,6 +312,11 @@ public final class SortingCodecReader extends FilterCodecReader {
       @Override
       public VectorValues getVectorValues(String field) throws IOException {
         return new VectorValuesWriter.SortingVectorValues(delegate.getVectorValues(field), docMap);
+      }
+
+      @Override
+      public TopDocs search(String field, float[] target, int k, int fanout) {
+        throw new UnsupportedOperationException();
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
@@ -21,8 +21,8 @@ import static org.apache.lucene.util.VectorUtil.dotProduct;
 import static org.apache.lucene.util.VectorUtil.squareDistance;
 
 import java.io.IOException;
+import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -76,28 +76,14 @@ public abstract class VectorValues extends DocIdSetIterator {
   }
 
   /**
-   * Return the k nearest neighbor documents as determined by comparison of their vector values for
-   * this field, to the given vector, by the field's search strategy. If the search strategy is
-   * reversed, lower values indicate nearer vectors, otherwise higher scores indicate nearer
-   * vectors. Unlike relevance scores, vector scores may be negative.
-   *
-   * @param target the vector-valued query
-   * @param k the number of docs to return
-   * @param fanout control the accuracy/speed tradeoff - larger values give better recall at higher
-   *     cost
-   * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
-   */
-  public abstract TopDocs search(float[] target, int k, int fanout) throws IOException;
-
-  /**
    * Search strategy. This is a label describing the method used during indexing and searching of
    * the vectors in order to determine the nearest neighbors.
    */
   public enum SearchStrategy {
 
     /**
-     * No search strategy is provided. Note: {@link VectorValues#search(float[], int, int)} is not
-     * supported for fields specifying this strategy.
+     * No search strategy is provided. Note: {@link VectorReader#search(String, float[], int, int)}
+     * is not supported for fields specifying this strategy.
      */
     NONE,
 
@@ -180,11 +166,6 @@ public abstract class VectorValues extends DocIdSetIterator {
         public float[] vectorValue() {
           throw new IllegalStateException(
               "Attempt to get vectors from EMPTY values (which was not advanced)");
-        }
-
-        @Override
-        public TopDocs search(float[] target, int k, int fanout) {
-          throw new UnsupportedOperationException();
         }
 
         @Override

--- a/lucene/core/src/java/org/apache/lucene/index/VectorValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorValuesWriter.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.codecs.VectorWriter;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Counter;
@@ -197,11 +196,6 @@ class VectorValuesWriter {
     }
 
     @Override
-    public TopDocs search(float[] target, int k, int fanout) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public long cost() {
       return size();
     }
@@ -341,11 +335,6 @@ class VectorValuesWriter {
     @Override
     public long cost() {
       return docsWithFieldIter.cost();
-    }
-
-    @Override
-    public TopDocs search(float[] target, int k, int fanout) throws IOException {
-      throw new UnsupportedOperationException();
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.index.KnnGraphValues;
 import org.apache.lucene.index.RandomAccessVectorValues;
 import org.apache.lucene.index.VectorValues;
@@ -46,10 +47,10 @@ import org.apache.lucene.util.SparseFixedBitSet;
  *       searching the graph for each newly inserted node.
  *   <li><code>maxConn</code> has the same meaning as <code>M</code> in the later paper; it controls
  *       how many of the <code>efConst</code> neighbors are connected to the new node
- *   <li><code>fanout</code> the fanout parameter of {@link VectorValues#search(float[], int, int)}
- *       is used to control the values of <code>numSeed</code> and <code>topK</code> that are passed
- *       to this API. Thus <code>fanout</code> is like a combination of <code>ef</code> (search beam
- *       width) from the 2016 paper and <code>m</code> from the 2014 paper.
+ *   <li><code>fanout</code> the fanout parameter of {@link VectorReader#search(String, float[],
+ *       int, int)} is used to control the values of <code>numSeed</code> and <code>topK</code> that
+ *       are passed to this API. Thus <code>fanout</code> is like a combination of <code>ef</code>
+ *       (search beam width) from the 2016 paper and <code>m</code> from the 2014 paper.
  * </ul>
  *
  * <p>Note: The graph may be searched by multiple threads concurrently, but updates are not

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -277,7 +277,7 @@ public class TestKnnGraph extends LuceneTestCase {
   private static TopDocs doKnnSearch(IndexReader reader, float[] vector, int k) throws IOException {
     TopDocs[] results = new TopDocs[reader.leaves().size()];
     for (LeafReaderContext ctx : reader.leaves()) {
-      results[ctx.ord] = ctx.reader().getVectorValues(KNN_GRAPH_FIELD).search(vector, k, 10);
+      results[ctx.ord] = ctx.reader().searchNearestVectors(KNN_GRAPH_FIELD, vector, k, 10);
       if (ctx.docBase > 0) {
         for (ScoreDoc doc : results[ctx.ord].scoreDocs) {
           doc.doc += ctx.docBase;

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
@@ -28,6 +28,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
@@ -106,6 +107,11 @@ public class TestSegmentToThreadMapping extends LuceneTestCase {
 
       @Override
       public VectorValues getVectorValues(String field) {
+        return null;
+      }
+
+      @Override
+      public TopDocs searchNearestVectors(String field, float[] target, int k, int fanout) {
         return null;
       }
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
@@ -420,7 +420,7 @@ public class KnnGraphTester {
       IndexReader reader, String field, float[] vector, int k, int fanout) throws IOException {
     TopDocs[] results = new TopDocs[reader.leaves().size()];
     for (LeafReaderContext ctx : reader.leaves()) {
-      results[ctx.ord] = ctx.reader().getVectorValues(field).search(vector, k, fanout);
+      results[ctx.ord] = ctx.reader().searchNearestVectors(field, vector, k, fanout);
       int docBase = ctx.docBase;
       for (ScoreDoc scoreDoc : results[ctx.ord].scoreDocs) {
         scoreDoc.doc += docBase;

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
@@ -20,7 +20,6 @@ package org.apache.lucene.util.hnsw;
 import org.apache.lucene.index.RandomAccessVectorValues;
 import org.apache.lucene.index.RandomAccessVectorValuesProducer;
 import org.apache.lucene.index.VectorValues;
-import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.LuceneTestCase;
 
@@ -97,11 +96,6 @@ class MockVectorValues extends VectorValues
 
   @Override
   public BytesRef binaryValue(int targetOrd) {
-    return null;
-  }
-
-  @Override
-  public TopDocs search(float[] target, int k, int fanout) {
     return null;
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnsw.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnsw.java
@@ -39,7 +39,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.RandomAccessVectorValues;
 import org.apache.lucene.index.RandomAccessVectorValuesProducer;
 import org.apache.lucene.index.VectorValues;
-import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
@@ -345,11 +344,6 @@ public class TestHnsw extends LuceneTestCase {
 
     @Override
     public BytesRef binaryValue(int ord) {
-      return null;
-    }
-
-    @Override
-    public TopDocs search(float[] target, int k, int fanout) {
       return null;
     }
   }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
@@ -35,6 +35,7 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.Version;
 
@@ -155,6 +156,11 @@ public class TermVectorLeafReader extends LeafReader {
 
   @Override
   public VectorValues getVectorValues(String fieldName) {
+    return null;
+  }
+
+  @Override
+  public TopDocs searchNearestVectors(String field, float[] target, int k, int fanout) {
     return null;
   }
 

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -40,6 +40,8 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SimpleCollector;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.ArrayUtil;
@@ -1355,6 +1357,11 @@ public class MemoryIndex {
     @Override
     public VectorValues getVectorValues(String fieldName) {
       return VectorValues.EMPTY;
+    }
+
+    @Override
+    public TopDocs searchNearestVectors(String field, float[] target, int k, int fanout) {
+      return TopDocsCollector.EMPTY_TOPDOCS;
     }
 
     @Override

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -41,7 +41,6 @@ import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SimpleCollector;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.ArrayUtil;
@@ -1356,12 +1355,12 @@ public class MemoryIndex {
 
     @Override
     public VectorValues getVectorValues(String fieldName) {
-      return VectorValues.EMPTY;
+      return null;
     }
 
     @Override
     public TopDocs searchNearestVectors(String field, float[] target, int k, int fanout) {
-      return TopDocsCollector.EMPTY_TOPDOCS;
+      return null;
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/QueryUtils.java
@@ -216,6 +216,11 @@ public class QueryUtils {
       }
 
       @Override
+      public TopDocs searchNearestVectors(String field, float[] target, int k, int fanout) {
+        return null;
+      }
+
+      @Override
       public FieldInfos getFieldInfos() {
         return FieldInfos.EMPTY;
       }


### PR DESCRIPTION
This PR removes `VectorValues#search` in favor of exposing NN search through
`VectorReader#search` and `LeafReader#searchNearestVectors`. It also marks the
vector methods on `LeafReader` as experimental.