### PR TITLE
LUCENE-10039: Fix single-field scoring for CombinedFieldQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -418,6 +418,9 @@ Bug Fixes
 * LUCENE-10026: Fix CombinedFieldQuery equals and hashCode, which ensures
   query rewrites don't drop CombinedFieldQuery clauses. (Julie Tibshirani)
 
+* LUCENE-10039: Correct CombinedFieldQuery scoring when there is a single
+  field. (Julie Tibshirani)
+
 Other
 ---------------------
 (No changes)

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiNormsLeafSimScorer.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiNormsLeafSimScorer.java
@@ -71,8 +71,6 @@ final class MultiNormsLeafSimScorer {
 
       if (normsList.isEmpty()) {
         norms = null;
-      } else if (normsList.size() == 1) {
-        norms = normsList.get(0);
       } else {
         final NumericDocValues[] normsArr = normsList.toArray(new NumericDocValues[0]);
         final float[] weightArr = new float[normsList.size()];


### PR DESCRIPTION
When there's only one field, CombinedFieldQuery will ignore its weight while
scoring. This makes the scoring inconsistent, since the field weight is supposed
to multiply its term frequency.

This PR removes the optimizations around single-field scoring to make sure the
weight is always taken into account. These optimizations don't seem critical
since it should be rare for CombinedFieldQuery to run over only one field.