### PR TITLE
LUCENE-10263: Implement Weight.count() on NormsFieldExistsQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -51,6 +51,9 @@ New Features
   points are indexed.
   (Quentin Pradet, Adrien Grand)
 
+* LUCENE-10263: Added Weight#count to NormsFieldExistsQuery to speed up the query if there are no
+  deleted documents. (Alan Woodward)
+
 Improvements
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -51,8 +51,8 @@ New Features
   points are indexed.
   (Quentin Pradet, Adrien Grand)
 
-* LUCENE-10263: Added Weight#count to NormsFieldExistsQuery to speed up the query if there are no
-  deleted documents. (Alan Woodward)
+* LUCENE-10263: Added Weight#count to NormsFieldExistsQuery to speed up the query if all 
+  documents have the field.. (Alan Woodward)
 
 Improvements
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/NormsFieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NormsFieldExistsQuery.java
@@ -16,14 +16,14 @@
  */
 package org.apache.lucene.search;
 
-import java.io.IOException;
-import java.util.Objects;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
-import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
+
+import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A {@link Query} that matches documents that have a value for a given field as reported by field

--- a/lucene/core/src/java/org/apache/lucene/search/NormsFieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NormsFieldExistsQuery.java
@@ -16,14 +16,13 @@
  */
 package org.apache.lucene.search;
 
+import java.io.IOException;
+import java.util.Objects;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-
-import java.io.IOException;
-import java.util.Objects;
 
 /**
  * A {@link Query} that matches documents that have a value for a given field as reported by field

--- a/lucene/core/src/java/org/apache/lucene/search/NormsFieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NormsFieldExistsQuery.java
@@ -87,8 +87,9 @@ public final class NormsFieldExistsQuery extends Query {
         if (fieldInfo == null || fieldInfo.hasNorms() == false) {
           return 0;
         }
-        if (reader.hasDeletions() == false && fieldInfo.getIndexOptions() != IndexOptions.NONE) {
-          return reader.terms(field).getDocCount();
+        // If every field has a value then we can shortcut
+        if (reader.getDocCount(field) == reader.maxDoc()) {
+          return reader.numDocs();
         }
         return super.count(context);
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestNormsFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestNormsFieldExistsQuery.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.search;
 
+import java.io.IOException;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
@@ -33,8 +34,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
-
-import java.io.IOException;
 
 public class TestNormsFieldExistsQuery extends LuceneTestCase {
 
@@ -255,8 +254,8 @@ public class TestNormsFieldExistsQuery extends LuceneTestCase {
   }
 
   private void assertSameCount(
-          IndexReader reader, IndexSearcher searcher, String field, int numMatchingDocs)
-          throws IOException {
+      IndexReader reader, IndexSearcher searcher, String field, int numMatchingDocs)
+      throws IOException {
     final Query testQuery = new NormsFieldExistsQuery(field);
     assertEquals(searcher.count(testQuery), numMatchingDocs);
     final Weight weight = searcher.createWeight(testQuery, ScoreMode.COMPLETE, 1);

--- a/lucene/core/src/test/org/apache/lucene/search/TestNormsFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestNormsFieldExistsQuery.java
@@ -247,7 +247,7 @@ public class TestNormsFieldExistsQuery extends LuceneTestCase {
 
     // We can still shortcut with deleted docs
     w.w.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
-    w.deleteDocuments(new Term("text", "text"));  // deletes all but the first doc
+    w.deleteDocuments(new Term("text", "text")); // deletes all but the first doc
     DirectoryReader reader2 = w.getReader();
     final IndexSearcher searcher2 = new IndexSearcher(reader2);
     assertCountWithShortcut(searcher2, "text", 1);
@@ -255,7 +255,8 @@ public class TestNormsFieldExistsQuery extends LuceneTestCase {
     IOUtils.close(reader, reader2, w, dir);
   }
 
-  private void assertCountWithoutShortcut(IndexSearcher searcher, String field, int expectedCount) throws IOException {
+  private void assertCountWithoutShortcut(IndexSearcher searcher, String field, int expectedCount)
+      throws IOException {
     final Query q = new NormsFieldExistsQuery(field);
     final Weight weight = searcher.createWeight(q, ScoreMode.COMPLETE, 1);
     assertEquals(-1, weight.count(searcher.reader.leaves().get(0)));

--- a/lucene/core/src/test/org/apache/lucene/search/TestNormsFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestNormsFieldExistsQuery.java
@@ -16,14 +16,10 @@
  */
 package org.apache.lucene.search;
 
-import java.io.IOException;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.FieldType;
-import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.document.NumericDocValuesField;
-import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
@@ -34,10 +30,11 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
+
+import java.io.IOException;
 
 public class TestNormsFieldExistsQuery extends LuceneTestCase {
 


### PR DESCRIPTION
If there are no deleted documents in a segment, we can get a count
of documents that contain a text field by calling `getDocCount()` on 
the fields `Terms` instance.