### PR TITLE
LUCENE-9998: delete useless param fis in StoredFieldsWriter.finish() and TermVectorsWriter.finish() 

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -127,6 +127,9 @@ API Changes
 
 * LUCENE-8143: SpanBoostQuery has been removed. (Alan Woodward)
 
+* LUCENE-9998: Remove unused parameter fis in StoredFieldsWriter.finish() and TermVectorsWriter.finish(),
+  including those subclasses. (kkewwei)
+
 Improvements
 
 * LUCENE-9960: Avoid unnecessary top element replacement for equal elements in PriorityQueue. (Dawid Weiss)

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsWriter.java
@@ -36,7 +36,6 @@ import org.apache.lucene.codecs.StoredFieldsWriter;
 import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.codecs.compressing.Compressor;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.SegmentInfo;
@@ -480,7 +479,7 @@ public final class Lucene50CompressingStoredFieldsWriter extends StoredFieldsWri
   }
 
   @Override
-  public void finish(FieldInfos fis, int numDocs) throws IOException {
+  public void finish(int numDocs) throws IOException {
     if (numBufferedDocs > 0) {
       flush(true);
     } else {

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsWriter.java
@@ -42,7 +42,6 @@ import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.codecs.compressing.Compressor;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.store.ByteBuffersDataOutput;
@@ -701,7 +700,7 @@ public final class Lucene50CompressingTermVectorsWriter extends TermVectorsWrite
   }
 
   @Override
-  public void finish(FieldInfos fis, int numDocs) throws IOException {
+  public void finish(int numDocs) throws IOException {
     if (!pendingDocs.isEmpty()) {
       numDirtyChunks++; // incomplete: we had to force this flush
       numDirtyDocs += pendingDocs.size();

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextStoredFieldsWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextStoredFieldsWriter.java
@@ -19,7 +19,6 @@ package org.apache.lucene.codecs.simpletext;
 import java.io.IOException;
 import org.apache.lucene.codecs.StoredFieldsWriter;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.store.Directory;
@@ -152,7 +151,7 @@ public class SimpleTextStoredFieldsWriter extends StoredFieldsWriter {
   }
 
   @Override
-  public void finish(FieldInfos fis, int numDocs) throws IOException {
+  public void finish(int numDocs) throws IOException {
     if (numDocsWritten != numDocs) {
       throw new RuntimeException(
           "mergeFields produced an invalid result: docCount is "

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsWriter.java
@@ -19,7 +19,6 @@ package org.apache.lucene.codecs.simpletext;
 import java.io.IOException;
 import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -165,7 +164,7 @@ public class SimpleTextTermVectorsWriter extends TermVectorsWriter {
   }
 
   @Override
-  public void finish(FieldInfos fis, int numDocs) throws IOException {
+  public void finish(int numDocs) throws IOException {
     if (numDocsWritten != numDocs) {
       throw new RuntimeException(
           "mergeVectors produced an invalid result: mergedDocs is "

--- a/lucene/core/src/java/org/apache/lucene/codecs/StoredFieldsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/StoredFieldsWriter.java
@@ -44,7 +44,7 @@ import org.apache.lucene.util.BytesRef;
  *   <li>For every document, {@link #startDocument()} is called, informing the Codec that a new
  *       document has started.
  *   <li>{@link #writeField(FieldInfo, IndexableField)} is called for each field in the document.
- *   <li>After all documents have been written, {@link #finish(FieldInfos, int)} is called for
+ *   <li>After all documents have been written, {@link #finish(int)} is called for
  *       verification/sanity-checks.
  *   <li>Finally the writer is closed ({@link #close()})
  * </ol>
@@ -74,7 +74,7 @@ public abstract class StoredFieldsWriter implements Closeable, Accountable {
    * this is intentionally redundant (equivalent to the number of calls to {@link #startDocument()},
    * but a Codec should check that this is the case to detect the JRE bug described in LUCENE-1282.
    */
-  public abstract void finish(FieldInfos fis, int numDocs) throws IOException;
+  public abstract void finish(int numDocs) throws IOException;
 
   private static class StoredFieldsMergeSub extends DocIDMerger.Sub {
     private final StoredFieldsReader reader;
@@ -104,9 +104,9 @@ public abstract class StoredFieldsWriter implements Closeable, Accountable {
   /**
    * Merges in the stored fields from the readers in <code>mergeState</code>. The default
    * implementation skips over deleted documents, and uses {@link #startDocument()}, {@link
-   * #writeField(FieldInfo, IndexableField)}, and {@link #finish(FieldInfos, int)}, returning the
-   * number of documents that were written. Implementations can override this method for more
-   * sophisticated merging (bulk-byte copying, etc).
+   * #writeField(FieldInfo, IndexableField)}, and {@link #finish(int)}, returning the number of
+   * documents that were written. Implementations can override this method for more sophisticated
+   * merging (bulk-byte copying, etc).
    */
   public int merge(MergeState mergeState) throws IOException {
     List<StoredFieldsMergeSub> subs = new ArrayList<>();
@@ -136,7 +136,7 @@ public abstract class StoredFieldsWriter implements Closeable, Accountable {
       finishDocument();
       docCount++;
     }
-    finish(mergeState.mergeFieldInfos, docCount);
+    finish(docCount);
     return docCount;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/TermVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/TermVectorsWriter.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
 import java.util.List;
 import org.apache.lucene.index.DocIDMerger;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.PostingsEnum;
@@ -49,7 +48,7 @@ import org.apache.lucene.util.BytesRefBuilder;
  *   <li>Within each field, {@link #startTerm(BytesRef, int)} is called for each term.
  *   <li>If offsets and/or positions are enabled, then {@link #addPosition(int, int, int, BytesRef)}
  *       will be called for each term occurrence.
- *   <li>After all documents have been written, {@link #finish(FieldInfos, int)} is called for
+ *   <li>After all documents have been written, {@link #finish(int)} is called for
  *       verification/sanity-checks.
  *   <li>Finally the writer is closed ({@link #close()})
  * </ol>
@@ -105,7 +104,7 @@ public abstract class TermVectorsWriter implements Closeable, Accountable {
    * #startDocument(int)}, but a Codec should check that this is the case to detect the JRE bug
    * described in LUCENE-1282.
    */
-  public abstract void finish(FieldInfos fis, int numDocs) throws IOException;
+  public abstract void finish(int numDocs) throws IOException;
 
   /**
    * Called by IndexWriter when writing new segments.
@@ -193,9 +192,9 @@ public abstract class TermVectorsWriter implements Closeable, Accountable {
    * Merges in the term vectors from the readers in <code>mergeState</code>. The default
    * implementation skips over deleted documents, and uses {@link #startDocument(int)}, {@link
    * #startField(FieldInfo, int, boolean, boolean, boolean)}, {@link #startTerm(BytesRef, int)},
-   * {@link #addPosition(int, int, int, BytesRef)}, and {@link #finish(FieldInfos, int)}, returning
-   * the number of documents that were written. Implementations can override this method for more
-   * sophisticated merging (bulk-byte copying, etc).
+   * {@link #addPosition(int, int, int, BytesRef)}, and {@link #finish(int)}, returning the number
+   * of documents that were written. Implementations can override this method for more sophisticated
+   * merging (bulk-byte copying, etc).
    */
   public int merge(MergeState mergeState) throws IOException {
 
@@ -229,7 +228,7 @@ public abstract class TermVectorsWriter implements Closeable, Accountable {
       addAllDocVectors(vectors, mergeState);
       docCount++;
     }
-    finish(mergeState.mergeFieldInfos, docCount);
+    finish(docCount);
     return docCount;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
@@ -31,7 +31,6 @@ import org.apache.lucene.codecs.lucene90.compressing.Lucene90CompressingStoredFi
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DocIDMerger;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.MergeState;
@@ -478,7 +477,7 @@ public final class Lucene90CompressingStoredFieldsWriter extends StoredFieldsWri
   }
 
   @Override
-  public void finish(FieldInfos fis, int numDocs) throws IOException {
+  public void finish(int numDocs) throws IOException {
     if (numBufferedDocs > 0) {
       flush(true);
     } else {
@@ -654,7 +653,7 @@ public final class Lucene90CompressingStoredFieldsWriter extends StoredFieldsWri
         throw new AssertionError("Unknown merge strategy [" + sub.mergeStrategy + "]");
       }
     }
-    finish(mergeState.mergeFieldInfos, docCount);
+    finish(docCount);
     return docCount;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsWriter.java
@@ -37,7 +37,6 @@ import org.apache.lucene.codecs.compressing.MatchingReaders;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DocIDMerger;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergeState;
@@ -721,7 +720,7 @@ public final class Lucene90CompressingTermVectorsWriter extends TermVectorsWrite
   }
 
   @Override
-  public void finish(FieldInfos fis, int numDocs) throws IOException {
+  public void finish(int numDocs) throws IOException {
     if (!pendingDocs.isEmpty()) {
       flush(true);
     }
@@ -939,7 +938,7 @@ public final class Lucene90CompressingTermVectorsWriter extends TermVectorsWrite
         sub = docIDMerger.next();
       }
     }
-    finish(mergeState.mergeFieldInfos, docCount);
+    finish(docCount);
     return docCount;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
@@ -115,7 +115,7 @@ final class SortingStoredFieldsConsumer extends StoredFieldsConsumer {
         reader.visitDocument(sortMap == null ? docID : sortMap.newToOld(docID), visitor);
         sortWriter.finishDocument();
       }
-      sortWriter.finish(state.fieldInfos, state.segmentInfo.maxDoc());
+      sortWriter.finish(state.segmentInfo.maxDoc());
     } finally {
       IOUtils.close(reader, sortWriter);
       IOUtils.deleteFiles(tmpDirectory, tmpDirectory.getTemporaryFiles().values());

--- a/lucene/core/src/java/org/apache/lucene/index/SortingTermVectorsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingTermVectorsConsumer.java
@@ -75,7 +75,7 @@ final class SortingTermVectorsConsumer extends TermVectorsConsumer {
           Fields vectors = reader.get(sortMap == null ? docID : sortMap.newToOld(docID));
           writeTermVectors(writer, vectors, state.fieldInfos);
         }
-        writer.finish(state.fieldInfos, state.segmentInfo.maxDoc());
+        writer.finish(state.segmentInfo.maxDoc());
       } finally {
         IOUtils.close(reader, writer);
         IOUtils.deleteFiles(tmpDirectory, tmpDirectory.getTemporaryFiles().values());

--- a/lucene/core/src/java/org/apache/lucene/index/StoredFieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StoredFieldsConsumer.java
@@ -79,7 +79,7 @@ class StoredFieldsConsumer {
 
   void flush(SegmentWriteState state, Sorter.DocMap sortMap) throws IOException {
     try {
-      writer.finish(state.fieldInfos, state.segmentInfo.maxDoc());
+      writer.finish(state.segmentInfo.maxDoc());
     } finally {
       IOUtils.close(writer);
     }

--- a/lucene/core/src/java/org/apache/lucene/index/TermVectorsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermVectorsConsumer.java
@@ -82,7 +82,7 @@ class TermVectorsConsumer extends TermsHash {
       try {
         fill(numDocs);
         assert state.segmentInfo != null;
-        writer.finish(state.fieldInfos, numDocs);
+        writer.finish(numDocs);
       } finally {
         IOUtils.close(writer);
       }

--- a/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingStoredFieldsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingStoredFieldsFormat.java
@@ -136,9 +136,9 @@ public class AssertingStoredFieldsFormat extends StoredFieldsFormat {
     }
 
     @Override
-    public void finish(FieldInfos fis, int numDocs) throws IOException {
+    public void finish(int numDocs) throws IOException {
       assert docStatus == (numDocs > 0 ? Status.FINISHED : Status.UNDEFINED);
-      in.finish(fis, numDocs);
+      in.finish(numDocs);
       assert numDocs == numWritten;
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingTermVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingTermVectorsFormat.java
@@ -185,12 +185,12 @@ public class AssertingTermVectorsFormat extends TermVectorsFormat {
     }
 
     @Override
-    public void finish(FieldInfos fis, int numDocs) throws IOException {
+    public void finish(int numDocs) throws IOException {
       assert docCount == numDocs;
       assert docStatus == (numDocs > 0 ? Status.FINISHED : Status.UNDEFINED);
       assert fieldStatus != Status.STARTED;
       assert termStatus != Status.STARTED;
-      in.finish(fis, numDocs);
+      in.finish(numDocs);
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/codecs/cranky/CrankyStoredFieldsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/codecs/cranky/CrankyStoredFieldsFormat.java
@@ -66,11 +66,11 @@ class CrankyStoredFieldsFormat extends StoredFieldsFormat {
     }
 
     @Override
-    public void finish(FieldInfos fis, int numDocs) throws IOException {
+    public void finish(int numDocs) throws IOException {
       if (random.nextInt(100) == 0) {
         throw new IOException("Fake IOException from StoredFieldsWriter.finish()");
       }
-      delegate.finish(fis, numDocs);
+      delegate.finish(numDocs);
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/codecs/cranky/CrankyTermVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/codecs/cranky/CrankyTermVectorsFormat.java
@@ -77,11 +77,11 @@ class CrankyTermVectorsFormat extends TermVectorsFormat {
     }
 
     @Override
-    public void finish(FieldInfos fis, int numDocs) throws IOException {
+    public void finish(int numDocs) throws IOException {
       if (random.nextInt(100) == 0) {
         throw new IOException("Fake IOException from TermVectorsWriter.finish()");
       }
-      delegate.finish(fis, numDocs);
+      delegate.finish(numDocs);
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
@@ -529,7 +529,7 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
       consumer.finishTerm();
       consumer.finishField();
       consumer.finishDocument();
-      consumer.finish(fieldInfos, 1);
+      consumer.finish(1);
       IOUtils.close(consumer);
       IOUtils.close(consumer);
     }
@@ -545,7 +545,7 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
       consumer.startDocument();
       consumer.writeField(field, customField);
       consumer.finishDocument();
-      consumer.finish(fieldInfos, 1);
+      consumer.finish(1);
       IOUtils.close(consumer);
       IOUtils.close(consumer);
     }


### PR DESCRIPTION
# Description
the paramater `fis` in In `StoredFieldsWriter.finish()` and `TermVectorsWriter.finish()` is useless, and deleting it would help simplify the API.
# Solution
Deleting it from `StoredFieldsWriter.finish()` and `TermVectorsWriter.finish()`, including those subclasses
# Tests
Just run  ./gradlew precommit ./gradlew test   ./gradlew check
# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
