### PR TITLE
LUCENE-10094: Delegate count() from CachingWrapperWeight

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -824,6 +824,11 @@ public class LRUQueryCache implements QueryCache, Accountable {
     }
 
     @Override
+    public int count(LeafReaderContext context) throws IOException {
+      return in.count(context);
+    }
+
+    @Override
     public boolean isCacheable(LeafReaderContext ctx) {
       return in.isCacheable(ctx);
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -1719,7 +1719,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
         new BooleanQuery.Builder()
             .add(new TermQuery(new Term("id", "1")), BooleanClause.Occur.FILTER)
             .build();
-    assertEquals(1, searcher.count(query));
+    searcher.search(query, 10);
     assertEquals(1, queryCache.getCacheSize());
     assertEquals(0, queryCache.getEvictionCount());
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -1860,6 +1860,30 @@ public class TestLRUQueryCache extends LuceneTestCase {
     dir.close();
   }
 
+  public void testCountDelegation() throws IOException {
+    Directory dir = newDirectory();
+    final RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+    Document doc = new Document();
+    doc.add(new StringField("foo", "bar", Store.NO));
+    int numDocs = random().nextInt(100) + 20;
+    for (int i = 0; i < numDocs; i++) {
+      w.addDocument(doc);
+    }
+    final IndexReader reader = w.getReader();
+    final IndexSearcher searcher = newSearcher(reader);
+    searcher.setQueryCachingPolicy(ALWAYS_CACHE);
+
+    Query q = new TermQuery(new Term("foo", "bar"));
+    searcher.count(q); // add to cache
+
+    Weight weight = searcher.createWeight(searcher.rewrite(q), ScoreMode.COMPLETE_NO_SCORES, 1);
+    assertNotEquals(-1, weight.count(reader.leaves().get(0)));
+
+    reader.close();
+    w.close();
+    dir.close();
+  }
+
   public void testSkipCachingForTermQuery() throws IOException {
     Directory dir = newDirectory();
     final RandomIndexWriter w = new RandomIndexWriter(random(), dir);


### PR DESCRIPTION
CachingWrapperWeight always returns -1 from its `count()` method, which
disables the fast path for TermQuery, MatchAllDocQuery, etc, when running
`IndexSearcher.count(Query)`.  This commit makes it delegate the method
to its wrapped Weight.