### PR TITLE
LUCENE-10089 Disable numeric sort optim when needed

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -141,8 +141,9 @@ API Changes
   The Weight#count API represents a cleaner way for Query classes to optimize their counting method.
   (Gautam Worah, Adrien Grand)
 
-* LUCENE-10089 Add a method to SortField that allows to disable numeric sort optimization, which is
-  enabled by default from 9.0 (Mayya Sharipova, Adrien Grand)
+* LUCENE-10089 Add a method to SortField that allows to disable numeric sort
+  optimization to use the points index to skip over non-competitive documents,
+  which is enabled by default from 9.0 (Mayya Sharipova, Adrien Grand)
 
 Improvements
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -141,7 +141,7 @@ API Changes
   The Weight#count API represents a cleaner way for Query classes to optimize their counting method.
   (Gautam Worah, Adrien Grand)
 
-* LUCENE-10089 Add a method to SortField that allows to disable numeric sort
+* LUCENE-10089: Add a method to SortField that allows to disable numeric sort
   optimization to use the points index to skip over non-competitive documents,
   which is enabled by default from 9.0 (Mayya Sharipova, Adrien Grand)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -141,6 +141,9 @@ API Changes
   The Weight#count API represents a cleaner way for Query classes to optimize their counting method.
   (Gautam Worah, Adrien Grand)
 
+* LUCENE-10089 Add a method to SortField that allows to disable numeric sort optimization, which is
+  enabled by default from 9.0 (Mayya Sharipova, Adrien Grand)
+
 Improvements
 
 * LUCENE-9960: Avoid unnecessary top element replacement for equal elements in PriorityQueue. (Dawid Weiss)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -141,7 +141,7 @@ API Changes
   The Weight#count API represents a cleaner way for Query classes to optimize their counting method.
   (Gautam Worah, Adrien Grand)
 
-* LUCENE-10089: Add a method to SortField that allows to disable numeric sort
+* LUCENE-10089: Add a method to SortField that allows to enable or disable numeric sort
   optimization to use the points index to skip over non-competitive documents,
   which is enabled by default from 9.0 (Mayya Sharipova, Adrien Grand)
 

--- a/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
@@ -135,6 +135,7 @@ public abstract class FieldValueHitQueue<T extends FieldValueHitQueue.Entry>
       SortField field = fields[i];
       reverseMul[i] = field.reverse ? -1 : 1;
       comparators[i] = field.getComparator(size, i);
