### PR TITLE
LUCENE-9827: Update backward codec in Lucene 9.0

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/Lucene50TermVectorsFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/Lucene50TermVectorsFormat.java
@@ -154,6 +154,6 @@ public final class Lucene50TermVectorsFormat extends Lucene50CompressingTermVect
 
   /** Sole constructor. */
   public Lucene50TermVectorsFormat() {
-    super("Lucene50TermVectorsData", "", CompressionMode.FAST, 1 << 12, 10);
+    super("Lucene50TermVectorsData", "", CompressionMode.FAST, 1 << 12, 128, 10);
   }
 }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsReader.java
@@ -104,9 +104,6 @@ public final class Lucene50CompressingStoredFieldsReader extends StoredFieldsRea
   private final int numDocs;
   private final boolean merging;
   private final BlockState state;
-  private final long numChunks; // number of written blocks
-  private final long numDirtyChunks; // number of incomplete compressed blocks written
-  private final long numDirtyDocs; // cumulative number of docs in incomplete chunks
   private boolean closed;
 
   // used by clone
@@ -122,9 +119,6 @@ public final class Lucene50CompressingStoredFieldsReader extends StoredFieldsRea
     this.compressionMode = reader.compressionMode;
     this.decompressor = reader.decompressor.clone();
     this.numDocs = reader.numDocs;
-    this.numChunks = reader.numChunks;
-    this.numDirtyChunks = reader.numDirtyChunks;
-    this.numDirtyDocs = reader.numDirtyDocs;
     this.merging = merging;
     this.state = new BlockState();
     this.closed = false;
@@ -239,44 +233,13 @@ public final class Lucene50CompressingStoredFieldsReader extends StoredFieldsRea
       this.indexReader = indexReader;
 
       if (version >= VERSION_NUM_CHUNKS) {
-        numChunks = metaIn.readVLong();
-        numDirtyChunks = metaIn.readVLong();
-        numDirtyDocs = metaIn.readVLong();
-      } else {
-        if (version >= VERSION_META) {
-          // consume dirty chunks/docs stats we wrote
-          metaIn.readVLong();
-          metaIn.readVLong();
-        }
-        // Old versions of this format did not record these. Since bulk
-        // merges are disabled on version increments anyway, we make no effort
-        // to get valid values for these stats.
-        numChunks = numDirtyChunks = numDirtyDocs = -1;
+        // discard num_chunks
+        metaIn.readVLong();
       }
