### PR TITLE
LUCENE-10146: Add note that dot product is preferred over cosine

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
@@ -59,8 +59,8 @@ public enum VectorSimilarityFunction {
   /**
    * Cosine similarity. NOTE: the preferred way to perform cosine similarity is to normalize all
    * vectors to unit length, and instead use {@link VectorSimilarityFunction#DOT_PRODUCT}. You
-   * should only use this function if you need to preserve the original vectors and cannot
-   * normalize them in advance.
+   * should only use this function if you need to preserve the original vectors and cannot normalize
+   * them in advance.
    */
   COSINE {
     @Override

--- a/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
@@ -56,7 +56,12 @@ public enum VectorSimilarityFunction {
     }
   },
 
-  /** Cosine similarity */
+  /**
+   * Cosine similarity. NOTE: the preferred way to perform cosine similarity is to normalize all
+   * vectors to unit length, and instead use {@link VectorSimilarityFunction#DOT_PRODUCT}. You
+   * should only use this function if you need to preserve the original vectors and cannot
+   * normalize them in advance.
+   */
   COSINE {
     @Override
     public float compare(float[] v1, float[] v2) {


### PR DESCRIPTION
While VectorSimilarityFunction#COSINE is helpful when you need to preserve the
original vectors, it is significantly slower than DOT_PRODUCT. This commit adds
javadocs to COSINE explaining that dot product is the fastest option.