### PR TITLE
LUCENE-10118: Fix thread visibility issue in testMergeThreadMessages

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
@@ -19,6 +19,7 @@ package org.apache.lucene.index;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -638,7 +639,7 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
         };
     iwc.setMergeScheduler(cms);
 
-    List<String> messages = new ArrayList<>();
+    List<String> messages = Collections.synchronizedList(new ArrayList<>());
     iwc.setInfoStream(
         new InfoStream() {
           @Override
@@ -682,7 +683,12 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
           messages.stream()
               .filter(line -> line.startsWith("merge thread " + name))
               .collect(Collectors.toList());
-      assertTrue(threadMsgs.size() >= 3);
+      assertTrue(
+          "Expected:·a·value·equal·to·or·greater·than·3,·got:"
+              + threadMsgs.size()
+              + ", threadMsgs="
+              + threadMsgs,
+          threadMsgs.size() >= 3);
       assertTrue(threadMsgs.get(0).startsWith("merge thread " + name + " start"));
       assertTrue(
           threadMsgs.stream()


### PR DESCRIPTION
# Description

The new test case, testMergeThreadMessages, added as part of LUCENE-10118 has been seen to fail, one time.

# Solution

There is a potential visibility issue between the thread capturing the messages and the main test thread asserting the messages. The solution is to simply use a synchronised list to guarantee visibility.

# Tests

The test case has been run several 100s of thousands of time, without failure.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
