### PR TITLE
LUCENE-10147: ensure that KnnVectorQuery scores are positive

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -66,7 +66,7 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
   Lucene90HnswVectorsReader(SegmentReadState state) throws IOException {
     this.fieldInfos = state.fieldInfos;
 
-    int versionMeta = readMetadata(state, Lucene90HnswVectorsFormat.META_EXTENSION);
+    int versionMeta = readMetadata(state);
     long[] checksumRef = new long[1];
     boolean success = false;
     try {
@@ -93,9 +93,10 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
     checksumSeed = checksumRef[0];
   }
 
-  private int readMetadata(SegmentReadState state, String fileExtension) throws IOException {
+  private int readMetadata(SegmentReadState state) throws IOException {
     String metaFileName =
-        IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
+        IndexFileNames.segmentFileName(
+            state.segmentInfo.name, state.segmentSuffix, Lucene90HnswVectorsFormat.META_EXTENSION);
     int versionMeta = -1;
     try (ChecksumIndexInput meta = state.directory.openChecksumInput(metaFileName, state.context)) {
       Throwable priorE = null;
@@ -255,14 +256,10 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
             random);
     int i = 0;
     ScoreDoc[] scoreDocs = new ScoreDoc[Math.min(results.size(), k)];
-    boolean reversed = fieldEntry.similarityFunction.reversed;
     while (results.size() > 0) {
       int node = results.topNode();
-      float score = results.topScore();
+      float score = fieldEntry.similarityFunction.convertToScore(results.topScore());
       results.pop();
-      if (reversed) {
-        score = 1 / (1 + score);
-      }
       scoreDocs[scoreDocs.length - ++i] = new ScoreDoc(fieldEntry.ordToDoc[node], score);
     }
     // always return >= the case where we can assert == is only when there are fewer than topK
@@ -358,7 +355,7 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
   }
 
   /** Read the vector values from the index input. This supports both iterated and random access. */
-  private class OffHeapVectorValues extends VectorValues
+  private static class OffHeapVectorValues extends VectorValues
       implements RandomAccessVectorValues, RandomAccessVectorValuesProducer {
 
     final FieldEntry fieldEntry;

--- a/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
@@ -32,6 +32,11 @@ public enum VectorSimilarityFunction {
     public float compare(float[] v1, float[] v2) {
       return squareDistance(v1, v2);
     }
+
+    @Override
+    public float convertToScore(float similarity) {
+      return 1 / (1 + similarity);
+    }
   },
 
   /** Dot product */
@@ -39,6 +44,11 @@ public enum VectorSimilarityFunction {
     @Override
     public float compare(float[] v1, float[] v2) {
       return dotProduct(v1, v2);
+    }
+
+    @Override
+    public float convertToScore(float similarity) {
+      return (1 + similarity) / 2;
     }
   };
 
@@ -65,4 +75,13 @@ public enum VectorSimilarityFunction {
    * @return the value of the similarity function applied to the two vectors
    */
   public abstract float compare(float[] v1, float[] v2);
+
+  /**
+   * Converts similarity scores used (may be negative, reversed, etc) into document scores, which
+   * must be positive, with higher scores representing better matches.
+   *
+   * @param similarity the raw internal score as returned by {@link #compare(float[], float[])}.
+   * @return normalizedSimilarity
+   */
+  public abstract float convertToScore(float similarity);
 }

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -115,9 +115,12 @@ public final class VectorUtil {
   /**
    * Modifies the argument to be unit length, dividing by its l2-norm. IllegalArgumentException is
    * thrown for zero vectors.
+   *
+   * @return the input array after normalization
    */
-  public static void l2normalize(float[] v) {
+  public static float[] l2normalize(float[] v) {
     l2normalize(v, true);
+    return v;
   }
 
   /**
@@ -125,9 +128,10 @@ public final class VectorUtil {
    *
    * @param v the vector to normalize
    * @param throwOnZero whether to throw an exception when <code>v</code> has all zeros
+   * @return the input array after normalization
    * @throws IllegalArgumentException when the vector is all zero and throwOnZero is true
    */
-  public static void l2normalize(float[] v, boolean throwOnZero) {
+  public static float[] l2normalize(float[] v, boolean throwOnZero) {
     double squareSum = 0.0f;
     int dim = v.length;
     for (float x : v) {
@@ -137,13 +141,14 @@ public final class VectorUtil {
       if (throwOnZero) {
         throw new IllegalArgumentException("Cannot normalize a zero-length vector");
       } else {
-        return;
+        return v;
       }
     }
     double length = Math.sqrt(squareSum);
     for (int i = 0; i < dim; i++) {
       v[i] /= length;
     }
+    return v;
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -33,8 +33,10 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.VectorUtil;
 
 /** TestKnnVectorQuery tests KnnVectorQuery. */
 public class TestKnnVectorQuery extends LuceneTestCase {
@@ -164,12 +166,13 @@ public class TestKnnVectorQuery extends LuceneTestCase {
     }
   }
 
-  public void testScore() throws IOException {
+  public void testScoreEuclidean() throws IOException {
     try (Directory d = newDirectory()) {
       try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
         for (int j = 0; j < 5; j++) {
           Document doc = new Document();
-          doc.add(new KnnVectorField("field", new float[] {j, j}));
+          doc.add(
+              new KnnVectorField("field", new float[] {j, j}, VectorSimilarityFunction.EUCLIDEAN));
           w.addDocument(doc);
         }
       }
@@ -198,6 +201,64 @@ public class TestKnnVectorQuery extends LuceneTestCase {
         assertEquals(1 / 6f, scorer.score(), 0);
         assertEquals(3, it.advance(3));
         assertEquals(1 / 2f, scorer.score(), 0);
+        assertEquals(NO_MORE_DOCS, it.advance(4));
+        expectThrows(ArrayIndexOutOfBoundsException.class, () -> scorer.score());
+      }
+    }
+  }
+
+  public void testScoreDotProduct() throws IOException {
+    try (Directory d = newDirectory()) {
+      try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
+        for (int j = 1; j <= 5; j++) {
+          Document doc = new Document();
+          doc.add(
+              new KnnVectorField(
+                  "field",
+                  VectorUtil.l2normalize(new float[] {j, j * j}),
+                  VectorSimilarityFunction.DOT_PRODUCT));
+          w.addDocument(doc);
+        }
+      }
+      try (IndexReader reader = DirectoryReader.open(d)) {
+        assertEquals(1, reader.leaves().size());
+        IndexSearcher searcher = new IndexSearcher(reader);
+        KnnVectorQuery query =
+            new KnnVectorQuery("field", VectorUtil.l2normalize(new float[] {2, 3}), 3);
+        Query rewritten = query.rewrite(reader);
+        Weight weight = searcher.createWeight(rewritten, ScoreMode.COMPLETE, 1);
+        Scorer scorer = weight.scorer(reader.leaves().get(0));
+
+        // prior to advancing, score is 0
+        assertEquals(-1, scorer.docID());
+        expectThrows(ArrayIndexOutOfBoundsException.class, () -> scorer.score());
+
+        // test getMaxScore
+        assertEquals(0, scorer.getMaxScore(-1), 0);
+        /* maxAtZero = ((2,3) * (1, 1) = 5) / (||2, 3|| * ||1, 1|| = sqrt(26)) = 0.5, then
+         * normalized by (1 + x) /2.
+         */
+        float maxAtZero = 0.99029f;
+        assertEquals(maxAtZero, scorer.getMaxScore(0), 0.001);
+
+        /* max at 2 is actually the score for doc 1 which is the highest (since doc 1 vector (2, 4)
+         * is the closest to (2, 3)). This is ((2,3) * (2, 4) = 16) / (||2, 3|| * ||2, 4|| = sqrt(260)), then
+         * normalized by (1 + x) /2
+         */
+        float expected =
+            (float) ((1 + (2 * 2 + 3 * 4) / Math.sqrt((2 * 2 + 3 * 3) * (2 * 2 + 4 * 4))) / 2);
+        assertEquals(expected, scorer.getMaxScore(2), 0);
+        assertEquals(expected, scorer.getMaxScore(Integer.MAX_VALUE), 0);
+
+        DocIdSetIterator it = scorer.iterator();
+        assertEquals(3, it.cost());
+        assertEquals(0, it.nextDoc());
+        // doc 0 has (1, 1)
+        assertEquals(maxAtZero, scorer.score(), 0.0001);
+        assertEquals(1, it.advance(1));
+        assertEquals(expected, scorer.score(), 0);
+        assertEquals(2, it.nextDoc());
+        // since topK was 3
         assertEquals(NO_MORE_DOCS, it.advance(4));
         expectThrows(ArrayIndexOutOfBoundsException.class, () -> scorer.score());
       }


### PR DESCRIPTION
Adds VectorSimilarity.convertToScore and uses that to "normalize" scores in vector search() function 
before returning in TopDocs.scoreDocs..score 