### PR TITLE
Fix gradle task name conflict ('run' to 'runLuke')

### DIFF
--- a/lucene/luke/build.gradle
+++ b/lucene/luke/build.gradle
@@ -126,7 +126,7 @@ task standalonePackage(type: Tar) {
 }
 
 // Utility to launch Luke (and fork it from the build).
-task run() {
+task runLuke() {
   dependsOn standaloneAssemble
   description "Launches (spawns) Luke directly from the build process."
   group "Utility launchers"


### PR DESCRIPTION
There are two Gradle tasks named "run": the one is defined in the "benchmark" project, and another one is in the "luke" project.

`gradlew tasks` shows:
```
Utility launchers tasks
-----------------------
run - Launches (spawns) Luke directly from the build process.
```

When I run `gradlew run`, this actually invokes the `run` task that belongs to "benchmark" (and fails).
```
> Task :lucene:benchmark:run FAILED
Running algorithm from: /mnt/hdd/repo/lucene/lucene/benchmark/conf/micro-standard.alg
------------> config properties:
analyzer = org.apache.lucene.analysis.standard.StandardAnalyzer
compound = true
content.source = org.apache.lucene.benchmark.byTask.feeds.ReutersContentSource
directory = FSDirectory
doc.stored = true
doc.term.vector = false
doc.tokenized = true
docs.dir = reuters21578
log.queries = true
log.step = 500
max.buffered = buf:10:10:100:100
merge.factor = mrg:10:100:10:100
query.maker = org.apache.lucene.benchmark.byTask.feeds.ReutersQueryMaker
task.max.depth.log = 2
work.dir = data
-------------------------------
java.lang.RuntimeException: java.nio.file.NoSuchFileException: data/reuters21578
        at org.apache.lucene.benchmark.byTask.feeds.ReutersContentSource.setConfig(ReutersContentSource.java:70)
        at org.apache.lucene.benchmark.byTask.PerfRunData.<init>(PerfRunData.java:126)
        at org.apache.lucene.benchmark.byTask.Benchmark.<init>(Benchmark.java:57)
        at org.apache.lucene.benchmark.byTask.Benchmark.exec(Benchmark.java:113)
        at org.apache.lucene.benchmark.byTask.Benchmark.main(Benchmark.java:87)
```

This quick-fix resolves the naming conflict. There could be a proper way to handle such conflicts, though.

```
./gradlew tasks

Utility launchers tasks
-----------------------
runLuke - Launches (spawns) Luke directly from the build process.
```

To avoid a too generic name for each task seems to be a good practice.
https://discuss.gradle.org/t/what-occur-on-a-task-name-conflict/11693

