### PR TITLE
LUCENE-9823: Fix not to rewrite boosted single term SynonymQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -323,6 +323,14 @@ Other
 * LUCENE-9907: Remove dependency on PackedInts#getReader() from the current codecs and move the
   method to backwards codec. (Ignacio Vera)   
 
+======================= Lucene 8.10.0 =======================
+
+Bug Fixes
+---------------------
+
+* LUCENE-9823: Prevent unsafe rewrites for SynonymQuery and CombinedFieldQuery. Before, rewriting
+could slightly change the scoring when weights were specified. (Naoto Minami via Julie Tibshirani)
+
 ======================= Lucene 8.9.0 =======================
 
 API Changes

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -263,6 +263,9 @@ Bug fixes
 * LUCENE-9940: The order of disjuncts in DisjunctionMaxQuery does not matter
   for equality checks (Alan Woodward)
 
+* LUCENE-9823: Prevent unsafe rewrites for SynonymQuery and CombinedFieldQuery. Before, rewriting
+  could slightly change the scoring when weights were specified. (Naoto Minami via Julie Tibshirani)
+
 Changes in Backwards Compatibility Policy
 
 * LUCENE-9904: regenerated UAX29URLEmailTokenizer and the corresponding analyzer with up-to-date top
@@ -321,15 +324,7 @@ Other
   the existing ones to the backwards codecs. (Julie Tibshirani, Ignacio Vera)  
   
 * LUCENE-9907: Remove dependency on PackedInts#getReader() from the current codecs and move the
-  method to backwards codec. (Ignacio Vera)   
-
-======================= Lucene 8.10.0 =======================
-
-Bug Fixes
----------------------
-
-* LUCENE-9823: Prevent unsafe rewrites for SynonymQuery and CombinedFieldQuery. Before, rewriting
-could slightly change the scoring when weights were specified. (Naoto Minami via Julie Tibshirani)
+  method to backwards codec. (Ignacio Vera)
 
 ======================= Lucene 8.9.0 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
