### PR TITLE
LUCENE-10259: Fix startup scripts to allow whitespace in path names

### DIFF
--- a/lucene/distribution/src/binary-release/bin/luke.cmd
+++ b/lucene/distribution/src/binary-release/bin/luke.cmd
@@ -17,5 +17,5 @@
 
 SETLOCAL
 SET MODULES=%~dp0..
-start javaw --module-path %MODULES%\modules;%MODULES%\modules-thirdparty --add-modules org.apache.logging.log4j --module lucene.luke
+start javaw --module-path "%MODULES%\modules;%MODULES%\modules-thirdparty" --add-modules org.apache.logging.log4j --module lucene.luke
 ENDLOCAL

--- a/lucene/distribution/src/binary-release/bin/luke.sh
+++ b/lucene/distribution/src/binary-release/bin/luke.sh
@@ -15,5 +15,5 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-MODULES=$(cd $(dirname $0)/.. && pwd)
-java --module-path $MODULES/modules:$MODULES/modules-thirdparty --add-modules org.apache.logging.log4j --module lucene.luke
+MODULES="$(cd "$(dirname "$0")/.." && pwd)"
+java --module-path "$MODULES/modules:$MODULES/modules-thirdparty" --add-modules org.apache.logging.log4j --module lucene.luke

--- a/lucene/distribution/src/binary-release/bin/luke.sh
+++ b/lucene/distribution/src/binary-release/bin/luke.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
@@ -15,5 +15,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-MODULES="$(cd "$(dirname "$0")/.." && pwd)"
+MODULES=`dirname "$0"`/..
+MODULES=`cd "$MODULES" && pwd`
 java --module-path "$MODULES/modules:$MODULES/modules-thirdparty" --add-modules org.apache.logging.log4j --module lucene.luke


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/LUCENE-10259