### PR TITLE
LUCENE-9947: Exclude luke from the published jar list.

### DIFF
--- a/gradle/publishing/defaults-maven.gradle
+++ b/gradle/publishing/defaults-maven.gradle
@@ -44,7 +44,6 @@ configure(rootProject) {
         ":lucene:grouping",
         ":lucene:highlighter",
         ":lucene:join",
-        ":lucene:luke",
         ":lucene:memory",
         ":lucene:misc",
         ":lucene:monitor",


### PR DESCRIPTION
Luke is not a API but a packaged GUI tool so it doesn't much make sense to publish the jar itself to the Maven Central.
In 8.x the luke jar is intentionally excluded from the published JAR list, I think we should also exclude it on 9.0.
See https://issues.apache.org/jira/browse/LUCENE-9947

