### PR TITLE
LUCENE-10075: Hotfix for overlapping wildcard-based intervals

### DIFF
--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermIntervals.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermIntervals.java
@@ -51,6 +51,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.uhighlight.UnifiedHighlighter.HighlightFlag;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.LuceneTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -1080,6 +1081,42 @@ public class TestUnifiedHighlighterTermIntervals extends LuceneTestCase {
     assertEquals(1, snippets.length);
     assertEquals("Just a test <b>highlighting</b> from postings. ", snippets[0]);
 
+    ir.close();
+  }
+
+  public void testOverlappingWildcardInterval() throws Exception {
+    String text = "Compare Computer Science";
+
+    RandomIndexWriter iw = new RandomIndexWriter(random(), dir, indexAnalyzer);
+
+    Field body = new Field("body", text, fieldType);
+    Document document = new Document();
+    document.add(body);
+    iw.addDocument(document);
+    IndexReader ir = iw.getReader();
+    iw.close();
+    IndexSearcher searcher = newSearcher(ir);
+    Query query =
+        new IntervalQuery(
+            "body",
+            Intervals.maxgaps(
+                3,
+                Intervals.ordered(
+                    Intervals.wildcard(new BytesRef("comp*")), Intervals.term("science"))));
+    TopDocs topDocs = searcher.search(query, 10);
+    assertEquals(1, topDocs.totalHits.value);
+    UnifiedHighlighter highlighter =
+        new UnifiedHighlighter(searcher, indexAnalyzer) {
+          @Override
+          protected Set<HighlightFlag> getFlags(String field) {
+            Set<HighlightFlag> flags = super.getFlags(field);
+            flags.add(HighlightFlag.WEIGHT_MATCHES);
+            return flags;
+          }
+        };
+
+    String snippets[] = highlighter.highlight("body", query, topDocs, 5);
+    assertEquals(1, snippets.length);
     ir.close();
   }
 }


### PR DESCRIPTION
# Description
Intervals matching iterator with wildcards and gaps for now throws NPE when highlighting overlapping wildcard-based intervals.
Minimal reproducible example is highlighting "Compare Computer Science" by `Intervals.maxgaps(1, Intervals.ordered(Intervals.wildcard(new BytesRef("comp*")), Intervals.term("science")))`;

https://issues.apache.org/jira/browse/LUCENE-10075
# Solution

Proposed hotfix is weird, because it allows incorrect calls to `DisjunctionMatchesIterator`, effectively breaking a contract from javadoc.
But, some implementations return Integer.MAX_VALUE instead of throwing an exception, and at least `CachingMatchesIterator` relies on this behaviour (for example, see `ConjunctionMatchesIterator.endPosition` code and `IntervalIterator.end` javadoc).

I absolutely sure that altering logic in `CachingMatchesIterator` will be the best solution for the issue, but I'm not very familiar with intervals and cannot find yet a good fix for caching logic.

So I think about this PR as an only temporary hotfix that points an issue and somewhat fixes it and I'm not sure that it worth to merge except the new testcase.

# Tests

Added a new testc for interval highlighting based on example from issue.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
