### PR TITLE
LUCENE-10058: fix gradle lucene:benchmark:run error

### DIFF
--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/ReutersContentSource.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/ReutersContentSource.java
@@ -107,14 +107,16 @@ public class ReutersContentSource extends ContentSource {
 
     int threadIndexSize = Thread.currentThread().getName().length();
     int parallelTaskThreadSize = Constants.PARALLEL_TASK_THREAD_NAME_PREFIX.length();
-
-    // Extract ThreadIndex from unique ThreadName which is set with '"ParallelTaskThread-"+index',
-    // in TaskSequence.java's doParallelTasks()
-    int threadIndex =
-        Integer.parseInt(
-            Thread.currentThread()
-                .getName()
-                .substring(parallelTaskThreadSize + 1, threadIndexSize));
+    int threadIndex = 0;
+    if (docCountArr.length > 1) {
+      // Extract ThreadIndex from unique ThreadName which is set with '"ParallelTaskThread-"+index',
+      // in TaskSequence.java's doParallelTasks()
+      threadIndex =
+          Integer.parseInt(
+              Thread.currentThread()
+                  .getName()
+                  .substring(parallelTaskThreadSize + 1, threadIndexSize));
+    }
 
     assert (threadIndex >= 0 && threadIndex < docCountArr.length)
         : "Please check threadIndex or docCountArr length";


### PR DESCRIPTION
When running ./gradlew lucene:benchmark:run, the default thread name is main not ParallelTaskThread, StringIndexOutOfBoundsException error is thrown.
I set the threadIndex default value to 0 to fix this bug.
