### PR TITLE
LUCENE-10085: Rename DocValuesFieldExistsQuery test

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesFieldExistsQuery.java
@@ -29,7 +29,7 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 
-public class TestFieldValueQuery extends LuceneTestCase {
+public class TestDocValuesFieldExistsQuery extends LuceneTestCase {
 
   public void testRandom() throws IOException {
     final int iters = atLeast(10);


### PR DESCRIPTION
FieldValueQuery got renamed to DocValuesFieldExistsQuery but the test
wasn't renamed.