### PR TITLE
LUCENE-9614: Prevent TestKnnVectorQuery from using simple text codec

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -35,8 +35,10 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
 
 /** TestKnnVectorQuery tests KnnVectorQuery. */
+@SuppressCodecs("SimpleText") // The codec must support kNN searches
 public class TestKnnVectorQuery extends LuceneTestCase {
 
   public void testEquals() {


### PR DESCRIPTION
The simple text codec doesn't support kNN searches, so the test will fail when
we randomly chose to use it.