### PR TITLE
LUCENE-10113: Use VarHandles to access int/long/short types in byte arrays (e.g. ByteArrayDataInput)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -271,6 +271,11 @@ Improvements
   The getPath API now throws an IAE instead of returning null if the ordinal is out of bounds.
   (Gautam Worah, Mike McCandless)
 
+* LUCENE-10113: Use VarHandles to access int/long/short primitive types in byte arrays.
+  This improves readability and performance of encoding/decoding of primitives to index
+  file format in input/output classes like DataInput / DataOutput and codecs.
+  (Uwe Schindler, Robert Muir)
+
 Bug fixes
 
 * LUCENE-10070 Skip deleted docs when accumulating facet counts for all docs. (Ankur Goel, Greg Miller)

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/minhash/MinHashFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/minhash/MinHashFilter.java
@@ -28,6 +28,7 @@ import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionLengthAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.apache.lucene.util.BitUtil;
 
 /**
  * Generate min hash tokens from an incoming stream of tokens. The incoming tokens would typically
@@ -97,10 +98,7 @@ public class MinHashFilter extends TokenFilter {
 
   static byte[] getBytes(int i) {
     byte[] answer = new byte[4];
-    answer[3] = (byte) (i);
-    answer[2] = (byte) (i >> 8);
-    answer[1] = (byte) (i >> 16);
-    answer[0] = (byte) (i >> 24);
+    BitUtil.VH_BE_INT.set(answer, 0, i);
     return answer;
   }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/PayloadHelper.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/PayloadHelper.java
@@ -26,7 +26,8 @@ public class PayloadHelper {
   }
 
   public static byte[] encodeFloat(float payload, byte[] data, int offset) {
-    return encodeInt(Float.floatToIntBits(payload), data, offset);
+    BitUtil.VH_BE_FLOAT.set(data, offset, payload);
+    return data;
   }
 
   public static byte[] encodeInt(int payload) {
@@ -57,8 +58,7 @@ public class PayloadHelper {
    * @see #encodeFloat(float)
    */
   public static final float decodeFloat(byte[] bytes, int offset) {
-
-    return Float.intBitsToFloat(decodeInt(bytes, offset));
+    return (float) BitUtil.VH_BE_FLOAT.get(bytes, offset);
   }
 
   public static final int decodeInt(byte[] bytes, int offset) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/PayloadHelper.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/PayloadHelper.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.analysis.payloads;
 
