### PR TITLE
LUCENE-10138: Use maven central to resolve third-party gradle plugins

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,13 @@
  * limitations under the License.
  */
 
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = "lucene-root"
 
 includeBuild("dev-tools/missing-doclet")


### PR DESCRIPTION
The gradle plugin portal uses jcenter to resolve third-party plugins, which
can be flaky.  This commit instructs gradle to look first in maven central,
and only use the plugin portal for gradle's own plugins.