### PR TITLE
LUCENE-10054 Handle hierarchy in graph construction and search

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -480,8 +480,12 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
       this.dataIn = dataIn;
     }
 
+    // TODO : implement hierarchy
     @Override
-    public void seek(int level, int targetOrd) throws IOException {
+    public void seekLevel(int level) throws IOException {}
+
+    @Override
+    public void seek(int targetOrd) throws IOException {
       // unsafe; no bounds checking
       dataIn.seek(entry.ordOffsets[targetOrd]);
       arcCount = dataIn.readInt();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -503,5 +503,15 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
       arc += dataIn.readVInt();
       return arc;
     }
+
+    @Override
+    public int maxLevel() throws IOException {
+      return 0;
+    }
+
+    @Override
+    public int entryNode() throws IOException {
+      return 0;
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -480,7 +480,6 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
       this.dataIn = dataIn;
     }
 
-    // TODO : implement hierarchy
     @Override
     public void seekLevel(int level) throws IOException {}
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
@@ -204,7 +204,7 @@ public final class Lucene90HnswVectorsWriter extends KnnVectorsWriter {
       throws IOException {
     HnswGraphBuilder hnswGraphBuilder =
         new HnswGraphBuilder(
-            vectorValues, similarityFunction, maxConn, beamWidth, HnswGraphBuilder.randSeed, 0);
+            vectorValues, similarityFunction, maxConn, beamWidth, 0, HnswGraphBuilder.randSeed);
     hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
     HnswGraph graph = hnswGraphBuilder.build(vectorValues.randomAccess());
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
@@ -204,7 +204,7 @@ public final class Lucene90HnswVectorsWriter extends KnnVectorsWriter {
       throws IOException {
     HnswGraphBuilder hnswGraphBuilder =
         new HnswGraphBuilder(
-            vectorValues, similarityFunction, maxConn, beamWidth, HnswGraphBuilder.randSeed);
+            vectorValues, similarityFunction, maxConn, beamWidth, HnswGraphBuilder.randSeed, 0);
     hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
     HnswGraph graph = hnswGraphBuilder.build(vectorValues.randomAccess());
 

--- a/lucene/core/src/java/org/apache/lucene/index/KnnGraphValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/KnnGraphValues.java
@@ -32,21 +32,28 @@ public abstract class KnnGraphValues {
   protected KnnGraphValues() {}
 
   /**
+   * Positions the graph on the given {@code level}. After this method returns, call {@link
+   * #seek(int)} to position the graph on a specific node of the current level.
+   *
+   * @param level level of the graph
+   */
+  public abstract void seekLevel(int level) throws IOException;
+
+  /**
    * Move the pointer to exactly {@code target}, the id of a node in the graph. After this method
    * returns, call {@link #nextNeighbor()} to return successive (ordered) connected node ordinals.
    *
-   * @param level level of the graph
    * @param target must be a valid node in the graph, ie. &ge; 0 and &lt; {@link
    *     VectorValues#size()}.
    */
-  public abstract void seek(int level, int target) throws IOException;
+  public abstract void seek(int target) throws IOException;
 
   /** Returns the number of nodes in the graph */
   public abstract int size();
 
   /**
    * Iterates over the neighbor list. It is illegal to call this method after it returns
-   * NO_MORE_DOCS without calling {@link #seek(int, int)}, which resets the iterator.
+   * NO_MORE_DOCS without calling {@link #seek(int)}, which resets the iterator.
    *
    * @return a node ordinal in the graph, or NO_MORE_DOCS if the iteration is complete.
    */
@@ -68,7 +75,10 @@ public abstract class KnnGraphValues {
         }
 
         @Override
-        public void seek(int level, int target) {}
+        public void seekLevel(int level) {}
+
+        @Override
+        public void seek(int target) {}
 
         @Override
         public int size() {

--- a/lucene/core/src/java/org/apache/lucene/index/KnnGraphValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/KnnGraphValues.java
@@ -52,6 +52,12 @@ public abstract class KnnGraphValues {
    */
   public abstract int nextNeighbor() throws IOException;
 
+  /** Returns top level of the graph * */
+  public abstract int maxLevel() throws IOException;
+
+  /** Returns graph's entry point on the top level * */
+  public abstract int entryNode() throws IOException;
+
   /** Empty graph value */
   public static KnnGraphValues EMPTY =
       new KnnGraphValues() {
@@ -66,6 +72,16 @@ public abstract class KnnGraphValues {
 
         @Override
         public int size() {
+          return 0;
+        }
+
+        @Override
+        public int maxLevel() {
+          return 0;
+        }
+
+        @Override
+        public int entryNode() {
           return 0;
         }
       };

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -244,7 +244,6 @@ public final class HnswGraph extends KnnGraphValues {
   }
 
   // TODO: optimize RAM usage so not to store references for all nodes for levels > 0
-  // TODO: add extra levels if level >= numLevels
   public void addNode(int level, int node) {
     if (level > 0) {
       // if the new node introduces a new level, add more levels to the graph,

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -61,14 +61,22 @@ public final class HnswGraph extends KnnGraphValues {
   // Each entry in the list has the top maxConn neighbors of a node. The nodes correspond to vectors
   // added to HnswBuilder, and the node values are the ordinals of those vectors.
   private final List<List<NeighborArray>> graph;
+  private int curMaxLevel; // the current max graph level
+  private int entryNode; // the current graph entry node on the top level
 
   // KnnGraphValues iterator members
   private int upto;
   private NeighborArray cur;
 
+  // used for iterating over graph values
+  private int curLevel = -1;
+  private int curNode = -1;
+
   HnswGraph(int maxConn, int numLevels, int levelOfFirstNode) {
     this.maxConn = maxConn;
     this.graph = new ArrayList<>(numLevels);
+    this.curMaxLevel = levelOfFirstNode;
+    this.entryNode = 0;
     for (int i = 0; i < numLevels; i++) {
       graph.add(new ArrayList<>());
     }
@@ -81,12 +89,11 @@ public final class HnswGraph extends KnnGraphValues {
   }
 
   /**
-   * Searches for the nearest neighbors of a query vector.
+   * Searches HNSW graph for the nearest neighbors of a query vector.
    *
    * @param query search query vector
    * @param topK the number of nodes to be returned
-   * @param numSeed the size of the queue maintained while searching, and controls the number of
-   *     random entry points to sample
+   * @param numSeed the size of the queue maintained while searching
    * @param vectors vector values
    * @param graphValues the graph values. May represent the entire graph, or a level in a
    *     hierarchical graph.
@@ -95,7 +102,6 @@ public final class HnswGraph extends KnnGraphValues {
    * @param random a source of randomness, used for generating entry points to the graph
    * @return a priority queue holding the closest neighbors found
    */
-  // TODO: implement hierarchical search, currently searches only 0th level
   public static NeighborQueue search(
       float[] query,
       int topK,
@@ -107,32 +113,82 @@ public final class HnswGraph extends KnnGraphValues {
       Random random)
       throws IOException {
     int size = graphValues.size();
+    int boundedNumSeed = Math.min(numSeed, 2 * size);
+    NeighborQueue results;
 
+    if (graphValues.maxLevel() == 0) {
+      // search in SNW; generate a number of entry points randomly
+      final int[] eps = new int[boundedNumSeed];
+      for (int i = 0; i < boundedNumSeed; i++) {
+        eps[i] = random.nextInt(size);
+      }
+      return searchLevel(query, topK, 0, eps, vectors, similarityFunction, graphValues, acceptOrds);
+    } else {
+      // search in hierarchical SNW
+      int[] eps = new int[] {graphValues.entryNode()};
+      for (int level = graphValues.maxLevel(); level >= 1; level--) {
+        results =
+            HnswGraph.searchLevel(
+                query, 1, level, eps, vectors, similarityFunction, graphValues, acceptOrds);
+        eps = new int[] {results.pop()};
+      }
+      results =
+          HnswGraph.searchLevel(
+              query, boundedNumSeed, 0, eps, vectors, similarityFunction, graphValues, acceptOrds);
+      while (results.size() > topK) {
+        results.pop();
+      }
+      return results;
+    }
+  }
+
+  /**
+   * Searches for the nearest neighbors of a query vector in a given level
+   *
+   * @param query search query vector
+   * @param topK the number of nearest to query results to return
+   * @param level level to search
+   * @param eps the entry points for search at this level
+   * @param vectors vector values
+   * @param similarityFunction similarity function
+   * @param graphValues the graph values
+   * @param acceptOrds {@link Bits} that represents the allowed document ordinals to match, or
+   *     {@code null} if they are all allowed to match.
+   * @return a priority queue holding the closest neighbors found
+   */
+  static NeighborQueue searchLevel(
+      float[] query,
+      int topK,
+      int level,
+      final int[] eps,
+      RandomAccessVectorValues vectors,
+      VectorSimilarityFunction similarityFunction,
+      KnnGraphValues graphValues,
+      Bits acceptOrds)
+      throws IOException {
+
+    int size = graphValues.size();
+    int queueSize = Math.max(eps.length, topK);
     // MIN heap, holding the top results
-    NeighborQueue results = new NeighborQueue(numSeed, similarityFunction.reversed);
+    NeighborQueue results = new NeighborQueue(queueSize, similarityFunction.reversed);
     // MAX heap, from which to pull the candidate nodes
-    NeighborQueue candidates = new NeighborQueue(numSeed, !similarityFunction.reversed);
-
+    NeighborQueue candidates = new NeighborQueue(queueSize, !similarityFunction.reversed);
     // set of ordinals that have been visited by search on this layer, used to avoid backtracking
     SparseFixedBitSet visited = new SparseFixedBitSet(size);
-    // get initial candidates at random
-    int boundedNumSeed = Math.min(numSeed, 2 * size);
-    for (int i = 0; i < boundedNumSeed; i++) {
-      int entryPoint = random.nextInt(size);
-      if (visited.get(entryPoint) == false) {
-        visited.set(entryPoint);
-        // explore the topK starting points of some random numSeed probes
-        float score = similarityFunction.compare(query, vectors.vectorValue(entryPoint));
-        candidates.add(entryPoint, score);
-        if (acceptOrds == null || acceptOrds.get(entryPoint)) {
-          results.add(entryPoint, score);
+
+    for (int i = 0; i < eps.length; i++) {
+      if (visited.get(eps[i]) == false) {
+        visited.set(eps[i]);
+        float score = similarityFunction.compare(query, vectors.vectorValue(eps[i]));
+        candidates.add(eps[i], score);
+        if (level > 0 || acceptOrds == null || acceptOrds.get(eps[i])) {
+          results.add(eps[i], score);
         }
       }
     }
 
     // Set the bound to the worst current result and below reject any newly-generated candidates
-    // failing
-    // to exceed this bound
+    // failing to exceed this bound
     BoundsChecker bound = BoundsChecker.create(similarityFunction.reversed);
     bound.set(results.topScore());
     while (candidates.size() > 0) {
@@ -144,7 +200,7 @@ public final class HnswGraph extends KnnGraphValues {
         }
       }
       int topCandidateNode = candidates.pop();
-      graphValues.seek(0, topCandidateNode);
+      graphValues.seek(level, topCandidateNode);
       int friendOrd;
       while ((friendOrd = graphValues.nextNeighbor()) != NO_MORE_DOCS) {
         assert friendOrd < size : "friendOrd=" + friendOrd + "; size=" + size;
@@ -154,7 +210,7 @@ public final class HnswGraph extends KnnGraphValues {
         visited.set(friendOrd);
 
         float score = similarityFunction.compare(query, vectors.vectorValue(friendOrd));
-        if (results.size() < numSeed || bound.check(score) == false) {
+        if (results.size() < topK || bound.check(score) == false) {
           candidates.add(friendOrd, score);
           if (acceptOrds == null || acceptOrds.get(friendOrd)) {
             results.insertWithOverflow(friendOrd, score);
@@ -188,8 +244,20 @@ public final class HnswGraph extends KnnGraphValues {
   }
 
   // TODO: optimize RAM usage so not to store references for all nodes for levels > 0
+  // TODO: add extra levels if level >= numLevels
   public void addNode(int level, int node) {
     if (level > 0) {
+      // if the new node introduces a new level, make this node the graph's new entry point
+      if (level > curMaxLevel) {
+        curMaxLevel = level;
+        entryNode = node;
+        // add more levels if needed
+        if (level >= graph.size()) {
+          for (int i = graph.size(); i <= level; i++) {
+            graph.add(new ArrayList<>());
+          }
+        }
+      }
       // Levels above 0th don't contain all nodes,
       // so for missing nodes we add null NeighborArray
       int nullsToAdd = node - graph.get(level).size();
@@ -197,6 +265,7 @@ public final class HnswGraph extends KnnGraphValues {
         graph.get(level).add(null);
       }
     }
+
     graph.get(level).add(new NeighborArray(maxConn + 1));
   }
 
@@ -206,11 +275,65 @@ public final class HnswGraph extends KnnGraphValues {
     upto = -1;
   }
 
+  /**
+   * Positions the graph on the given level. Must be used before iterating over nodes on this level
+   * with the method {@code nextNodeOnLevel()}.
+   *
+   * <p>Package private access to use only for tests
+   */
+  void seekLevel(int level) {
+    curLevel = level;
+    curNode = -1;
+  }
+
+  /**
+   * Returns the next node on the current level As levels > 0 don't contain all nodes, this returns
+   * the next node on this level expressed as ordinals of nodes on the 0th level.
+   *
+   * <p>Must be used after the graph was positioned on the current level with {@code seekLevel(int)}
+   *
+   * <p>Package private access to use only for tests
+   *
+   * @return next node on the current level
+   */
+  int nextNodeOnLevel() {
+    List<NeighborArray> nodesNeighbors = graph.get(curLevel);
+    curNode++;
+    while (curNode < nodesNeighbors.size()) {
+      if (nodesNeighbors.get(curNode) != null) {
+        return curNode;
+      }
+      curNode++;
+    }
+    return NO_MORE_DOCS;
+  }
+
   @Override
   public int nextNeighbor() {
     if (++upto < cur.size()) {
       return cur.node[upto];
     }
     return NO_MORE_DOCS;
+  }
+
+  /**
+   * Returns the current top level of the graph
+   *
+   * @return current maximum level of the graph
+   */
+  @Override
+  public int maxLevel() {
+    return curMaxLevel;
+  }
+
+  /**
+   * Returns the graph's current entry node on the top level shown as ordinals of the nodes on 0th
+   * level
+   *
+   * @return the graph's current entry node on the top level
+   */
+  @Override
+  public int entryNode() {
+    return entryNode;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -67,17 +67,17 @@ public final class HnswGraphBuilder {
    * @param maxConn the number of connections to make when adding a new graph node; roughly speaking
    *     the graph fanout.
    * @param beamWidth the size of the beam search to use when finding nearest neighbors.
+   * @param ml normalization factor for level generation
    * @param seed the seed for a random number generator used during graph construction. Provide this
    *     to ensure repeatable construction.
-   * @param ml normalization factor for level generation
    */
   public HnswGraphBuilder(
       RandomAccessVectorValuesProducer vectors,
       VectorSimilarityFunction similarityFunction,
       int maxConn,
       int beamWidth,
-      long seed,
-      double ml) {
+      double ml,
+      long seed) {
     vectorValues = vectors.randomAccess();
     buildVectors = vectors.randomAccess();
     this.similarityFunction = Objects.requireNonNull(similarityFunction);

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -212,9 +212,10 @@ public class TestKnnGraph extends LuceneTestCase {
     int size = values.size();
     int[][] graph = new int[size][];
     int[] scratch = new int[maxConn];
+    values.seekLevel(0);
     for (int node = 0; node < size; node++) {
       int n, count = 0;
-      values.seek(0, node);
+      values.seek(node);
       while ((n = values.nextNeighbor()) != NO_MORE_DOCS) {
         scratch[count++] = n;
         // graph[node][i++] = n;
@@ -340,6 +341,7 @@ public class TestKnnGraph extends LuceneTestCase {
         int[][] graph = new int[reader.maxDoc()][];
         boolean foundOrphan = false;
         int graphSize = 0;
+        graphValues.seekLevel(0);
         for (int i = 0; i < reader.maxDoc(); i++) {
           int nextDocWithVectors = vectorValues.advance(i);
           // System.out.println("advanced to " + nextDocWithVectors);
@@ -352,7 +354,7 @@ public class TestKnnGraph extends LuceneTestCase {
             break;
           }
           int id = Integer.parseInt(reader.document(i).get("id"));
-          graphValues.seek(0, graphSize);
+          graphValues.seek(graphSize);
           // documents with KnnGraphValues have the expected vectors
           float[] scratch = vectorValues.vectorValue();
           assertArrayEquals(

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -407,7 +407,7 @@ public class TestKnnGraph extends LuceneTestCase {
     assertEquals(expectedCount, totalGraphDocs);
   }
 
-  private void assertMaxConn(int[][] graph, int maxConn) {
+  public static void assertMaxConn(int[][] graph, int maxConn) {
     for (int[] ints : graph) {
       if (ints != null) {
         assert (ints.length <= maxConn);
@@ -418,7 +418,7 @@ public class TestKnnGraph extends LuceneTestCase {
     }
   }
 
-  private void assertConnected(int[][] graph) {
+  private static void assertConnected(int[][] graph) {
     // every node in the graph is reachable from every other node
     Set<Integer> visited = new HashSet<>();
     List<Integer> queue = new LinkedList<>();

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
@@ -296,8 +296,9 @@ public class KnnGraphTester {
     int min = Integer.MAX_VALUE, max = 0, total = 0;
     int count = 0;
     int[] leafHist = new int[numDocs];
+    knnValues.seekLevel(0);
     for (int node = 0; node < numDocs; node++) {
-      knnValues.seek(0, node);
+      knnValues.seek(node);
       int n = 0;
       while (knnValues.nextNeighbor() != NO_MORE_DOCS) {
         ++n;

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
@@ -253,7 +253,7 @@ public class KnnGraphTester {
     try (BinaryFileVectors vectors = new BinaryFileVectors(docsPath)) {
       RandomAccessVectorValues values = vectors.randomAccess();
       HnswGraphBuilder builder =
-          new HnswGraphBuilder(vectors, SIMILARITY_FUNCTION, maxConn, beamWidth, 0);
+          new HnswGraphBuilder(vectors, SIMILARITY_FUNCTION, maxConn, beamWidth, 0, 0);
       // start at node 1
       for (int i = 1; i < numDocs; i++) {
         builder.addGraphNode(i, values.vectorValue(i));

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHNSWGraph2.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHNSWGraph2.java
@@ -47,7 +47,7 @@ public class TestHNSWGraph2 extends LuceneTestCase {
         VectorSimilarityFunction.values()[
             random().nextInt(VectorSimilarityFunction.values().length - 1) + 1];
     HnswGraphBuilder builder =
-        new HnswGraphBuilder(values, similarityFunction, maxConn, beamWidth, seed, ml);
+        new HnswGraphBuilder(values, similarityFunction, maxConn, beamWidth, ml, seed);
     HnswGraph hnsw = builder.build(values);
     assertConsistentGraph(hnsw, maxConn);
   }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHNSWGraph2.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHNSWGraph2.java
@@ -78,7 +78,7 @@ public class TestHNSWGraph2 extends LuceneTestCase {
       for (int node = hnsw.nextNodeOnLevel();
           node != DocIdSetIterator.NO_MORE_DOCS;
           node = hnsw.nextNodeOnLevel()) {
-        hnsw.seek(level, node);
+        hnsw.seek(node);
         int arc;
         List<Integer> friends = new ArrayList<>();
         while ((arc = hnsw.nextNeighbor()) != NO_MORE_DOCS) {
@@ -104,8 +104,8 @@ public class TestHNSWGraph2 extends LuceneTestCase {
       } else {
         assertFalse("Graph has orphan nodes with no friends on level [" + level + "]", foundOrphan);
         if (maxConn > nodesCount) {
-          // assert that the graph in fully connected, i.e. any node can be reached from any other
-          // node
+          // assert that the graph is fully connected,
+          // i.e. any node can be reached from any other node
           assertConnected(graph);
         } else {
           // assert that max-connections was respected

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHNSWGraph2.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHNSWGraph2.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import static org.apache.lucene.index.TestKnnGraph.assertMaxConn;
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.VectorUtil;
+
+public class TestHNSWGraph2 extends LuceneTestCase {
+
+  // Tests that graph is consistent.
+  public void testGraphConsistent() throws IOException {
+    int dim = random().nextInt(100) + 1;
+    int nDoc = random().nextInt(100) + 1;
+    MockVectorValues values = new MockVectorValues(createRandomVectors(nDoc, dim, random()));
+    int beamWidth = random().nextInt(10) + 5;
+    int maxConn = random().nextInt(10) + 5;
+    double ml = 1 / Math.log(1.0 * maxConn);
+    long seed = random().nextLong();
+    VectorSimilarityFunction similarityFunction =
+        VectorSimilarityFunction.values()[
+            random().nextInt(VectorSimilarityFunction.values().length - 1) + 1];
+    HnswGraphBuilder builder =
+        new HnswGraphBuilder(values, similarityFunction, maxConn, beamWidth, seed, ml);
+    HnswGraph hnsw = builder.build(values);
+    assertConsistentGraph(hnsw, maxConn);
+  }
+
+  /**
+   * For each level of the graph, test that
+   *
+   * <p>1. There are no orphan nodes without any friends
+   *
+   * <p>2. If orphans are found, than the level must contain only 0 or a single node
+   *
+   * <p>3. If the number of nodes on the level doesn't exceed maxConn, assert that the graph is
+   * fully connected, i.e. any node is reachable from any other node.
+   *
+   * <p>4. If the number of nodes on the level exceeds maxConn, assert that maxConn is respected.
+   *
+   * <p>copy from TestKnnGraph::assertConsistentGraph with parts relevant only to in-memory graphs
+   * TODO: remove when hierarchical graph is implemented on disk
+   */
+  private static void assertConsistentGraph(HnswGraph hnsw, int maxConn) {
+    for (int level = hnsw.maxLevel(); level >= 0; level--) {
+      hnsw.seekLevel(level);
+
+      int[][] graph = new int[hnsw.size()][];
+      int nodesCount = 0;
+      boolean foundOrphan = false;
+
+      for (int node = hnsw.nextNodeOnLevel();
+          node != DocIdSetIterator.NO_MORE_DOCS;
+          node = hnsw.nextNodeOnLevel()) {
+        hnsw.seek(level, node);
+        int arc;
+        List<Integer> friends = new ArrayList<>();
+        while ((arc = hnsw.nextNeighbor()) != NO_MORE_DOCS) {
+          friends.add(arc);
+        }
+        if (friends.size() == 0) {
+          foundOrphan = true;
+        } else {
+          int[] friendsCopy = new int[friends.size()];
+          for (int f = 0; f < friends.size(); f++) {
+            friendsCopy[f] = friends.get(f);
+          }
+          graph[node] = friendsCopy;
+        }
+        nodesCount++;
+      }
+      // System.out.println("Level[" + level + "] has [" + nodesCount + "] nodes.");
+
+      assertFalse("No nodes on level [" + level + "]", nodesCount == 0);
+      if (nodesCount == 1) {
+        assertTrue(
+            "Graph with 1 node has unexpected neighbors on level [" + level + "]", foundOrphan);
+      } else {
+        assertFalse("Graph has orphan nodes with no friends on level [" + level + "]", foundOrphan);
+        if (maxConn > nodesCount) {
+          // assert that the graph in fully connected, i.e. any node can be reached from any other
+          // node
+          assertConnected(graph);
+        } else {
+          // assert that max-connections was respected
+          assertMaxConn(graph, maxConn);
+        }
+      }
+    }
+  }
+
+  /** Assert that every node is reachable from some other node */
+  private static void assertConnected(int[][] graph) {
+    List<Integer> nodes = new ArrayList<>();
+    Set<Integer> visited = new HashSet<>();
+    List<Integer> queue = new LinkedList<>();
+    for (int i = 0; i < graph.length; i++) {
+      if (graph[i] != null) {
+        nodes.add(i);
+      }
+    }
+
+    // start from any node
+    int startIdx = random().nextInt(nodes.size());
+    queue.add(nodes.get(startIdx));
+    while (queue.isEmpty() == false) {
+      int i = queue.remove(0);
+      assertNotNull("expected neighbors of " + i, graph[i]);
+      visited.add(i);
+      for (int j : graph[i]) {
+        if (visited.contains(j) == false) {
+          queue.add(j);
+        }
+      }
+    }
+    // assert that every node is reachable from some other node as it was visited
+    for (int node : nodes) {
+      assertTrue(
+          "Attempted to walk entire graph but never visited node [" + node + "]",
+          visited.contains(node));
+    }
+  }
+
+  private static float[][] createRandomVectors(int size, int dim, Random random) {
+    float[][] vectors = new float[size][];
+    for (int offset = 0; offset < size; offset++) {
+      float[] vec = new float[dim];
+      for (int i = 0; i < dim; i++) {
+        vec[i] = random.nextFloat();
+      }
+      VectorUtil.l2normalize(vec);
+      vectors[offset] = vec;
+    }
+    return vectors;
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswGraph.java
@@ -68,7 +68,7 @@ public class TestHnswGraph extends LuceneTestCase {
         VectorSimilarityFunction.values()[
             random().nextInt(VectorSimilarityFunction.values().length - 1) + 1];
     HnswGraphBuilder builder =
-        new HnswGraphBuilder(vectors, similarityFunction, maxConn, beamWidth, seed, 0);
+        new HnswGraphBuilder(vectors, similarityFunction, maxConn, beamWidth, 0, seed);
     HnswGraph hnsw = builder.build(vectors);
 
     // Recreate the graph while indexing with the same random seed and write it out
@@ -140,7 +140,7 @@ public class TestHnswGraph extends LuceneTestCase {
     TestHnswGraph.CircularVectorValues vectors = new TestHnswGraph.CircularVectorValues(nDoc);
     HnswGraphBuilder builder =
         new HnswGraphBuilder(
-            vectors, VectorSimilarityFunction.DOT_PRODUCT, maxConn, 100, random().nextInt(), ml);
+            vectors, VectorSimilarityFunction.DOT_PRODUCT, maxConn, 100, ml, random().nextInt());
     HnswGraph hnsw = builder.build(vectors);
     // run some searches
     NeighborQueue nn =
@@ -182,7 +182,7 @@ public class TestHnswGraph extends LuceneTestCase {
     for (double ml : new double[] {ml1, ml2}) {
       HnswGraphBuilder builder =
           new HnswGraphBuilder(
-              vectors, VectorSimilarityFunction.DOT_PRODUCT, maxConn, 100, random().nextInt(), ml);
+              vectors, VectorSimilarityFunction.DOT_PRODUCT, maxConn, 100, ml, random().nextInt());
       HnswGraph hnsw = builder.build(vectors);
       NeighborQueue nn =
           HnswGraph.search(
@@ -268,7 +268,7 @@ public class TestHnswGraph extends LuceneTestCase {
     // First add nodes until everybody gets a full neighbor list
     HnswGraphBuilder builder =
         new HnswGraphBuilder(
-            vectors, VectorSimilarityFunction.DOT_PRODUCT, 2, 10, random().nextInt(), 0);
+            vectors, VectorSimilarityFunction.DOT_PRODUCT, 2, 10, 0, random().nextInt());
     // node 0 is added by the builder constructor
     // builder.addGraphNode(vectors.vectorValue(0));
     builder.addGraphNode(1, vectors.vectorValue(1));
@@ -325,7 +325,7 @@ public class TestHnswGraph extends LuceneTestCase {
     double ml = 1 / Math.log(1.0 * maxConn);
     HnswGraphBuilder builder =
         new HnswGraphBuilder(
-            vectors, VectorSimilarityFunction.DOT_PRODUCT, maxConn, 10, random().nextInt(), ml);
+            vectors, VectorSimilarityFunction.DOT_PRODUCT, maxConn, 10, ml, random().nextInt());
     // node 0 is added by the builder constructor
     builder.addGraphNodeHNSW(1, vectors.vectorValue(1));
     builder.addGraphNodeHNSW(2, vectors.vectorValue(2));
@@ -393,7 +393,7 @@ public class TestHnswGraph extends LuceneTestCase {
 
     for (double ml : new double[] {ml1, ml2}) {
       HnswGraphBuilder builder =
-          new HnswGraphBuilder(vectors, similarityFunction, maxConn, 30, random().nextLong(), ml);
+          new HnswGraphBuilder(vectors, similarityFunction, maxConn, 30, ml, random().nextLong());
       HnswGraph hnsw = builder.build(vectors);
       Bits acceptOrds = random().nextBoolean() ? null : createRandomAcceptOrds(0, size);
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswGraph.java
@@ -68,7 +68,7 @@ public class TestHnswGraph extends LuceneTestCase {
         VectorSimilarityFunction.values()[
             random().nextInt(VectorSimilarityFunction.values().length - 1) + 1];
     HnswGraphBuilder builder =
-        new HnswGraphBuilder(vectors, similarityFunction, maxConn, beamWidth, seed);
+        new HnswGraphBuilder(vectors, similarityFunction, maxConn, beamWidth, seed, 0);
     HnswGraph hnsw = builder.build(vectors);
 
     // Recreate the graph while indexing with the same random seed and write it out
@@ -125,11 +125,22 @@ public class TestHnswGraph extends LuceneTestCase {
   // ensuring that we have all the distance functions, comparators, priority queues and so on
   // oriented in the right directions
   public void testAknnDiverse() throws IOException {
+    int maxConn = 10;
+    // single level graph
+    double ml = 0;
+    doTestAknnDiverse(maxConn, ml);
+
+    // multi level graph
+    ml = 1 / Math.log(1.0 * maxConn);
+    doTestAknnDiverse(maxConn, ml);
+  }
+
+  private void doTestAknnDiverse(int maxConn, double ml) throws IOException {
     int nDoc = 100;
-    CircularVectorValues vectors = new CircularVectorValues(nDoc);
+    TestHnswGraph.CircularVectorValues vectors = new TestHnswGraph.CircularVectorValues(nDoc);
     HnswGraphBuilder builder =
         new HnswGraphBuilder(
-            vectors, VectorSimilarityFunction.DOT_PRODUCT, 16, 100, random().nextInt());
+            vectors, VectorSimilarityFunction.DOT_PRODUCT, maxConn, 100, random().nextInt(), ml);
     HnswGraph hnsw = builder.build(vectors);
     // run some searches
     NeighborQueue nn =
@@ -146,8 +157,8 @@ public class TestHnswGraph extends LuceneTestCase {
     for (int node : nn.nodes()) {
       sum += node;
     }
-    // We expect to get approximately 100% recall; the lowest docIds are closest to zero; sum(0,9) =
-    // 45
+    // We expect to get approximately 100% recall;
+    // the lowest docIds are closest to zero; sum(0,9) = 45
     assertTrue("sum(result docs)=" + sum, sum < 75);
     for (int i = 0; i < nDoc; i++) {
       NeighborArray neighbors = hnsw.getNeighbors(0, i);
@@ -161,31 +172,36 @@ public class TestHnswGraph extends LuceneTestCase {
 
   public void testSearchWithAcceptOrds() throws IOException {
     int nDoc = 100;
+    int maxConn = 10;
     CircularVectorValues vectors = new CircularVectorValues(nDoc);
-    HnswGraphBuilder builder =
-        new HnswGraphBuilder(
-            vectors, VectorSimilarityFunction.DOT_PRODUCT, 16, 100, random().nextInt());
-    HnswGraph hnsw = builder.build(vectors);
-
     Bits acceptOrds = createRandomAcceptOrds(vectors.size);
-    NeighborQueue nn =
-        HnswGraph.search(
-            new float[] {1, 0},
-            10,
-            5,
-            vectors.randomAccess(),
-            VectorSimilarityFunction.DOT_PRODUCT,
-            hnsw,
-            acceptOrds,
-            random());
-    int sum = 0;
-    for (int node : nn.nodes()) {
-      assertTrue("the results include a deleted document: " + node, acceptOrds.get(node));
-      sum += node;
+
+    double ml1 = 0; // single level graph
+    double ml2 = 1 / Math.log(1.0 * maxConn); // multi level graph
+    for (double ml : new double[] {ml1, ml2}) {
+      HnswGraphBuilder builder =
+          new HnswGraphBuilder(
+              vectors, VectorSimilarityFunction.DOT_PRODUCT, maxConn, 100, random().nextInt(), ml);
+      HnswGraph hnsw = builder.build(vectors);
+      NeighborQueue nn =
+          HnswGraph.search(
+              new float[] {1, 0},
+              10,
+              5,
+              vectors.randomAccess(),
+              VectorSimilarityFunction.DOT_PRODUCT,
+              hnsw,
+              acceptOrds,
+              random());
+      int sum = 0;
+      for (int node : nn.nodes()) {
+        assertTrue("the results include a deleted document: " + node, acceptOrds.get(node));
+        sum += node;
+      }
+      // We expect to get approximately 100% recall;
+      // the lowest docIds are closest to zero; sum(0,9) = 45
+      assertTrue("sum(result docs)=" + sum, sum < 75);
     }
-    // We expect to get approximately 100% recall; the lowest docIds are closest to zero; sum(0,9) =
-    // 45
-    assertTrue("sum(result docs)=" + sum, sum < 75);
   }
 
   public void testBoundsCheckerMax() {
@@ -213,7 +229,7 @@ public class TestHnswGraph extends LuceneTestCase {
   }
 
   public void testHnswGraphBuilderInvalid() {
-    expectThrows(NullPointerException.class, () -> new HnswGraphBuilder(null, null, 0, 0, 0));
+    expectThrows(NullPointerException.class, () -> new HnswGraphBuilder(null, null, 0, 0, 0, 0));
     expectThrows(
         IllegalArgumentException.class,
         () ->
@@ -222,6 +238,7 @@ public class TestHnswGraph extends LuceneTestCase {
                 VectorSimilarityFunction.EUCLIDEAN,
                 0,
                 10,
+                0,
                 0));
     expectThrows(
         IllegalArgumentException.class,
@@ -230,6 +247,7 @@ public class TestHnswGraph extends LuceneTestCase {
                 new RandomVectorValues(1, 1, random()),
                 VectorSimilarityFunction.EUCLIDEAN,
                 10,
+                0,
                 0,
                 0));
   }
@@ -249,7 +267,7 @@ public class TestHnswGraph extends LuceneTestCase {
     // First add nodes until everybody gets a full neighbor list
     HnswGraphBuilder builder =
         new HnswGraphBuilder(
-            vectors, VectorSimilarityFunction.DOT_PRODUCT, 2, 10, random().nextInt());
+            vectors, VectorSimilarityFunction.DOT_PRODUCT, 2, 10, random().nextInt(), 0);
     // node 0 is added by the builder constructor
     // builder.addGraphNode(vectors.vectorValue(0));
     builder.addGraphNode(1, vectors.vectorValue(1));
@@ -289,9 +307,69 @@ public class TestHnswGraph extends LuceneTestCase {
     assertNeighbors(builder.hnsw, 5, 1, 4);
   }
 
+  public void testDiversityHNSW() throws IOException {
+    // Some carefully checked test cases with simple 2d vectors on the unit circle:
+    MockVectorValues vectors =
+        new MockVectorValues(
+            new float[][] {
+              unitVector2d(0.5),
+              unitVector2d(0.75),
+              unitVector2d(0.2),
+              unitVector2d(0.9),
+              unitVector2d(0.8),
+              unitVector2d(0.77),
+            });
+    // First add nodes until everybody gets a full neighbor list
+    int maxConn = 2;
+    double ml = 1 / Math.log(1.0 * maxConn);
+    HnswGraphBuilder builder =
+        new HnswGraphBuilder(
+            vectors, VectorSimilarityFunction.DOT_PRODUCT, maxConn, 10, random().nextInt(), ml);
+    // node 0 is added by the builder constructor
+    builder.addGraphNodeHNSW(1, vectors.vectorValue(1));
+    builder.addGraphNodeHNSW(2, vectors.vectorValue(2));
+    // now every node has tried to attach every other node as a neighbor, but
+    // some were excluded based on diversity check.
+    assertNeighbors(builder.hnsw, 0, 1, 2);
+    assertNeighbors(builder.hnsw, 1, 0);
+    assertNeighbors(builder.hnsw, 2, 0);
+
+    builder.addGraphNodeHNSW(3, vectors.vectorValue(3));
+    assertNeighbors(builder.hnsw, 0, 1, 2);
+    // we added 3 here
+    assertNeighbors(builder.hnsw, 1, 0, 3);
+    assertNeighbors(builder.hnsw, 2, 0);
+    assertNeighbors(builder.hnsw, 3, 1);
+
+    // supplant an existing neighbor
+    builder.addGraphNodeHNSW(4, vectors.vectorValue(4));
+    // 4 is the same distance from 0 that 2 is; we leave the existing node in place
+    assertNeighbors(builder.hnsw, 0, 1, 2);
+    // 4 is closer to 1 than either existing neighbor (0, 3). 3 fails diversity check with 4, so
+    // replace it
+    assertNeighbors(builder.hnsw, 1, 0, 4);
+    assertNeighbors(builder.hnsw, 2, 0);
+    // 1 survives the diversity check
+    assertNeighbors(builder.hnsw, 3, 1, 4);
+    assertNeighbors(builder.hnsw, 4, 1, 3);
+
+    builder.addGraphNodeHNSW(5, vectors.vectorValue(5));
+    assertNeighbors(builder.hnsw, 0, 1, 2);
+    assertNeighbors(builder.hnsw, 1, 0, 5);
+    assertNeighbors(builder.hnsw, 2, 0);
+    // even though 5 is closer, 3 is not a neighbor of 5, so no update to *its* neighbors occurs
+    assertNeighbors(builder.hnsw, 3, 1, 4);
+    assertNeighbors(builder.hnsw, 4, 3, 5);
+    assertNeighbors(builder.hnsw, 5, 1, 4);
+  }
+
   private void assertNeighbors(HnswGraph graph, int node, int... expected) {
+    assertLevelNeighbors(graph, 0, node, expected);
+  }
+
+  private void assertLevelNeighbors(HnswGraph graph, int level, int node, int... expected) {
     Arrays.sort(expected);
-    NeighborArray nn = graph.getNeighbors(0, node);
+    NeighborArray nn = graph.getNeighbors(level, node);
     int[] actual = ArrayUtil.copyOfSubArray(nn.node, 0, nn.size());
     Arrays.sort(actual);
     assertArrayEquals(
@@ -303,37 +381,43 @@ public class TestHnswGraph extends LuceneTestCase {
   public void testRandom() throws IOException {
     int size = atLeast(100);
     int dim = atLeast(10);
-    int topK = 5;
+    int maxConn = 10;
+    double ml1 = 0; // single level graph
+    double ml2 = 1 / Math.log(1.0 * maxConn); // multi level graph
     RandomVectorValues vectors = new RandomVectorValues(size, dim, random());
     VectorSimilarityFunction similarityFunction =
         VectorSimilarityFunction.values()[
             random().nextInt(VectorSimilarityFunction.values().length - 1) + 1];
-    HnswGraphBuilder builder =
-        new HnswGraphBuilder(vectors, similarityFunction, 10, 30, random().nextLong());
-    HnswGraph hnsw = builder.build(vectors);
-    Bits acceptOrds = random().nextBoolean() ? null : createRandomAcceptOrds(size);
+    int topK = 5;
 
-    int totalMatches = 0;
-    for (int i = 0; i < 100; i++) {
-      float[] query = randomVector(random(), dim);
-      NeighborQueue actual =
-          HnswGraph.search(
-              query, topK, 100, vectors, similarityFunction, hnsw, acceptOrds, random());
-      NeighborQueue expected = new NeighborQueue(topK, similarityFunction.reversed);
-      for (int j = 0; j < size; j++) {
-        if (vectors.vectorValue(j) != null && (acceptOrds == null || acceptOrds.get(j))) {
-          expected.add(j, similarityFunction.compare(query, vectors.vectorValue(j)));
-          if (expected.size() > topK) {
-            expected.pop();
+    for (double ml : new double[] {ml1, ml2}) {
+      HnswGraphBuilder builder =
+          new HnswGraphBuilder(vectors, similarityFunction, maxConn, 30, random().nextLong(), ml);
+      HnswGraph hnsw = builder.build(vectors);
+      Bits acceptOrds = random().nextBoolean() ? null : createRandomAcceptOrds(size);
+
+      int totalMatches = 0;
+      for (int i = 0; i < 100; i++) {
+        float[] query = randomVector(random(), dim);
+        NeighborQueue actual =
+            HnswGraph.search(
+                query, topK, 100, vectors, similarityFunction, hnsw, acceptOrds, random());
+        NeighborQueue expected = new NeighborQueue(topK, similarityFunction.reversed);
+        for (int j = 0; j < size; j++) {
+          if (vectors.vectorValue(j) != null && (acceptOrds == null || acceptOrds.get(j))) {
+            expected.add(j, similarityFunction.compare(query, vectors.vectorValue(j)));
+            if (expected.size() > topK) {
+              expected.pop();
+            }
           }
         }
+        assertEquals(topK, actual.size());
+        totalMatches += computeOverlap(actual.nodes(), expected.nodes());
       }
-      assertEquals(topK, actual.size());
-      totalMatches += computeOverlap(actual.nodes(), expected.nodes());
+      double overlap = totalMatches / (double) (100 * topK);
+      System.out.println("overlap=" + overlap + " totalMatches=" + totalMatches);
+      assertTrue("overlap=" + overlap, overlap > 0.9);
     }
-    double overlap = totalMatches / (double) (100 * topK);
-    System.out.println("overlap=" + overlap + " totalMatches=" + totalMatches);
-    assertTrue("overlap=" + overlap, overlap > 0.9);
   }
 
   private int computeOverlap(int[] a, int[] b) {


### PR DESCRIPTION
This patch handles hierarchy in graph construction and search,
but only in memory.

Changes:

- `HnswGraphBuilder` has an extra parameter :`ml` normalization factor for level generation.  When `ml=0`,  the graph will have only a single layer: SNW. When `ml > 0`, the graph will have multiple layers.  
     - The recommended `ml` value from 2018 HNSW paper is : `ml = 1 / Math.log(1.0 * maxConn)`, which was used for tests in `TestHnswGraph` class.
    - When `ml = 0`,  we use the previous code in the method `buildSNW`
    - When `ml > 0`,  the method `buildHNSW` is used, that according the paper, for every new node: generates a random level for this node, and then places the new node in those levels with its connections.
- `HnswGraph`'s `search` method has also been modified to handle two cases:
   - When `ml = 0`,  we use the previous code for a flat graph: generate `boundedNumSeed` number of random entry points, and use them to search a flat graph
   - When `ml > 0`, we use the hierarchical graph: from max level till level 1 using `topK=1`, and on the level 0th using `topK=boundedNumSeed`


Work left for future: handle hierarchy on disk