### PR TITLE
LUCENE-10036: Add factory method to ScoreCachingWrappingScorer that ensures unnecessary wrapping doesn't occur

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -357,6 +357,9 @@ API Changes
   Users can now access the count of an ordinal directly without constructing an extra FacetLabel.
   Also use variable length arguments for the getOrdinal call in TaxonomyReader. (Gautam Worah)
 
+* LUCENE-10036: Replaced the ScoreCachingWrappingScorer ctor with a static factory method that
+  ensures unnecessary wrapping doesn't occur. (Greg Miller)
+
 New Features
 ---------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
@@ -187,11 +187,7 @@ public abstract class FieldComparator<T> {
       // wrap with a ScoreCachingWrappingScorer so that successive calls to
       // score() will not incur score computation over and
       // over again.
-      if (!(scorer instanceof ScoreCachingWrappingScorer)) {
-        this.scorer = new ScoreCachingWrappingScorer(scorer);
-      } else {
-        this.scorer = scorer;
-      }
+      this.scorer = ScoreCachingWrappingScorer.wrap(scorer);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
@@ -158,7 +158,7 @@ public class MultiCollector implements Collector {
     @Override
     public void setScorer(Scorable scorer) throws IOException {
       if (cacheScores) {
-        scorer = new ScoreCachingWrappingScorer(scorer);
+        scorer = ScoreCachingWrappingScorer.wrap(scorer);
       }
       if (skipNonCompetitiveScores) {
         for (int i = 0; i < collectors.length; ++i) {

--- a/lucene/core/src/java/org/apache/lucene/search/PositiveScoresOnlyCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PositiveScoresOnlyCollector.java
@@ -37,7 +37,7 @@ public class PositiveScoresOnlyCollector extends FilterCollector {
 
       @Override
       public void setScorer(Scorable scorer) throws IOException {
-        this.scorer = new ScoreCachingWrappingScorer(scorer);
+        this.scorer = ScoreCachingWrappingScorer.wrap(scorer);
         in.setScorer(this.scorer);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/search/ScoreCachingWrappingScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScoreCachingWrappingScorer.java
@@ -35,7 +35,15 @@ public final class ScoreCachingWrappingScorer extends Scorable {
   private float curScore;
   private final Scorable in;
 
+  public static Scorable wrap(Scorable scorer) {
+    if (scorer instanceof ScoreCachingWrappingScorer) {
+      return scorer;
+    }
+    return new ScoreCachingWrappingScorer(scorer);
+  }
+
   /** Creates a new instance by wrapping the given scorer. */
+  @Deprecated
   public ScoreCachingWrappingScorer(Scorable scorer) {
     this.in = scorer;
   }

--- a/lucene/core/src/java/org/apache/lucene/search/ScoreCachingWrappingScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScoreCachingWrappingScorer.java
@@ -35,6 +35,12 @@ public final class ScoreCachingWrappingScorer extends Scorable {
   private float curScore;
   private final Scorable in;
 
+  /**
+   * Wraps the provided {@link Scorable} unless it's already an instance of
+   * {@code ScoreCachingWrappingScorer}, in which case it will just return the provided instance.
+   * @param scorer Underlying {@code Scorable} to wrap
+   * @return Instance of {@code ScoreCachingWrappingScorer} wrapping the underlying {@code scorer}
+   */
   public static Scorable wrap(Scorable scorer) {
     if (scorer instanceof ScoreCachingWrappingScorer) {
       return scorer;
@@ -43,8 +49,7 @@ public final class ScoreCachingWrappingScorer extends Scorable {
   }
 
   /** Creates a new instance by wrapping the given scorer. */
-  @Deprecated
-  public ScoreCachingWrappingScorer(Scorable scorer) {
+  private ScoreCachingWrappingScorer(Scorable scorer) {
     this.in = scorer;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/ScoreCachingWrappingScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScoreCachingWrappingScorer.java
@@ -36,8 +36,9 @@ public final class ScoreCachingWrappingScorer extends Scorable {
   private final Scorable in;
 
   /**
-   * Wraps the provided {@link Scorable} unless it's already an instance of
-   * {@code ScoreCachingWrappingScorer}, in which case it will just return the provided instance.
+   * Wraps the provided {@link Scorable} unless it's already an instance of {@code
+   * ScoreCachingWrappingScorer}, in which case it will just return the provided instance.
+   *
    * @param scorer Underlying {@code Scorable} to wrap
    * @return Instance of {@code ScoreCachingWrappingScorer} wrapping the underlying {@code scorer}
    */

--- a/lucene/core/src/test/org/apache/lucene/search/TestScoreCachingWrappingScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestScoreCachingWrappingScorer.java
@@ -22,7 +22,6 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
-import org.junit.Assert;
 
 public class TestScoreCachingWrappingScorer extends LuceneTestCase {
 
@@ -174,11 +173,11 @@ public class TestScoreCachingWrappingScorer extends LuceneTestCase {
 
     // Wrapping the first time should produce a different instance:
     Scorable wrapped = ScoreCachingWrappingScorer.wrap(base);
-    Assert.assertNotEquals(base, wrapped);
+    assertNotEquals(base, wrapped);
 
     // But if we try to wrap an instance of ScoreCachingWrappingScorer, it shouldn't unnecessarily
     // wrap again:
     Scorable doubleWrapped = ScoreCachingWrappingScorer.wrap(wrapped);
-    Assert.assertEquals(wrapped, doubleWrapped);
+    assertEquals(wrapped, doubleWrapped);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestScoreCachingWrappingScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestScoreCachingWrappingScorer.java
@@ -178,6 +178,6 @@ public class TestScoreCachingWrappingScorer extends LuceneTestCase {
     // But if we try to wrap an instance of ScoreCachingWrappingScorer, it shouldn't unnecessarily
     // wrap again:
     Scorable doubleWrapped = ScoreCachingWrappingScorer.wrap(wrapped);
-    assertEquals(wrapped, doubleWrapped);
+    assertSame(wrapped, doubleWrapped);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestScoreCachingWrappingScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestScoreCachingWrappingScorer.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
+import org.junit.Assert;
 
 public class TestScoreCachingWrappingScorer extends LuceneTestCase {
 
@@ -105,7 +106,7 @@ public class TestScoreCachingWrappingScorer extends LuceneTestCase {
 
     @Override
     public void setScorer(Scorable scorer) {
-      this.scorer = new ScoreCachingWrappingScorer(scorer);
+      this.scorer = ScoreCachingWrappingScorer.wrap(scorer);
     }
 
     @Override
@@ -155,5 +156,29 @@ public class TestScoreCachingWrappingScorer extends LuceneTestCase {
     }
     ir.close();
     directory.close();
+  }
+
+  public void testNoUnnecessaryWrap() throws Exception {
+    Scorable base =
+        new Scorable() {
+          @Override
+          public float score() throws IOException {
+            return -1;
+          }
+
+          @Override
+          public int docID() {
+            return -1;
+          }
+        };
+
+    // Wrapping the first time should produce a different instance:
+    Scorable wrapped = ScoreCachingWrappingScorer.wrap(base);
+    Assert.assertNotEquals(base, wrapped);
+
+    // But if we try to wrap an instance of ScoreCachingWrappingScorer, it shouldn't unnecessarily
+    // wrap again:
+    Scorable doubleWrapped = ScoreCachingWrappingScorer.wrap(wrapped);
+    Assert.assertEquals(wrapped, doubleWrapped);
   }
 }

--- a/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysScorer.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysScorer.java
@@ -152,7 +152,7 @@ class DrillSidewaysScorer extends BulkScorer {
     // if (DEBUG) {
     //  System.out.println("  doQueryFirstScoring");
     // }
-    setScorer(collector, new ScoreCachingWrappingScorer(baseScorer));
+    setScorer(collector, ScoreCachingWrappingScorer.wrap(baseScorer));
 
     int docID = baseScorer.docID();
 


### PR DESCRIPTION
# Description

Current users of `ScoreCachingWrappingScorer` must do their own instancetype checks if they want to avoid unnecessarily wrapping an existing `ScoreCachingWrappingScorer` instance. This change encapsulates the check in a factory method.

NOTE: There's [another PR](https://github.com/apache/lucene-solr/pull/2534) for backporting this change into 8.x, but marking the ctor as `@deprecated` to provide API back-compat.

# Solution

A factory method was added to `ScoreCachingWrappingScorer` and the ctor was made `private`.

# Tests

Added a new test that ensures a new instance isn't created when attempting to wrap an existing `ScoreCachingWrappingScorer` instance.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
