### PR TITLE
LUCENE-10111: Missing calculating the bytes used of DocsWithFieldSet in NormValuesWriter

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/NormValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NormValuesWriter.java
@@ -60,7 +60,7 @@ class NormValuesWriter {
   }
 
   private void updateBytesUsed() {
-    final long newBytesUsed = pending.ramBytesUsed();
+    final long newBytesUsed = pending.ramBytesUsed() + docsWithField.ramBytesUsed();;
     iwBytesUsed.addAndGet(newBytesUsed - bytesUsed);
     bytesUsed = newBytesUsed;
   }


### PR DESCRIPTION
Basing on the implement of updateBytesUsed() in SortedDocValuesWriter and the other DocValuesWriters, it seems to lack of calculating the BytesUsed of DocsWithFieldSet in NormValuesWriter？
