### PR TITLE
LUCENE-9963 Add tests for alternate path failures in FlattenGraphFilter

### DIFF
--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestFlattenGraphFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestFlattenGraphFilter.java
@@ -443,7 +443,15 @@ public class TestFlattenGraphFilter extends BaseTokenStreamTestCase {
         2);
   }
 
-  private CharsRef buildMultiTokenCarRef(
+  /**
+   * build CharsRef containing 2-4 tokens
+   *
+   * @param tokens vocabulary of tokens
+   * @param charsRefBuilder CharsRefBuilder
+   * @param random Random for selecting tokens
+   * @return Charsref containing 2-4 tokens.
+   */
+  private CharsRef buildMultiTokenCharsRef(
       String[] tokens, CharsRefBuilder charsRefBuilder, Random random) {
     int srcLen = random.nextInt(2) + 2;
     String[] srcTokens = new String[srcLen];
@@ -481,7 +489,7 @@ public class TestFlattenGraphFilter extends BaseTokenStreamTestCase {
           break;
         case 1:
           // many:1
-          src = buildMultiTokenCarRef(baseTokens, charRefBuilder, random);
+          src = buildMultiTokenCharsRef(baseTokens, charRefBuilder, random);
           charRefBuilder.clear();
           dest = charRefBuilder.append(synTokens[random.nextInt(synTokens.length)]).toCharsRef();
           charRefBuilder.clear();
@@ -490,14 +498,14 @@ public class TestFlattenGraphFilter extends BaseTokenStreamTestCase {
           // 1:many
           src = charRefBuilder.append(baseTokens[random.nextInt(baseTokens.length)]).toCharsRef();
           charRefBuilder.clear();
-          dest = buildMultiTokenCarRef(synTokens, charRefBuilder, random);
+          dest = buildMultiTokenCharsRef(synTokens, charRefBuilder, random);
           charRefBuilder.clear();
           break;
         default:
           // many:many
-          src = buildMultiTokenCarRef(baseTokens, charRefBuilder, random);
+          src = buildMultiTokenCharsRef(baseTokens, charRefBuilder, random);
           charRefBuilder.clear();
-          dest = buildMultiTokenCarRef(synTokens, charRefBuilder, random);
+          dest = buildMultiTokenCharsRef(synTokens, charRefBuilder, random);
           charRefBuilder.clear();
       }
       mapBuilder.add(src, dest, true);


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/projects/LUCENE-9963

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>

LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Add tests for alternate path failures in FlattenGraphFilter.

Currently failing tests marked AwaitingFix so they will be ignored. Adding these tests before fix to allow others to also develop towards a fix.


# Solution

None

# Tests

Tests cover 3 problems that can arise for holes in alternate paths.
1) hole at start of path causes long path to not flatten correctly
2) hole at end of path causes long path to not move it's output point correctly
3) token stream ends before last shows up to end alternate path.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
