### PR TITLE
LUCENE-10116: Missing calculating the bytes used of DocsWithFieldSet and currentValues in SortedSetDocValuesWriter

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -423,6 +423,9 @@ Bug Fixes
 * LUCENE-10111: Missing calculating the bytes used of DocsWithFieldSet in NormValuesWriter.
   (Lu Xugang)
 
+* LUCENE-10116: Missing calculating the bytes used of DocsWithFieldSet and currentValues in SortedSetDocValuesWriter.
+  (Lu Xugang)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValuesWriter.java
@@ -30,6 +30,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefHash;
 import org.apache.lucene.util.BytesRefHash.DirectBytesStartArray;
 import org.apache.lucene.util.Counter;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.packed.PackedInts;
 import org.apache.lucene.util.packed.PackedLongValues;
 
@@ -66,7 +67,11 @@ class SortedSetDocValuesWriter extends DocValuesWriter<SortedSetDocValues> {
     pending = PackedLongValues.packedBuilder(PackedInts.COMPACT);
     pendingCounts = PackedLongValues.deltaPackedBuilder(PackedInts.COMPACT);
     docsWithField = new DocsWithFieldSet();
-    bytesUsed = pending.ramBytesUsed() + pendingCounts.ramBytesUsed();
+    bytesUsed =
+        pending.ramBytesUsed()
+            + pendingCounts.ramBytesUsed()
+            + docsWithField.ramBytesUsed()
+            + RamUsageEstimator.sizeOf(currentValues);
     iwBytesUsed.addAndGet(bytesUsed);
   }
 
@@ -139,7 +144,11 @@ class SortedSetDocValuesWriter extends DocValuesWriter<SortedSetDocValues> {
   }
 
   private void updateBytesUsed() {
-    final long newBytesUsed = pending.ramBytesUsed() + pendingCounts.ramBytesUsed();
+    final long newBytesUsed =
+        pending.ramBytesUsed()
+            + pendingCounts.ramBytesUsed()
+            + docsWithField.ramBytesUsed()
+            + RamUsageEstimator.sizeOf(currentValues);
     iwBytesUsed.addAndGet(newBytesUsed - bytesUsed);
     bytesUsed = newBytesUsed;
   }


### PR DESCRIPTION
After [LUCENE-10111](https://github.com/apache/lucene/pull/307) ,  I read the bytes counting in SortedSetDocValuesWriter, Comparing
SortedNumericDocValuesWriter, it seems to lack of bytes used of DocsWithFieldSet and currentValues .  

Sorry for pushing a new commit with same issue
