### PR TITLE
LUCENE-9662: fix test failure from merging away soft-deletes

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.lucene.analysis.CannedTokenStream;
 import org.apache.lucene.analysis.Token;
 import org.apache.lucene.document.*;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.Directory;
@@ -70,10 +71,14 @@ public class TestCheckIndex extends BaseTestCheckIndex {
   public void testCheckIndexAllValid() throws Exception {
     try (Directory dir = newDirectory()) {
       int liveDocCount = 1 + random().nextInt(10);
-      IndexWriterConfig conifg = newIndexWriterConfig();
-      conifg.setIndexSort(new Sort(new SortField("sort_field", SortField.Type.INT, true)));
-      conifg.setSoftDeletesField("soft_delete");
-      try (IndexWriter w = new IndexWriter(dir, conifg)) {
+      IndexWriterConfig config = newIndexWriterConfig();
+      config.setIndexSort(new Sort(new SortField("sort_field", SortField.Type.INT, true)));
+      config.setSoftDeletesField("soft_delete");
+      // preserves soft-deletes across merges
+      config.setMergePolicy(
+          new SoftDeletesRetentionMergePolicy(
+              "soft_delete", MatchAllDocsQuery::new, config.getMergePolicy()));
+      try (IndexWriter w = new IndexWriter(dir, config)) {
         for (int i = 0; i < liveDocCount; i++) {
           Document doc = new Document();
 


### PR DESCRIPTION
# Description

Fix test failure from merging away soft-deletes

# Tests

Passed the previously failed test: `./gradlew test --tests=TestCheckIndex -Ptests.seed=9A1EDD2CC45CBE0A`

Passed `./gradlew clean; ./gradlew check -Ptests.nightly=true -Pvalidation.git.failOnModified=false`

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
