### PR TITLE
Slight improvement/optimization to duplicate facet value checking (ref: LUCENE-9964)

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
@@ -162,14 +162,14 @@ public class LongValueFacetCounts extends Facets {
           if (limit > 0) {
             totCount++;
           }
-          long previousValue = 0;
+          long previousValue = -1;
           for (int i = 0; i < limit; i++) {
             long value = multiValues.nextValue();
             // do not increment the count for duplicate values
-            if (i == 0 || value != previousValue) {
+            if (value != previousValue) {
               increment(value);
+              previousValue = value;
             }
-            previousValue = value;
           }
         }
       }
@@ -214,14 +214,14 @@ public class LongValueFacetCounts extends Facets {
           if (limit > 0) {
             totCount++;
           }
-          long previousValue = 0;
+          long previousValue = -1;
           for (int i = 0; i < limit; i++) {
             long value = multiValues.nextValue();
             // do not increment the count for duplicate values
-            if (i == 0 || value != previousValue) {
+            if (value != previousValue) {
               increment(value);
+              previousValue = value;
             }
-            previousValue = value;
           }
         }
       }

--- a/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
@@ -193,8 +193,13 @@ abstract class RangeFacetCounts extends Facets {
               totCount++;
             } else {
               counter.startMultiValuedDoc();
+              long previous = -1;
               for (int j = 0; j < limit; j++) {
-                counter.addMultiValued(mapDocValue(multiValues.nextValue()));
+                long val = mapDocValue(multiValues.nextValue());
+                if (val != previous) {
+                  counter.addMultiValued(val);
+                  previous = val;
+                }
               }
               if (counter.endMultiValuedDoc()) {
                 totCount++;


### PR DESCRIPTION

# Description

Slight improvement to the way duplicate numeric doc values are de-duped when facet counting. Main benefit is avoiding the overhead in the `LongCounter` segment-tree when encountering duplicate numeric doc values.

NOTE: I'm planning to push this with no tracking Jira issue given how minor the change is and the fact that it's functionally equivalent to what's already on `main`. I'm using this PR only as a triple-check for the `precommit` tastk and slight audit-ability. No CHANGES entry is included as such.

# Solution

Maintain previous value and de-dupe before proceeding with counting. Tweaked the impl in `LongValueFacetCounts` to init previous to -1 (instead of 0) so the index check isn't needed (since -1 is an invalid value).

# Tests

Tests for these two facet counting implementations already cover duplicate value checking. All tests continue to pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
