### PR TITLE
Specify minimum required python version for dev scripts

### DIFF
--- a/dev-tools/scripts/README.md
+++ b/dev-tools/scripts/README.md
@@ -20,7 +20,7 @@
 This folder contains various useful scripts for developers, mostly related to
 releasing new versions of Lucene and testing those.
 
-Python scripts require Python 3.3 or avobe. To install necessary python modules, please run:
+Python scripts require Python 3.6 or avobe. To install necessary python modules, please run:
 
     pip3 install -r requirements.txt
 

--- a/dev-tools/scripts/README.md
+++ b/dev-tools/scripts/README.md
@@ -20,7 +20,7 @@
 This folder contains various useful scripts for developers, mostly related to
 releasing new versions of Lucene and testing those.
 
-Python scripts require Python 3. To install necessary python modules, please run:
+Python scripts require Python 3.3 or avobe. To install necessary python modules, please run:
 
     pip3 install -r requirements.txt
 


### PR DESCRIPTION
As far as I know, dev scripts require python 3.3 or above.

`subprocess.TimeoutError` was introduced in 3.3.
https://docs.python.org/3/library/subprocess.html#subprocess.TimeoutExpired
https://github.com/apache/lucene/blob/f38c401283c43b17fa5c63b4da0a9ffc13660bc4/dev-tools/scripts/buildAndPushRelease.py#L25

It may be better to explicitly specify the minimum required version.
(When introducing newly added APIs in 3.4 or above, the minimum required version should be also maintained; I think it's a good convention to avoid unnecessary conflicts. Some common utility to check interpreter version would be more desirable though...)

If 3.3 is too old (this has reached EOL years ago), `3.6` or above (minimum actively maintained version at this time) might be okay.