### PR TITLE
LUCENE-10143: Delegate primitive writes in RateLimitedIndexOutput

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -292,6 +292,9 @@ Improvements
 * LUCENE-10125: Optimize primitive writes in OutputStreamIndexOutput.
   (Uwe Schindler, Robert Muir, Adrien Grand)
 
+* LUCENE-10143: Delegate primitive writes in RateLimitedIndexOutput.
+  (Uwe Schindler, Robert Muir, Adrien Grand)
+
 Bug fixes
 
 * LUCENE-9686: Fix read past EOF handling in DirectIODirectory. (Zach Chen,

--- a/lucene/core/src/java/org/apache/lucene/store/RateLimitedIndexOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RateLimitedIndexOutput.java
@@ -73,6 +73,27 @@ public final class RateLimitedIndexOutput extends IndexOutput {
     delegate.writeBytes(b, offset, length);
   }
 
+  @Override
+  public void writeInt(int i) throws IOException {
+    bytesSinceLastPause += Integer.BYTES;
+    checkRate();
+    delegate.writeInt(i);
+  }
+
+  @Override
+  public void writeShort(short i) throws IOException {
+    bytesSinceLastPause += Short.BYTES;
+    checkRate();
+    delegate.writeShort(i);
+  }
+
+  @Override
+  public void writeLong(long i) throws IOException {
+    bytesSinceLastPause += Long.BYTES;
+    checkRate();
+    delegate.writeLong(i);
+  }
+
   private void checkRate() throws IOException {
     if (bytesSinceLastPause > currentMinPauseCheckBytes) {
       rateLimiter.pause(bytesSinceLastPause);


### PR DESCRIPTION
As simple as possible fix for https://issues.apache.org/jira/browse/LUCENE-10143