@@ -144,14 +144,12 @@ public final class SynonymQuery extends Query {
 
   @Override
   public Query rewrite(IndexReader reader) throws IOException {
-    // optimize zero and single term cases
+    // optimize zero and non-boosted single term cases
     if (terms.length == 0) {
       return new BooleanQuery.Builder().build();
     }
-    if (terms.length == 1) {
-      return terms[0].boost == 1f
-          ? new TermQuery(terms[0].term)
-          : new BoostQuery(new TermQuery(terms[0].term), terms[0].boost);
+    if (terms.length == 1 && terms[0].boost == 1f) {
+      return new TermQuery(terms[0].term);
     }
     return this;
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.index.ImpactsSource;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
@@ -465,5 +466,27 @@ public class TestSynonymQuery extends LuceneTestCase {
     }
     reader.close();
     dir.close();
+  }
+
+  public void testRewrite() throws IOException {
+    // zero length SynonymQuery is rewritten
+    SynonymQuery q = new SynonymQuery.Builder("f").build();
+    assertTrue(q.getTerms().isEmpty());
+    assertEquals(q.rewrite(new MultiReader()), new BooleanQuery.Builder().build());
+
+    // non-boosted single term SynonymQuery is rewritten
+    q = new SynonymQuery.Builder("f").addTerm(new Term("f"), 1f).build();
+    assertEquals(q.getTerms().size(), 1);
+    assertEquals(q.rewrite(new MultiReader()), new TermQuery(new Term("f")));
+
+    // boosted single term SynonymQuery is not rewritten
+    q = new SynonymQuery.Builder("f").addTerm(new Term("f"), 0.8f).build();
+    assertEquals(q.getTerms().size(), 1);
+    assertEquals(q.rewrite(new MultiReader()), q);
+
+    // multiple term SynonymQuery is not rewritten
+    q = new SynonymQuery.Builder("f").addTerm(new Term("f"), 1f).addTerm(new Term("f"), 1f).build();
+    assertEquals(q.getTerms().size(), 2);
+    assertEquals(q.rewrite(new MultiReader()), q);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
@@ -469,24 +469,26 @@ public class TestSynonymQuery extends LuceneTestCase {
   }
 
   public void testRewrite() throws IOException {
+    IndexSearcher searcher = new IndexSearcher(new MultiReader());
+
     // zero length SynonymQuery is rewritten
     SynonymQuery q = new SynonymQuery.Builder("f").build();
     assertTrue(q.getTerms().isEmpty());
-    assertEquals(q.rewrite(new MultiReader()), new BooleanQuery.Builder().build());
+    assertEquals(searcher.rewrite(q), new MatchNoDocsQuery());
 
     // non-boosted single term SynonymQuery is rewritten
     q = new SynonymQuery.Builder("f").addTerm(new Term("f"), 1f).build();
     assertEquals(q.getTerms().size(), 1);
-    assertEquals(q.rewrite(new MultiReader()), new TermQuery(new Term("f")));
+    assertEquals(searcher.rewrite(q), new TermQuery(new Term("f")));
 
     // boosted single term SynonymQuery is not rewritten
     q = new SynonymQuery.Builder("f").addTerm(new Term("f"), 0.8f).build();
     assertEquals(q.getTerms().size(), 1);
-    assertEquals(q.rewrite(new MultiReader()), q);
+    assertEquals(searcher.rewrite(q), q);
 
     // multiple term SynonymQuery is not rewritten
     q = new SynonymQuery.Builder("f").addTerm(new Term("f"), 1f).addTerm(new Term("f"), 1f).build();
     assertEquals(q.getTerms().size(), 2);
-    assertEquals(q.rewrite(new MultiReader()), q);
+    assertEquals(searcher.rewrite(q), q);
   }
 }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
@@ -232,10 +232,6 @@ public final class CombinedFieldQuery extends Query implements Accountable {
     if (terms.length == 0) {
       return new BooleanQuery.Builder().build();
     }
-    // single field and one term
-    if (fieldTerms.length == 1) {
-      return new TermQuery(fieldTerms[0]);
-    }
     return this;
   }
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
@@ -48,7 +48,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermScorer;
 import org.apache.lucene.search.TermStatistics;
@@ -236,14 +235,6 @@ public final class CombinedFieldQuery extends Query implements Accountable {
     // single field and one term
     if (fieldTerms.length == 1) {
       return new TermQuery(fieldTerms[0]);
-    }
-    // single field and multiple terms
-    if (fieldAndWeights.size() == 1) {
-      SynonymQuery.Builder builder = new SynonymQuery.Builder(fieldTerms[0].field());
-      for (Term term : fieldTerms) {
-        builder.addTerm(term);
-      }
-      return builder.build();
     }
     return this;
   }

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
@@ -67,9 +67,6 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
     actual = searcher.rewrite(builder.build());
     assertEquals(actual, new MatchNoDocsQuery());
     builder.addTerm(new BytesRef("foo"));
-    actual = searcher.rewrite(builder.build());
-    assertEquals(actual, new TermQuery(new Term("field", "foo")));
-    builder.addTerm(new BytesRef("bar"));
     Query query = builder.build();
     actual = searcher.rewrite(query);
     assertEquals(actual, query);

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
@@ -34,7 +34,6 @@ import org.apache.lucene.search.CollectionStatistics;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermStatistics;
 import org.apache.lucene.search.TopDocs;
@@ -71,14 +70,6 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
     actual = searcher.rewrite(builder.build());
     assertEquals(actual, new TermQuery(new Term("field", "foo")));
     builder.addTerm(new BytesRef("bar"));
-    actual = searcher.rewrite(builder.build());
-    assertEquals(
-        actual,
-        new SynonymQuery.Builder("field")
-            .addTerm(new Term("field", "foo"))
-            .addTerm(new Term("field", "bar"))
-            .build());
-    builder.addField("another_field", 1f);
     Query query = builder.build();
     actual = searcher.rewrite(query);
     assertEquals(actual, query);


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/projects/LUCENE

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>

LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

> When rewriting a SynonymQuery with a single term, we create a BoostQuery wrapping a TermQuery. 

However, 

>  it now multiplies the final TermQuery score instead of multiplying the term frequency before it's passed to the score calculation.

JIRA: https://issues.apache.org/jira/browse/LUCENE-9823

# Solution

Remove unsafe codes of `SynonymQuery` and `CombinedFieldQuery`.

# Tests

Added:
- `TestSynonymQuery#testRewrite`

Fixed:
- `TestCombinedFieldQuery#testRewrite`

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] ~I have created a Jira issue and added the issue ID to my pull request title.~ **I've picked newdev ticket**
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.