### PR TITLE
LUCENE-9917: Smaller block sizes for BEST_SPEED.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -425,6 +425,9 @@ Improvements
 
 * LUCENE-5309: Optimize facet counting for single-valued SSDV / StringValueFacetCounts. (Greg Miller)
 
+* LUCENE-9917: The BEST_SPEED compression mode now trades more compression ratio
+  in exchange of faster reads. (Adrien Grand)
+
 Optimizations
 ---------------------
 * LUCENE-9996: Improved memory efficiency of IndexWriter's RAM buffer, in

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/LZ4WithPresetDictCompressionMode.java
@@ -38,8 +38,8 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
 
   // Shoot for 10 sub blocks
   private static final int NUM_SUB_BLOCKS = 10;
-  // And a dictionary whose size is about 16x smaller than sub blocks
-  private static final int DICT_SIZE_FACTOR = 16;
+  // And a dictionary whose size is about 2x smaller than sub blocks
+  private static final int DICT_SIZE_FACTOR = 2;
 
   /** Sole constructor. */
   public LZ4WithPresetDictCompressionMode() {}

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/Lucene87StoredFieldsFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/Lucene87StoredFieldsFormat.java
@@ -167,9 +167,9 @@ public class Lucene87StoredFieldsFormat extends StoredFieldsFormat {
   public static final CompressionMode BEST_COMPRESSION_MODE =
       new DeflateWithPresetDictCompressionMode();
 
-  // Shoot for 10 sub blocks of 60kB each.
+  // Shoot for 10 sub blocks of 8kB each.
   /** Block length for {@link Mode#BEST_SPEED} */
-  protected static final int BEST_SPEED_BLOCK_LENGTH = 10 * 60 * 1024;
+  protected static final int BEST_SPEED_BLOCK_LENGTH = 10 * 8 * 1024;
 
   /** Compression mode for {@link Mode#BEST_SPEED} */
   public static final CompressionMode BEST_SPEED_MODE = new LZ4WithPresetDictCompressionMode();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -38,8 +38,8 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
 
   // Shoot for 10 sub blocks
   private static final int NUM_SUB_BLOCKS = 10;
-  // And a dictionary whose size is about 16x smaller than sub blocks
-  private static final int DICT_SIZE_FACTOR = 16;
+  // And a dictionary whose size is about 2x smaller than sub blocks
+  private static final int DICT_SIZE_FACTOR = 2;
 
   /** Sole constructor. */
   public LZ4WithPresetDictCompressionMode() {}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90StoredFieldsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90StoredFieldsFormat.java
@@ -178,8 +178,8 @@ public class Lucene90StoredFieldsFormat extends StoredFieldsFormat {
   public static final CompressionMode BEST_COMPRESSION_MODE =
       new DeflateWithPresetDictCompressionMode();
 
-  // Shoot for 10 sub blocks of 60kB each.
-  private static final int BEST_SPEED_BLOCK_LENGTH = 10 * 60 * 1024;
+  // Shoot for 10 sub blocks of 8kB each.
+  private static final int BEST_SPEED_BLOCK_LENGTH = 10 * 8 * 1024;
 
   /** Compression mode for {@link Mode#BEST_SPEED} */
   public static final CompressionMode BEST_SPEED_MODE = new LZ4WithPresetDictCompressionMode();


### PR DESCRIPTION
This reduces the block size for BEST_SPEED in order to trade some compression
ratio in exchange for better retrieval speed.
