### PR TITLE
LUCENE-10028: Add git pre-commit hook that runs precommit task.

### DIFF
--- a/dev-tools/git/hooks/pre-commit
+++ b/dev-tools/git/hooks/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/sh
+#
+# Run precommit check
+#
+
+## TODO: Windows support
+./gradlew precommit -Pvalidation.git.failOnModified=false

--- a/gradle/validation/precommit.gradle
+++ b/gradle/validation/precommit.gradle
@@ -48,15 +48,17 @@ configure(rootProject) {
   // precommit() as a whole is a dependency on rootProject.check
   check.dependsOn precommit
 
+  // install git hook.
+  // TODO: there can be an existing hook; extra checks will be needed.
   task precommitHook(type: Copy) {
     group = 'Precommit'
-    description = "Initialize Git pre-commit hook"
+    description = "Install Git pre-commit hook"
 
-    from "${project.file('dev-tools/git/hooks')}"
+    from "${project.file('dev-tools/git/hooks/pre-commit')}"
     into "${project.file('.git/hooks')}"
 
     doFirst {
-      println('Copy git hooks to local .git/hooks; See https://git-scm.com/docs/githooks for details.')
+      println('Copy git pre-commit hooks to local .git/hooks; See https://git-scm.com/docs/githooks for details.')
     }
   }
 }

--- a/gradle/validation/precommit.gradle
+++ b/gradle/validation/precommit.gradle
@@ -47,5 +47,17 @@ configure(rootProject) {
   // Each validation task should be attached to check but make sure
   // precommit() as a whole is a dependency on rootProject.check
   check.dependsOn precommit
+
+  task precommitHook(type: Copy) {
+    group = 'Precommit'
+    description = "Initialize Git pre-commit hook"
+
+    from "${project.file('dev-tools/git/hooks')}"
+    into "${project.file('.git/hooks')}"
+
+    doFirst {
+      println('Copy git hooks to local .git/hooks; See https://git-scm.com/docs/githooks for details.')
+    }
+  }
 }
 


### PR DESCRIPTION
This adds git pre-commit hook for Lucene precommit check.
See also: https://issues.apache.org/jira/browse/LUCENE-10028

(Usage)

Install pre-commit hook (opt-in)
```
./gradlew precommitHook
```

After installing, precommit will be automatically performed before every commit.

```
git commit -m "commit attempt that doesn't pass spotless check"
......
> Task :lucene:luke:spotlessJavaCheck FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':lucene:luke:spotlessJavaCheck'.
> The following files had format violations:
......
// commit fails.
```
