### PR TITLE
speed up TestSimpleExplanationsWithFillerDocs

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanationsWithFillerDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanationsWithFillerDocs.java
@@ -21,7 +21,6 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.lucene.util.TestUtil;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -32,12 +31,10 @@ import org.junit.BeforeClass;
  * they will all use terms from same set of source data as our regular docs (to emphasis the DocFreq
  * factor in scoring), in which case the queries will be wrapped so they can be excluded.
  */
-@Slow // can this be sped up to be non-slow? filler docs make it quite a bit slower and many test
-// methods...
 public class TestSimpleExplanationsWithFillerDocs extends TestSimpleExplanations {
 
   /** num of empty docs injected between every doc in the index */
-  private static final int NUM_FILLER_DOCS = BooleanScorer.SIZE;
+  private static final int NUM_FILLER_DOCS = TEST_NIGHTLY ? BooleanScorer.SIZE : 4;
   /** num of empty docs injected prior to the first doc in the (main) index */
   private static int PRE_FILLER_DOCS;
   /**


### PR DESCRIPTION
This is the slowest test suite, runs for ~ 60s, because between every
document it adds 2048 "filler docs". This just adds up to a ton of
indexing across all the test methods.

Use 2048 for Nightly, and instead a smaller number (4) for local builds. It saves almost a minute of cpu time in tests.

Before:
```
The slowest suites (exceeding 1s) during this run:
  59.44s TestSimpleExplanationsWithFillerDocs (:lucene:core)
```

After: (no longer on the list < 9s for sure)
```
The slowest suites (exceeding 1s) during this run:
  14.98s TestSimpleTextDocValuesFormat (:lucene:codecs)
  14.06s TestLucene90DocValuesFormat (:lucene:core)
  13.96s TestLucene90DocValuesFormatMergeInstance (:lucene:core)
  13.64s TestFSTPostingsFormat (:lucene:codecs)
  11.41s TestPerFieldDocValuesFormat (:lucene:core)
  11.29s TestSimpleTextTermVectorsFormat (:lucene:codecs)
  11.10s TestAssertingDocValuesFormat (:lucene:test-framework)
  10.62s TestDirectPostingsFormat (:lucene:codecs)
   9.43s TestIndexSorting (:lucene:core)
   9.28s TestLatLonPointQueries (:lucene:core)
```