### PR TITLE
LUCENE-10126: Fix competitiveIterator wrongly skip documents

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/Weight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Weight.java
@@ -231,10 +231,8 @@ public abstract class Weight implements SegmentCacheable {
         filteredIterator = scorerIterator;
       } else {
         // Wrap CompetitiveIterator and ScorerIterator start with (i.e., calling nextDoc()) the last
-        // visited docID
-        // because ConjunctionDISI might have advanced to it in the previous scoreRange, but we
-        // didn't process
-        // due to the range limit of scoreRange.
+        // visited docID because ConjunctionDISI might have advanced to it in the previous
+        // scoreRange, but we didn't process due to the range limit of scoreRange.
         if (scorerIterator.docID() != -1) {
           scorerIterator = new StartDISIWrapper(scorerIterator);
         }

--- a/lucene/core/src/java/org/apache/lucene/search/Weight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Weight.java
@@ -225,18 +225,25 @@ public abstract class Weight implements SegmentCacheable {
         throws IOException {
       collector.setScorer(scorer);
       DocIdSetIterator scorerIterator = twoPhase == null ? iterator : twoPhase.approximation();
-      DocIdSetIterator collectorIterator = collector.competitiveIterator();
+      DocIdSetIterator competitiveIterator = collector.competitiveIterator();
       DocIdSetIterator filteredIterator;
-      if (collectorIterator == null) {
+      if (competitiveIterator == null) {
         filteredIterator = scorerIterator;
       } else {
+        // Wrap CompetitiveIterator and ScorerIterator start with (i.e., calling nextDoc()) the last
+        // visited docID
+        // because ConjunctionDISI might have advanced to it in the previous scoreRange, but we
+        // didn't process
+        // due to the range limit of scoreRange.
         if (scorerIterator.docID() != -1) {
-          // Wrap ScorerIterator to start from -1 for conjunction
           scorerIterator = new StartDISIWrapper(scorerIterator);
+        }
+        if (competitiveIterator.docID() != -1) {
+          competitiveIterator = new StartDISIWrapper(competitiveIterator);
         }
         // filter scorerIterator to keep only competitive docs as defined by collector
         filteredIterator =
-            ConjunctionUtils.intersectIterators(Arrays.asList(scorerIterator, collectorIterator));
+            ConjunctionUtils.intersectIterators(Arrays.asList(scorerIterator, competitiveIterator));
       }
       if (filteredIterator.docID() == -1 && min == 0 && max == DocIdSetIterator.NO_MORE_DOCS) {
         scoreAll(collector, filteredIterator, twoPhase, acceptDocs);
@@ -314,15 +321,15 @@ public abstract class Weight implements SegmentCacheable {
     }
   }
 
-  /** Wraps an internal docIdSetIterator for it to start with docID = -1 */
-  protected static class StartDISIWrapper extends DocIdSetIterator {
+  /** Wraps an internal docIdSetIterator for it to start with the last visited docID */
+  private static class StartDISIWrapper extends DocIdSetIterator {
     private final DocIdSetIterator in;
-    private final int min;
+    private final int startDocID;
     private int docID = -1;
 
-    public StartDISIWrapper(DocIdSetIterator in) {
+    StartDISIWrapper(DocIdSetIterator in) {
       this.in = in;
-      this.min = in.docID();
+      this.startDocID = in.docID();
     }
 
     @Override
@@ -337,8 +344,8 @@ public abstract class Weight implements SegmentCacheable {
 
     @Override
     public int advance(int target) throws IOException {
-      if (target <= min) {
-        return docID = min;
+      if (target <= startDocID) {
+        return docID = startDocID;
       }
       return docID = in.advance(target);
     }

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
@@ -127,7 +127,33 @@ public class DocComparator extends FieldComparator<Integer> {
 
     @Override
     public DocIdSetIterator competitiveIterator() {
-      return enableSkipping ? competitiveIterator : null;
+      if (enableSkipping == false) {
+        return null;
+      } else {
+        return new DocIdSetIterator() {
+          private int docID = competitiveIterator.docID();
+
+          @Override
+          public int nextDoc() throws IOException {
+            return advance(docID + 1);
+          }
+
+          @Override
+          public int docID() {
+            return docID;
+          }
+
+          @Override
+          public long cost() {
+            return competitiveIterator.cost();
+          }
+
+          @Override
+          public int advance(int target) throws IOException {
+            return docID = competitiveIterator.advance(target);
+          }
+        };
+      }
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
@@ -127,11 +127,7 @@ public class DocComparator extends FieldComparator<Integer> {
 
     @Override
     public DocIdSetIterator competitiveIterator() {
-      if (enableSkipping == false) {
-        return null;
-      } else {
-        return competitiveIterator;
-      }
+      return enableSkipping ? competitiveIterator : null;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
@@ -130,29 +130,7 @@ public class DocComparator extends FieldComparator<Integer> {
       if (enableSkipping == false) {
         return null;
       } else {
-        return new DocIdSetIterator() {
-          private int docID = -1;
-
-          @Override
-          public int nextDoc() throws IOException {
-            return advance(docID + 1);
-          }
-
-          @Override
-          public int docID() {
-            return docID;
-          }
-
-          @Override
-          public long cost() {
-            return competitiveIterator.cost();
-          }
-
-          @Override
-          public int advance(int target) throws IOException {
-            return docID = competitiveIterator.advance(target);
-          }
-        };
+        return competitiveIterator;
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -271,7 +271,30 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
 
     @Override
     public DocIdSetIterator competitiveIterator() {
-      return enableSkipping ? competitiveIterator : null;
+      if (enableSkipping == false) return null;
+      return new DocIdSetIterator() {
+        private int docID = competitiveIterator.docID();
+
+        @Override
+        public int nextDoc() throws IOException {
+          return advance(docID + 1);
+        }
+
+        @Override
+        public int docID() {
+          return docID;
+        }
+
+        @Override
+        public long cost() {
+          return competitiveIterator.cost();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+          return docID = competitiveIterator.advance(target);
+        }
+      };
     }
 
     protected abstract boolean isMissingValueCompetitive();

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -274,6 +274,7 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
       if (enableSkipping == false) return null;
       return new DocIdSetIterator() {
         private int docID = -1;
+        private final int startDocID = competitiveIterator.docID();
 
         @Override
         public int nextDoc() throws IOException {
@@ -292,7 +293,11 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
 
         @Override
         public int advance(int target) throws IOException {
-          return docID = competitiveIterator.advance(target);
+          if (target <= startDocID) {
+            return docID = startDocID;
+          } else {
+            return docID = competitiveIterator.advance(target);
+          }
         }
       };
     }

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -271,35 +271,11 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
 
     @Override
     public DocIdSetIterator competitiveIterator() {
-      if (enableSkipping == false) return null;
-      return new DocIdSetIterator() {
-        private int docID = -1;
-        private final int startDocID = competitiveIterator.docID();
-
-        @Override
-        public int nextDoc() throws IOException {
-          return advance(docID + 1);
-        }
-
-        @Override
-        public int docID() {
-          return docID;
-        }
-
-        @Override
-        public long cost() {
-          return competitiveIterator.cost();
-        }
-
-        @Override
-        public int advance(int target) throws IOException {
-          if (target <= startDocID) {
-            return docID = startDocID;
-          } else {
-            return docID = competitiveIterator.advance(target);
-          }
-        }
-      };
+      if (enableSkipping == false) {
+        return null;
+      } else {
+        return competitiveIterator;
+      }
     }
 
     protected abstract boolean isMissingValueCompetitive();

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -271,11 +271,7 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
 
     @Override
     public DocIdSetIterator competitiveIterator() {
-      if (enableSkipping == false) {
-        return null;
-      } else {
-        return competitiveIterator;
-      }
+      return enableSkipping ? competitiveIterator : null;
     }
 
     protected abstract boolean isMissingValueCompetitive();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -16,6 +16,13 @@
  */
 package org.apache.lucene.search;
 
+import static org.apache.lucene.search.SortField.FIELD_DOC;
+import static org.apache.lucene.search.SortField.FIELD_SCORE;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FloatDocValuesField;
@@ -34,14 +41,6 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static org.apache.lucene.search.SortField.FIELD_DOC;
-import static org.apache.lucene.search.SortField.FIELD_SCORE;
 
 public class TestSortOptimization extends LuceneTestCase {
 

--- a/lucene/test-framework/src/java/org/apache/lucene/search/AssertingBulkScorer.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/AssertingBulkScorer.java
@@ -80,8 +80,22 @@ final class AssertingBulkScorer extends BulkScorer {
     assert min <= max : "max must be greater than min, got min=" + min + ", and max=" + max;
     this.max = max;
     collector = new AssertingLeafCollector(collector, min, max);
-    final int next = in.score(collector, acceptDocs, min, max);
-    assert next >= max;
+    int next = min;
+    while (next < max) {
+      final int upTo;
+      if (random.nextBoolean()) {
+        upTo = max;
+      } else {
+        final int interval;
+        if (random.nextInt(100) <= 5) {
+          interval = 1 + random.nextInt(10);
+        } else {
+          interval = 1 + random.nextInt(random.nextBoolean() ? 100 : 5000);
+        }
+        upTo = Math.toIntExact(Math.min(min + interval, max));
+      }
+      next = in.score(collector, acceptDocs, min, upTo);
+    }
     if (max >= maxDoc || next >= maxDoc) {
       assert next == DocIdSetIterator.NO_MORE_DOCS;
       return DocIdSetIterator.NO_MORE_DOCS;

--- a/lucene/test-framework/src/java/org/apache/lucene/search/AssertingWeight.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/AssertingWeight.java
@@ -21,7 +21,6 @@ import static org.apache.lucene.util.LuceneTestCase.usually;
 import java.io.IOException;
 import java.util.Random;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.util.Bits;
 
 class AssertingWeight extends FilterWeight {
 
@@ -110,41 +109,7 @@ class AssertingWeight extends FilterWeight {
     if (inScorer == null) {
       return null;
     }
-    if (random.nextBoolean()) {
-      inScorer = new ChunkedBulkScorer(inScorer, random);
-    }
     return AssertingBulkScorer.wrap(
         new Random(random.nextLong()), inScorer, context.reader().maxDoc(), scoreMode);
-  }
-
-  private static class ChunkedBulkScorer extends BulkScorer {
-    private final BulkScorer in;
-    private final Random random;
-
-    ChunkedBulkScorer(BulkScorer in, Random random) {
-      this.in = in;
-      this.random = random;
-    }
-
-    @Override
-    public int score(LeafCollector collector, Bits acceptDocs, int min, int max)
-        throws IOException {
-      while (min < max) {
-        final int interval;
-        if (random.nextInt(100) <= 5) {
-          interval = 1 + random.nextInt(10);
-        } else {
-          interval = 1 + random.nextInt(random.nextBoolean() ? 100 : 5000);
-        }
-        final int newMax = Math.toIntExact(Math.min(min + interval, max));
-        min = in.score(collector, acceptDocs, min, newMax);
-      }
-      return min;
-    }
-
-    @Override
-    public long cost() {
-      return in.cost();
-    }
   }
 }


### PR DESCRIPTION
The competitive iterator can wrongly skip a document that is advanced but not collected in the previous scoreRange.