### PR TITLE
upgrade ecj linter from 3.25.0 -> 3.27.0

### DIFF
--- a/buildSrc/scriptDepVersions.gradle
+++ b/buildSrc/scriptDepVersions.gradle
@@ -23,7 +23,7 @@ ext {
   scriptDepVersions = [
       "apache-rat": "0.11",
       "commons-codec": "1.13",
-      "ecj": "3.25.0",
+      "ecj": "3.27.0",
       "flexmark": "0.61.24",
       "javacc": "7.0.4",
       "jflex": "1.8.2",


### PR DESCRIPTION
The most recent `ecj` has significant performance improvements for our use-case. It removes minutes from precommit checks.

I ran tests several times to be sure:
```
Test commandline: ./gradlew clean ecjLintMain ecjLintTest -Ptask.times=true

3.25.0:
Aggregate task times (possibly running in parallel!):
 284.90 sec.  ecjLintTest
 256.59 sec.  ecjLintMain

3.27.0:
Aggregate task times (possibly running in parallel!):
 160.88 sec.  ecjLintTest
 149.60 sec.  ecjLintMain
```