### PR TITLE
LUCENE-10101: Use getField() instead of getDeclaredField() to minimize security impact by analysis SPI discovery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -310,6 +310,9 @@ Bug fixes
 
 * LUCENE-10047: Fix a value de-duping bug in LongValueFacetCounts and RangeFacetCounts
   (Greg Miller)
+  
+* LUCENE-10101, LUCENE-9281: Use getField() instead of getDeclaredField() to
+  minimize security impact by analysis SPI discovery. (Uwe Schindler)
 
 Changes in Backwards Compatibility Policy
 

--- a/lucene/core/src/java/org/apache/lucene/analysis/AnalysisSPILoader.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/AnalysisSPILoader.java
@@ -174,11 +174,11 @@ public final class AnalysisSPILoader<S extends AbstractAnalysisFactory> {
    */
   public static String lookupSPIName(Class<? extends AbstractAnalysisFactory> service)
       throws NoSuchFieldException, IllegalAccessException, IllegalStateException {
-    final Field field = service.getDeclaredField("NAME");
+    final Field field = service.getField("NAME");
     int modifier = field.getModifiers();
-    if (Modifier.isPublic(modifier)
-        && Modifier.isStatic(modifier)
+    if (Modifier.isStatic(modifier)
         && Modifier.isFinal(modifier)
+        && Objects.equals(field.getDeclaringClass(), service)
         && Objects.equals(field.getType(), String.class)) {
       return ((String) field.get(null));
     }


### PR DESCRIPTION
Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/browse/LUCENE-10101

# Description

This PR changes the AnalyisSPILoader's method to lookup the `NAME` field of the SPI to use `Class#getField()` instead of `Class#getDeclaredField()`. This does not require special security privileges if the class is in a related classloader. As `getField()` unfortunately also looks into superclass if the field is not found, the checks for validness of the field have to be changed to check the declaring class. In contrast, the public check is obsolete, as only public fields are returned.

# Tests

Testing is hard, as our security policy of tests allows to do declared member access. So no test will be added. Testing will be done by Elasticsearch people (@romseygeek). 

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
