### PR TITLE
LUCENE-10182: Order assertion parameters correctly

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
@@ -60,44 +60,44 @@ public class TestRamUsageEstimator extends LuceneTestCase {
 
     {
       boolean[] array = new boolean[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), ramUsed(array));
-      assertEquals(shallowSizeOf(array), ramUsed(array));
+      assertEquals(ramUsed(array), sizeOf(array));
+      assertEquals(ramUsed(array), shallowSizeOf(array));
     }
 
     {
       char[] array = new char[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), ramUsed(array));
-      assertEquals(shallowSizeOf(array), ramUsed(array));
+      assertEquals(ramUsed(array), sizeOf(array));
+      assertEquals(ramUsed(array), shallowSizeOf(array));
     }
 
     {
       short[] array = new short[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), ramUsed(array));
-      assertEquals(shallowSizeOf(array), ramUsed(array));
+      assertEquals(ramUsed(array), sizeOf(array));
+      assertEquals(ramUsed(array), shallowSizeOf(array));
     }
 
     {
       int[] array = new int[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), ramUsed(array));
-      assertEquals(shallowSizeOf(array), ramUsed(array));
+      assertEquals(ramUsed(array), sizeOf(array));
+      assertEquals(ramUsed(array), shallowSizeOf(array));
     }
 
     {
       float[] array = new float[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), ramUsed(array));
-      assertEquals(shallowSizeOf(array), ramUsed(array));
+      assertEquals(ramUsed(array), sizeOf(array));
+      assertEquals(ramUsed(array), shallowSizeOf(array));
     }
 
     {
       long[] array = new long[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), ramUsed(array));
-      assertEquals(shallowSizeOf(array), ramUsed(array));
+      assertEquals(ramUsed(array), sizeOf(array));
+      assertEquals(ramUsed(array), shallowSizeOf(array));
     }
 
     {
       double[] array = new double[rnd.nextInt(1024)];
-      assertEquals(sizeOf(array), ramUsed(array));
-      assertEquals(shallowSizeOf(array), ramUsed(array));
+      assertEquals(ramUsed(array), sizeOf(array));
+      assertEquals(ramUsed(array), shallowSizeOf(array));
     }
   }
 


### PR DESCRIPTION
# Description

Reorder assert parameters in `TestRamUsageEstimator.testStaticOverloads` like `assertEquals(expected, actual)` instead of `assertEquals(actual, expected)`.


# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
