### PR TITLE
LUCENE-10242: The TopScoreDocCollector::createSharedManager should use ScoreDoc instead of FieldDoc

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
@@ -254,7 +254,7 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
    * shared {@link MaxScoreAccumulator} to propagate the minimum score accross segments
    */
   public static CollectorManager<TopScoreDocCollector, TopDocs> createSharedManager(
-      int numHits, FieldDoc after, int totalHitsThreshold) {
+      int numHits, ScoreDoc after, int totalHitsThreshold) {
     return new CollectorManager<>() {
 
       private final HitsThresholdChecker hitsThresholdChecker =


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

# Description

The `TopScoreDocCollector::createSharedManager` should use `ScoreDoc` instead of `FieldDoc` as a type of `after` argument. The `FieldDoc` is really needed only in case of `TopFieldCollector` but now its usage is mandated by `TopScoreDocCollector` and leads to unnecessary conversion tricks. 

# Solution

Relax  `after` argument type from `FieldDoc` to `ScoreDoc`

# Tests

The functionality is covered by existing tests. Since `FieldDoc` is a subclass of `ScoreDoc`, the change is fully compatible and non breaking.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
