### PR TITLE
LUCENE-10273: Deprecate SpanishMinimalStemmer in favor of SpanishPluralStemmer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -82,7 +82,8 @@ Bug Fixes
 
 Other
 ---------------------
-(No changes)
+
+* LUCENE-10273: Deprecate SpanishMinimalStemFilter in favor of SpanishPluralStemFilter. (Robert Muir)
 
 ======================= Lucene 9.0.0 =======================
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishMinimalStemFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishMinimalStemFilter.java
@@ -30,7 +30,10 @@ import org.apache.lucene.analysis.tokenattributes.KeywordAttribute;
  * <p>To prevent terms from being stemmed use an instance of {@link SetKeywordMarkerFilter} or a
  * custom {@link TokenFilter} that sets the {@link KeywordAttribute} before this {@link
  * TokenStream}.
+ *
+ * @deprecated Use {@link SpanishPluralStemFilter} instead.
  */
+@Deprecated
 public final class SpanishMinimalStemFilter extends TokenFilter {
   private final SpanishMinimalStemmer stemmer = new SpanishMinimalStemmer();
   private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishMinimalStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishMinimalStemFilterFactory.java
@@ -34,7 +34,9 @@ import org.apache.lucene.analysis.TokenStream;
  * &lt;/fieldType&gt;</pre>
  *
  * @lucene.spi {@value #NAME}
+ * @deprecated Use {@link SpanishPluralStemFilterFactory} instead
  */
+@Deprecated
 public class SpanishMinimalStemFilterFactory extends TokenFilterFactory {
 
   /** SPI name */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishMinimalStemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishMinimalStemmer.java
@@ -21,7 +21,10 @@ package org.apache.lucene.analysis.es;
  * Minimal plural stemmer for Spanish.
  *
  * <p>This stemmer implements the "plurals" stemmer for spanish lanugage.
+ *
+ * @deprecated Use {@link SpanishPluralStemmer} instead.
  */
+@Deprecated
 public class SpanishMinimalStemmer {
 
   public int stem(char[] s, int len) {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/es/TestSpanishMinimalStemFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/es/TestSpanishMinimalStemFilter.java
@@ -25,7 +25,12 @@ import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.analysis.en.EnglishMinimalStemFilter;
 
-/** Simple tests for {@link SpanishMinimalStemFilter} */
+/**
+ * Simple tests for {@link SpanishMinimalStemFilter}
+ *
+ * @deprecated Remove with SpanishMinimalStemFilter
+ */
+@Deprecated
 public class TestSpanishMinimalStemFilter extends BaseTokenStreamTestCase {
   private Analyzer analyzer;
 

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/es/TestSpanishMinimalStemFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/es/TestSpanishMinimalStemFilterFactory.java
@@ -24,7 +24,12 @@ import org.apache.lucene.analysis.MockTokenizer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 
-/** Simple tests to ensure the spanish minimal stem factory is working. */
+/**
+ * Simple tests to ensure the spanish minimal stem factory is working.
+ *
+ * @deprecated Remove with SpanishMinimalStemFilterFactory
+ */
+@Deprecated
 public class TestSpanishMinimalStemFilterFactory extends BaseTokenStreamFactoryTestCase {
   public void testStemming() throws Exception {
     Reader reader = new StringReader("camisetas");


### PR DESCRIPTION
The new SpanishPluralStemmer is in fact more "minimal", less agressive  stemming and normalization. For the user that wants only plural stemming, it is the better choice.

Analysis: https://s.apache.org/spanishplural
Original Issue: https://issues.apache.org/jira/browse/LUCENE-10248
Discussion on PR: https://github.com/apache/lucene/pull/461