+import org.apache.lucene.util.BitUtil;
+
 /** Utility methods for encoding payloads. */
 public class PayloadHelper {
 
@@ -32,10 +34,7 @@ public class PayloadHelper {
   }
 
   public static byte[] encodeInt(int payload, byte[] data, int offset) {
-    data[offset] = (byte) (payload >> 24);
-    data[offset + 1] = (byte) (payload >> 16);
-    data[offset + 2] = (byte) (payload >> 8);
-    data[offset + 3] = (byte) payload;
+    BitUtil.VH_BE_INT.set(data, offset, payload);
     return data;
   }
 
@@ -63,9 +62,6 @@ public class PayloadHelper {
   }
 
   public static final int decodeInt(byte[] bytes, int offset) {
-    return ((bytes[offset] & 0xFF) << 24)
-        | ((bytes[offset + 1] & 0xFF) << 16)
-        | ((bytes[offset + 2] & 0xFF) << 8)
-        | (bytes[offset + 3] & 0xFF);
+    return (int) BitUtil.VH_BE_INT.get(bytes, offset);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/ByteSliceReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ByteSliceReader.java
@@ -19,6 +19,7 @@ package org.apache.lucene.index;
 import java.io.IOException;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.ByteBlockPool;
 
 /* IndexInput that knows how to read the byte slices written
@@ -94,11 +95,7 @@ final class ByteSliceReader extends DataInput {
   public void nextSlice() {
 
     // Skip to our next slice
-    final int nextIndex =
-        ((buffer[limit] & 0xff) << 24)
-            + ((buffer[1 + limit] & 0xff) << 16)
-            + ((buffer[2 + limit] & 0xff) << 8)
-            + (buffer[3 + limit] & 0xff);
+    final int nextIndex = (int) BitUtil.VH_BE_INT.get(buffer, limit);
 
     level = ByteBlockPool.NEXT_LEVEL_ARRAY[level];
     final int newSize = ByteBlockPool.LEVEL_SIZE_ARRAY[level];

--- a/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataInput.java
@@ -16,9 +16,7 @@
  */
 package org.apache.lucene.store;
 
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -27,13 +25,6 @@ import org.apache.lucene.util.BytesRef;
  * @lucene.experimental
  */
 public final class ByteArrayDataInput extends DataInput {
-
-  private static final VarHandle VH_SHORT =
-      MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
-  private static final VarHandle VH_INT =
-      MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
-  private static final VarHandle VH_LONG =
-      MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
   private byte[] bytes;
 
@@ -91,21 +82,21 @@ public final class ByteArrayDataInput extends DataInput {
 
   @Override
   public short readShort() {
-    final short ret = (short) VH_SHORT.get(bytes, pos);
+    final short ret = (short) BitUtil.VH_LE_SHORT.get(bytes, pos);
     pos += Short.BYTES;
     return ret;
   }
 
   @Override
   public int readInt() {
-    final int ret = (int) VH_INT.get(bytes, pos);
+    final int ret = (int) BitUtil.VH_LE_INT.get(bytes, pos);
     pos += Integer.BYTES;
     return ret;
   }
 
   @Override
   public long readLong() {
-    final long ret = (long) VH_LONG.get(bytes, pos);
+    final long ret = (long) BitUtil.VH_LE_LONG.get(bytes, pos);
     pos += Long.BYTES;
     return ret;
   }

--- a/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataInput.java
@@ -16,6 +16,9 @@
  */
 package org.apache.lucene.store;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -24,6 +27,13 @@ import org.apache.lucene.util.BytesRef;
  * @lucene.experimental
  */
 public final class ByteArrayDataInput extends DataInput {
+
+  private static final VarHandle VH_SHORT =
+      MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
+  private static final VarHandle VH_INT =
+      MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+  private static final VarHandle VH_LONG =
+      MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
   private byte[] bytes;
 
@@ -81,38 +91,23 @@ public final class ByteArrayDataInput extends DataInput {
 
   @Override
   public short readShort() {
-    final byte b1 = bytes[pos++];
-    final byte b2 = bytes[pos++];
-    return (short) ((b2 & 0xFF) << 8 | (b1 & 0xFF));
+    final short ret = (short) VH_SHORT.get(bytes, pos);
+    pos += Short.BYTES;
+    return ret;
   }
 
   @Override
   public int readInt() {
-    final byte b1 = bytes[pos++];
-    final byte b2 = bytes[pos++];
-    final byte b3 = bytes[pos++];
-    final byte b4 = bytes[pos++];
-    return (b4 & 0xFF) << 24 | (b3 & 0xFF) << 16 | (b2 & 0xFF) << 8 | (b1 & 0xFF);
+    final int ret = (int) VH_INT.get(bytes, pos);
+    pos += Integer.BYTES;
+    return ret;
   }
 
   @Override
   public long readLong() {
-    final byte b1 = bytes[pos++];
-    final byte b2 = bytes[pos++];
-    final byte b3 = bytes[pos++];
-    final byte b4 = bytes[pos++];
-    final byte b5 = bytes[pos++];
-    final byte b6 = bytes[pos++];
-    final byte b7 = bytes[pos++];
-    final byte b8 = bytes[pos++];
-    return (b8 & 0xFFL) << 56
-        | (b7 & 0xFFL) << 48
-        | (b6 & 0xFFL) << 40
-        | (b5 & 0xFFL) << 32
-        | (b4 & 0xFFL) << 24
-        | (b3 & 0xFFL) << 16
-        | (b2 & 0xFFL) << 8
-        | (b1 & 0xFFL);
+    final long ret = (long) VH_LONG.get(bytes, pos);
+    pos += Long.BYTES;
+    return ret;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataInput.java
@@ -82,23 +82,29 @@ public final class ByteArrayDataInput extends DataInput {
 
   @Override
   public short readShort() {
-    final short ret = (short) BitUtil.VH_LE_SHORT.get(bytes, pos);
-    pos += Short.BYTES;
-    return ret;
+    try {
+      return (short) BitUtil.VH_LE_SHORT.get(bytes, pos);
+    } finally {
+      pos += Short.BYTES;
+    }
   }
 
   @Override
   public int readInt() {
-    final int ret = (int) BitUtil.VH_LE_INT.get(bytes, pos);
-    pos += Integer.BYTES;
-    return ret;
+    try {
+      return (int) BitUtil.VH_LE_INT.get(bytes, pos);
+    } finally {
+      pos += Integer.BYTES;
+    }
   }
 
   @Override
   public long readLong() {
-    final long ret = (long) BitUtil.VH_LE_LONG.get(bytes, pos);
-    pos += Long.BYTES;
-    return ret;
+    try {
+      return (long) BitUtil.VH_LE_LONG.get(bytes, pos);
+    } finally {
+      pos += Long.BYTES;
+    }
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataOutput.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.store;
 
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -68,4 +69,26 @@ public class ByteArrayDataOutput extends DataOutput {
     System.arraycopy(b, offset, bytes, pos, length);
     pos += length;
   }
+
+  @Override
+  public void writeShort(short i) {
+    assert pos + Short.BYTES <= limit;
+    BitUtil.VH_LE_SHORT.set(bytes, pos, i);
+    pos += Short.BYTES;
+  }
+
+  @Override
+  public void writeInt(int i) {
+    assert pos + Integer.BYTES <= limit;
+    BitUtil.VH_LE_INT.set(bytes, pos, i);
+    pos += Integer.BYTES;
+  }
+
+  @Override
+  public void writeLong(long i) {
+    assert pos + Long.BYTES <= limit;
+    BitUtil.VH_LE_LONG.set(bytes, pos, i);
+    pos += Long.BYTES;
+  }
+  
 }

--- a/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteArrayDataOutput.java
@@ -90,5 +90,4 @@ public class ByteArrayDataOutput extends DataOutput {
     BitUtil.VH_LE_LONG.set(bytes, pos, i);
     pos += Long.BYTES;
   }
-  
 }

--- a/lucene/core/src/java/org/apache/lucene/util/BitUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitUtil.java
@@ -21,7 +21,7 @@ import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 
 /**
- * A variety of high efficiency bit twiddling routines.
+ * A variety of high efficiency bit twiddling routines and encoders for primitives.
  *
  * @lucene.internal
  */
@@ -30,43 +30,44 @@ public final class BitUtil {
   private BitUtil() {} // no instance
 
   /**
-   * A {@link VarHandle} to read/write little endian {@code short} from a byte array. Shape: {@code
-   * short vh.get(byte[] arr, int offset)}
+   * A {@link VarHandle} to read/write little endian {@code short} from/to a byte array. Shape:
+   * {@code short vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, short
+   * val)}
    */
   public static final VarHandle VH_LE_SHORT =
       MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
 
   /**
    * A {@link VarHandle} to read/write little endian {@code int} from a byte array. Shape: {@code
-   * int vh.get(byte[] arr, int offset)}
+   * int vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, int val)}
    */
   public static final VarHandle VH_LE_INT =
       MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
 
   /**
    * A {@link VarHandle} to read/write little endian {@code long} from a byte array. Shape: {@code
-   * long vh.get(byte[] arr, int offset)}
+   * long vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, long val)}
    */
   public static final VarHandle VH_LE_LONG =
       MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
   /**
-   * A {@link VarHandle} to read/write big endian {@code float} from a byte array. Shape: {@code
-   * float vh.get(byte[] arr, int offset)}
+   * A {@link VarHandle} to read/write little endian {@code float} from a byte array. Shape: {@code
+   * float vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, float val)}
    */
   public static final VarHandle VH_LE_FLOAT =
       MethodHandles.byteArrayViewVarHandle(float[].class, ByteOrder.LITTLE_ENDIAN);
 
   /**
-   * A {@link VarHandle} to read/write big endian {@code double} from a byte array. Shape: {@code
-   * double vh.get(byte[] arr, int offset)}
+   * A {@link VarHandle} to read/write little endian {@code double} from a byte array. Shape: {@code
+   * double vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, double val)}
    */
   public static final VarHandle VH_LE_DOUBLE =
       MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.LITTLE_ENDIAN);
 
   /**
    * A {@link VarHandle} to read/write big endian {@code short} from a byte array. Shape: {@code
-   * short vh.get(byte[] arr, int offset)}
+   * short vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, short val)}
    *
    * @deprecated Better use little endian unless it is needed for backwards compatibility.
    */
@@ -76,7 +77,7 @@ public final class BitUtil {
 
   /**
    * A {@link VarHandle} to read/write big endian {@code int} from a byte array. Shape: {@code int
-   * vh.get(byte[] arr, int offset)}
+   * vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, int val)}
    *
    * @deprecated Better use little endian unless it is needed for backwards compatibility.
    */
@@ -86,7 +87,7 @@ public final class BitUtil {
 
   /**
    * A {@link VarHandle} to read/write big endian {@code long} from a byte array. Shape: {@code long
-   * vh.get(byte[] arr, int offset)}
+   * vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, long val)}
    *
    * @deprecated Better use little endian unless it is needed for backwards compatibility.
    */
@@ -96,7 +97,7 @@ public final class BitUtil {
 
   /**
    * A {@link VarHandle} to read/write big endian {@code float} from a byte array. Shape: {@code
-   * float vh.get(byte[] arr, int offset)}
+   * float vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, float val)}
    *
    * @deprecated Better use little endian unless it is needed for backwards compatibility.
    */
@@ -106,7 +107,7 @@ public final class BitUtil {
 
   /**
    * A {@link VarHandle} to read/write big endian {@code double} from a byte array. Shape: {@code
-   * double vh.get(byte[] arr, int offset)}
+   * double vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, double val)}
    *
    * @deprecated Better use little endian unless it is needed for backwards compatibility.
    */

--- a/lucene/core/src/java/org/apache/lucene/util/BitUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitUtil.java
@@ -51,6 +51,20 @@ public final class BitUtil {
       MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
   /**
+   * A {@link VarHandle} to read/write big endian {@code float} from a byte array. Shape: {@code
+   * float vh.get(byte[] arr, int offset)}
+   */
+  public static final VarHandle VH_LE_FLOAT =
+      MethodHandles.byteArrayViewVarHandle(float[].class, ByteOrder.LITTLE_ENDIAN);
+
+  /**
+   * A {@link VarHandle} to read/write big endian {@code double} from a byte array. Shape: {@code
+   * double vh.get(byte[] arr, int offset)}
+   */
+  public static final VarHandle VH_LE_DOUBLE =
+      MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.LITTLE_ENDIAN);
+
+  /**
    * A {@link VarHandle} to read/write big endian {@code short} from a byte array. Shape: {@code
    * short vh.get(byte[] arr, int offset)}
    *
@@ -79,6 +93,26 @@ public final class BitUtil {
   @Deprecated
   public static final VarHandle VH_BE_LONG =
       MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN);
+
+  /**
+   * A {@link VarHandle} to read/write big endian {@code float} from a byte array. Shape: {@code
+   * float vh.get(byte[] arr, int offset)}
+   *
+   * @deprecated Better use little endian unless it is needed for backwards compatibility.
+   */
+  @Deprecated
+  public static final VarHandle VH_BE_FLOAT =
+      MethodHandles.byteArrayViewVarHandle(float[].class, ByteOrder.BIG_ENDIAN);
+
+  /**
+   * A {@link VarHandle} to read/write big endian {@code double} from a byte array. Shape: {@code
+   * double vh.get(byte[] arr, int offset)}
+   *
+   * @deprecated Better use little endian unless it is needed for backwards compatibility.
+   */
+  @Deprecated
+  public static final VarHandle VH_BE_DOUBLE =
+      MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.BIG_ENDIAN);
 
   // The pop methods used to rely on bit-manipulation tricks for speed but it
   // turns out that it is faster to use the Long.bitCount method (which is an

--- a/lucene/core/src/java/org/apache/lucene/util/BitUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitUtil.java
@@ -16,6 +16,10 @@
  */
 package org.apache.lucene.util; // from org.apache.solr.util rev 555343
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
 /**
  * A variety of high efficiency bit twiddling routines.
  *
@@ -24,6 +28,57 @@ package org.apache.lucene.util; // from org.apache.solr.util rev 555343
 public final class BitUtil {
 
   private BitUtil() {} // no instance
+
+  /**
+   * A {@link VarHandle} to read/write little endian {@code short} from a byte array. Shape: {@code
+   * short vh.get(byte[] arr, int offset)}
+   */
+  public static final VarHandle VH_LE_SHORT =
+      MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
+
+  /**
+   * A {@link VarHandle} to read/write little endian {@code int} from a byte array. Shape: {@code
+   * int vh.get(byte[] arr, int offset)}
+   */
+  public static final VarHandle VH_LE_INT =
+      MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+
+  /**
+   * A {@link VarHandle} to read/write little endian {@code long} from a byte array. Shape: {@code
+   * long vh.get(byte[] arr, int offset)}
+   */
+  public static final VarHandle VH_LE_LONG =
+      MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+
+  /**
+   * A {@link VarHandle} to read/write big endian {@code short} from a byte array. Shape: {@code
+   * short vh.get(byte[] arr, int offset)}
+   *
+   * @deprecated Better use little endian unless it is needed for backwards compatibility.
+   */
+  @Deprecated
+  public static final VarHandle VH_BE_SHORT =
+      MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.BIG_ENDIAN);
+
+  /**
+   * A {@link VarHandle} to read/write big endian {@code int} from a byte array. Shape: {@code int
+   * vh.get(byte[] arr, int offset)}
+   *
+   * @deprecated Better use little endian unless it is needed for backwards compatibility.
+   */
+  @Deprecated
+  public static final VarHandle VH_BE_INT =
+      MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
+
+  /**
+   * A {@link VarHandle} to read/write big endian {@code long} from a byte array. Shape: {@code long
+   * vh.get(byte[] arr, int offset)}
+   *
+   * @deprecated Better use little endian unless it is needed for backwards compatibility.
+   */
+  @Deprecated
+  public static final VarHandle VH_BE_LONG =
+      MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN);
 
   // The pop methods used to rely on bit-manipulation tricks for speed but it
   // turns out that it is faster to use the Long.bitCount method (which is an

--- a/lucene/core/src/java/org/apache/lucene/util/NumericUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/NumericUtils.java
@@ -141,10 +141,7 @@ public final class NumericUtils {
   public static void intToSortableBytes(int value, byte[] result, int offset) {
     // Flip the sign bit, so negative ints sort before positive ints correctly:
     value ^= 0x80000000;
-    result[offset] = (byte) (value >> 24);
-    result[offset + 1] = (byte) (value >> 16);
-    result[offset + 2] = (byte) (value >> 8);
-    result[offset + 3] = (byte) value;
+    BitUtil.VH_BE_INT.set(result, offset, value);
   }
 
   /**
@@ -153,11 +150,7 @@ public final class NumericUtils {
    * @see #intToSortableBytes(int, byte[], int)
    */
   public static int sortableBytesToInt(byte[] encoded, int offset) {
-    int x =
-        ((encoded[offset] & 0xFF) << 24)
-            | ((encoded[offset + 1] & 0xFF) << 16)
-            | ((encoded[offset + 2] & 0xFF) << 8)
-            | (encoded[offset + 3] & 0xFF);
+    int x = (int) BitUtil.VH_BE_INT.get(encoded, offset);
     // Re-flip the sign bit to restore the original value:
     return x ^ 0x80000000;
   }
@@ -171,14 +164,7 @@ public final class NumericUtils {
   public static void longToSortableBytes(long value, byte[] result, int offset) {
     // Flip the sign bit so negative longs sort before positive longs:
     value ^= 0x8000000000000000L;
-    result[offset] = (byte) (value >> 56);
-    result[offset + 1] = (byte) (value >> 48);
-    result[offset + 2] = (byte) (value >> 40);
-    result[offset + 3] = (byte) (value >> 32);
-    result[offset + 4] = (byte) (value >> 24);
-    result[offset + 5] = (byte) (value >> 16);
-    result[offset + 6] = (byte) (value >> 8);
-    result[offset + 7] = (byte) value;
+    BitUtil.VH_BE_LONG.set(result, offset, value);
   }
 
   /**
@@ -187,15 +173,7 @@ public final class NumericUtils {
    * @see #longToSortableBytes(long, byte[], int)
    */
   public static long sortableBytesToLong(byte[] encoded, int offset) {
-    long v =
-        ((encoded[offset] & 0xFFL) << 56)
-            | ((encoded[offset + 1] & 0xFFL) << 48)
-            | ((encoded[offset + 2] & 0xFFL) << 40)
-            | ((encoded[offset + 3] & 0xFFL) << 32)
-            | ((encoded[offset + 4] & 0xFFL) << 24)
-            | ((encoded[offset + 5] & 0xFFL) << 16)
-            | ((encoded[offset + 6] & 0xFFL) << 8)
-            | (encoded[offset + 7] & 0xFFL);
+    long v = (long) BitUtil.VH_BE_LONG.get(encoded, offset);
     // Flip the sign bit back
     v ^= 0x8000000000000000L;
     return v;

--- a/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
@@ -17,10 +17,7 @@
 package org.apache.lucene.util;
 
 import java.io.DataInputStream;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
 import java.math.BigInteger;
-import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -152,9 +149,6 @@ public abstract class StringHelper {
     }
   }
 
-  private static final VarHandle VH_INT =
-      MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
-
   /**
    * Returns the MurmurHash3_x86_32 hash. Original source/tests at
    * https://github.com/yonik/java_util/
@@ -170,7 +164,7 @@ public abstract class StringHelper {
 
     for (int i = offset; i < roundedEnd; i += 4) {
       // little endian load order
-      int k1 = (int) VH_INT.get(data, i);
+      int k1 = (int) BitUtil.VH_LE_INT.get(data, i);
       k1 *= c1;
       k1 = Integer.rotateLeft(k1, 15);
       k1 *= c2;

--- a/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
@@ -16,9 +16,9 @@
  */
 package org.apache.lucene.util;
 
+import java.io.DataInputStream;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-import java.io.DataInputStream;
 import java.math.BigInteger;
 import java.nio.ByteOrder;
 import java.nio.file.Files;

--- a/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
@@ -16,8 +16,11 @@
  */
 package org.apache.lucene.util;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.io.DataInputStream;
 import java.math.BigInteger;
+import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -149,6 +152,9 @@ public abstract class StringHelper {
     }
   }
 
+  private static final VarHandle VH_INT =
+      MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+
   /**
    * Returns the MurmurHash3_x86_32 hash. Original source/tests at
    * https://github.com/yonik/java_util/
@@ -164,11 +170,7 @@ public abstract class StringHelper {
 
     for (int i = offset; i < roundedEnd; i += 4) {
       // little endian load order
-      int k1 =
-          (data[i] & 0xff)
-              | ((data[i + 1] & 0xff) << 8)
-              | ((data[i + 2] & 0xff) << 16)
-              | (data[i + 3] << 24);
+      int k1 = (int) VH_INT.get(data, i);
       k1 *= c1;
       k1 = Integer.rotateLeft(k1, 15);
       k1 *= c2;

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/HeapPointReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/HeapPointReader.java
@@ -91,11 +91,7 @@ public final class HeapPointReader implements PointReader {
     @Override
     public int docID() {
       int position = packedValueDocID.offset + packedValueLength;
-      try {
-        return (int) VH_BE_INT.get(packedValueDocID.bytes, position);
-      } finally {
-        position += 4;
-      }
+      return (int) VH_BE_INT.get(packedValueDocID.bytes, position);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/HeapPointReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/HeapPointReader.java
@@ -16,9 +16,7 @@
  */
 package org.apache.lucene.util.bkd;
 
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -85,13 +83,10 @@ public final class HeapPointReader implements PointReader {
       return packedValue;
     }
 
-    private static final VarHandle VH_BE_INT =
-        MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
-
     @Override
     public int docID() {
       int position = packedValueDocID.offset + packedValueLength;
-      return (int) VH_BE_INT.get(packedValueDocID.bytes, position);
+      return (int) BitUtil.VH_BE_INT.get(packedValueDocID.bytes, position);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/HeapPointWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/HeapPointWriter.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.util.bkd;
 
 import java.util.Arrays;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -67,10 +68,7 @@ public final class HeapPointWriter implements PointWriter {
     System.arraycopy(
         packedValue, 0, block, nextWrite * config.bytesPerDoc, config.packedBytesLength);
     int position = nextWrite * config.bytesPerDoc + config.packedBytesLength;
-    block[position] = (byte) (docID >> 24);
-    block[++position] = (byte) (docID >> 16);
-    block[++position] = (byte) (docID >> 8);
-    block[++position] = (byte) (docID >> 0);
+    BitUtil.VH_BE_INT.set(block, position, docID);
     nextWrite++;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointReader.java
@@ -18,6 +18,9 @@ package org.apache.lucene.util.bkd;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
@@ -177,13 +180,17 @@ public final class OfflinePointReader implements PointReader {
       return packedValue;
     }
 
+    private static final VarHandle VH_BE_INT =
+        MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
+
     @Override
     public int docID() {
       int position = packedValueDocID.offset + packedValueLength;
-      return ((packedValueDocID.bytes[position] & 0xFF) << 24)
-          | ((packedValueDocID.bytes[++position] & 0xFF) << 16)
-          | ((packedValueDocID.bytes[++position] & 0xFF) << 8)
-          | (packedValueDocID.bytes[++position] & 0xFF);
+      try {
+        return (int) VH_BE_INT.get(packedValueDocID.bytes, position);
+      } finally {
+        position += 4;
+      }
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointReader.java
@@ -18,14 +18,12 @@ package org.apache.lucene.util.bkd;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -180,13 +178,10 @@ public final class OfflinePointReader implements PointReader {
       return packedValue;
     }
 
-    private static final VarHandle VH_BE_INT =
-        MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
-
     @Override
     public int docID() {
       int position = packedValueDocID.offset + packedValueLength;
-      return (int) VH_BE_INT.get(packedValueDocID.bytes, position);
+      return (int) BitUtil.VH_BE_INT.get(packedValueDocID.bytes, position);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointReader.java
@@ -186,11 +186,7 @@ public final class OfflinePointReader implements PointReader {
     @Override
     public int docID() {
       int position = packedValueDocID.offset + packedValueLength;
-      try {
-        return (int) VH_BE_INT.get(packedValueDocID.bytes, position);
-      } finally {
-        position += 4;
-      }
+      return (int) VH_BE_INT.get(packedValueDocID.bytes, position);
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteArrayDataInput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteArrayDataInput.java
@@ -29,4 +29,21 @@ public class TestByteArrayDataInput extends LuceneTestCase {
     in.reset(bytes, 1, 2);
     assertEquals("A", in.readString());
   }
+
+  public void testDatatypes() throws Exception {
+    final byte[] bytes = new byte[32];
+    final ByteArrayDataOutput out = new ByteArrayDataOutput(bytes);
+    out.writeByte((byte) 43);
+    out.writeShort((short) 12345);
+    out.writeInt(1234567890);
+    out.writeLong(1234567890123456789L);
+    final int size = out.getPosition();
+    assertEquals(15, size);
+
+    final ByteArrayDataInput in = new ByteArrayDataInput(bytes, 0, size);
+    assertEquals(43, in.readByte());
+    assertEquals(12345, in.readShort());
+    assertEquals(1234567890, in.readInt());
+    assertEquals(1234567890123456789L, in.readLong());
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteArrayDataInput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteArrayDataInput.java
@@ -16,6 +16,9 @@
  */
 package org.apache.lucene.store;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
 import org.apache.lucene.util.LuceneTestCase;
 
 public class TestByteArrayDataInput extends LuceneTestCase {
@@ -31,6 +34,7 @@ public class TestByteArrayDataInput extends LuceneTestCase {
   }
 
   public void testDatatypes() throws Exception {
+    // write some primitives using ByteArrayDataOutput:
     final byte[] bytes = new byte[32];
     final ByteArrayDataOutput out = new ByteArrayDataOutput(bytes);
     out.writeByte((byte) 43);
@@ -40,6 +44,15 @@ public class TestByteArrayDataInput extends LuceneTestCase {
     final int size = out.getPosition();
     assertEquals(15, size);
 
+    // read the primitives using ByteBuffer to ensure encoding in byte array is LE:
+    final ByteBuffer buf = ByteBuffer.wrap(bytes, 0, size).order(ByteOrder.LITTLE_ENDIAN);
+    assertEquals(43, buf.get());
+    assertEquals(12345, buf.getShort());
+    assertEquals(1234567890, buf.getInt());
+    assertEquals(1234567890123456789L, buf.getLong());
+    assertEquals(0, buf.remaining());
+    
+    // read the primitives using ByteArrayDataInput:
     final ByteArrayDataInput in = new ByteArrayDataInput(bytes, 0, size);
     assertEquals(43, in.readByte());
     assertEquals(12345, in.readShort());

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteArrayDataInput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteArrayDataInput.java
@@ -18,7 +18,6 @@ package org.apache.lucene.store;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-
 import org.apache.lucene.util.LuceneTestCase;
 
 public class TestByteArrayDataInput extends LuceneTestCase {
@@ -51,7 +50,7 @@ public class TestByteArrayDataInput extends LuceneTestCase {
     assertEquals(1234567890, buf.getInt());
     assertEquals(1234567890123456789L, buf.getLong());
     assertEquals(0, buf.remaining());
-    
+
     // read the primitives using ByteArrayDataInput:
     final ByteArrayDataInput in = new ByteArrayDataInput(bytes, 0, size);
     assertEquals(43, in.readByte());

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteArrayDataInput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteArrayDataInput.java
@@ -26,10 +26,12 @@ public class TestByteArrayDataInput extends LuceneTestCase {
     byte[] bytes = new byte[] {1, 65};
     ByteArrayDataInput in = new ByteArrayDataInput(bytes);
     assertEquals("A", in.readString());
+    assertTrue(in.eof());
 
     bytes = new byte[] {1, 1, 65};
     in.reset(bytes, 1, 2);
     assertEquals("A", in.readString());
+    assertTrue(in.eof());
   }
 
   public void testDatatypes() throws Exception {
@@ -57,5 +59,6 @@ public class TestByteArrayDataInput extends LuceneTestCase {
     assertEquals(12345, in.readShort());
     assertEquals(1234567890, in.readInt());
     assertEquals(1234567890123456789L, in.readLong());
+    assertTrue(in.eof());
   }
 }

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetsConfig.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetsConfig.java
@@ -39,6 +39,7 @@ import org.apache.lucene.facet.taxonomy.TaxonomyWriter;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.IntsRefBuilder;
@@ -492,10 +493,8 @@ public class FacetsConfig {
           bytes = ArrayUtil.grow(bytes, upto + 4);
         }
         // big-endian:
-        bytes[upto++] = (byte) (ordinal >> 24);
-        bytes[upto++] = (byte) (ordinal >> 16);
-        bytes[upto++] = (byte) (ordinal >> 8);
-        bytes[upto++] = (byte) ordinal;
+        BitUtil.VH_BE_INT.set(bytes, upto, ordinal);
+        upto += 4;
         if (upto + field.assoc.length > bytes.length) {
           bytes = ArrayUtil.grow(bytes, upto + field.assoc.length);
         }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntAssociationFacetField.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntAssociationFacetField.java
@@ -18,6 +18,7 @@ package org.apache.lucene.facet.taxonomy;
 
 import java.util.Arrays;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -37,19 +38,13 @@ public class IntAssociationFacetField extends AssociationFacetField {
   public static BytesRef intToBytesRef(int v) {
     byte[] bytes = new byte[4];
     // big-endian:
-    bytes[0] = (byte) (v >> 24);
-    bytes[1] = (byte) (v >> 16);
-    bytes[2] = (byte) (v >> 8);
-    bytes[3] = (byte) v;
+    BitUtil.VH_BE_INT.set(bytes, 0, v);
     return new BytesRef(bytes);
   }
 
   /** Decodes a previously encoded {@code int}. */
   public static int bytesRefToInt(BytesRef b) {
-    return ((b.bytes[b.offset] & 0xFF) << 24)
-        | ((b.bytes[b.offset + 1] & 0xFF) << 16)
-        | ((b.bytes[b.offset + 2] & 0xFF) << 8)
-        | (b.bytes[b.offset + 3] & 0xFF);
+    return (int) BitUtil.VH_BE_INT.get(b.bytes, b.offset);
   }
 
   @Override

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumFloatAssociations.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumFloatAssociations.java
@@ -74,9 +74,9 @@ public class TaxonomyFacetSumFloatAssociations extends FloatTaxonomyFacets {
           while (offset < end) {
             int ord = (int) BitUtil.VH_BE_INT.get(bytes, offset);
             offset += 4;
-            int value = (int) BitUtil.VH_BE_INT.get(bytes, offset);
+            float value = (float) BitUtil.VH_BE_FLOAT.get(bytes, offset);
             offset += 4;
-            values[ord] += Float.intBitsToFloat(value);
+            values[ord] += value;
           }
         }
       }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumFloatAssociations.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumFloatAssociations.java
@@ -17,15 +17,13 @@
 package org.apache.lucene.facet.taxonomy;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 import java.util.List;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.facet.FacetsCollector.MatchingDocs;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -49,9 +47,6 @@ public class TaxonomyFacetSumFloatAssociations extends FloatTaxonomyFacets {
     super(indexFieldName, taxoReader, config);
     sumValues(fc.getMatchingDocs());
   }
-
-  private static final VarHandle VH_BE_INT =
-      MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
 
   private final void sumValues(List<MatchingDocs> matchingDocs) throws IOException {
     // System.out.println("count matchingDocs=" + matchingDocs + " facetsField=" + facetsFieldName);
@@ -77,9 +72,9 @@ public class TaxonomyFacetSumFloatAssociations extends FloatTaxonomyFacets {
           int end = bytesRef.offset + bytesRef.length;
           int offset = bytesRef.offset;
           while (offset < end) {
-            int ord = (int) VH_BE_INT.get(bytes, offset);
+            int ord = (int) BitUtil.VH_BE_INT.get(bytes, offset);
             offset += 4;
-            int value = (int) VH_BE_INT.get(bytes, offset);
+            int value = (int) BitUtil.VH_BE_INT.get(bytes, offset);
             offset += 4;
             values[ord] += Float.intBitsToFloat(value);
           }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumIntAssociations.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumIntAssociations.java
@@ -17,15 +17,13 @@
 package org.apache.lucene.facet.taxonomy;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 import java.util.List;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.facet.FacetsCollector.MatchingDocs;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -49,9 +47,6 @@ public class TaxonomyFacetSumIntAssociations extends IntTaxonomyFacets {
     super(indexFieldName, taxoReader, config, fc);
     sumValues(fc.getMatchingDocs());
   }
-
-  private static final VarHandle VH_BE_INT =
-      MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
 
   private final void sumValues(List<MatchingDocs> matchingDocs) throws IOException {
     // System.out.println("count matchingDocs=" + matchingDocs + " facetsField=" + facetsFieldName);
@@ -77,9 +72,9 @@ public class TaxonomyFacetSumIntAssociations extends IntTaxonomyFacets {
           int end = bytesRef.offset + bytesRef.length;
           int offset = bytesRef.offset;
           while (offset < end) {
-            int ord = (int) VH_BE_INT.get(bytes, offset);
+            int ord = (int) BitUtil.VH_BE_INT.get(bytes, offset);
             offset += 4;
-            int value = (int) VH_BE_INT.get(bytes, offset);
+            int value = (int) BitUtil.VH_BE_INT.get(bytes, offset);
             offset += 4;
             increment(ord, value);
           }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumIntAssociations.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumIntAssociations.java
@@ -17,6 +17,9 @@
 package org.apache.lucene.facet.taxonomy;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
 import java.util.List;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.facet.FacetsCollector.MatchingDocs;
@@ -47,6 +50,9 @@ public class TaxonomyFacetSumIntAssociations extends IntTaxonomyFacets {
     sumValues(fc.getMatchingDocs());
   }
 
+  private static final VarHandle VH_BE_INT =
+      MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
+
   private final void sumValues(List<MatchingDocs> matchingDocs) throws IOException {
     // System.out.println("count matchingDocs=" + matchingDocs + " facetsField=" + facetsFieldName);
     for (MatchingDocs hits : matchingDocs) {
@@ -71,17 +77,9 @@ public class TaxonomyFacetSumIntAssociations extends IntTaxonomyFacets {
           int end = bytesRef.offset + bytesRef.length;
           int offset = bytesRef.offset;
           while (offset < end) {
-            int ord =
-                ((bytes[offset] & 0xFF) << 24)
-                    | ((bytes[offset + 1] & 0xFF) << 16)
-                    | ((bytes[offset + 2] & 0xFF) << 8)
-                    | (bytes[offset + 3] & 0xFF);
+            int ord = (int) VH_BE_INT.get(bytes, offset);
             offset += 4;
-            int value =
-                ((bytes[offset] & 0xFF) << 24)
-                    | ((bytes[offset + 1] & 0xFF) << 16)
-                    | ((bytes[offset + 2] & 0xFF) << 8)
-                    | (bytes[offset + 3] & 0xFF);
+            int value = (int) VH_BE_INT.get(bytes, offset);
             offset += 4;
             increment(ord, value);
           }

--- a/lucene/queries/src/java/org/apache/lucene/queries/payloads/PayloadMatcherFactory.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/payloads/PayloadMatcherFactory.java
@@ -21,6 +21,7 @@ import java.util.EnumMap;
 import org.apache.lucene.queries.payloads.SpanPayloadCheckQuery.MatchOperation;
 import org.apache.lucene.queries.payloads.SpanPayloadCheckQuery.PayloadType;
 import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -153,10 +154,7 @@ public class PayloadMatcherFactory {
     }
 
     private int decodeInt(byte[] bytes, int offset) {
-      return ((bytes[offset] & 0xFF) << 24)
-          | ((bytes[offset + 1] & 0xFF) << 16)
-          | ((bytes[offset + 2] & 0xFF) << 8)
-          | (bytes[offset + 3] & 0xFF);
+      return (int) BitUtil.VH_BE_INT.get(bytes, offset);
     }
 
     protected abstract boolean intCompare(int val, int threshold);
@@ -203,11 +201,7 @@ public class PayloadMatcherFactory {
     }
 
     private float decodeFloat(byte[] bytes, int offset) {
-      return Float.intBitsToFloat(
-          ((bytes[offset] & 0xFF) << 24)
-              | ((bytes[offset + 1] & 0xFF) << 16)
-              | ((bytes[offset + 2] & 0xFF) << 8)
-              | (bytes[offset + 3] & 0xFF));
+      return Float.intBitsToFloat((int) BitUtil.VH_BE_INT.get(bytes, offset));
     }
 
     protected abstract boolean floatCompare(float val, float threshold);

--- a/lucene/queries/src/java/org/apache/lucene/queries/payloads/PayloadMatcherFactory.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/payloads/PayloadMatcherFactory.java
@@ -201,7 +201,7 @@ public class PayloadMatcherFactory {
     }
 
     private float decodeFloat(byte[] bytes, int offset) {
-      return Float.intBitsToFloat((int) BitUtil.VH_BE_INT.get(bytes, offset));
+      return (float) BitUtil.VH_BE_FLOAT.get(bytes, offset);
     }
 
     protected abstract boolean floatCompare(float val, float threshold);

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/idversion/IDVersionPostingsFormat.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/idversion/IDVersionPostingsFormat.java
@@ -26,6 +26,7 @@ import org.apache.lucene.codecs.lucene90.blocktree.Lucene90BlockTreeTermsWriter;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.search.LiveFieldValues;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 
@@ -108,14 +109,7 @@ public class IDVersionPostingsFormat extends PostingsFormat {
   }
 
   public static long bytesToLong(BytesRef bytes) {
-    return ((bytes.bytes[bytes.offset] & 0xFFL) << 56)
-        | ((bytes.bytes[bytes.offset + 1] & 0xFFL) << 48)
-        | ((bytes.bytes[bytes.offset + 2] & 0xFFL) << 40)
-        | ((bytes.bytes[bytes.offset + 3] & 0xFFL) << 32)
-        | ((bytes.bytes[bytes.offset + 4] & 0xFFL) << 24)
-        | ((bytes.bytes[bytes.offset + 5] & 0xFFL) << 16)
-        | ((bytes.bytes[bytes.offset + 6] & 0xFFL) << 8)
-        | (bytes.bytes[bytes.offset + 7] & 0xFFL);
+    return (long) BitUtil.VH_BE_LONG.get(bytes.bytes, bytes.offset);
   }
 
   public static void longToBytes(long v, BytesRef bytes) {
@@ -131,14 +125,7 @@ public class IDVersionPostingsFormat extends PostingsFormat {
     }
     bytes.offset = 0;
     bytes.length = 8;
-    bytes.bytes[0] = (byte) (v >> 56);
-    bytes.bytes[1] = (byte) (v >> 48);
-    bytes.bytes[2] = (byte) (v >> 40);
-    bytes.bytes[3] = (byte) (v >> 32);
-    bytes.bytes[4] = (byte) (v >> 24);
-    bytes.bytes[5] = (byte) (v >> 16);
-    bytes.bytes[6] = (byte) (v >> 8);
-    bytes.bytes[7] = (byte) v;
+    BitUtil.VH_BE_LONG.set(bytes.bytes, 0, v);
     assert bytesToLong(bytes) == v : bytesToLong(bytes) + " vs " + v + " bytes=" + bytes;
   }
 }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/document/HalfFloatPoint.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/document/HalfFloatPoint.java
@@ -26,6 +26,7 @@ import org.apache.lucene.index.PointValues;
 import org.apache.lucene.search.PointInSetQuery;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -190,12 +191,11 @@ public final class HalfFloatPoint extends Field {
   static void shortToSortableBytes(short value, byte[] result, int offset) {
     // Flip the sign bit, so negative shorts sort before positive shorts correctly:
     value ^= 0x8000;
-    result[offset] = (byte) (value >> 8);
-    result[offset + 1] = (byte) value;
+    BitUtil.VH_BE_SHORT.set(result, offset, value);
   }
 
   static short sortableBytesToShort(byte[] encoded, int offset) {
-    short x = (short) (((encoded[offset] & 0xFF) << 8) | (encoded[offset + 1] & 0xFF));
+    short x = (short) BitUtil.VH_BE_SHORT.get(encoded, offset);
     // Re-flip the sign bit to restore the original value:
     return (short) (x ^ 0x8000);
   }


### PR DESCRIPTION
See issue: https://issues.apache.org/jira/browse/LUCENE-10113