### PR TITLE
LUCENE-9335: [Discussion Only] Implement BMM with BulkScorer interface

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
@@ -30,7 +30,7 @@ public class BMMBulkScorer extends BulkScorer {
   private ScoreMode scoreMode;
   private int scalingFactor;
   private long cost;
-  private static final int FIXED_WINDOW_SIZE = 2048;
+  private static final int FIXED_WINDOW_SIZE = 1024;
 
   public BMMBulkScorer(BooleanWeight weight, List<Scorer> scorers, ScoreMode scoreMode)
       throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
@@ -59,9 +59,7 @@ public class BMMBulkScorer extends BulkScorer {
 
     while (scorer.doc < max) {
       int doc;
-      for (doc = scorer.updateBoundary(lowerBound, upTo);
-          doc < upTo;
-          doc = disi.nextDoc()) {
+      for (doc = scorer.updateBoundary(lowerBound, upTo); doc < upTo; doc = disi.nextDoc()) {
 
         if ((acceptDocs == null || acceptDocs.get(doc))) {
           collector.collect(doc);
@@ -102,9 +100,6 @@ public class BMMBulkScorer extends BulkScorer {
 
     // sum of max scores of scorers in nonEssentialScorers list
     private long nonEssentialMaxScoreSum;
-
-    // sum of score of scorers in essentialScorers list that are positioned on matching doc
-    private long matchedDocScoreSum;
 
     private final MaxScoreSumPropagator maxScoreSumPropagator;
 

--- a/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import static org.apache.lucene.search.ScorerUtil.costWithMinShouldMatch;
+
+import java.io.IOException;
+import java.util.*;
+import org.apache.lucene.util.Bits;
+
+/** BulkScorer that leverages BMM algorithm within interval (min, max) */
+public class BMMBulkScorer extends BulkScorer {
+  private List<Scorer> scorers;
+  private Weight weight;
+  private ScoreMode scoreMode;
+  private int scalingFactor;
+  private long cost;
+  private static final int FIXED_WINDOW_SIZE = 2048;
+
+  public BMMBulkScorer(BooleanWeight weight, List<Scorer> scorers, ScoreMode scoreMode)
+      throws IOException {
+    assert scoreMode == ScoreMode.TOP_SCORES;
+    this.weight = weight;
+    this.scorers = scorers;
+    this.scoreMode = scoreMode;
+    this.scalingFactor = WANDScorer.getScalingFactor(scorers).orElse(0);
+    this.cost =
+        costWithMinShouldMatch(
+            scorers.stream().map(Scorer::iterator).mapToLong(DocIdSetIterator::cost),
+            scorers.size(),
+            1);
+  }
+
+  @Override
+  public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+    // The BMM algorithm is only valid within the boundary [min, max)
+    BMMBoundaryAwareScorer scorer = new BMMBoundaryAwareScorer(weight);
+    TwoPhaseIterator twoPhase = scorer.twoPhaseIterator();
+    DocIdSetIterator approximation = twoPhase.approximation;
+    collector.setScorer(scorer);
+
+    int lowerBound = min;
+    int upperBound = getUpperBound(lowerBound, FIXED_WINDOW_SIZE, max);
+
+    while (scorer.doc < max) {
+      int doc;
+      for (doc = scorer.updateIntervalBoundary(lowerBound, upperBound);
+          doc < upperBound;
+          doc = approximation.nextDoc()) {
+
+        if ((acceptDocs == null || acceptDocs.get(doc)) && twoPhase.matches()) {
+          collector.collect(doc);
+        }
+      }
+
+      lowerBound = doc;
+      upperBound = getUpperBound(lowerBound, FIXED_WINDOW_SIZE, max);
+    }
+
+    return scorer.doc;
+  }
+
+  private int getUpperBound(int lowerBound, int fixedWindowSize, int max) {
+    // use minus instead of plus to avoid integer overflow when close to
+    // DocIdSetIterator.NO_MORE_DOCS
+    if (DocIdSetIterator.NO_MORE_DOCS - lowerBound < fixedWindowSize) {
+      return DocIdSetIterator.NO_MORE_DOCS;
+    } else {
+      return Math.min(lowerBound + fixedWindowSize, max);
+    }
+  }
+
+  @Override
+  public long cost() {
+    return cost;
+  }
+
+  private class BMMBoundaryAwareScorer extends Scorer {
+    // current doc ID of the leads
+    private int doc;
+
+    // heap of scorers ordered by doc ID
+    private final DisiPriorityQueue essentialsScorers;
+
+    // list of scorers whose sum of maxScore is less than minCompetitiveScore, ordered by maxScore
+    private List<DisiWrapper> nonEssentialScorers;
+
+    // sum of max scores of scorers in nonEssentialScorers list
+    private long nonEssentialMaxScoreSum;
+
+    // sum of score of scorers in essentialScorers list that are positioned on matching doc
+    private long matchedDocScoreSum;
+
+    private final MaxScoreSumPropagator maxScoreSumPropagator;
+
+    // upperBound on doc id where BMM algorithm is valid
+    private int upperBound;
+
+    // scaled min competitive score
+    private long minCompetitiveScore = 0;
+
+    /**
+     * Constructs a Scorer
+     *
+     * @param weight The scorers <code>Weight</code>.
+     */
+    protected BMMBoundaryAwareScorer(Weight weight) throws IOException {
+      super(weight);
+      doc = -1;
+      essentialsScorers = new DisiPriorityQueue(scorers.size());
+      nonEssentialScorers = new LinkedList<>();
+      maxScoreSumPropagator = new MaxScoreSumPropagator(scorers);
+      for (Scorer scorer : scorers) {
+        nonEssentialScorers.add(new DisiWrapper(scorer));
+      }
+    }
+
+    // returns the doc id from which iteration begins
+    public int updateIntervalBoundary(int lowerBound, int upperBound) throws IOException {
+      assert lowerBound <= upperBound : "loweBound: " + lowerBound + " upperBound: " + upperBound;
+      this.upperBound = upperBound;
+
+      // update all scorers' position and maxScore by the new boundary information
+      long sumOfAllMaxScore = 0;
+      int minNextDoc = DocIdSetIterator.NO_MORE_DOCS;
+      List<DisiWrapper> newNonEssentialScorers = new LinkedList<>();
+
+      while (essentialsScorers.size() > 0) {
+        nonEssentialScorers.add(essentialsScorers.pop());
+      }
+
+      for (DisiWrapper w : nonEssentialScorers) {
+        if (w.doc < lowerBound) {
+          w.scorer.advanceShallow(lowerBound);
+          w.doc = w.scorer.iterator().advance(lowerBound);
+          minNextDoc = Math.min(minNextDoc, w.doc);
+        } else if (w.doc != DocIdSetIterator.NO_MORE_DOCS) {
+          w.scorer.advanceShallow(w.doc);
+          minNextDoc = Math.min(minNextDoc, w.doc);
+        }
+        // maxScore valid between lowerBound and upperBound
+        w.maxScore = WANDScorer.scaleMaxScore(w.scorer.getMaxScore(upperBound), scalingFactor);
+
+        if (w.doc != DocIdSetIterator.NO_MORE_DOCS) {
+          newNonEssentialScorers.add(w);
+          sumOfAllMaxScore += w.maxScore;
+        }
+      }
+
+      nonEssentialScorers = newNonEssentialScorers;
+
+      // optimization: returns early if certain condition is met
+      if (nonEssentialScorers.size() == 0) {
+        // all scorers reach NO_MORE_DOCS
+        doc = DocIdSetIterator.NO_MORE_DOCS;
+        return doc;
+      } else if (minNextDoc > upperBound) {
+        // next candidate doc already beyond upperBound
+        doc = minNextDoc;
+        return doc;
+      } else if (sumOfAllMaxScore < minCompetitiveScore) {
+        // sum of all scorers' max score is lower than minCompetitiveScore
+        doc = upperBound;
+        return doc;
+      }
+
+      Collections.sort(nonEssentialScorers, (w1, w2) -> (int) (w1.maxScore - w2.maxScore));
+
+      // Re-partition the scorers into non-essential list and essential list, as defined
+      // in the "Optimizing Top-k Document Retrieval Strategies for Block-Max Indexes" paper.
+      nonEssentialMaxScoreSum = 0;
+      for (int i = 0; i < nonEssentialScorers.size(); i++) {
+        DisiWrapper w = nonEssentialScorers.get(i);
+        if (nonEssentialMaxScoreSum + w.maxScore < minCompetitiveScore) {
+          nonEssentialMaxScoreSum += w.maxScore;
+        } else {
+          // the logic is a bit ugly here...but as soon as we find maxScore of scorers in
+          // non-essential list sum to above minCompetitiveScore, we move the rest of
+          // scorers into essential list
+          for (int j = nonEssentialScorers.size() - 1; j >= i; j--) {
+            essentialsScorers.add(nonEssentialScorers.remove(j));
+          }
+          break;
+        }
+      }
+
+      // if sum of all maxScore is less than minCompetitiveScore, then doc would have been set to
+      // upperBound and return already
+      assert essentialsScorers.size() > 0;
+      doc = essentialsScorers.top().doc;
+
+      return doc;
+    }
+
+    @Override
+    public DocIdSetIterator iterator() {
+      return TwoPhaseIterator.asDocIdSetIterator(twoPhaseIterator());
+    }
+
+    @Override
+    public TwoPhaseIterator twoPhaseIterator() {
+      DocIdSetIterator approximation =
+          new DocIdSetIterator() {
+            @Override
+            public int docID() {
+              return doc;
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+              return advance(doc + 1);
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+              // avoiding overflow causing target to be < 0
+              assert 0 <= target && target <= upperBound;
+              assert essentialsScorers.size() > 0;
+
+              doAdvance(target);
+
+              while (doc < upperBound
+                  && nonEssentialMaxScoreSum + matchedDocScoreSum < minCompetitiveScore) {
+                doAdvance(doc + 1);
+              }
+
+              return doc;
+            }
+
+            private void doAdvance(int target) throws IOException {
+              // Find next smallest doc id that is larger than or equal to target from the essential
+              // scorers
+              if (essentialsScorers.top().doc == DocIdSetIterator.NO_MORE_DOCS) {
+                doc = essentialsScorers.top().doc;
+                return;
+              }
+
+              while (essentialsScorers.top().doc < target) {
+                DisiWrapper w = essentialsScorers.pop();
+                w.doc = w.iterator.advance(target);
+                essentialsScorers.add(w);
+              }
+
+              // If the next candidate doc id is still within interval boundary,
+              if (essentialsScorers.top().doc <= upperBound) {
+                doc = essentialsScorers.top().doc;
+
+                matchedDocScoreSum = 0;
+                for (DisiWrapper w : essentialsScorers) {
+                  if (w.doc == doc) {
+                    matchedDocScoreSum += WANDScorer.scaleMaxScore(w.scorer.score(), scalingFactor);
+                  }
+                }
+              } else {
+                // next doc > upperBound already
+                doc = upperBound;
+              }
+            }
+
+            @Override
+            public long cost() {
+              return cost;
+            }
+          };
+
+      return new TwoPhaseIterator(approximation) {
+        @Override
+        public boolean matches() throws IOException {
+          // The doc is a match when all scores sum above minCompetitiveScore
+          for (DisiWrapper w : nonEssentialScorers) {
+            if (w.doc < doc) {
+              w.doc = w.iterator.advance(doc);
+            }
+          }
+
+          if (matchedDocScoreSum != 0 && matchedDocScoreSum > minCompetitiveScore) {
+            return true;
+          }
+
+          for (Scorer scorer : scorers) {
+            if (scorer.docID() == doc) {
+              matchedDocScoreSum += WANDScorer.scaleMaxScore(scorer.score(), scalingFactor);
+
+              if (matchedDocScoreSum >= minCompetitiveScore) {
+                return true;
+              }
+            }
+          }
+          return false;
+        }
+
+        @Override
+        public float matchCost() {
+          // maximum number of scorer that matches() might advance
+          // use length of nonEssentials as it needs to check all scores
+          return nonEssentialScorers.size();
+        }
+      };
+    }
+
+    @Override
+    public int advanceShallow(int target) throws IOException {
+      int result = DocIdSetIterator.NO_MORE_DOCS;
+      for (Scorer s : scorers) {
+        if (s.docID() < target) {
+          result = Math.min(result, s.advanceShallow(target));
+        }
+      }
+
+      return result;
+    }
+
+    @Override
+    public float getMaxScore(int upTo) throws IOException {
+      return maxScoreSumPropagator.getMaxScore(upTo);
+    }
+
+    @Override
+    public float score() throws IOException {
+      double sum = 0;
+      assert ensureAllMatchedAccountedFor();
+      for (Scorer scorer : scorers) {
+        if (scorer.docID() == doc) {
+          sum += scorer.score();
+        }
+      }
+      return (float) sum;
+    }
+
+    private boolean ensureAllMatchedAccountedFor() {
+      for (Scorer scorer : scorers) {
+        if (scorer.docID() < doc) {
+          return false;
+        }
+      }
+
+      // all scorers positioned on or after current doc
+      return true;
+    }
+
+    @Override
+    public int docID() {
+      return doc;
+    }
+
+    @Override
+    public final Collection<ChildScorable> getChildren() {
+      List<ChildScorable> matchingChildren = new ArrayList<>();
+      for (Scorer scorer : scorers) {
+        if (scorer.docID() == doc) {
+          matchingChildren.add(new ChildScorable(scorer, "SHOULD"));
+        }
+      }
+      return matchingChildren;
+    }
+
+    @Override
+    public void setMinCompetitiveScore(float minScore) throws IOException {
+      assert scoreMode == ScoreMode.TOP_SCORES
+          : "minCompetitiveScore can only be set for ScoreMode.TOP_SCORES, but got: " + scoreMode;
+      assert minScore >= 0;
+      long scaledMinScore = WANDScorer.scaleMinScore(minScore, scalingFactor);
+      // minScore increases monotonically
+      assert scaledMinScore >= minCompetitiveScore;
+      minCompetitiveScore = scaledMinScore;
+      maxScoreSumPropagator.setMinCompetitiveScore(minScore);
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
@@ -30,7 +30,7 @@ public class BMMBulkScorer extends BulkScorer {
   private ScoreMode scoreMode;
   private int scalingFactor;
   private long cost;
-  private static final int FIXED_WINDOW_SIZE = 1024;
+  private static final int FIXED_WINDOW_SIZE = 512;
 
   public BMMBulkScorer(BooleanWeight weight, List<Scorer> scorers, ScoreMode scoreMode)
       throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
@@ -30,7 +30,7 @@ public class BMMBulkScorer extends BulkScorer {
   private ScoreMode scoreMode;
   private int scalingFactor;
   private long cost;
-  private static final int FIXED_WINDOW_SIZE = 512;
+  private static final int FIXED_WINDOW_SIZE = 1024;
 
   public BMMBulkScorer(BooleanWeight weight, List<Scorer> scorers, ScoreMode scoreMode)
       throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BMMBulkScorer.java
@@ -203,6 +203,13 @@ public class BMMBulkScorer extends BulkScorer {
       assert essentialsScorers.size() > 0;
       doc = essentialsScorers.top().doc;
 
+      matchedDocScoreSum = 0;
+      for (DisiWrapper w : essentialsScorers) {
+        if (w.doc == doc) {
+          matchedDocScoreSum += WANDScorer.scaleMaxScore(w.scorer.score(), scalingFactor);
+        }
+      }
+
       return doc;
     }
 
@@ -287,13 +294,13 @@ public class BMMBulkScorer extends BulkScorer {
             }
           }
 
-          if (matchedDocScoreSum != 0 && matchedDocScoreSum > minCompetitiveScore) {
+          if (matchedDocScoreSum >= minCompetitiveScore) {
             return true;
           }
 
-          for (Scorer scorer : scorers) {
-            if (scorer.docID() == doc) {
-              matchedDocScoreSum += WANDScorer.scaleMaxScore(scorer.score(), scalingFactor);
+          for (DisiWrapper w : nonEssentialScorers) {
+            if (w.doc == doc) {
+              matchedDocScoreSum += WANDScorer.scaleMaxScore(w.scorer.score(), scalingFactor);
 
               if (matchedDocScoreSum >= minCompetitiveScore) {
                 return true;

--- a/lucene/core/src/java/org/apache/lucene/search/DisiPriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisiPriorityQueue.java
@@ -163,4 +163,11 @@ public final class DisiPriorityQueue implements Iterable<DisiWrapper> {
   public Iterator<DisiWrapper> iterator() {
     return Arrays.asList(heap).subList(0, size).iterator();
   }
+
+  public void clear() {
+    for (int i = 0; i < size; ++i) {
+      heap[i] = null;
+    }
+    size = 0;
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
@@ -83,7 +83,7 @@ final class WANDScorer extends Scorer {
    * are used) as well as floating-point arithmetic errors. Those are rounded up in order to make
    * sure we do not miss any matches.
    */
-  private static long scaleMaxScore(float maxScore, int scalingFactor) {
+  static long scaleMaxScore(float maxScore, int scalingFactor) {
     assert Float.isNaN(maxScore) == false;
     assert maxScore >= 0;
 
@@ -106,7 +106,7 @@ final class WANDScorer extends Scorer {
    * Scale min competitive scores the same way as max scores but this time by rounding down in order
    * to make sure that we do not miss any matches.
    */
-  private static long scaleMinScore(float minScore, int scalingFactor) {
+  static long scaleMinScore(float minScore, int scalingFactor) {
     assert Float.isNaN(minScore) == false;
     assert minScore >= 0;
 
@@ -171,17 +171,7 @@ final class WANDScorer extends Scorer {
     tail = new DisiWrapper[scorers.size()];
 
     if (this.scoreMode == ScoreMode.TOP_SCORES) {
-      OptionalInt scalingFactor = OptionalInt.empty();
-      for (Scorer scorer : scorers) {
-        scorer.advanceShallow(0);
-        float maxScore = scorer.getMaxScore(DocIdSetIterator.NO_MORE_DOCS);
-        if (maxScore != 0 && Float.isFinite(maxScore)) {
-          // 0 and +Infty should not impact the scale
-          scalingFactor =
-              OptionalInt.of(
-                  Math.min(scalingFactor.orElse(Integer.MAX_VALUE), scalingFactor(maxScore)));
-        }
-      }
+      OptionalInt scalingFactor = getScalingFactor(scorers);
 
       // Use a scaling factor of 0 if all max scores are either 0 or +Infty
       this.scalingFactor = scalingFactor.orElse(0);
@@ -200,6 +190,21 @@ final class WANDScorer extends Scorer {
             scorers.stream().map(Scorer::iterator).mapToLong(DocIdSetIterator::cost),
             scorers.size(),
             minShouldMatch);
+  }
+
+  static OptionalInt getScalingFactor(Collection<Scorer> scorers) throws IOException {
+    OptionalInt scalingFactor = OptionalInt.empty();
+    for (Scorer scorer : scorers) {
+      scorer.advanceShallow(0);
+      float maxScore = scorer.getMaxScore(DocIdSetIterator.NO_MORE_DOCS);
+      if (maxScore != 0 && Float.isFinite(maxScore)) {
+        // 0 and +Infty should not impact the scale
+        scalingFactor =
+            OptionalInt.of(
+                Math.min(scalingFactor.orElse(Integer.MAX_VALUE), scalingFactor(maxScore)));
+      }
+    }
+    return scalingFactor;
   }
 
   // returns a boolean so that it can be called from assert


### PR DESCRIPTION
Implement BMM algorithm from "Optimizing Top-k Document Retrieval Strategies for Block-Max Indexes" by Dimopoulos, Nepomnyachiy and Suel, using BulkScorer interface. 

This BMM implementation passes all existing tests run by `./gradlew check` as well as luceneutil benchmark

---

luceneutil benchmark result with wikimedium5m

run1
```
                 TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
              OrHighHigh       49.25     (25.5%)       33.99     (15.4%)  -31.0% ( -57% -   13%) 0.000
               OrHighMed      103.90     (25.6%)       72.93     (15.7%)  -29.8% ( -56% -   15%) 0.000
               OrHighLow      433.78     (28.7%)      348.83     (19.8%)  -19.6% ( -52% -   40%) 0.012
            OrHighNotLow      668.06     (24.5%)      662.81     (24.1%)   -0.8% ( -39% -   63%) 0.919
              HighPhrase      201.08     (25.3%)      199.69     (23.3%)   -0.7% ( -39% -   64%) 0.928
                 LowTerm     1389.04     (24.7%)     1382.36     (21.4%)   -0.5% ( -37% -   60%) 0.948
           OrHighNotHigh      570.25     (26.8%)      567.67     (23.5%)   -0.5% ( -40% -   68%) 0.955
               MedPhrase       76.47     (24.6%)       76.43     (22.8%)   -0.1% ( -38% -   62%) 0.994
   HighTermDayOfYearSort      242.22     (28.8%)      242.29     (26.3%)    0.0% ( -42% -   77%) 0.997
              AndHighMed      268.58     (25.9%)      268.94     (23.6%)    0.1% ( -39% -   66%) 0.986
             AndHighHigh      145.41     (25.8%)      145.82     (23.2%)    0.3% ( -38% -   66%) 0.971
           OrNotHighHigh      607.64     (26.2%)      611.09     (23.9%)    0.6% ( -39% -   68%) 0.943
                  Fuzzy1       75.16     (25.0%)       75.70     (24.0%)    0.7% ( -38% -   66%) 0.925
                HighTerm     1119.66     (26.3%)     1130.69     (24.8%)    1.0% ( -39% -   70%) 0.903
         LowSloppyPhrase       61.22     (24.1%)       61.87     (22.9%)    1.1% ( -37% -   63%) 0.886
               LowPhrase      244.64     (24.3%)      247.88     (23.4%)    1.3% ( -37% -   64%) 0.861
                Wildcard      144.88     (24.8%)      146.81     (23.9%)    1.3% ( -37% -   66%) 0.863
            HighSpanNear      251.85     (25.5%)      255.33     (24.0%)    1.4% ( -38% -   68%) 0.860
    BrowseDateTaxoFacets        9.50     (26.2%)        9.64     (25.0%)    1.4% ( -39% -   71%) 0.860
         MedSloppyPhrase       32.97     (24.2%)       33.45     (23.1%)    1.4% ( -36% -   64%) 0.848
BrowseDayOfYearTaxoFacets        9.47     (26.0%)        9.63     (25.1%)    1.7% ( -39% -   71%) 0.837
   BrowseMonthTaxoFacets       11.45     (24.7%)       11.66     (24.2%)    1.8% ( -37% -   67%) 0.817
        HighSloppyPhrase       10.82     (24.6%)       11.02     (23.4%)    1.8% ( -37% -   66%) 0.813
                  IntNRQ      138.36     (25.3%)      140.88     (23.9%)    1.8% ( -37% -   68%) 0.815
              TermDTSort      170.37     (29.0%)      173.48     (28.5%)    1.8% ( -43% -   83%) 0.841
                PKLookup      188.19     (24.7%)      191.73     (23.3%)    1.9% ( -37% -   66%) 0.805
                 Prefix3      219.68     (25.3%)      223.82     (23.7%)    1.9% ( -37% -   68%) 0.808
             MedSpanNear       61.43     (25.2%)       62.62     (23.9%)    1.9% ( -37% -   68%) 0.803
            OrNotHighLow      726.78     (24.9%)      741.06     (24.1%)    2.0% ( -37% -   67%) 0.800
                 Respell       71.95     (25.2%)       73.38     (24.1%)    2.0% ( -37% -   68%) 0.799
                 MedTerm     1212.78     (24.5%)     1237.53     (23.5%)    2.0% ( -36% -   66%) 0.788
    HighTermTitleBDVSort      248.46     (24.9%)      253.82     (26.1%)    2.2% ( -39% -   70%) 0.789
   BrowseMonthSSDVFacets       27.46     (25.1%)       28.05     (24.2%)    2.2% ( -37% -   68%) 0.781
       HighTermMonthSort      237.54     (26.2%)      242.81     (26.7%)    2.2% ( -40% -   74%) 0.791
    HighIntervalsOrdered       11.33     (25.2%)       11.58     (24.0%)    2.3% ( -37% -   68%) 0.769
             LowSpanNear       65.31     (25.1%)       66.88     (24.0%)    2.4% ( -37% -   68%) 0.758
                  Fuzzy2       18.90     (24.7%)       19.37     (24.0%)    2.5% ( -37% -   68%) 0.746
            OrNotHighMed      564.18     (24.6%)      578.80     (24.5%)    2.6% ( -37% -   68%) 0.739
            OrHighNotMed      638.80     (25.3%)      655.57     (23.5%)    2.6% ( -36% -   68%) 0.734
              AndHighLow      783.88     (26.1%)      804.77     (25.4%)    2.7% ( -38% -   73%) 0.744
BrowseDayOfYearSSDVFacets       24.07     (26.3%)       24.71     (25.5%)    2.7% ( -38% -   73%) 0.744
```

run2
```
                   TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
              OrHighHigh       69.45     (29.7%)       27.97     (11.0%)  -59.7% ( -77% -  -27%) 0.000
               OrHighMed      147.57     (30.1%)      109.15     (19.7%)  -26.0% ( -58% -   33%) 0.001
               OrHighLow      445.93     (31.1%)      400.05     (24.7%)  -10.3% ( -50% -   65%) 0.246
            OrHighNotLow      749.07     (30.6%)      723.82     (26.5%)   -3.4% ( -46% -   77%) 0.710
                  Fuzzy1       75.77     (30.0%)       73.95     (26.6%)   -2.4% ( -45% -   77%) 0.789
                Wildcard      150.05     (30.0%)      147.70     (26.5%)   -1.6% ( -44% -   78%) 0.861
            OrNotHighLow      800.61     (28.7%)      790.41     (26.4%)   -1.3% ( -43% -   75%) 0.884
              HighPhrase      368.11     (29.7%)      363.58     (28.3%)   -1.2% ( -45% -   80%) 0.893
           OrHighNotHigh      559.20     (29.7%)      554.99     (28.0%)   -0.8% ( -45% -   81%) 0.934
               MedPhrase      154.49     (29.4%)      153.44     (27.0%)   -0.7% ( -44% -   78%) 0.940
            OrHighNotMed      583.51     (29.5%)      579.70     (27.3%)   -0.7% ( -44% -   79%) 0.942
             LowSpanNear      193.10     (29.6%)      193.61     (27.4%)    0.3% ( -43% -   81%) 0.977
             AndHighHigh       85.87     (29.7%)       86.12     (27.3%)    0.3% ( -43% -   81%) 0.974
                 LowTerm     1248.33     (27.5%)     1253.40     (25.9%)    0.4% ( -41% -   74%) 0.962
                 MedTerm     1149.07     (29.6%)     1156.58     (27.9%)    0.7% ( -43% -   82%) 0.943
                 Prefix3      365.87     (30.0%)      369.81     (28.6%)    1.1% ( -44% -   85%) 0.907
                PKLookup      183.27     (28.0%)      185.36     (26.4%)    1.1% ( -41% -   77%) 0.894
   BrowseMonthSSDVFacets       26.35     (29.7%)       26.65     (29.3%)    1.1% ( -44% -   85%) 0.903
                 Respell       57.06     (29.5%)       57.89     (27.8%)    1.4% ( -43% -   83%) 0.873
           OrNotHighHigh      556.85     (30.3%)      565.02     (29.2%)    1.5% ( -44% -   87%) 0.876
                  IntNRQ      285.81     (30.2%)      290.43     (28.4%)    1.6% ( -43% -   86%) 0.862
         MedSloppyPhrase      106.22     (29.1%)      107.97     (27.6%)    1.6% ( -42% -   82%) 0.854
BrowseDayOfYearSSDVFacets       23.05     (29.9%)       23.45     (28.7%)    1.7% ( -43% -   86%) 0.853
    HighIntervalsOrdered       37.18     (29.7%)       37.84     (27.8%)    1.8% ( -42% -   84%) 0.845
   HighTermDayOfYearSort      221.44     (32.7%)      225.50     (31.5%)    1.8% ( -46% -   98%) 0.857
              TermDTSort      185.35     (34.2%)      188.79     (30.7%)    1.9% ( -46% -  101%) 0.857
                  Fuzzy2       18.28     (29.6%)       18.63     (28.9%)    1.9% ( -43% -   85%) 0.838
            OrNotHighMed      616.11     (29.7%)      627.98     (28.9%)    1.9% ( -43% -   85%) 0.835
         LowSloppyPhrase       25.86     (28.8%)       26.38     (27.4%)    2.0% ( -42% -   81%) 0.823
       HighTermMonthSort      200.69     (32.8%)      204.83     (29.9%)    2.1% ( -45% -   96%) 0.835
              AndHighLow      774.01     (29.7%)      790.21     (29.2%)    2.1% ( -43% -   86%) 0.822
                HighTerm     1182.82     (30.3%)     1209.53     (29.5%)    2.3% ( -44% -   88%) 0.811
   BrowseMonthTaxoFacets       10.85     (29.4%)       11.11     (28.2%)    2.3% ( -42% -   84%) 0.798
        HighSloppyPhrase       40.46     (29.4%)       41.41     (28.6%)    2.4% ( -43% -   85%) 0.798
             MedSpanNear       65.07     (29.8%)       66.68     (28.6%)    2.5% ( -43% -   86%) 0.788
    BrowseDateTaxoFacets        9.07     (29.0%)        9.30     (27.4%)    2.6% ( -41% -   83%) 0.773
BrowseDayOfYearTaxoFacets        9.08     (29.0%)        9.32     (27.4%)    2.6% ( -41% -   83%) 0.767
            HighSpanNear       12.84     (30.2%)       13.19     (28.7%)    2.7% ( -43% -   88%) 0.771
               LowPhrase      260.26     (29.0%)      267.46     (28.7%)    2.8% ( -42% -   85%) 0.762
              AndHighMed      305.41     (29.4%)      314.11     (28.4%)    2.8% ( -42% -   85%) 0.755
    HighTermTitleBDVSort      219.88     (27.6%)      236.23     (27.6%)    7.4% ( -37% -   86%) 0.394
```


