### PR TITLE
LUCENE-10143: Make DataInput/Output short/int/long reads and writes abstract

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsReader.java
@@ -665,6 +665,23 @@ public final class Lucene50CompressingStoredFieldsReader extends StoredFieldsRea
                 bytes.length -= len;
               }
 
+              // TODO: can/should these be more efficient?
+
+              @Override
+              public short readShort() throws IOException {
+                return readShortSlowly();
+              }
+
+              @Override
+              public int readInt() throws IOException {
+                return readIntSlowly();
+              }
+
+              @Override
+              public long readLong() throws IOException {
+                return readLongSlowly();
+              }
+
               @Override
               public void skipBytes(long numBytes) throws IOException {
                 if (numBytes < 0) {

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene70/Lucene70NormsProducer.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene70/Lucene70NormsProducer.java
@@ -301,6 +301,11 @@ final class Lucene70NormsProducer extends NormsProducer implements Cloneable {
       }
 
       @Override
+      public int readInt() throws IOException {
+        throw new UnsupportedOperationException("Unused by IndexedDISI");
+      }
+
+      @Override
       public long readLong() throws IOException {
         inF.seek(offset);
         offset += Long.BYTES;

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80NormsProducer.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80NormsProducer.java
@@ -318,6 +318,11 @@ final class Lucene80NormsProducer extends NormsProducer implements Cloneable {
       }
 
       @Override
+      public int readInt() throws IOException {
+        throw new UnsupportedOperationException("Unused by IndexedDISI");
+      }
+
+      @Override
       public long readLong() throws IOException {
         inF.seek(offset);
         offset += Long.BYTES;

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
@@ -345,5 +345,20 @@ public class SimpleTextSegmentInfoFormat extends SegmentInfoFormat {
     public void writeBytes(byte[] b, int offset, int length) {
       bytes.append(b, offset, length);
     }
+
+    @Override
+    public void writeInt(int i) throws IOException {
+      writeIntSlowly(i); // we're simpletext!
+    }
+
+    @Override
+    public void writeShort(short i) throws IOException {
+      writeShortSlowly(i); // we're simpletext!
+    }
+
+    @Override
+    public void writeLong(long i) throws IOException {
+      writeLongSlowly(i); // we're simpletext!
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/MultiLevelSkipListReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/MultiLevelSkipListReader.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.MathUtil;
 
 /**
@@ -317,6 +318,27 @@ public abstract class MultiLevelSkipListReader implements Closeable {
     public void readBytes(byte[] b, int offset, int len) {
       System.arraycopy(data, pos, b, offset, len);
       pos += len;
+    }
+
+    @Override
+    public short readShort() throws IOException {
+      short value = (short) BitUtil.VH_LE_SHORT.get(pos);
+      pos += Short.BYTES;
+      return value;
+    }
+
+    @Override
+    public int readInt() throws IOException {
+      int value = (int) BitUtil.VH_LE_INT.get(pos);
+      pos += Integer.BYTES;
+      return value;
+    }
+
+    @Override
+    public long readLong() throws IOException {
+      long value = (long) BitUtil.VH_LE_LONG.get(pos);
+      pos += Long.BYTES;
+      return value;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
@@ -323,6 +323,11 @@ final class Lucene90NormsProducer extends NormsProducer implements Cloneable {
       }
 
       @Override
+      public int readInt() throws IOException {
+        throw new UnsupportedOperationException("Unused by IndexedDISI");
+      }
+
+      @Override
       public void seek(long pos) throws IOException {
         offset = pos;
       }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
@@ -577,6 +577,23 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
                 bytes.length -= len;
               }
 
+              // TODO: can/should these be more efficient?
+
+              @Override
+              public short readShort() throws IOException {
+                return readShortSlowly();
+              }
+
+              @Override
+              public int readInt() throws IOException {
+                return readIntSlowly();
+              }
+
+              @Override
+              public long readLong() throws IOException {
+                return readLongSlowly();
+              }
+
               @Override
               public void skipBytes(long numBytes) throws IOException {
                 if (numBytes < 0) {

--- a/lucene/core/src/java/org/apache/lucene/index/ByteSliceReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ByteSliceReader.java
@@ -74,6 +74,23 @@ final class ByteSliceReader extends DataInput {
     return buffer[upto++];
   }
 
+  // TODO: should/can these be more efficient?
+
+  @Override
+  public short readShort() throws IOException {
+    return readShortSlowly();
+  }
+
+  @Override
+  public int readInt() throws IOException {
+    return readIntSlowly();
+  }
+
+  @Override
+  public long readLong() throws IOException {
+    return readLongSlowly();
+  }
+
   public long writeTo(DataOutput out) throws IOException {
     long size = 0;
     while (true) {

--- a/lucene/core/src/java/org/apache/lucene/index/ByteSliceWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ByteSliceWriter.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import static org.apache.lucene.util.ByteBlockPool.BYTE_BLOCK_MASK;
 
+import java.io.IOException;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.ByteBlockPool;
 
@@ -62,6 +63,23 @@ final class ByteSliceWriter extends DataOutput {
     }
     slice[upto++] = b;
     assert upto != slice.length;
+  }
+
+  // TODO: should/could these be more efficient?
+
+  @Override
+  public void writeInt(int i) throws IOException {
+    writeIntSlowly(i);
+  }
+
+  @Override
+  public void writeShort(short i) throws IOException {
+    writeShortSlowly(i);
+  }
+
+  @Override
+  public void writeLong(long i) throws IOException {
+    writeLongSlowly(i);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/store/BufferedChecksumIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/BufferedChecksumIndexInput.java
@@ -42,6 +42,21 @@ public class BufferedChecksumIndexInput extends ChecksumIndexInput {
   }
 
   @Override
+  public short readShort() throws IOException {
+    return readShortSlowly();
+  }
+
+  @Override
+  public int readInt() throws IOException {
+    return readIntSlowly();
+  }
+
+  @Override
+  public long readLong() throws IOException {
+    return readLongSlowly();
+  }
+
+  @Override
   public void readBytes(byte[] b, int offset, int len) throws IOException {
     main.readBytes(b, offset, len);
     digest.update(b, offset, len);

--- a/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
@@ -137,7 +137,7 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
     if (Short.BYTES <= buffer.remaining()) {
       return buffer.getShort();
     } else {
-      return super.readShort();
+      return readShortSlowly();
     }
   }
 
@@ -146,7 +146,7 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
     if (Integer.BYTES <= buffer.remaining()) {
       return buffer.getInt();
     } else {
-      return super.readInt();
+      return readIntSlowly();
     }
   }
 
@@ -155,7 +155,7 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
     if (Long.BYTES <= buffer.remaining()) {
       return buffer.getLong();
     } else {
-      return super.readLong();
+      return readLongSlowly();
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -217,7 +217,7 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     } catch (
         @SuppressWarnings("unused")
         BufferUnderflowException e) {
-      return super.readShort();
+      return readShortSlowly();
     } catch (
         @SuppressWarnings("unused")
         NullPointerException npe) {
@@ -232,7 +232,7 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     } catch (
         @SuppressWarnings("unused")
         BufferUnderflowException e) {
-      return super.readInt();
+      return readIntSlowly();
     } catch (
         @SuppressWarnings("unused")
         NullPointerException npe) {
@@ -247,7 +247,7 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     } catch (
         @SuppressWarnings("unused")
         BufferUnderflowException e) {
-      return super.readLong();
+      return readLongSlowly();
     } catch (
         @SuppressWarnings("unused")
         NullPointerException npe) {

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
@@ -103,6 +103,24 @@ public final class ByteBuffersDataInput extends DataInput
     }
   }
 
+  @Override
+  public short readShort() throws IOException {
+    // TODO: use ByteBuffer.getShort
+    return readShortSlowly();
+  }
+
+  @Override
+  public int readInt() throws IOException {
+    // TODO: use ByteBuffer.getInt
+    return readIntSlowly();
+  }
+
+  @Override
+  public long readLong() throws IOException {
+    // TODO: use ByteBuffer.getLong
+    return readLongSlowly();
+  }
+
   /**
    * Reads exactly {@code len} bytes into the given buffer. The buffer must have enough remaining
    * limit.

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
@@ -308,7 +308,7 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
       if (currentBlock.remaining() >= Short.BYTES) {
         currentBlock.putShort(v);
       } else {
-        super.writeShort(v);
+        writeShortSlowly(v);
       }
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -321,7 +321,7 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
       if (currentBlock.remaining() >= Integer.BYTES) {
         currentBlock.putInt(v);
       } else {
-        super.writeInt(v);
+        writeIntSlowly(v);
       }
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -334,7 +334,7 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
       if (currentBlock.remaining() >= Long.BYTES) {
         currentBlock.putLong(v);
       } else {
-        super.writeLong(v);
+        writeLongSlowly(v);
       }
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/lucene/core/src/java/org/apache/lucene/store/DataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataInput.java
@@ -75,9 +75,17 @@ public abstract class DataInput implements Cloneable {
   /**
    * Reads two bytes and returns a short.
    *
+   * @see #readShortSlowly()
+   * @see BitUtil#VH_LE_SHORT
+   */
+  public abstract short readShort() throws IOException;
+
+  /**
+   * Reads two bytes (one-at-a-time) and returns a short.
+   *
    * @see DataOutput#writeByte(byte)
    */
-  public short readShort() throws IOException {
+  protected final short readShortSlowly() throws IOException {
     final byte b1 = readByte();
     final byte b2 = readByte();
     return (short) (((b2 & 0xFF) << 8) | (b1 & 0xFF));
@@ -86,9 +94,17 @@ public abstract class DataInput implements Cloneable {
   /**
    * Reads four bytes and returns an int.
    *
+   * @see #readIntSlowly()
+   * @see BitUtil#VH_LE_INT
+   */
+  public abstract int readInt() throws IOException;
+
+  /**
+   * Reads four bytes (one-at-a-time) and returns an int.
+   *
    * @see DataOutput#writeInt(int)
    */
-  public int readInt() throws IOException {
+  protected final int readIntSlowly() throws IOException {
     final byte b1 = readByte();
     final byte b2 = readByte();
     final byte b3 = readByte();
@@ -148,9 +164,17 @@ public abstract class DataInput implements Cloneable {
   /**
    * Reads eight bytes and returns a long.
    *
+   * @see #readLongSlowly()
+   * @see BitUtil#VH_LE_LONG
+   */
+  public abstract long readLong() throws IOException;
+
+  /**
+   * Reads eight bytes (one-at-a-time) and returns a long.
+   *
    * @see DataOutput#writeLong(long)
    */
-  public long readLong() throws IOException {
+  protected final long readLongSlowly() throws IOException {
     return (readInt() & 0xFFFFFFFFL) | (((long) readInt()) << 32);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
@@ -67,9 +67,17 @@ public abstract class DataOutput {
    *
    * <p>32-bit unsigned integer written as four bytes, low-order bytes first.
    *
+   * @see #writeIntSlowly(int)
+   * @see BitUtil#VH_LE_INT
+   */
+  public abstract void writeInt(int i) throws IOException;
+
+  /**
+   * Writes an int as four bytes (one-at-a-time).
+   *
    * @see DataInput#readInt()
    */
-  public void writeInt(int i) throws IOException {
+  protected final void writeIntSlowly(int i) throws IOException {
     writeByte((byte) i);
     writeByte((byte) (i >> 8));
     writeByte((byte) (i >> 16));
@@ -79,9 +87,17 @@ public abstract class DataOutput {
   /**
    * Writes a short as two bytes.
    *
+   * @see #writeShortSlowly(short)
+   * @see BitUtil#VH_LE_SHORT
+   */
+  public abstract void writeShort(short i) throws IOException;
+
+  /**
+   * Writes a short as two bytes (one-at-a-time).
+   *
    * @see DataInput#readShort()
    */
-  public void writeShort(short i) throws IOException {
+  protected final void writeShortSlowly(short i) throws IOException {
     writeByte((byte) i);
     writeByte((byte) (i >> 8));
   }
@@ -219,9 +235,17 @@ public abstract class DataOutput {
    *
    * <p>64-bit unsigned integer written as eight bytes, low-order bytes first.
    *
+   * @see #writeLongSlowly(long)
+   * @see BitUtil#VH_LE_LONG
+   */
+  public abstract void writeLong(long i) throws IOException;
+
+  /**
+   * Writes a long as eight bytes (one-at-a-time).
+   *
    * @see DataInput#readLong()
    */
-  public void writeLong(long i) throws IOException {
+  protected final void writeLongSlowly(long i) throws IOException {
     writeInt((int) i);
     writeInt((int) (i >> 32));
   }

--- a/lucene/core/src/java/org/apache/lucene/store/InputStreamDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/InputStreamDataInput.java
@@ -34,6 +34,21 @@ public class InputStreamDataInput extends DataInput implements Closeable {
   }
 
   @Override
+  public short readShort() throws IOException {
+    return readShortSlowly();
+  }
+
+  @Override
+  public int readInt() throws IOException {
+    return readIntSlowly();
+  }
+
+  @Override
+  public long readLong() throws IOException {
+    return readLongSlowly();
+  }
+
+  @Override
   public void readBytes(byte[] b, int offset, int len) throws IOException {
     while (len > 0) {
       final int cnt = is.read(b, offset, len);

--- a/lucene/core/src/java/org/apache/lucene/store/OutputStreamDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/OutputStreamDataOutput.java
@@ -36,6 +36,23 @@ public class OutputStreamDataOutput extends DataOutput implements Closeable {
     os.write(b, offset, length);
   }
 
+  // TODO: we could buffer the output and be more efficient, like OutputStreamIndexOutput?
+
+  @Override
+  public void writeInt(int i) throws IOException {
+    writeIntSlowly(i);
+  }
+
+  @Override
+  public void writeShort(short i) throws IOException {
+    writeShortSlowly(i);
+  }
+
+  @Override
+  public void writeLong(long i) throws IOException {
+    writeLongSlowly(i);
+  }
+
   @Override
   public void close() throws IOException {
     os.close();

--- a/lucene/core/src/java/org/apache/lucene/store/RateLimitedIndexOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RateLimitedIndexOutput.java
@@ -73,6 +73,27 @@ public final class RateLimitedIndexOutput extends IndexOutput {
     delegate.writeBytes(b, offset, length);
   }
 
+  @Override
+  public void writeInt(int i) throws IOException {
+    bytesSinceLastPause += Integer.BYTES;
+    checkRate();
+    delegate.writeInt(i);
+  }
+
+  @Override
+  public void writeShort(short i) throws IOException {
+    bytesSinceLastPause += Short.BYTES;
+    checkRate();
+    delegate.writeShort(i);
+  }
+
+  @Override
+  public void writeLong(long i) throws IOException {
+    bytesSinceLastPause += Long.BYTES;
+    checkRate();
+    delegate.writeLong(i);
+  }
+
   private void checkRate() throws IOException {
     if (bytesSinceLastPause > currentMinPauseCheckBytes) {
       rateLimiter.pause(bytesSinceLastPause);

--- a/lucene/core/src/java/org/apache/lucene/util/PagedBytes.java
+++ b/lucene/core/src/java/org/apache/lucene/util/PagedBytes.java
@@ -355,6 +355,23 @@ public final class PagedBytes implements Accountable {
       }
     }
 
+    // TODO: can/should these be more efficient?
+
+    @Override
+    public short readShort() throws IOException {
+      return readShortSlowly();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+      return readIntSlowly();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+      return readLongSlowly();
+    }
+
     @Override
     public void skipBytes(long numBytes) {
       if (numBytes < 0) {
@@ -422,6 +439,22 @@ public final class PagedBytes implements Accountable {
           break;
         }
       }
+    }
+
+    // TODO: can/should these be more efficient?
+    @Override
+    public void writeInt(int i) throws IOException {
+      writeIntSlowly(i);
+    }
+
+    @Override
+    public void writeShort(short i) throws IOException {
+      writeShortSlowly(i);
+    }
+
+    @Override
+    public void writeLong(long i) throws IOException {
+      writeLongSlowly(i);
     }
 
     /** Return the current byte position. */

--- a/lucene/core/src/java/org/apache/lucene/util/fst/BytesStore.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/BytesStore.java
@@ -113,6 +113,23 @@ class BytesStore extends DataOutput implements Accountable {
     }
   }
 
+  // TODO: can/should these be more efficient?
+
+  @Override
+  public void writeInt(int i) throws IOException {
+    writeIntSlowly(i);
+  }
+
+  @Override
+  public void writeShort(short i) throws IOException {
+    writeShortSlowly(i);
+  }
+
+  @Override
+  public void writeLong(long i) throws IOException {
+    writeLongSlowly(i);
+  }
+
   int getBlockBits() {
     return blockBits;
   }
@@ -417,6 +434,23 @@ class BytesStore extends DataOutput implements Accountable {
         }
       }
 
+      // TODO: can/should these be more efficient?
+
+      @Override
+      public short readShort() throws IOException {
+        return readShortSlowly();
+      }
+
+      @Override
+      public int readInt() throws IOException {
+        return readIntSlowly();
+      }
+
+      @Override
+      public long readLong() throws IOException {
+        return readLongSlowly();
+      }
+
       @Override
       public long getPosition() {
         return ((long) nextBuffer - 1) * blockSize + nextRead;
@@ -472,6 +506,23 @@ class BytesStore extends DataOutput implements Accountable {
         for (int i = 0; i < len; i++) {
           b[offset + i] = readByte();
         }
+      }
+
+      // TODO: can/should these be more efficient?
+
+      @Override
+      public short readShort() throws IOException {
+        return readShortSlowly();
+      }
+
+      @Override
+      public int readInt() throws IOException {
+        return readIntSlowly();
+      }
+
+      @Override
+      public long readLong() throws IOException {
+        return readLongSlowly();
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/util/fst/ForwardBytesReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/ForwardBytesReader.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.util.fst;
 
+import java.io.IOException;
+
 // TODO: can we use just ByteArrayDataInput...?  need to
 // add a .skipBytes to DataInput.. hmm and .setPosition
 
@@ -37,6 +39,23 @@ final class ForwardBytesReader extends FST.BytesReader {
   public void readBytes(byte[] b, int offset, int len) {
     System.arraycopy(bytes, pos, b, offset, len);
     pos += len;
+  }
+
+  // TODO: can/should these be more efficient?
+
+  @Override
+  public short readShort() throws IOException {
+    return readShortSlowly();
+  }
+
+  @Override
+  public int readInt() throws IOException {
+    return readIntSlowly();
+  }
+
+  @Override
+  public long readLong() throws IOException {
+    return readLongSlowly();
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/fst/ReverseBytesReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/ReverseBytesReader.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.util.fst;
 
+import java.io.IOException;
+
 /** Reads in reverse from a single byte[]. */
 final class ReverseBytesReader extends FST.BytesReader {
   private final byte[] bytes;
@@ -35,6 +37,23 @@ final class ReverseBytesReader extends FST.BytesReader {
     for (int i = 0; i < len; i++) {
       b[offset + i] = bytes[pos--];
     }
+  }
+
+  // TODO: can/should these be more efficient?
+
+  @Override
+  public short readShort() throws IOException {
+    return readShortSlowly();
+  }
+
+  @Override
+  public int readInt() throws IOException {
+    return readIntSlowly();
+  }
+
+  @Override
+  public long readLong() throws IOException {
+    return readLongSlowly();
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/fst/ReverseRandomAccessReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/ReverseRandomAccessReader.java
@@ -41,6 +41,23 @@ final class ReverseRandomAccessReader extends FST.BytesReader {
     }
   }
 
+  // TODO: can/should these be more efficient?
+
+  @Override
+  public short readShort() throws IOException {
+    return readShortSlowly();
+  }
+
+  @Override
+  public int readInt() throws IOException {
+    return readIntSlowly();
+  }
+
+  @Override
+  public long readLong() throws IOException {
+    return readLongSlowly();
+  }
+
   @Override
   public void skipBytes(long count) {
     pos -= count;

--- a/lucene/core/src/test/org/apache/lucene/codecs/TestCodecUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/TestCodecUtil.java
@@ -316,6 +316,21 @@ public class TestCodecUtil extends LuceneTestCase {
           public void writeBytes(byte[] b, int offset, int length) throws IOException {
             output.writeBytes(b, offset, length);
           }
+
+          @Override
+          public void writeInt(int i) throws IOException {
+            writeIntSlowly(i);
+          }
+
+          @Override
+          public void writeShort(short i) throws IOException {
+            writeShortSlowly(i);
+          }
+
+          @Override
+          public void writeLong(long i) throws IOException {
+            writeLongSlowly(i);
+          }
         };
 
     fakeChecksum.set(-1L); // bad

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexInput.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexInput.java
@@ -381,6 +381,21 @@ public class TestIndexInput extends LuceneTestCase {
     }
 
     @Override
+    public short readShort() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void close() {
       // no-op
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestLazyProxSkipping.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestLazyProxSkipping.java
@@ -191,6 +191,21 @@ public class TestLazyProxSkipping extends LuceneTestCase {
     }
 
     @Override
+    public short readShort() throws IOException {
+      return input.readShort();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+      return input.readInt();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+      return input.readLong();
+    }
+
+    @Override
     public void close() throws IOException {
       this.input.close();
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestMultiLevelSkipList.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMultiLevelSkipList.java
@@ -167,6 +167,24 @@ public class TestMultiLevelSkipList extends LuceneTestCase {
     }
 
     @Override
+    public short readShort() throws IOException {
+      TestMultiLevelSkipList.this.counter += Short.BYTES;
+      return input.readShort();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+      TestMultiLevelSkipList.this.counter += Integer.BYTES;
+      return input.readInt();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+      TestMultiLevelSkipList.this.counter += Long.BYTES;
+      return input.readLong();
+    }
+
+    @Override
     public void close() throws IOException {
       this.input.close();
     }

--- a/lucene/core/src/test/org/apache/lucene/util/fst/TestBitTableUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/TestBitTableUtil.java
@@ -165,6 +165,21 @@ public class TestBitTableUtil extends LuceneTestCase {
     }
 
     @Override
+    public short readShort() throws IOException {
+      return readShortSlowly();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+      return readIntSlowly();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+      return readLongSlowly();
+    }
+
+    @Override
     public void readBytes(byte[] b, int offset, int len) {
       throw new UnsupportedOperationException();
     }

--- a/lucene/facet/src/test/org/apache/lucene/facet/SlowDirectory.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/SlowDirectory.java
@@ -113,6 +113,23 @@ public class SlowDirectory extends FilterDirectory {
       ii.readBytes(b, offset, len);
     }
 
+    // TODO: can/should these be more efficient?
+
+    @Override
+    public short readShort() throws IOException {
+      return readShortSlowly();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+      return readIntSlowly();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+      return readLongSlowly();
+    }
+
     // TODO: is it intentional that clone doesnt wrap?
     @Override
     public IndexInput clone() {
@@ -186,6 +203,23 @@ public class SlowDirectory extends FilterDirectory {
       }
       numWrote += length;
       io.writeBytes(b, offset, length);
+    }
+
+    // TODO: can/should these be more efficient?
+
+    @Override
+    public void writeInt(int i) throws IOException {
+      writeIntSlowly(i);
+    }
+
+    @Override
+    public void writeShort(short i) throws IOException {
+      writeShortSlowly(i);
+    }
+
+    @Override
+    public void writeLong(long i) throws IOException {
+      writeLongSlowly(i);
     }
 
     @Override

--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -253,6 +253,23 @@ public class DirectIODirectory extends FilterDirectory {
       }
     }
 
+    // TODO: can/should these be more efficient?
+
+    @Override
+    public void writeInt(int i) throws IOException {
+      writeIntSlowly(i);
+    }
+
+    @Override
+    public void writeShort(short i) throws IOException {
+      writeShortSlowly(i);
+    }
+
+    @Override
+    public void writeLong(long i) throws IOException {
+      writeLongSlowly(i);
+    }
+
     private void dump() throws IOException {
       final int size = buffer.position();
 
@@ -424,6 +441,23 @@ public class DirectIODirectory extends FilterDirectory {
           break;
         }
       }
+    }
+
+    // TODO: can/should these be more efficient?
+
+    @Override
+    public short readShort() throws IOException {
+      return readShortSlowly();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+      return readIntSlowly();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+      return readLongSlowly();
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
@@ -811,6 +811,23 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
       }
       in.readBytes(b, offset, len);
     }
+
+    // TODO: can/should these be more efficient?
+
+    @Override
+    public short readShort() throws IOException {
+      return readShortSlowly();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+      return readIntSlowly();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+      return readLongSlowly();
+    }
   }
 
   /** A directory that tracks read bytes. */
@@ -860,6 +877,23 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
         public byte readByte() throws IOException {
           set.set(Math.toIntExact(getFilePointer()));
           return in.readByte();
+        }
+
+        // TODO: can/should these be more efficient?
+
+        @Override
+        public short readShort() throws IOException {
+          return readShortSlowly();
+        }
+
+        @Override
+        public int readInt() throws IOException {
+          return readIntSlowly();
+        }
+
+        @Override
+        public long readLong() throws IOException {
+          return readLongSlowly();
         }
 
         @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/store/CorruptingIndexOutput.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/store/CorruptingIndexOutput.java
@@ -19,7 +19,7 @@ package org.apache.lucene.store;
 
 import java.io.IOException;
 
-/** Corrupts on bit of a file after close */
+/** Corrupts one bit of a file after close */
 public class CorruptingIndexOutput extends IndexOutput {
   protected final IndexOutput out;
   final Directory dir;
@@ -101,8 +101,21 @@ public class CorruptingIndexOutput extends IndexOutput {
 
   @Override
   public void writeBytes(byte[] b, int offset, int length) throws IOException {
-    for (int i = 0; i < length; i++) {
-      writeByte(b[offset + i]);
-    }
+    out.writeBytes(b, offset, length);
+  }
+
+  @Override
+  public void writeInt(int i) throws IOException {
+    out.writeInt(i);
+  }
+
+  @Override
+  public void writeShort(short i) throws IOException {
+    out.writeShort(i);
+  }
+
+  @Override
+  public void writeLong(long i) throws IOException {
+    out.writeLong(i);
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/store/MockIndexOutputWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/store/MockIndexOutputWrapper.java
@@ -155,6 +155,21 @@ public class MockIndexOutputWrapper extends IndexOutput {
   }
 
   @Override
+  public void writeInt(int i) throws IOException {
+    writeIntSlowly(i);
+  }
+
+  @Override
+  public void writeShort(short i) throws IOException {
+    writeShortSlowly(i);
+  }
+
+  @Override
+  public void writeLong(long i) throws IOException {
+    writeLongSlowly(i);
+  }
+
+  @Override
   public long getFilePointer() {
     return delegate.getFilePointer();
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/util/ThrottledIndexOutput.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/ThrottledIndexOutput.java
@@ -111,6 +111,23 @@ public class ThrottledIndexOutput extends IndexOutput {
     sleep(getDelay(false));
   }
 
+  // TODO: can/should these be more efficient?
+
+  @Override
+  public void writeInt(int i) throws IOException {
+    writeIntSlowly(i);
+  }
+
+  @Override
+  public void writeShort(short i) throws IOException {
+    writeShortSlowly(i);
+  }
+
+  @Override
+  public void writeLong(long i) throws IOException {
+    writeLongSlowly(i);
+  }
+
   protected long getDelay(boolean closing) {
     if (pendingBytes > 0 && (closing || pendingBytes > minBytesWritten)) {
       long actualBps = (timeElapsed / pendingBytes) * 1000000000l; // nano to sec


### PR DESCRIPTION
Make the following methods abstract:
* DataInput.readShort
* DataInput.readInt
* DataInput.readLong
* DataOutput.writeShort
* DataOutput.writeInt
* DataOutput.writeLong

In javadocs of each, reference both the relevant BitUtil VH constant,
and a protected slow fallback implementation (e.g. readShortSlowly).
Slow implementations document that they read/write bytes one-at-a-time

Not all subclasses were fixed to be fast: some have TODOs.

I only fixed subclasses to be fast if it was completely 100% obvious to me. There are a lot of TODOs, feel free to push stuff to my branch (as long as tests pass!)