### PR TITLE
LUCENE-9047:  Write checksum as big endian in NRT replicator

### DIFF
--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/CopyOneFile.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/CopyOneFile.java
@@ -20,6 +20,8 @@ package org.apache.lucene.replicator.nrt;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Locale;
+
+import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
@@ -111,7 +113,7 @@ public class CopyOneFile implements Closeable {
         // Paranoia: make sure the primary node is not smoking crack, by somehow sending us an
         // already corrupted file whose checksum (in its
         // footer) disagrees with reality:
-        long actualChecksumIn = in.readLong();
+        long actualChecksumIn = CodecUtil.readBELong(in);
         if (actualChecksumIn != checksum) {
           dest.message(
               "file "
@@ -122,7 +124,7 @@ public class CopyOneFile implements Closeable {
                   + actualChecksumIn);
           throw new IOException("file " + name + ": checksum mismatch after file copy");
         }
-        out.writeLong(checksum);
+        CodecUtil.writeBELong(out, checksum);
         bytesCopied += Long.BYTES;
         close();
 

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/CopyOneFile.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/CopyOneFile.java
@@ -20,7 +20,6 @@ package org.apache.lucene.replicator.nrt;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Locale;
-
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.IOContext;


### PR DESCRIPTION
Left over from  #107, we should read / write checksums using big endian in the NRT replicator.