### PR TITLE
LUCENE-10174 Speed up 'pushLocal'

### DIFF
--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -220,14 +220,14 @@ def pushLocal(version, root, rev, rcNum, localDir):
   lucene_dist_dir = '%s/lucene/distribution/build/release' % root
   os.chdir(lucene_dist_dir)
   print('    zip...')
-  if os.path.exists('lucene.tar.bz2'):
-    os.remove('lucene.tar.bz2')
-  run('tar cjf lucene.tar.bz2 *')
+  if os.path.exists('lucene.tar'):
+    os.remove('lucene.tar')
+  run('tar cf lucene.tar *')
 
   os.chdir('%s/%s/lucene' % (localDir, dir))
   print('    unzip...')
-  run('tar xjf "%s/lucene.tar.bz2"' % lucene_dist_dir)
-  os.remove('%s/lucene.tar.bz2' % lucene_dist_dir)
+  run('tar xf "%s/lucene.tar"' % lucene_dist_dir)
+  os.remove('%s/lucene.tar' % lucene_dist_dir)
   os.chdir('..')
 
   print('  chmod...')

--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -219,13 +219,13 @@ def pushLocal(version, root, rev, rcNum, localDir):
   print('  Lucene')
   lucene_dist_dir = '%s/lucene/distribution/build/release' % root
   os.chdir(lucene_dist_dir)
-  print('    zip...')
+  print('    archive...')
   if os.path.exists('lucene.tar'):
     os.remove('lucene.tar')
   run('tar cf lucene.tar *')
 
   os.chdir('%s/%s/lucene' % (localDir, dir))
-  print('    unzip...')
+  print('    extract...')
   run('tar xf "%s/lucene.tar"' % lucene_dist_dir)
   os.remove('%s/lucene.tar' % lucene_dist_dir)
   os.chdir('..')


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-10174

When copying files from `lucene/distribution/build/release` to the target directory, the script uses `tar.bz2`, i.e. with compression. This is super slow and usesless since files are already compressed. This PR uses plain `tar` without compression to greatly speed up this step.

In my test, we reduced this step from 36 seconds to 0.05 seconds :-)