### PR TITLE
Make TestNRTReplication.testCrashReplica nightly

### DIFF
--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestNRTReplication.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestNRTReplication.java
@@ -740,6 +740,7 @@ public class TestNRTReplication extends LuceneTestCase {
     }
   }
 
+  @Nightly
   public void testCrashReplica() throws Exception {
 
     Path path1 = createTempDir("1");


### PR DESCRIPTION
This test is forking and crashing JVMs, always runs over 10 seconds.
The other JVM-crashers are nightly, this one slipped through.

Sorry I don't have a good quick solution yet to make the test run faster, it is difficult to inspect because of the JVM forking (things like profiling the test are not very helpful)