### PR TITLE
LUCENE-10287: Re-add abstract FSDirectory class as a supported directory (luke)

### DIFF
--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OpenIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OpenIndexDialogFactory.java
@@ -55,9 +55,8 @@ import org.apache.lucene.luke.app.desktop.util.FontUtils;
 import org.apache.lucene.luke.app.desktop.util.MessageUtils;
 import org.apache.lucene.luke.app.desktop.util.StyleConstants;
 import org.apache.lucene.luke.models.LukeException;
+import org.apache.lucene.luke.models.util.IndexUtils;
 import org.apache.lucene.luke.util.LoggerFactory;
-import org.apache.lucene.store.MMapDirectory;
-import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.util.NamedThreadFactory;
 import org.apache.lucene.util.SuppressForbidden;
 
@@ -127,7 +126,7 @@ public final class OpenIndexDialogFactory implements DialogOpener.DialogFactory 
         Executors.newFixedThreadPool(1, new NamedThreadFactory("load-directory-types"));
     executorService.execute(
         () -> {
-          for (String clazzName : supportedDirImpls()) {
+          for (String clazzName : IndexUtils.supportedDirectoryImpls()) {
             dirImplCombo.addItem(clazzName);
           }
         });
@@ -252,10 +251,6 @@ public final class OpenIndexDialogFactory implements DialogOpener.DialogFactory 
     panel.add(keepCommits);
 
     return panel;
-  }
-
-  private String[] supportedDirImpls() {
-    return new String[] {MMapDirectory.class.getName(), NIOFSDirectory.class.getName()};
   }
 
   private JPanel buttons() {

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/util/IndexUtils.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/util/IndexUtils.java
@@ -47,6 +47,8 @@ import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.LockFactory;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.util.Bits;
 
 /**
@@ -106,6 +108,17 @@ public final class IndexUtils {
     } else {
       return new MultiReader(readers.toArray(new IndexReader[readers.size()]));
     }
+  }
+
+  /**
+   * Returns supported {@link Directory} implementations.
+   *
+   * @return class names of supported directory implementation
+   */
+  public static String[] supportedDirectoryImpls() {
+    return new String[] {
+      FSDirectory.class.getName(), MMapDirectory.class.getName(), NIOFSDirectory.class.getName()
+    };
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-10287

Having abstract `FSDirectory` in the supported directory list seems to be useful to check if the expected FSDirectory implementation (MMapDirectory for 64bit architecture) is selected when opening an index. (on module-mode)