### PR TITLE
LUCENE-10059: Additional fix to handle n_best backtrace

### DIFF
--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseTokenizer.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseTokenizer.java
@@ -1021,6 +1021,11 @@ public final class JapaneseTokenizer extends Tokenizer {
     if (pos > 0) {
 
       final Position endPosData = positions.get(pos);
+      if (endPosData.pos == lastBackTracePos) {
+        // no more characters after the last backtrace; return no tokens!
+        return;
+      }
+
       int leastCost = Integer.MAX_VALUE;
       int leastIDX = -1;
       if (VERBOSE) {
@@ -1764,15 +1769,6 @@ public final class JapaneseTokenizer extends Tokenizer {
   // (last token should be returned first).
   private void backtrace(final Position endPosData, final int fromIDX) throws IOException {
     final int endPos = endPosData.pos;
-
-    /**
-     * LUCENE-10059: If the endPos is the same as lastBackTracePos, we don't want to backtrace to
-     * avoid an assertion error {@link RollingCharBuffer#get(int)} when it tries to generate an
-     * empty buffer
-     */
-    if (endPos == lastBackTracePos) {
-      return;
-    }
 
     if (VERBOSE) {
       System.out.println(

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseTokenizer.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseTokenizer.java
@@ -910,5 +910,10 @@ public class TestJapaneseTokenizer extends BaseTokenStreamTestCase {
     outputs.add("手紙");
 
     assertAnalyzesTo(analyzer, text, outputs.toArray(new String[0]));
+    try (TokenStream ts = analyzerNormalNBest.tokenStream("", text)) {
+      ts.reset();
+      while (ts.incrementToken()) {}
+      ts.end();
+    }
   }
 }


### PR DESCRIPTION
This commit handles possible empty backtrace when using the nbest option.
The general case (best path) was fixed in a previous commit so this change
is a follow up to handle all cases.