### PR TITLE
support tables in generated html documentation

### DIFF
--- a/gradle/documentation/markdown.gradle
+++ b/gradle/documentation/markdown.gradle
@@ -107,7 +107,12 @@ class MarkdownFilter extends FilterReader {
     // convert the markdown
     MutableDataSet options = new MutableDataSet();
     options.setFrom(ParserEmulationProfile.MARKDOWN);
-    options.set(Parser.EXTENSIONS, [ AbbreviationExtension.create(), AutolinkExtension.create(), AttributesExtension.create(), TablesExtension.create() ]);
+    options.set(Parser.EXTENSIONS, [
+      AbbreviationExtension.create(),
+      AutolinkExtension.create(),
+      AttributesExtension.create(),
+      TablesExtension.create(),
+    ]);
     options.set(HtmlRenderer.RENDER_HEADER_ID, true);
     options.set(HtmlRenderer.MAX_TRAILING_BLANK_LINES, 0);
     Document parsed = Parser.builder(options).build().parse(markdownSource);

--- a/gradle/documentation/markdown.gradle
+++ b/gradle/documentation/markdown.gradle
@@ -19,6 +19,7 @@ import com.vladsch.flexmark.ast.Heading;
 import com.vladsch.flexmark.ext.abbreviation.AbbreviationExtension;
 import com.vladsch.flexmark.ext.attributes.AttributesExtension;
 import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.parser.ParserEmulationProfile;
@@ -37,6 +38,7 @@ buildscript {
     classpath "com.vladsch.flexmark:flexmark-ext-abbreviation:${scriptDepVersions['flexmark']}"
     classpath "com.vladsch.flexmark:flexmark-ext-attributes:${scriptDepVersions['flexmark']}"
     classpath "com.vladsch.flexmark:flexmark-ext-autolink:${scriptDepVersions['flexmark']}"
+    classpath "com.vladsch.flexmark:flexmark-ext-tables:${scriptDepVersions['flexmark']}"
   }
 }
 
@@ -105,7 +107,7 @@ class MarkdownFilter extends FilterReader {
     // convert the markdown
     MutableDataSet options = new MutableDataSet();
     options.setFrom(ParserEmulationProfile.MARKDOWN);
-    options.set(Parser.EXTENSIONS, [ AbbreviationExtension.create(), AutolinkExtension.create(), AttributesExtension.create() ]);
+    options.set(Parser.EXTENSIONS, [ AbbreviationExtension.create(), AutolinkExtension.create(), AttributesExtension.create(), TablesExtension.create() ]);
     options.set(HtmlRenderer.RENDER_HEADER_ID, true);
     options.set(HtmlRenderer.MAX_TRAILING_BLANK_LINES, 0);
     Document parsed = Parser.builder(options).build().parse(markdownSource);


### PR DESCRIPTION
https://github.com/apache/lucene/pull/488 added table of analyzer artifacts changes.

Unfortunately it looks like crap in generated HTML unless we bring in the tables extension.

Before:

![Screen_Shot_2021-11-29_at_17 20 15](https://user-images.githubusercontent.com/504194/143952027-9744fbc9-0f8d-46cd-8575-604e54fded56.png)

After:

![Screen_Shot_2021-11-29_at_17 20 26](https://user-images.githubusercontent.com/504194/143952047-3cd0b6fe-5a21-4f1f-bd38-bf43515b0829.png)
