### PR TITLE
LUCENE-10019: Align file starts in CFS files to have proper alignment (8 bytes)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundFormat.java
@@ -108,7 +108,7 @@ public final class Lucene90CompoundFormat extends CompoundFormat {
     entries.writeVInt(si.files().size());
     for (String file : si.files()) {
       // align file start offset
-      long startOffset = data.alignFilePointer();
+      long startOffset = data.alignFilePointer(Long.BYTES);
       // write bytes for file
       try (ChecksumIndexInput in = dir.openChecksumInput(file, IOContext.READONCE)) {
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundFormat.java
@@ -108,11 +108,7 @@ public final class Lucene90CompoundFormat extends CompoundFormat {
     entries.writeVInt(si.files().size());
     for (String file : si.files()) {
       // align file start offset
-      long startOffset = data.getFilePointer(), alignedStartOffset = alignOffset(startOffset);
-      for (long o = startOffset; o < alignedStartOffset; o++) {
-        data.writeByte((byte) 0);
-      }
-      startOffset = alignedStartOffset;
+      long startOffset = data.alignFilePointer();
       // write bytes for file
       try (ChecksumIndexInput in = dir.openChecksumInput(file, IOContext.READONCE)) {
 
@@ -142,9 +138,5 @@ public final class Lucene90CompoundFormat extends CompoundFormat {
       entries.writeLong(startOffset);
       entries.writeLong(length);
     }
-  }
-
-  static long alignOffset(long v) {
-    return (v + 7L) & (-8L);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundFormat.java
@@ -143,7 +143,7 @@ public final class Lucene90CompoundFormat extends CompoundFormat {
       entries.writeLong(length);
     }
   }
-  
+
   static long alignOffset(long v) {
     return (v + 7L) & (-8L);
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundFormat.java
@@ -60,7 +60,8 @@ import org.apache.lucene.store.IndexOutput;
  *   <li>FileCount indicates how many files are contained in this compound file. The entry table
  *       that follows has that many entries.
  *   <li>Each directory entry contains a long pointer to the start of this file's data section, the
- *       files length, and a String with that file's name.
+ *       files length, and a String with that file's name. The start of file's data section is
+ *       aligned to 8 bytes to not introduce additional unaligned accesses with mmap.
  * </ul>
  */
 public final class Lucene90CompoundFormat extends CompoundFormat {
@@ -106,8 +107,13 @@ public final class Lucene90CompoundFormat extends CompoundFormat {
     // write number of files
     entries.writeVInt(si.files().size());
     for (String file : si.files()) {
+      // align file start offset
+      long startOffset = data.getFilePointer(), alignedStartOffset = alignOffset(startOffset);
+      for (long o = startOffset; o < alignedStartOffset; o++) {
+        data.writeByte((byte) 0);
+      }
+      startOffset = alignedStartOffset;
       // write bytes for file
-      long startOffset = data.getFilePointer();
       try (ChecksumIndexInput in = dir.openChecksumInput(file, IOContext.READONCE)) {
 
         // just copies the index header, verifying that its id matches what we expect
@@ -136,5 +142,9 @@ public final class Lucene90CompoundFormat extends CompoundFormat {
       entries.writeLong(startOffset);
       entries.writeLong(length);
     }
+  }
+  
+  static long alignOffset(long v) {
+    return (v + 7L) & (-8L);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
@@ -139,6 +139,7 @@ final class Lucene90CompoundReader extends CompoundDirectory {
         throw new CorruptIndexException("Duplicate cfs entry id=" + id + " in CFS ", entriesStream);
       }
       fileEntry.offset = entriesStream.readLong();
+      assert (fileEntry.offset & 7) == 0L : "cfs file alignment mismatch";
       fileEntry.length = entriesStream.readLong();
     }
     return mapping;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
@@ -31,6 +31,7 @@ import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.IOUtils;
 
 /**
@@ -69,7 +70,7 @@ final class Lucene90CompoundReader extends CompoundDirectory {
 
     long expectedLength = CodecUtil.indexHeaderLength(Lucene90CompoundFormat.DATA_CODEC, "");
     for (Map.Entry<String, FileEntry> ent : entries.entrySet()) {
-      expectedLength = Lucene90CompoundFormat.alignOffset(expectedLength) + ent.getValue().length;
+      expectedLength = IndexOutput.alignOffset(expectedLength) + ent.getValue().length;
     }
     expectedLength += CodecUtil.footerLength();
 
@@ -139,7 +140,7 @@ final class Lucene90CompoundReader extends CompoundDirectory {
         throw new CorruptIndexException("Duplicate cfs entry id=" + id + " in CFS ", entriesStream);
       }
       fileEntry.offset = entriesStream.readLong();
-      assert (fileEntry.offset & 7) == 0L : "cfs file alignment mismatch";
+      assert (fileEntry.offset & 7L) == 0L : "cfs file alignment mismatch";
       fileEntry.length = entriesStream.readLong();
     }
     return mapping;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
@@ -19,7 +19,7 @@ package org.apache.lucene.codecs.lucene90;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.apache.lucene.codecs.CodecUtil;
@@ -69,7 +69,7 @@ final class Lucene90CompoundReader extends CompoundDirectory {
 
     long expectedLength = CodecUtil.indexHeaderLength(Lucene90CompoundFormat.DATA_CODEC, "");
     for (Map.Entry<String, FileEntry> ent : entries.entrySet()) {
-      expectedLength += ent.getValue().length;
+      expectedLength = Lucene90CompoundFormat.alignOffset(expectedLength) + ent.getValue().length;
     }
     expectedLength += CodecUtil.footerLength();
 
@@ -130,7 +130,7 @@ final class Lucene90CompoundReader extends CompoundDirectory {
 
   private Map<String, FileEntry> readMapping(IndexInput entriesStream) throws IOException {
     final int numEntries = entriesStream.readVInt();
-    Map<String, FileEntry> mapping = new HashMap<>(numEntries);
+    Map<String, FileEntry> mapping = new LinkedHashMap<>(numEntries);
     for (int i = 0; i < numEntries; i++) {
       final FileEntry fileEntry = new FileEntry();
       final String id = entriesStream.readString();

--- a/lucene/core/src/java/org/apache/lucene/store/IndexOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IndexOutput.java
@@ -73,4 +73,24 @@ public abstract class IndexOutput extends DataOutput implements Closeable {
   public String toString() {
     return resourceDescription;
   }
+
+  /**
+   * Aligns the current file pointer to multiples of 8 bytes to improve reads with mmap. This will
+   * write between 0 and 7 zero bytes using {@link #writeByte(byte)}.
+   *
+   * @return the new file pointer after alignment
+   */
+  public final long alignFilePointer() throws IOException {
+    final long offset = getFilePointer(), alignedOffset = alignOffset(offset);
+    final int count = (int) (alignedOffset - offset);
+    for (int i = 0; i < count; i++) {
+      writeByte((byte) 0);
+    }
+    return alignedOffset;
+  }
+
+  /** Aligns the given offset to multiples of 8 bytes by rounding up. */
+  public static final long alignOffset(long v) {
+    return (v + 7L) & (-8L);
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestSizeBoundedForceMerge.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSizeBoundedForceMerge.java
@@ -45,6 +45,8 @@ public class TestSizeBoundedForceMerge extends LuceneTestCase {
     IndexWriterConfig conf = newIndexWriterConfig(null);
     conf.setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH);
     conf.setRAMBufferSizeMB(IndexWriterConfig.DEFAULT_RAM_BUFFER_SIZE_MB);
+    // don't use compound files, because the overhead make size checks unreliable.
+    conf.setUseCompoundFile(false);
     // prevent any merges by default.
     conf.setMergePolicy(NoMergePolicy.INSTANCE);
     return conf;

--- a/lucene/core/src/test/org/apache/lucene/store/TestIndexOutputAlignment.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestIndexOutputAlignment.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.store;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.stream.IntStream;
+import org.apache.lucene.util.LuceneTestCase;
+
+public class TestIndexOutputAlignment extends LuceneTestCase {
+
+  public void testAlignmentCalculation() {
+    assertEquals(0L, IndexOutput.alignOffset(0L, Long.BYTES));
+    assertEquals(0L, IndexOutput.alignOffset(0L, Integer.BYTES));
+    assertEquals(0L, IndexOutput.alignOffset(0L, Short.BYTES));
+    assertEquals(0L, IndexOutput.alignOffset(0L, Byte.BYTES));
+
+    assertEquals(8L, IndexOutput.alignOffset(1L, Long.BYTES));
+    assertEquals(4L, IndexOutput.alignOffset(1L, Integer.BYTES));
+    assertEquals(2L, IndexOutput.alignOffset(1L, Short.BYTES));
+    assertEquals(1L, IndexOutput.alignOffset(1L, Byte.BYTES));
+
+    assertEquals(32L, IndexOutput.alignOffset(25L, Long.BYTES));
+    assertEquals(28L, IndexOutput.alignOffset(25L, Integer.BYTES));
+    assertEquals(26L, IndexOutput.alignOffset(25L, Short.BYTES));
+    assertEquals(25L, IndexOutput.alignOffset(25L, Byte.BYTES));
+
+    final long val = 1L << 48;
+    assertEquals(val, IndexOutput.alignOffset(val - 1, Long.BYTES));
+    assertEquals(val, IndexOutput.alignOffset(val - 1, Integer.BYTES));
+    assertEquals(val, IndexOutput.alignOffset(val - 1, Short.BYTES));
+    // byte alignment never changes anything:
+    assertEquals(val - 1, IndexOutput.alignOffset(val - 1, Byte.BYTES));
+  }
+
+  public void testInvalidAlignments() {
+    assertInvalidAligment(0);
+    assertInvalidAligment(-1);
+    assertInvalidAligment(-2);
+    assertInvalidAligment(6);
+    assertInvalidAligment(43);
+  }
+
+  private static void assertInvalidAligment(int size) {
+    assertThrows(IllegalArgumentException.class, () -> IndexOutput.alignOffset(1L, size));
+  }
+
+  public void testOutputAlignment() throws IOException {
+    IntStream.of(Long.BYTES, Integer.BYTES, Short.BYTES, Byte.BYTES)
+        .forEach(TestIndexOutputAlignment::runTestOutputAlignment);
+  }
+
+  private static void runTestOutputAlignment(int alignment) {
+    try (IndexOutput out =
+        new OutputStreamIndexOutput("test output", "test", new ByteArrayOutputStream(), 8192)) {
+      for (int i = 0; i < 10 * RANDOM_MULTIPLIER; i++) {
+        // write some bytes
+        int length = random().nextInt(32);
+        out.writeBytes(new byte[length], length);
+        long origPos = out.getFilePointer();
+        // align to next boundary
+        long newPos = out.alignFilePointer(alignment);
+        assertEquals(out.getFilePointer(), newPos);
+        assertTrue("not aligned", newPos % alignment == 0);
+        assertTrue("newPos >=", newPos >= origPos);
+        assertTrue("too much added", newPos - origPos < alignment);
+      }
+    } catch (IOException ioe) {
+      throw new AssertionError(ioe);
+    }
+  }
+}


### PR DESCRIPTION
While discussing about MMapDirectory and fast access to file contents through MMap #177 and previous versions of this draft, also), I figured out that for most Lucene files, the data inside is not aligned at all.

We can't fix this easily and it's also not always important, but some files should really have a CPU fieldly alignment from beginning! This is escpecially important when we use slices().

I got many tests with aligned VarHandles to pass, but it broke instantly, if the file was inside a Compound CFS file.

CompoundFormat.write() just appends all data to the IndexOutput and writes the offset to the entries file. The fix to make at least file starts aligned is to just write some null-bytes between the files, so startOffset is aligned to multiples of 8 bytes.

At a later stage we could also think of aligning to LBA blocks/sectors/whatever to make OS paging work better. But for performance of index access, slices of compound files when memory mapped should at least align to 8 bytes.

More info: https://issues.apache.org/jira/browse/LUCENE-10019