### PR TITLE
LUCENE-10026: Fix CombinedFieldQuery equals and hashCode

### DIFF
--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
@@ -230,7 +230,8 @@ public final class CombinedFieldQuery extends Query implements Accountable {
     if (this == o) return true;
     if (sameClassAs(o) == false) return false;
     CombinedFieldQuery that = (CombinedFieldQuery) o;
-    return Objects.equals(fieldAndWeights, that.fieldAndWeights) && Arrays.equals(terms, that.terms);
+    return Objects.equals(fieldAndWeights, that.fieldAndWeights)
+        && Arrays.equals(terms, that.terms);
   }
 
   @Override

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import org.apache.lucene.index.IndexReader;
@@ -147,6 +148,19 @@ public final class CombinedFieldQuery extends Query implements Accountable {
       this.field = field;
       this.weight = weight;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      FieldAndWeight that = (FieldAndWeight) o;
+      return Float.compare(that.weight, weight) == 0 && Objects.equals(field, that.field);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field, weight);
+    }
   }
 
   // sorted map for fields.
@@ -212,13 +226,18 @@ public final class CombinedFieldQuery extends Query implements Accountable {
   }
 
   @Override
-  public int hashCode() {
-    return 31 * classHash() + Arrays.hashCode(terms);
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CombinedFieldQuery that = (CombinedFieldQuery) o;
+    return Objects.equals(fieldAndWeights, that.fieldAndWeights) && Arrays.equals(terms, that.terms);
   }
 
   @Override
-  public boolean equals(Object other) {
-    return sameClassAs(other) && Arrays.equals(terms, ((CombinedFieldQuery) other).terms);
+  public int hashCode() {
+    int result = Objects.hash(fieldAndWeights);
+    result = 31 * result + Arrays.hashCode(terms);
+    return result;
   }
 
   @Override

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
@@ -228,14 +228,15 @@ public final class CombinedFieldQuery extends Query implements Accountable {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (sameClassAs(o) == false) return false;
     CombinedFieldQuery that = (CombinedFieldQuery) o;
     return Objects.equals(fieldAndWeights, that.fieldAndWeights) && Arrays.equals(terms, that.terms);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(fieldAndWeights);
+    int result = classHash();
+    result += Objects.hash(fieldAndWeights);
     result = 31 * result + Arrays.hashCode(terms);
     return result;
   }

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
@@ -29,8 +29,6 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.CheckHits;
 import org.apache.lucene.search.CollectionStatistics;
 import org.apache.lucene.search.IndexSearcher;
@@ -75,33 +73,37 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
   }
 
   public void testEqualsAndHashCode() {
-    CombinedFieldQuery query1 = new CombinedFieldQuery.Builder()
-        .addField("field1")
-        .addField("field2")
-        .addTerm(new BytesRef("value"))
-        .build();
+    CombinedFieldQuery query1 =
+        new CombinedFieldQuery.Builder()
+            .addField("field1")
+            .addField("field2")
+            .addTerm(new BytesRef("value"))
+            .build();
 
-    CombinedFieldQuery query2 = new CombinedFieldQuery.Builder()
-        .addField("field1")
-        .addField("field2", 1.3f)
-        .addTerm(new BytesRef("value"))
-        .build();
+    CombinedFieldQuery query2 =
+        new CombinedFieldQuery.Builder()
+            .addField("field1")
+            .addField("field2", 1.3f)
+            .addTerm(new BytesRef("value"))
+            .build();
     assertNotEquals(query1, query2);
     assertNotEquals(query1.hashCode(), query2.hashCode());
 
-    CombinedFieldQuery query3 =new CombinedFieldQuery.Builder()
-        .addField("field3")
-        .addField("field4")
-        .addTerm(new BytesRef("value"))
-        .build();
+    CombinedFieldQuery query3 =
+        new CombinedFieldQuery.Builder()
+            .addField("field3")
+            .addField("field4")
+            .addTerm(new BytesRef("value"))
+            .build();
     assertNotEquals(query1, query3);
     assertNotEquals(query1.hashCode(), query2.hashCode());
 
-    CombinedFieldQuery duplicateQuery1 = new CombinedFieldQuery.Builder()
-        .addField("field1")
-        .addField("field2")
-        .addTerm(new BytesRef("value"))
-        .build();
+    CombinedFieldQuery duplicateQuery1 =
+        new CombinedFieldQuery.Builder()
+            .addField("field1")
+            .addField("field2")
+            .addTerm(new BytesRef("value"))
+            .build();
     assertEquals(query1, duplicateQuery1);
     assertEquals(query1.hashCode(), duplicateQuery1.hashCode());
   }

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
@@ -29,6 +29,8 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.CheckHits;
 import org.apache.lucene.search.CollectionStatistics;
 import org.apache.lucene.search.IndexSearcher;
@@ -70,6 +72,38 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
     Query query = builder.build();
     actual = searcher.rewrite(query);
     assertEquals(actual, query);
+  }
+
+  public void testEqualsAndHashCode() {
+    CombinedFieldQuery query1 = new CombinedFieldQuery.Builder()
+        .addField("field1")
+        .addField("field2")
+        .addTerm(new BytesRef("value"))
+        .build();
+
+    CombinedFieldQuery query2 = new CombinedFieldQuery.Builder()
+        .addField("field1")
+        .addField("field2", 1.3f)
+        .addTerm(new BytesRef("value"))
+        .build();
+    assertNotEquals(query1, query2);
+    assertNotEquals(query1.hashCode(), query2.hashCode());
+
+    CombinedFieldQuery query3 =new CombinedFieldQuery.Builder()
+        .addField("field3")
+        .addField("field4")
+        .addTerm(new BytesRef("value"))
+        .build();
+    assertNotEquals(query1, query3);
+    assertNotEquals(query1.hashCode(), query2.hashCode());
+
+    CombinedFieldQuery duplicateQuery1 = new CombinedFieldQuery.Builder()
+        .addField("field1")
+        .addField("field2")
+        .addTerm(new BytesRef("value"))
+        .build();
+    assertEquals(query1, duplicateQuery1);
+    assertEquals(query1.hashCode(), duplicateQuery1.hashCode());
   }
 
   public void testToString() {


### PR DESCRIPTION
The previous equals and hashCode methods only compared query terms. This meant
that queries on different fields, or with different field weights, were
considered the same.

During boolean query rewrites, duplicate clauses are removed. So because
equals/ hashCode was incorrect, rewrites could accidentally drop
CombinedFieldQuery clauses.