### PR TITLE
LUCENE-10233: Use AND NOT for inverse intersector

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -298,7 +298,7 @@ final class LatLonPointDistanceQuery extends Query {
           @Override
           public void visit(DocIdSetIterator iterator) throws IOException {
             result.andNot(iterator);
-            cost[0] = (int)Math.max(0, cost[0] - iterator.cost());
+            cost[0] = (int) Math.max(0, cost[0] - iterator.cost());
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -296,6 +296,12 @@ final class LatLonPointDistanceQuery extends Query {
           }
 
           @Override
+          public void visit(DocIdSetIterator iterator) throws IOException {
+            result.andNot(iterator);
+            cost[0] -= iterator.cost();
+          }
+
+          @Override
           public void visit(int docID, byte[] packedValue) {
             if (matches(packedValue) == false) {
               visit(docID);

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -298,7 +298,7 @@ final class LatLonPointDistanceQuery extends Query {
           @Override
           public void visit(DocIdSetIterator iterator) throws IOException {
             result.andNot(iterator);
-            cost[0] -= iterator.cost();
+            cost[0] = (int)Math.max(0, cost[0] - iterator.cost());
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -166,7 +166,7 @@ final class LatLonPointDistanceQuery extends Query {
               // by computing the set of documents that do NOT match the range
               final FixedBitSet result = new FixedBitSet(reader.maxDoc());
               result.set(0, reader.maxDoc());
-              int[] cost = new int[] {reader.maxDoc()};
+              long[] cost = new long[] {reader.maxDoc()};
               values.intersect(getInverseIntersectVisitor(result, cost));
               final DocIdSetIterator iterator = new BitSetIterator(result, cost[0]);
               return new ConstantScoreScorer(weight, score(), scoreMode, iterator);
@@ -286,7 +286,7 @@ final class LatLonPointDistanceQuery extends Query {
       }
 
       /** Create a visitor that clears documents that do NOT match the range. */
-      private IntersectVisitor getInverseIntersectVisitor(FixedBitSet result, int[] cost) {
+      private IntersectVisitor getInverseIntersectVisitor(FixedBitSet result, long[] cost) {
         return new IntersectVisitor() {
 
           @Override
@@ -298,7 +298,7 @@ final class LatLonPointDistanceQuery extends Query {
           @Override
           public void visit(DocIdSetIterator iterator) throws IOException {
             result.andNot(iterator);
-            cost[0] = (int) Math.max(0, cost[0] - iterator.cost());
+            cost[0] = Math.max(0, cost[0] - iterator.cost());
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
@@ -638,7 +638,7 @@ abstract class SpatialQuery extends Query {
       @Override
       public void visit(DocIdSetIterator iterator) throws IOException {
         result.andNot(iterator);
-        cost[0] = (int) Math.max(0, cost[0] - iterator.cost());
+        cost[0] = Math.max(0, cost[0] - iterator.cost());
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
@@ -469,6 +469,12 @@ abstract class SpatialQuery extends Query {
       }
 
       @Override
+      public void visit(DocIdSetIterator iterator) throws IOException {
+        result.or(iterator);
+        cost[0] += iterator.cost();
+      }
+
+      @Override
       public void visit(int docID, byte[] t) {
         if (result.get(docID) == false) {
           if (leafPredicate.test(t)) {
@@ -512,6 +518,12 @@ abstract class SpatialQuery extends Query {
       public void visit(int docID) {
         result.set(docID);
         cost[0]++;
+      }
+
+      @Override
+      public void visit(DocIdSetIterator iterator) throws IOException {
+        result.or(iterator);
+        cost[0] += iterator.cost();
       }
 
       @Override
@@ -562,6 +574,11 @@ abstract class SpatialQuery extends Query {
       @Override
       public void visit(int docID) {
         excluded.set(docID);
+      }
+
+      @Override
+      public void visit(DocIdSetIterator iterator) throws IOException {
+        excluded.or(iterator);
       }
 
       @Override
@@ -619,6 +636,12 @@ abstract class SpatialQuery extends Query {
       }
 
       @Override
+      public void visit(DocIdSetIterator iterator) throws IOException {
+        result.andNot(iterator);
+        cost[0] -= iterator.cost();
+      }
+
+      @Override
       public void visit(int docID, byte[] packedTriangle) {
         if (result.get(docID)) {
           if (leafPredicate.test(packedTriangle) == false) {
@@ -658,6 +681,11 @@ abstract class SpatialQuery extends Query {
       @Override
       public void visit(int docID) {
         result.clear(docID);
+      }
+
+      @Override
+      public void visit(DocIdSetIterator iterator) throws IOException {
+        result.andNot(iterator);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
@@ -638,7 +638,7 @@ abstract class SpatialQuery extends Query {
       @Override
       public void visit(DocIdSetIterator iterator) throws IOException {
         result.andNot(iterator);
-        cost[0] = (int)Math.max(0, cost[0] - iterator.cost());
+        cost[0] = (int) Math.max(0, cost[0] - iterator.cost());
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
@@ -638,7 +638,7 @@ abstract class SpatialQuery extends Query {
       @Override
       public void visit(DocIdSetIterator iterator) throws IOException {
         result.andNot(iterator);
-        cost[0] -= iterator.cost();
+        cost[0] = (int)Math.max(0, cost[0] - iterator.cost());
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -220,7 +220,7 @@ public abstract class PointRangeQuery extends Query {
           @Override
           public void visit(DocIdSetIterator iterator) throws IOException {
             result.andNot(iterator);
-            cost[0] -= iterator.cost();
+            cost[0] = (int)Math.max(0, cost[0] - iterator.cost());
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -220,7 +220,7 @@ public abstract class PointRangeQuery extends Query {
           @Override
           public void visit(DocIdSetIterator iterator) throws IOException {
             result.andNot(iterator);
-            cost[0] = (int)Math.max(0, cost[0] - iterator.cost());
+            cost[0] = (int) Math.max(0, cost[0] - iterator.cost());
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -218,6 +218,12 @@ public abstract class PointRangeQuery extends Query {
           }
 
           @Override
+          public void visit(DocIdSetIterator iterator) throws IOException {
+            result.andNot(iterator);
+            cost[0] -= iterator.cost();
+          }
+
+          @Override
           public void visit(int docID, byte[] packedValue) {
             if (matches(packedValue) == false) {
               visit(docID);

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -208,7 +208,7 @@ public abstract class PointRangeQuery extends Query {
       }
 
       /** Create a visitor that clears documents that do NOT match the range. */
-      private IntersectVisitor getInverseIntersectVisitor(FixedBitSet result, int[] cost) {
+      private IntersectVisitor getInverseIntersectVisitor(FixedBitSet result, long[] cost) {
         return new IntersectVisitor() {
 
           @Override
@@ -220,7 +220,7 @@ public abstract class PointRangeQuery extends Query {
           @Override
           public void visit(DocIdSetIterator iterator) throws IOException {
             result.andNot(iterator);
-            cost[0] = (int) Math.max(0, cost[0] - iterator.cost());
+            cost[0] = Math.max(0, cost[0] - iterator.cost());
           }
 
           @Override
@@ -336,7 +336,7 @@ public abstract class PointRangeQuery extends Query {
                 // by computing the set of documents that do NOT match the range
                 final FixedBitSet result = new FixedBitSet(reader.maxDoc());
                 result.set(0, reader.maxDoc());
-                int[] cost = new int[] {reader.maxDoc()};
+                long[] cost = new long[] {reader.maxDoc()};
                 values.intersect(getInverseIntersectVisitor(result, cost));
                 final DocIdSetIterator iterator = new BitSetIterator(result, cost[0]);
                 return new ConstantScoreScorer(weight, score(), scoreMode, iterator);

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -379,6 +379,13 @@ public final class FixedBitSet extends BitSet {
   }
 
   private void andNot(final int otherOffsetWords, final long[] otherArr, final int otherNumWords) {
+    assert otherNumWords + otherOffsetWords <= numWords
+        : "numWords="
+            + numWords
+            + ", otherNumWords="
+            + otherNumWords
+            + ", otherOffsetWords="
+            + otherOffsetWords;
     int pos = Math.min(numWords - otherOffsetWords, otherNumWords);
     final long[] thisArr = this.bits;
     while (--pos >= 0) {

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -379,13 +379,6 @@ public final class FixedBitSet extends BitSet {
   }
 
   private void andNot(final int otherOffsetWords, final long[] otherArr, final int otherNumWords) {
-    assert otherNumWords + otherOffsetWords <= numWords
-        : "numWords="
-            + numWords
-            + ", otherNumWords="
-            + otherNumWords
-            + ", otherOffsetWords="
-            + otherOffsetWords;
     int pos = Math.min(numWords - otherOffsetWords, otherNumWords);
     final long[] thisArr = this.bits;
     while (--pos >= 0) {

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -355,6 +355,7 @@ public final class FixedBitSet extends BitSet {
     if (BitSetIterator.getFixedBitSetOrNull(iter) != null) {
       checkUnpositioned(iter);
       final FixedBitSet bits = BitSetIterator.getFixedBitSetOrNull(iter);
+      assert bits != null;
       andNot(bits);
     } else if (iter instanceof DocBaseBitSetIterator) {
       checkUnpositioned(iter);

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -361,7 +361,10 @@ public final class FixedBitSet extends BitSet {
       DocBaseBitSetIterator baseIter = (DocBaseBitSetIterator) iter;
       andNot(baseIter.getDocBase() >> 6, baseIter.getBitSet());
     } else {
-      super.or(iter);
+      checkUnpositioned(iter);
+      for (int doc = iter.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iter.nextDoc()) {
+        clear(doc);
+      }
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.util;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Random;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -444,6 +445,55 @@ public class TestFixedBitSet extends BaseBitSetTestCase<FixedBitSet> {
     bitSet1.and(bitSet2);
 
     assertEquals(bitSet1.cardinality(), intersectionCount);
+  }
+
+  public void testAndNot() throws IOException {
+    Random random = random();
+
+    int numBits2 = TestUtil.nextInt(random, 1000, 2000);
+    int numBits1 = TestUtil.nextInt(random, 1000, numBits2);
+
+    int count1 = TestUtil.nextInt(random, 0, numBits1 - 1);
+    int count2 = TestUtil.nextInt(random, 0, numBits2 - 1);
+
+    int offSetWord1 = FixedBitSet.bits2words(TestUtil.nextInt(random, 0, count1));
+    int offset1 = offSetWord1 << 6;
+    int[] bits1 = makeIntArray(random, count1, offset1, numBits1 - 1);
+    int[] bits2 = makeIntArray(random, count2, 0, numBits2 - 1);
+
+    java.util.BitSet bitSet1 = makeBitSet(bits1);
+    java.util.BitSet bitSet2 = makeBitSet(bits2);
+    bitSet2.andNot(bitSet1);
+
+    {
+      // test BitSetIterator
+      FixedBitSet fixedBitSet2 = makeFixedBitSet(bits2, numBits2);
+      DocIdSetIterator disi = new BitSetIterator(makeFixedBitSet(bits1, numBits1), count1);
+      fixedBitSet2.andNot(disi);
+      doGet(bitSet2, fixedBitSet2);
+    }
+
+    {
+      // test DocBaseBitSetIterator
+      FixedBitSet fixedBitSet2 = makeFixedBitSet(bits2, numBits2);
+      int[] offsetBits = Arrays.stream(bits1).map(i -> i - offset1).toArray();
+      DocIdSetIterator disi =
+          new DocBaseBitSetIterator(
+              makeFixedBitSet(offsetBits, numBits1 - offset1), count1, offset1);
+      fixedBitSet2.andNot(disi);
+      doGet(bitSet2, fixedBitSet2);
+    }
+
+    {
+      // test other
+      FixedBitSet fixedBitSet2 = makeFixedBitSet(bits2, numBits2);
+      int[] sorted = new int[bits1.length + 1];
+      System.arraycopy(bits1, 0, sorted, 0, bits1.length);
+      sorted[bits1.length] = DocIdSetIterator.NO_MORE_DOCS;
+      DocIdSetIterator disi = new IntArrayDocIdSet.IntArrayDocIdSetIterator(sorted, count1);
+      fixedBitSet2.andNot(disi);
+      doGet(bitSet2, fixedBitSet2);
+    }
   }
 
   // Demonstrates that the presence of ghost bits in the last used word can cause spurious failures


### PR DESCRIPTION
This is a follow up of #438. I find that `intersector` has some 'inversing' usage, we can use ` AND NOT ` to speed up the bitset situation.