### PR TITLE
LUCENE-10082: add detail to schema inconsistency error messages

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -1336,9 +1336,21 @@ final class IndexingChain implements Accountable {
       this.name = name;
     }
 
-    private void assertSame(boolean same) {
+    private void assertSame(String label, boolean same, Object expected, Object given) {
       if (same == false) {
-        throw new IllegalArgumentException(errMsg + "[" + name + "] of doc [" + docID + "].");
+        throw new IllegalArgumentException(
+            errMsg
+                + "["
+                + name
+                + "] of doc ["
+                + docID
+                + "]. "
+                + label
+                + ": expected '"
+                + expected
+                + "', but it has '"
+                + given
+                + "'.");
       }
     }
 
@@ -1353,10 +1365,13 @@ final class IndexingChain implements Accountable {
         omitNorms = newOmitNorms;
         storeTermVector = newStoreTermVector;
       } else {
+        assertSame("index options", indexOptions == newIndexOptions, indexOptions, newIndexOptions);
+        assertSame("omit norms", omitNorms == newOmitNorms, omitNorms, newOmitNorms);
         assertSame(
-            indexOptions == newIndexOptions
-                && omitNorms == newOmitNorms
-                && storeTermVector == newStoreTermVector);
+            "store term vector",
+            storeTermVector == newStoreTermVector,
+            storeTermVector,
+            newStoreTermVector);
       }
     }
 
@@ -1365,7 +1380,9 @@ final class IndexingChain implements Accountable {
         this.docValuesType = newDocValuesType;
         this.dvGen = newDvGen;
       } else {
-        assertSame(docValuesType == newDocValuesType && dvGen == newDvGen);
+        assertSame(
+            "doc values type", docValuesType == newDocValuesType, docValuesType, newDocValuesType);
+        assertSame("doc values generation", dvGen == newDvGen, dvGen, newDvGen);
       }
     }
 
@@ -1376,9 +1393,16 @@ final class IndexingChain implements Accountable {
         pointNumBytes = numBytes;
       } else {
         assertSame(
-            pointDimensionCount == dimensionCount
-                && pointIndexDimensionCount == indexDimensionCount
-                && pointNumBytes == numBytes);
+            "point dimension",
+            pointDimensionCount == dimensionCount,
+            pointDimensionCount,
+            dimensionCount);
+        assertSame(
+            "point index dimension",
+            pointIndexDimensionCount == indexDimensionCount,
+            pointIndexDimensionCount,
+            indexDimensionCount);
+        assertSame("point num bytes", pointNumBytes == numBytes, pointNumBytes, numBytes);
       }
     }
 
@@ -1387,7 +1411,12 @@ final class IndexingChain implements Accountable {
         this.vectorDimension = dimension;
         this.vectorSimilarityFunction = similarityFunction;
       } else {
-        assertSame(vectorSimilarityFunction == similarityFunction && vectorDimension == dimension);
+        assertSame(
+            "vector similarity function",
+            vectorSimilarityFunction == similarityFunction,
+            vectorSimilarityFunction,
+            similarityFunction);
+        assertSame("vector dimension", vectorDimension == dimension, vectorDimension, dimension);
       }
     }
 
@@ -1407,16 +1436,48 @@ final class IndexingChain implements Accountable {
 
     void assertSameSchema(FieldInfo fi) {
       assertSame(
-          indexOptions == fi.getIndexOptions()
-              && omitNorms == fi.omitsNorms()
-              && storeTermVector == fi.hasVectors()
-              && docValuesType == fi.getDocValuesType()
-              && dvGen == fi.getDocValuesGen()
-              && pointDimensionCount == fi.getPointDimensionCount()
-              && pointIndexDimensionCount == fi.getPointIndexDimensionCount()
-              && pointNumBytes == fi.getPointNumBytes()
-              && vectorDimension == fi.getVectorDimension()
-              && vectorSimilarityFunction == fi.getVectorSimilarityFunction());
+          "index options",
+          indexOptions == fi.getIndexOptions(),
+          fi.getIndexOptions(),
+          indexOptions);
+      assertSame("omit norms", omitNorms == fi.omitsNorms(), fi.omitsNorms(), omitNorms);
+      assertSame(
+          "store term vector",
+          storeTermVector == fi.hasVectors(),
+          fi.hasVectors(),
+          storeTermVector);
+      assertSame(
+          "doc values type",
+          docValuesType == fi.getDocValuesType(),
+          fi.getDocValuesType(),
+          docValuesType);
+      assertSame(
+          "doc values generation", dvGen == fi.getDocValuesGen(), fi.getDocValuesGen(), dvGen);
+      assertSame(
+          "vector similarity function",
+          vectorSimilarityFunction == fi.getVectorSimilarityFunction(),
+          fi.getVectorSimilarityFunction(),
+          vectorSimilarityFunction);
+      assertSame(
+          "vector dimension",
+          vectorDimension == fi.getVectorDimension(),
+          fi.getVectorDimension(),
+          vectorDimension);
+      assertSame(
+          "point dimension",
+          pointDimensionCount == fi.getPointDimensionCount(),
+          fi.getPointDimensionCount(),
+          pointDimensionCount);
+      assertSame(
+          "point index dimension",
+          pointIndexDimensionCount == fi.getPointIndexDimensionCount(),
+          fi.getPointIndexDimensionCount(),
+          pointIndexDimensionCount);
+      assertSame(
+          "point num bytes",
+          pointNumBytes == fi.getPointNumBytes(),
+          fi.getPointNumBytes(),
+          pointNumBytes);
     }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/document/TestPerFieldConsistency.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestPerFieldConsistency.java
