### PR TITLE
Remove duplicate entries in SpanishPluralStemmer invariants list

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishPluralStemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishPluralStemmer.java
@@ -41,7 +41,6 @@ public class SpanishPluralStemmer {
           "albricias",
           "aledaños",
           "alexis",
-          "aries",
           "alicates",
           "analisis",
           "andurriales",

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishPluralStemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishPluralStemmer.java
@@ -147,7 +147,7 @@ public class SpanishPluralStemmer {
   static {
     final CharArraySet invariantSet = new CharArraySet(invariantsList, true);
     invariants = CharArraySet.unmodifiableSet(invariantSet);
-
+    assert invariants.size() == invariantsList.size();
     final List<String> specialCasesList =
         Arrays.asList(
             "yoes",

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishPluralStemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishPluralStemmer.java
@@ -119,7 +119,6 @@ public class SpanishPluralStemmer {
           "portamantas",
           "quinientas",
           "quinientos",
-          "quinientos",
           "quitamanchas",
           "recogepelotas",
           "rictus",


### PR DESCRIPTION
The word "quinientos" is repeated 2 times in the `invariantsList` constant. Removing the extra entry.

Follow-up to #461.