### PR TITLE
Investigate whether should Packed64 use a byte[] plus VarHandles instead of a long[]

### DIFF
--- a/lucene/core/build.gradle
+++ b/lucene/core/build.gradle
@@ -20,6 +20,9 @@ apply plugin: 'java-library'
 description = 'Lucene core library'
 
 dependencies {
+  testImplementation('org.openjdk.jmh:jmh-core:1.33')
+  testImplementation('org.openjdk.jmh:jmh-generator-annprocess:1.33')
+
   testImplementation project(':lucene:codecs')
   testImplementation project(':lucene:test-framework')
 }

--- a/lucene/core/src/java/org/apache/lucene/util/packed/Packed64VHLongAndByte.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/Packed64VHLongAndByte.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util.packed;
+
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BitUtil;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.sql.Array;
+import java.util.Arrays;
+
+/**
+ * Space optimized random access capable array of values with a fixed number of bits/value. Values
+ * are packed contiguously.
+ *
+ * <p>The implementation strives to perform as fast as possible under the constraint of contiguous
+ * bits, by avoiding expensive operations. This comes at the cost of code clarity.
+ *
+ * <p>Technical details: This implementation is a refinement of a non-branching version. The
+ * non-branching get and set methods meant that 2 or 4 atomics in the underlying array were always
+ * accessed, even for the cases where only 1 or 2 were needed. Even with caching, this had a
+ * detrimental effect on performance. Related to this issue, the old implementation used lookup
+ * tables for shifts and masks, which also proved to be a bit slower than calculating the shifts and
+ * masks on the fly. See https://issues.apache.org/jira/browse/LUCENE-4062 for details.
+ */
+class Packed64VHLongAndByte extends PackedInts.MutableImpl {
+  static final int BLOCK_SIZE = 64; // 32 = int, 64 = long
+  static final int BLOCK_BITS = 6; // The #bits representing BLOCK_SIZE
+  static final int MOD_MASK = BLOCK_SIZE - 1; // x % BLOCK_SIZE
+  static final int BYTE_BLOCK_MOD_MASK = 8 - 1; // x % BYTE_BLOCK
+
+  /** Values are stores contiguously in the blocks array. */
+  private final byte[] blocks;
+  /** A right-aligned mask of width BitsPerValue used by {@link #get(int)}. */
+  private final long maskRight;
+  /** Optimization: Saves one lookup in {@link #get(int)}. */
+  private final int bpvMinusBlockSize;
+  private final int bpvMinusByteBlockSize;
+
+  /**
+   * Creates an array with the internal structures adjusted for the given limits and initialized to
+   * 0.
+   *
+   * @param valueCount the number of elements.
+   * @param bitsPerValue the number of bits available for any given value.
+   */
+  public Packed64VHLongAndByte(int valueCount, int bitsPerValue) {
+    super(valueCount, bitsPerValue);
+    final PackedInts.Format format = PackedInts.Format.PACKED;
+    final long byteCount = format.byteCount(PackedInts.VERSION_CURRENT, valueCount, bitsPerValue);
+    if (byteCount > ArrayUtil.MAX_ARRAY_LENGTH) {
+      throw new IllegalArgumentException("Not yet supported");
+    }
+    this.blocks = new byte[(int) byteCount + 64];
+    maskRight = ~0L << (BLOCK_SIZE - bitsPerValue) >>> (BLOCK_SIZE - bitsPerValue);
+    bpvMinusBlockSize = bitsPerValue - BLOCK_SIZE;
+    bpvMinusByteBlockSize = bitsPerValue - 8;
+  }
+
+  /**
+   * @param index the position of the value.
+   * @return the value at the given index.
+   */
+  @Override
+  public long get(final int index) {
+    // The abstract index in a bit stream
+    final long majorBitPos = (long) index * bitsPerValue;
+    // The index in the backing byte-array
+    final int elementPos = (int) (majorBitPos >>> 3); // BYTE_BLOCK
+
+    final int maskOffset = (int) majorBitPos & BYTE_BLOCK_MOD_MASK;
+    // The number of value-bits in the second long
+    final long packed = ((long) BitUtil.VH_LE_LONG.get(blocks, elementPos) >>> maskOffset) & maskRight;
+
+    if (bpvMinusByteBlockSize + maskOffset <= 56) { // Single block
+      return packed;
+    }
+    long shift = (int) ((majorBitPos + bitsPerValue) & BYTE_BLOCK_MOD_MASK);
+    return packed | (blocks[elementPos + 8] & ~(~0L << shift)) << (64 - maskOffset);
+  }
+
+  @Override
+  public void set(final int index, final long value) {
+    // The abstract index in a contiguous bit stream
+    final long majorBitPos = (long) index * bitsPerValue;
+    // The index in the backing byte-array
+    final int elementPos = (int) (majorBitPos >>> 3); // / BYTE_BLOCK
+    // The number of bits already occupied from the previous position
+    final int maskOffset = (int) majorBitPos & BYTE_BLOCK_MOD_MASK;
+
+    // Read the main long
+    long packed = (long) BitUtil.VH_LE_LONG.get(blocks, elementPos);
+    BitUtil.VH_LE_LONG.set(blocks, elementPos, packed & ~(maskRight << maskOffset) | (value << maskOffset));
+
+    if (bpvMinusByteBlockSize + maskOffset <= 56) { // Fits in single block, bail out
+      return;
+    }
+
+    // Extra read for the overflow bits
+    int nextPos = elementPos + 8;
+
+    long shift = (int) ((majorBitPos + bitsPerValue) & BYTE_BLOCK_MOD_MASK);
+    blocks[nextPos] = (byte) (blocks[nextPos] & (~0L << shift) | (value >>> bitsPerValue - shift));
+  }
+
+  @Override
+  public String toString() {
+    return "Packed64(bitsPerValue="
+        + bitsPerValue
+        + ",size="
+        + size()
+        + ",blocks="
+        + blocks.length
+        + ")";
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return RamUsageEstimator.alignObjectSize(
+            RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
+                + 3 * Integer.BYTES // bpvMinusBlockSize,valueCount,bitsPerValue
+                + Long.BYTES // maskRight
+                + RamUsageEstimator.NUM_BYTES_OBJECT_REF) // blocks ref
+        + RamUsageEstimator.sizeOf(blocks);
+  }
+
+  private static int gcd(int a, int b) {
+    if (a < b) {
+      return gcd(b, a);
+    } else if (b == 0) {
+      return a;
+    } else {
+      return gcd(b, a % b);
+    }
+  }
+
+  @Override
+  public void clear() {
+    Arrays.fill(blocks, (byte) 0);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/packed/Packed64VHLongAndByte.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/Packed64VHLongAndByte.java
@@ -103,10 +103,10 @@ class Packed64VHLongAndByte extends PackedInts.MutableImpl {
     final int elementPos = (int) (majorBitPos >>> BYTE_BITS); // / BYTE_BLOCK
     // The number of bits already occupied from the previous position
     final int maskOffset = (int) majorBitPos & BYTE_BLOCK_MOD_MASK;
-    final int endBits = maskOffset + bpvMinusBlockSize;
+//    final int endBits = maskOffset + bpvMinusBlockSize;
     // Read the main long
     final long packed = (long) BitUtil.VH_LE_LONG.get(blocks, elementPos);
-    BitUtil.VH_LE_LONG.set(blocks, elementPos, packed & ~(maskRight << maskOffset) | (value << maskOffset));
+    BitUtil.VH_LE_LONG.set(blocks, elementPos, (packed & ~(maskRight << maskOffset)) | (value << maskOffset));
 
 //    if (endBits <= 0) { // Fits in single block, bail out
 //      return;

--- a/lucene/core/src/java/org/apache/lucene/util/packed/Packed64VHLongAndByte.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/Packed64VHLongAndByte.java
@@ -47,7 +47,7 @@ class Packed64VHLongAndByte extends PackedInts.MutableImpl {
   /** A right-aligned mask of width BitsPerValue used by {@link #get(int)}. */
   private final long maskRight;
   /** Optimization: Saves one lookup in {@link #get(int)}. */
-  private final int bpvMinusBlockSize;
+  //private final int bpvMinusBlockSize;
 
   /**
    * Creates an array with the internal structures adjusted for the given limits and initialized to
@@ -68,7 +68,7 @@ class Packed64VHLongAndByte extends PackedInts.MutableImpl {
     }
     this.blocks = new byte[(int) byteCount + Long.BYTES];
     maskRight = ~0L << (BLOCK_SIZE - bitsPerValue) >>> (BLOCK_SIZE - bitsPerValue);
-    bpvMinusBlockSize = bitsPerValue - BLOCK_SIZE;
+    //bpvMinusBlockSize = bitsPerValue - BLOCK_SIZE;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/packed/Packed64VHLongLong.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/Packed64VHLongLong.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util.packed;
+
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BitUtil;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.sql.Array;
+import java.util.Arrays;
+
+/**
+ * Space optimized random access capable array of values with a fixed number of bits/value. Values
+ * are packed contiguously.
+ *
+ * <p>The implementation strives to perform as fast as possible under the constraint of contiguous
+ * bits, by avoiding expensive operations. This comes at the cost of code clarity.
+ *
+ * <p>Technical details: This implementation is a refinement of a non-branching version. The
+ * non-branching get and set methods meant that 2 or 4 atomics in the underlying array were always
+ * accessed, even for the cases where only 1 or 2 were needed. Even with caching, this had a
+ * detrimental effect on performance. Related to this issue, the old implementation used lookup
+ * tables for shifts and masks, which also proved to be a bit slower than calculating the shifts and
+ * masks on the fly. See https://issues.apache.org/jira/browse/LUCENE-4062 for details.
+ */
+class Packed64VHLongLong extends PackedInts.MutableImpl {
+    static final int BLOCK_SIZE = 64; // 32 = int, 64 = long
+    static final int BLOCK_BITS = 6; // The #bits representing BLOCK_SIZE
+    static final int MOD_MASK = BLOCK_SIZE - 1; // x % BLOCK_SIZE
+
+    /** Values are stores contiguously in the blocks array. */
+    private final byte[] blocks;
+    /** A right-aligned mask of width BitsPerValue used by {@link #get(int)}. */
+    private final long maskRight;
+    /** Optimization: Saves one lookup in {@link #get(int)}. */
+    private final int bpvMinusBlockSize;
+
+    /**
+     * Creates an array with the internal structures adjusted for the given limits and initialized to
+     * 0.
+     *
+     * @param valueCount the number of elements.
+     * @param bitsPerValue the number of bits available for any given value.
+     */
+    public Packed64VHLongLong(int valueCount, int bitsPerValue) {
+        super(valueCount, bitsPerValue);
+        final PackedInts.Format format = PackedInts.Format.PACKED;
+        final long byteCount = format.byteCount(PackedInts.VERSION_CURRENT, valueCount, bitsPerValue);
+        if (byteCount > ArrayUtil.MAX_ARRAY_LENGTH) {
+            throw new IllegalArgumentException("Not yet supported");
+        }
+        this.blocks = new byte[(int) byteCount + 8];
+        maskRight = ~0L << (BLOCK_SIZE - bitsPerValue) >>> (BLOCK_SIZE - bitsPerValue);
+        bpvMinusBlockSize = bitsPerValue - BLOCK_SIZE;
+    }
+
+    /**
+     * @param index the position of the value.
+     * @return the value at the given index.
+     */
+    @Override
+    public long get(final int index) {
+        // The abstract index in a bit stream
+        final long majorBitPos = (long) index * bitsPerValue;
+        // The index in the backing byte-array
+        final int elementPos = (int) (majorBitPos >>> BLOCK_BITS) * 8;
+        // read entry as a long
+        long packed;
+
+        // The number of value-bits in the second long
+        final long endBits = (majorBitPos & MOD_MASK) + bpvMinusBlockSize;
+
+        if (endBits <= 0) { // Single block
+            packed = (long) BitUtil.VH_LE_LONG.get(blocks, elementPos);
+            return (packed >>> -endBits) & maskRight;
+        }
+        // Two blocks
+        packed = (long) BitUtil.VH_LE_LONG.get(blocks, elementPos);
+        long next = (long) BitUtil.VH_LE_LONG.get(blocks, elementPos + 8);
+        return ((packed << endBits) | (next >>> (BLOCK_SIZE - endBits)))
+                & maskRight;
+    }
+
+    @Override
+    public void set(final int index, final long value) {
+        // The abstract index in a contiguous bit stream
+        final long majorBitPos = (long) index * bitsPerValue;
+        // The index in the backing byte-array
+        final int elementPos = (int) (majorBitPos >>> BLOCK_BITS) * 8; // / BLOCK_SIZE
+        // The number of value-bits in the last block
+        final long endBits = (majorBitPos & MOD_MASK) + bpvMinusBlockSize;
+
+        long packed;
+        if (endBits <= 0) { // Single block
+            packed = (long) BitUtil.VH_LE_LONG.get(blocks, elementPos);
+            packed = packed & ~(maskRight << -endBits) | (value << -endBits);
+            BitUtil.VH_LE_LONG.set(blocks, elementPos, packed);
+            return;
+        }
+        // Two blocks
+        packed = (long) BitUtil.VH_LE_LONG.get(blocks, elementPos);
+        long newPacked = packed & ~(maskRight >>> endBits) | (value >>> endBits);
+        BitUtil.VH_LE_LONG.set(blocks, elementPos, newPacked);
+
+        long packed2 = (long) BitUtil.VH_LE_LONG.get(blocks, elementPos + 8);
+        long newPacked2 = packed2 & (~0L >>> endBits) | (value << (BLOCK_SIZE - endBits));
+        BitUtil.VH_LE_LONG.set(blocks, elementPos + 8, newPacked2);
+    }
+
+    @Override
+    public String toString() {
+        return "Packed64(bitsPerValue="
+                + bitsPerValue
+                + ",size="
+                + size()
+                + ",blocks="
+                + blocks.length
+                + ")";
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return RamUsageEstimator.alignObjectSize(
+                RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
+                        + 3 * Integer.BYTES // bpvMinusBlockSize,valueCount,bitsPerValue
+                        + Long.BYTES // maskRight
+                        + RamUsageEstimator.NUM_BYTES_OBJECT_REF) // blocks ref
+                + RamUsageEstimator.sizeOf(blocks);
+    }
+
+    private static int gcd(int a, int b) {
+        if (a < b) {
+            return gcd(b, a);
+        } else if (b == 0) {
+            return a;
+        } else {
+            return gcd(b, a % b);
+        }
+    }
+
+    @Override
+    public void clear() {
+        Arrays.fill(blocks, (byte) 0);
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/packed/Packed64VHLongLong.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/Packed64VHLongLong.java
@@ -107,17 +107,17 @@ class Packed64VHLongLong extends PackedInts.MutableImpl {
         long packed;
         if (endBits <= 0) { // Single block
             packed = (long) BitUtil.VH_LE_LONG.get(blocks, elementPos);
-            packed = packed & ~(maskRight << -endBits) | (value << -endBits);
+            packed = (packed & ~(maskRight << -endBits)) | (value << -endBits);
             BitUtil.VH_LE_LONG.set(blocks, elementPos, packed);
             return;
         }
         // Two blocks
         packed = (long) BitUtil.VH_LE_LONG.get(blocks, elementPos);
-        long newPacked = packed & ~(maskRight >>> endBits) | (value >>> endBits);
+        long newPacked = (packed & ~(maskRight >>> endBits)) | (value >>> endBits);
         BitUtil.VH_LE_LONG.set(blocks, elementPos, newPacked);
 
         long packed2 = (long) BitUtil.VH_LE_LONG.get(blocks, elementPos + 8);
-        long newPacked2 = packed2 & (~0L >>> endBits) | (value << (BLOCK_SIZE - endBits));
+        long newPacked2 = (packed2 & (~0L >>> endBits)) | (value << (BLOCK_SIZE - endBits));
         BitUtil.VH_LE_LONG.set(blocks, elementPos + 8, newPacked2);
     }
 

--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
@@ -716,7 +716,8 @@ public class PackedInts {
       case PACKED_SINGLE_BLOCK:
         return Packed64SingleBlock.create(valueCount, bitsPerValue);
       case PACKED:
-        return new Packed64(valueCount, bitsPerValue);
+        //return new Packed64(valueCount, bitsPerValue);
+        return new Packed64VHLongLong(valueCount, bitsPerValue);
       default:
         throw new AssertionError();
     }

--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.LongsRef;
 import org.apache.lucene.util.RamUsageEstimator;
 
@@ -716,8 +717,12 @@ public class PackedInts {
       case PACKED_SINGLE_BLOCK:
         return Packed64SingleBlock.create(valueCount, bitsPerValue);
       case PACKED:
-        //return new Packed64(valueCount, bitsPerValue);
-        return new Packed64VHLongAndByte(valueCount, bitsPerValue);
+        if ((valueCount + 1) * Long.BYTES < ArrayUtil.MAX_ARRAY_LENGTH && bitsPerValue <= 56) {
+          return new Packed64VHLongAndByte(valueCount, bitsPerValue);
+        }
+        else {
+          return new Packed64(valueCount, bitsPerValue);
+        }
       default:
         throw new AssertionError();
     }

--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
@@ -717,7 +717,7 @@ public class PackedInts {
         return Packed64SingleBlock.create(valueCount, bitsPerValue);
       case PACKED:
         //return new Packed64(valueCount, bitsPerValue);
-        return new Packed64VHLongLong(valueCount, bitsPerValue);
+        return new Packed64VHLongAndByte(valueCount, bitsPerValue);
       default:
         throw new AssertionError();
     }

--- a/lucene/core/src/test/org/apache/lucene/util/packed/Packed64Benchmark.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/Packed64Benchmark.java
@@ -1,0 +1,71 @@
+package org.apache.lucene.util.packed;
+
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Warmup(iterations = 2, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+public class Packed64Benchmark {
+
+    @Param({"10240"})
+    private int size;
+    @Param({"1", "4", "5", "8", "11", "16", "23", "25", "31", "32", "47", "59", "61", "64"})
+    private int bpv;
+    long[] values;
+    long[] baseLine;
+    Packed64 packed64;
+    Packed64VHLongLong packed64vhll;
+    Packed64VHLongAndByte packed64vhlb;
+
+    @Setup
+    public void setup() {
+        var max = PackedInts.maxValue(bpv);
+        values = new long[size];
+        var r = new Random(size);
+        for (int i = 0; i < values.length; i++) {
+            values[i] = RandomNumbers.randomLongBetween(r, 0, max);
+        }
+        // field initialization
+        baseLine = new long[size];
+        packed64 = new Packed64(size, bpv);
+        packed64vhll = new Packed64VHLongLong(size, bpv);
+        packed64vhlb = new Packed64VHLongAndByte(size, bpv);
+    }
+
+    @Benchmark
+    public void packed64(Blackhole bh) {
+        for (int i = 0; i < values.length; i++) {
+            packed64.set(i, values[i]);
+        }
+        bh.consume(packed64.get(0));
+    }
+
+    @Benchmark
+    public void packed64VarHandleDoubleLong(Blackhole bh) {
+        for (int i = 0; i < values.length; i++) {
+            packed64vhll.set(i, values[i]);
+        }
+        bh.consume(packed64vhll.get(0));
+    }
+
+    @Benchmark
+    public void packed64VarHandleLongAndByte(Blackhole bh) {
+        for (int i = 0; i < values.length; i++) {
+            packed64vhlb.set(i, values[i]);
+        }
+        bh.consume(packed64vhlb.get(0));
+    }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/packed/Packed64Benchmark.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/Packed64Benchmark.java
@@ -1,6 +1,7 @@
 package org.apache.lucene.util.packed;
 
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import org.apache.lucene.util.packed.PackedInts.Mutable;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
@@ -9,7 +10,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +25,6 @@ public class Packed64Benchmark {
     @Param({"1", "4", "5", "8", "11", "16", "23", "25", "31", "32", "47", "59", "61", "64"})
     private int bpv;
     long[] values;
-    long[] baseLine;
     Packed64 packed64;
     Packed64VHLongLong packed64vhll;
     Packed64VHLongAndByte packed64vhlb;
@@ -39,33 +38,61 @@ public class Packed64Benchmark {
             values[i] = RandomNumbers.randomLongBetween(r, 0, max);
         }
         // field initialization
-        baseLine = new long[size];
         packed64 = new Packed64(size, bpv);
         packed64vhll = new Packed64VHLongLong(size, bpv);
         packed64vhlb = new Packed64VHLongAndByte(size, bpv);
     }
 
-    @Benchmark
-    public void packed64(Blackhole bh) {
+    private final Mutable consecutiveReadWrite(Mutable mutable) {
         for (int i = 0; i < values.length; i++) {
-            packed64.set(i, values[i]);
+            mutable.set(i, values[i]);
         }
-        bh.consume(packed64.get(0));
+        for (int i = 0; i < values.length; i++) {
+            mutable.get(i);
+        }
+        return mutable;
+    }
+
+    private final Mutable sparseReadWrite(Mutable mutable) {
+        int middle = values.length / 2;
+        for (int i = 0; i < middle; i++) {
+            mutable.set(i, values[i]);
+            mutable.set(values.length - i - 1, values[values.length - i - 1]);
+        }
+        for (int i = 0; i < middle; i++) {
+            mutable.get(i);
+            mutable.get(values.length - i - 1);
+        }
+        return mutable;
     }
 
     @Benchmark
-    public void packed64VarHandleLongLong(Blackhole bh) {
-        for (int i = 0; i < values.length; i++) {
-            packed64vhll.set(i, values[i]);
-        }
-        bh.consume(packed64vhll.get(0));
+    public Mutable packed64_Consecutive() {
+        return consecutiveReadWrite(packed64);
     }
 
     @Benchmark
-    public void packed64VarHandleLongAndByte(Blackhole bh) {
-        for (int i = 0; i < values.length; i++) {
-            packed64vhlb.set(i, values[i]);
-        }
-        bh.consume(packed64vhlb.get(0));
+    public Mutable packed64_Sparse() {
+        return sparseReadWrite(packed64);
+    }
+
+    @Benchmark
+    public Mutable packed64VarHandleLongLong_Consecutive() {
+        return consecutiveReadWrite(packed64vhll);
+    }
+
+    @Benchmark
+    public Mutable packed64VarHandleLongLong_Sparse() {
+        return sparseReadWrite(packed64vhll);
+    }
+
+    @Benchmark
+    public Mutable packed64VarHandleLongByte_Consecutive() {
+        return consecutiveReadWrite(packed64vhlb);
+    }
+
+    @Benchmark
+    public Mutable packed64VarHandleLongByte_Sparse() {
+        return sparseReadWrite(packed64vhlb);
     }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/packed/Packed64Benchmark.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/Packed64Benchmark.java
@@ -54,7 +54,7 @@ public class Packed64Benchmark {
     }
 
     @Benchmark
-    public void packed64VarHandleDoubleLong(Blackhole bh) {
+    public void packed64VarHandleLongLong(Blackhole bh) {
         for (int i = 0; i < values.length; i++) {
             packed64vhll.set(i, values[i]);
         }

--- a/lucene/core/src/test/org/apache/lucene/util/packed/PackedMacroTest.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/PackedMacroTest.java
@@ -10,8 +10,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.BytesRef;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/lucene/core/src/test/org/apache/lucene/util/packed/PackedMacroTest.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/PackedMacroTest.java
@@ -1,0 +1,38 @@
+package org.apache.lucene.util.packed;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LogDocMergePolicy;
+import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class PackedMacroTest {
+    public static void main(String[] args) throws Exception {
+        String log = "/tmp/merge.log";
+        Directory dir = FSDirectory.open(Paths.get("/tmp/temp-index-dir"));
+        IndexWriterConfig config = new IndexWriterConfig()
+                //.setInfoStream(new PrintStream(System.out))
+                .setInfoStream(new PrintStream(Files.newOutputStream(Paths.get(log))))
+                .setMergeScheduler(new SerialMergeScheduler())
+                .setMergePolicy(new LogDocMergePolicy())
+                .setMaxBufferedDocs(65536);
+        IndexWriter w = new IndexWriter(dir, config);
+        Document doc = new Document();
+        SortedDocValuesField field = new SortedDocValuesField("foo", new BytesRef());
+        doc.add(field);
+        for (int i = 0; i < 100_000_000; ++i) {
+            field.setBytesValue(new BytesRef(Integer.toString(i)));
+            w.addDocument(doc);
+        }
+    }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/packed/PackedRandomTest.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/PackedRandomTest.java
@@ -1,0 +1,34 @@
+package org.apache.lucene.util.packed;
+
+import org.apache.lucene.util.packed.Packed64VHLongAndByte;
+import org.apache.lucene.util.packed.PackedInts;
+
+import java.util.SplittableRandom;
+
+public class PackedRandomTest {
+    private static long DUMMY = 0;
+
+    public static void main(String[] args) {
+        int valueCount = 1 << 10;
+        int bitsPerValue = 11;
+        PackedInts.Mutable mut = new Packed64VHLongAndByte(valueCount, bitsPerValue);
+        //PackedInts.Mutable mut = new Packed64(valueCount, bitsPerValue);
+        SplittableRandom r = new SplittableRandom(0L);
+        for (int i = 0; i < valueCount; ++i) {
+            mut.set(i, r.nextInt(1 << bitsPerValue));
+        }
+        long min = Long.MAX_VALUE;
+        for (int iter = 0; iter < 1000; ++iter) {
+            long start = System.nanoTime();
+            long sum = 0;
+            int index = 42;
+            for (int i = 0; i < 1_000_000; ++i) {
+                sum += mut.get(index);
+                index = (index + 47) & (valueCount - 1);
+            }
+            DUMMY = sum;
+            min = Math.min(System.nanoTime() - start, min);
+        }
+        System.out.println(min);
+    }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/packed/PackedTest.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/PackedTest.java
@@ -1,0 +1,73 @@
+package org.apache.lucene.util.packed;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PackedTest {
+
+    @Test
+    public void testPacked() throws Exception {
+        int count = 1024;
+        int bits = 57;
+        long val = PackedInts.maxValue(bits) - 1;
+        Packed64VHLongAndByte vh = new Packed64VHLongAndByte(count, bits);
+        for (int i = 0; i < count; i++) {
+            vh.set(i, val);
+            // test right away
+            assertEquals("Incorrect value set at " + i, val, vh.get(i));
+        }
+        // test the list again
+        for (int i = 0; i < count; i++) {
+            assertEquals("Incorrect value set at " + i, val, vh.get(i));
+        }
+    }
+
+    @Test
+    public void testFailure() throws Exception {
+        int count = 1111;
+        int bits = 61;
+        long val = 177_687_460_430_102_016L;
+        Packed64VHLongAndByte vh = new Packed64VHLongAndByte(count, bits);
+
+        vh.set(0, 1);
+        vh.set(1, 1);
+        vh.set(2, 1);
+
+        assertEquals(1, vh.get(0));
+        assertEquals(1, vh.get(1));
+        vh.set(1, val);
+        assertEquals(1, vh.get(2));
+    }
+
+    @Test
+    public void testFill() throws Exception {
+        int count = 1111;
+        int bits = 61;
+        long val = 177_687_460_430_102_016L;
+        int from = 456, to=1039;
+        Packed64VHLongAndByte vh = new Packed64VHLongAndByte(count, bits);
+        vh.fill(0, vh.size(), 1);
+        vh.fill(from, to, val);
+        for (int i = 0; i < vh.size(); i++) {
+            var v = vh.get(i);
+            var expected = 1L;
+            if (i >= from && i < to) {
+                expected = val;
+            }
+            assertEquals("Incorrect value set at " + i, expected, vh.get(i));
+        }
+    }
+
+    @Test
+    public void testOverflow() throws Exception {
+        int count = 128;
+        int bits = 63;
+        long val = PackedInts.maxValue(bits);
+        Packed64VHLongAndByte vh = new Packed64VHLongAndByte(count, bits);
+        vh.fill(0, vh.size(), val);
+        for (int i = 0; i < vh.size(); i++) {
+            assertEquals("Incorrect value set at " + i, val, vh.get(i));
+        }
+    }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
@@ -246,6 +246,7 @@ public class TestPackedInts extends LuceneTestCase {
     for (PackedInts.Mutable packedInt : packedInts) {
       for (int i = 0; i < packedInt.size(); i++) {
         packedInt.set(i, i + 1);
+        assertEquals("The value just set at " + i + " is not correct", i + 1, packedInt.get(i));
       }
     }
     assertListEquality(packedInts);
@@ -349,9 +350,13 @@ public class TestPackedInts extends LuceneTestCase {
     assertListEquality(packedInts);
   }
 
+  private static PackedInts.MutableImpl packed64(int valueCount, int bitsPerValue) {
+    return new Packed64VHLongAndByte(valueCount, bitsPerValue);
+  }
+
   private static List<PackedInts.Mutable> createPackedInts(int valueCount, int bitsPerValue) {
     List<PackedInts.Mutable> packedInts = new ArrayList<>();
-    packedInts.add(new Packed64(valueCount, bitsPerValue));
+    packedInts.add(packed64(valueCount, bitsPerValue));
     for (int bpv = bitsPerValue; bpv <= Packed64SingleBlock.MAX_SUPPORTED_BITS_PER_VALUE; ++bpv) {
       if (Packed64SingleBlock.isSupported(bpv)) {
         packedInts.add(Packed64SingleBlock.create(valueCount, bpv));
@@ -409,7 +414,7 @@ public class TestPackedInts extends LuceneTestCase {
   }
 
   public void testSecondaryBlockChange() {
-    PackedInts.Mutable mutable = new Packed64(26, 5);
+    PackedInts.Mutable mutable = packed64(26, 5);
     mutable.set(24, 31);
     assertEquals("The value #24 should be correct", 31, mutable.get(24));
     mutable.set(4, 16);


### PR DESCRIPTION
Add VarHandle variants for `Packed64` to investigate whether using VarHandles 
improved performance or not.

This PR introduces two new Packed64 variants:
~ Packed64LongLong
Same as Packed64 however instead of using direct array access, it
relies on `VarHandle`. It's main purpose benchmarking.
~ Packed64LongByte
A different implementation of Packed64 backed by a byte[]. It reads the data as a
 long and in case of overflow reads an extra byte. The algorithm is slightly different
since the overflowing bits need to be computed on a different block size (8 vs 64)
which requires extra cycles.

Related LUCENE-10205