### PR TITLE
LUCENE-10230 make demo builds easier to execute

### DIFF
--- a/lucene/demo/build.gradle
+++ b/lucene/demo/build.gradle
@@ -19,6 +19,10 @@ apply plugin: 'java-library'
 
 description = 'Simple example code for Apache Lucene'
 
+ext {
+  standaloneDistDir = file("$buildDir/${archivesBaseName}-${project.version}")
+}
+
 dependencies {
   implementation project(':lucene:core')
   implementation project(':lucene:facet')
@@ -28,4 +32,56 @@ dependencies {
   implementation project(':lucene:expressions')
 
   testImplementation project(':lucene:test-framework')
+}
+
+// Configure "stand-alone" JAR with proper dependency classpath links.
+task standaloneJar(type: Jar) {
+  dependsOn classes
+
+  archiveFileName = "${archivesBaseName}-${project.version}-standalone.jar"
+
+  from(sourceSets.main.output)
+
+  // manifest attributes are resolved eagerly and we can't access runtimeClasspath
+  // at configuration time so push it until execution.
+  doFirst {
+    manifest {
+      attributes("Class-Path": configurations.runtimeClasspath.collect {
+        "${it.getName()}"
+      }.join(' '))
+    }
+  }
+}
+
+task standaloneAssemble(type: Sync) {
+  def antHelper = new org.apache.tools.ant.Project()
+  afterEvaluate {
+    def substituteProperties = [
+        "required.java.version": project.java.targetCompatibility
+    ]
+    substituteProperties.each { k, v -> antHelper.setProperty(k.toString(), v.toString()) }
+  }
+
+  from standaloneJar
+  from configurations.runtimeClasspath
+
+  into standaloneDistDir
+
+  doLast {
+    logger.lifecycle("Standalone demo distribution assembled. You can execute demos with:\n"
+        + "java -cp " + file("${standaloneDistDir}/${standaloneJar.archiveFileName.get()} org.apache.lucene.demo.{the-demo} {demo-args}"))
+  }
+}
+
+// Attach standalone distribution assembly to main assembly.
+assemble.dependsOn standaloneAssemble
+
+// Create a standalone package bundle.
+task standalonePackage(type: Tar) {
+  from standaloneAssemble
+
+  into "${archivesBaseName}-${project.version}/"
+
+  compression = Compression.GZIP
+  archiveFileName = "${archivesBaseName}-${project.version}-standalone.tgz"
 }

--- a/lucene/demo/src/java/overview.html
+++ b/lucene/demo/src/java/overview.html
@@ -26,7 +26,7 @@
 <ul class="minitoc">
 <li><a href="#About_this_Document">About this Document</a></li>
 <li><a href="#About_the_Demo">About the Demo</a></li>
-<li><a href="#Setting_your_CLASSPATH">Setting your CLASSPATH</a></li>
+<li><a href="#Setting_up_your_Build">Setting up your build</a></li>
 <li><a href="#Indexing_Files">Indexing Files</a></li>
 <li><a href="#About_the_code">About the code</a></li>
 <li><a href="#Location_of_the_source">Location of the source</a></li>
@@ -49,22 +49,15 @@ configuration.</p>
 demonstrates various functionalities of Lucene and how you can add Lucene to
 your applications.</p>
 </div>
-<a id="Setting_your_CLASSPATH"></a>
-<h2 class="boxed">Setting your CLASSPATH</h2>
+<a id="Setting_up_your_Build"></a>
+<h2 class="boxed">Setting up your build</h2>
 <div class="section">
-<p>First, you should <a href=
-"http://www.apache.org/dyn/closer.cgi/lucene/java/">download</a> the latest
-Lucene distribution and then extract it to a working directory.</p>
-<p>You need four JARs: the Lucene JAR, the queryparser JAR, the common analysis JAR, and the Lucene
-demo JAR. You should see the Lucene JAR file in the core/ directory you created
-when you extracted the archive -- it should be named something like
-<span class="codefrag">lucene-core-{version}.jar</span>. You should also see
-files called <span class="codefrag">lucene-queryparser-{version}.jar</span>,
-<span class=
-"codefrag">lucene-analysis-common-{version}.jar</span> and <span class=
-"codefrag">lucene-demo-{version}.jar</span> under queryparser, analysis/common/ and demo/,
-respectively.</p>
-<p>Put all four of these files in your Java CLASSPATH.</p>
+<p>First, build Lucene folling the <a href=
+"https://github.com/apache/lucene#building-with-gradle">guide</a>.</p>
+<p>Assuming the build passed, you can start the demo with:</p>
+<pre>
+    java -cp {path-to-jar}/lucene-demo-{version}-SNAPSHOT-standalone.jar} org.apache.lucene.demo.{the-demo} {demo-args}
+</pre>
 </div>
 <a id="Indexing_Files"></a>
 <h2 class="boxed">Indexing Files</h2>
@@ -72,13 +65,13 @@ respectively.</p>
 <p>Once you've gotten this far you're probably itching to go. Let's <b>build an
 index!</b> Assuming you've set your CLASSPATH correctly, just type:</p>
 <pre>
-    java org.apache.lucene.demo.IndexFiles -docs {path-to-lucene}
+    java -cp {path-to-jar}/lucene-demo-{version}-SNAPSHOT-standalone.jar org.apache.lucene.demo.IndexFiles -docs {path-to-lucene}
 </pre>
 This will produce a subdirectory called <span class="codefrag">index</span>
 which will contain an index of all of the Lucene source code.
 <p>To <b>search the index</b> type:</p>
 <pre>
-    java org.apache.lucene.demo.SearchFiles
+    java -cp {path-to-jar}/lucene-demo-{version}-SNAPSHOT-standalone.jar org.apache.lucene.demo.SearchFiles
 </pre>
 You'll be prompted for a query. Type in a gibberish or made up word (for example: 
 "superca<!-- need to break up word in a way that is not visibile so it doesn't cause this ile to match a search on this word -->lifragilisticexpialidocious").


### PR DESCRIPTION
# Description

Setting up and executing the demo is complicated, but it should be as easy as starting luke. This change adds build steps to create a jar for executing the demos easier.

#11266

# Solution

The change is mainly gradle and some documentation adjustments.

Note: I followed/copied logic from https://github.com/apache/lucene/blob/main/lucene/luke/build.gradle.

# Tests

Does not apply, the change only affects build code.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
