### PR TITLE
Optimize storage of neighbours on level > 0

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -481,10 +481,7 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
     }
 
     @Override
-    public void seekLevel(int level) throws IOException {}
-
-    @Override
-    public void seek(int targetOrd) throws IOException {
+    public void seek(int level, int targetOrd) throws IOException {
       // unsafe; no bounds checking
       dataIn.seek(entry.ordOffsets[targetOrd]);
       arcCount = dataIn.readInt();

--- a/lucene/core/src/java/org/apache/lucene/index/KnnGraphValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/KnnGraphValues.java
@@ -32,28 +32,21 @@ public abstract class KnnGraphValues {
   protected KnnGraphValues() {}
 
   /**
-   * Positions the graph on the given {@code level}. After this method returns, call {@link
-   * #seek(int)} to position the graph on a specific node of the current level.
-   *
-   * @param level level of the graph
-   */
-  public abstract void seekLevel(int level) throws IOException;
-
-  /**
-   * Move the pointer to exactly {@code target}, the id of a node in the graph. After this method
+   * Move the pointer to exactly the given {@code level}'s {@code target}. After this method
    * returns, call {@link #nextNeighbor()} to return successive (ordered) connected node ordinals.
    *
-   * @param target must be a valid node in the graph, ie. &ge; 0 and &lt; {@link
+   * @param level level of the graph
+   * @param target ordinal of a node in the graph, must be &ge; 0 and &lt; {@link
    *     VectorValues#size()}.
    */
-  public abstract void seek(int target) throws IOException;
+  public abstract void seek(int level, int target) throws IOException;
 
   /** Returns the number of nodes in the graph */
   public abstract int size();
 
   /**
    * Iterates over the neighbor list. It is illegal to call this method after it returns
-   * NO_MORE_DOCS without calling {@link #seek(int)}, which resets the iterator.
+   * NO_MORE_DOCS without calling {@link #seek(int, int)}, which resets the iterator.
    *
    * @return a node ordinal in the graph, or NO_MORE_DOCS if the iteration is complete.
    */
@@ -75,10 +68,7 @@ public abstract class KnnGraphValues {
         }
 
         @Override
-        public void seekLevel(int level) {}
-
-        @Override
-        public void seek(int target) {}
+        public void seek(int level, int target) {}
 
         @Override
         public int size() {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -331,6 +331,7 @@ public final class HnswGraph extends KnnGraphValues {
    * @param level level for which to get all nodes
    * @return an iterator over nodes where {@code nextDoc} returns a next node
    */
+  // TODO: return a more suitable iterator over nodes than DocIdSetIterator
   public DocIdSetIterator getAllNodesOnLevel(int level) {
     return new DocIdSetIterator() {
       int[] nodes = level == 0 ? null : nodesByLevel.get(level);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -21,11 +21,13 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.apache.lucene.index.KnnGraphValues;
 import org.apache.lucene.index.RandomAccessVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.SparseFixedBitSet;
 
@@ -56,13 +58,19 @@ import org.apache.lucene.util.SparseFixedBitSet;
 public final class HnswGraph extends KnnGraphValues {
 
   private final int maxConn;
+  private int curMaxLevel; // the current max graph level
+  private int entryNode; // the current graph entry node on the top level
+
+  // Nodes by level expressed as the level 0's nodes' ordinals.
+  // As level 0 contains all nodes, nodesByLevel.get(0) is null.
+  private final List<int[]> nodesByLevel;
+
   // graph is a list of graph levels.
   // Each level is represented as List<NeighborArray> – nodes' connections on this level.
   // Each entry in the list has the top maxConn neighbors of a node. The nodes correspond to vectors
   // added to HnswBuilder, and the node values are the ordinals of those vectors.
+  // Thus, on all levels, neighbors expressed as the level 0's nodes' ordinals.
   private final List<List<NeighborArray>> graph;
-  private int curMaxLevel; // the current max graph level
-  private int entryNode; // the current graph entry node on the top level
 
   // KnnGraphValues iterator members
   private int upto;
@@ -70,7 +78,7 @@ public final class HnswGraph extends KnnGraphValues {
 
   // used for iterating over graph values
   private int curLevel = -1;
-  private int curNode = -1;
+  private int curNodeOrd = -1;
 
   HnswGraph(int maxConn, int levelOfFirstNode) {
     this.maxConn = maxConn;
@@ -83,6 +91,12 @@ public final class HnswGraph extends KnnGraphValues {
       // average fanout seems to be about 1/2 maxConn.
       // There is some indexing time penalty for under-allocating, but saves RAM
       graph.get(i).add(new NeighborArray(Math.max(32, maxConn / 4)));
+    }
+
+    this.nodesByLevel = new ArrayList<>(curMaxLevel + 1);
+    nodesByLevel.add(null); // we don't need this for 0th level, as it contians all nodes
+    for (int l = 1; l <= curMaxLevel; l++) {
+      nodesByLevel.add(new int[] {0});
     }
   }
 
@@ -147,7 +161,7 @@ public final class HnswGraph extends KnnGraphValues {
    * @param query search query vector
    * @param topK the number of nearest to query results to return
    * @param level level to search
-   * @param eps the entry points for search at this level
+   * @param eps the entry points for search at this level expressed as level 0th ordinals
    * @param vectors vector values
    * @param similarityFunction similarity function
    * @param graphValues the graph values
@@ -230,12 +244,15 @@ public final class HnswGraph extends KnnGraphValues {
    * Returns the {@link NeighborQueue} connected to the given node.
    *
    * @param level level of the graph
-   * @param node the node whose neighbors are returned
+   * @param node the node whose neighbors are returned, represented as an ordinal on the level 0.
    */
   public NeighborArray getNeighbors(int level, int node) {
-    NeighborArray result = graph.get(level).get(node);
-    assert result != null;
-    return result;
+    if (level == 0) {
+      return graph.get(level).get(node);
+    }
+    int nodeOrd = Arrays.binarySearch(nodesByLevel.get(level), 0, graph.get(level).size(), node);
+    assert nodeOrd >= 0;
+    return graph.get(level).get(nodeOrd);
   }
 
   @Override
@@ -243,7 +260,12 @@ public final class HnswGraph extends KnnGraphValues {
     return graph.get(0).size(); // all nodes are located on the 0th level
   }
 
-  // TODO: optimize RAM usage so not to store references for all nodes for levels > 0
+  /**
+   * Add node on the given level
+   *
+   * @param level level to add a node on
+   * @param node the node to add, represented as an ordinal on the level 0.
+   */
   public void addNode(int level, int node) {
     if (level > 0) {
       // if the new node introduces a new level, add more levels to the graph,
@@ -251,15 +273,21 @@ public final class HnswGraph extends KnnGraphValues {
       if (level > curMaxLevel) {
         for (int i = curMaxLevel + 1; i <= level; i++) {
           graph.add(new ArrayList<>());
+          nodesByLevel.add(new int[] {node});
         }
         curMaxLevel = level;
         entryNode = node;
-      }
-      // Levels above 0th don't contain all nodes,
-      // so for missing nodes we add null NeighborArray
-      int nullsToAdd = node - graph.get(level).size();
-      for (int i = 0; i < nullsToAdd; i++) {
-        graph.get(level).add(null);
+      } else {
+        // Add this node id to this level's nodes
+        int[] nodes = nodesByLevel.get(level);
+        int idx = graph.get(level).size();
+        if (idx < nodes.length) {
+          nodes[idx] = node;
+        } else {
+          nodes = ArrayUtil.grow(nodes);
+          nodes[idx] = node;
+          nodesByLevel.set(level, nodes);
+        }
       }
     }
 
@@ -281,29 +309,25 @@ public final class HnswGraph extends KnnGraphValues {
   @Override
   public void seekLevel(int level) {
     curLevel = level;
-    curNode = -1;
+    curNodeOrd = -1;
   }
 
   /**
-   * Returns the next node on the current level As levels > 0 don't contain all nodes, this returns
-   * the next node on this level expressed as ordinals of nodes on the 0th level.
+   * Returns the next node on the current level expressed as ordinals of nodes on the 0th level.
    *
    * <p>Must be used after the graph was positioned on the current level with {@code seekLevel(int)}
    *
    * <p>Package private access to use only for tests
    *
-   * @return next node on the current level
+   * @return next node on the current level represented as an ordinal on the level 0.
    */
   int nextNodeOnLevel() {
-    List<NeighborArray> nodesNeighbors = graph.get(curLevel);
-    curNode++;
-    while (curNode < nodesNeighbors.size()) {
-      if (nodesNeighbors.get(curNode) != null) {
-        return curNode;
-      }
-      curNode++;
+    curNodeOrd++;
+    if (curNodeOrd < graph.get(curLevel).size()) {
+      return curLevel == 0 ? curNodeOrd : nodesByLevel.get(curLevel)[curNodeOrd];
+    } else {
+      return NO_MORE_DOCS;
     }
-    return NO_MORE_DOCS;
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -212,10 +212,9 @@ public class TestKnnGraph extends LuceneTestCase {
     int size = values.size();
     int[][] graph = new int[size][];
     int[] scratch = new int[maxConn];
-    values.seekLevel(0);
     for (int node = 0; node < size; node++) {
       int n, count = 0;
-      values.seek(node);
+      values.seek(0, node);
       while ((n = values.nextNeighbor()) != NO_MORE_DOCS) {
         scratch[count++] = n;
         // graph[node][i++] = n;
@@ -341,7 +340,6 @@ public class TestKnnGraph extends LuceneTestCase {
         int[][] graph = new int[reader.maxDoc()][];
         boolean foundOrphan = false;
         int graphSize = 0;
-        graphValues.seekLevel(0);
         for (int i = 0; i < reader.maxDoc(); i++) {
           int nextDocWithVectors = vectorValues.advance(i);
           // System.out.println("advanced to " + nextDocWithVectors);
@@ -354,7 +352,7 @@ public class TestKnnGraph extends LuceneTestCase {
             break;
           }
           int id = Integer.parseInt(reader.document(i).get("id"));
-          graphValues.seek(graphSize);
+          graphValues.seek(0, graphSize);
           // documents with KnnGraphValues have the expected vectors
           float[] scratch = vectorValues.vectorValue();
           assertArrayEquals(

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
@@ -296,9 +296,8 @@ public class KnnGraphTester {
     int min = Integer.MAX_VALUE, max = 0, total = 0;
     int count = 0;
     int[] leafHist = new int[numDocs];
-    knnValues.seekLevel(0);
     for (int node = 0; node < numDocs; node++) {
-      knnValues.seek(node);
+      knnValues.seek(0, node);
       int n = 0;
       while (knnValues.nextNeighbor() != NO_MORE_DOCS) {
         ++n;

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHNSWGraph2.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHNSWGraph2.java
@@ -67,18 +67,17 @@ public class TestHNSWGraph2 extends LuceneTestCase {
    * <p>copy from TestKnnGraph::assertConsistentGraph with parts relevant only to in-memory graphs
    * TODO: remove when hierarchical graph is implemented on disk
    */
-  private static void assertConsistentGraph(HnswGraph hnsw, int maxConn) {
+  private static void assertConsistentGraph(HnswGraph hnsw, int maxConn) throws IOException {
     for (int level = hnsw.maxLevel(); level >= 0; level--) {
-      hnsw.seekLevel(level);
-
       int[][] graph = new int[hnsw.size()][];
       int nodesCount = 0;
       boolean foundOrphan = false;
 
-      for (int node = hnsw.nextNodeOnLevel();
+      DocIdSetIterator nodesItr = hnsw.getAllNodesOnLevel(level);
+      for (int node = nodesItr.nextDoc();
           node != DocIdSetIterator.NO_MORE_DOCS;
-          node = hnsw.nextNodeOnLevel()) {
-        hnsw.seek(node);
+          node = nodesItr.nextDoc()) {
+        hnsw.seek(level, node);
         int arc;
         List<Integer> friends = new ArrayList<>();
         while ((arc = hnsw.nextNeighbor()) != NO_MORE_DOCS) {

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswGraph.java
@@ -523,11 +523,9 @@ public class TestHnswGraph extends LuceneTestCase {
   }
 
   private void assertGraphEqual(KnnGraphValues g, KnnGraphValues h, int size) throws IOException {
-    g.seekLevel(0);
-    h.seekLevel(0);
     for (int node = 0; node < size; node++) {
-      g.seek(node);
-      h.seek(node);
+      g.seek(0, node);
+      h.seek(0, node);
       assertEquals("arcs differ for node " + node, getNeighborNodes(g), getNeighborNodes(h));
     }
   }


### PR DESCRIPTION
Currently we are storing neighbourhoods of all nodes for all levels,
even though level > 0 contain fewer nodes.

This patch fixes this by:
- graph stores for a level a list of neighbourhoods only for nodes
  present on this level. Neighbours on all levels are presented
  as level 0's ordinals.
- nodesByLevel defines which nodes are stored on this level, presented
  as level 0's nodes' ordinals.
- to get neighbours for a given node for level > 0, we first do a binary
  search on nodesByLevel for this level to find node's index in the
  graph's lists of neighbourhoods for this level. We then use this
  index to retrieve a desired neighbourhood.

