### PR TITLE
LUCENE-10185: pass --release 11 to ECJ linter, fix JDK 17 build

### DIFF
--- a/gradle/validation/ecj-lint.gradle
+++ b/gradle/validation/ecj-lint.gradle
@@ -65,6 +65,7 @@ allprojects {
         // Compilation environment.
         args += [ "-source", project.java.sourceCompatibility ]
         args += [ "-target", project.java.targetCompatibility ]
+        args += [ "--release", project.java.targetCompatibility ]
         args += [ "-encoding", "UTF-8"]
         args += [ "-proc:none" ]
         args += [ "-nowarn" ]

--- a/gradle/validation/ecj-lint.gradle
+++ b/gradle/validation/ecj-lint.gradle
@@ -63,8 +63,6 @@ allprojects {
         args += [ "-d", "none" ]
 
         // Compilation environment.
-        args += [ "-source", project.java.sourceCompatibility ]
-        args += [ "-target", project.java.targetCompatibility ]
         args += [ "--release", project.java.targetCompatibility ]
         args += [ "-encoding", "UTF-8"]
         args += [ "-proc:none" ]

--- a/lucene/core/src/java/org/apache/lucene/util/AttributeFactory.java
+++ b/lucene/core/src/java/org/apache/lucene/util/AttributeFactory.java
@@ -148,13 +148,14 @@ public abstract class AttributeFactory {
       AttributeFactory delegate, Class<A> clazz) {
     final MethodHandle constr = findAttributeImplCtor(clazz);
     return new StaticImplementationAttributeFactory<A>(delegate, clazz) {
-      // UweSays: It's ok. I know why it happens, but it's a bug. The type safety is checked by the
-      // invokeexact
       @Override
       @SuppressWarnings("unchecked")
       protected A createInstance() {
         try {
-          return (A) constr.invokeExact();
+          // be explicit with casting, so javac compiles correct call to polymorphic signature:
+          final AttributeImpl impl = (AttributeImpl) constr.invokeExact();
+          // now cast to generic type:
+          return (A) impl;
         } catch (Error | RuntimeException e) {
           throw e;
         } catch (Throwable e) {

--- a/lucene/core/src/java/org/apache/lucene/util/AttributeFactory.java
+++ b/lucene/core/src/java/org/apache/lucene/util/AttributeFactory.java
@@ -148,7 +148,10 @@ public abstract class AttributeFactory {
       AttributeFactory delegate, Class<A> clazz) {
     final MethodHandle constr = findAttributeImplCtor(clazz);
     return new StaticImplementationAttributeFactory<A>(delegate, clazz) {
+      // UweSays: It's ok. I know why it happens, but it's a bug. The type safety is checked by the
+      // invokeexact
       @Override
+      @SuppressWarnings("unchecked")
       protected A createInstance() {
         try {
           return (A) constr.invokeExact();


### PR DESCRIPTION
Otherwise, new java releases such as JDK 18, JDK 19, ... may have even
more new deprecations, the build shouldn't fail in such cases.

Note: I did a very simple suppression-fix for the AttributeFactory type-safety issue that pops up when enabling `--release`.  If you have a better fix, please commit it in here.