@@ -115,7 +115,9 @@ public class TestPerFieldConsistency extends LuceneTestCase {
     }
     IllegalArgumentException exception =
         expectThrows(IllegalArgumentException.class, () -> writer.addDocument(doc));
-    assertTrue(exception.getMessage().contains(errorMsg));
+    assertTrue(
+        "'" + errorMsg + "' not found in '" + exception.getMessage() + "'",
+        exception.getMessage().contains(errorMsg));
   }
 
   private static void doTestDocWithExtraSchemaOptionsThrowsError(
@@ -125,7 +127,9 @@ public class TestPerFieldConsistency extends LuceneTestCase {
     doc.add(extra);
     IllegalArgumentException exception =
         expectThrows(IllegalArgumentException.class, () -> writer.addDocument(doc));
-    assertTrue(exception.getMessage().contains(errorMsg));
+    assertTrue(
+        "'" + errorMsg + "' not found in '" + exception.getMessage() + "'",
+        exception.getMessage().contains(errorMsg));
   }
 
   public void testDocWithMissingSchemaOptionsThrowsError() throws IOException {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexOptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexOptions.java
@@ -52,7 +52,12 @@ public class TestIndexOptions extends LuceneTestCase {
               IllegalArgumentException.class,
               () -> w.addDocument(Collections.singleton(new Field("foo", "bar", ft2))));
       assertEquals(
-          "Inconsistency of field data structures across documents for field [foo] of doc [1].",
+          "Inconsistency of field data structures across documents for field [foo] of doc [1]."
+              + " index options: expected '"
+              + from
+              + "', but it has '"
+              + to
+              + "'.",
           e.getMessage());
     }
     w.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
@@ -2824,7 +2824,11 @@ public class TestIndexSorting extends LuceneTestCase {
         doc.add(dvs.get(j));
         exc = expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
         assertEquals(
-            "Inconsistency of field data structures across documents for field [field] of doc [2].",
+            "Inconsistency of field data structures across documents for field [field] of doc [2]. doc values type: expected '"
+                + dvs.get(i).fieldType().docValuesType()
+                + "', but it has '"
+                + dvs.get(j).fieldType().docValuesType()
+                + "'.",
             exc.getMessage());
         w.rollback();
         IOUtils.close(w);

--- a/lucene/core/src/test/org/apache/lucene/index/TestPointValues.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPointValues.java
@@ -74,7 +74,8 @@ public class TestPointValues extends LuceneTestCase {
               w.addDocument(doc);
             });
     assertEquals(
-        "Inconsistency of field data structures across documents for field [dim] of doc [0].",
+        "Inconsistency of field data structures across documents for field [dim] of doc [0]."
+            + " point dimension: expected '1', but it has '2'.",
         expected.getMessage());
     w.close();
     dir.close();
@@ -97,7 +98,8 @@ public class TestPointValues extends LuceneTestCase {
               w.addDocument(doc2);
             });
     assertEquals(
-        "Inconsistency of field data structures across documents for field [dim] of doc [1].",
+        "Inconsistency of field data structures across documents for field [dim] of doc [1]."
+            + " point dimension: expected '1', but it has '2'.",
         expected.getMessage());
     w.close();
     dir.close();
@@ -254,7 +256,8 @@ public class TestPointValues extends LuceneTestCase {
               w.addDocument(doc);
             });
     assertEquals(
-        "Inconsistency of field data structures across documents for field [dim] of doc [0].",
+        "Inconsistency of field data structures across documents for field [dim] of doc [0]."
+            + " point num bytes: expected '4', but it has '6'.",
         expected.getMessage());
     w.close();
     dir.close();
@@ -277,7 +280,8 @@ public class TestPointValues extends LuceneTestCase {
               w.addDocument(doc2);
             });
     assertEquals(
-        "Inconsistency of field data structures across documents for field [dim] of doc [1].",
+        "Inconsistency of field data structures across documents for field [dim] of doc [1]."
+            + " point num bytes: expected '4', but it has '6'.",
         expected.getMessage());
     w.close();
     dir.close();

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseKnnVectorsFormatTestCase.java
@@ -100,7 +100,8 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc2));
       String errMsg =
-          "Inconsistency of field data structures across documents for field [f] of doc [1].";
+          "Inconsistency of field data structures across documents for field [f] of doc [1]."
+              + " vector dimension: expected '4', but it has '3'.";
       assertEquals(errMsg, expected.getMessage());
     }
 
@@ -136,7 +137,8 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc2));
       String errMsg =
-          "Inconsistency of field data structures across documents for field [f] of doc [1].";
+          "Inconsistency of field data structures across documents for field [f] of doc [1]."
+              + " vector similarity function: expected 'DOT_PRODUCT', but it has 'EUCLIDEAN'.";
       assertEquals(errMsg, expected.getMessage());
     }
 


### PR DESCRIPTION
Adds details about which indexing "feature" was inconsistent to the exception thrown when IndexingChain discovers inconsistent field types.