### PR TITLE
LUCENE-9613: Encode ordinals like numerics.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
@@ -52,7 +52,7 @@ import org.apache.lucene.util.packed.DirectWriter;
  *       by accumulating the {@link Long#bitCount(long) bit counts} of the visited longs. Advancing
  *       &gt;= 512 documents is performed by skipping to the start of the needed 512 document
  *       sub-block and iterating to the specific document within that block. The index for the
- *       sub-block that is skipped to is retrieved from a rank-table positioned beforethe bit set.
+ *       sub-block that is skipped to is retrieved from a rank-table positioned before the bit set.
  *       The rank-table holds the origo index numbers for all 512 documents sub-blocks, represented
  *       as an unsigned short for each 128 blocks.
  *   <li>ALL: This strategy is used when a block contains exactly 65536 documents, meaning that the


### PR DESCRIPTION
This helps simplify the code, and also adds some optimizations to ordinals like
better compression for long runs of equal values or fields that are used in
index sorts.
