### PR TITLE
LUCENE-10232: Fix MultiRangeQuery to confirm all dimensions for a given range match

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -55,7 +55,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+
+* LUCENE-10232: Fix MultiRangeQuery to confirm all dimensions for a given range match. (Greg Miller)
 
 Other
 ---------------------

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiRangeQuery.java
@@ -149,6 +149,8 @@ public abstract class MultiRangeQuery extends Query {
   public final Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
       throws IOException {
 
+    final ArrayUtil.ByteArrayComparator comparator = ArrayUtil.getUnsignedComparator(bytesPerDim);
+
     // We don't use RandomAccessWeight here: it's no good to approximate with "match all docs".
     // This is an inverted structure and should be used in the first pass:
 
@@ -172,31 +174,21 @@ public abstract class MultiRangeQuery extends Query {
           @Override
           public void visit(int docID, byte[] packedValue) {
             // If a single OR clause has the value in range, the entire query accepts the value
+            continueRange:
             for (RangeClause rangeClause : rangeClauses) {
               for (int dim = 0; dim < numDims; dim++) {
                 int offset = dim * bytesPerDim;
-                if ((Arrays.compareUnsigned(
-                            packedValue,
-                            offset,
-                            offset + bytesPerDim,
-                            rangeClause.lowerValue,
-                            offset,
-                            offset + bytesPerDim)
-                        >= 0)
-                    && (Arrays.compareUnsigned(
-                            packedValue,
-                            offset,
-                            offset + bytesPerDim,
-                            rangeClause.upperValue,
-                            offset,
-                            offset + bytesPerDim)
-                        <= 0)) {
-                  // Doc is in-bounds. Add and short circuit
-                  adder.add(docID);
-                  return;
+                if (comparator.compare(packedValue, offset, rangeClause.lowerValue, offset) < 0) {
+                  // Doc value is too low in this dim:
+                  continue continueRange;
                 }
-                // Iterate till we have any OR clauses remaining
+                if (comparator.compare(packedValue, offset, rangeClause.upperValue, offset) > 0) {
+                  // Doc value is too high in this dim:
+                  continue continueRange;
+                }
               }
+              // Doc matched on all dimensions:
+              adder.add(docID);
             }
           }
 
@@ -211,46 +203,34 @@ public abstract class MultiRangeQuery extends Query {
              * as inside and atleast one range sees the point as CROSSES, return CROSSES 3) If none
              * of the above, return OUTSIDE
              */
+            continueRange:
             for (RangeClause rangeClause : rangeClauses) {
+              boolean rangeCrosses = false;
+
               for (int dim = 0; dim < numDims; dim++) {
                 int offset = dim * bytesPerDim;
 
-                if ((Arrays.compareUnsigned(
-                            minPackedValue,
-                            offset,
-                            offset + bytesPerDim,
-                            rangeClause.lowerValue,
-                            offset,
-                            offset + bytesPerDim)
-                        >= 0)
-                    && (Arrays.compareUnsigned(
-                            maxPackedValue,
-                            offset,
-                            offset + bytesPerDim,
-                            rangeClause.upperValue,
-                            offset,
-                            offset + bytesPerDim)
-                        <= 0)) {
-                  return PointValues.Relation.CELL_INSIDE_QUERY;
+                if (comparator.compare(minPackedValue, offset, rangeClause.upperValue, offset) > 0
+                    || comparator.compare(maxPackedValue, offset, rangeClause.lowerValue, offset)
+                        < 0) {
+                  continue continueRange;
                 }
 
-                crosses |=
-                    Arrays.compareUnsigned(
-                                minPackedValue,
-                                offset,
-                                offset + bytesPerDim,
-                                rangeClause.lowerValue,
-                                offset,
-                                offset + bytesPerDim)
-                            < 0
-                        || Arrays.compareUnsigned(
-                                maxPackedValue,
-                                offset,
-                                offset + bytesPerDim,
-                                rangeClause.upperValue,
-                                offset,
-                                offset + bytesPerDim)
+                rangeCrosses |=
+                    comparator.compare(minPackedValue, offset, rangeClause.lowerValue, offset) < 0
+                        || comparator.compare(
+                                maxPackedValue, offset, rangeClause.upperValue, offset)
                             > 0;
+              }
+
+              if (rangeCrosses == false) {
+                // At this point we know that the cell is fully inside the range clause, so we
+                // return early:
+                return PointValues.Relation.CELL_INSIDE_QUERY;
+              } else {
+                // This range clause crosses the cell, but we'll keep checking more ranges to see if
+                // one fully contains the cell:
+                crosses = true;
               }
             }
 
@@ -300,21 +280,8 @@ public abstract class MultiRangeQuery extends Query {
           for (RangeClause rangeClause : rangeClauses) {
             for (int i = 0; i < numDims; ++i) {
               int offset = i * bytesPerDim;
-              if (Arrays.compareUnsigned(
-                          rangeClause.lowerValue,
-                          offset,
-                          offset + bytesPerDim,
-                          fieldPackedLower,
-                          offset,
-                          offset + bytesPerDim)
-                      > 0
-                  || Arrays.compareUnsigned(
-                          rangeClause.upperValue,
-                          offset,
-                          offset + bytesPerDim,
-                          fieldPackedUpper,
-                          offset,
-                          offset + bytesPerDim)
+              if (comparator.compare(rangeClause.lowerValue, offset, fieldPackedLower, offset) > 0
+                  || comparator.compare(rangeClause.upperValue, offset, fieldPackedUpper, offset)
                       < 0) {
                 allDocsMatch = false;
                 break;

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestMultiRangeQueries.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestMultiRangeQueries.java
@@ -123,9 +123,9 @@ public class TestMultiRangeQueries extends LuceneTestCase {
 
     assertEquals(searcher.count(query), 2);
 
-    // None match
-    double[] nonMatchingFirstRangeLower = {1.3, 3.5, 2.7};
-    double[] nonMatchingFirstRangeUpper = {5.2, 8.3, 7.8};
+    // None match (one dimension is in range but the rest aren't)
+    double[] nonMatchingFirstRangeLower = {111.3, 3.5, 2.7};
+    double[] nonMatchingFirstRangeUpper = {117.3, 8.3, 7.8};
 
     double[] nonMatchingSecondRangeLower = {11246.3, 19388.7, 21248.4};
     double[] nonMatchingSecondRangeUpper = {13242.9, 20214.2, 23236.5};
@@ -244,9 +244,9 @@ public class TestMultiRangeQueries extends LuceneTestCase {
 
     assertEquals(searcher.count(query), 2);
 
-    // None match
-    long[] nonMatchingFirstRangeLower = {1, 3, 2};
-    long[] nonMatchingFirstRangeUpper = {5, 8, 7};
+    // None match (one dimension is in range but the rest aren't)
+    long[] nonMatchingFirstRangeLower = {111, 3, 2};
+    long[] nonMatchingFirstRangeUpper = {117, 8, 7};
 
     long[] nonMatchingSecondRangeLower = {11246, 19388, 21248};
     long[] nonMatchingSecondRangeUpper = {13242, 20214, 23236};
@@ -365,9 +365,9 @@ public class TestMultiRangeQueries extends LuceneTestCase {
 
     assertEquals(searcher.count(query), 2);
 
-    // None Match
-    float[] nonMatchingFirstRangeLower = {1.4f, 3.3f, 2.7f};
-    float[] nonMatchingFirstRangeUpper = {5.4f, 8.2f, 7.3f};
+    // None match (one dimension is in range but the rest aren't)
+    float[] nonMatchingFirstRangeLower = {111.3f, 3.3f, 2.7f};
+    float[] nonMatchingFirstRangeUpper = {117.3f, 8.2f, 7.3f};
 
     float[] nonMatchingSecondRangeLower = {11246.2f, 19388.6f, 21248.3f};
     float[] nonMatchingSecondRangeUpper = {13242.4f, 20214.7f, 23236.3f};
@@ -486,9 +486,9 @@ public class TestMultiRangeQueries extends LuceneTestCase {
 
     assertEquals(searcher.count(query), 2);
 
-    // None match
-    int[] nonMatchingFirstRangeLower = {1, 3, 2};
-    int[] nonMatchingFirstRangeUpper = {5, 8, 7};
+    // None match (one dimension is in range but the rest aren't)
+    int[] nonMatchingFirstRangeLower = {111, 3, 2};
+    int[] nonMatchingFirstRangeUpper = {117, 8, 7};
 
     int[] nonMatchingSecondRangeLower = {11246, 19388, 21248};
     int[] nonMatchingSecondRangeUpper = {13242, 20214, 23236};


### PR DESCRIPTION
# Description

`MultiRangeQuery` was incorrectly considering a range to match if at least one dimension matched (instead of requiring all dimensions to match).

# Solution

Corrected the logic in `MultiRangeQuery`. Also updated comparisons to use `ArrayUtil.ByteArrayComparator`.

# Tests

Updated existing tests to expose the bug and confirmed the fix addresses it.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
