### PR TITLE
LUCENE-10086:  Fix an AssertionError when KoreanTokenizer tries to backtrace from and to the same position

### DIFF
--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizer.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizer.java
@@ -936,6 +936,11 @@ public final class KoreanTokenizer extends Tokenizer {
     if (pos > 0) {
 
       final Position endPosData = positions.get(pos);
+      if (endPosData.pos == lastBackTracePos) {
+        // no more characters after the last backtrace; return no tokens!
+        return;
+      }
+
       int leastCost = Integer.MAX_VALUE;
       int leastIDX = -1;
       if (VERBOSE) {
@@ -963,6 +968,11 @@ public final class KoreanTokenizer extends Tokenizer {
   // (last token should be returned first).
   private void backtrace(final Position endPosData, final int fromIDX) {
     final int endPos = endPosData.pos;
+
+    // empty backtrace
+    if (endPos == lastBackTracePos) {
+      return;
+    }
 
     if (VERBOSE) {
       System.out.println(

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.BaseTokenStreamTestCase;
@@ -591,6 +593,29 @@ public class TestKoreanTokenizer extends BaseTokenStreamTestCase {
         new POS.Tag[] {POS.Tag.SL},
         new POS.Tag[] {POS.Tag.SL});
   }
+
+    public void testEmptyBacktrace() throws IOException {
+        String text = "";
+
+        // since the max backtrace gap ({@link KoreanTokenizer#MAX_BACKTRACE_GAP)
+        // is set to 1024, we want the first 1023 characters to generate multiple paths
+        // so that the regular backtrace is not executed.
+        for (int i = 0; i < 1023; i++) {
+            text += "끙";
+        }
+
+        // and the last 2 characters to be a valid word so that they
+        // will end-up together
+        text += "언어";
+
+        List<String> outputs = new ArrayList<>();
+        outputs.add("끙");
+        for (int i = 0; i < 511; i++) {
+            outputs.add("끙끙");
+        }
+        outputs.add("언어");
+        assertAnalyzesTo(analyzer, text, outputs.toArray(new String[0]));
+    }
 
   private void assertReadings(Analyzer analyzer, String input, String... readings)
       throws IOException {

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
@@ -595,26 +595,26 @@ public class TestKoreanTokenizer extends BaseTokenStreamTestCase {
   }
 
     public void testEmptyBacktrace() throws IOException {
-        String text = "";
+      String text = "";
 
-        // since the max backtrace gap ({@link KoreanTokenizer#MAX_BACKTRACE_GAP)
-        // is set to 1024, we want the first 1023 characters to generate multiple paths
-        // so that the regular backtrace is not executed.
-        for (int i = 0; i < 1023; i++) {
-            text += "끙";
-        }
+      // since the max backtrace gap ({@link KoreanTokenizer#MAX_BACKTRACE_GAP
+      // is set to 1024, we want the first 1023 characters to generate multiple paths
+      // so that the regular backtrace is not executed.
+      for (int i = 0; i < 1023; i++) {
+        text += "끙";
+      }
 
-        // and the last 2 characters to be a valid word so that they
-        // will end-up together
-        text += "언어";
+      // and the last 2 characters to be a valid word so that they
+      // will end-up together
+      text += "언어";
 
-        List<String> outputs = new ArrayList<>();
-        outputs.add("끙");
-        for (int i = 0; i < 511; i++) {
-            outputs.add("끙끙");
-        }
-        outputs.add("언어");
-        assertAnalyzesTo(analyzer, text, outputs.toArray(new String[0]));
+      List<String> outputs = new ArrayList<>();
+      outputs.add("끙");
+      for (int i = 0; i < 511; i++) {
+        outputs.add("끙끙");
+      }
+      outputs.add("언어");
+      assertAnalyzesTo(analyzer, text, outputs.toArray(new String[0]));
     }
 
   private void assertReadings(Analyzer analyzer, String input, String... readings)

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
@@ -594,28 +594,28 @@ public class TestKoreanTokenizer extends BaseTokenStreamTestCase {
         new POS.Tag[] {POS.Tag.SL});
   }
 
-    public void testEmptyBacktrace() throws IOException {
-      String text = "";
+  public void testEmptyBacktrace() throws IOException {
+    String text = "";
 
-      // since the max backtrace gap ({@link KoreanTokenizer#MAX_BACKTRACE_GAP
-      // is set to 1024, we want the first 1023 characters to generate multiple paths
-      // so that the regular backtrace is not executed.
-      for (int i = 0; i < 1023; i++) {
-        text += "끙";
-      }
-
-      // and the last 2 characters to be a valid word so that they
-      // will end-up together
-      text += "언어";
-
-      List<String> outputs = new ArrayList<>();
-      outputs.add("끙");
-      for (int i = 0; i < 511; i++) {
-        outputs.add("끙끙");
-      }
-      outputs.add("언어");
-      assertAnalyzesTo(analyzer, text, outputs.toArray(new String[0]));
+    // since the max backtrace gap ({@link KoreanTokenizer#MAX_BACKTRACE_GAP
+    // is set to 1024, we want the first 1023 characters to generate multiple paths
+    // so that the regular backtrace is not executed.
+    for (int i = 0; i < 1023; i++) {
+      text += "끙";
     }
+
+    // and the last 2 characters to be a valid word so that they
+    // will end-up together
+    text += "언어";
+
+    List<String> outputs = new ArrayList<>();
+    outputs.add("끙");
+    for (int i = 0; i < 511; i++) {
+      outputs.add("끙끙");
+    }
+    outputs.add("언어");
+    assertAnalyzesTo(analyzer, text, outputs.toArray(new String[0]));
+  }
 
   private void assertReadings(Analyzer analyzer, String input, String... readings)
       throws IOException {


### PR DESCRIPTION
This change is a follow up of https://issues.apache.org/jira/browse/LUCENE-10059 for the Korean tokenizer.

#11124