### PR TITLE
LUCENE-9950: move changes entry for backport to 8.9

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -19,9 +19,6 @@ New Features
 * LUCENE-9507: Custom order for leaves in IndexReader and IndexWriter
   (Mayya Sharipova, Mike McCandless, Jim Ferenczi)
 
-* LUCENE-9950: New facet counting implementation for general string doc value fields
-  (SortedSetDocValues / SortedDocValues) not created through FacetsConfig (Greg Miller)
-
 System Requirements
 
 * LUCENE-8738: Move to Java 11 as minimum Java version.
@@ -356,6 +353,9 @@ New Features
 
 * LUCENE-9385: Add FacetsConfig option to control which drill-down
   terms are indexed for a FacetLabel (Zachary Chen)
+
+* LUCENE-9950: New facet counting implementation for general string doc value fields
+  (SortedSetDocValues / SortedDocValues) not created through FacetsConfig (Greg Miller)
 
 Improvements
 ---------------------


### PR DESCRIPTION
# Description

I've posted a [separate PR](https://github.com/apache/lucene-solr/pull/2497) to backport the LUCENE-9950 work into 8.9. If we move forward with that, we should update the CHANGES.txt entry.

# Solution

Just move the CHANGE.txt entry under 8.9.

# Tests

N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
