### PR TITLE
LUCENE-10018 Introduce DocTermVectors in lieu of Fields.

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsReader.java
@@ -27,6 +27,7 @@ import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.codecs.compressing.Decompressor;
 import org.apache.lucene.index.BaseTermsEnum;
 import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.DocTermVectors;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.Fields;
@@ -275,7 +276,7 @@ public final class Lucene50CompressingTermVectorsReader extends TermVectorsReade
   }
 
   @Override
-  public Fields get(int doc) throws IOException {
+  public DocTermVectors get(int doc) throws IOException {
     ensureOpen();
 
     // seek to the right place
@@ -758,7 +759,7 @@ public final class Lucene50CompressingTermVectorsReader extends TermVectorsReade
     return positions;
   }
 
-  private class TVFields extends Fields {
+  private class TVFields extends DocTermVectors {
 
     private final int[] fieldNums, fieldFlags, fieldNumOffs, numTerms, fieldLengths;
     private final int[][] prefixLengths,

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
@@ -26,6 +26,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.apache.lucene.codecs.TermVectorsReader;
 import org.apache.lucene.index.BaseTermsEnum;
+import org.apache.lucene.index.DocTermVectors;
 import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.index.IndexFileNames;
@@ -107,7 +108,7 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
   }
 
   @Override
-  public Fields get(int doc) throws IOException {
+  public DocTermVectors get(int doc) throws IOException {
     SortedMap<String, SimpleTVTerms> fields = new TreeMap<>();
     in.seek(offsets[doc]);
     readLine();
@@ -241,7 +242,7 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
     return scratchUTF16.toString();
   }
 
-  private static class SimpleTVFields extends Fields {
+  private static class SimpleTVFields extends DocTermVectors {
     private final SortedMap<String, SimpleTVTerms> fields;
 
     SimpleTVFields(SortedMap<String, SimpleTVTerms> fields) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -40,6 +40,7 @@ import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.codecs.compressing.Decompressor;
 import org.apache.lucene.index.BaseTermsEnum;
 import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.DocTermVectors;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.Fields;
@@ -334,7 +335,7 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
   }
 
   @Override
-  public Fields get(int doc) throws IOException {
+  public DocTermVectors get(int doc) throws IOException {
     ensureOpen();
 
     // seek to the right place
@@ -801,7 +802,7 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
     return positions;
   }
 
-  private class TVFields extends Fields {
+  private class TVFields extends DocTermVectors {
 
     private final int[] fieldNums, fieldFlags, fieldNumOffs, numTerms, fieldLengths;
     private final int[][] prefixLengths,

--- a/lucene/core/src/java/org/apache/lucene/index/BaseCompositeReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BaseCompositeReader.java
@@ -117,7 +117,7 @@ public abstract class BaseCompositeReader<R extends IndexReader> extends Composi
 
     return new TermVectors() {
       @Override
-      public Fields get(int doc) throws IOException {
+      public DocTermVectors get(int doc) throws IOException {
         ensureOpen();
         final int i = readerIndex(doc); // find subreader num
 

--- a/lucene/core/src/java/org/apache/lucene/index/DocTermVectors.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocTermVectors.java
@@ -14,20 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.lucene.index;
 
-import java.io.IOException;
-import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+/** Holds all the Term Vector {@link Terms} for a document. */
+public abstract class DocTermVectors extends Fields {
+  //nocommit don't extend Fields
 
-/** Index API to access TermVectors */
-public abstract class TermVectors {
-  /** Sole constructor. (For invocation by subclass constructors, typically implicit.) */
-  protected TermVectors() {}
-
-  /**
-   * Returns term vectors for this document, or null if term vectors were not indexed. If offsets
-   * are available they are in an {@link OffsetAttribute} available from the {@link
-   * org.apache.lucene.index.PostingsEnum}.
-   */
-  public abstract DocTermVectors get(int doc) throws IOException;
+  /** Constructor */
+  protected DocTermVectors() {
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexReader.java
@@ -311,7 +311,7 @@ public abstract class IndexReader implements Closeable {
    * @deprecated Use {@link IndexReader#getTermVectorsReader} instead.
    */
   @Deprecated
-  public final Fields getTermVectors(int docID) throws IOException {
+  public final DocTermVectors getTermVectors(int docID) throws IOException {
     TermVectors termVectors = getTermVectorsReader();
     if (termVectors != null) {
       return termVectors.get(docID);

--- a/lucene/core/src/java/org/apache/lucene/index/MergeReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeReaderWrapper.java
@@ -187,7 +187,7 @@ class MergeReaderWrapper extends LeafReader {
   public TermVectors getTermVectorsReader() {
     return new TermVectors() {
       @Override
-      public Fields get(int docID) throws IOException {
+      public DocTermVectors get(int docID) throws IOException {
         ensureOpen();
         checkBounds(docID);
         if (vectors == null) {

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -203,7 +203,7 @@ public class ParallelLeafReader extends LeafReader {
   }
 
   // Single instance of this, per ParallelReader instance
-  private static final class ParallelFields extends Fields {
+  private static final class ParallelFields extends DocTermVectors {
     final Map<String, Terms> fields = new TreeMap<>();
 
     ParallelFields() {}
@@ -303,7 +303,7 @@ public class ParallelLeafReader extends LeafReader {
   public TermVectors getTermVectorsReader() {
     return new TermVectors() {
       @Override
-      public Fields get(int doc) throws IOException {
+      public DocTermVectors get(int doc) throws IOException {
         ensureOpen();
         ParallelFields fields = null;
         for (Map.Entry<String, LeafReader> ent : tvFieldToReader.entrySet()) {

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
@@ -267,7 +267,7 @@ public final class SlowCodecReaderWrapper {
   private static TermVectorsReader readerToTermVectorsReader(final LeafReader reader) {
     return new TermVectorsReader() {
       @Override
-      public Fields get(int docID) throws IOException {
+      public DocTermVectors get(int docID) throws IOException {
         return reader.getTermVectors(docID);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -449,7 +449,7 @@ public final class SortingCodecReader extends FilterCodecReader {
   private TermVectorsReader newTermVectorsReader(TermVectorsReader delegate) {
     return new TermVectorsReader() {
       @Override
-      public Fields get(int doc) throws IOException {
+      public DocTermVectors get(int doc) throws IOException {
         return delegate.get(docMap.newToOld(doc));
       }
 

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocTermVectors;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
@@ -47,12 +48,12 @@ import org.apache.lucene.util.Version;
  */
 public class TermVectorLeafReader extends LeafReader {
 
-  private final Fields fields;
+  private final DocTermVectors fields;
   private final FieldInfos fieldInfos;
 
   public TermVectorLeafReader(String field, Terms terms) {
     fields =
-        new Fields() {
+        new DocTermVectors() {
           @Override
           public Iterator<String> iterator() {
             return Collections.singletonList(field).iterator();
@@ -172,7 +173,7 @@ public class TermVectorLeafReader extends LeafReader {
   public TermVectors getTermVectorsReader() {
     return new TermVectors() {
       @Override
-      public Fields get(int docID) {
+      public DocTermVectors get(int docID) {
         if (docID != 0) {
           return null;
         }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -36,6 +36,7 @@ import java.util.function.Supplier;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.BaseCompositeReader;
+import org.apache.lucene.index.DocTermVectors;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.Fields;
@@ -1129,7 +1130,7 @@ public class UnifiedHighlighter {
     }
 
     private int lastDocId = -1;
-    private Fields tvFields;
+    private DocTermVectors tvFields;
 
     TermVectorReusingLeafReader(LeafReader in) {
       super(in);
@@ -1143,7 +1144,7 @@ public class UnifiedHighlighter {
 
       return new TermVectors() {
         @Override
-        public Fields get(int docID) throws IOException {
+        public DocTermVectors get(int docID) throws IOException {
           if (docID != lastDocId) {
             lastDocId = docID;
             tvFields = in.getTermVectorsReader().get(docID);

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
@@ -32,6 +32,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocTermVectors;
 import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.FilterDirectoryReader;
 import org.apache.lucene.index.FilterLeafReader;
@@ -139,7 +140,7 @@ public class TestUnifiedHighlighterTermVec extends LuceneTestCase {
                 BitSet seenDocIDs = new BitSet();
                 return new TermVectors() {
                   @Override
-                  public Fields get(int docID) throws IOException {
+                  public DocTermVectors get(int docID) throws IOException {
                     // if we're invoked by ParallelLeafReader then we can't do our assertion. TODO
                     // see LUCENE-6868
                     if (callStackContains(ParallelLeafReader.class) == false

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -1239,9 +1239,24 @@ public class MemoryIndex {
     public TermVectors getTermVectorsReader() {
       return new TermVectors() {
         @Override
-        public Fields get(int docID) {
+        public DocTermVectors get(int docID) {
           if (docID == 0) {
-            return memoryFields;
+            return new DocTermVectors() {
+              @Override
+              public Iterator<String> iterator() {
+                return memoryFields.iterator();
+              }
+
+              @Override
+              public Terms terms(String field) throws IOException {
+                return memoryFields.terms(field);
+              }
+
+              @Override
+              public int size() {
+                return memoryFields.size();
+              }
+            };
           } else {
             return null;
           }

--- a/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingTermVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingTermVectorsFormat.java
@@ -22,7 +22,8 @@ import java.util.Collections;
 import org.apache.lucene.codecs.TermVectorsFormat;
 import org.apache.lucene.codecs.TermVectorsReader;
 import org.apache.lucene.codecs.TermVectorsWriter;
-import org.apache.lucene.index.AssertingLeafReader;
+import org.apache.lucene.index.AssertingLeafReader.AssertingDocTermVectors;
+import org.apache.lucene.index.DocTermVectors;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.Fields;
@@ -67,9 +68,9 @@ public class AssertingTermVectorsFormat extends TermVectorsFormat {
     }
 
     @Override
-    public Fields get(int doc) throws IOException {
-      Fields fields = in.get(doc);
-      return fields == null ? null : new AssertingLeafReader.AssertingFields(fields);
+    public DocTermVectors get(int doc) throws IOException {
+      DocTermVectors fields = in.get(doc);
+      return fields == null ? null : new AssertingDocTermVectors(fields);
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/AssertingLeafReader.java
@@ -86,23 +86,31 @@ public class AssertingLeafReader extends FilterLeafReader {
     return terms == null ? null : new AssertingTerms(terms);
   }
 
-  /** Wraps a Fields but with additional asserts */
-  public static class AssertingFields extends FilterFields {
-    public AssertingFields(Fields in) {
-      super(in);
+  /** Wraps a DocTermVectors but with additional asserts */
+  public static class AssertingDocTermVectors extends DocTermVectors {
+
+    protected final DocTermVectors in;
+
+    public AssertingDocTermVectors(DocTermVectors in) {
+      this.in = Objects.requireNonNull(in);
     }
 
     @Override
     public Iterator<String> iterator() {
-      Iterator<String> iterator = super.iterator();
+      Iterator<String> iterator = in.iterator();
       assert iterator != null;
       return iterator;
     }
 
     @Override
     public Terms terms(String field) throws IOException {
-      Terms terms = super.terms(field);
+      Terms terms = in.terms(field);
       return terms == null ? null : new AssertingTerms(terms);
+    }
+
+    @Override
+    public int size() {
+      return in.size();
     }
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/index/FieldFilterLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/FieldFilterLeafReader.java
@@ -59,12 +59,12 @@ public final class FieldFilterLeafReader extends FilterLeafReader {
   public TermVectors getTermVectorsReader() {
     return new TermVectors() {
       @Override
-      public Fields get(int docID) throws IOException {
-        Fields f = in.getTermVectorsReader().get(docID);
+      public DocTermVectors get(int docID) throws IOException {
+        DocTermVectors f = in.getTermVectorsReader().get(docID);
         if (f == null) {
           return null;
         }
-        f = new FieldFilterFields(f);
+        f = new FieldFilterDocTermVectors(f);
         // we need to check for emptyness, so we can return
         // null:
         return f.iterator().hasNext() ? f : null;
@@ -153,10 +153,12 @@ public final class FieldFilterLeafReader extends FilterLeafReader {
     return sb.append(fields).append(')').toString();
   }
 
-  private class FieldFilterFields extends FilterFields {
+  private class FieldFilterDocTermVectors extends DocTermVectors {
 
-    public FieldFilterFields(Fields in) {
-      super(in);
+    protected final DocTermVectors in;
+
+    public FieldFilterDocTermVectors(DocTermVectors in) {
+      this.in = Objects.requireNonNull(in);
     }
 
     @Override
@@ -167,7 +169,7 @@ public final class FieldFilterLeafReader extends FilterLeafReader {
 
     @Override
     public Iterator<String> iterator() {
-      return new FilterIterator<String, String>(super.iterator()) {
+      return new FilterIterator<>(in.iterator()) {
         @Override
         protected boolean predicateFunction(String field) {
           return hasField(field);
@@ -177,7 +179,7 @@ public final class FieldFilterLeafReader extends FilterLeafReader {
 
     @Override
     public Terms terms(String field) throws IOException {
-      return hasField(field) ? super.terms(field) : null;
+      return hasField(field) ? in.terms(field) : null;
     }
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-10018
Let's not use the Fields class anymore for TermVectors.  In this PR, we introduce a new class "DocTermVectors" in its stead.

#11057