### PR TITLE
LUCENE-10097: Replace TreeMap use by HashMap when unnecessary

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilterFactory.java
@@ -21,10 +21,9 @@ import static org.apache.lucene.analysis.miscellaneous.WordDelimiterIterator.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.lucene.analysis.CharArraySet;
@@ -145,7 +144,8 @@ public class WordDelimiterGraphFilterFactory extends TokenFilterFactory
 
   // parses a list of MappingCharFilter style rules into a custom byte[] type table
   private byte[] parseTypes(List<String> rules) {
-    SortedMap<Character, Byte> typeMap = new TreeMap<>();
+    Map<Character, Byte> typeMap = new HashMap<>();
+    char maxChar = 0;
     for (String rule : rules) {
       Matcher m = typePattern.matcher(rule);
       if (!m.find()) throw new IllegalArgumentException("Invalid Mapping Rule : [" + rule + "]");
@@ -156,14 +156,16 @@ public class WordDelimiterGraphFilterFactory extends TokenFilterFactory
             "Invalid Mapping Rule : [" + rule + "]. Only a single character is allowed.");
       if (rhs == null)
         throw new IllegalArgumentException("Invalid Mapping Rule : [" + rule + "]. Illegal type.");
-      typeMap.put(lhs.charAt(0), rhs);
+      char c = lhs.charAt(0);
+      typeMap.put(c, rhs);
+      if (c > maxChar) {
+        maxChar = c;
+      }
     }
 
     // ensure the table is always at least as big as DEFAULT_WORD_DELIM_TABLE for performance
     byte[] types =
