### PR TITLE
remove no-longer-accurate sentence in TopTermsScoringBooleanQueryRewrite javadocs

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -119,7 +119,7 @@ public abstract class MultiTermQuery extends Query {
    * in a BooleanQuery, and keeps the scores as computed by the query.
    *
    * <p>This rewrite method only uses the top scoring terms so it will not overflow the boolean max
-   * clause count. It is the default rewrite method for {@link FuzzyQuery}.
+   * clause count.
    *
    * @see #setRewriteMethod
    */


### PR DESCRIPTION
https://github.com/apache/lucene/blob/834041f286e7b58aec8c06fb11c1ce999a7480d3/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java#L122 says _"It is the default rewrite method for {@link FuzzyQuery}."_ but as per https://github.com/apache/lucene/blob/834041f286e7b58aec8c06fb11c1ce999a7480d3/lucene/core/src/java/org/apache/lucene/search/FuzzyQuery.java#L100 that is no longer accurate since the https://github.com/apache/lucene/commit/463d453abfd38262d375228aee862454de734dee#diff-0b007abe4be9ce27f7c39cd5243b43109bc688a4e8a1a3706fea7c469d930e1d change.