### PR TITLE
LUCENE-9940: DisjunctionMaxQuery shouldn't depend on disjunct order for equals checks

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -109,7 +109,6 @@ API Changes
   only applicable for fields that are indexed with doc values only. (Mayya Sharipova,
   Adrien Grand, Simon Willnauer)
 
-
 Improvements
 
 * LUCENE-9687: Hunspell support improvements: add API for spell-checking and suggestions, support compound words,
@@ -245,6 +244,9 @@ Bug fixes
 
 * LUCENE-9930: The Ukrainian analyzer was reloading its dictionary for every new
   TokenStreamComponents, which could lead to memory leaks. (Alan Woodward)
+
+* LUCENE-9940: The order of disjuncts in DisjunctionMaxQuery does not matter
+  for equality checks (Alan Woodward)
 
 Changes in Backwards Compatibility Policy
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -496,11 +496,21 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
     Query sub2 = tq("hed", "elephant");
     DisjunctionMaxQuery q = new DisjunctionMaxQuery(Arrays.asList(sub1, sub2), 1.0f);
     Query rewritten = s.rewrite(q);
-    assertTrue(rewritten instanceof BooleanQuery);
-    BooleanQuery bq = (BooleanQuery) rewritten;
-    assertEquals(bq.clauses().size(), 2);
-    assertEquals(bq.clauses().get(0), new BooleanClause(sub1, BooleanClause.Occur.SHOULD));
-    assertEquals(bq.clauses().get(1), new BooleanClause(sub2, BooleanClause.Occur.SHOULD));
+    Query expected =
+        new BooleanQuery.Builder()
+            .add(sub1, BooleanClause.Occur.SHOULD)
+            .add(sub2, BooleanClause.Occur.SHOULD)
+            .build();
+    assertEquals(expected, rewritten);
+  }
+
+  public void testDisjunctOrderAndEquals() throws Exception {
+    // the order that disjuncts are provided in should not matter for equals() comparisons
+    Query sub1 = tq("hed", "albino");
+    Query sub2 = tq("hed", "elephant");
+    Query q1 = new DisjunctionMaxQuery(Arrays.asList(sub1, sub2), 1.0f);
+    Query q2 = new DisjunctionMaxQuery(Arrays.asList(sub2, sub1), 1.0f);
+    assertEquals(q1, q2);
   }
 
   public void testRandomTopDocs() throws Exception {

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/xml/TestCoreParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/xml/TestCoreParser.java
@@ -18,16 +18,19 @@ package org.apache.lucene.queryparser.xml;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.MockAnalyzer;
 import org.apache.lucene.analysis.MockTokenFilter;
 import org.apache.lucene.analysis.MockTokenizer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.util.LuceneTestCase;
@@ -99,13 +102,14 @@ public class TestCoreParser extends LuceneTestCase {
 
   public void testDisjunctionMaxQueryXML() throws ParserException, IOException {
     Query q = parse("DisjunctionMaxQuery.xml");
-    assertTrue(q instanceof DisjunctionMaxQuery);
-    DisjunctionMaxQuery d = (DisjunctionMaxQuery) q;
-    assertEquals(0.0f, d.getTieBreakerMultiplier(), 0.0001f);
-    assertEquals(2, d.getDisjuncts().size());
-    DisjunctionMaxQuery ndq = (DisjunctionMaxQuery) d.getDisjuncts().get(1);
-    assertEquals(0.3f, ndq.getTieBreakerMultiplier(), 0.0001f);
-    assertEquals(1, ndq.getDisjuncts().size());
+    Query expected =
+        new DisjunctionMaxQuery(
+            Arrays.asList(
+                new TermQuery(new Term("a", "merger")),
+                new DisjunctionMaxQuery(
+                    Arrays.asList(new TermQuery(new Term("b", "verger"))), 0.3f)),
+            0.0f);
+    assertEquals(expected, q);
   }
 
   public void testRangeQueryXML() throws ParserException, IOException {


### PR DESCRIPTION
DisjunctionMaxQuery stores its disjuncts in a `Query[]`, and uses
`Arrays.equals()` for comparisons in its `equals()` implementation.
This means that the order in which disjuncts are added to the query
matters for equality checks.

This commit changes DMQ to instead store its disjuncts in a Multiset,
meaning that ordering no longer matters.  The `getDisjuncts()`
method now returns a `Collection<Query>` rather than a `List`, and
some tests are changed to use query equality checks rather than 
iterating over disjuncts and expecting a particular order.