### PR TITLE
LUCENE-10182: Be specific about which sizeOf() is called

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -163,6 +163,10 @@ API Changes
 
 Improvements
 
+* LUCENE-10182: TestRamUsageEstimator used RamUsageTester.sizeOf throughout, making some of the
+  tests trivial. Now, it compares results from RamUsageEstimator with those from RamUsageTester.
+  (Uwe Schindler, Stefan Vodita)
+
 * LUCENE-10129: RamUsageEstimator overloads the shallowSizeOf method for primitive arrays
   to avoid falling back on shallowSizeOf(Object), which could lead to performance traps.
   (Robert Muir, Uwe Schindler, Stefan Vodita)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -165,7 +165,8 @@ Improvements
 
 * LUCENE-10182: TestRamUsageEstimator used RamUsageTester.sizeOf throughout, making some of the
   tests trivial. Now, it compares results from RamUsageEstimator with those from RamUsageTester.
-  (Uwe Schindler, Stefan Vodita)
+  To prevent this error in the future, RamUsageTester.sizeOf was renamed to ramUsed.
+  (Uwe Schindler, Dawid Weiss, Stefan Vodita)
 
 * LUCENE-10129: RamUsageEstimator overloads the shallowSizeOf method for primitive arrays
   to avoid falling back on shallowSizeOf(Object), which could lead to performance traps.

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestAllDictionaries.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestAllDictionaries.java
@@ -159,8 +159,8 @@ public class TestAllDictionaries extends LuceneTestCase {
         (Path aff) -> {
           try {
             Dictionary dic = loadDictionary(aff);
-            totalMemory.addAndGet(RamUsageTester.sizeOf(dic));
-            totalWords.addAndGet(RamUsageTester.sizeOf(dic.words));
+            totalMemory.addAndGet(RamUsageTester.ramUsed(dic));
+            totalWords.addAndGet(RamUsageTester.ramUsed(dic.words));
             System.out.println(aff + "\t" + memoryUsageSummary(dic));
           } catch (Throwable e) {
             failures.add(aff);

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/packed/TestLegacyPackedInts.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/packed/TestLegacyPackedInts.java
@@ -85,7 +85,7 @@ public class TestLegacyPackedInts extends LuceneTestCase {
                 r.get(i));
           }
           in.close();
-          final long expectedBytesUsed = RamUsageTester.sizeOf(r);
+          final long expectedBytesUsed = RamUsageTester.ramUsed(r);
           final long computedBytesUsed = r.ramBytesUsed();
           assertEquals(
               r.getClass() + "expected " + expectedBytesUsed + ", got: " + computedBytesUsed,

--- a/lucene/core/src/test/org/apache/lucene/index/TestOrdinalMap.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestOrdinalMap.java
@@ -93,12 +93,12 @@ public class TestOrdinalMap extends LuceneTestCase {
     SortedDocValues sdv = MultiDocValues.getSortedValues(r, "sdv");
     if (sdv instanceof MultiDocValues.MultiSortedDocValues) {
       OrdinalMap map = ((MultiDocValues.MultiSortedDocValues) sdv).mapping;
-      assertEquals(RamUsageTester.sizeOf(map, ORDINAL_MAP_ACCUMULATOR), map.ramBytesUsed());
+      assertEquals(RamUsageTester.ramUsed(map, ORDINAL_MAP_ACCUMULATOR), map.ramBytesUsed());
     }
     SortedSetDocValues ssdv = MultiDocValues.getSortedSetValues(r, "ssdv");
     if (ssdv instanceof MultiDocValues.MultiSortedSetDocValues) {
       OrdinalMap map = ((MultiDocValues.MultiSortedSetDocValues) ssdv).mapping;
-      assertEquals(RamUsageTester.sizeOf(map, ORDINAL_MAP_ACCUMULATOR), map.ramBytesUsed());
+      assertEquals(RamUsageTester.ramUsed(map, ORDINAL_MAP_ACCUMULATOR), map.ramBytesUsed());
     }
     iw.close();
     r.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -418,7 +418,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
         }
       }
       queryCache.assertConsistent();
-      assertEquals(RamUsageTester.sizeOf(queryCache, acc), queryCache.ramBytesUsed());
+      assertEquals(RamUsageTester.ramUsed(queryCache, acc), queryCache.ramBytesUsed());
     }
 
     w.close();
@@ -523,7 +523,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     }
     assertTrue(queryCache.getCacheCount() > 0);
 
