### PR TITLE
LUCENE-10174 BuildAndPushRelease additional improvements

### DIFF
--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -121,13 +121,13 @@ def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=
   checkDOAPfiles(version)
 
   if not dev_mode:
-    print('  ./gradlew -Dtests.badapples=false clean check')
-    run('./gradlew -Dtests.badapples=false clean check')
+    print('  ./gradlew --no-daemon -Dtests.badapples=false clean check')
+    run('./gradlew --no-daemon -Dtests.badapples=false clean check')
   else:
     print('  skipping precommit check due to dev-mode')
 
   print('  prepare-release')
-  cmd = './gradlew assembleRelease' \
+  cmd = './gradlew --no-daemon assembleRelease' \
         ' -Dversion.release=%s' % version
   if dev_mode:
     cmd += ' -Pvalidation.git.failOnModified=false'

--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -127,12 +127,12 @@ def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=
     print('  skipping precommit check due to dev-mode')
 
   print('  prepare-release')
-  cmd = './gradlew clean assembleRelease' \
+  cmd = './gradlew assembleRelease' \
         ' -Dversion.release=%s' % version
   if dev_mode:
     cmd += ' -Pvalidation.git.failOnModified=false'
   if gpg_key_id is not None:
-    cmd += ' -Psign'
+    cmd += ' -Psign --max-workers 2'
     if sign_gradle:
       print("  Signing method is gradle java-plugin")
       cmd += ' -Psigning.keyId="%s"' % gpg_key_id


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-10174

Makes assembleRelease OOM safe with max-workers=2 and faster by avoiding 'clean'