-        new byte
-            [Math.max(
-                typeMap.lastKey() + 1, WordDelimiterIterator.DEFAULT_WORD_DELIM_TABLE.length)];
+        new byte[Math.max(maxChar + 1, WordDelimiterIterator.DEFAULT_WORD_DELIM_TABLE.length)];
     for (int i = 0; i < types.length; i++) types[i] = WordDelimiterIterator.getType(i);
     for (Map.Entry<Character, Byte> mapping : typeMap.entrySet())
       types[mapping.getKey()] = mapping.getValue();

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UserDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UserDictionary.java
@@ -49,6 +49,8 @@ public final class UserDictionary implements Dictionary {
 
   public static final int RIGHT_ID = 5;
 
+  private static final int[][] EMPTY_RESULT = new int[0][];
+
   public static UserDictionary open(Reader reader) throws IOException {
 
     BufferedReader br = new BufferedReader(reader);
@@ -160,7 +162,7 @@ public final class UserDictionary implements Dictionary {
    * @param len length of text
    * @return List of {wordId, position, length}
    */
-  public List<int[]> lookup(char[] chars, int off, int len) throws IOException {
+  public int[][] lookup(char[] chars, int off, int len) throws IOException {
     ArrayList<int[]> occurrences = null;
     boolean found = false; // true if we found any occurrences.
     FST.BytesReader fstReader = fst.getBytesReader();
@@ -192,7 +194,7 @@ public final class UserDictionary implements Dictionary {
         }
       }
     }
-    return found ? occurrences : Collections.emptyList();
+    return found ? occurrences.toArray(new int[0][]) : EMPTY_RESULT;
   }
 
   public TokenInfoFST getFST() {

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestUserDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestUserDictionary.java
@@ -18,7 +18,6 @@ package org.apache.lucene.analysis.ja.dict;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.List;
 import org.apache.lucene.analysis.ja.TestJapaneseTokenizer;
 import org.apache.lucene.util.LuceneTestCase;
 import org.junit.Test;
@@ -29,46 +28,46 @@ public class TestUserDictionary extends LuceneTestCase {
   public void testLookup() throws IOException {
     UserDictionary dictionary = TestJapaneseTokenizer.readDict();
     String s = "関西国際空港に行った";
-    List<int[]> dictionaryEntryResult = dictionary.lookup(s.toCharArray(), 0, s.length());
+    int[][] dictionaryEntryResult = dictionary.lookup(s.toCharArray(), 0, s.length());
     // Length should be three 関西, 国際, 空港
-    assertEquals(3, dictionaryEntryResult.size());
+    assertEquals(3, dictionaryEntryResult.length);
 
     // Test positions
-    assertEquals(0, dictionaryEntryResult.get(0)[1]); // index of 関西
-    assertEquals(2, dictionaryEntryResult.get(1)[1]); // index of 国際
-    assertEquals(4, dictionaryEntryResult.get(2)[1]); // index of 空港
+    assertEquals(0, dictionaryEntryResult[0][1]); // index of 関西
+    assertEquals(2, dictionaryEntryResult[1][1]); // index of 国際
+    assertEquals(4, dictionaryEntryResult[2][1]); // index of 空港
 
     // Test lengths
-    assertEquals(2, dictionaryEntryResult.get(0)[2]); // length of 関西
-    assertEquals(2, dictionaryEntryResult.get(1)[2]); // length of 国際
-    assertEquals(2, dictionaryEntryResult.get(2)[2]); // length of 空港
+    assertEquals(2, dictionaryEntryResult[0][2]); // length of 関西
+    assertEquals(2, dictionaryEntryResult[1][2]); // length of 国際
+    assertEquals(2, dictionaryEntryResult[2][2]); // length of 空港
 
     s = "関西国際空港と関西国際空港に行った";
-    List<int[]> dictionaryEntryResult2 = dictionary.lookup(s.toCharArray(), 0, s.length());
+    int[][] dictionaryEntryResult2 = dictionary.lookup(s.toCharArray(), 0, s.length());
     // Length should be six
-    assertEquals(6, dictionaryEntryResult2.size());
+    assertEquals(6, dictionaryEntryResult2.length);
   }
 
   @Test
   public void testReadings() throws IOException {
     UserDictionary dictionary = TestJapaneseTokenizer.readDict();
-    List<int[]> result = dictionary.lookup("日本経済新聞".toCharArray(), 0, 6);
-    assertEquals(3, result.size());
-    int wordIdNihon = result.get(0)[0]; // wordId of 日本 in 日本経済新聞
+    int[][] result = dictionary.lookup("日本経済新聞".toCharArray(), 0, 6);
+    assertEquals(3, result.length);
+    int wordIdNihon = result[0][0]; // wordId of 日本 in 日本経済新聞
     assertEquals("ニホン", dictionary.getReading(wordIdNihon, "日本".toCharArray(), 0, 2));
 
     result = dictionary.lookup("朝青龍".toCharArray(), 0, 3);
-    assertEquals(1, result.size());
-    int wordIdAsashoryu = result.get(0)[0]; // wordId for 朝青龍
+    assertEquals(1, result.length);
+    int wordIdAsashoryu = result[0][0]; // wordId for 朝青龍
     assertEquals("アサショウリュウ", dictionary.getReading(wordIdAsashoryu, "朝青龍".toCharArray(), 0, 3));
   }
 
   @Test
   public void testPartOfSpeech() throws IOException {
     UserDictionary dictionary = TestJapaneseTokenizer.readDict();
-    List<int[]> result = dictionary.lookup("日本経済新聞".toCharArray(), 0, 6);
-    assertEquals(3, result.size());
-    int wordIdKeizai = result.get(1)[0]; // wordId of 経済 in 日本経済新聞
+    int[][] result = dictionary.lookup("日本経済新聞".toCharArray(), 0, 6);
+    assertEquals(3, result.length);
+    int wordIdKeizai = result[1][0]; // wordId of 経済 in 日本経済新聞
     assertEquals("カスタム名詞", dictionary.getPartOfSpeech(wordIdKeizai));
   }
 
@@ -109,8 +108,8 @@ public class TestUserDictionary extends LuceneTestCase {
 
     for (String input : inputs) {
       System.out.println(input);
-      List<int[]> result = dictionary.lookup(input.toCharArray(), 0, input.length());
-      assertEquals("カスタム名刺", dictionary.getPartOfSpeech(result.get(0)[0]));
+      int[][] result = dictionary.lookup(input.toCharArray(), 0, input.length());
+      assertEquals("カスタム名刺", dictionary.getPartOfSpeech(result[0][0]));
     }
   }
 }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestUserDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestUserDictionary.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.ja.dict;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.List;
 import org.apache.lucene.analysis.ja.TestJapaneseTokenizer;
 import org.apache.lucene.util.LuceneTestCase;
 import org.junit.Test;
@@ -28,46 +29,46 @@ public class TestUserDictionary extends LuceneTestCase {
   public void testLookup() throws IOException {
     UserDictionary dictionary = TestJapaneseTokenizer.readDict();
     String s = "関西国際空港に行った";
-    int[][] dictionaryEntryResult = dictionary.lookup(s.toCharArray(), 0, s.length());
+    List<int[]> dictionaryEntryResult = dictionary.lookup(s.toCharArray(), 0, s.length());
     // Length should be three 関西, 国際, 空港
-    assertEquals(3, dictionaryEntryResult.length);
+    assertEquals(3, dictionaryEntryResult.size());
 
     // Test positions
-    assertEquals(0, dictionaryEntryResult[0][1]); // index of 関西
-    assertEquals(2, dictionaryEntryResult[1][1]); // index of 国際
-    assertEquals(4, dictionaryEntryResult[2][1]); // index of 空港
+    assertEquals(0, dictionaryEntryResult.get(0)[1]); // index of 関西
+    assertEquals(2, dictionaryEntryResult.get(1)[1]); // index of 国際
+    assertEquals(4, dictionaryEntryResult.get(2)[1]); // index of 空港
 
     // Test lengths
-    assertEquals(2, dictionaryEntryResult[0][2]); // length of 関西
-    assertEquals(2, dictionaryEntryResult[1][2]); // length of 国際
-    assertEquals(2, dictionaryEntryResult[2][2]); // length of 空港
+    assertEquals(2, dictionaryEntryResult.get(0)[2]); // length of 関西
+    assertEquals(2, dictionaryEntryResult.get(1)[2]); // length of 国際
+    assertEquals(2, dictionaryEntryResult.get(2)[2]); // length of 空港
 
     s = "関西国際空港と関西国際空港に行った";
-    int[][] dictionaryEntryResult2 = dictionary.lookup(s.toCharArray(), 0, s.length());
+    List<int[]> dictionaryEntryResult2 = dictionary.lookup(s.toCharArray(), 0, s.length());
     // Length should be six
-    assertEquals(6, dictionaryEntryResult2.length);
+    assertEquals(6, dictionaryEntryResult2.size());
   }
 
   @Test
   public void testReadings() throws IOException {
     UserDictionary dictionary = TestJapaneseTokenizer.readDict();
-    int[][] result = dictionary.lookup("日本経済新聞".toCharArray(), 0, 6);
-    assertEquals(3, result.length);
-    int wordIdNihon = result[0][0]; // wordId of 日本 in 日本経済新聞
+    List<int[]> result = dictionary.lookup("日本経済新聞".toCharArray(), 0, 6);
+    assertEquals(3, result.size());
+    int wordIdNihon = result.get(0)[0]; // wordId of 日本 in 日本経済新聞
     assertEquals("ニホン", dictionary.getReading(wordIdNihon, "日本".toCharArray(), 0, 2));
 
     result = dictionary.lookup("朝青龍".toCharArray(), 0, 3);
-    assertEquals(1, result.length);
-    int wordIdAsashoryu = result[0][0]; // wordId for 朝青龍
+    assertEquals(1, result.size());
+    int wordIdAsashoryu = result.get(0)[0]; // wordId for 朝青龍
     assertEquals("アサショウリュウ", dictionary.getReading(wordIdAsashoryu, "朝青龍".toCharArray(), 0, 3));
   }
 
   @Test
   public void testPartOfSpeech() throws IOException {
     UserDictionary dictionary = TestJapaneseTokenizer.readDict();
-    int[][] result = dictionary.lookup("日本経済新聞".toCharArray(), 0, 6);
-    assertEquals(3, result.length);
-    int wordIdKeizai = result[1][0]; // wordId of 経済 in 日本経済新聞
+    List<int[]> result = dictionary.lookup("日本経済新聞".toCharArray(), 0, 6);
+    assertEquals(3, result.size());
+    int wordIdKeizai = result.get(1)[0]; // wordId of 経済 in 日本経済新聞
     assertEquals("カスタム名詞", dictionary.getPartOfSpeech(wordIdKeizai));
   }
 
@@ -108,8 +109,8 @@ public class TestUserDictionary extends LuceneTestCase {
 
     for (String input : inputs) {
       System.out.println(input);
-      int[][] result = dictionary.lookup(input.toCharArray(), 0, input.length());
-      assertEquals("カスタム名刺", dictionary.getPartOfSpeech(result[0][0]));
+      List<int[]> result = dictionary.lookup(input.toCharArray(), 0, input.length());
+      assertEquals("カスタム名刺", dictionary.getPartOfSpeech(result.get(0)[0]));
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
-import java.util.TreeMap;
 import org.apache.lucene.codecs.DocValuesConsumer;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.DocValuesProducer;
@@ -262,9 +261,9 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
     }
   }
 
-  private class FieldsReader extends DocValuesProducer {
+  private static class FieldsReader extends DocValuesProducer {
 
-    private final Map<String, DocValuesProducer> fields = new TreeMap<>();
+    private final Map<String, DocValuesProducer> fields = new HashMap<>();
     private final Map<String, DocValuesProducer> formats = new HashMap<>();
 
     // clone for merge

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
-import java.util.TreeMap;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
@@ -167,7 +166,7 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
   /** VectorReader that can wrap multiple delegate readers, selected by field. */
   public static class FieldsReader extends KnnVectorsReader {
 
-    private final Map<String, KnnVectorsReader> fields = new TreeMap<>();
+    private final Map<String, KnnVectorsReader> fields = new HashMap<>();
 
     /**
      * Create a FieldsReader over a segment, opening VectorReaders for each KnnVectorsFormat

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
@@ -20,6 +20,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -278,7 +279,7 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
   private static class FieldsReader extends FieldsProducer {
 
     private final Map<String, FieldsProducer> fields = new HashMap<>();
-    private final List<String> fieldList;
+    private final List<String> fieldNames;
     private final Map<String, FieldsProducer> formats = new HashMap<>();
     private final String segment;
 
@@ -298,7 +299,7 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
         assert producer != null;
         fields.put(ent.getKey(), producer);
       }
-      fieldList = buildFieldList(fields);
+      fieldNames = createSortedCopy(fields.keySet());
 
       segment = other.segment;
     }
@@ -331,7 +332,7 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
             }
           }
         }
-        fieldList = buildFieldList(fields);
+        fieldNames = createSortedCopy(fields.keySet());
         success = true;
       } finally {
         if (!success) {
@@ -342,15 +343,15 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
       this.segment = readState.segmentInfo.name;
     }
 
-    private static List<String> buildFieldList(Map<String, FieldsProducer> fields) {
-      List<String> fieldList = new ArrayList<>(fields.keySet());
-      fieldList.sort(null);
-      return Collections.unmodifiableList(fieldList);
+    private static List<String> createSortedCopy(Collection<String> strings) {
+      List<String> sortedStrings = new ArrayList<>(strings);
+      sortedStrings.sort(null);
+      return Collections.unmodifiableList(sortedStrings);
     }
 
     @Override
     public Iterator<String> iterator() {
-      return fieldList.iterator();
+      return fieldNames.iterator();
     }
 
     @Override


### PR DESCRIPTION
I separated the changes in several commits to be able to drop a commit if it is not appropriate.
- PerFieldDocValuesFormat and PerFieldPostingsFormat.
- WDFFactory, WDGFFactory and PerFieldKnnVectorsFormat.
- Japanese UserDictionary.