### PR TITLE
LUCENE-10111: Missing calculating the bytes used of DocsWithFieldSet in NormValuesWriter

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -410,9 +410,6 @@ Improvements
 * LUCENE-9662: Make CheckIndex concurrent by parallelizing index check across segments.
   (Zach Chen, Mike McCandless, Dawid Weiss, Robert Muir)
 
-* LUCENE-10111: Missing calculating the bytes used of DocsWithFieldSet in NormValuesWriter.
-  (Lu Xugang)
-
 Optimizations
 ---------------------
 (No changes)
@@ -422,6 +419,9 @@ Bug Fixes
 
 * LUCENE-10110: MultiCollector now handles single leaf collector that wants to skip low-scoring hits
  but the combined score mode doesn't allow it. (Jim Ferenczi)
+
+* LUCENE-10111: Missing calculating the bytes used of DocsWithFieldSet in NormValuesWriter.
+  (Lu Xugang)
 
 Build
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -410,6 +410,9 @@ Improvements
 * LUCENE-9662: Make CheckIndex concurrent by parallelizing index check across segments.
   (Zach Chen, Mike McCandless, Dawid Weiss, Robert Muir)
 
+* LUCENE-10111: Missing calculating the bytes used of DocsWithFieldSet in NormValuesWriter.
+  (Lu Xugang)
+
 Optimizations
 ---------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/index/NormValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NormValuesWriter.java
@@ -60,7 +60,7 @@ class NormValuesWriter {
   }
 
   private void updateBytesUsed() {
-    final long newBytesUsed = pending.ramBytesUsed();
+    final long newBytesUsed = pending.ramBytesUsed() + docsWithField.ramBytesUsed();
     iwBytesUsed.addAndGet(newBytesUsed - bytesUsed);
     bytesUsed = newBytesUsed;
   }


### PR DESCRIPTION
Basing on the implement of updateBytesUsed() in SortedDocValuesWriter and the other DocValuesWriters, it seems to lack of calculating the BytesUsed of DocsWithFieldSet in NormValuesWriter？
