### PR TITLE
LUCENE-10001: Make CollectionTerminatedException handling in MultiCollector configurable

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -127,6 +127,10 @@ API Changes
 
 * LUCENE-8143: SpanBoostQuery has been removed. (Alan Woodward)
 
+* LUCENE-10001: MultiCollector allows users to specify whether to early terminate all collecting
+  when a wrapped Collector throws a CollectionTerminatedException vs. continuing to collect others
+  that have not indicated early termination. The latter is maintained as the default. (Greg Miller)
+
 Improvements
 
 * LUCENE-9960: Avoid unnecessary top element replacement for equal elements in PriorityQueue. (Dawid Weiss)


### PR DESCRIPTION
# Description

There could be use-cases where a user wants to terminate all wrapped collectors in a MultiCollector when one terminates. Today, other collectors continue collecting. For example, a user collecting matching docs while also collecting into a FacetsCollector may want to terminate both collectors when the "main" matching docs collector terminates.

#11040

# Solution

Added the ability to configure the behavior through an enum specified to `wrap`

# Tests

Updated the existing tests to check behavior under both options.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
