### PR TITLE
LUCENE-10098: add note/link to GermanAnalyzer for decompounding nouns.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -376,6 +376,8 @@ Other
 * LUCENE-10024: Catch NoSuchFileException when opening index directory with Luke.
   (Michael Wechner, Tomoko Uchida)
 
+* LUCENE-10098: Add docs/links to GermanAnalyzer describing how to decompound nouns. (Robert Muir)
+
 ======================= Lucene 8.10.0 =======================
 
 API Changes

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -376,6 +376,33 @@ Other
 * LUCENE-10024: Catch NoSuchFileException when opening index directory with Luke.
   (Michael Wechner, Tomoko Uchida)
 
+======================= Lucene 8.11.0 =======================
+
+API Changes
+---------------------
+(No changes)
+
+New Features
+---------------------
+(No changes)
+
+Improvements
+---------------------
+
+* LUCENE-9662: Make CheckIndex concurrent by parallelizing index check across segments.
+  (Zach Chen, Mike McCandless, Dawid Weiss, Robert Muir)
+
+Optimizations
+---------------------
+(No changes)
+
+Bug Fixes
+---------------------
+(No changes)
+
+Other
+---------------------
+
 * LUCENE-10098: Add docs/links to GermanAnalyzer describing how to decompound nouns. (Robert Muir)
 
 ======================= Lucene 8.10.0 =======================

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanAnalyzer.java
@@ -46,7 +46,7 @@ import org.apache.lucene.util.IOUtils;
  * settings as {@link StandardAnalyzer}.
  *
  * <p><b>NOTE</b>: This class does not decompound nouns, additional data files are needed,
- * incompatible with the Apache 2.0 License. You can * find these data files and example code for
+ * incompatible with the Apache 2.0 License. You can find these data files and example code for
  * decompounding <a
  * href="https://github.com/uschindler/german-decompounder#lucene-api-example">here</a>.
  *

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanAnalyzer.java
@@ -45,7 +45,13 @@ import org.apache.lucene.util.IOUtils;
  * <p><b>NOTE</b>: This class uses the same {@link org.apache.lucene.util.Version} dependent
  * settings as {@link StandardAnalyzer}.
  *
+ * <p><b>NOTE</b>: This class does not decompound nouns, additional data files are needed. You can
+ * find these data files and example code for decompounding <a
+ * href="https://github.com/uschindler/german-decompounder#lucene-api-example">here</a>.
+ *
  * @since 3.1
+ * @see <a
+ *     href="https://github.com/uschindler/german-decompounder">https://github.com/uschindler/german-decompounder</a>
  */
 public final class GermanAnalyzer extends StopwordAnalyzerBase {
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanAnalyzer.java
@@ -45,8 +45,9 @@ import org.apache.lucene.util.IOUtils;
  * <p><b>NOTE</b>: This class uses the same {@link org.apache.lucene.util.Version} dependent
  * settings as {@link StandardAnalyzer}.
  *
- * <p><b>NOTE</b>: This class does not decompound nouns, additional data files are needed. You can
- * find these data files and example code for decompounding <a
+ * <p><b>NOTE</b>: This class does not decompound nouns, additional data files are needed,
+ * incompatible with the Apache 2.0 License. You can * find these data files and example code for
+ * decompounding <a
  * href="https://github.com/uschindler/german-decompounder#lucene-api-example">here</a>.
  *
  * @since 3.1


### PR DESCRIPTION
We can't do this out of box with the analyzer, due to incompatible
licenses. But we can make it easy on the user to do this, by linking to
repo that has sample code, documentation, and the required data files.
