### PR TITLE
tone down TestIndexWriter.testMaxCompletedSequenceNumber in non-nightly

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -4279,7 +4279,8 @@ public class TestIndexWriter extends LuceneTestCase {
         IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
         SearcherManager manager = new SearcherManager(writer, new SearcherFactory())) {
       CountDownLatch start = new CountDownLatch(1);
-      int numDocs = 100 + random().nextInt(500);
+      int numDocs =
+          TEST_NIGHTLY ? TestUtil.nextInt(random(), 100, 600) : TestUtil.nextInt(random(), 10, 60);
       AtomicLong maxCompletedSeqID = new AtomicLong(-1);
       Thread[] threads = new Thread[2 + random().nextInt(2)];
       for (int i = 0; i < threads.length; i++) {


### PR DESCRIPTION
this test currently indexes up to 600 docs for each thread.

```
The slowest tests (exceeding 500 ms) during this run:
   7.88s TestIndexWriter.testMaxCompletedSequenceNumber (:lucene:core)
```

We can use less documents in non-nightly tests.