### PR TITLE
LUCENE-9488 Assemble source tar, with checksum and signing

### DIFF
--- a/lucene/packaging/build.gradle
+++ b/lucene/packaging/build.gradle
@@ -210,8 +210,7 @@ task assembleSourceDist() {
         checksum(sourceTarFile)
     }
 }
-tasks.findByName("assembleDist").dependsOn(assembleSourceDist)
-
+assembleDist.dependsOn assembleSourceDist
 
 // NOTE: we don't use the convinence DSL of the 'signing' extension to define our 'Sign' tasks because
 // that (by default) adds our signature files to the 'archives' configuration -- which is what

--- a/lucene/packaging/build.gradle
+++ b/lucene/packaging/build.gradle
@@ -213,7 +213,7 @@ task assembleSourceDist() {
         checksum(sourceTarFile)
     }
 }
-
+tasks.findByName("assembleDist").dependsOn(assembleSourceDist)
 
 
 // NOTE: we don't use the convinence DSL of the 'signing' extension to define our 'Sign' tasks because

--- a/lucene/packaging/build.gradle
+++ b/lucene/packaging/build.gradle
@@ -207,9 +207,6 @@ task assembleSourceDist() {
                     "HEAD"
             ]
         }
-    }
-
-    doLast {
         checksum(sourceTarFile)
     }
 }

--- a/lucene/packaging/build.gradle
+++ b/lucene/packaging/build.gradle
@@ -179,6 +179,41 @@ artifacts {
   luceneZip(distZip)
 }
 
+// Source distribution using git export
+def sourceTarFile = file("build/distributions/lucene-${version}-src.tgz")
+import org.apache.commons.codec.digest.DigestUtils
+
+task assembleSourceDist() {
+    def target = sourceTarFile
+
+    outputs.files target
+
+    // TODO: This is copied from distribution.gradle - reuse?
+    def checksum = { file ->
+        String sha512 = new DigestUtils(DigestUtils.sha512Digest).digestAsHex(file).trim()
+        new File(file.parent, file.name + ".sha512").write(sha512 + "  " + file.name, "UTF-8")
+    }
+
+    doFirst {
+        quietExec {
+            executable = project.externalTool("git")
+            workingDir = project.rootDir
+
+            args += [
+                    "archive",
+                    "--format", "tgz",
+                    "--prefix", "lucene-${version}/",
+                    "--output", target,
+                    "HEAD"
+            ]
+        }
+    }
+
+    doLast {
+        checksum(sourceTarFile)
+    }
+}
+
 
 
 // NOTE: we don't use the convinence DSL of the 'signing' extension to define our 'Sign' tasks because
@@ -213,8 +248,12 @@ task signDistZip(type: Sign) {
   dependsOn failUnlessGpgKeyProperty
   sign configurations.luceneZip
 }
+task signSourceDistTar(type: Sign) {
+    dependsOn failUnlessGpgKeyProperty, assembleSourceDist
+    sign sourceTarFile
+}
 task signDist {
   group = 'Distribution'
   description = 'GPG Signs the main distributions'
-  dependsOn signDistTar, signDistZip
+  dependsOn signDistTar, signDistZip, signSourceDistTar
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-9488

Creates the source tar, with checksum and gpg signing. Usage:

```
./gradlew -Dversion.release=9.0.0 assembleSourceDist
ls -l lucene/packaging/build/distributions 
./gradlew -Psigning.gnupg.keyName=0D8D0B93 -Dversion.release=9.0.0 signSourceDistTar
ls -l lucene/packaging/build/distributions 
```