### PR TITLE
LUCENE-10005: Improve AlreadyClosedException logging

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
@@ -1619,13 +1619,18 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           iw.addDocument(doc);
         });
 
-    assertNull(iw.getTragicException());
+    assertNoTragic(iw);
     iw.close();
     // make sure we see our good doc
     DirectoryReader r = DirectoryReader.open(dir);
     assertEquals(1, r.numDocs());
     r.close();
     dir.close();
+  }
+
+  private void assertNoTragic(IndexWriter iw) {
+    assertNull(iw.getTragicException());
+    assertEquals(0, iw.getTragicTime());
   }
 
   /** test a null string value doesn't abort the entire segment */
@@ -1646,7 +1651,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           iw.addDocument(doc);
         });
 
-    assertNull(iw.getTragicException());
+    assertNoTragic(iw);
     iw.close();
     // make sure we see our good doc
     DirectoryReader r = DirectoryReader.open(dir);
@@ -1674,7 +1679,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           iw.addDocument(doc);
         });
 
-    assertNull(iw.getTragicException());
+    assertNoTragic(iw);
     iw.close();
     // make sure we see our good doc
     DirectoryReader r = DirectoryReader.open(dir);
@@ -1702,7 +1707,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           iw.addDocument(doc);
         });
 
-    assertNull(iw.getTragicException());
+    assertNoTragic(iw);
     iw.close();
     // make sure we see our good doc
     DirectoryReader r = DirectoryReader.open(dir);
@@ -1731,7 +1736,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           fail("didn't get expected exception");
         });
 
-    assertNull(iw.getTragicException());
+    assertNoTragic(iw);
     iw.close();
     // make sure we see our good doc
     DirectoryReader r = DirectoryReader.open(dir);
@@ -1760,7 +1765,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           fail("didn't get expected exception");
         });
 
-    assertNull(iw.getTragicException());
+    assertNoTragic(iw);
     iw.close();
     // make sure we see our good doc
     DirectoryReader r = DirectoryReader.open(dir);
@@ -1795,7 +1800,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           iw.addDocument(doc);
         });
 
-    assertNull(iw.getTragicException());
+    assertNoTragic(iw);
     iw.close();
 
     // make sure we see our good doc
@@ -2172,6 +2177,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
     }
 
     assertNotNull(w.getTragicException());
+    assertEquals("tragicTime should be filled out", 0, w.getTragicTime());
     assertFalse(w.isOpen());
     assertTrue(didFail.get());
 


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/projects/LUCENE

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>

LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

AlreadyClosedException logging is misleading.

#11044

# Solution

Improve logging.

# Tests

Tested by backporting to Lucene 8.4.1

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
