### PR TITLE
improve term vector merging tests

### DIFF
--- a/lucene/codecs/src/test/org/apache/lucene/codecs/simpletext/TestSimpleTextTermVectorsFormat.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/simpletext/TestSimpleTextTermVectorsFormat.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.codecs.simpletext;
 
-import java.io.IOException;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.index.BaseTermVectorsFormatTestCase;
 

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/simpletext/TestSimpleTextTermVectorsFormat.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/simpletext/TestSimpleTextTermVectorsFormat.java
@@ -19,7 +19,6 @@ package org.apache.lucene.codecs.simpletext;
 import java.io.IOException;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.index.BaseTermVectorsFormatTestCase;
-import org.apache.lucene.util.LuceneTestCase;
 
 public class TestSimpleTextTermVectorsFormat extends BaseTermVectorsFormatTestCase {
   @Override
@@ -30,19 +29,5 @@ public class TestSimpleTextTermVectorsFormat extends BaseTermVectorsFormatTestCa
   @Override
   protected Codec getCodec() {
     return new SimpleTextCodec();
-  }
-
-  // TODO: can we speed up the underlying base test?
-  @Override
-  @LuceneTestCase.Nightly
-  public void testMergeWithIndexSort() throws IOException {
-    super.testMergeWithIndexSort();
-  }
-
-  // TODO: can we speed up the underlying base test?
-  @Override
-  @LuceneTestCase.Nightly
-  public void testMergeWithoutIndexSort() throws IOException {
-    super.testMergeWithoutIndexSort();
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseTermVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseTermVectorsFormatTestCase.java
@@ -676,7 +676,7 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
 
   private void doTestMerge(Sort indexSort, boolean allowDeletes) throws IOException {
     final RandomDocumentFactory docFactory = new RandomDocumentFactory(5, 20);
-    final int numDocs = atLeast(100);
+    final int numDocs = TEST_NIGHTLY ? atLeast(100) : atLeast(10);
     for (Options options : validOptions()) {
       Map<String, RandomDocument> docs = new HashMap<>();
       for (int i = 0; i < numDocs; ++i) {
@@ -749,6 +749,14 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
       IOUtils.close(writer, dir);
     }
   }
+  
+  public void testMerge() throws IOException {
+    doTestMerge(null, false);
+  }
+  
+  public void testMergeWithDeletes() throws IOException {
+    doTestMerge(null, true);
+  }
 
   public void testMergeWithIndexSort() throws IOException {
     SortField[] sortFields = new SortField[TestUtil.nextInt(random(), 1, 2)];
@@ -756,12 +764,14 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
       sortFields[i] = new SortField("sort_field_" + i, SortField.Type.LONG);
     }
     doTestMerge(new Sort(sortFields), false);
-    doTestMerge(new Sort(sortFields), true);
   }
-
-  public void testMergeWithoutIndexSort() throws IOException {
-    doTestMerge(null, false);
-    doTestMerge(null, true);
+  
+  public void testMergeWithIndexSortAndDeletes() throws IOException {
+    SortField[] sortFields = new SortField[TestUtil.nextInt(random(), 1, 2)];
+    for (int i = 0; i < sortFields.length; i++) {
+      sortFields[i] = new SortField("sort_field_" + i, SortField.Type.LONG);
+    }
+    doTestMerge(new Sort(sortFields), true);
   }
 
   // run random tests from different threads to make sure the per-thread clones

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseTermVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseTermVectorsFormatTestCase.java
@@ -749,11 +749,11 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
       IOUtils.close(writer, dir);
     }
   }
-  
+
   public void testMerge() throws IOException {
     doTestMerge(null, false);
   }
-  
+
   public void testMergeWithDeletes() throws IOException {
     doTestMerge(null, true);
   }
@@ -765,7 +765,7 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
     }
     doTestMerge(new Sort(sortFields), false);
   }
-  
+
   public void testMergeWithIndexSortAndDeletes() throws IOException {
     SortField[] sortFields = new SortField[TestUtil.nextInt(random(), 1, 2)];
     for (int i = 0; i < sortFields.length; i++) {


### PR DESCRIPTION
Recently when running tests, I noticed slowest-test/suite times were dominated by term vectors merging tests:

Here's a typical run:
```
The slowest tests (exceeding 500 ms) during this run:
  13.61s TestSimpleTextTermVectorsFormat.testMergeWithIndexSort (:lucene:codecs)
  11.73s TestNRTReplication.testCrashReplica (:lucene:replicator)
  10.86s TestSimpleTextTermVectorsFormat.testMergeWithoutIndexSort (:lucene:codecs)
   6.44s TestGeo3dRpt.testOperationsFromFile (:lucene:spatial-extras)
   6.15s TestAssertingTermVectorsFormat.testMergeWithIndexSort (:lucene:test-framework)
   5.99s TestCachePurging.testConcurrentPurges (:lucene:monitor)
   5.99s TestCompressingTermVectorsFormat.testMergeWithIndexSort (:lucene:test-framework)
   5.70s TestBagOfPostings.test (:lucene:core)
   5.39s TestAssertingTermVectorsFormat.testMergeWithoutIndexSort (:lucene:test-framework)
   5.38s TestCompressingTermVectorsFormat.testMergeWithoutIndexSort (:lucene:test-framework)
The slowest suites (exceeding 1s) during this run:
  36.35s TestSimpleTextTermVectorsFormat (:lucene:codecs)
  17.50s TestSimpleTextDocValuesFormat (:lucene:codecs)
  16.76s TestCompressingTermVectorsFormat (:lucene:test-framework)
  15.44s TestAssertingTermVectorsFormat (:lucene:test-framework)
  12.80s TestLucene90DocValuesFormat (:lucene:core)
  12.58s TestAssertingDocValuesFormat (:lucene:test-framework)
  11.91s TestLucene90TermVectorsFormat (:lucene:core)
  11.81s TestNRTReplication (:lucene:replicator)
  11.76s TestPerFieldDocValuesFormat (:lucene:core)
  11.58s TestLucene90DocValuesFormatMergeInstance (:lucene:core)
```

So it doesn't help to just mark the tests nightly for SimpleText, as they are slow for the other formats too. The main problem is each test indexes 100 docs many different ways (different index options X deletes X sort). Rather than make things nightly, let's just use less documents for normal runs:

* Use less iterations locally so that term vector merging doesn't dominate the list of slowest tests.
* Split out deletes/no-deletes into separate methods to improve debuggability.
* Remove nightly from SimpleText term vectors merging tests, now that they run much faster.
