### PR TITLE
LUCENE-10247 - reduce size of FSTs by relative coding

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/NormalizeCharMap.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/NormalizeCharMap.java
@@ -49,6 +49,8 @@ public class NormalizeCharMap {
         final FST.BytesReader fstReader = map.getBytesReader();
         map.getFirstArc(scratchArc);
         if (FST.targetHasArcs(scratchArc)) {
+          long node = scratchArc.target();
+
           map.readFirstRealTargetArc(scratchArc.target(), scratchArc, fstReader);
           while (true) {
             assert scratchArc.label() != FST.END_LABEL;
@@ -58,7 +60,7 @@ public class NormalizeCharMap {
             if (scratchArc.isLast()) {
               break;
             }
-            map.readNextRealArc(scratchArc, fstReader, scratchArc.target());
+            map.readNextRealArc(scratchArc, fstReader, node);
           }
         }
         // System.out.println("cached " + cachedRootArcs.size() + " root arcs");

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/NormalizeCharMap.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/NormalizeCharMap.java
@@ -58,7 +58,7 @@ public class NormalizeCharMap {
             if (scratchArc.isLast()) {
               break;
             }
-            map.readNextRealArc(scratchArc, fstReader);
+            map.readNextRealArc(scratchArc, fstReader, scratchArc.target());
           }
         }
         // System.out.println("cached " + cachedRootArcs.size() + " root arcs");

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/FSTOrdsOutputs.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/FSTOrdsOutputs.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.fst.Outputs;
+import org.apache.lucene.util.fst.Util;
 
 /**
  * A custom FST outputs implementation that stores block data (BytesRef), long ordStart, long
@@ -180,6 +181,14 @@ final class FSTOrdsOutputs extends Outputs<FSTOrdsOutputs.Output> {
     out.writeBytes(prefix.bytes.bytes, prefix.bytes.offset, prefix.bytes.length);
     out.writeVLong(prefix.startOrd);
     out.writeVLong(prefix.endOrd);
+  }
+
+  @Override
+  public long outputSize(Output prefix) {
+    return Util.calculateVIntLength(prefix.bytes.length)
+        + prefix.bytes.length
+        + Util.calculateVLongLength(prefix.startOrd)
+        + Util.calculateVLongLength(prefix.endOrd);
   }
 
   @Override

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/OrdsSegmentTermsEnum.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/OrdsSegmentTermsEnum.java
@@ -1309,7 +1309,6 @@ public final class OrdsSegmentTermsEnum extends BaseTermsEnum {
             } else {
               // System.out.println("  next arc");
               // Read next arc in this node:
-
               fr.index.readNextRealArc(arc, fstReader, node);
             }
           }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/OrdsSegmentTermsEnum.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/OrdsSegmentTermsEnum.java
@@ -1228,6 +1228,7 @@ public final class OrdsSegmentTermsEnum extends BaseTermsEnum {
       if (FST.targetHasArcs(arc)) {
         // System.out.println("  targetHasArcs");
         result.grow(1 + upto);
+        long node = arc.target();
         fr.index.readFirstRealTargetArc(arc.target(), arc, fstReader);
 
         if (arc.bytesPerArc() != 0 && arc.nodeFlags() == FST.ARCS_FOR_BINARY_SEARCH) {
@@ -1308,7 +1309,8 @@ public final class OrdsSegmentTermsEnum extends BaseTermsEnum {
             } else {
               // System.out.println("  next arc");
               // Read next arc in this node:
-              fr.index.readNextRealArc(arc, fstReader);
+
+              fr.index.readNextRealArc(arc, fstReader, node);
             }
           }
         }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
@@ -646,7 +646,7 @@ public class FSTTermsReader extends FieldsProducer {
           return null;
         }
         while (!frame.fstArc.isLast()) {
-          frame.fstArc = fst.readNextRealArc(frame.fstArc, fstReader);
+          frame.fstArc = fst.readNextRealArc(frame.fstArc, fstReader, top.fstArc.target());
           frame.fsaState = fsa.step(top.fsaState, frame.fstArc.label());
           if (frame.fsaState != -1) {
             break;
@@ -764,7 +764,7 @@ public class FSTTermsReader extends FieldsProducer {
           if (arc.isLast()) {
             break;
           } else {
-            fst.readNextRealArc(arc, reader);
+            fst.readNextRealArc(arc, reader, node);
           }
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/util/fst/ByteSequenceOutputs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/ByteSequenceOutputs.java
@@ -117,6 +117,11 @@ public final class ByteSequenceOutputs extends Outputs<BytesRef> {
   }
 
   @Override
+  public long outputSize(BytesRef prefix) {
+    return Util.calculateVIntLength(prefix.length) + prefix.length;
+  }
+
+  @Override
   public BytesRef read(DataInput in) throws IOException {
     final int len = in.readVInt();
     if (len == 0) {

--- a/lucene/core/src/java/org/apache/lucene/util/fst/CharSequenceOutputs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/CharSequenceOutputs.java
@@ -116,6 +116,15 @@ public final class CharSequenceOutputs extends Outputs<CharsRef> {
   }
 
   @Override
+  public long outputSize(CharsRef prefix) {
+    long length = Util.calculateVIntLength(prefix.length);
+    for (int idx = 0; idx < prefix.length; idx++) {
+      length += Util.calculateVIntLength(prefix.chars[prefix.offset + idx]);
+    }
+    return length;
+  }
+
+  @Override
   public CharsRef read(DataInput in) throws IOException {
     final int len = in.readVInt();
     if (len == 0) {

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -125,7 +125,7 @@ public final class FST<T> implements Accountable {
   private static final String FILE_FORMAT_NAME = "FST";
   private static final int VERSION_START = 6;
   private static final int VERSION_LITTLE_ENDIAN = 8;
-  private static final int VERSION_CURRENT = VERSION_LITTLE_ENDIAN;
+  private static final int VERSION_CURRENT = 9;
 
   // Never serialized; just used to represent the virtual
   // final node w/ no arcs:
@@ -672,10 +672,10 @@ public final class FST<T> implements Accountable {
     int maxBytesPerArc = 0;
     int maxBytesPerArcWithoutLabel = 0;
 
-    long precalculatedNodeAddress = 0;
+    long calculatedNodeAddress = 0;
 
     if (doFixedLengthArcs == false) {
-      precalculatedNodeAddress = precalculateNodeAddress(fstCompiler, nodeIn);
+      calculatedNodeAddress = calculateNodeAddress(fstCompiler, nodeIn);
     }
 
     for (int arcIdx = 0; arcIdx < nodeIn.numArcs; arcIdx++) {
@@ -721,7 +721,7 @@ public final class FST<T> implements Accountable {
       if (targetHasArcs && (flags & BIT_TARGET_NEXT) == 0) {
         assert target.node > 0;
         long relativeTarget =
-            precalculatedNodeAddress > 0 ? precalculatedNodeAddress - target.node : Long.MAX_VALUE;
+            calculatedNodeAddress > 0 ? calculatedNodeAddress - target.node : Long.MAX_VALUE;
 
         if (relativeTarget > target.node) {
           targetNode = target.node;
@@ -811,7 +811,7 @@ public final class FST<T> implements Accountable {
     fstCompiler.bytes.reverse(startAddress, thisNodeAddress);
     fstCompiler.nodeCount++;
 
-    assert precalculatedNodeAddress == 0 || precalculatedNodeAddress == thisNodeAddress;
+    assert calculatedNodeAddress == 0 || calculatedNodeAddress == thisNodeAddress;
     return thisNodeAddress;
   }
 
@@ -1033,7 +1033,7 @@ public final class FST<T> implements Accountable {
     assert bytePos - dest == numPresenceBytes;
   }
 
-  private long precalculateNodeAddress(
+  private long calculateNodeAddress(
       FSTCompiler<T> fstCompiler, FSTCompiler.UnCompiledNode<T> nodeIn) {
     T NO_OUTPUT = outputs.getNoOutput();
 

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -1058,7 +1058,7 @@ public final class FST<T> implements Accountable {
         }
       } else if (nodeIn.numArcs == 1) {
         // just 1 arc, which is encoded with BIT_TARGET_NEXT, this optimization is not required
-        return -1L;
+        return 0L;
       }
 
       // account for flags

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -1454,7 +1454,6 @@ public final class FST<T> implements Accountable {
         in.setPosition(arc.nextArc());
         arc.flags = in.readByte();
     }
-
     return readArc(arc, in, node);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTEnum.java
@@ -109,7 +109,7 @@ abstract class FSTEnum<T> {
           return;
         }
       }
-      fst.readNextArc(arcs[upto], fstReader);
+      fst.readNextArc(arcs[upto], fstReader, arcs[upto - 1].target());
     }
 
     pushFirst();
@@ -177,7 +177,7 @@ abstract class FSTEnum<T> {
         // System.out.println("  rollback upto=" + upto + " arc.label=" + prevArc.label + "
         // isLast?=" + prevArc.isLast());
         if (!prevArc.isLast()) {
-          fst.readNextArc(prevArc, fstReader);
+          fst.readNextArc(prevArc, fstReader, arcs[upto - 1].target());
           pushFirst();
           return null;
         }
@@ -242,7 +242,7 @@ abstract class FSTEnum<T> {
         // System.out.println("  rollback upto=" + upto + " arc.label=" + prevArc.label + "
         // isLast?=" + prevArc.isLast());
         if (!prevArc.isLast()) {
-          fst.readNextArc(prevArc, fstReader);
+          fst.readNextArc(prevArc, fstReader, arcs[upto - 1].target());
           pushFirst();
           return null;
         }
@@ -284,7 +284,7 @@ abstract class FSTEnum<T> {
         // System.out.println("  rollback upto=" + upto + " arc.label=" + prevArc.label + "
         // isLast?=" + prevArc.isLast());
         if (!prevArc.isLast()) {
-          fst.readNextArc(prevArc, fstReader);
+          fst.readNextArc(prevArc, fstReader, arcs[upto - 1].target());
           pushFirst();
           return null;
         }
@@ -293,7 +293,7 @@ abstract class FSTEnum<T> {
     } else {
       // keep scanning
       // System.out.println("    next scan");
-      fst.readNextArc(arc, fstReader);
+      fst.readNextArc(arc, fstReader, arcs[upto - 1].target());
     }
     return arc;
   }
@@ -405,7 +405,7 @@ abstract class FSTEnum<T> {
             }
           } else {
             while (!arc.isLast() && fst.readNextArcLabel(arc, in) < targetLabel) {
-              fst.readNextArc(arc, fstReader);
+              fst.readNextArc(arc, fstReader, arcs[upto - 1].target());
             }
           }
         }
@@ -524,7 +524,7 @@ abstract class FSTEnum<T> {
           // Then, scan forwards to the arc just before
           // the targetLabel:
           while (!arc.isLast() && fst.readNextArcLabel(arc, fstReader) < targetLabel) {
-            fst.readNextArc(arc, fstReader);
+            fst.readNextArc(arc, fstReader, arcs[upto - 1].target());
           }
           pushLast();
           return null;
@@ -544,7 +544,7 @@ abstract class FSTEnum<T> {
         return null;
       } else {
         // keep scanning
-        return fst.readNextArc(arc, fstReader);
+        return fst.readNextArc(arc, fstReader, arcs[upto - 1].target());
       }
     } else {
       pushLast();
@@ -656,7 +656,7 @@ abstract class FSTEnum<T> {
       }
       incr();
 
-      arc = fst.readLastTargetArc(arc, getArc(upto), fstReader);
+      arc = fst.readLastTargetArc(arc, getArc(upto), fstReader, arcs[upto].target());
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/fst/IntSequenceOutputs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/IntSequenceOutputs.java
@@ -115,6 +115,15 @@ public final class IntSequenceOutputs extends Outputs<IntsRef> {
   }
 
   @Override
+  public long outputSize(IntsRef prefix) {
+    long length = Util.calculateVIntLength(prefix.length);
+    for (int idx = 0; idx < prefix.length; idx++) {
+      length += Util.calculateVIntLength(prefix.ints[prefix.offset + idx]);
+    }
+    return length;
+  }
+
+  @Override
   public IntsRef read(DataInput in) throws IOException {
     final int len = in.readVInt();
     if (len == 0) {

--- a/lucene/core/src/java/org/apache/lucene/util/fst/NoOutputs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/NoOutputs.java
@@ -83,6 +83,11 @@ public final class NoOutputs extends Outputs<Object> {
   }
 
   @Override
+  public long outputSize(Object ouput) {
+    return 0;
+  }
+
+  @Override
   public Object read(DataInput in) {
     // assert false;
     // return null;

--- a/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
@@ -72,7 +72,7 @@ final class NodeHash<T> {
           return false;
         }
       }
-      fst.readNextRealArc(scratchArc, in);
+      fst.readNextRealArc(scratchArc, in, address);
     }
 
     return false;
@@ -123,7 +123,7 @@ final class NodeHash<T> {
       if (scratchArc.isLast()) {
         break;
       }
-      fst.readNextRealArc(scratchArc, in);
+      fst.readNextRealArc(scratchArc, in, node);
     }
     // System.out.println("  ret " + (h&Integer.MAX_VALUE));
     return h & Long.MAX_VALUE;

--- a/lucene/core/src/java/org/apache/lucene/util/fst/Outputs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/Outputs.java
@@ -49,6 +49,20 @@ public abstract class Outputs<T> {
   /** Encode an output value into a {@link DataOutput}. */
   public abstract void write(T output, DataOutput out) throws IOException;
 
+  /** Get the required size of the output before writing */
+  // TODO: this must become abstract
+  public long outputSize(T ouput) {
+    return 1;
+  }
+  ;
+
+  /** Get the required size of the final output before writing */
+  // TODO: this must become abstract
+  public long finalOutputSize(T ouput) {
+    return 1;
+  }
+  ;
+
   /**
    * Encode an final node output value into a {@link DataOutput}. By default this just calls {@link
    * #write(Object, DataOutput)}.

--- a/lucene/core/src/java/org/apache/lucene/util/fst/Outputs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/Outputs.java
@@ -50,18 +50,7 @@ public abstract class Outputs<T> {
   public abstract void write(T output, DataOutput out) throws IOException;
 
   /** Get the required size of the output before writing */
-  // TODO: this must become abstract
-  public long outputSize(T ouput) {
-    return 1;
-  }
-  ;
-
-  /** Get the required size of the final output before writing */
-  // TODO: this must become abstract
-  public long finalOutputSize(T ouput) {
-    return 1;
-  }
-  ;
+  public abstract long outputSize(T ouput);
 
   /**
    * Encode an final node output value into a {@link DataOutput}. By default this just calls {@link
@@ -69,6 +58,14 @@ public abstract class Outputs<T> {
    */
   public void writeFinalOutput(T output, DataOutput out) throws IOException {
     write(output, out);
+  }
+
+  /**
+   * Get the required size of the final output before writing By default this just calls {@link
+   * #outputSize(Object)}.
+   */
+  public long finalOutputSize(T output) {
+    return outputSize(output);
   }
 
   /** Decode an output value previously written with {@link #write(Object, DataOutput)}. */

--- a/lucene/core/src/java/org/apache/lucene/util/fst/PairOutputs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/PairOutputs.java
@@ -150,6 +150,11 @@ public class PairOutputs<A, B> extends Outputs<PairOutputs.Pair<A, B>> {
   }
 
   @Override
+  public long outputSize(Pair<A, B> output) {
+    return outputs1.outputSize(output.output1) + outputs2.outputSize(output.output2);
+  }
+
+  @Override
   public Pair<A, B> read(DataInput in) throws IOException {
     A output1 = outputs1.read(in);
     B output2 = outputs2.read(in);

--- a/lucene/core/src/java/org/apache/lucene/util/fst/PositiveIntOutputs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/PositiveIntOutputs.java
@@ -86,6 +86,16 @@ public final class PositiveIntOutputs extends Outputs<Long> {
   }
 
   @Override
+  public long outputSize(Long output) {
+    return Util.calculateVLongLength(output);
+  }
+
+  @Override
+  public long finalOutputSize(Long output) {
+    return Util.calculateVLongLength(output);
+  }
+
+  @Override
   public Long read(DataInput in) throws IOException {
     long v = in.readVLong();
     if (v == 0) {

--- a/lucene/core/src/java/org/apache/lucene/util/fst/PositiveIntOutputs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/PositiveIntOutputs.java
@@ -91,11 +91,6 @@ public final class PositiveIntOutputs extends Outputs<Long> {
   }
 
   @Override
-  public long finalOutputSize(Long output) {
-    return Util.calculateVLongLength(output);
-  }
-
-  @Override
   public Long read(DataInput in) throws IOException {
     long v = in.readVLong();
     if (v == 0) {

--- a/lucene/core/src/java/org/apache/lucene/util/fst/Util.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/Util.java
@@ -883,13 +883,30 @@ public final class Util {
     }
   }
 
-  public static int calculateVLongLength(long i) {
-    int l = 1;
-    while ((i & ~0x7FL) != 0L) {
-      i >>>= 7;
-      ++l;
+  public static int calculateVLongLength(long value) {
+    // todo: test if branching is faster, handle negative longs
+    return (63 - Long.numberOfLeadingZeros(value)) / 7 + 1;
+  }
+
+  public static int calculateVIntLength(int value) {
+    // branching is faster than counting Zeros
+    if (value < 0) {
+      return 5;
     }
-    return l;
+
+    if ((value & (~0 << 7)) == 0) {
+      return 1;
+    }
+    if ((value & (~0 << 14)) == 0) {
+      return 2;
+    }
+    if ((value & (~0 << 21)) == 0) {
+      return 3;
+    }
+    if ((value & (~0 << 28)) == 0) {
+      return 4;
+    }
+    return 5;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/fst/Util.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/Util.java
@@ -288,7 +288,7 @@ public final class Util {
         if (path.arc.isLast()) {
           break;
         }
-        fst.readNextArc(path.arc, bytesReader);
+        fst.readNextArc(path.arc, bytesReader, node.target());
       }
     }
 
@@ -351,7 +351,7 @@ public final class Util {
 
         // For each input letter:
         while (true) {
-
+          long node = path.arc.target();
           fst.readFirstTargetArc(path.arc, path.arc, fstReader);
 
           // For each arc leaving this node:
@@ -380,7 +380,7 @@ public final class Util {
               scratchArc.copyFrom(path.arc);
               arcCopyIsPending = false;
             }
-            fst.readNextArc(path.arc, fstReader);
+            fst.readNextArc(path.arc, fstReader, node);
           }
 
           assert foundZero;
@@ -682,7 +682,7 @@ public final class Util {
               // System.out.println("    break");
               break;
             }
-            fst.readNextRealArc(arc, r);
+            fst.readNextRealArc(arc, r, node);
           }
         }
       }
@@ -878,9 +878,18 @@ public final class Util {
       } else if (arc.isLast()) {
         return null;
       } else {
-        fst.readNextRealArc(arc, in);
+        fst.readNextRealArc(arc, in, follow.target());
       }
     }
+  }
+
+  public static int calculateVLongLength(long i) {
+    int l = 1;
+    while ((i & ~0x7FL) != 0L) {
+      i >>>= 7;
+      ++l;
+    }
+    return l;
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
@@ -1120,9 +1120,10 @@ public class TestFSTs extends LuceneTestCase {
         if (FST.targetHasArcs(arc)) {
           int childCount = 0;
           BytesReader fstReader = fst.getBytesReader();
+          long node = arc.target();
           for (arc = fst.readFirstTargetArc(arc, arc, fstReader);
               ;
-              arc = fst.readNextArc(arc, fstReader), childCount++) {
+              arc = fst.readNextArc(arc, fstReader, node), childCount++) {
             boolean expanded = fst.isExpandedTarget(arc, fstReader);
             int children = verifyStateAndBelow(fst, new FST.Arc<>().copyFrom(arc), depth + 1);
 
@@ -1262,7 +1263,7 @@ public class TestFSTs extends LuceneTestCase {
     assertEquals(17, arc.nextFinalOutput().longValue());
     assertTrue(arc.isFinal());
 
-    arc = fst.readNextArc(arc, fst.getBytesReader());
+    arc = fst.readNextArc(arc, fst.getBytesReader(), startArc.target());
     assertEquals('b', arc.label());
     assertFalse(arc.isFinal());
     assertEquals(42, arc.output().longValue());

--- a/lucene/misc/src/java/org/apache/lucene/misc/util/fst/ListOfOutputs.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/util/fst/ListOfOutputs.java
@@ -25,6 +25,7 @@ import org.apache.lucene.util.IntsRef; // javadocs
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.fst.FSTCompiler;
 import org.apache.lucene.util.fst.Outputs;
+import org.apache.lucene.util.fst.Util;
 
 /**
  * Wraps another Outputs implementation and encodes one or more of its output values. You can use
@@ -99,6 +100,11 @@ public final class ListOfOutputs<T> extends Outputs<Object> {
   }
 
   @Override
+  public long outputSize(Object output) {
+    return outputs.outputSize((T) output);
+  }
+
+  @Override
   public void writeFinalOutput(Object output, DataOutput out) throws IOException {
     if (!(output instanceof List)) {
       out.writeVInt(1);
@@ -109,6 +115,20 @@ public final class ListOfOutputs<T> extends Outputs<Object> {
       for (T eachOutput : outputList) {
         outputs.write(eachOutput, out);
       }
+    }
+  }
+
+  @Override
+  public long finalOutputSize(Object output) {
+    if (!(output instanceof List)) {
+      return 1 + outputs.outputSize((T) output);
+    } else {
+      List<T> outputList = (List<T>) output;
+      long outputSize = Util.calculateVIntLength(outputList.size());
+      for (T eachOutput : outputList) {
+        outputSize += outputs.outputSize(eachOutput);
+      }
+      return outputSize;
     }
   }
 

--- a/lucene/misc/src/java/org/apache/lucene/misc/util/fst/UpToTwoPositiveIntOutputs.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/util/fst/UpToTwoPositiveIntOutputs.java
@@ -22,6 +22,7 @@ import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.fst.FSTCompiler;
 import org.apache.lucene.util.fst.Outputs;
+import org.apache.lucene.util.fst.Util;
 
 /**
  * An FST {@link Outputs} implementation where each output is one or two non-negative long values.
@@ -170,6 +171,18 @@ public final class UpToTwoPositiveIntOutputs extends Outputs<Object> {
       final TwoLongs output = (TwoLongs) _output;
       out.writeVLong((output.first << 1) | 1);
       out.writeVLong(output.second);
+    }
+  }
+
+  @Override
+  public long outputSize(Object _output) {
+    if (_output instanceof Long) {
+      final Long output = (Long) _output;
+      return Util.calculateVLongLength(output << 1);
+    } else {
+      final TwoLongs output = (TwoLongs) _output;
+      return Util.calculateVLongLength((output.first << 1) | 1)
+          + Util.calculateVLongLength(output.second);
     }
   }
 

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/FSTUtil.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/FSTUtil.java
@@ -130,7 +130,10 @@ public class FSTUtil {
                     fst.outputs.add(path.output, nextArc.output()),
                     newInput));
             final int label = nextArc.label(); // used in assert
-            nextArc = nextArc.isLast() ? null : fst.readNextRealArc(nextArc, fstReader);
+            nextArc =
+                nextArc.isLast()
+                    ? null
+                    : fst.readNextRealArc(nextArc, fstReader, path.fstNode.target());
             assert nextArc == null || label < nextArc.label()
                 : "last: " + label + " next: " + nextArc.label();
           }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletion.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletion.java
@@ -137,11 +137,14 @@ public class FSTCompletion {
       List<Arc<Object>> rootArcs = new ArrayList<>();
       Arc<Object> arc = automaton.getFirstArc(new Arc<>());
       FST.BytesReader fstReader = automaton.getBytesReader();
+
+      long node = arc.target();
+
       automaton.readFirstTargetArc(arc, arc, fstReader);
       while (true) {
         rootArcs.add(new Arc<>().copyFrom(arc));
         if (arc.isLast()) break;
-        automaton.readNextArc(arc, fstReader);
+        automaton.readNextArc(arc, fstReader, node);
       }
 
       Collections.reverse(rootArcs); // we want highest weights first.

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletion.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletion.java
@@ -294,10 +294,12 @@ public class FSTCompletion {
     FST.BytesReader fstReader = automaton.getBytesReader();
 
     class State {
+      long node;
       Arc<Object> arc;
       int outputLength;
 
       State(Arc<Object> arc, int outputLength) throws IOException {
+        this.node = arc.target();
         this.arc = automaton.readFirstTargetArc(arc, new Arc<>(), fstReader);
         this.outputLength = outputLength;
       }
@@ -324,7 +326,7 @@ public class FSTCompletion {
                   if (arc.isLast()) {
                     states.removeLast();
                   } else {
-                    automaton.readNextArc(arc, fstReader);
+                    automaton.readNextArc(arc, fstReader, state.node);
                   }
 
                   return true;
@@ -340,7 +342,7 @@ public class FSTCompletion {
                   if (arc.isLast()) {
                     states.removeLast();
                   } else {
-                    automaton.readNextArc(arc, fstReader);
+                    automaton.readNextArc(arc, fstReader, state.node);
                   }
 
                   states.addLast(newState);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/fst/FSTTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/fst/FSTTester.java
@@ -242,10 +242,11 @@ public class FSTTester<T> {
 
     while (true) {
       // read all arcs:
+      long node = arc.target();
       fst.readFirstTargetArc(arc, arc, fstReader);
       arcs.add(new FST.Arc<T>().copyFrom(arc));
       while (!arc.isLast()) {
-        fst.readNextArc(arc, fstReader);
+        fst.readNextArc(arc, fstReader, node);
         arcs.add(new FST.Arc<T>().copyFrom(arc));
       }
 


### PR DESCRIPTION
See: https://github.com/apache/lucene/issues/11283

FST's use various tricks to reduce size. One more trick that can be added is using relative coding for the target pointers that connect nodes.

Currently if a node has a target and it's not optimized using the `next` flag, it writes a VLong which contains the address of the child. This is an absolute address. A relative address can be shorter, relative address means taking the address of the node and expressing the result of child node as diff between the parent and the child. E.g. if the child is 10099 and the parent 10000, an absolute pointer requires 2 bytes, but the relative pointer (10099 - 10000) requires only 1 byte. This PR introduces a new flag to differ between relative and absolute pointers. Whatever is smaller is used. The flag makes use of an currently unused bit, so does not require additional space.

As a result of this PR FST's requires less storage. I measured between 1% and 5% difference in size, depending on the data I use. In the bigger context FST's aren't using much space in an lucene index, so the overall savings are smaller. As important lookup structure it might still be a good enhancement.

For other uses of FST's - e.g. completion and suggest - this change will reduce memory usage.
