### PR TITLE
speed up extremely slow test methods (runtime 15-30s)

### DIFF
--- a/lucene/codecs/src/test/org/apache/lucene/codecs/simpletext/TestSimpleTextTermVectorsFormat.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/simpletext/TestSimpleTextTermVectorsFormat.java
@@ -16,8 +16,10 @@
  */
 package org.apache.lucene.codecs.simpletext;
 
+import java.io.IOException;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.index.BaseTermVectorsFormatTestCase;
+import org.apache.lucene.util.LuceneTestCase;
 
 public class TestSimpleTextTermVectorsFormat extends BaseTermVectorsFormatTestCase {
   @Override
@@ -28,5 +30,19 @@ public class TestSimpleTextTermVectorsFormat extends BaseTermVectorsFormatTestCa
   @Override
   protected Codec getCodec() {
     return new SimpleTextCodec();
+  }
+
+  // TODO: can we speed up the underlying base test?
+  @Override
+  @LuceneTestCase.Nightly
+  public void testMergeWithIndexSort() throws IOException {
+    super.testMergeWithIndexSort();
+  }
+
+  // TODO: can we speed up the underlying base test?
+  @Override
+  @LuceneTestCase.Nightly
+  public void testMergeWithoutIndexSort() throws IOException {
+    super.testMergeWithoutIndexSort();
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterThreadsToSegments.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterThreadsToSegments.java
@@ -303,6 +303,8 @@ public class TestIndexWriterThreadsToSegments extends LuceneTestCase {
     dir.close();
   }
 
+  // TODO: can we make this test more efficient so it doesn't need to be nightly?
+  @LuceneTestCase.Nightly
   public void testDocsStuckInRAMForever() throws Exception {
     Directory dir = newDirectory();
     IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -708,7 +708,8 @@ public class TestSortOptimization extends LuceneTestCase {
     Directory dir = newDirectory();
     IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig());
     List<Long> seqNos = new ArrayList<>();
-    int iterations = 10000 + random().nextInt(10000);
+    int limit = TEST_NIGHTLY ? 10000 : 1000;
+    int iterations = limit + random().nextInt(limit);
     long seqNoGenerator = random().nextInt(1000);
     for (long i = 0; i < iterations; i++) {
       int copies = random().nextInt(100) <= 5 ? 1 : 1 + random().nextInt(5);


### PR DESCRIPTION
These tests take between 15 and 30 seconds on my computer.

We have so many thousands of tests, we really shouldnt have individual tests taking this long, it slows the whole process down.

This is just a quick fix for the worst offenders. With the patch, I was able to achieve a test run in less than 7 minutes.