### PR TITLE
set group to 'run' benchmark task

### DIFF
--- a/lucene/benchmark/build.gradle
+++ b/lucene/benchmark/build.gradle
@@ -50,6 +50,7 @@ sourceSets {
 
 task run(type: JavaExec) {
   description "Run a perf test (optional: -PtaskAlg=conf/your-algorithm-file -PmaxHeapSize=1G)"
+  group "Utility launchers"
   mainClass = 'org.apache.lucene.benchmark.byTask.Benchmark'
 
   classpath sourceSets.main.runtimeClasspath

--- a/lucene/benchmark/build.gradle
+++ b/lucene/benchmark/build.gradle
@@ -49,7 +49,7 @@ sourceSets {
 }
 
 task run(type: JavaExec) {
-  description "Run a perf test (optional: -PtaskAlg=conf/your-algorithm-file -PmaxHeapSize=1G)"
+  description "Run a perf test (optional: -PtaskAlg=conf/your-algorithm-file -PmaxHeapSize=1G). Before running this, you need to download the dataset the benchmark run against (e.g., by getReuters task). See dataset download tasks for more details."
   group "Utility launchers"
   mainClass = 'org.apache.lucene.benchmark.byTask.Benchmark'
 


### PR DESCRIPTION
A spin-off from #479.

```
./gradlew tasks

Utility launchers tasks
-----------------------
run - Run a perf test (optional: -PtaskAlg=conf/your-algorithm-file -PmaxHeapSize=1G)
```

It seems the description of the "run" task in the luke sub-project disappeared. I think this is okay.