### PR TITLE
LUCENE-10244: Please consider opening MultiCollector::getCollectors for public use

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
@@ -150,7 +150,7 @@ public class MultiCollector implements Collector {
   }
 
   /** Provides access to the wrapped {@code Collector}s for advanced use-cases */
-  Collector[] getCollectors() {
+  public Collector[] getCollectors() {
     return collectors;
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestCollectorManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestCollectorManager.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.LuceneTestCase;
+
+public class TestCollectorManager extends LuceneTestCase {
+
+  @SuppressWarnings("unchecked")
+  public void testCollection() throws IOException {
+    Directory dir = newDirectory();
+    DirectoryReader reader = reader(dir);
+    LeafReaderContext ctx = reader.leaves().get(0);
+
+    // Setup two collectors, one that will only collect even doc ids and one that
+    // only collects odd. Create some random doc ids and keep track of the ones that we
+    // expect each collector manager to collect:
+    Predicate<Integer> evenPredicate = val -> val % 2 == 0;
+    Predicate<Integer> oddPredicate = val -> val % 2 == 1;
+
+    CompositeCollectorManager cm =
+        new CompositeCollectorManager(Arrays.asList(evenPredicate, oddPredicate));
+
+    for (int iter = 0; iter < 100; iter++) {
+      int docs = RandomNumbers.randomIntBetween(random(), 1000, 10000);
+      List<Integer> expected = generateDocIds(docs, random());
+      IntStream expectedEven = expected.stream().filter(evenPredicate).mapToInt(i -> i);
+      IntStream expectedOdd = expected.stream().filter(oddPredicate).mapToInt(i -> i);
+
+      // Test only wrapping one of the collector managers:
+      Object result = collectAll(ctx, expected, cm);
+      assertThat(result, instanceOf(List.class));
+      IntStream intResults = ((List<Integer>) result).stream().mapToInt(i -> i);
+      assertArrayEquals(
+          IntStream.concat(expectedEven, expectedOdd).sorted().toArray(),
+          intResults.sorted().toArray());
+    }
+
+    reader.close();
+    dir.close();
+  }
+
+  public void testEmptyCollectors() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CompositeCollectorManager(Collections.emptyList()).newCollector());
+  }
+
+  private static DirectoryReader reader(Directory dir) throws IOException {
+    RandomIndexWriter iw = new RandomIndexWriter(random(), dir);
+    iw.addDocument(new Document());
+    iw.commit();
+    DirectoryReader reader = iw.getReader();
+    iw.close();
+
+    return reader;
+  }
+
+  private static <C extends Collector> Object collectAll(
+      LeafReaderContext ctx, List<Integer> values, CollectorManager<C, ?> collectorManager)
+      throws IOException {
+    List<C> collectors = new ArrayList<>();
+    C collector = collectorManager.newCollector();
+    collectors.add(collector);
+    LeafCollector leafCollector = collector.getLeafCollector(ctx);
+    for (Integer v : values) {
+      if (random().nextInt(10) == 1) {
+        collector = collectorManager.newCollector();
+        collectors.add(collector);
+        leafCollector = collector.getLeafCollector(ctx);
+      }
+      leafCollector.collect(v);
+    }
+    return collectorManager.reduce(collectors);
+  }
+
+  /**
+   * Generate test doc ids. This will de-dupe and create a sorted list to be more realistic with
+   * real-world use-cases. Note that it's possible this will generate fewer than 'count' entries
+   * because of de-duping, but that should be quite rare and probably isn't worth worrying about for
+   * these testing purposes.
+   */
+  private List<Integer> generateDocIds(int count, Random random) {
+    Set<Integer> generated = new HashSet<>(count);
+    for (int i = 0; i < count; i++) {
+      generated.add(random.nextInt());
+    }
+
+    return generated.stream().sorted().collect(Collectors.toList());
+  }
+
+  private static final class CompositeCollectorManager
+      implements CollectorManager<Collector, List<Integer>> {
+    private final List<Predicate<Integer>> predicates;
+
+    CompositeCollectorManager(List<Predicate<Integer>> predicates) {
+      this.predicates = predicates;
+    }
+
+    @Override
+    public Collector newCollector() throws IOException {
+      return MultiCollector.wrap(
+          predicates.stream().map(SimpleListCollector::new).toArray(Collector[]::new));
+    }
+
+    @Override
+    public List<Integer> reduce(Collection<Collector> collectors) throws IOException {
+      List<Integer> all = new ArrayList<>();
+      for (Collector m : collectors) {
+        for (Collector c : ((MultiCollector) m).getCollectors()) {
+          all.addAll(((SimpleListCollector) c).collected);
+        }
+      }
+
+      return all;
+    }
+  }
+
+  private static final class SimpleListCollector implements Collector {
+    final Predicate<Integer> predicate;
+    final List<Integer> collected = new ArrayList<>();
+
+    SimpleListCollector(Predicate<Integer> predicate) {
+      this.predicate = predicate;
+    }
+
+    @Override
+    public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+      return new LeafCollector() {
+        @Override
+        public void setScorer(Scorable scorer) throws IOException {}
+
+        @Override
+        public void collect(int doc) throws IOException {
+          if (predicate.test(doc)) {
+            collected.add(doc);
+          }
+        }
+      };
+    }
+
+    @Override
+    public ScoreMode scoreMode() {
+      return ScoreMode.COMPLETE;
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

# Description



The usage of `MultiCollector` sometimes is very convenient along with `CollectorManager` instances (as an alternative to `MultiCollectorManager`), for example:

```
class SomeCollectorManager implements CollectorManager<Collector, ?> {
    @Override
    public Collector newCollector() throws IOException {
      return MultiCollector.wrap(new Collector1(), new Collector2(), ...);
    }
    @Override
    public List<Integer> reduce(Collection<Collector> collectors) throws IOException {
      return ...;
    }
}
```

Unfortunately, the reduce() phase is lacking the access to  `MultiCollector::getCollectors` method, since it is package protected at the moment. Making `MultiCollector::getCollectors`  public would make it convenient to use `MultiCollector` + `CollectorManager` and implement the reduce phase by accessing individual collectors.

# Solution

Make `MultiCollector::getCollectors`  public 

# Tests

The test which illustrates the usage of the `MultiCollector` + `CollectorManager` has been added.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
