### PR TITLE
LUCENE-9935: Clone term vectors reader for merges

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -304,6 +304,11 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
     return new Lucene90CompressingTermVectorsReader(this);
   }
 
+  @Override
+  public TermVectorsReader getMergeInstance() {
+    return new Lucene90CompressingTermVectorsReader(this);
+  }
+
   private static RandomAccessInput slice(IndexInput in) throws IOException {
     final int length = in.readVInt();
     final byte[] bytes = new byte[length];


### PR DESCRIPTION
The newly added [assertion](https://github.com/apache/lucene/blob/50607e0fb9090a1321093aca4117b6560c511af0/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsWriter.java#L898) in the bulk-merge logic doesn't always hold because we do not create a new instance of `Lucene90CompressingTermVectorsReader` for merges and that reader can be accessed in tests (as long as it happens on the same thread).

This change clones a new term vectors reader for merges.

The issue was uncovered by Elastic CI: https://elasticsearch-ci.elastic.co/job/apache+lucene-solr+nightly+main/361/consoleText.