### PR TITLE
LUCENE-10097: Replace TreeMap - batch 2

### DIFF
--- a/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/OrdsBlockTreeTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/OrdsBlockTreeTermsReader.java
@@ -17,9 +17,12 @@
 package org.apache.lucene.codecs.blocktreeords;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
-import java.util.TreeMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.PostingsReaderBase;
@@ -50,7 +53,8 @@ public final class OrdsBlockTreeTermsReader extends FieldsProducer {
   // produce DocsEnum on demand
   final PostingsReaderBase postingsReader;
 
-  private final TreeMap<String, OrdsFieldReader> fields = new TreeMap<>();
+  private final Map<String, OrdsFieldReader> fields = new HashMap<>();
+  private final List<String> fieldNames;
 
   /** Sole constructor. */
   public OrdsBlockTreeTermsReader(PostingsReaderBase postingsReader, SegmentReadState state)
@@ -173,7 +177,9 @@ public final class OrdsBlockTreeTermsReader extends FieldsProducer {
         }
       }
       indexIn.close();
-
+      List<String> fieldNames = new ArrayList<>(fields.keySet());
+      fieldNames.sort(null);
+      this.fieldNames = Collections.unmodifiableList(fieldNames);
       success = true;
     } finally {
       if (!success) {
@@ -216,7 +222,7 @@ public final class OrdsBlockTreeTermsReader extends FieldsProducer {
 
   @Override
   public Iterator<String> iterator() {
-    return Collections.unmodifiableSet(fields.keySet()).iterator();
+    return fieldNames.iterator();
   }
 
   @Override

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectPostingsFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectPostingsFormat.java
@@ -17,10 +17,12 @@
 package org.apache.lucene.codecs.memory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.PostingsFormat;
@@ -118,7 +120,8 @@ public final class DirectPostingsFormat extends PostingsFormat {
   }
 
   private static final class DirectFields extends FieldsProducer {
-    private final Map<String, DirectField> fields = new TreeMap<>();
+    private final Map<String, DirectField> fields = new HashMap<>();
+    private final List<String> fieldNames;
 
     public DirectFields(SegmentReadState state, Fields fields, int minSkipCount, int lowFreqCutoff)
         throws IOException {
@@ -126,11 +129,14 @@ public final class DirectPostingsFormat extends PostingsFormat {
         this.fields.put(
             field, new DirectField(state, field, fields.terms(field), minSkipCount, lowFreqCutoff));
       }
+      List<String> fieldNames = new ArrayList<>(this.fields.keySet());
+      fieldNames.sort(null);
+      this.fieldNames = Collections.unmodifiableList(fieldNames);
     }
 
     @Override
     public Iterator<String> iterator() {
-      return Collections.unmodifiableSet(fields.keySet()).iterator();
+      return fieldNames.iterator();
     }
 
     @Override

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
@@ -20,8 +20,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
-import java.util.TreeMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.lucene.codecs.BlockTermState;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.FieldsProducer;
@@ -61,7 +63,8 @@ import org.apache.lucene.util.fst.Util;
  * @lucene.experimental
  */
 public class FSTTermsReader extends FieldsProducer {
-  final TreeMap<String, TermsReader> fields = new TreeMap<>();
+  final Map<String, TermsReader> fields = new HashMap<>();
+  final List<String> fieldNames;
   final PostingsReaderBase postingsReader;
   // static boolean TEST = false;
 
@@ -103,6 +106,9 @@ public class FSTTermsReader extends FieldsProducer {
         TermsReader previous = fields.put(fieldInfo.name, current);
         checkFieldSummary(state.segmentInfo, in, current, previous);
       }
+      List<String> fieldNames = new ArrayList<>(fields.keySet());
+      fieldNames.sort(null);
+      this.fieldNames = Collections.unmodifiableList(fieldNames);
       success = true;
     } finally {
       if (success) {
@@ -146,7 +152,7 @@ public class FSTTermsReader extends FieldsProducer {
 
   @Override
   public Iterator<String> iterator() {
-    return Collections.unmodifiableSet(fields.keySet()).iterator();
+    return fieldNames.iterator();
   }
 
   @Override

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
@@ -19,8 +19,11 @@ package org.apache.lucene.codecs.simpletext;
 import static org.apache.lucene.codecs.simpletext.SimpleTextTermVectorsWriter.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -108,7 +111,7 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
 
   @Override
   public Fields get(int doc) throws IOException {
-    SortedMap<String, SimpleTVTerms> fields = new TreeMap<>();
+    Map<String, SimpleTVTerms> fields = new HashMap<>();
     in.seek(offsets[doc]);
     readLine();
     assert StringHelper.startsWith(scratch.get(), NUMFIELDS);
@@ -242,15 +245,19 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
   }
 
   private static class SimpleTVFields extends Fields {
-    private final SortedMap<String, SimpleTVTerms> fields;
+    private final Map<String, SimpleTVTerms> fields;
+    private final List<String> fieldNames;
 
-    SimpleTVFields(SortedMap<String, SimpleTVTerms> fields) {
+    SimpleTVFields(Map<String, SimpleTVTerms> fields) {
       this.fields = fields;
+      List<String> fieldNames = new ArrayList<>(fields.keySet());
+      fieldNames.sort(null);
+      this.fieldNames = Collections.unmodifiableList(fieldNames);
     }
 
     @Override
     public Iterator<String> iterator() {
-      return Collections.unmodifiableSet(fields.keySet()).iterator();
+      return fieldNames.iterator();
     }
 
     @Override


### PR DESCRIPTION
Another batch of TreeMap replacement:
- Replace FieldsProducer fields TreeMap by Map+List in the codecs package.
  (those codecs are not used much, but I hope to reduce the TreeMap usage globally, more like a cleaning)
- in ParallelLeafReader.