### PR TITLE
LUCENE-10041: Remove TieredMergePolicy's redundant query computation

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
@@ -82,6 +82,11 @@ public class FilterMergePolicy extends MergePolicy {
   }
 
   @Override
+  protected long size(SegmentCommitInfo info, int delCount) throws IOException {
+    return in.size(info, delCount);
+  }
+
+  @Override
   public double getNoCFSRatio() {
     return in.getNoCFSRatio();
   }

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -649,14 +649,23 @@ public abstract class MergePolicy {
    * non-deleted documents is set.
    */
   protected long size(SegmentCommitInfo info, MergeContext mergeContext) throws IOException {
-    long byteSize = info.sizeInBytes();
     int delCount = mergeContext.numDeletesToMerge(info);
+    return size(info, delCount);
+  }
+
+  /**
+   * Return the byte size of the provided {@link SegmentCommitInfo}, pro-rated by percentage of
+   * non-deleted documents is set.
+   */
+  protected long size(SegmentCommitInfo info, int delCount) throws IOException {
+    long byteSize = info.sizeInBytes();
     assert assertDelCount(delCount, info);
     double delRatio =
-        info.info.maxDoc() <= 0 ? 0d : (double) delCount / (double) info.info.maxDoc();
+            info.info.maxDoc() <= 0 ? 0d : (double) delCount / (double) info.info.maxDoc();
     assert delRatio <= 1.0;
     return (info.info.maxDoc() <= 0 ? byteSize : (long) (byteSize * (1.0 - delRatio)));
   }
+
 
   /** Asserts that the delCount for this SegmentCommitInfo is valid */
   protected final boolean assertDelCount(int delCount, SegmentCommitInfo info) {

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -649,23 +649,21 @@ public abstract class MergePolicy {
    * non-deleted documents is set.
    */
   protected long size(SegmentCommitInfo info, MergeContext mergeContext) throws IOException {
-    int delCount = mergeContext.numDeletesToMerge(info);
-    return size(info, delCount);
+    return size(info, mergeContext.numDeletesToMerge(info));
   }
 
   /**
-   * Return the byte size of the provided {@link SegmentCommitInfo}, pro-rated by percentage of
-   * non-deleted documents is set.
+   * Return the byte size of the provided {@link SegmentCommitInfo} if number of deleted documents
+   * is given, pro-rated by percentage of non-deleted documents is set.
    */
   protected long size(SegmentCommitInfo info, int delCount) throws IOException {
     long byteSize = info.sizeInBytes();
     assert assertDelCount(delCount, info);
     double delRatio =
-            info.info.maxDoc() <= 0 ? 0d : (double) delCount / (double) info.info.maxDoc();
+        info.info.maxDoc() <= 0 ? 0d : (double) delCount / (double) info.info.maxDoc();
     assert delRatio <= 1.0;
     return (info.info.maxDoc() <= 0 ? byteSize : (long) (byteSize * (1.0 - delRatio)));
   }
-
 
   /** Asserts that the delCount for this SegmentCommitInfo is valid */
   protected final boolean assertDelCount(int delCount, SegmentCommitInfo info) {

--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -299,9 +299,8 @@ public class TieredMergePolicy extends MergePolicy {
     List<SegmentSizeAndDocs> sortedBySize = new ArrayList<>();
 
     for (SegmentCommitInfo info : infos) {
-      sortedBySize.add(
-          new SegmentSizeAndDocs(
-              info, size(info, mergeContext), mergeContext.numDeletesToMerge(info)));
+      int delCount = mergeContext.numDeletesToMerge(info);
+      sortedBySize.add(new SegmentSizeAndDocs(info, size(info, delCount), delCount));
     }
 
     sortedBySize.sort(


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/projects/LUCENE

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>

LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->

[LUCENE-10041](https://issues.apache.org/jira/browse/LUCENE-10041)

# Description 
 In lucene 8.4 (Elasticsearch 7.6.2), all indices are enabled with soft-deletes. We found the TieredMergePolicy contains redundant query computation to acquire **numDeletesToMerge** for **findMerges**. According to code from [getSortedBySegmentSize](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java#L303) , I think we should reuse the result of numDeletesToMerge which can reduce 3% CPU and some IO overheads.

# Solution
 Reuse the result of numDeletesToMerge

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
