### PR TITLE
LUCENE-9905: Move HNSW build parameters to codec

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorFormat.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import org.apache.lucene.codecs.VectorFormat;
 import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.codecs.VectorWriter;
-import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.util.hnsw.HnswGraph;
@@ -79,10 +78,6 @@ public final class Lucene90HnswVectorFormat extends VectorFormat {
   static final int VERSION_START = 0;
   static final int VERSION_CURRENT = VERSION_START;
 
-  static final String BEAM_WIDTH_KEY =
-      Lucene90HnswVectorFormat.class.getSimpleName() + ".beam_width";
-  static final String MAX_CONN_KEY = Lucene90HnswVectorFormat.class.getSimpleName() + ".max_conn";
-
   /**
    * Controls how many of the nearest neighbor candidates are connected to the new node. See {@link
    * HnswGraph} for details.
@@ -109,25 +104,7 @@ public final class Lucene90HnswVectorFormat extends VectorFormat {
 
   @Override
   public VectorWriter fieldsWriter(SegmentWriteState state) throws IOException {
-    SegmentInfo segmentInfo = state.segmentInfo;
-    putFormatAttribute(segmentInfo, MAX_CONN_KEY, String.valueOf(maxConn));
-    putFormatAttribute(segmentInfo, BEAM_WIDTH_KEY, String.valueOf(beamWidth));
     return new Lucene90HnswVectorWriter(state, maxConn, beamWidth);
-  }
-
-  private void putFormatAttribute(SegmentInfo si, String key, String value) {
-    String previousValue = si.putAttribute(key, value);
-    if (previousValue != null && previousValue.equals(value) == false) {
-      throw new IllegalStateException(
-          "found existing value for "
-              + key
-              + " for segment: "
-              + si.name
-              + "old="
-              + previousValue
-              + ", new="
-              + value);
-    }
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorFormat.java
@@ -24,7 +24,6 @@ import org.apache.lucene.codecs.VectorWriter;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.util.hnsw.HnswGraph;
-import org.apache.lucene.util.hnsw.HnswGraphBuilder;
 
 /**
  * Lucene 9.0 vector format, which encodes numeric vector values and an optional associated graph
@@ -78,22 +77,26 @@ public final class Lucene90HnswVectorFormat extends VectorFormat {
   static final int VERSION_START = 0;
   static final int VERSION_CURRENT = VERSION_START;
 
+  public static final int DEFAULT_MAX_CONN = 16;
+  public static final int DEFAULT_BEAM_WIDTH = 16;
+
   /**
-   * Controls how many of the nearest neighbor candidates are connected to the new node. See {@link
-   * HnswGraph} for details.
+   * Controls how many of the nearest neighbor candidates are connected to the new node. Defaults to
+   * {@link Lucene90HnswVectorFormat#DEFAULT_MAX_CONN}. See {@link HnswGraph} for more details.
    */
   private final int maxConn;
 
   /**
    * The number of candidate neighbors to track while searching the graph for each newly inserted
-   * node. See {@link HnswGraph} for details.
+   * node. Defaults to to {@link Lucene90HnswVectorFormat#DEFAULT_BEAM_WIDTH}. See {@link HnswGraph}
+   * for details.
    */
   private final int beamWidth;
 
   public Lucene90HnswVectorFormat() {
     super("Lucene90HnswVectorFormat");
-    this.maxConn = HnswGraphBuilder.DEFAULT_MAX_CONN;
-    this.beamWidth = HnswGraphBuilder.DEFAULT_BEAM_WIDTH;
+    this.maxConn = DEFAULT_MAX_CONN;
+    this.beamWidth = DEFAULT_BEAM_WIDTH;
   }
 
   public Lucene90HnswVectorFormat(int maxConn, int beamWidth) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorFormat.java
@@ -21,8 +21,11 @@ import java.io.IOException;
 import org.apache.lucene.codecs.VectorFormat;
 import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.codecs.VectorWriter;
+import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.util.hnsw.HnswGraph;
+import org.apache.lucene.util.hnsw.HnswGraphBuilder;
 
 /**
  * Lucene 9.0 vector format, which encodes numeric vector values and an optional associated graph
@@ -76,14 +79,55 @@ public final class Lucene90HnswVectorFormat extends VectorFormat {
   static final int VERSION_START = 0;
   static final int VERSION_CURRENT = VERSION_START;
 
-  /** Sole constructor */
+  static final String BEAM_WIDTH_KEY =
+      Lucene90HnswVectorFormat.class.getSimpleName() + ".beam_width";
+  static final String MAX_CONN_KEY = Lucene90HnswVectorFormat.class.getSimpleName() + ".max_conn";
+
+  /**
+   * Controls how many of the nearest neighbor candidates are connected to the new node. See {@link
+   * HnswGraph} for details.
+   */
+  private final int maxConn;
+
+  /**
+   * The number of candidate neighbors to track while searching the graph for each newly inserted
+   * node. See {@link HnswGraph} for details.
+   */
+  private final int beamWidth;
+
   public Lucene90HnswVectorFormat() {
     super("Lucene90HnswVectorFormat");
+    this.maxConn = HnswGraphBuilder.DEFAULT_MAX_CONN;
+    this.beamWidth = HnswGraphBuilder.DEFAULT_BEAM_WIDTH;
+  }
+
+  public Lucene90HnswVectorFormat(int maxConn, int beamWidth) {
+    super("Lucene90HnswVectorFormat");
+    this.maxConn = maxConn;
+    this.beamWidth = beamWidth;
   }
 
   @Override
   public VectorWriter fieldsWriter(SegmentWriteState state) throws IOException {
-    return new Lucene90HnswVectorWriter(state);
+    SegmentInfo segmentInfo = state.segmentInfo;
+    putFormatAttribute(segmentInfo, MAX_CONN_KEY, String.valueOf(maxConn));
+    putFormatAttribute(segmentInfo, BEAM_WIDTH_KEY, String.valueOf(beamWidth));
+    return new Lucene90HnswVectorWriter(state, maxConn, beamWidth);
+  }
+
+  private void putFormatAttribute(SegmentInfo si, String key, String value) {
+    String previousValue = si.putAttribute(key, value);
+    if (previousValue != null && previousValue.equals(value) == false) {
+      throw new IllegalStateException(
+          "found existing value for "
+              + key
+              + " for segment: "
+              + si.name
+              + "old="
+              + previousValue
+              + ", new="
+              + value);
+    }
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorWriter.java
@@ -45,9 +45,14 @@ public final class Lucene90HnswVectorWriter extends VectorWriter {
   private final SegmentWriteState segmentWriteState;
   private final IndexOutput meta, vectorData, vectorIndex;
 
+  private final int maxConn;
+  private final int beamWidth;
   private boolean finished;
 
-  Lucene90HnswVectorWriter(SegmentWriteState state) throws IOException {
+  Lucene90HnswVectorWriter(SegmentWriteState state, int maxConn, int beamWidth) throws IOException {
+    this.maxConn = maxConn;
+    this.beamWidth = beamWidth;
+
     assert state.fieldInfos.hasVectorValues();
     segmentWriteState = state;
 
@@ -129,8 +134,8 @@ public final class Lucene90HnswVectorWriter extends VectorWriter {
             vectorIndexOffset,
             offsets,
             count,
-            fieldInfo.getAttribute(HnswGraphBuilder.HNSW_MAX_CONN_ATTRIBUTE_KEY),
-            fieldInfo.getAttribute(HnswGraphBuilder.HNSW_BEAM_WIDTH_ATTRIBUTE_KEY));
+            maxConn,
+            beamWidth);
       } else {
         throw new IllegalArgumentException(
             "Indexing an HNSW graph requires a random access vector values, got " + vectors);
@@ -196,36 +201,9 @@ public final class Lucene90HnswVectorWriter extends VectorWriter {
       long graphDataOffset,
       long[] offsets,
       int count,
-      String maxConnStr,
-      String beamWidthStr)
+      int maxConn,
+      int beamWidth)
       throws IOException {
-    int maxConn, beamWidth;
-    if (maxConnStr == null) {
-      maxConn = HnswGraphBuilder.DEFAULT_MAX_CONN;
-    } else {
-      try {
-        maxConn = Integer.parseInt(maxConnStr);
-      } catch (
-          @SuppressWarnings("unused")
-          NumberFormatException e) {
-        throw new NumberFormatException(
-            "Received non integer value for max-connections parameter of HnswGraphBuilder, value: "
-                + maxConnStr);
-      }
-    }
-    if (beamWidthStr == null) {
-      beamWidth = HnswGraphBuilder.DEFAULT_BEAM_WIDTH;
-    } else {
-      try {
-        beamWidth = Integer.parseInt(beamWidthStr);
-      } catch (
-          @SuppressWarnings("unused")
-          NumberFormatException e) {
-        throw new NumberFormatException(
-            "Received non integer value for beam-width parameter of HnswGraphBuilder, value: "
-                + beamWidthStr);
-      }
-    }
     HnswGraphBuilder hnswGraphBuilder =
         new HnswGraphBuilder(vectorValues, maxConn, beamWidth, HnswGraphBuilder.randSeed);
     hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);

--- a/lucene/core/src/java/org/apache/lucene/document/VectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/VectorField.java
@@ -18,7 +18,6 @@
 package org.apache.lucene.document;
 
 import org.apache.lucene.index.VectorValues;
-import org.apache.lucene.util.hnsw.HnswGraphBuilder;
 
 /**
  * A field that contains a single floating-point numeric vector (or none) for each document. Vectors
@@ -57,34 +56,16 @@ public class VectorField extends Field {
   }
 
   /**
-   * Public method to create HNSW field type with the given max-connections and beam-width
-   * parameters that would be used by HnswGraphBuilder while constructing HNSW graph.
+   * A convenience method for creating a vector field type.
    *
    * @param dimension dimension of vectors
    * @param similarityFunction a function defining vector proximity.
-   * @param maxConn max-connections at each HNSW graph node
-   * @param beamWidth size of list to be used while constructing HNSW graph
    * @throws IllegalArgumentException if any parameter is null, or has dimension &gt; 1024.
    */
-  public static FieldType createHnswType(
-      int dimension,
-      VectorValues.SimilarityFunction similarityFunction,
-      int maxConn,
-      int beamWidth) {
-    if (dimension == 0) {
-      throw new IllegalArgumentException("cannot index an empty vector");
-    }
-    if (dimension > VectorValues.MAX_DIMENSIONS) {
-      throw new IllegalArgumentException(
-          "cannot index vectors with dimension greater than " + VectorValues.MAX_DIMENSIONS);
-    }
-    if (similarityFunction == null || similarityFunction == VectorValues.SimilarityFunction.NONE) {
-      throw new IllegalArgumentException("similarity function must not be: " + similarityFunction);
-    }
+  public static FieldType createFieldType(
+      int dimension, VectorValues.SimilarityFunction similarityFunction) {
     FieldType type = new FieldType();
     type.setVectorDimensionsAndSimilarityFunction(dimension, similarityFunction);
-    type.putAttribute(HnswGraphBuilder.HNSW_MAX_CONN_ATTRIBUTE_KEY, String.valueOf(maxConn));
-    type.putAttribute(HnswGraphBuilder.HNSW_BEAM_WIDTH_ATTRIBUTE_KEY, String.valueOf(beamWidth));
     type.freeze();
     return type;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -60,11 +60,6 @@ public final class HnswGraphBuilder {
   // colliding
   private RandomAccessVectorValues buildVectors;
 
-  /** Construct the builder with default configurations */
-  public HnswGraphBuilder(RandomAccessVectorValuesProducer vectors) {
-    this(vectors, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, randSeed);
-  }
-
   /**
    * Reads all the vectors from a VectorValues, builds a graph connecting them by their dense
    * ordinals, using the given hyperparameter settings, and returns the resulting graph.

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -38,12 +38,6 @@ public final class HnswGraphBuilder {
   // expose for testing.
   public static long randSeed = DEFAULT_RAND_SEED;
 
-  // default max connections per node
-  public static final int DEFAULT_MAX_CONN = 16;
-
-  // default candidate list size
-  public static final int DEFAULT_BEAM_WIDTH = 16;
-
   private final int maxConn;
   private final int beamWidth;
   private final NeighborArray scratch;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -38,17 +38,11 @@ public final class HnswGraphBuilder {
   // expose for testing.
   public static long randSeed = DEFAULT_RAND_SEED;
 
-  /* These "default" hyper-parameter settings are exposed (and non-final) to enable performance
-   * testing since the indexing API doesn't provide any control over them.
-   */
-
   // default max connections per node
   public static final int DEFAULT_MAX_CONN = 16;
-  public static String HNSW_MAX_CONN_ATTRIBUTE_KEY = "max_connections";
 
   // default candidate list size
   public static final int DEFAULT_BEAM_WIDTH = 16;
-  public static String HNSW_BEAM_WIDTH_ATTRIBUTE_KEY = "beam_width";
 
   private final int maxConn;
   private final int beamWidth;

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90HnswVectorFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90HnswVectorFormat.java
@@ -16,14 +16,76 @@
  */
 package org.apache.lucene.codecs.lucene90;
 
+import java.util.List;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.VectorFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.VectorField;
 import org.apache.lucene.index.BaseVectorFormatTestCase;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.TestUtil;
+import org.apache.lucene.util.hnsw.HnswGraphBuilder;
 
 public class TestLucene90HnswVectorFormat extends BaseVectorFormatTestCase {
 
   @Override
   protected Codec getCodec() {
     return TestUtil.getDefaultCodec();
+  }
+
+  public void testCodecParameters() throws Exception {
+    Directory dir = newDirectory();
+
+    // Create a segment using the default parameters
+    IndexWriterConfig iwc = newIndexWriterConfig();
+    IndexWriter w = new IndexWriter(dir, iwc);
+    Document doc = new Document();
+    doc.add(new VectorField("field", new float[4], VectorValues.SimilarityFunction.DOT_PRODUCT));
+    w.addDocument(doc);
+    w.close();
+
+    // Write another segment using different parameters
+    int newMaxConn = HnswGraphBuilder.DEFAULT_MAX_CONN + 3;
+    int newBeamWidth = HnswGraphBuilder.DEFAULT_BEAM_WIDTH + 42;
+    IndexWriterConfig iwc2 =
+        newIndexWriterConfig()
+            .setCodec(
+                new Lucene90Codec() {
+                  @Override
+                  public VectorFormat getVectorFormatForField(String field) {
+                    return new Lucene90HnswVectorFormat(newMaxConn, newBeamWidth);
+                  }
+                });
+    IndexWriter w2 = new IndexWriter(dir, iwc2);
+    Document doc2 = new Document();
+    doc2.add(new VectorField("field", new float[4], VectorValues.SimilarityFunction.DOT_PRODUCT));
+    w2.addDocument(doc2);
+    w2.close();
+
+    // Check that we record the parameters that were used in the segment infos
+    List<SegmentCommitInfo> commitInfos = SegmentInfos.readLatestCommit(dir).asList();
+    assertEquals(2, commitInfos.size());
+
+    SegmentInfo si = commitInfos.get(0).info;
+    assertEquals(
+        String.valueOf(HnswGraphBuilder.DEFAULT_MAX_CONN),
+        si.getAttribute(Lucene90HnswVectorFormat.MAX_CONN_KEY));
+    assertEquals(
+        String.valueOf(HnswGraphBuilder.DEFAULT_BEAM_WIDTH),
+        si.getAttribute(Lucene90HnswVectorFormat.BEAM_WIDTH_KEY));
+
+    SegmentInfo si2 = commitInfos.get(1).info;
+    assertEquals(
+        String.valueOf(newMaxConn), si2.getAttribute(Lucene90HnswVectorFormat.MAX_CONN_KEY));
+    assertEquals(
+        String.valueOf(newBeamWidth), si2.getAttribute(Lucene90HnswVectorFormat.BEAM_WIDTH_KEY));
+
+    dir.close();
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90HnswVectorFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90HnswVectorFormat.java
@@ -39,7 +39,7 @@ public class TestLucene90HnswVectorFormat extends BaseVectorFormatTestCase {
     return TestUtil.getDefaultCodec();
   }
 
-  public void testCodecParameters() throws Exception {
+  public void testFormatParameters() throws Exception {
     Directory dir = newDirectory();
 
     // Create a segment using the default parameters

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90HnswVectorFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90HnswVectorFormat.java
@@ -16,76 +16,13 @@
  */
 package org.apache.lucene.codecs.lucene90;
 
-import java.util.List;
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.VectorFormat;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.document.VectorField;
 import org.apache.lucene.index.BaseVectorFormatTestCase;
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.SegmentCommitInfo;
-import org.apache.lucene.index.SegmentInfo;
-import org.apache.lucene.index.SegmentInfos;
-import org.apache.lucene.index.VectorValues;
-import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.TestUtil;
-import org.apache.lucene.util.hnsw.HnswGraphBuilder;
 
 public class TestLucene90HnswVectorFormat extends BaseVectorFormatTestCase {
-
   @Override
   protected Codec getCodec() {
     return TestUtil.getDefaultCodec();
-  }
-
-  public void testFormatParameters() throws Exception {
-    Directory dir = newDirectory();
-
-    // Create a segment using the default parameters
-    IndexWriterConfig iwc = newIndexWriterConfig();
-    IndexWriter w = new IndexWriter(dir, iwc);
-    Document doc = new Document();
-    doc.add(new VectorField("field", new float[4], VectorValues.SimilarityFunction.DOT_PRODUCT));
-    w.addDocument(doc);
-    w.close();
-
-    // Write another segment using different parameters
-    int newMaxConn = HnswGraphBuilder.DEFAULT_MAX_CONN + 3;
-    int newBeamWidth = HnswGraphBuilder.DEFAULT_BEAM_WIDTH + 42;
-    IndexWriterConfig iwc2 =
-        newIndexWriterConfig()
-            .setCodec(
-                new Lucene90Codec() {
-                  @Override
-                  public VectorFormat getVectorFormatForField(String field) {
-                    return new Lucene90HnswVectorFormat(newMaxConn, newBeamWidth);
-                  }
-                });
-    IndexWriter w2 = new IndexWriter(dir, iwc2);
-    Document doc2 = new Document();
-    doc2.add(new VectorField("field", new float[4], VectorValues.SimilarityFunction.DOT_PRODUCT));
-    w2.addDocument(doc2);
-    w2.close();
-
-    // Check that we record the parameters that were used in the segment infos
-    List<SegmentCommitInfo> commitInfos = SegmentInfos.readLatestCommit(dir).asList();
-    assertEquals(2, commitInfos.size());
-
-    SegmentInfo si = commitInfos.get(0).info;
-    assertEquals(
-        String.valueOf(HnswGraphBuilder.DEFAULT_MAX_CONN),
-        si.getAttribute(Lucene90HnswVectorFormat.MAX_CONN_KEY));
-    assertEquals(
-        String.valueOf(HnswGraphBuilder.DEFAULT_BEAM_WIDTH),
-        si.getAttribute(Lucene90HnswVectorFormat.BEAM_WIDTH_KEY));
-
-    SegmentInfo si2 = commitInfos.get(1).info;
-    assertEquals(
-        String.valueOf(newMaxConn), si2.getAttribute(Lucene90HnswVectorFormat.MAX_CONN_KEY));
-    assertEquals(
-        String.valueOf(newBeamWidth), si2.getAttribute(Lucene90HnswVectorFormat.BEAM_WIDTH_KEY));
-
-    dir.close();
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -55,7 +55,7 @@ public class TestKnnGraph extends LuceneTestCase {
 
   private static final String KNN_GRAPH_FIELD = "vector";
 
-  private static int maxConn = HnswGraphBuilder.DEFAULT_MAX_CONN;
+  private static int maxConn = Lucene90HnswVectorFormat.DEFAULT_MAX_CONN;
 
   private Codec codec;
   private SimilarityFunction similarityFunction;
@@ -71,7 +71,8 @@ public class TestKnnGraph extends LuceneTestCase {
         new Lucene90Codec() {
           @Override
           public VectorFormat getVectorFormatForField(String field) {
-            return new Lucene90HnswVectorFormat(maxConn, HnswGraphBuilder.DEFAULT_BEAM_WIDTH);
+            return new Lucene90HnswVectorFormat(
+                maxConn, Lucene90HnswVectorFormat.DEFAULT_BEAM_WIDTH);
           }
         };
 
@@ -81,7 +82,7 @@ public class TestKnnGraph extends LuceneTestCase {
 
   @After
   public void cleanup() {
-    maxConn = HnswGraphBuilder.DEFAULT_MAX_CONN;
+    maxConn = Lucene90HnswVectorFormat.DEFAULT_MAX_CONN;
   }
 
   /** Basic test of creating documents in a graph */

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -27,6 +27,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.VectorFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90Codec;
+import org.apache.lucene.codecs.lucene90.Lucene90HnswVectorFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90HnswVectorReader;
 import org.apache.lucene.codecs.perfield.PerFieldVectorFormat;
 import org.apache.lucene.document.Document;
@@ -54,6 +57,7 @@ public class TestKnnGraph extends LuceneTestCase {
 
   private static int maxConn = HnswGraphBuilder.DEFAULT_MAX_CONN;
 
+  private Codec codec;
   private SimilarityFunction similarityFunction;
 
   @Before
@@ -62,6 +66,15 @@ public class TestKnnGraph extends LuceneTestCase {
     if (random().nextBoolean()) {
       maxConn = random().nextInt(256) + 3;
     }
+
+    codec =
+        new Lucene90Codec() {
+          @Override
+          public VectorFormat getVectorFormatForField(String field) {
+            return new Lucene90HnswVectorFormat(maxConn, HnswGraphBuilder.DEFAULT_BEAM_WIDTH);
+          }
+        };
+
     int similarity = random().nextInt(SimilarityFunction.values().length - 1) + 1;
     similarityFunction = SimilarityFunction.values()[similarity];
   }
@@ -74,8 +87,7 @@ public class TestKnnGraph extends LuceneTestCase {
   /** Basic test of creating documents in a graph */
   public void testBasic() throws Exception {
     try (Directory dir = newDirectory();
-        IndexWriter iw =
-            new IndexWriter(dir, newIndexWriterConfig(null).setCodec(Codec.forName("Lucene90")))) {
+        IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig(null).setCodec(codec))) {
       int numDoc = atLeast(10);
       int dimension = atLeast(3);
       float[][] values = new float[numDoc][];
@@ -94,8 +106,7 @@ public class TestKnnGraph extends LuceneTestCase {
 
   public void testSingleDocument() throws Exception {
     try (Directory dir = newDirectory();
-        IndexWriter iw =
-            new IndexWriter(dir, newIndexWriterConfig(null).setCodec(Codec.forName("Lucene90")))) {
+        IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig(null).setCodec(codec))) {
       float[][] values = new float[][] {new float[] {0, 1, 2}};
       add(iw, 0, values[0]);
       assertConsistentGraph(iw, values);
@@ -107,8 +118,7 @@ public class TestKnnGraph extends LuceneTestCase {
   /** Verify that the graph properties are preserved when merging */
   public void testMerge() throws Exception {
     try (Directory dir = newDirectory();
-        IndexWriter iw =
-            new IndexWriter(dir, newIndexWriterConfig(null).setCodec(Codec.forName("Lucene90")))) {
+        IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig(null).setCodec(codec))) {
       int numDoc = atLeast(100);
       int dimension = atLeast(10);
       float[][] values = randomVectors(numDoc, dimension);
@@ -160,7 +170,7 @@ public class TestKnnGraph extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       IndexWriterConfig iwc = newIndexWriterConfig();
       iwc.setMergePolicy(new LogDocMergePolicy()); // for predictable segment ordering when merging
-      iwc.setCodec(Codec.forName("Lucene90")); // don't use SimpleTextCodec
+      iwc.setCodec(codec); // don't use SimpleTextCodec
       try (IndexWriter iw = new IndexWriter(dir, iwc)) {
         for (int i = 0; i < values.length; i++) {
           add(iw, i, values[i]);
@@ -218,7 +228,7 @@ public class TestKnnGraph extends LuceneTestCase {
     // We can't use dot product here since the vectors are laid out on a grid, not a sphere.
     similarityFunction = SimilarityFunction.EUCLIDEAN;
     IndexWriterConfig config = newIndexWriterConfig();
-    config.setCodec(Codec.forName("Lucene90")); // test is not compatible with simpletext
+    config.setCodec(codec); // test is not compatible with simpletext
     try (Directory dir = newDirectory();
         IndexWriter iw = new IndexWriter(dir, config)) {
       // Add a document for every cartesian point in an NxN square so we can
@@ -447,9 +457,7 @@ public class TestKnnGraph extends LuceneTestCase {
       throws IOException {
     Document doc = new Document();
     if (vector != null) {
-      FieldType fieldType =
-          VectorField.createHnswType(
-              vector.length, similarityFunction, maxConn, HnswGraphBuilder.DEFAULT_BEAM_WIDTH);
+      FieldType fieldType = VectorField.createFieldType(vector.length, similarityFunction);
       doc.add(new VectorField(KNN_GRAPH_FIELD, vector, fieldType));
     }
     String idString = Integer.toString(id);

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseVectorFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseVectorFormatTestCase.java
@@ -85,28 +85,6 @@ public abstract class BaseVectorFormatTestCase extends BaseIndexFileFormatTestCa
     expectThrows(IllegalArgumentException.class, () -> field.setVectorValue(null));
   }
 
-  public void testFieldCreateFieldType() {
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> VectorField.createHnswType(0, VectorValues.SimilarityFunction.EUCLIDEAN, 16, 16));
-    expectThrows(
-        IllegalArgumentException.class,
-        () ->
-            VectorField.createHnswType(
-                VectorValues.MAX_DIMENSIONS + 1,
-                VectorValues.SimilarityFunction.EUCLIDEAN,
-                16,
-                16));
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> VectorField.createHnswType(VectorValues.MAX_DIMENSIONS + 1, null, 16, 16));
-    expectThrows(
-        IllegalArgumentException.class,
-        () ->
-            VectorField.createHnswType(
-                VectorValues.MAX_DIMENSIONS + 1, VectorValues.SimilarityFunction.NONE, 16, 16));
-  }
-
   // Illegal schema change tests:
   public void testIllegalDimChangeTwoDocs() throws Exception {
     // illegal change in the same segment


### PR DESCRIPTION
Previously, the max connections and beam width parameters could be configured as
field type attributes. This PR moves them to be parameters on
Lucene90HnswVectorFormat, to avoid exposing details of the vector format
implementation in the API.
