### PR TITLE
Speed up ECJ tasks by avoiding --release

### DIFF
--- a/gradle/validation/ecj-lint.gradle
+++ b/gradle/validation/ecj-lint.gradle
@@ -63,7 +63,9 @@ allprojects {
         args += [ "-d", "none" ]
 
         // Compilation environment.
-        args += [ "--release", project.java.targetCompatibility ]
+        // we use -source/-target as it is significantly faster than --release
+        args += [ "-source", project.java.sourceCompatibility ]
+        args += [ "-target", project.java.targetCompatibility ]
         args += [ "-encoding", "UTF-8"]
         args += [ "-proc:none" ]
         args += [ "-nowarn" ]

--- a/gradle/validation/ecj-lint/ecj.javadocs.prefs
+++ b/gradle/validation/ecj-lint/ecj.javadocs.prefs
@@ -101,7 +101,9 @@ org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled
 org.eclipse.jdt.core.compiler.problem.suppressWarningsNotFullyAnalysed=error
 org.eclipse.jdt.core.compiler.problem.syntacticNullAnalysisForFields=disabled
 org.eclipse.jdt.core.compiler.problem.syntheticAccessEmulation=ignore
-org.eclipse.jdt.core.compiler.problem.terminalDeprecation=error
+# Ignore terminal deprecation, allowing this tool to run faster.
+# we can just let javac do this check instead!
+org.eclipse.jdt.core.compiler.problem.terminalDeprecation=ignore
 org.eclipse.jdt.core.compiler.problem.typeParameterHiding=error
 org.eclipse.jdt.core.compiler.problem.unavoidableGenericTypeProblems=enabled
 org.eclipse.jdt.core.compiler.problem.uncheckedTypeOperation=error


### PR DESCRIPTION
LUCENE-10185 caused a large performance regression in ECJ tasks by using the --release flag. See graph: http://people.apache.org/~mikemccand/lucenebench/antcleantest.html

We recovered some, but not all, of the performance with https://github.com/apache/lucene/pull/483, but it is still 50% slower.

Instead of using --release, we can just disable "terminal deprecation", and leave this check to `javac`. That single check makes this tool run 50% slower, so it isn't worth it.

I've confirmed that the change fully recovers the build performance drop that was lost from LUCENE-10185:
```
Trunk:
Aggregate task times (possibly running in parallel!):
 160.88 sec.  ecjLintTest
 149.60 sec.  ecjLintMain

Patch:
Aggregate task times (possibly running in parallel!):
 112.95 sec.  ecjLintMain
 105.10 sec.  ecjLintTest
```