### PR TITLE
LUCENE-10231: Do not cache too large PointInSetQuery

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
@@ -200,7 +200,7 @@ public abstract class PointInSetQuery extends Query implements Accountable {
 
       @Override
       public boolean isCacheable(LeafReaderContext ctx) {
-        return true;
+        return ramBytesUsed() <= RamUsageEstimator.QUERY_DEFAULT_RAM_BYTES_USED;
       }
     };
   }

--- a/lucene/join/src/java/org/apache/lucene/search/join/PointInSetIncludingScoreQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/PointInSetIncludingScoreQuery.java
@@ -230,7 +230,7 @@ abstract class PointInSetIncludingScoreQuery extends Query implements Accountabl
 
       @Override
       public boolean isCacheable(LeafReaderContext ctx) {
-        return true;
+        return ramBytesUsed() <= RamUsageEstimator.QUERY_DEFAULT_RAM_BYTES_USED;
       }
     };
   }


### PR DESCRIPTION
TermInSetQuery will avoid caching queries using too much memory, but there is no such limit in PointInSetQuery and PointInSetQueryWithScore, which may have similar problems. I added the logic to these two queries, but I'm not sure whether this is the most reasonable way. May be this logic is common and we can judge this in LRUQueryCache?

#11267