### PR TITLE
LUCENE-10132: Support addition of diagnostics by custom merge policies

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -153,6 +153,8 @@ API Changes
 * LUCENE-10115: Add an extension point, BaseQueryParser#getFuzzyDistance, to allow custom
   query parsers to determine the similarity distance for fuzzy queries. (Chris Hegarty)
 
+*  LUCENE-10132: Support addition of diagnostics by custom merge policies (Chris Hegarty)
+
 Improvements
 
 * LUCENE-9960: Avoid unnecessary top element replacement for equal elements in PriorityQueue. (Dawid Weiss)

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -269,7 +269,7 @@ public abstract class MergePolicy {
 
     /**
      * Expert: Sets the {@link SegmentCommitInfo} of the merged segment. Allows sub-classes to e.g.
-     * set diagnostics properties.
+     * {@link SegmentInfo#addDiagnostics(Map) add diagnostic} properties.
      */
     public void setMergeInfo(SegmentCommitInfo info) {
       this.info = info;

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
@@ -85,6 +85,21 @@ public final class SegmentInfo {
     this.diagnostics = Map.copyOf(Objects.requireNonNull(diagnostics));
   }
 
+  /**
+   * Adds or modifies this segment's diagnostics.
+   *
+   * <p>Entries in the given map whose keys are not present in the current diagnostics are added.
+   * Otherwise, existing entries are modified with the given map's value.
+   *
+   * @param diagnostics the additional diagnostics
+   */
+  public void addDiagnostics(Map<String, String> diagnostics) {
+    Objects.requireNonNull(diagnostics);
+    Map<String, String> copy = new HashMap<>(this.diagnostics);
+    copy.putAll(diagnostics);
+    setDiagnostics(copy);
+  }
+
   /** Returns diagnostics saved into the segment when it was written. The map is immutable. */
   public Map<String, String> getDiagnostics() {
     return diagnostics;

--- a/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -676,9 +675,7 @@ public class TestDemoParallelLeafReader extends LuceneTestCase {
         @Override
         public void setMergeInfo(SegmentCommitInfo info) {
           // Record that this merged segment is current as of this schemaGen:
-          Map<String, String> copy = new HashMap<>(info.info.getDiagnostics());
-          copy.put(SCHEMA_GEN_KEY, Long.toString(schemaGen));
-          info.info.setDiagnostics(copy);
+          info.info.addDiagnostics(Map.of(SCHEMA_GEN_KEY, Long.toString(schemaGen)));
           super.setMergeInfo(info);
         }
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
@@ -392,4 +392,50 @@ public class TestSegmentInfos extends LuceneTestCase {
     dir.close();
     corruptDir.close();
   }
+
+  /** Test addDiagnostics method */
+  public void testAddDiagnostics() throws Throwable {
+    SegmentInfo si;
+    final Directory dir = newDirectory();
+    Codec codec = Codec.getDefault();
+
+    // diagnostics map
+    Map<String, String> diagnostics = Map.of("key1", "value1", "key2", "value2");
+
+    // adds an additional key/value pair
+    si =
+        new SegmentInfo(
+            dir,
+            Version.LATEST,
+            Version.LATEST,
+            "TEST",
+            10000,
+            false,
+            codec,
+            diagnostics,
+            StringHelper.randomId(),
+            new HashMap<>(),
+            Sort.INDEXORDER);
+    si.addDiagnostics(Map.of("key3", "value3"));
+    assertEquals(Map.of("key1", "value1", "key2", "value2", "key3", "value3"), si.getDiagnostics());
+
+    // modifies an existing key/value pair
+    si =
+        new SegmentInfo(
+            dir,
+            Version.LATEST,
+            Version.LATEST,
+            "TEST",
+            10000,
+            false,
+            codec,
+            diagnostics,
+            StringHelper.randomId(),
+            new HashMap<>(),
+            Sort.INDEXORDER);
+    si.addDiagnostics(Map.of("key2", "foo"));
+    assertEquals(Map.of("key1", "value1", "key2", "foo"), si.getDiagnostics());
+
+    dir.close();
+  }
 }


### PR DESCRIPTION
# Description

It is currently not possible for custom merge policies to add additional diagnostics.

# Solution

Add a new method, `SegmentInfo::addDiagnostics`, that allows to add or modify the segment's diagnostics.

Alternatives:
 - The new method could be constrained to simply "add", rather than "modify" (it could throw an exception if the given diagnostics map contains an entry with a key that is already present in the segment's diagnostics )
- We could avoid the new method completely and simply expose the existing `setDiagnostics`, by adding the public modifier.

On balance, the addition of the new `addDiagnostics` seems like a more cooperative way for custom merge policies to behave. 

# Tests

An additional test scenarios, testAddDiagnostics, has been added that exercises the behaviour.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
