### PR TITLE
LUCENE-9959: Rename TermVectorsReader to TermVectorsReaderBase

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsFormat.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.index.FieldInfos;
@@ -96,7 +96,7 @@ public class Lucene50CompressingTermVectorsFormat extends TermVectorsFormat {
   }
 
   @Override
-  public final TermVectorsReader vectorsReader(
+  public final TermVectorsReaderBase vectorsReader(
       Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext context)
       throws IOException {
     return new Lucene50CompressingTermVectorsReader(

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsReader.java
@@ -22,7 +22,7 @@ import java.util.NoSuchElementException;
 import org.apache.lucene.backward_codecs.packed.LegacyPackedInts;
 import org.apache.lucene.backward_codecs.store.EndiannessReverserUtil;
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.codecs.compressing.Decompressor;
 import org.apache.lucene.index.BaseTermsEnum;
@@ -51,11 +51,11 @@ import org.apache.lucene.util.packed.BlockPackedReaderIterator;
 import org.apache.lucene.util.packed.PackedInts;
 
 /**
- * {@link TermVectorsReader} for {@link Lucene50CompressingTermVectorsFormat}.
+ * {@link TermVectorsReaderBase} for {@link Lucene50CompressingTermVectorsFormat}.
  *
  * @lucene.experimental
  */
-public final class Lucene50CompressingTermVectorsReader extends TermVectorsReader {
+public final class Lucene50CompressingTermVectorsReader extends TermVectorsReaderBase {
 
   static final String VECTORS_EXTENSION = "tvd";
   static final String VECTORS_INDEX_EXTENSION = "tvx";
@@ -270,7 +270,7 @@ public final class Lucene50CompressingTermVectorsReader extends TermVectorsReade
   }
 
   @Override
-  public TermVectorsReader clone() {
+  public TermVectorsReaderBase clone() {
     return new Lucene50CompressingTermVectorsReader(this);
   }
 

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsFormat.java
@@ -18,7 +18,7 @@ package org.apache.lucene.codecs.simpletext;
 
 import java.io.IOException;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
@@ -35,7 +35,7 @@ import org.apache.lucene.store.IOContext;
 public class SimpleTextTermVectorsFormat extends TermVectorsFormat {
 
   @Override
-  public TermVectorsReader vectorsReader(
+  public TermVectorsReaderBase vectorsReader(
       Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext context)
       throws IOException {
     return new SimpleTextTermVectorsReader(directory, segmentInfo, context);

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.index.BaseTermsEnum;
 import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.ImpactsEnum;
@@ -54,7 +54,7 @@ import org.apache.lucene.util.StringHelper;
  *
  * @lucene.experimental
  */
-public class SimpleTextTermVectorsReader extends TermVectorsReader {
+public class SimpleTextTermVectorsReader extends TermVectorsReaderBase {
 
   private long offsets[]; /* docid -> offset in .vec file */
   private IndexInput in;
@@ -210,7 +210,7 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
   }
 
   @Override
-  public TermVectorsReader clone() {
+  public TermVectorsReaderBase clone() {
     if (in == null) {
       throw new AlreadyClosedException("this TermVectorsReader is closed");
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/TermVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/TermVectorsFormat.java
@@ -27,8 +27,8 @@ public abstract class TermVectorsFormat {
   /** Sole constructor. (For invocation by subclass constructors, typically implicit.) */
   protected TermVectorsFormat() {}
 
-  /** Returns a {@link TermVectorsReader} to read term vectors. */
-  public abstract TermVectorsReader vectorsReader(
+  /** Returns a {@link TermVectorsReaderBase} to read term vectors. */
+  public abstract TermVectorsReaderBase vectorsReader(
       Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext context)
       throws IOException;
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/TermVectorsReaderBase.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/TermVectorsReaderBase.java
@@ -26,10 +26,10 @@ import org.apache.lucene.index.Fields;
  *
  * @lucene.experimental
  */
-public abstract class TermVectorsReader implements Cloneable, Closeable {
+public abstract class TermVectorsReaderBase implements Cloneable, Closeable {
 
   /** Sole constructor. (For invocation by subclass constructors, typically implicit.) */
-  protected TermVectorsReader() {}
+  protected TermVectorsReaderBase() {}
 
   /**
    * Returns term vectors for this document, or null if term vectors were not indexed. If offsets
@@ -50,7 +50,7 @@ public abstract class TermVectorsReader implements Cloneable, Closeable {
 
   /** Create a clone that one caller at a time may use to read term vectors. */
   @Override
-  public abstract TermVectorsReader clone();
+  public abstract TermVectorsReaderBase clone();
 
   /**
    * Returns an instance optimized for merging. This instance may only be consumed in the thread
@@ -58,7 +58,7 @@ public abstract class TermVectorsReader implements Cloneable, Closeable {
    *
    * <p>The default implementation returns {@code this}
    */
-  public TermVectorsReader getMergeInstance() {
+  public TermVectorsReaderBase getMergeInstance() {
     return this;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/TermVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/TermVectorsWriter.java
@@ -167,11 +167,11 @@ public abstract class TermVectorsWriter implements Closeable, Accountable {
   }
 
   private static class TermVectorsMergeSub extends DocIDMerger.Sub {
-    private final TermVectorsReader reader;
+    private final TermVectorsReaderBase reader;
     private final int maxDoc;
     int docID = -1;
 
-    public TermVectorsMergeSub(MergeState.DocMap docMap, TermVectorsReader reader, int maxDoc) {
+    public TermVectorsMergeSub(MergeState.DocMap docMap, TermVectorsReaderBase reader, int maxDoc) {
       super(docMap);
       this.maxDoc = maxDoc;
       this.reader = reader;
@@ -200,7 +200,7 @@ public abstract class TermVectorsWriter implements Closeable, Accountable {
 
     List<TermVectorsMergeSub> subs = new ArrayList<>();
     for (int i = 0; i < mergeState.termVectorsReaders.length; i++) {
-      TermVectorsReader reader = mergeState.termVectorsReaders[i];
+      TermVectorsReaderBase reader = mergeState.termVectorsReaders[i];
       if (reader != null) {
         reader.checkIntegrity();
       }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsFormat.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.index.FieldInfos;
@@ -90,7 +90,7 @@ public class Lucene90CompressingTermVectorsFormat extends TermVectorsFormat {
   }
 
   @Override
-  public final TermVectorsReader vectorsReader(
+  public final TermVectorsReaderBase vectorsReader(
       Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext context)
       throws IOException {
     return new Lucene90CompressingTermVectorsReader(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.codecs.compressing.Decompressor;
 import org.apache.lucene.index.BaseTermsEnum;
@@ -70,11 +70,11 @@ import org.apache.lucene.util.packed.DirectWriter;
 import org.apache.lucene.util.packed.PackedInts;
 
 /**
- * {@link TermVectorsReader} for {@link Lucene90CompressingTermVectorsFormat}.
+ * {@link TermVectorsReaderBase} for {@link Lucene90CompressingTermVectorsFormat}.
  *
  * @lucene.experimental
  */
-public final class Lucene90CompressingTermVectorsReader extends TermVectorsReader {
+public final class Lucene90CompressingTermVectorsReader extends TermVectorsReaderBase {
 
   private final FieldInfos fieldInfos;
   final FieldsIndex indexReader;
@@ -300,12 +300,12 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
   }
 
   @Override
-  public TermVectorsReader clone() {
+  public TermVectorsReaderBase clone() {
     return new Lucene90CompressingTermVectorsReader(this);
   }
 
   @Override
-  public TermVectorsReader getMergeInstance() {
+  public TermVectorsReaderBase getMergeInstance() {
     return new Lucene90CompressingTermVectorsReader(this);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsWriter.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.codecs.compressing.Compressor;
@@ -906,7 +906,7 @@ public final class Lucene90CompressingTermVectorsWriter extends TermVectorsWrite
     final MatchingReaders matchingReaders = new MatchingReaders(mergeState);
     final List<CompressingTermVectorsSub> subs = new ArrayList<>(numReaders);
     for (int i = 0; i < numReaders; i++) {
-      final TermVectorsReader reader = mergeState.termVectorsReaders[i];
+      final TermVectorsReaderBase reader = mergeState.termVectorsReaders[i];
       if (reader != null) {
         reader.checkIntegrity();
       }
@@ -931,7 +931,7 @@ public final class Lucene90CompressingTermVectorsWriter extends TermVectorsWrite
         copyChunks(mergeState, current, fromDocID, toDocID);
         docCount += toDocID - fromDocID;
       } else {
-        final TermVectorsReader reader = mergeState.termVectorsReaders[sub.readerIndex];
+        final TermVectorsReaderBase reader = mergeState.termVectorsReaders[sub.readerIndex];
         final Fields vectors = reader != null ? reader.get(sub.docID) : null;
         addAllDocVectors(vectors, mergeState);
         ++docCount;

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -37,7 +37,7 @@ import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.StoredFieldsReader;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DocumentStoredFieldVisitor;
 import org.apache.lucene.index.CheckIndex.Status.DocValuesStatus;
@@ -3279,7 +3279,7 @@ public final class CheckIndex implements Closeable {
         postingsFields = null;
       }
 
-      TermVectorsReader vectorsReader = reader.getTermVectorsReader();
+      TermVectorsReaderBase vectorsReader = reader.getTermVectorsReader();
 
       if (vectorsReader != null) {
         vectorsReader = vectorsReader.getMergeInstance();

--- a/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
@@ -23,7 +23,7 @@ import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.search.TopDocs;
 
@@ -45,7 +45,7 @@ public abstract class CodecReader extends LeafReader {
    *
    * @lucene.internal
    */
-  public abstract TermVectorsReader getTermVectorsReader();
+  public abstract TermVectorsReaderBase getTermVectorsReader();
 
   /**
    * Expert: retrieve underlying NormsProducer
@@ -90,7 +90,7 @@ public abstract class CodecReader extends LeafReader {
 
   @Override
   public final Fields getTermVectors(int docID) throws IOException {
-    TermVectorsReader termVectorsReader = getTermVectorsReader();
+    TermVectorsReaderBase termVectorsReader = getTermVectorsReader();
     if (termVectorsReader == null) {
       return null;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/FilterCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterCodecReader.java
@@ -23,7 +23,7 @@ import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.util.Bits;
 
@@ -65,7 +65,7 @@ public abstract class FilterCodecReader extends CodecReader {
   }
 
   @Override
-  public TermVectorsReader getTermVectorsReader() {
+  public TermVectorsReaderBase getTermVectorsReader() {
     return in.getTermVectorsReader();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/MergeReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeReaderWrapper.java
@@ -23,7 +23,7 @@ import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.StoredFieldsReader;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
 
@@ -37,7 +37,7 @@ class MergeReaderWrapper extends LeafReader {
   final NormsProducer norms;
   final DocValuesProducer docValues;
   final StoredFieldsReader store;
-  final TermVectorsReader vectors;
+  final TermVectorsReaderBase vectors;
 
   MergeReaderWrapper(CodecReader in) throws IOException {
     this.in = in;
@@ -66,7 +66,7 @@ class MergeReaderWrapper extends LeafReader {
     }
     this.store = store;
 
-    TermVectorsReader vectors = in.getTermVectorsReader();
+    TermVectorsReaderBase vectors = in.getTermVectorsReader();
     if (vectors != null) {
       vectors = vectors.getMergeInstance();
     }

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -27,7 +27,7 @@ import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Bits;
@@ -59,7 +59,7 @@ public class MergeState {
   public final StoredFieldsReader[] storedFieldsReaders;
 
   /** Term vector producers being merged */
-  public final TermVectorsReader[] termVectorsReaders;
+  public final TermVectorsReaderBase[] termVectorsReaders;
 
   /** Norms producers being merged */
   public final NormsProducer[] normsProducers;
@@ -106,7 +106,7 @@ public class MergeState {
     fieldsProducers = new FieldsProducer[numReaders];
     normsProducers = new NormsProducer[numReaders];
     storedFieldsReaders = new StoredFieldsReader[numReaders];
-    termVectorsReaders = new TermVectorsReader[numReaders];
+    termVectorsReaders = new TermVectorsReaderBase[numReaders];
     docValuesProducers = new DocValuesProducer[numReaders];
     pointsReaders = new PointsReader[numReaders];
     vectorReaders = new VectorReader[numReaders];

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentCoreReaders.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentCoreReaders.java
@@ -32,7 +32,7 @@ import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.StoredFieldsReader;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.index.IndexReader.CacheKey;
 import org.apache.lucene.index.IndexReader.ClosedListener;
@@ -57,7 +57,7 @@ final class SegmentCoreReaders {
   final NormsProducer normsProducer;
 
   final StoredFieldsReader fieldsReaderOrig;
-  final TermVectorsReader termVectorsReaderOrig;
+  final TermVectorsReaderBase termVectorsReaderOrig;
   final PointsReader pointsReader;
   final VectorReader vectorReader;
   final CompoundDirectory cfsReader;
@@ -80,10 +80,10 @@ final class SegmentCoreReaders {
         }
       };
 
-  final CloseableThreadLocal<TermVectorsReader> termVectorsLocal =
-      new CloseableThreadLocal<TermVectorsReader>() {
+  final CloseableThreadLocal<TermVectorsReaderBase> termVectorsLocal =
+      new CloseableThreadLocal<TermVectorsReaderBase>() {
         @Override
-        protected TermVectorsReader initialValue() {
+        protected TermVectorsReaderBase initialValue() {
           return (termVectorsReaderOrig == null) ? null : termVectorsReaderOrig.clone();
         }
       };

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentReader.java
@@ -27,7 +27,7 @@ import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -243,7 +243,7 @@ public final class SegmentReader extends CodecReader {
   }
 
   @Override
-  public TermVectorsReader getTermVectorsReader() {
+  public TermVectorsReaderBase getTermVectorsReader() {
     ensureOpen();
     return core.termVectorsLocal.get();
   }

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
@@ -25,7 +25,7 @@ import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
@@ -54,7 +54,7 @@ public final class SlowCodecReaderWrapper {
       return new CodecReader() {
 
         @Override
-        public TermVectorsReader getTermVectorsReader() {
+        public TermVectorsReaderBase getTermVectorsReader() {
           reader.ensureOpen();
           return readerToTermVectorsReader(reader);
         }
@@ -264,15 +264,15 @@ public final class SlowCodecReaderWrapper {
     };
   }
 
-  private static TermVectorsReader readerToTermVectorsReader(final LeafReader reader) {
-    return new TermVectorsReader() {
+  private static TermVectorsReaderBase readerToTermVectorsReader(final LeafReader reader) {
+    return new TermVectorsReaderBase() {
       @Override
       public Fields get(int docID) throws IOException {
         return reader.getTermVectors(docID);
       }
 
       @Override
-      public TermVectorsReader clone() {
+      public TermVectorsReaderBase clone() {
         return readerToTermVectorsReader(reader);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -29,7 +29,7 @@ import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
@@ -442,12 +442,12 @@ public final class SortingCodecReader extends FilterCodecReader {
   }
 
   @Override
-  public TermVectorsReader getTermVectorsReader() {
+  public TermVectorsReaderBase getTermVectorsReader() {
     return newTermVectorsReader(in.getTermVectorsReader());
   }
 
-  private TermVectorsReader newTermVectorsReader(TermVectorsReader delegate) {
-    return new TermVectorsReader() {
+  private TermVectorsReaderBase newTermVectorsReader(TermVectorsReaderBase delegate) {
+    return new TermVectorsReaderBase() {
       @Override
       public Fields get(int doc) throws IOException {
         return delegate.get(docMap.newToOld(doc));
@@ -459,7 +459,7 @@ public final class SortingCodecReader extends FilterCodecReader {
       }
 
       @Override
-      public TermVectorsReader clone() {
+      public TermVectorsReaderBase clone() {
         return newTermVectorsReader(delegate.clone());
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SortingTermVectorsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingTermVectorsConsumer.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.codecs.lucene90.compressing.Lucene90CompressingTermVectorsFormat;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -59,7 +59,7 @@ final class SortingTermVectorsConsumer extends TermVectorsConsumer {
       throws IOException {
     super.flush(fieldsToFlush, state, sortMap, norms);
     if (tmpDirectory != null) {
-      TermVectorsReader reader =
+      TermVectorsReaderBase reader =
           TEMP_TERM_VECTORS_FORMAT.vectorsReader(
               tmpDirectory, state.segmentInfo, state.fieldInfos, IOContext.DEFAULT);
       // Don't pull a merge instance, since merge instances optimize for

--- a/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import org.apache.lucene.analysis.MockAnalyzer;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -181,8 +181,8 @@ public class TestSortingCodecReader extends LuceneTestCase {
               CodecReader wrap =
                   SortingCodecReader.wrap(SlowCodecReaderWrapper.wrap(ctx.reader()), indexSort);
               readers.add(wrap);
-              TermVectorsReader termVectorsReader = wrap.getTermVectorsReader();
-              TermVectorsReader clone = termVectorsReader.clone();
+              TermVectorsReaderBase termVectorsReader = wrap.getTermVectorsReader();
+              TermVectorsReaderBase clone = termVectorsReader.clone();
               assertNotSame(termVectorsReader, clone);
               clone.close();
             }

--- a/lucene/core/src/test/org/apache/lucene/index/TestTermVectorsReaderBase.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTermVectorsReaderBase.java
@@ -24,7 +24,7 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -36,7 +36,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
 
-public class TestTermVectorsReader extends LuceneTestCase {
+public class TestTermVectorsReaderBase extends LuceneTestCase {
   // Must be lexicographically sorted, will do in setup, versus trying to maintain here
   private String[] testFields = {"f1", "f2", "f3", "f4"};
   private boolean[] testFieldsStorePos = {true, false, true, false};
@@ -193,7 +193,7 @@ public class TestTermVectorsReader extends LuceneTestCase {
   }
 
   public void testReader() throws IOException {
-    TermVectorsReader reader =
+    TermVectorsReaderBase reader =
         Codec.getDefault()
             .termVectorsFormat()
             .vectorsReader(dir, seg.info, fieldInfos, newIOContext(random()));
@@ -215,7 +215,7 @@ public class TestTermVectorsReader extends LuceneTestCase {
   }
 
   public void testDocsEnum() throws IOException {
-    TermVectorsReader reader =
+    TermVectorsReaderBase reader =
         Codec.getDefault()
             .termVectorsFormat()
             .vectorsReader(dir, seg.info, fieldInfos, newIOContext(random()));
@@ -245,7 +245,7 @@ public class TestTermVectorsReader extends LuceneTestCase {
   }
 
   public void testPositionReader() throws IOException {
-    TermVectorsReader reader =
+    TermVectorsReaderBase reader =
         Codec.getDefault()
             .termVectorsFormat()
             .vectorsReader(dir, seg.info, fieldInfos, newIOContext(random()));
@@ -304,7 +304,7 @@ public class TestTermVectorsReader extends LuceneTestCase {
   }
 
   public void testOffsetReader() throws IOException {
-    TermVectorsReader reader =
+    TermVectorsReaderBase reader =
         Codec.getDefault()
             .termVectorsFormat()
             .vectorsReader(dir, seg.info, fieldInfos, newIOContext(random()));

--- a/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingTermVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingTermVectorsFormat.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.index.AssertingLeafReader;
 import org.apache.lucene.index.FieldInfo;
@@ -38,7 +38,7 @@ public class AssertingTermVectorsFormat extends TermVectorsFormat {
   private final TermVectorsFormat in = TestUtil.getDefaultCodec().termVectorsFormat();
 
   @Override
-  public TermVectorsReader vectorsReader(
+  public TermVectorsReaderBase vectorsReader(
       Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext context)
       throws IOException {
     return new AssertingTermVectorsReader(
@@ -51,10 +51,10 @@ public class AssertingTermVectorsFormat extends TermVectorsFormat {
     return new AssertingTermVectorsWriter(in.vectorsWriter(directory, segmentInfo, context));
   }
 
-  static class AssertingTermVectorsReader extends TermVectorsReader {
-    private final TermVectorsReader in;
+  static class AssertingTermVectorsReader extends TermVectorsReaderBase {
+    private final TermVectorsReaderBase in;
 
-    AssertingTermVectorsReader(TermVectorsReader in) {
+    AssertingTermVectorsReader(TermVectorsReaderBase in) {
       this.in = in;
       // do a few simple checks on init
       assert toString() != null;
@@ -73,7 +73,7 @@ public class AssertingTermVectorsFormat extends TermVectorsFormat {
     }
 
     @Override
-    public TermVectorsReader clone() {
+    public TermVectorsReaderBase clone() {
       return new AssertingTermVectorsReader(in.clone());
     }
 
@@ -83,7 +83,7 @@ public class AssertingTermVectorsFormat extends TermVectorsFormat {
     }
 
     @Override
-    public TermVectorsReader getMergeInstance() {
+    public TermVectorsReaderBase getMergeInstance() {
       return new AssertingTermVectorsReader(in.getMergeInstance());
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/codecs/cranky/CrankyTermVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/codecs/cranky/CrankyTermVectorsFormat.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Random;
 import org.apache.lucene.codecs.TermVectorsFormat;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
@@ -43,7 +43,7 @@ class CrankyTermVectorsFormat extends TermVectorsFormat {
   }
 
   @Override
-  public TermVectorsReader vectorsReader(
+  public TermVectorsReaderBase vectorsReader(
       Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext context)
       throws IOException {
     return delegate.vectorsReader(directory, segmentInfo, fieldInfos, context);

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
@@ -44,7 +44,7 @@ import org.apache.lucene.codecs.NormsConsumer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.StoredFieldsWriter;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsReaderBase;
 import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.codecs.simpletext.SimpleTextCodec;
 import org.apache.lucene.document.Document;
@@ -533,7 +533,7 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
       IOUtils.close(consumer);
       IOUtils.close(consumer);
     }
-    try (TermVectorsReader producer =
+    try (TermVectorsReaderBase producer =
         codec.termVectorsFormat().vectorsReader(dir, segmentInfo, fieldInfos, readState.context)) {
       IOUtils.close(producer);
       IOUtils.close(producer);


### PR DESCRIPTION
# Description

Rename `TermVectorsReader` to `TermVectorsReaderBase` in preparation for introducing `TermVectors` and new `TermVectorsReader` abstractions. Please see https://github.com/apache/lucene/pull/180#issuecomment-871155896 for details.

Please note that relevant variable names were currently not renamed, in order to keep the changes minimal and reduce the need to undo the renaming once `TermVectorsReader` is introduced back.

# Tests

Passed existing tests.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