-    final long actualRamBytesUsed = RamUsageTester.sizeOf(queryCache, acc);
+    final long actualRamBytesUsed = RamUsageTester.ramUsed(queryCache, acc);
     final long expectedRamBytesUsed = queryCache.ramBytesUsed();
     // error < 30%
     assertEquals(actualRamBytesUsed, expectedRamBytesUsed, 30 * actualRamBytesUsed / 100);

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
@@ -183,7 +183,7 @@ public class TestTermInSetQuery extends LuceneTestCase {
       terms.add(newBytesRef(RandomStrings.randomUnicodeOfLength(random(), 10)));
     }
     TermInSetQuery query = new TermInSetQuery("f", terms);
-    final long actualRamBytesUsed = RamUsageTester.sizeOf(query);
+    final long actualRamBytesUsed = RamUsageTester.ramUsed(query);
     final long expectedRamBytesUsed = query.ramBytesUsed();
     // error margin within 5%
     assertEquals(expectedRamBytesUsed, actualRamBytesUsed, actualRamBytesUsed / 20);

--- a/lucene/core/src/test/org/apache/lucene/util/TestFrequencyTrackingRingBuffer.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFrequencyTrackingRingBuffer.java
@@ -72,6 +72,6 @@ public class TestFrequencyTrackingRingBuffer extends LuceneTestCase {
     for (int i = 0; i < 10000; ++i) {
       buffer.add(random().nextInt());
     }
-    assertEquals(RamUsageTester.sizeOf(buffer), buffer.ramBytesUsed());
+    assertEquals(RamUsageTester.ramUsed(buffer), buffer.ramBytesUsed());
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestPagedBytes.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestPagedBytes.java
@@ -218,9 +218,9 @@ public class TestPagedBytes extends LuceneTestCase {
       BytesRef bytes = newBytesRef(TestUtil.randomSimpleString(random(), 10));
       pointer = b.copyUsingLengthPrefix(bytes);
     }
-    assertEquals(RamUsageTester.sizeOf(b), b.ramBytesUsed());
+    assertEquals(RamUsageTester.ramUsed(b), b.ramBytesUsed());
     final PagedBytes.Reader reader = b.freeze(random().nextBoolean());
-    assertEquals(RamUsageTester.sizeOf(b), b.ramBytesUsed());
-    assertEquals(RamUsageTester.sizeOf(reader), reader.ramBytesUsed());
+    assertEquals(RamUsageTester.ramUsed(b), b.ramBytesUsed());
+    assertEquals(RamUsageTester.ramUsed(reader), reader.ramBytesUsed());
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
@@ -46,72 +46,72 @@ public class TestRamUsageEstimator extends LuceneTestCase {
   static final String[] strings = new String[] {"test string", "hollow", "catchmaster"};
 
   public void testSanity() {
-    assertTrue(RamUsageTester.sizeOf("test string") > shallowSizeOfInstance(String.class));
+    assertTrue(RamUsageTester.ramUsed("test string") > shallowSizeOfInstance(String.class));
 
     Holder holder = new Holder();
     holder.holder = new Holder("string2", 5000L);
-    assertTrue(RamUsageTester.sizeOf(holder) > shallowSizeOfInstance(Holder.class));
-    assertTrue(RamUsageTester.sizeOf(holder) > RamUsageTester.sizeOf(holder.holder));
+    assertTrue(RamUsageTester.ramUsed(holder) > shallowSizeOfInstance(Holder.class));
+    assertTrue(RamUsageTester.ramUsed(holder) > RamUsageTester.ramUsed(holder.holder));
 
     assertTrue(shallowSizeOfInstance(HolderSubclass.class) >= shallowSizeOfInstance(Holder.class));
     assertTrue(shallowSizeOfInstance(Holder.class) == shallowSizeOfInstance(HolderSubclass2.class));
 
-    assertTrue(RamUsageTester.sizeOf(strings) > shallowSizeOf(strings));
+    assertTrue(RamUsageTester.ramUsed(strings) > shallowSizeOf(strings));
   }
 
   public void testStaticOverloads() {
     Random rnd = random();
     {
       byte[] array = new byte[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
     }
 
     {
       boolean[] array = new boolean[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
     }
 
     {
       char[] array = new char[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
     }
 
     {
       short[] array = new short[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
     }
 
     {
       int[] array = new int[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
     }
 
     {
       float[] array = new float[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
     }
 
     {
       long[] array = new long[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
     }
 
     {
       double[] array = new double[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
     }
   }
 
   public void testStrings() {
-    long actual = RamUsageTester.sizeOf(strings);
+    long actual = RamUsageTester.ramUsed(strings);
     long estimated = RamUsageEstimator.sizeOf(strings);
     assertEquals(actual, estimated);
   }
@@ -122,7 +122,7 @@ public class TestRamUsageEstimator extends LuceneTestCase {
       bytes.add(new BytesRef("foo bar " + i));
       bytes.add(new BytesRef("baz bam " + i));
     }
-    long actual = RamUsageTester.sizeOf(bytes);
+    long actual = RamUsageTester.ramUsed(bytes);
     long estimated = RamUsageEstimator.sizeOf(bytes);
     assertEquals((double) actual, (double) estimated, (double) actual * 0.1);
   }
@@ -136,13 +136,13 @@ public class TestRamUsageEstimator extends LuceneTestCase {
       map.put("complex " + i, new Term("foo " + i, "bar " + i));
     }
     double errorFactor = COMPRESSED_REFS_ENABLED ? 0.2 : 0.3;
-    long actual = RamUsageTester.sizeOf(map);
+    long actual = RamUsageTester.ramUsed(map);
     long estimated = RamUsageEstimator.sizeOfObject(map);
     assertEquals((double) actual, (double) estimated, (double) actual * errorFactor);
 
     // test recursion
     map.put("self", map);
-    actual = RamUsageTester.sizeOf(map);
+    actual = RamUsageTester.ramUsed(map);
     estimated = RamUsageEstimator.sizeOfObject(map);
     assertEquals((double) actual, (double) estimated, (double) actual * errorFactor);
   }
@@ -154,13 +154,13 @@ public class TestRamUsageEstimator extends LuceneTestCase {
     for (int i = 0; i < 100; i++) {
       list.add(new Term("foo " + i, "term " + i));
     }
-    long actual = RamUsageTester.sizeOf(list);
+    long actual = RamUsageTester.ramUsed(list);
     long estimated = RamUsageEstimator.sizeOfObject(list);
     assertEquals((double) actual, (double) estimated, (double) actual * 0.1);
 
     // test recursion
     list.add(list);
-    actual = RamUsageTester.sizeOf(list);
+    actual = RamUsageTester.ramUsed(list);
     estimated = RamUsageEstimator.sizeOfObject(list);
     assertEquals((double) actual, (double) estimated, (double) actual * 0.1);
   }
@@ -179,7 +179,7 @@ public class TestRamUsageEstimator extends LuceneTestCase {
                 BooleanClause.Occur.MUST_NOT)
             .add(dismax, BooleanClause.Occur.MUST)
             .build();
-    long actual = RamUsageTester.sizeOf(bq);
+    long actual = RamUsageTester.ramUsed(bq);
     long estimated = RamUsageEstimator.sizeOfObject(bq);
     // sizeOfObject uses much lower default size estimate than we normally use
     // but the query-specific default is so large that the comparison becomes meaningless.

--- a/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
@@ -16,17 +16,8 @@
  */
 package org.apache.lucene.util;
 
-import static org.apache.lucene.util.RamUsageEstimator.COMPRESSED_REFS_ENABLED;
-import static org.apache.lucene.util.RamUsageEstimator.HOTSPOT_BEAN_CLASS;
-import static org.apache.lucene.util.RamUsageEstimator.JVM_IS_HOTSPOT_64BIT;
-import static org.apache.lucene.util.RamUsageEstimator.LONG_SIZE;
-import static org.apache.lucene.util.RamUsageEstimator.MANAGEMENT_FACTORY_CLASS;
-import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
-import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_ALIGNMENT;
-import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
-import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-import static org.apache.lucene.util.RamUsageEstimator.shallowSizeOf;
-import static org.apache.lucene.util.RamUsageEstimator.shallowSizeOfInstance;
+import static org.apache.lucene.util.RamUsageEstimator.*;
+import static org.apache.lucene.util.RamUsageTester.ramUsed;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,73 +37,73 @@ public class TestRamUsageEstimator extends LuceneTestCase {
   static final String[] strings = new String[] {"test string", "hollow", "catchmaster"};
 
   public void testSanity() {
-    assertTrue(RamUsageTester.ramUsed("test string") > shallowSizeOfInstance(String.class));
+    assertTrue(ramUsed("test string") > shallowSizeOfInstance(String.class));
 
     Holder holder = new Holder();
     holder.holder = new Holder("string2", 5000L);
-    assertTrue(RamUsageTester.ramUsed(holder) > shallowSizeOfInstance(Holder.class));
-    assertTrue(RamUsageTester.ramUsed(holder) > RamUsageTester.ramUsed(holder.holder));
+    assertTrue(ramUsed(holder) > shallowSizeOfInstance(Holder.class));
+    assertTrue(ramUsed(holder) > ramUsed(holder.holder));
 
     assertTrue(shallowSizeOfInstance(HolderSubclass.class) >= shallowSizeOfInstance(Holder.class));
     assertTrue(shallowSizeOfInstance(Holder.class) == shallowSizeOfInstance(HolderSubclass2.class));
 
-    assertTrue(RamUsageTester.ramUsed(strings) > shallowSizeOf(strings));
+    assertTrue(ramUsed(strings) > shallowSizeOf(strings));
   }
 
   public void testStaticOverloads() {
     Random rnd = random();
     {
       byte[] array = new byte[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(sizeOf(array), ramUsed(array));
+      assertEquals(shallowSizeOf(array), ramUsed(array));
     }
 
     {
       boolean[] array = new boolean[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(sizeOf(array), ramUsed(array));
+      assertEquals(shallowSizeOf(array), ramUsed(array));
     }
 
     {
       char[] array = new char[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(sizeOf(array), ramUsed(array));
+      assertEquals(shallowSizeOf(array), ramUsed(array));
     }
 
     {
       short[] array = new short[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(sizeOf(array), ramUsed(array));
+      assertEquals(shallowSizeOf(array), ramUsed(array));
     }
 
     {
       int[] array = new int[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(sizeOf(array), ramUsed(array));
+      assertEquals(shallowSizeOf(array), ramUsed(array));
     }
 
     {
       float[] array = new float[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(sizeOf(array), ramUsed(array));
+      assertEquals(shallowSizeOf(array), ramUsed(array));
     }
 
     {
       long[] array = new long[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(sizeOf(array), ramUsed(array));
+      assertEquals(shallowSizeOf(array), ramUsed(array));
     }
 
     {
       double[] array = new double[rnd.nextInt(1024)];
-      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.ramUsed(array));
-      assertEquals(shallowSizeOf(array), RamUsageTester.ramUsed(array));
+      assertEquals(sizeOf(array), ramUsed(array));
+      assertEquals(shallowSizeOf(array), ramUsed(array));
     }
   }
 
   public void testStrings() {
-    long actual = RamUsageTester.ramUsed(strings);
-    long estimated = RamUsageEstimator.sizeOf(strings);
+    long actual = ramUsed(strings);
+    long estimated = sizeOf(strings);
     assertEquals(actual, estimated);
   }
 
@@ -122,8 +113,8 @@ public class TestRamUsageEstimator extends LuceneTestCase {
       bytes.add(new BytesRef("foo bar " + i));
       bytes.add(new BytesRef("baz bam " + i));
     }
-    long actual = RamUsageTester.ramUsed(bytes);
-    long estimated = RamUsageEstimator.sizeOf(bytes);
+    long actual = ramUsed(bytes);
+    long estimated = sizeOf(bytes);
     assertEquals((double) actual, (double) estimated, (double) actual * 0.1);
   }
 
@@ -136,13 +127,13 @@ public class TestRamUsageEstimator extends LuceneTestCase {
       map.put("complex " + i, new Term("foo " + i, "bar " + i));
     }
     double errorFactor = COMPRESSED_REFS_ENABLED ? 0.2 : 0.3;
-    long actual = RamUsageTester.ramUsed(map);
+    long actual = ramUsed(map);
     long estimated = RamUsageEstimator.sizeOfObject(map);
     assertEquals((double) actual, (double) estimated, (double) actual * errorFactor);
 
     // test recursion
     map.put("self", map);
-    actual = RamUsageTester.ramUsed(map);
+    actual = ramUsed(map);
     estimated = RamUsageEstimator.sizeOfObject(map);
     assertEquals((double) actual, (double) estimated, (double) actual * errorFactor);
   }
@@ -154,13 +145,13 @@ public class TestRamUsageEstimator extends LuceneTestCase {
     for (int i = 0; i < 100; i++) {
       list.add(new Term("foo " + i, "term " + i));
     }
-    long actual = RamUsageTester.ramUsed(list);
+    long actual = ramUsed(list);
     long estimated = RamUsageEstimator.sizeOfObject(list);
     assertEquals((double) actual, (double) estimated, (double) actual * 0.1);
 
     // test recursion
     list.add(list);
-    actual = RamUsageTester.ramUsed(list);
+    actual = ramUsed(list);
     estimated = RamUsageEstimator.sizeOfObject(list);
     assertEquals((double) actual, (double) estimated, (double) actual * 0.1);
   }
@@ -179,7 +170,7 @@ public class TestRamUsageEstimator extends LuceneTestCase {
                 BooleanClause.Occur.MUST_NOT)
             .add(dismax, BooleanClause.Occur.MUST)
             .build();
-    long actual = RamUsageTester.ramUsed(bq);
+    long actual = ramUsed(bq);
     long estimated = RamUsageEstimator.sizeOfObject(bq);
     // sizeOfObject uses much lower default size estimate than we normally use
     // but the query-specific default is so large that the comparison becomes meaningless.

--- a/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
@@ -27,7 +27,6 @@ import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
 import static org.apache.lucene.util.RamUsageEstimator.shallowSizeOf;
 import static org.apache.lucene.util.RamUsageEstimator.shallowSizeOfInstance;
-import static org.apache.lucene.util.RamUsageTester.sizeOf;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,72 +46,72 @@ public class TestRamUsageEstimator extends LuceneTestCase {
   static final String[] strings = new String[] {"test string", "hollow", "catchmaster"};
 
   public void testSanity() {
-    assertTrue(sizeOf("test string") > shallowSizeOfInstance(String.class));
+    assertTrue(RamUsageTester.sizeOf("test string") > shallowSizeOfInstance(String.class));
 
     Holder holder = new Holder();
     holder.holder = new Holder("string2", 5000L);
-    assertTrue(sizeOf(holder) > shallowSizeOfInstance(Holder.class));
-    assertTrue(sizeOf(holder) > sizeOf(holder.holder));
+    assertTrue(RamUsageTester.sizeOf(holder) > shallowSizeOfInstance(Holder.class));
+    assertTrue(RamUsageTester.sizeOf(holder) > RamUsageTester.sizeOf(holder.holder));
 
     assertTrue(shallowSizeOfInstance(HolderSubclass.class) >= shallowSizeOfInstance(Holder.class));
     assertTrue(shallowSizeOfInstance(Holder.class) == shallowSizeOfInstance(HolderSubclass2.class));
 
-    assertTrue(sizeOf(strings) > shallowSizeOf(strings));
+    assertTrue(RamUsageTester.sizeOf(strings) > shallowSizeOf(strings));
   }
 
   public void testStaticOverloads() {
     Random rnd = random();
     {
       byte[] array = new byte[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), sizeOf((Object) array));
-      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
     }
 
     {
       boolean[] array = new boolean[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), sizeOf((Object) array));
-      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
     }
 
     {
       char[] array = new char[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), sizeOf((Object) array));
-      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
     }
 
     {
       short[] array = new short[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), sizeOf((Object) array));
-      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
     }
 
     {
       int[] array = new int[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), sizeOf((Object) array));
-      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
     }
 
     {
       float[] array = new float[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), sizeOf((Object) array));
-      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
     }
 
     {
       long[] array = new long[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), sizeOf((Object) array));
-      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
     }
 
     {
       double[] array = new double[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), sizeOf((Object) array));
-      assertEquals(shallowSizeOf(array), sizeOf((Object) array));
+      assertEquals(RamUsageEstimator.sizeOf(array), RamUsageTester.sizeOf(array));
+      assertEquals(shallowSizeOf(array), RamUsageTester.sizeOf(array));
     }
   }
 
   public void testStrings() {
-    long actual = sizeOf(strings);
+    long actual = RamUsageTester.sizeOf(strings);
     long estimated = RamUsageEstimator.sizeOf(strings);
     assertEquals(actual, estimated);
   }
@@ -123,7 +122,7 @@ public class TestRamUsageEstimator extends LuceneTestCase {
       bytes.add(new BytesRef("foo bar " + i));
       bytes.add(new BytesRef("baz bam " + i));
     }
-    long actual = sizeOf(bytes);
+    long actual = RamUsageTester.sizeOf(bytes);
     long estimated = RamUsageEstimator.sizeOf(bytes);
     assertEquals((double) actual, (double) estimated, (double) actual * 0.1);
   }
@@ -137,13 +136,13 @@ public class TestRamUsageEstimator extends LuceneTestCase {
       map.put("complex " + i, new Term("foo " + i, "bar " + i));
     }
     double errorFactor = COMPRESSED_REFS_ENABLED ? 0.2 : 0.3;
-    long actual = sizeOf(map);
+    long actual = RamUsageTester.sizeOf(map);
     long estimated = RamUsageEstimator.sizeOfObject(map);
     assertEquals((double) actual, (double) estimated, (double) actual * errorFactor);
 
     // test recursion
     map.put("self", map);
-    actual = sizeOf(map);
+    actual = RamUsageTester.sizeOf(map);
     estimated = RamUsageEstimator.sizeOfObject(map);
     assertEquals((double) actual, (double) estimated, (double) actual * errorFactor);
   }
@@ -155,13 +154,13 @@ public class TestRamUsageEstimator extends LuceneTestCase {
     for (int i = 0; i < 100; i++) {
       list.add(new Term("foo " + i, "term " + i));
     }
-    long actual = sizeOf(list);
+    long actual = RamUsageTester.sizeOf(list);
     long estimated = RamUsageEstimator.sizeOfObject(list);
     assertEquals((double) actual, (double) estimated, (double) actual * 0.1);
 
     // test recursion
     list.add(list);
-    actual = sizeOf(list);
+    actual = RamUsageTester.sizeOf(list);
     estimated = RamUsageEstimator.sizeOfObject(list);
     assertEquals((double) actual, (double) estimated, (double) actual * 0.1);
   }
@@ -180,7 +179,7 @@ public class TestRamUsageEstimator extends LuceneTestCase {
                 BooleanClause.Occur.MUST_NOT)
             .add(dismax, BooleanClause.Occur.MUST)
             .build();
-    long actual = sizeOf(bq);
+    long actual = RamUsageTester.sizeOf(bq);
     long estimated = RamUsageEstimator.sizeOfObject(bq);
     // sizeOfObject uses much lower default size estimate than we normally use
     // but the query-specific default is so large that the comparison becomes meaningless.

--- a/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
@@ -667,7 +667,7 @@ public class TestPackedInts extends LuceneTestCase {
     assertEquals(10, wrt.get(7));
     assertEquals(99, wrt.get(valueCount - 10));
     assertEquals(1 << 10, wrt.get(valueCount - 1));
-    assertEquals(RamUsageTester.sizeOf(wrt), wrt.ramBytesUsed());
+    assertEquals(RamUsageTester.ramUsed(wrt), wrt.ramBytesUsed());
   }
 
   public void testPagedGrowableWriter() {
@@ -703,7 +703,7 @@ public class TestPackedInts extends LuceneTestCase {
     }
 
     // test ramBytesUsed
-    assertEquals(RamUsageTester.sizeOf(writer), writer.ramBytesUsed(), 8);
+    assertEquals(RamUsageTester.ramUsed(writer), writer.ramBytesUsed(), 8);
 
     // test copy
     PagedGrowableWriter copy =
@@ -756,7 +756,7 @@ public class TestPackedInts extends LuceneTestCase {
 
     // test ramBytesUsed
     assertEquals(
-        RamUsageTester.sizeOf(writer) - RamUsageTester.sizeOf(writer.format),
+        RamUsageTester.ramUsed(writer) - RamUsageTester.ramUsed(writer.format),
         writer.ramBytesUsed());
 
     // test copy
@@ -1017,7 +1017,7 @@ public class TestPackedInts extends LuceneTestCase {
         for (int i = 0; i < arr.length; ++i) {
           buf.add(arr[i]);
           if (rarely() && !TEST_NIGHTLY) {
-            final long expectedBytesUsed = RamUsageTester.sizeOf(buf);
+            final long expectedBytesUsed = RamUsageTester.ramUsed(buf);
             final long computedBytesUsed = buf.ramBytesUsed();
             assertEquals(expectedBytesUsed, computedBytesUsed);
           }
@@ -1044,7 +1044,7 @@ public class TestPackedInts extends LuceneTestCase {
         }
         assertFalse(it.hasNext());
 
-        final long expectedBytesUsed = RamUsageTester.sizeOf(values);
+        final long expectedBytesUsed = RamUsageTester.ramUsed(values);
         final long computedBytesUsed = values.ramBytesUsed();
         assertEquals(expectedBytesUsed, computedBytesUsed);
       }

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BasePostingsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BasePostingsFormatTestCase.java
@@ -594,7 +594,7 @@ public abstract class BasePostingsFormatTestCase extends BaseIndexFileFormatTest
       Document justBodyDoc = new Document();
       justBodyDoc.add(doc.getField("body"));
       w.addDocument(justBodyDoc);
-      bytesIndexed += RamUsageTester.sizeOf(justBodyDoc);
+      bytesIndexed += RamUsageTester.ramUsed(justBodyDoc);
     }
 
     IndexReader r = w.getReader();

--- a/lucene/test-framework/src/java/org/apache/lucene/util/BaseDocIdSetTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/BaseDocIdSetTestCase.java
@@ -190,9 +190,9 @@ public abstract class BaseDocIdSetTestCase<T extends DocIdSet> extends LuceneTes
     Dummy dummy = new Dummy();
     dummy.o1 = copyOf(new BitSet(length), length);
     dummy.o2 = set;
-    long bytes1 = RamUsageTester.sizeOf(dummy);
+    long bytes1 = RamUsageTester.ramUsed(dummy);
     dummy.o2 = null;
-    long bytes2 = RamUsageTester.sizeOf(dummy);
+    long bytes2 = RamUsageTester.ramUsed(dummy);
     return bytes1 - bytes2;
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/util/RamUsageTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/RamUsageTester.java
@@ -82,23 +82,23 @@ public final class RamUsageTester {
    * traversals so it does allocate memory (it isn't side-effect free). After the method exits, this
    * memory should be GCed.
    */
-  public static long sizeOf(Object obj, Accumulator accumulator) {
+  public static long ramUsed(Object obj, Accumulator accumulator) {
     return measureObjectSize(obj, accumulator);
   }
 
   /** Same as calling <code>sizeOf(obj, DEFAULT_FILTER)</code>. */
-  public static long sizeOf(Object obj) {
-    return sizeOf(obj, new Accumulator());
+  public static long ramUsed(Object obj) {
+    return ramUsed(obj, new Accumulator());
   }
 
   /**
    * Return a human-readable size of a given object.
    *
-   * @see #sizeOf(Object)
+   * @see #ramUsed(Object)
    * @see RamUsageEstimator#humanReadableUnits(long)
    */
   public static String humanSizeOf(Object object) {
-    return RamUsageEstimator.humanReadableUnits(sizeOf(object));
+    return RamUsageEstimator.humanReadableUnits(ramUsed(object));
   }
 
   /*

--- a/lucene/test-framework/src/test/org/apache/lucene/util/TestRamUsageTesterOnWildAnimals.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/util/TestRamUsageTesterOnWildAnimals.java
@@ -37,7 +37,7 @@ public class TestRamUsageTesterOnWildAnimals extends LuceneTestCase {
         for (int i = 0; i < mid; i++) {
           last = (last.next = new ListElement());
         }
-        RamUsageTester.sizeOf(first); // cause SOE or pass.
+        RamUsageTester.ramUsed(first); // cause SOE or pass.
         lower = mid;
       } catch (
           @SuppressWarnings("unused")


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/projects/LUCENE

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>

LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Improve on `TestRamUsageEstimator.testStaticOverloads`'s use of `RamUsageTester.sizeOf` for all calls to `sizeOf`.

# Solution

Remove static import for `RamUsageTester.sizeOf`, and instead use `RamUsageTester.sizeOf` and `RamUsageEstimator.sizeOf` explicitly, when appropriate.

# Tests

This code change is **for** one of the tests.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
