### PR TITLE
LUCENE-10207: Add "slow" term-in-set query support to SortedDocValuesField / SortedSetDocValuesField

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -128,6 +128,9 @@ New Features
 * LUCENE-10274: Added facetsets module for high dimensional (hyper-rectangle) faceting
 (Shai Erera, Marc D'Mello, Greg Miller)
 
+* LUCENE-10207: Add new "slow" term-in-set query support to SortedDocValuesField / SortedSetDocValuesField.
+  (Robert Muir, Greg Miller)
+
 Improvements
 ---------------------
 
@@ -252,7 +255,7 @@ New Features
 * LUCENE-10385: Implement Weight#count on IndexSortSortedNumericDocValuesRangeQuery
   to speed up computing the number of hits when possible. (Lu Xugang, Luca Cavanna, Adrien Grand)
 
-* LUCENE-10422: Monitor Improvements: `Monitor` can use a custom `Directory` 
+* LUCENE-10422: Monitor Improvements: `Monitor` can use a custom `Directory`
   implementation. `Monitor` can be created with a readonly `QueryIndex` in order to
   have readonly `Monitor` instances. (Niko Usai)
 
@@ -311,7 +314,7 @@ Optimizations
   term of each block as a dictionary when compressing suffixes of the other 63
   terms of the block. (Adrien Grand)
 
-* LUCENE-10411: Add nearest neighbors vectors support to ExitableDirectoryReader. 
+* LUCENE-10411: Add nearest neighbors vectors support to ExitableDirectoryReader.
   (Zach Chen, Adrien Grand, Julie Tibshirani, Tomoko Uchida)
 
 * LUCENE-10542: FieldSource exists implementations can avoid value retrieval (Kevin Risden)
@@ -476,7 +479,7 @@ New Features
   points are indexed.
   (Quentin Pradet, Adrien Grand)
 
-* LUCENE-10263: Added Weight#count to NormsFieldExistsQuery to speed up the query if all 
+* LUCENE-10263: Added Weight#count to NormsFieldExistsQuery to speed up the query if all
   documents have the field.. (Alan Woodward)
 
 * LUCENE-10248: Add SpanishPluralStemFilter, for precise stemming of Spanish plurals.
@@ -502,14 +505,14 @@ New Features
 
 * LUCENE-10403: Add ArrayUtil#grow(T[]). (Greg Miller)
 
-* LUCENE-10414: Add fn:fuzzyTerm interval function to flexible query parser (Dawid Weiss, 
+* LUCENE-10414: Add fn:fuzzyTerm interval function to flexible query parser (Dawid Weiss,
   Alan Woodward)
-  
+
 * LUCENE-10378: Implement Weight#count for PointRangeQuery to provide a faster way to calculate
   the number of matching range docs when each doc has at-most one point and the points are 1-dimensional.
   (Gautam Worah, Ignacio Vera, Adrien Grand)
 
-* LUCENE-10415: FunctionScoreQuery and IndexOrDocValuesQuery delegate Weight#count. (Ignacio Vera)     
+* LUCENE-10415: FunctionScoreQuery and IndexOrDocValuesQuery delegate Weight#count. (Ignacio Vera)
 
 * LUCENE-10382: Add support for filtering in KnnVectorQuery. This allows for finding the
   nearest k documents that also match a query. (Julie Tibshirani, Joel Bernstein)
@@ -526,10 +529,10 @@ Improvements
 
 * LUCENE-10238: Upgrade icu4j dependency to 70.1. (Dawid Weiss)
 
-* LUCENE-9820: Extract BKD tree interface and move intersecting logic to the 
+* LUCENE-9820: Extract BKD tree interface and move intersecting logic to the
   PointValues abstract class. (Ignacio Vera, Adrien Grand)
-  
-* LUCENE-10262: Lift up restrictions for navigating PointValues#PointTree 
+
+* LUCENE-10262: Lift up restrictions for navigating PointValues#PointTree
   added in LUCENE-9820 (Ignacio Vera)
 
 * LUCENE-9538: Detect polygon self-intersections in the Tessellator. (Ignacio Vera)
@@ -644,8 +647,8 @@ Bug Fixes
 
 * LUCENE-10407: Containing intervals could sometimes yield incorrect matches when wrapped
   in a disjunction. (Alan Woodward, Dawid Weiss)
-  
-* LUCENE-10405: When using the MemoryIndex, binary and Sorted doc values are stored 
+
+* LUCENE-10405: When using the MemoryIndex, binary and Sorted doc values are stored
    as BytesRef instead of BytesRefHash so they don't have a limit on size. (Ignacio Vera)
 
 * LUCENE-10428: Queries with a misbehaving score function may no longer cause
@@ -677,7 +680,7 @@ Other
 
 * LUCENE-10413: Make Ukrainian default stop words list available as a public getter. (Alan Woodward)
 
-* LUCENE-10437: Polygon tessellator throws a more informative error message when the provided polygon 
+* LUCENE-10437: Polygon tessellator throws a more informative error message when the provided polygon
   does not contain enough no-collinear points. (Ignacio Vera)
 
 ======================= Lucene 9.0.0 =======================
@@ -1009,7 +1012,7 @@ Improvements
   (David Smiley)
 
 * LUCENE-10062: Switch taxonomy faceting to use numeric doc values for storing ordinals instead of binary doc values
-  with its own custom encoding. (Greg Miller) 
+  with its own custom encoding. (Greg Miller)
 
 Bug fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -89,7 +89,9 @@ API Changes
 
 New Features
 ---------------------
-(No changes)
+
+* LUCENE-10207: Add new "slow" term-in-set query support to SortedDocValuesField / SortedSetDocValuesField.
+  (Robert Muir, Greg Miller)
 
 Improvements
 ---------------------
@@ -127,9 +129,6 @@ New Features
 
 * LUCENE-10274: Added facetsets module for high dimensional (hyper-rectangle) faceting
 (Shai Erera, Marc D'Mello, Greg Miller)
-
-* LUCENE-10207: Add new "slow" term-in-set query support to SortedDocValuesField / SortedSetDocValuesField.
-  (Robert Muir, Greg Miller)
 
 Improvements
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/document/SortedDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedDocValuesField.java
@@ -17,12 +17,15 @@
 package org.apache.lucene.document;
 
 import java.io.IOException;
+import java.util.Collection;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.DocValuesRewriteMethod;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -68,8 +71,8 @@ public class SortedDocValuesField extends Field {
    *
    * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
    * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
-   * in an {@link IndexOrDocValuesQuery}, alongside a range query that executes on points, such as
-   * {@link BinaryPoint#newRangeQuery}.
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link TermInSetQuery} containing all terms in
+   * the range.
    */
   public static Query newSlowRangeQuery(
       String field,
@@ -91,10 +94,21 @@ public class SortedDocValuesField extends Field {
    *
    * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
    * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
-   * in an {@link IndexOrDocValuesQuery}, alongside a range query that executes on points, such as
-   * {@link BinaryPoint#newExactQuery}.
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link org.apache.lucene.search.TermQuery}.
    */
   public static Query newSlowExactQuery(String field, BytesRef value) {
     return newSlowRangeQuery(field, value, value, true, true);
+  }
+
+  /**
+   * Create a query for matching against a set of {@link BytesRef} values.
+   *
+   * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
+   * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link TermInSetQuery} that uses the indexed
+   * terms.
+   */
+  public static Query newSlowTermInSetQuery(String field, Collection<BytesRef> terms) {
+    return new TermInSetQuery(DocValuesRewriteMethod.DOC_VALUES_REWRITE_METHOD, field, terms);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesField.java
@@ -17,12 +17,15 @@
 package org.apache.lucene.document;
 
 import java.io.IOException;
+import java.util.Collection;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.DocValuesRewriteMethod;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -68,8 +71,8 @@ public class SortedSetDocValuesField extends Field {
    *
    * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
    * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
-   * in an {@link IndexOrDocValuesQuery}, alongside a range query that executes on points, such as
-   * {@link BinaryPoint#newRangeQuery}.
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link TermInSetQuery} containing all terms in
+   * the range.
    */
   public static Query newSlowRangeQuery(
       String field,
@@ -93,10 +96,23 @@ public class SortedSetDocValuesField extends Field {
    *
    * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
    * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
-   * in an {@link IndexOrDocValuesQuery}, alongside a range query that executes on points, such as
-   * {@link BinaryPoint#newExactQuery}.
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link org.apache.lucene.search.TermQuery}.
    */
   public static Query newSlowExactQuery(String field, BytesRef value) {
     return newSlowRangeQuery(field, value, value, true, true);
+  }
+
+  /**
+   * Create a query for matching against a set of {@link BytesRef} values.
+   *
+   * <p>This query also works with fields that have indexed {@link SortedDocValuesField}s.
+   *
+   * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
+   * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link TermInSetQuery} that uses the indexed
+   * terms.
+   */
+  public static Query newSlowTermInSetQuery(String field, Collection<BytesRef> terms) {
+    return new TermInSetQuery(DocValuesRewriteMethod.DOC_VALUES_REWRITE_METHOD, field, terms);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesRewriteMethod.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesRewriteMethod.java
@@ -35,6 +35,9 @@ import org.apache.lucene.util.LongBitSet;
  */
 public final class DocValuesRewriteMethod extends MultiTermQuery.RewriteMethod {
 
+  public static final DocValuesRewriteMethod DOC_VALUES_REWRITE_METHOD =
+      new DocValuesRewriteMethod();
+
   @Override
   public Query rewrite(IndexReader reader, MultiTermQuery query) {
     return new ConstantScoreQuery(new MultiTermQueryDocValuesWrapper(query));

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -275,6 +275,14 @@ public abstract class MultiTermQuery extends Query {
   }
 
   /**
+   * Return the number of unique terms contained in this query, if known up-front. If not known, -1
+   * will be returned.
+   */
+  public int getTermsCount() throws IOException {
+    return -1;
+  }
+
+  /**
    * To rewrite to a simpler form, instead return a simpler enum from {@link #getTermsEnum(Terms,
    * AttributeSource)}. For example, to rewrite to a single term, return a {@link SingleTermsEnum}
    */

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -278,7 +278,7 @@ public abstract class MultiTermQuery extends Query {
    * Return the number of unique terms contained in this query, if known up-front. If not known, -1
    * will be returned.
    */
-  public int getTermsCount() throws IOException {
+  public long getTermsCount() throws IOException {
     return -1;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
@@ -124,99 +124,84 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
       throws IOException {
     return new ConstantScoreWeight(this, boost) {
 
-      /**
-       * Try to collect terms from the given terms enum and return true iff all terms could be
-       * collected. If {@code false} is returned, the enum is left positioned on the next term.
-       */
-      private boolean collectTerms(
-          LeafReaderContext context, TermsEnum termsEnum, List<TermAndState> terms)
-          throws IOException {
-        final int threshold =
-            Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
-        for (int i = 0; i < threshold; ++i) {
-          final BytesRef term = termsEnum.next();
-          if (term == null) {
-            return true;
-          }
-          TermState state = termsEnum.termState();
-          terms.add(
-              new TermAndState(
-                  BytesRef.deepCopyOf(term),
-                  state,
-                  termsEnum.docFreq(),
-                  termsEnum.totalTermFreq()));
-        }
-        return termsEnum.next() == null;
-      }
-
-      /**
-       * On the given leaf context, try to either rewrite to a disjunction if there are few terms,
-       * or build a bitset containing matching docs.
-       */
-      private WeightOrDocIdSet rewrite(LeafReaderContext context) throws IOException {
-        final Terms terms = context.reader().terms(query.field);
-        if (terms == null) {
-          // field does not exist
-          return new WeightOrDocIdSet((DocIdSet) null);
-        }
-
-        final TermsEnum termsEnum = query.getTermsEnum(terms);
-        assert termsEnum != null;
-
-        PostingsEnum docs = null;
-
-        final List<TermAndState> collectedTerms = new ArrayList<>();
-        if (collectTerms(context, termsEnum, collectedTerms)) {
-          // build a boolean query
-          BooleanQuery.Builder bq = new BooleanQuery.Builder();
-          for (TermAndState t : collectedTerms) {
-            final TermStates termStates = new TermStates(searcher.getTopReaderContext());
-            termStates.register(t.state, context.ord, t.docFreq, t.totalTermFreq);
-            bq.add(new TermQuery(new Term(query.field, t.term), termStates), Occur.SHOULD);
-          }
-          Query q = new ConstantScoreQuery(bq.build());
-          final Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
-          return new WeightOrDocIdSet(weight);
-        }
-
-        // Too many terms: go back to the terms we already collected and start building the bit set
-        DocIdSetBuilder builder = new DocIdSetBuilder(context.reader().maxDoc(), terms);
-        if (collectedTerms.isEmpty() == false) {
-          TermsEnum termsEnum2 = terms.iterator();
-          for (TermAndState t : collectedTerms) {
-            termsEnum2.seekExact(t.term, t.state);
-            docs = termsEnum2.postings(docs, PostingsEnum.NONE);
-            builder.add(docs);
-          }
-        }
-
-        // Then keep filling the bit set with remaining terms
-        do {
-          docs = termsEnum.postings(docs, PostingsEnum.NONE);
-          builder.add(docs);
-        } while (termsEnum.next() != null);
-
-        return new WeightOrDocIdSet(builder.build());
-      }
-
-      private Scorer scorer(DocIdSet set) throws IOException {
-        if (set == null) {
+      @Override
+      public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+        final Terms indexTerms = context.reader().terms(query.getField());
+        if (indexTerms == null) {
           return null;
         }
-        final DocIdSetIterator disi = set.iterator();
-        if (disi == null) {
+
+        // Estimate the cost. If the MTQ can provide its term count, we can do a better job
+        // estimating.
+        // Cost estimation reasoning is:
+        // 1. If we don't know how many query terms there are, we assume that every term could be
+        //    in the MTQ and estimate the work as the total docs across all terms.
+        // 2. If we know how many query terms there are...
+        //    2a. Assume every query term matches at least one document (queryTermsCount).
+        //    2b. Determine the total number of docs beyond the first one for each term.
+        //        That count provides a ceiling on the number of extra docs that could match beyond
+        //        that first one. (We omit the first since it's already been counted in 2a).
+        // See: LUCENE-10207
+        final long cost;
+        final int queryTermsCount = query.getTermsCount();
+        if (queryTermsCount == -1) {
+          cost = indexTerms.getSumDocFreq();
+        } else {
+          cost = queryTermsCount + (indexTerms.getSumDocFreq() - indexTerms.size());
+        }
+
+        final Weight weight = this;
+        return new ScorerSupplier() {
+          @Override
+          public Scorer get(long leadCost) throws IOException {
+            WeightOrDocIdSet weightOrBitSet = rewrite(context, indexTerms);
+            final Scorer scorer;
+            if (weightOrBitSet.weight != null) {
+              scorer = weightOrBitSet.weight.scorer(context);
+            } else {
+              scorer = scorerForDocIdSet(weight, score(), scoreMode, weightOrBitSet.set);
+            }
+
+            // It's against the API contract to return a null scorer from a non-null ScoreSupplier.
+            // So if our ScoreSupplier was non-null (i.e., thought there might be hits) but we now
+            // find that there are actually no hits, we need to return an empty Scorer as opposed
+            // to null:
+            return Objects.requireNonNullElseGet(
+                scorer,
+                () ->
+                    new ConstantScoreScorer(weight, score(), scoreMode, DocIdSetIterator.empty()));
+          }
+
+          @Override
+          public long cost() {
+            return cost;
+          }
+        };
+      }
+
+      @Override
+      public Scorer scorer(LeafReaderContext context) throws IOException {
+        final ScorerSupplier scorerSupplier = scorerSupplier(context);
+        if (scorerSupplier == null) {
           return null;
         }
-        return new ConstantScoreScorer(this, score(), scoreMode, disi);
+        return scorerSupplier.get(Long.MAX_VALUE);
       }
 
       @Override
       public BulkScorer bulkScorer(LeafReaderContext context) throws IOException {
-        final WeightOrDocIdSet weightOrBitSet = rewrite(context);
+        final Terms indexTerms = context.reader().terms(query.getField());
+        if (indexTerms == null) {
+          return null;
+        }
+
+        final WeightOrDocIdSet weightOrBitSet = rewrite(context, indexTerms);
         if (weightOrBitSet.weight != null) {
+          // If we're using a Weight, let it provide its bulk scorer:
           return weightOrBitSet.weight.bulkScorer(context);
         } else {
-          final Scorer scorer = scorer(weightOrBitSet.set);
+          // If we're using a pre-populated DocIdSet, produce a DefaultBulkScorer over it:
+          final Scorer scorer = scorerForDocIdSet(this, score(), scoreMode, weightOrBitSet.set);
           if (scorer == null) {
             return null;
           }
@@ -226,30 +211,95 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
 
       @Override
       public Matches matches(LeafReaderContext context, int doc) throws IOException {
-        final Terms terms = context.reader().terms(query.field);
-        if (terms == null) {
+        final Terms indexTerms = context.reader().terms(query.field);
+        if (indexTerms == null) {
           return null;
         }
         return MatchesUtils.forField(
             query.field,
             () ->
                 DisjunctionMatchesIterator.fromTermsEnum(
-                    context, doc, query, query.field, query.getTermsEnum(terms)));
-      }
-
-      @Override
-      public Scorer scorer(LeafReaderContext context) throws IOException {
-        final WeightOrDocIdSet weightOrBitSet = rewrite(context);
-        if (weightOrBitSet.weight != null) {
-          return weightOrBitSet.weight.scorer(context);
-        } else {
-          return scorer(weightOrBitSet.set);
-        }
+                    context, doc, query, query.field, query.getTermsEnum(indexTerms)));
       }
 
       @Override
       public boolean isCacheable(LeafReaderContext ctx) {
         return true;
+      }
+
+      /**
+       * On the given leaf context, try to either rewrite to a disjunction if there are few terms,
+       * or build a bitset containing matching docs.
+       */
+      private WeightOrDocIdSet rewrite(LeafReaderContext context, Terms indexTerms)
+          throws IOException {
+        assert indexTerms != null;
+
+        // Create a TermsEnum that will produce the intersection of the query terms with the indexed
+        // terms:
+        final TermsEnum termsEnum = query.getTermsEnum(indexTerms);
+        assert termsEnum != null;
+
+        // Collect terms up to BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD:
+        final List<TermAndState> collectedTerms = new ArrayList<>();
+        if (collectTerms(termsEnum, collectedTerms)) {
+          // If there were fewer than BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD terms, build a BQ:
+          final BooleanQuery.Builder bq = new BooleanQuery.Builder();
+          for (TermAndState t : collectedTerms) {
+            final TermStates termStates = new TermStates(searcher.getTopReaderContext());
+            termStates.register(t.state, context.ord, t.docFreq, t.totalTermFreq);
+            bq.add(new TermQuery(new Term(query.field, t.term), termStates), Occur.SHOULD);
+          }
+          final Query q = new ConstantScoreQuery(bq.build());
+          final Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
+          return new WeightOrDocIdSet(weight);
+        }
+
+        // More than BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD terms, so we'll build a bit set of the
+        // matching docs. First, go back through the terms already collected and add their docs:
+        PostingsEnum docs = null;
+        final DocIdSetBuilder builder = new DocIdSetBuilder(context.reader().maxDoc(), indexTerms);
+        if (collectedTerms.isEmpty() == false) {
+          final TermsEnum termsEnum2 = indexTerms.iterator();
+          for (TermAndState t : collectedTerms) {
+            termsEnum2.seekExact(t.term, t.state);
+            docs = termsEnum2.postings(docs, PostingsEnum.NONE);
+            builder.add(docs);
+          }
+        }
+
+        // Iterate the remaining terms and finish filling the bit set:
+        do {
+          // (remember that termsEnum was left positioned on the next term beyond the threshold):
+          docs = termsEnum.postings(docs, PostingsEnum.NONE);
+          builder.add(docs);
+        } while (termsEnum.next() != null);
+
+        return new WeightOrDocIdSet(builder.build());
+      }
+
+      /**
+       * Try to collect terms from the given terms enum and return true iff all terms could be
+       * collected. If {@code false} is returned, the enum is left positioned on the next term.
+       */
+      private boolean collectTerms(TermsEnum termsEnum, List<TermAndState> terms)
+          throws IOException {
+        final int threshold =
+            Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
+        for (int i = 0; i < threshold; i++) {
+          final BytesRef term = termsEnum.next();
+          if (term == null) {
+            return true;
+          }
+          final TermState state = termsEnum.termState();
+          terms.add(
+              new TermAndState(
+                  BytesRef.deepCopyOf(term),
+                  state,
+                  termsEnum.docFreq(),
+                  termsEnum.totalTermFreq()));
+        }
+        return termsEnum.next() == null;
       }
     };
   }
@@ -259,5 +309,18 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
     if (visitor.acceptField(getField())) {
       query.visit(visitor.getSubVisitor(Occur.FILTER, this));
     }
+  }
+
+  /** Provide a ConstantScoreScorer over the pre-populated DocIdSet */
+  private static Scorer scorerForDocIdSet(
+      Weight weight, float score, ScoreMode scoreMode, DocIdSet set) throws IOException {
+    if (set == null) {
+      return null;
+    }
+    final DocIdSetIterator disi = set.iterator();
+    if (disi == null) {
+      return null;
+    }
+    return new ConstantScoreScorer(weight, score, scoreMode, disi);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
@@ -147,7 +147,12 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
         if (queryTermsCount == -1) {
           cost = indexTerms.getSumDocFreq();
         } else {
-          cost = queryTermsCount + (indexTerms.getSumDocFreq() - indexTerms.size());
+          long potentialExtraCost = indexTerms.getSumDocFreq();
+          final long indexedTermCount = indexTerms.size();
+          if (indexedTermCount != -1) {
+            potentialExtraCost -= indexedTermCount;
+          }
+          cost = queryTermsCount + potentialExtraCost;
         }
 
         final Weight weight = this;

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
@@ -143,7 +143,7 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
         //        that first one. (We omit the first since it's already been counted in 2a).
         // See: LUCENE-10207
         final long cost;
-        final int queryTermsCount = query.getTermsCount();
+        final long queryTermsCount = query.getTermsCount();
         if (queryTermsCount == -1) {
           cost = indexTerms.getSumDocFreq();
         } else {

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -22,25 +22,18 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.SortedSet;
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.FilteredTermsEnum;
 import org.apache.lucene.index.PrefixCodedTerms;
 import org.apache.lucene.index.PrefixCodedTerms.TermIterator;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.index.TermState;
-import org.apache.lucene.index.TermStates;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
@@ -71,7 +64,7 @@ import org.apache.lucene.util.automaton.Operations;
  *
  * <p>NOTE: This query produces scores that are equal to its boost
  */
-public class TermInSetQuery extends Query implements Accountable {
+public class TermInSetQuery extends MultiTermQuery implements Accountable {
 
   private static final long BASE_RAM_BYTES_USED =
       RamUsageEstimator.shallowSizeOfInstance(TermInSetQuery.class);
@@ -80,10 +73,21 @@ public class TermInSetQuery extends Query implements Accountable {
 
   private final String field;
   private final PrefixCodedTerms termData;
+  private final int termCount;
   private final int termDataHashCode; // cached hashcode of termData
 
-  /** Creates a new {@link TermInSetQuery} from the given collection of terms. */
   public TermInSetQuery(String field, Collection<BytesRef> terms) {
+    this(MultiTermQuery.CONSTANT_SCORE_REWRITE, field, terms);
+  }
+
+  public TermInSetQuery(String field, BytesRef... terms) {
+    this(MultiTermQuery.CONSTANT_SCORE_REWRITE, field, terms);
+  }
+
+  /** Creates a new {@link TermInSetQuery} from the given collection of terms. */
+  public TermInSetQuery(RewriteMethod rewriteMethod, String field, Collection<BytesRef> terms) {
+    super(field, rewriteMethod);
+    int termCount = 0;
     BytesRef[] sortedTerms = terms.toArray(new BytesRef[0]);
     // already sorted if we are a SortedSet with natural order
     boolean sorted =
@@ -101,30 +105,22 @@ public class TermInSetQuery extends Query implements Accountable {
       }
       builder.add(field, term);
       previous.copyBytes(term);
+      termCount++;
     }
     this.field = field;
     termData = builder.finish();
+    this.termCount = termCount;
     termDataHashCode = termData.hashCode();
   }
 
   /** Creates a new {@link TermInSetQuery} from the given array of terms. */
-  public TermInSetQuery(String field, BytesRef... terms) {
-    this(field, Arrays.asList(terms));
+  public TermInSetQuery(RewriteMethod rewriteMethod, String field, BytesRef... terms) {
+    this(rewriteMethod, field, Arrays.asList(terms));
   }
 
   @Override
-  public Query rewrite(IndexReader reader) throws IOException {
-    final int threshold =
-        Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
-    if (termData.size() <= threshold) {
-      BooleanQuery.Builder bq = new BooleanQuery.Builder();
-      TermIterator iterator = termData.iterator();
-      for (BytesRef term = iterator.next(); term != null; term = iterator.next()) {
-        bq.add(new TermQuery(new Term(iterator.field(), BytesRef.deepCopyOf(term))), Occur.SHOULD);
-      }
-      return new ConstantScoreQuery(bq.build());
-    }
-    return super.rewrite(reader);
+  public int getTermsCount() throws IOException {
+    return termCount;
   }
 
   @Override
@@ -204,165 +200,50 @@ public class TermInSetQuery extends Query implements Accountable {
     return Collections.emptyList();
   }
 
-  private static class TermAndState {
-    final String field;
-    final TermsEnum termsEnum;
-    final BytesRef term;
-    final TermState state;
-    final int docFreq;
-    final long totalTermFreq;
-
-    TermAndState(String field, TermsEnum termsEnum) throws IOException {
-      this.field = field;
-      this.termsEnum = termsEnum;
-      this.term = BytesRef.deepCopyOf(termsEnum.term());
-      this.state = termsEnum.termState();
-      this.docFreq = termsEnum.docFreq();
-      this.totalTermFreq = termsEnum.totalTermFreq();
-    }
-  }
-
-  private static class WeightOrDocIdSet {
-    final Weight weight;
-    final DocIdSet set;
-
-    WeightOrDocIdSet(Weight weight) {
-      this.weight = Objects.requireNonNull(weight);
-      this.set = null;
-    }
-
-    WeightOrDocIdSet(DocIdSet bitset) {
-      this.set = bitset;
-      this.weight = null;
-    }
-  }
-
   @Override
-  public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
-      throws IOException {
-    return new ConstantScoreWeight(this, boost) {
+  protected TermsEnum getTermsEnum(Terms terms, AttributeSource atts) throws IOException {
+    return new SetEnum(terms.iterator());
+  }
 
-      @Override
-      public Matches matches(LeafReaderContext context, int doc) throws IOException {
-        Terms terms = Terms.getTerms(context.reader(), field);
-        if (terms.hasPositions() == false) {
-          return super.matches(context, doc);
-        }
-        return MatchesUtils.forField(
-            field,
-            () ->
-                DisjunctionMatchesIterator.fromTermsEnum(
-                    context, doc, getQuery(), field, termData.iterator()));
+  // like a baby AutomatonTermsEnum, ping-pong intersects the terms dict against our
+  // PrefixCodedTerms
+  class SetEnum extends FilteredTermsEnum {
+    final TermIterator iterator;
+    BytesRef seekTerm;
+
+    SetEnum(TermsEnum termsEnum) {
+      super(termsEnum);
+      iterator = termData.iterator();
+      seekTerm = iterator.next();
+    }
+
+    @Override
+    protected AcceptStatus accept(BytesRef term) throws IOException {
+      // next() our iterator until it is >= the incoming term
+      // if it matches exactly, its a hit, otherwise its a miss
+      int cmp = 0;
+      while (seekTerm != null && (cmp = seekTerm.compareTo(term)) < 0) {
+        seekTerm = iterator.next();
       }
-
-      /**
-       * On the given leaf context, try to either rewrite to a disjunction if there are few matching
-       * terms, or build a bitset containing matching docs.
-       */
-      private WeightOrDocIdSet rewrite(LeafReaderContext context) throws IOException {
-        final LeafReader reader = context.reader();
-
-        Terms terms = reader.terms(field);
-        if (terms == null) {
-          return null;
-        }
-        TermsEnum termsEnum = terms.iterator();
-        PostingsEnum docs = null;
-        TermIterator iterator = termData.iterator();
-
-        // We will first try to collect up to 'threshold' terms into 'matchingTerms'
-        // if there are too many terms, we will fall back to building the 'builder'
-        final int threshold =
-            Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
-        assert termData.size() > threshold : "Query should have been rewritten";
-        List<TermAndState> matchingTerms = new ArrayList<>(threshold);
-        DocIdSetBuilder builder = null;
-
-        for (BytesRef term = iterator.next(); term != null; term = iterator.next()) {
-          assert field.equals(iterator.field());
-          if (termsEnum.seekExact(term)) {
-            if (matchingTerms == null) {
-              docs = termsEnum.postings(docs, PostingsEnum.NONE);
-              builder.add(docs);
-            } else if (matchingTerms.size() < threshold) {
-              matchingTerms.add(new TermAndState(field, termsEnum));
-            } else {
-              assert matchingTerms.size() == threshold;
-              builder = new DocIdSetBuilder(reader.maxDoc(), terms);
-              docs = termsEnum.postings(docs, PostingsEnum.NONE);
-              builder.add(docs);
-              for (TermAndState t : matchingTerms) {
-                t.termsEnum.seekExact(t.term, t.state);
-                docs = t.termsEnum.postings(docs, PostingsEnum.NONE);
-                builder.add(docs);
-              }
-              matchingTerms = null;
-            }
-          }
-        }
-        if (matchingTerms != null) {
-          assert builder == null;
-          BooleanQuery.Builder bq = new BooleanQuery.Builder();
-          for (TermAndState t : matchingTerms) {
-            final TermStates termStates = new TermStates(searcher.getTopReaderContext());
-            termStates.register(t.state, context.ord, t.docFreq, t.totalTermFreq);
-            bq.add(new TermQuery(new Term(t.field, t.term), termStates), Occur.SHOULD);
-          }
-          Query q = new ConstantScoreQuery(bq.build());
-          final Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
-          return new WeightOrDocIdSet(weight);
-        } else {
-          assert builder != null;
-          return new WeightOrDocIdSet(builder.build());
-        }
+      if (seekTerm == null) {
+        return AcceptStatus.END;
+      } else if (cmp == 0) {
+        return AcceptStatus.YES_AND_SEEK;
+      } else {
+        return AcceptStatus.NO_AND_SEEK;
       }
+    }
 
-      private Scorer scorer(DocIdSet set) throws IOException {
-        if (set == null) {
-          return null;
-        }
-        final DocIdSetIterator disi = set.iterator();
-        if (disi == null) {
-          return null;
-        }
-        return new ConstantScoreScorer(this, score(), scoreMode, disi);
+    @Override
+    protected BytesRef nextSeekTerm(BytesRef currentTerm) throws IOException {
+      // next() our iterator until it is > the currentTerm, must always make progress.
+      if (currentTerm == null) {
+        return seekTerm;
       }
-
-      @Override
-      public BulkScorer bulkScorer(LeafReaderContext context) throws IOException {
-        final WeightOrDocIdSet weightOrBitSet = rewrite(context);
-        if (weightOrBitSet == null) {
-          return null;
-        } else if (weightOrBitSet.weight != null) {
-          return weightOrBitSet.weight.bulkScorer(context);
-        } else {
-          final Scorer scorer = scorer(weightOrBitSet.set);
-          if (scorer == null) {
-            return null;
-          }
-          return new DefaultBulkScorer(scorer);
-        }
+      while (seekTerm != null && seekTerm.compareTo(currentTerm) <= 0) {
+        seekTerm = iterator.next();
       }
-
-      @Override
-      public Scorer scorer(LeafReaderContext context) throws IOException {
-        final WeightOrDocIdSet weightOrBitSet = rewrite(context);
-        if (weightOrBitSet == null) {
-          return null;
-        } else if (weightOrBitSet.weight != null) {
-          return weightOrBitSet.weight.scorer(context);
-        } else {
-          return scorer(weightOrBitSet.set);
-        }
-      }
-
-      @Override
-      public boolean isCacheable(LeafReaderContext ctx) {
-        // Only cache instances that have a reasonable size. Otherwise it might cause memory issues
-        // with the query cache if most memory ends up being spent on queries rather than doc id
-        // sets.
-        return ramBytesUsed() <= RamUsageEstimator.QUERY_DEFAULT_RAM_BYTES_USED;
-      }
-    };
+      return seekTerm;
+    }
   }
 }

--- a/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
@@ -95,7 +95,7 @@ class TermsQuery extends MultiTermQuery implements Accountable {
   }
 
   @Override
-  public int getTermsCount() throws IOException {
+  public long getTermsCount() throws IOException {
     return terms.size();
   }
 

--- a/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
@@ -95,6 +95,11 @@ class TermsQuery extends MultiTermQuery implements Accountable {
   }
 
   @Override
+  public int getTermsCount() throws IOException {
+    return terms.size();
+  }
+
+  @Override
   public String toString(String string) {
     return "TermsQuery{" + "field=" + field + "fromQuery=" + fromQuery.toString(field) + '}';
   }

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestPresearcherMatchCollector.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestPresearcherMatchCollector.java
@@ -46,8 +46,8 @@ public class TestPresearcherMatchCollector extends MonitorTestBase {
 
       assertNotNull(matches.match("2", 0));
       String pm = matches.match("2", 0).presearcherMatches;
-      assertThat(pm, containsString("field:foo"));
-      assertThat(pm, containsString("f2:quuz"));
+      assertThat(pm, containsString("field:(foo test)"));
+      assertThat(pm, containsString("f2:(quuz)"));
 
       assertNotNull(matches.match("3", 0));
       assertEquals(" field:foo", matches.match("3", 0).presearcherMatches);

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestPresearcherMatchCollector.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestPresearcherMatchCollector.java
@@ -46,8 +46,8 @@ public class TestPresearcherMatchCollector extends MonitorTestBase {
 
       assertNotNull(matches.match("2", 0));
       String pm = matches.match("2", 0).presearcherMatches;
-      assertThat(pm, containsString("field:(foo test)"));
-      assertThat(pm, containsString("f2:(quuz)"));
+      assertThat(pm, containsString("field:foo"));
+      assertThat(pm, containsString("f2:quuz"));
 
       assertNotNull(matches.match("3", 0));
       assertEquals(" field:foo", matches.match("3", 0).presearcherMatches);


### PR DESCRIPTION
# Description

This change introduces "slow" term-in-set query support exposed through SDV and SSDV Fields. These "slow" queries can be combined with standard TermInSet queries in an IndexOrDocValues query for efficient term-in-set querying when both postings and doc values exist for a given string field.

# Solution

`TermInSetQuery` now extends `MultiTermQuery`, which allows it to be rewritten as a "doc values query" using `DocValuesRewriteMethod`. `scorerSupplier` support was added to `MultiTermQueryConstantScoreWrapper` and `DocValuesRewriteMethod`, allowing up-front cost estimation without doing the "heavy lifting" of intersecting the query terms with the indexed terms (while the "doc values" based approach doesn't require score estimation, `IndexOrDocValuesQuery` creates `ScorerSupplier`s for both delegate queries up-front, so we want to avoid the term intersection cost).

# Tests

Added new unit test coverage for the updated functionality. Note that I also needed to update `TestPresearcherMatchCollector` since it relies on `toString()`. Previously, the `TermInSetQuery` was being rewritten directly to a `BooleanQuery`. Now though, it gets rewritten to `MultiTermQueryConstantScoreWrapper` which handles the `BooleanQuery` rewriting on-demand when a `Scorer` is requested. Because these two queries have different `toString` representations, the test started failing (even though it's functionally equivalent).

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
