### PR TITLE
Make DocValuesIterator class public

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
@@ -19,7 +19,7 @@ package org.apache.lucene.index;
 import java.io.IOException;
 import org.apache.lucene.search.DocIdSetIterator;
 
-abstract class DocValuesIterator extends DocIdSetIterator {
+public abstract class DocValuesIterator extends DocIdSetIterator {
 
   /**
    * Advance the iterator to exactly {@code target} and return whether {@code target} has a value.


### PR DESCRIPTION
This change makes DocValuesIterator public so we use the `advanceExact()` method on a "generic" doc values iterator. 