### PR TITLE
LUCENE-10129: Add RamUsageEstimator.shallowSizeOf() for primitive arrays

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -159,6 +159,10 @@ API Changes
 
 Improvements
 
+* LUCENE-10129: RamUsageEstimator overloads the shallowSizeOf method for primitive arrays
+  to avoid falling back on shallowSizeOf(Object), which could lead to performance traps.
+  (Robert Muir, Uwe Schindler, Stefan Vodita)
+
 * LUCENE-10139: ExternalRefSorter returns a covariant with a subtype of BytesRefIterator
   that is Closeable. (Dawid Weiss).
 

--- a/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
@@ -486,6 +486,46 @@ public final class RamUsageEstimator {
     return alignObjectSize(size);
   }
 
+  /** Returns the size in bytes of the byte[] object. */
+  public static long shallowSizeOf(byte[] arr) {
+    return sizeOf(arr);
+  }
+
+  /** Returns the size in bytes of the boolean[] object. */
+  public static long shallowSizeOf(boolean[] arr) {
+    return sizeOf(arr);
+  }
+
+  /** Returns the size in bytes of the char[] object. */
+  public static long shallowSizeOf(char[] arr) {
+    return sizeOf(arr);
+  }
+
+  /** Returns the size in bytes of the short[] object. */
+  public static long shallowSizeOf(short[] arr) {
+    return sizeOf(arr);
+  }
+
+  /** Returns the size in bytes of the int[] object. */
+  public static long shallowSizeOf(int[] arr) {
+    return sizeOf(arr);
+  }
+
+  /** Returns the size in bytes of the float[] object. */
+  public static long shallowSizeOf(float[] arr) {
+    return sizeOf(arr);
+  }
+
+  /** Returns the size in bytes of the long[] object. */
+  public static long shallowSizeOf(long[] arr) {
+    return sizeOf(arr);
+  }
+
+  /** Returns the size in bytes of the double[] object. */
+  public static long shallowSizeOf(double[] arr) {
+    return sizeOf(arr);
+  }
+
   /** Returns the shallow size in bytes of the Object[] object. */
   // Use this method instead of #shallowSizeOf(Object) to avoid costly reflection
   public static long shallowSizeOf(Object[] arr) {

--- a/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
@@ -65,41 +65,49 @@ public class TestRamUsageEstimator extends LuceneTestCase {
     {
       byte[] array = new byte[rnd.nextInt(1024)];
       assertEquals(sizeOf(array), sizeOf((Object) array));
+      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
     }
 
     {
       boolean[] array = new boolean[rnd.nextInt(1024)];
       assertEquals(sizeOf(array), sizeOf((Object) array));
+      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
     }
 
     {
       char[] array = new char[rnd.nextInt(1024)];
       assertEquals(sizeOf(array), sizeOf((Object) array));
+      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
     }
 
     {
       short[] array = new short[rnd.nextInt(1024)];
       assertEquals(sizeOf(array), sizeOf((Object) array));
+      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
     }
 
     {
       int[] array = new int[rnd.nextInt(1024)];
       assertEquals(sizeOf(array), sizeOf((Object) array));
+      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
     }
 
     {
       float[] array = new float[rnd.nextInt(1024)];
       assertEquals(sizeOf(array), sizeOf((Object) array));
+      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
     }
 
     {
       long[] array = new long[rnd.nextInt(1024)];
       assertEquals(sizeOf(array), sizeOf((Object) array));
+      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
     }
 
     {
       double[] array = new double[rnd.nextInt(1024)];
       assertEquals(sizeOf(array), sizeOf((Object) array));
+      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
     }
   }
 


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/projects/LUCENE

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>

LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

`shallowSizeOf(long[])` would call `shallowSizeOf(Object)`, which is slower, but leads to the same result as `sizeOf(long[])`. The same applies to all primitive types.

# Solution

Overload call to `shallowSizeOf()` for primitive arrays so it would not default to `shallowSizeOf(Object)`.

# Tests

Unit test calls `shallowSizeOf()` for primitive arrays and checks that result is the same as calling `sizeOf()`.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
