### PR TITLE
LUCENE-10032: Remove leafDocMaps from MergeState

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4138,7 +4138,6 @@ public class IndexWriter
       assert rld != null : "seg=" + info.info.name;
 
       MergeState.DocMap segDocMap = mergeState.docMaps[i];
-      MergeState.DocMap segLeafDocMap = mergeState.leafDocMaps[i];
 
       carryOverHardDeletes(
           mergedDeletesAndUpdates,
@@ -4146,8 +4145,7 @@ public class IndexWriter
           mergeState.liveDocs[i],
           merge.getMergeReader().get(i).hardLiveDocs,
           rld.getHardLiveDocs(),
-          segDocMap,
-          segLeafDocMap);
+          segDocMap);
 
       // Now carry over all doc values updates that were resolved while we were merging, remapping
       // the docIDs to the newly merged docIDs.
@@ -4200,7 +4198,7 @@ public class IndexWriter
           DocValuesFieldUpdates.Iterator it = updates.iterator();
           int doc;
           while ((doc = it.nextDoc()) != NO_MORE_DOCS) {
-            int mappedDoc = segDocMap.get(segLeafDocMap.get(doc));
+            int mappedDoc = segDocMap.get(doc);
             if (mappedDoc != -1) {
               if (it.hasValue()) {
                 // not deleted
@@ -4250,8 +4248,7 @@ public class IndexWriter
       Bits mergeLiveDocs, // the liveDocs used to build the segDocMaps
       Bits prevHardLiveDocs, // the hard deletes when the merge reader was pulled
       Bits currentHardLiveDocs, // the current hard deletes
-      MergeState.DocMap segDocMap,
-      MergeState.DocMap segLeafDocMap)
+      MergeState.DocMap segDocMap)
       throws IOException {
 
     assert mergeLiveDocs == null || mergeLiveDocs.length() == maxDoc;
@@ -4293,7 +4290,7 @@ public class IndexWriter
             assert currentHardLiveDocs.get(j) == false;
           } else if (carryOverDelete.test(j)) {
             // the document was deleted while we were merging:
-            mergedReadersAndUpdates.delete(segDocMap.get(segLeafDocMap.get(j)));
+            mergedReadersAndUpdates.delete(segDocMap.get(j));
           }
         }
       }
@@ -4303,7 +4300,7 @@ public class IndexWriter
       // does:
       for (int j = 0; j < maxDoc; j++) {
         if (carryOverDelete.test(j)) {
-          mergedReadersAndUpdates.delete(segDocMap.get(segLeafDocMap.get(j)));
+          mergedReadersAndUpdates.delete(segDocMap.get(j));
         }
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -45,10 +45,6 @@ public class MergeState {
   /** Maps document IDs from old segments to document IDs in the new segment */
   public final DocMap[] docMaps;
 
-  // Only used by IW when it must remap deletes that arrived against the merging segments while a
-  // merge was running:
-  final DocMap[] leafDocMaps;
-
   /** {@link SegmentInfo} of the newly merged segment. */
   public final SegmentInfo segmentInfo;
 
@@ -99,7 +95,6 @@ public class MergeState {
 
     final Sort indexSort = segmentInfo.getIndexSort();
     int numReaders = originalReaders.size();
-    leafDocMaps = new DocMap[numReaders];
     List<CodecReader> readers = maybeSortReaders(originalReaders, segmentInfo);
 
     maxDocs = new int[numReaders];
@@ -226,20 +221,7 @@ public class MergeState {
     }
   }
 
-  private List<CodecReader> maybeSortReaders(
-      List<CodecReader> originalReaders, SegmentInfo segmentInfo) throws IOException {
-
-    // Default to identity:
-    for (int i = 0; i < originalReaders.size(); i++) {
-      leafDocMaps[i] =
-          new DocMap() {
-            @Override
-            public int get(int docID) {
-              return docID;
-            }
-          };
-    }
-
+  private List<CodecReader> maybeSortReaders(List<CodecReader> originalReaders, SegmentInfo segmentInfo) {
     Sort indexSort = segmentInfo.getIndexSort();
     if (indexSort == null) {
       return originalReaders;

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -221,7 +221,8 @@ public class MergeState {
     }
   }
 
-  private List<CodecReader> maybeSortReaders(List<CodecReader> originalReaders, SegmentInfo segmentInfo) {
+  private List<CodecReader> maybeSortReaders(
+      List<CodecReader> originalReaders, SegmentInfo segmentInfo) {
     Sort indexSort = segmentInfo.getIndexSort();
     if (indexSort == null) {
       return originalReaders;


### PR DESCRIPTION
These maps are no longer useful after [LUCENE-8505](https://issues.apache.org/jira/browse/LUCENE-8505).