-
-      if (numChunks < numDirtyChunks) {
-        throw new CorruptIndexException(
-            "Cannot have more dirty chunks than chunks: numChunks="
-                + numChunks
-                + ", numDirtyChunks="
-                + numDirtyChunks,
-            metaIn);
-      }
-      if ((numDirtyChunks == 0) != (numDirtyDocs == 0)) {
-        throw new CorruptIndexException(
-            "Cannot have dirty chunks without dirty docs or vice-versa: numDirtyChunks="
-                + numDirtyChunks
-                + ", numDirtyDocs="
-                + numDirtyDocs,
-            metaIn);
-      }
-      if (numDirtyDocs < numDirtyChunks) {
-        throw new CorruptIndexException(
-            "Cannot have more dirty chunks than documents within dirty chunks: numDirtyChunks="
-                + numDirtyChunks
-                + ", numDirtyDocs="
-                + numDirtyDocs,
-            metaIn);
+      if (version >= VERSION_META) {
+        // consume dirty chunks/docs stats we wrote
+        metaIn.readVLong();
+        metaIn.readVLong();
       }
 
       if (metaIn != null) {
@@ -776,65 +739,6 @@ public final class Lucene50CompressingStoredFieldsReader extends StoredFieldsRea
   public StoredFieldsReader getMergeInstance() {
     ensureOpen();
     return new Lucene50CompressingStoredFieldsReader(this, true);
-  }
-
-  int getVersion() {
-    return version;
-  }
-
-  CompressionMode getCompressionMode() {
-    return compressionMode;
-  }
-
-  FieldsIndex getIndexReader() {
-    return indexReader;
-  }
-
-  long getMaxPointer() {
-    return maxPointer;
-  }
-
-  IndexInput getFieldsStream() {
-    return fieldsStream;
-  }
-
-  int getChunkSize() {
-    return chunkSize;
-  }
-
-  long getNumDirtyDocs() {
-    if (version != VERSION_CURRENT) {
-      throw new IllegalStateException(
-          "getNumDirtyDocs should only ever get called when the reader is on the current version");
-    }
-    assert numDirtyDocs >= 0;
-    return numDirtyDocs;
-  }
-
-  long getNumDirtyChunks() {
-    if (version != VERSION_CURRENT) {
-      throw new IllegalStateException(
-          "getNumDirtyChunks should only ever get called when the reader is on the current version");
-    }
-    assert numDirtyChunks >= 0;
-    return numDirtyChunks;
-  }
-
-  int getNumDocs() {
-    return numDocs;
-  }
-
-  int getPackedIntsVersion() {
-    return packedIntsVersion;
-  }
-
-  long getNumChunks() {
-    if (version != VERSION_CURRENT) {
-      throw new IllegalStateException(
-          "getNumChunks should only ever get called when the reader is on the current version");
-    }
-    assert numChunks >= 0;
-    return numChunks;
   }
 
   @Override

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsFormat.java
@@ -46,6 +46,8 @@ public class Lucene50CompressingTermVectorsFormat extends TermVectorsFormat {
   protected final int chunkSize;
   /** block size */
   protected final int blockSize;
+  /** max docs per chunk */
+  protected final int maxDocsPerChunk;
 
   /**
    * Create a new {@link Lucene50CompressingTermVectorsFormat}.
@@ -68,6 +70,7 @@ public class Lucene50CompressingTermVectorsFormat extends TermVectorsFormat {
    * @param segmentSuffix a suffix to append to files created by this format
    * @param compressionMode the {@link CompressionMode} to use
    * @param chunkSize the minimum number of bytes of a single chunk of stored documents
+   * @param maxDocsPerChunk the maximum number of documents in a single chunk
    * @param blockSize the number of chunks to store in an index block.
    * @see CompressionMode
    */
@@ -76,6 +79,7 @@ public class Lucene50CompressingTermVectorsFormat extends TermVectorsFormat {
       String segmentSuffix,
       CompressionMode compressionMode,
       int chunkSize,
+      int maxDocsPerChunk,
       int blockSize) {
     this.formatName = formatName;
     this.segmentSuffix = segmentSuffix;
@@ -84,6 +88,7 @@ public class Lucene50CompressingTermVectorsFormat extends TermVectorsFormat {
       throw new IllegalArgumentException("chunkSize must be >= 1");
     }
     this.chunkSize = chunkSize;
+    this.maxDocsPerChunk = maxDocsPerChunk;
     if (blockSize < 1) {
       throw new IllegalArgumentException("blockSize must be >= 1");
     }
@@ -111,6 +116,8 @@ public class Lucene50CompressingTermVectorsFormat extends TermVectorsFormat {
         + compressionMode
         + ", chunkSize="
         + chunkSize
+        + ", maxDocsPerChunk="
+        + maxDocsPerChunk
         + ", blockSize="
         + blockSize
         + ")";

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/Lucene50RWTermVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/Lucene50RWTermVectorsFormat.java
@@ -24,6 +24,6 @@ public final class Lucene50RWTermVectorsFormat extends Lucene50RWCompressingTerm
 
   /** Sole constructor. */
   public Lucene50RWTermVectorsFormat() {
-    super("Lucene50TermVectorsData", "", CompressionMode.FAST, 1 << 12, 10);
+    super("Lucene50TermVectorsData", "", CompressionMode.FAST, 1 << 12, 128, 10);
   }
 }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsWriter.java
@@ -28,35 +28,25 @@ import static org.apache.lucene.backward_codecs.lucene50.compressing.Lucene50Com
 import static org.apache.lucene.backward_codecs.lucene50.compressing.Lucene50CompressingStoredFieldsReader.STRING;
 import static org.apache.lucene.backward_codecs.lucene50.compressing.Lucene50CompressingStoredFieldsReader.TYPE_BITS;
 import static org.apache.lucene.backward_codecs.lucene50.compressing.Lucene50CompressingStoredFieldsReader.VERSION_CURRENT;
-import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.lucene.backward_codecs.store.EndiannessReverserUtil;
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.StoredFieldsWriter;
 import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.codecs.compressing.Compressor;
-import org.apache.lucene.codecs.compressing.MatchingReaders;
-import org.apache.lucene.index.CorruptIndexException;
-import org.apache.lucene.index.DocIDMerger;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
-import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitUtil;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.packed.PackedInts;
@@ -73,7 +63,6 @@ public final class Lucene50CompressingStoredFieldsWriter extends StoredFieldsWri
   private IndexOutput metaStream, fieldsStream;
 
   private Compressor compressor;
-  private final CompressionMode compressionMode;
   private final int chunkSize;
   private final int maxDocsPerChunk;
 
@@ -101,7 +90,6 @@ public final class Lucene50CompressingStoredFieldsWriter extends StoredFieldsWri
       throws IOException {
     assert directory != null;
     this.segment = si.name;
-    this.compressionMode = compressionMode;
     this.compressor = compressionMode.newCompressor();
     this.chunkSize = chunkSize;
     this.maxDocsPerChunk = maxDocsPerChunk;
@@ -527,221 +515,6 @@ public final class Lucene50CompressingStoredFieldsWriter extends StoredFieldsWri
         SecurityException ignored) {
     }
     BULK_MERGE_ENABLED = v;
-  }
-
-  @Override
-  public int merge(MergeState mergeState) throws IOException {
-    int docCount = 0;
-    int numReaders = mergeState.maxDocs.length;
-
-    MatchingReaders matching = new MatchingReaders(mergeState);
-    if (mergeState.needsIndexSort) {
-      /**
-       * If all readers are compressed and they have the same fieldinfos then we can merge the
-       * serialized document directly.
-       */
-      List<CompressingStoredFieldsMergeSub> subs = new ArrayList<>();
-      for (int i = 0; i < mergeState.storedFieldsReaders.length; i++) {
-        if (matching.matchingReaders[i]
-            && mergeState.storedFieldsReaders[i] instanceof Lucene50CompressingStoredFieldsReader) {
-          Lucene50CompressingStoredFieldsReader storedFieldsReader =
-              (Lucene50CompressingStoredFieldsReader) mergeState.storedFieldsReaders[i];
-          storedFieldsReader.checkIntegrity();
-          subs.add(
-              new CompressingStoredFieldsMergeSub(
-                  storedFieldsReader, mergeState.docMaps[i], mergeState.maxDocs[i]));
-        } else {
-          return super.merge(mergeState);
-        }
-      }
-
-      final DocIDMerger<CompressingStoredFieldsMergeSub> docIDMerger = DocIDMerger.of(subs, true);
-      while (true) {
-        CompressingStoredFieldsMergeSub sub = docIDMerger.next();
-        if (sub == null) {
-          break;
-        }
-        assert sub.mappedDocID == docCount;
-        Lucene50CompressingStoredFieldsReader.SerializedDocument doc =
-            sub.reader.document(sub.docID);
-        startDocument();
-        bufferedDocs.copyBytes(doc.in, doc.length);
-        numStoredFieldsInDoc = doc.numStoredFields;
-        finishDocument();
-        ++docCount;
-      }
-      finish(mergeState.mergeFieldInfos, docCount);
-      return docCount;
-    }
-
-    for (int readerIndex = 0; readerIndex < numReaders; readerIndex++) {
-      MergeVisitor visitor = new MergeVisitor(mergeState, readerIndex);
-      Lucene50CompressingStoredFieldsReader matchingFieldsReader = null;
-      if (matching.matchingReaders[readerIndex]) {
-        final StoredFieldsReader fieldsReader = mergeState.storedFieldsReaders[readerIndex];
-        // we can only bulk-copy if the matching reader is also a CompressingStoredFieldsReader
-        if (fieldsReader != null && fieldsReader instanceof Lucene50CompressingStoredFieldsReader) {
-          matchingFieldsReader = (Lucene50CompressingStoredFieldsReader) fieldsReader;
-        }
-      }
-
-      final int maxDoc = mergeState.maxDocs[readerIndex];
-      final Bits liveDocs = mergeState.liveDocs[readerIndex];
-
-      // if its some other format, or an older version of this format, or safety switch:
-      if (matchingFieldsReader == null
-          || matchingFieldsReader.getVersion() != VERSION_CURRENT
-          || BULK_MERGE_ENABLED == false) {
-        // naive merge...
-        StoredFieldsReader storedFieldsReader = mergeState.storedFieldsReaders[readerIndex];
-        if (storedFieldsReader != null) {
-          storedFieldsReader.checkIntegrity();
-        }
-        for (int docID = 0; docID < maxDoc; docID++) {
-          if (liveDocs != null && liveDocs.get(docID) == false) {
-            continue;
-          }
-          startDocument();
-          storedFieldsReader.visitDocument(docID, visitor);
-          finishDocument();
-          ++docCount;
-        }
-      } else if (matchingFieldsReader.getCompressionMode() == compressionMode
-          && matchingFieldsReader.getChunkSize() == chunkSize
-          && matchingFieldsReader.getPackedIntsVersion() == PackedInts.VERSION_CURRENT
-          && liveDocs == null
-          && !tooDirty(matchingFieldsReader)) {
-        // optimized merge, raw byte copy
-        // its not worth fine-graining this if there are deletions.
-
-        // if the format is older, its always handled by the naive merge case above
-        assert matchingFieldsReader.getVersion() == VERSION_CURRENT;
-        matchingFieldsReader.checkIntegrity();
-
-        // flush any pending chunks
-        if (numBufferedDocs > 0) {
-          flush(true);
-        }
-
-        // iterate over each chunk. we use the stored fields index to find chunk boundaries,
-        // read the docstart + doccount from the chunk header (we write a new header, since doc
-        // numbers will change),
-        // and just copy the bytes directly.
-        IndexInput rawDocs = matchingFieldsReader.getFieldsStream();
-        FieldsIndex index = matchingFieldsReader.getIndexReader();
-        rawDocs.seek(index.getStartPointer(0));
-        int docID = 0;
-        while (docID < maxDoc) {
-          // read header
-          int base = rawDocs.readVInt();
-          if (base != docID) {
-            throw new CorruptIndexException(
-                "invalid state: base=" + base + ", docID=" + docID, rawDocs);
-          }
-          int code = rawDocs.readVInt();
-
-          // write a new index entry and new header for this chunk.
-          int bufferedDocs = code >>> 2;
-          indexWriter.writeIndex(bufferedDocs, fieldsStream.getFilePointer());
-          fieldsStream.writeVInt(docBase); // rebase
-          fieldsStream.writeVInt(code);
-          docID += bufferedDocs;
-          docBase += bufferedDocs;
-          docCount += bufferedDocs;
-
-          if (docID > maxDoc) {
-            throw new CorruptIndexException(
-                "invalid state: base=" + base + ", count=" + bufferedDocs + ", maxDoc=" + maxDoc,
-                rawDocs);
-          }
-
-          // copy bytes until the next chunk boundary (or end of chunk data).
-          // using the stored fields index for this isn't the most efficient, but fast enough
-          // and is a source of redundancy for detecting bad things.
-          final long end;
-          if (docID == maxDoc) {
-            end = matchingFieldsReader.getMaxPointer();
-          } else {
-            end = index.getStartPointer(docID);
-          }
-          fieldsStream.copyBytes(rawDocs, end - rawDocs.getFilePointer());
-        }
-
-        if (rawDocs.getFilePointer() != matchingFieldsReader.getMaxPointer()) {
-          throw new CorruptIndexException(
-              "invalid state: pos="
-                  + rawDocs.getFilePointer()
-                  + ", max="
-                  + matchingFieldsReader.getMaxPointer(),
-              rawDocs);
-        }
-
-        // since we bulk merged all chunks, we inherit any dirty ones from this segment.
-        numChunks += matchingFieldsReader.getNumChunks();
-        numDirtyChunks += matchingFieldsReader.getNumDirtyChunks();
-        numDirtyDocs += matchingFieldsReader.getNumDirtyDocs();
-      } else {
-        // optimized merge, we copy serialized (but decompressed) bytes directly
-        // even on simple docs (1 stored field), it seems to help by about 20%
-
-        // if the format is older, its always handled by the naive merge case above
-        assert matchingFieldsReader.getVersion() == VERSION_CURRENT;
-        matchingFieldsReader.checkIntegrity();
-
-        for (int docID = 0; docID < maxDoc; docID++) {
-          if (liveDocs != null && liveDocs.get(docID) == false) {
-            continue;
-          }
-          Lucene50CompressingStoredFieldsReader.SerializedDocument doc =
-              matchingFieldsReader.document(docID);
-          startDocument();
-          bufferedDocs.copyBytes(doc.in, doc.length);
-          numStoredFieldsInDoc = doc.numStoredFields;
-          finishDocument();
-          ++docCount;
-        }
-      }
-    }
-    finish(mergeState.mergeFieldInfos, docCount);
-    return docCount;
-  }
-
-  /**
-   * Returns true if we should recompress this reader, even though we could bulk merge compressed
-   * data
-   *
-   * <p>The last chunk written for a segment is typically incomplete, so without recompressing, in
-   * some worst-case situations (e.g. frequent reopen with tiny flushes), over time the compression
-   * ratio can degrade. This is a safety switch.
-   */
-  boolean tooDirty(Lucene50CompressingStoredFieldsReader candidate) {
-    // A segment is considered dirty only if it has enough dirty docs to make a full block
-    // AND more than 1% blocks are dirty.
-    return candidate.getNumDirtyDocs() > maxDocsPerChunk
-        && candidate.getNumDirtyChunks() * 100 > candidate.getNumChunks();
-  }
-
-  private static class CompressingStoredFieldsMergeSub extends DocIDMerger.Sub {
-    private final Lucene50CompressingStoredFieldsReader reader;
-    private final int maxDoc;
-    int docID = -1;
-
-    CompressingStoredFieldsMergeSub(
-        Lucene50CompressingStoredFieldsReader reader, MergeState.DocMap docMap, int maxDoc) {
-      super(docMap);
-      this.maxDoc = maxDoc;
-      this.reader = reader;
-    }
-
-    @Override
-    public int nextDoc() {
-      docID++;
-      if (docID == maxDoc) {
-        return NO_MORE_DOCS;
-      } else {
-        return docID;
-      }
-    }
   }
 
   @Override

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsWriter.java
@@ -38,27 +38,20 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import org.apache.lucene.backward_codecs.store.EndiannessReverserUtil;
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.codecs.TermVectorsReader;
 import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.codecs.compressing.Compressor;
-import org.apache.lucene.codecs.compressing.MatchingReaders;
-import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
-import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.IndexFileNames;
-import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
-import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.StringHelper;
@@ -76,7 +69,6 @@ public final class Lucene50CompressingTermVectorsWriter extends TermVectorsWrite
   private FieldsIndexWriter indexWriter;
   private IndexOutput metaStream, vectorsStream;
 
-  private final CompressionMode compressionMode;
   private final Compressor compressor;
   private final int chunkSize;
 
@@ -234,7 +226,6 @@ public final class Lucene50CompressingTermVectorsWriter extends TermVectorsWrite
       throws IOException {
     assert directory != null;
     this.segment = si.name;
-    this.compressionMode = compressionMode;
     this.compressor = compressionMode.newCompressor();
     this.chunkSize = chunkSize;
     this.maxDocsPerChunk = maxDocsPerChunk;
@@ -801,148 +792,6 @@ public final class Lucene50CompressingTermVectorsWriter extends TermVectorsWrite
         SecurityException ignored) {
     }
     BULK_MERGE_ENABLED = v;
-  }
-
-  @Override
-  public int merge(MergeState mergeState) throws IOException {
-    if (mergeState.needsIndexSort) {
-      // TODO: can we gain back some optos even if index is sorted?  E.g. if sort results in large
-      // chunks of contiguous docs from one sub
-      // being copied over...?
-      return super.merge(mergeState);
-    }
-    int docCount = 0;
-    int numReaders = mergeState.maxDocs.length;
-
-    MatchingReaders matching = new MatchingReaders(mergeState);
-
-    for (int readerIndex = 0; readerIndex < numReaders; readerIndex++) {
-      Lucene50CompressingTermVectorsReader matchingVectorsReader = null;
-      final TermVectorsReader vectorsReader = mergeState.termVectorsReaders[readerIndex];
-      if (matching.matchingReaders[readerIndex]) {
-        // we can only bulk-copy if the matching reader is also a CompressingTermVectorsReader
-        if (vectorsReader != null
-            && vectorsReader instanceof Lucene50CompressingTermVectorsReader) {
-          matchingVectorsReader = (Lucene50CompressingTermVectorsReader) vectorsReader;
-        }
-      }
-
-      final int maxDoc = mergeState.maxDocs[readerIndex];
-      final Bits liveDocs = mergeState.liveDocs[readerIndex];
-
-      if (matchingVectorsReader != null
-          && matchingVectorsReader.getCompressionMode() == compressionMode
-          && matchingVectorsReader.getChunkSize() == chunkSize
-          && matchingVectorsReader.getVersion() == VERSION_CURRENT
-          && matchingVectorsReader.getPackedIntsVersion() == PackedInts.VERSION_CURRENT
-          && BULK_MERGE_ENABLED
-          && liveDocs == null
-          && !tooDirty(matchingVectorsReader)) {
-        // optimized merge, raw byte copy
-        // its not worth fine-graining this if there are deletions.
-
-        matchingVectorsReader.checkIntegrity();
-
-        // flush any pending chunks
-        if (!pendingDocs.isEmpty()) {
-          numDirtyChunks++; // incomplete: we had to force this flush
-          numDirtyDocs += pendingDocs.size();
-          flush();
-        }
-
-        // iterate over each chunk. we use the vectors index to find chunk boundaries,
-        // read the docstart + doccount from the chunk header (we write a new header, since doc
-        // numbers will change),
-        // and just copy the bytes directly.
-        IndexInput rawDocs = matchingVectorsReader.getVectorsStream();
-        FieldsIndex index = matchingVectorsReader.getIndexReader();
-        rawDocs.seek(index.getStartPointer(0));
-        int docID = 0;
-        while (docID < maxDoc) {
-          // read header
-          int base = rawDocs.readVInt();
-          if (base != docID) {
-            throw new CorruptIndexException(
-                "invalid state: base=" + base + ", docID=" + docID, rawDocs);
-          }
-          int bufferedDocs = rawDocs.readVInt();
-
-          // write a new index entry and new header for this chunk.
-          indexWriter.writeIndex(bufferedDocs, vectorsStream.getFilePointer());
-          vectorsStream.writeVInt(docCount); // rebase
-          vectorsStream.writeVInt(bufferedDocs);
-          docID += bufferedDocs;
-          docCount += bufferedDocs;
-          numDocs += bufferedDocs;
-
-          if (docID > maxDoc) {
-            throw new CorruptIndexException(
-                "invalid state: base=" + base + ", count=" + bufferedDocs + ", maxDoc=" + maxDoc,
-                rawDocs);
-          }
-
-          // copy bytes until the next chunk boundary (or end of chunk data).
-          // using the stored fields index for this isn't the most efficient, but fast enough
-          // and is a source of redundancy for detecting bad things.
-          final long end;
-          if (docID == maxDoc) {
-            end = matchingVectorsReader.getMaxPointer();
-          } else {
-            end = index.getStartPointer(docID);
-          }
-          vectorsStream.copyBytes(rawDocs, end - rawDocs.getFilePointer());
-        }
-
-        if (rawDocs.getFilePointer() != matchingVectorsReader.getMaxPointer()) {
-          throw new CorruptIndexException(
-              "invalid state: pos="
-                  + rawDocs.getFilePointer()
-                  + ", max="
-                  + matchingVectorsReader.getMaxPointer(),
-              rawDocs);
-        }
-
-        // since we bulk merged all chunks, we inherit any dirty ones from this segment.
-        numChunks += matchingVectorsReader.getNumChunks();
-        numDirtyChunks += matchingVectorsReader.getNumDirtyChunks();
-        numDirtyDocs += matchingVectorsReader.getNumDirtyDocs();
-      } else {
-        // naive merge...
-        if (vectorsReader != null) {
-          vectorsReader.checkIntegrity();
-        }
-        for (int i = 0; i < maxDoc; i++) {
-          if (liveDocs != null && liveDocs.get(i) == false) {
-            continue;
-          }
-          Fields vectors;
-          if (vectorsReader == null) {
-            vectors = null;
-          } else {
-            vectors = vectorsReader.get(i);
-          }
-          addAllDocVectors(vectors, mergeState);
-          ++docCount;
-        }
-      }
-    }
-    finish(mergeState.mergeFieldInfos, docCount);
-    return docCount;
-  }
-
-  /**
-   * Returns true if we should recompress this reader, even though we could bulk merge compressed
-   * data
-   *
-   * <p>The last chunk written for a segment is typically incomplete, so without recompressing, in
-   * some worst-case situations (e.g. frequent reopen with tiny flushes), over time the compression
-   * ratio can degrade. This is a safety switch.
-   */
-  boolean tooDirty(Lucene50CompressingTermVectorsReader candidate) {
-    // A segment is considered dirty only if it has enough dirty docs to make a full block
-    // AND more than 1% blocks are dirty.
-    return candidate.getNumDirtyDocs() > maxDocsPerChunk
-        && candidate.getNumDirtyChunks() * 100 > candidate.getNumChunks();
   }
 
   @Override

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50RWCompressingTermVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50RWCompressingTermVectorsFormat.java
@@ -32,8 +32,9 @@ public class Lucene50RWCompressingTermVectorsFormat extends Lucene50CompressingT
       String segmentSuffix,
       CompressionMode compressionMode,
       int chunkSize,
+      int maxDocsPerChunk,
       int blockSize) {
-    super(formatName, segmentSuffix, compressionMode, chunkSize, blockSize);
+    super(formatName, segmentSuffix, compressionMode, chunkSize, maxDocsPerChunk, blockSize);
   }
 
   @Override
@@ -47,6 +48,7 @@ public class Lucene50RWCompressingTermVectorsFormat extends Lucene50CompressingT
         formatName,
         compressionMode,
         chunkSize,
+        maxDocsPerChunk,
         blockSize);
   }
 }


### PR DESCRIPTION
We need to update the reading logic of the backward codec in Lucene 9 for [LUCENE-9827](https://github.com/apache/lucene-solr/pull/2495) and [LUCENE-9935](https://github.com/apache/lucene-solr/pull/2494) as we have backported them to Lucene 8.

Relates https://github.com/apache/lucene-solr/pull/2495
Relates https://github.com/apache/lucene-solr/pull/2494