### PR TITLE
LUCENE-9947: Exclude luke javadocs from the documentation site.

### DIFF
--- a/gradle/documentation/render-javadoc.gradle
+++ b/gradle/documentation/render-javadoc.gradle
@@ -255,6 +255,14 @@ configure(subprojects) {
   }
 }
 
+configure(project(':lucene:luke')) {
+  project.tasks.withType(RenderJavadocTask) { task ->
+    if (task.name == 'renderSiteJavadoc') {
+      task.enabled = false
+    }
+  }
+}
+
 class RenderJavadocTask extends DefaultTask {
   @InputFiles
   @SkipWhenEmpty

--- a/gradle/documentation/render-javadoc.gradle
+++ b/gradle/documentation/render-javadoc.gradle
@@ -256,7 +256,7 @@ configure(subprojects) {
 }
 
 configure(project(':lucene:luke')) {
-  project.tasks.matching { it.name == 'renderSiteJavadoc' }.configureEach {it.enabled = false }
+  project.tasks.matching { it.name == 'renderSiteJavadoc' }.configureEach { it.enabled = false }
 }
 
 class RenderJavadocTask extends DefaultTask {

--- a/gradle/documentation/render-javadoc.gradle
+++ b/gradle/documentation/render-javadoc.gradle
@@ -256,11 +256,7 @@ configure(subprojects) {
 }
 
 configure(project(':lucene:luke')) {
-  project.tasks.withType(RenderJavadocTask) { task ->
-    if (task.name == 'renderSiteJavadoc') {
-      task.enabled = false
-    }
-  }
+  project.tasks.matching { it.name == 'renderSiteJavadoc' }.configureEach {it.enabled = false }
 }
 
 class RenderJavadocTask extends DefaultTask {

--- a/lucene/documentation/src/markdown/index.template.md
+++ b/lucene/documentation/src/markdown/index.template.md
@@ -48,3 +48,7 @@ on some of the conceptual or inner details of Lucene:
 ## API Javadocs
 
 ${projectList}
+
+## Tools
+
+* Luke - Lucene Toolbox GUI tool: A Swing app for browsing documents, indexed terms and posting lists, searching an index, and so on. Type "/path/to/lucene-x.x.x/luke/luke.{sh|bat}" to launch Luke.


### PR DESCRIPTION
This excludes Javadocs of luke module from the documentation site by explicitly disable "renderSiteJavadoc" task for it.
While removing the link to javadocs, I added a short description and launch command for the tool.

![docsite](https://user-images.githubusercontent.com/1825333/116776541-df704480-aaa3-11eb-9172-f1810e5e5995.png)
