### PR TITLE
LUCENE-9905: Allow Lucene90Codec to be configured with a per-field vector format

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90Codec.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90Codec.java
@@ -63,8 +63,9 @@ public class Lucene90Codec extends Codec {
   private final SegmentInfoFormat segmentInfosFormat = new Lucene90SegmentInfoFormat();
   private final LiveDocsFormat liveDocsFormat = new Lucene90LiveDocsFormat();
   private final CompoundFormat compoundFormat = new Lucene90CompoundFormat();
-  private final PostingsFormat defaultFormat;
+  private final NormsFormat normsFormat = new Lucene90NormsFormat();
 
+  private final PostingsFormat defaultPostingsFormat;
   private final PostingsFormat postingsFormat =
       new PerFieldPostingsFormat() {
         @Override
@@ -73,6 +74,7 @@ public class Lucene90Codec extends Codec {
         }
       };
 
+  private final DocValuesFormat defaultDVFormat;
   private final DocValuesFormat docValuesFormat =
       new PerFieldDocValuesFormat() {
         @Override
@@ -81,11 +83,12 @@ public class Lucene90Codec extends Codec {
         }
       };
 
+  private final VectorFormat defaultVectorFormat;
   private final VectorFormat vectorFormat =
       new PerFieldVectorFormat() {
         @Override
         public VectorFormat getVectorFormatForField(String field) {
-          return new Lucene90HnswVectorFormat();
+          return Lucene90Codec.this.getVectorFormatForField(field);
         }
       };
 
@@ -105,8 +108,9 @@ public class Lucene90Codec extends Codec {
     super("Lucene90");
     this.storedFieldsFormat =
         new Lucene90StoredFieldsFormat(Objects.requireNonNull(mode).storedMode);
-    this.defaultFormat = new Lucene90PostingsFormat();
+    this.defaultPostingsFormat = new Lucene90PostingsFormat();
     this.defaultDVFormat = new Lucene90DocValuesFormat();
+    this.defaultVectorFormat = new Lucene90HnswVectorFormat();
   }
 
   @Override
@@ -163,7 +167,7 @@ public class Lucene90Codec extends Codec {
    * future version of Lucene are only guaranteed to be able to read the default implementation,
    */
   public PostingsFormat getPostingsFormatForField(String field) {
-    return defaultFormat;
+    return defaultPostingsFormat;
   }
 
   /**
@@ -179,14 +183,22 @@ public class Lucene90Codec extends Codec {
     return defaultDVFormat;
   }
 
+  /**
+   * Returns the vectors format that should be used for writing new segments of <code>field</code>
+   *
+   * <p>The default implementation always returns "Lucene90".
+   *
+   * <p><b>WARNING:</b> if you subclass, you are responsible for index backwards compatibility:
+   * future version of Lucene are only guaranteed to be able to read the default implementation.
+   */
+  public VectorFormat getVectorFormatForField(String field) {
+    return defaultVectorFormat;
+  }
+
   @Override
   public final DocValuesFormat docValuesFormat() {
     return docValuesFormat;
   }
-
-  private final DocValuesFormat defaultDVFormat;
-
-  private final NormsFormat normsFormat = new Lucene90NormsFormat();
 
   @Override
   public final NormsFormat normsFormat() {

--- a/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingCodec.java
@@ -27,6 +27,7 @@ import org.apache.lucene.codecs.TermVectorsFormat;
 import org.apache.lucene.codecs.VectorFormat;
 import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
 import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldVectorFormat;
 import org.apache.lucene.util.TestUtil;
 
 /** Acts like the default codec but with additional asserts. */
@@ -58,6 +59,14 @@ public class AssertingCodec extends FilterCodec {
         @Override
         public DocValuesFormat getDocValuesFormatForField(String field) {
           return AssertingCodec.this.getDocValuesFormatForField(field);
+        }
+      };
+
+  private final VectorFormat vectorFormat =
+      new PerFieldVectorFormat() {
+        @Override
+        public VectorFormat getVectorFormatForField(String field) {
+          return AssertingCodec.this.getVectorFormatForField(field);
         }
       };
 
@@ -111,7 +120,7 @@ public class AssertingCodec extends FilterCodec {
 
   @Override
   public VectorFormat vectorFormat() {
-    return defaultVectorFormat;
+    return vectorFormat;
   }
 
   @Override
@@ -138,6 +147,11 @@ public class AssertingCodec extends FilterCodec {
     return defaultDVFormat;
   }
 
+  /**
+   * Returns the vectors format that should be used for writing new segments of <code>field</code>.
+   *
+   * <p>The default implementation always returns "Asserting"
+   */
   public VectorFormat getVectorFormatForField(String field) {
     return defaultVectorFormat;
   }


### PR DESCRIPTION
Previously only AssertingCodec could handle a per-field vector format. This PR
also strengthens the checks in TestPerFieldVectorFormat.