### PR TITLE
LUCENE-10174 Update buildAndPushRelease.py for new gradle build

### DIFF
--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -113,7 +113,8 @@ def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=
   rev = getGitRev(dev_mode=dev_mode)
   print('  git rev: %s' % rev)
   log('\nGIT rev: %s\n' % rev)
-  open('rev.txt', mode='wb').write(rev.encode('UTF-8'))
+  with open('rev.txt', mode='wb') as f:
+      f.write(rev.encode('UTF-8'))
 
   print('  Check DOAP files')
   checkDOAPfiles(version)

--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -126,7 +126,7 @@ def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=
       if gpg_home is not None:
         cmd += ' -Psigning.secretKeyRingFile="%s"' % os.path.join(gpg_home, 'secring.gpg')
     else:
-      cmd += ' -PuseGpg --signing.gnupg.keyName="%s"' % gpg_key_id
+      cmd += ' -PuseGpg -Psigning.gnupg.keyName="%s"' % gpg_key_id
       if gpg_home is not None:
         cmd += ' -Psigning.gnupg.homeDir="%s"' % gpg_home
     # Gpg password can optionally fall back to gradle.properties signing.keyId and signing.secretKeyRingFile


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-10174

* New dev mode for easier debugging the script itself
* Build correct gradle command line for `assembleRelease`
* Correct path where gradle puts the release artifacts
* New script arguments
  * `--sign-method-gradle`: Use Gradle built-in GPG signing instead of gpg command for signing artifacts
  * `--gpg-pass-noprompt`: Do not prompt for gpg passphrase
  * `--gpg-home`: Path to gpg home containing your secring.gpg
  * `--dev-mode`: Enable development mode, which disables some strict checks
 
Default gpg signing mode this script uses will be `-PuseGpg`, and combined with `--gpg-pass-noprompt` this will delegate passphrase entry to pinentry, if properly configured.

If user wants to try java-native gpg signing, pass `--sign-method-gradle`. The script will attempt to resolve gpg-home to find secring, or it can be specified with `--gpg-home`. Password can either be prompted as earler, in which case it will be passed to gradle using environment variable, not command argument. Or user can specify `--gpg-pass-noprompt` and have passphrase configured in gradle.properties or env.var `ORG_GRADLE_PROJECT_signingPassword`.
