### PR TITLE
LUCENE-10287: Fix startup script of module-enabled Luke to pass jdk.unsupported as module

### DIFF
--- a/lucene/distribution/src/binary-release/bin/luke.cmd
+++ b/lucene/distribution/src/binary-release/bin/luke.cmd
@@ -17,5 +17,5 @@
 
 SETLOCAL
 SET MODULES=%~dp0..
-start javaw --module-path "%MODULES%\modules;%MODULES%\modules-thirdparty" --add-modules org.apache.logging.log4j --module org.apache.lucene.luke
+start javaw --module-path "%MODULES%\modules;%MODULES%\modules-thirdparty" --add-modules jdk.unsupported,org.apache.logging.log4j --module org.apache.lucene.luke
 ENDLOCAL

--- a/lucene/distribution/src/binary-release/bin/luke.sh
+++ b/lucene/distribution/src/binary-release/bin/luke.sh
@@ -17,4 +17,4 @@
 
 MODULES=`dirname "$0"`/..
 MODULES=`cd "$MODULES" && pwd`
-java --module-path "$MODULES/modules:$MODULES/modules-thirdparty" --add-modules org.apache.logging.log4j --module org.apache.lucene.luke
+java --module-path "$MODULES/modules:$MODULES/modules-thirdparty" --add-modules jdk.unsupported,org.apache.logging.log4j --module org.apache.lucene.luke

--- a/lucene/luke/src/distribution/README.md
+++ b/lucene/luke/src/distribution/README.md
@@ -27,7 +27,7 @@ java -jar ${luke.cmd}
 or, using Java modules:
 
 ```
-java --module-path . --add-modules org.apache.logging.log4j --module org.apache.lucene.luke
+java --module-path . --add-modules jdk.unsupported,org.apache.logging.log4j --module org.apache.lucene.luke
 ```
 
 Happy index hacking!


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/LUCENE-10287