### PR TITLE
LUCENE-9662: Update concurrent index checking usage instructions

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -3984,7 +3984,7 @@ public final class CheckIndex implements Closeable {
     if (opts.indexPath == null) {
       throw new IllegalArgumentException(
           "\nERROR: index path not specified"
-              + "\nUsage: java org.apache.lucene.index.CheckIndex pathToIndex [-exorcise] [-slow] [-segment X] [-segment Y] [-dir-impl X]\n"
+              + "\nUsage: java org.apache.lucene.index.CheckIndex pathToIndex [-exorcise] [-slow] [-segment X] [-segment Y] [-threadCount X] [-dir-impl X]\n"
               + "\n"
               + "  -exorcise: actually write a new segments_N file, removing any problematic segments\n"
               + "  -fast: just verify file checksums, omitting logical integrity checks\n"
@@ -3994,6 +3994,9 @@ public final class CheckIndex implements Closeable {
               + "  -segment X: only check the specified segments.  This can be specified multiple\n"
               + "              times, to check more than one segment, eg '-segment _2 -segment _a'.\n"
               + "              You can't use this with the -exorcise option\n"
+              + "  -threadCount X: number of new threads created and used to check index concurrently.\n"
+              + "                  When not specified, this will default to the number of CPU cores up to 4.\n"
+              + "                  When '-threadCount 1' is used, index checking will be performed sequentially.\n"
               + "  -dir-impl X: use a specific "
               + FSDirectory.class.getSimpleName()
               + " implementation. "

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -489,8 +489,7 @@ public final class CheckIndex implements Closeable {
     threadCount = tc;
   }
 
-  // capped threadCount at 4 for default
-  private int threadCount = Math.min(Runtime.getRuntime().availableProcessors(), 4);
+  private int threadCount = Runtime.getRuntime().availableProcessors();
 
   /**
    * Set infoStream where messages should go. If null, no messages are printed. If verbose is true
@@ -3994,8 +3993,8 @@ public final class CheckIndex implements Closeable {
               + "  -segment X: only check the specified segments.  This can be specified multiple\n"
               + "              times, to check more than one segment, eg '-segment _2 -segment _a'.\n"
               + "              You can't use this with the -exorcise option\n"
-              + "  -threadCount X: number of new threads created and used to check index concurrently.\n"
-              + "                  When not specified, this will default to the number of CPU cores up to 4.\n"
+              + "  -threadCount X: number of threads used to check index concurrently.\n"
+              + "                  When not specified, this will default to the number of CPU cores.\n"
               + "                  When '-threadCount 1' is used, index checking will be performed sequentially.\n"
               + "  -dir-impl X: use a specific "
               + FSDirectory.class.getSimpleName()


### PR DESCRIPTION

# Description

Update concurrent index checking usage instructions

# Sample output

```
> Task :lucene:core:CheckIndex.main() FAILED

ERROR: index path not specified
Usage: java org.apache.lucene.index.CheckIndex pathToIndex [-exorcise] [-slow] [-segment X] [-segment Y] [-threadCount X] [-dir-impl X]

  -exorcise: actually write a new segments_N file, removing any problematic segments
  -fast: just verify file checksums, omitting logical integrity checks
  -slow: do additional slow checks; THIS IS VERY SLOW!
  -codec X: when exorcising, codec to write the new segments_N file with
  -verbose: print additional details
  -segment X: only check the specified segments.  This can be specified multiple
              times, to check more than one segment, eg '-segment _2 -segment _a'.
              You can't use this with the -exorcise option
  -threadCount X: number of new threads created and used to check index concurrently.
                  When not specified, this will default to the number of CPU cores up to 4.
                  When '-threadCount 1' is used, index checking will be performed sequentially.
  -dir-impl X: use a specific FSDirectory implementation. If no package is specified the org.apache.lucene.store package will be used.

**WARNING**: -exorcise *LOSES DATA*. This should only be used on an emergency basis as it will cause
documents (perhaps many) to be permanently removed from the index.  Always make
a backup copy of your index before running this!  Do not run this tool on an index
that is actively being written to.  You have been warned!

Run without -exorcise, this tool will open the index, report version information
and report any exceptions it hits and what action it would take if -exorcise were
specified.  With -exorcise, this tool will remove any segments that have issues and
write a new segments_N file.  This means all documents contained in the affected
segments will be removed.

This tool exits with exit code 1 if the index cannot be opened or has any
corruption, else 0.
```

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