+      if (field.sortOptimizationDisabled()) comparators[i].disableSkipping();
     }
     if (numComparators == 1) {
       // inform a comparator that sort is based on this single field

--- a/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
@@ -135,7 +135,7 @@ public abstract class FieldValueHitQueue<T extends FieldValueHitQueue.Entry>
       SortField field = fields[i];
       reverseMul[i] = field.reverse ? -1 : 1;
       comparators[i] = field.getComparator(size, i);
-      if (field.pointSortOptimizationDisabled()) comparators[i].disableSkipping();
+      if (field.getOptimizeSortWithPoints() == false) comparators[i].disableSkipping();
     }
     if (numComparators == 1) {
       // inform a comparator that sort is based on this single field

--- a/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
@@ -135,7 +135,7 @@ public abstract class FieldValueHitQueue<T extends FieldValueHitQueue.Entry>
       SortField field = fields[i];
       reverseMul[i] = field.reverse ? -1 : 1;
       comparators[i] = field.getComparator(size, i);
-      if (field.sortOptimizationDisabled()) comparators[i].disableSkipping();
+      if (field.pointSortOptimizationDisabled()) comparators[i].disableSkipping();
     }
     if (numComparators == 1) {
       // inform a comparator that sort is based on this single field

--- a/lucene/core/src/java/org/apache/lucene/search/SortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortField.java
@@ -131,7 +131,7 @@ public class SortField {
   protected Object missingValue = null;
 
   // Indicates if numeric sort optimization is disabled. Enabled by default.
-  private boolean sortOptimizationDisabled = false;
+  private boolean pointSortOptimizationDisabled = false;
 
   /**
    * Creates a sort by terms in the given field with the type of term values explicitly given.
@@ -611,18 +611,24 @@ public class SortField {
   }
 
   /**
-   * Disable numeric sort optimization. By default sorting on a numeric field activates sort
-   * optimization that can efficiently skip non-competitive hits. Sort optimization has a number of
-   * requirements, one of which is that SortField.Type matches the Point type with which the field
-   * was indexed (e.g. sort on IntPoint field should use SortField.Type.INT).
+   * Disable numeric sort optimization to use the Points index to skip over non-competitive
+   * documents. By default sorting on a numeric field activates point sort optimization that can
+   * efficiently skip non-competitive hits. Sort optimization has a number of requirements, one of
+   * which is that SortField.Type matches the Point type with which the field was indexed (e.g. sort
+   * on IntPoint field should use SortField.Type.INT). Another requirement is that the same data is
+   * indexed with points and doc values for the field.
    *
    * <p>This allows to disable sort optimization, in cases where these requirements can't be met.
+   *
+   * @deprecated should only be used for compatibility with 8.x indices that got created with
+   *     inconsistent data across fields, or the wrong sort configuration in the index sort
    */
-  public void disableSortOptimization() {
-    this.sortOptimizationDisabled = true;
+  @Deprecated // Remove in Lucene 9
+  public void disablePointSortOptimization() {
+    this.pointSortOptimizationDisabled = true;
   }
 
-  protected boolean sortOptimizationDisabled() {
-    return sortOptimizationDisabled;
+  protected boolean pointSortOptimizationDisabled() {
+    return pointSortOptimizationDisabled;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/SortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortField.java
@@ -130,6 +130,9 @@ public class SortField {
   // Used for 'sortMissingFirst/Last'
   protected Object missingValue = null;
 
+  // Indicates if numeric sort optimization is disabled. Enabled by default.
+  private boolean sortOptimizationDisabled = false;
+
   /**
    * Creates a sort by terms in the given field with the type of term values explicitly given.
    *
@@ -605,5 +608,21 @@ public class SortField {
       default:
         return null;
     }
+  }
+
+  /**
+   * Disable numeric sort optimization. By default sorting on a numeric field activates sort
+   * optimization that can efficiently skip non-competitive hits. Sort optimization has a number of
+   * requirements, one of which is that SortField.Type matches the Point type with which the field
+   * was indexed (e.g. sort on IntPoint field should use SortField.Type.INT).
+   *
+   * <p>This allows to disable sort optimization, in cases where these requirements can't be met.
+   */
+  public void disableSortOptimization() {
+    this.sortOptimizationDisabled = true;
+  }
+
+  protected boolean sortOptimizationDisabled() {
+    return sortOptimizationDisabled;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/SortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortField.java
@@ -130,8 +130,8 @@ public class SortField {
   // Used for 'sortMissingFirst/Last'
   protected Object missingValue = null;
 
-  // Indicates if numeric sort optimization is disabled. Enabled by default.
-  private boolean pointSortOptimizationDisabled = false;
+  // Indicates if numeric sort should be optimized with Points index. Set to true by default.
+  @Deprecated private boolean optimizeSortWithPoints = true;
 
   /**
    * Creates a sort by terms in the given field with the type of term values explicitly given.
@@ -623,12 +623,18 @@ public class SortField {
    * @deprecated should only be used for compatibility with 8.x indices that got created with
    *     inconsistent data across fields, or the wrong sort configuration in the index sort
    */
-  @Deprecated // Remove in Lucene 9
-  public void disablePointSortOptimization() {
-    this.pointSortOptimizationDisabled = true;
+  @Deprecated // Remove in Lucene 10
+  public void disableSortOptimizationWithPoints() {
+    this.optimizeSortWithPoints = false;
   }
 
-  protected boolean pointSortOptimizationDisabled() {
-    return pointSortOptimizationDisabled;
+  /**
+   * Returns whether sort optimization should be optimized with points index
+   *
+   * @return whether sort optimization should be optimized with points index
+   */
+  @Deprecated // Remove in Lucene 10
+  public boolean getOptimizeSortWithPoints() {
+    return optimizeSortWithPoints;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/SortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortField.java
@@ -611,21 +611,22 @@ public class SortField {
   }
 
   /**
-   * Disable numeric sort optimization to use the Points index to skip over non-competitive
-   * documents. By default sorting on a numeric field activates point sort optimization that can
-   * efficiently skip non-competitive hits. Sort optimization has a number of requirements, one of
-   * which is that SortField.Type matches the Point type with which the field was indexed (e.g. sort
-   * on IntPoint field should use SortField.Type.INT). Another requirement is that the same data is
-   * indexed with points and doc values for the field.
+   * Enables/disables numeric sort optimization to use the Points index.
    *
-   * <p>This allows to disable sort optimization, in cases where these requirements can't be met.
+   * <p>Enabled by default. By default, sorting on a numeric field activates point sort optimization
+   * that can efficiently skip over non-competitive hits. Sort optimization has a number of
+   * requirements, one of which is that SortField.Type matches the Point type with which the field
+   * was indexed (e.g. sort on IntPoint field should use SortField.Type.INT). Another requirement is
+   * that the same data is indexed with points and doc values for the field.
    *
+   * @param optimizeSortWithPoints providing {@code false} disables the optimization, in cases where
+   *     these requirements can't be met.
    * @deprecated should only be used for compatibility with 8.x indices that got created with
    *     inconsistent data across fields, or the wrong sort configuration in the index sort
    */
   @Deprecated // Remove in Lucene 10
-  public void disableSortOptimizationWithPoints() {
-    this.optimizeSortWithPoints = false;
+  public void setOptimizeSortWithPoints(boolean optimizeSortWithPoints) {
+    this.optimizeSortWithPoints = optimizeSortWithPoints;
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -611,7 +611,7 @@ public class TestSortOptimization extends LuceneTestCase {
         IllegalArgumentException.class,
         () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(longSortOnIntField)));
     // assert that when sort optimization is disabled we can use LONG sort on int field
-    longSortOnIntField.disableSortOptimizationWithPoints();
+    longSortOnIntField.setOptimizeSortWithPoints(false);
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(longSortOnIntField));
 
     SortField intSortOnLongField = new SortField("longField", SortField.Type.INT);
@@ -619,7 +619,7 @@ public class TestSortOptimization extends LuceneTestCase {
         IllegalArgumentException.class,
         () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnLongField)));
     // assert that when sort optimization is disabled we can use INT sort on long field
-    intSortOnLongField.disableSortOptimizationWithPoints();
+    intSortOnLongField.setOptimizeSortWithPoints(false);
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnLongField));
 
     SortField intSortOnIntRangeField = new SortField("intRange", SortField.Type.INT);
@@ -627,7 +627,7 @@ public class TestSortOptimization extends LuceneTestCase {
         IllegalArgumentException.class,
         () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnIntRangeField)));
     // assert that when sort optimization is disabled we can use INT sort on intRange field
-    intSortOnIntRangeField.disableSortOptimizationWithPoints();
+    intSortOnIntRangeField.setOptimizeSortWithPoints(false);
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnIntRangeField));
 
     reader.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -611,7 +611,7 @@ public class TestSortOptimization extends LuceneTestCase {
         IllegalArgumentException.class,
         () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(longSortOnIntField)));
     // assert that when sort optimization is disabled we can use LONG sort on int field
-    longSortOnIntField.disableSortOptimization();
+    longSortOnIntField.disablePointSortOptimization();
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(longSortOnIntField));
 
     SortField intSortOnLongField = new SortField("longField", SortField.Type.INT);
@@ -619,7 +619,7 @@ public class TestSortOptimization extends LuceneTestCase {
         IllegalArgumentException.class,
         () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnLongField)));
     // assert that when sort optimization is disabled we can use INT sort on long field
