### PR TITLE
LUCENE-10047: Fix value de-duping check in LongValueFacetCounts and RangeFacetCounts

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -281,6 +281,9 @@ Bug fixes
 * LUCENE-9823: Prevent unsafe rewrites for SynonymQuery and CombinedFieldQuery. Before, rewriting
   could slightly change the scoring when weights were specified. (Naoto Minami via Julie Tibshirani)
 
+* LUCENE-10047: Fix a value de-duping bug in LongValueFacetCounts and RangeFacetCounts
+  (Greg Miller)
+
 Changes in Backwards Compatibility Policy
 
 * LUCENE-9904: regenerated UAX29URLEmailTokenizer and the corresponding analyzer with up-to-date top
@@ -434,9 +437,6 @@ Bug Fixes
   field. (Julie Tibshirani)
 
 * LUCENE-10046: Counting bug fixed in StringValueFacetCounts. (Greg Miller)
-
-* LUCENE-10047: Fix a value de-duping bug in LongValueFacetCounts and RangeFacetCounts
-  (Greg Miller)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -435,6 +435,9 @@ Bug Fixes
 
 * LUCENE-10046: Counting bug fixed in StringValueFacetCounts. (Greg Miller)
 
+* LUCENE-10047: Fix a value de-duping bug in LongValueFacetCounts and RangeFacetCounts
+  (Greg Miller)
+
 Other
 ---------------------
 (No changes)

--- a/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
@@ -162,11 +162,11 @@ public class LongValueFacetCounts extends Facets {
           if (limit > 0) {
             totCount++;
           }
-          long previousValue = -1;
+          long previousValue = 0;
           for (int i = 0; i < limit; i++) {
             long value = multiValues.nextValue();
             // do not increment the count for duplicate values
-            if (value != previousValue) {
+            if (i == 0 || value != previousValue) {
               increment(value);
               previousValue = value;
             }
@@ -214,11 +214,11 @@ public class LongValueFacetCounts extends Facets {
           if (limit > 0) {
             totCount++;
           }
-          long previousValue = -1;
+          long previousValue = 0;
           for (int i = 0; i < limit; i++) {
             long value = multiValues.nextValue();
             // do not increment the count for duplicate values
-            if (value != previousValue) {
+            if (i == 0 || value != previousValue) {
               increment(value);
               previousValue = value;
             }

--- a/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
@@ -193,10 +193,10 @@ abstract class RangeFacetCounts extends Facets {
               totCount++;
             } else {
               counter.startMultiValuedDoc();
-              long previous = -1;
+              long previous = 0;
               for (int j = 0; j < limit; j++) {
                 long val = mapDocValue(multiValues.nextValue());
-                if (val != previous) {
+                if (j == 0 || val != previous) {
                   counter.addMultiValued(val);
                   previous = val;
                 }


### PR DESCRIPTION
# Description

These two facet counting implementations are incorrectly assuming that -1 is an invalid value (for the purpose of value de-duping), which isn't the case.

# Solution

Fix the above assumption.

# Tests

Existing randomized testing caught the bug. Tests now pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