-    intSortOnLongField.disableSortOptimization();
+    intSortOnLongField.disablePointSortOptimization();
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnLongField));
 
     SortField intSortOnIntRangeField = new SortField("intRange", SortField.Type.INT);
@@ -627,7 +627,7 @@ public class TestSortOptimization extends LuceneTestCase {
         IllegalArgumentException.class,
         () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnIntRangeField)));
     // assert that when sort optimization is disabled we can use INT sort on intRange field
-    intSortOnIntRangeField.disableSortOptimization();
+    intSortOnIntRangeField.disablePointSortOptimization();
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnIntRangeField));
 
     reader.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -605,27 +605,30 @@ public class TestSortOptimization extends LuceneTestCase {
     writer.close();
 
     IndexSearcher searcher = newSearcher(reader);
+
+    SortField longSortOnIntField = new SortField("intField", SortField.Type.LONG);
     assertThrows(
         IllegalArgumentException.class,
-        () ->
-            searcher.search(
-                new MatchAllDocsQuery(),
-                1,
-                new Sort(new SortField("intField", SortField.Type.LONG))));
+        () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(longSortOnIntField)));
+    // assert that when sort optimization is disabled we can use LONG sort on int field
+    longSortOnIntField.disableSortOptimization();
+    searcher.search(new MatchAllDocsQuery(), 1, new Sort(longSortOnIntField));
+
+    SortField intSortOnLongField = new SortField("longField", SortField.Type.INT);
     assertThrows(
         IllegalArgumentException.class,
-        () ->
-            searcher.search(
-                new MatchAllDocsQuery(),
-                1,
-                new Sort(new SortField("longField", SortField.Type.INT))));
+        () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnLongField)));
+    // assert that when sort optimization is disabled we can use INT sort on long field
+    intSortOnLongField.disableSortOptimization();
+    searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnLongField));
+
+    SortField intSortOnIntRangeField = new SortField("intRange", SortField.Type.INT);
     assertThrows(
         IllegalArgumentException.class,
-        () ->
-            searcher.search(
-                new MatchAllDocsQuery(),
-                1,
-                new Sort(new SortField("intRange", SortField.Type.INT))));
+        () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnIntRangeField)));
+    // assert that when sort optimization is disabled we can use INT sort on intRange field
+    intSortOnIntRangeField.disableSortOptimization();
+    searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnIntRangeField));
 
     reader.close();
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -611,7 +611,7 @@ public class TestSortOptimization extends LuceneTestCase {
         IllegalArgumentException.class,
         () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(longSortOnIntField)));
     // assert that when sort optimization is disabled we can use LONG sort on int field
-    longSortOnIntField.disablePointSortOptimization();
+    longSortOnIntField.disableSortOptimizationWithPoints();
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(longSortOnIntField));
 
     SortField intSortOnLongField = new SortField("longField", SortField.Type.INT);
@@ -619,7 +619,7 @@ public class TestSortOptimization extends LuceneTestCase {
         IllegalArgumentException.class,
         () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnLongField)));
     // assert that when sort optimization is disabled we can use INT sort on long field
-    intSortOnLongField.disablePointSortOptimization();
+    intSortOnLongField.disableSortOptimizationWithPoints();
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnLongField));
 
     SortField intSortOnIntRangeField = new SortField("intRange", SortField.Type.INT);
@@ -627,7 +627,7 @@ public class TestSortOptimization extends LuceneTestCase {
         IllegalArgumentException.class,
         () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnIntRangeField)));
     // assert that when sort optimization is disabled we can use INT sort on intRange field
-    intSortOnIntRangeField.disablePointSortOptimization();
+    intSortOnIntRangeField.disableSortOptimizationWithPoints();
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnIntRangeField));
 
     reader.close();


### PR DESCRIPTION
Add a method to SortField that allows to disable numeric sort optimization,
which is enabled by default from 9.0.