### PR TITLE
LUCENE-10297: Speed up medium cardinality fields with readLongs and SIMD

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -85,6 +85,8 @@ Improvements
 Optimizations
 ---------------------
 
+* LUCENE-10297: Faster decoding BKD leaves' sorted doc IDs. (Guo Feng)
+
 * LUCENE-10280: Optimize BKD leaves' doc IDs codec when they are continuous. (Guo Feng)
 
 * LUCENE-10233: Store BKD leaves' doc IDs as bitset in some cases (typically for low cardinality fields

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/StoredFieldsInts.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/StoredFieldsInts.java
@@ -20,11 +20,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.IndexInput;
+import static org.apache.lucene.util.IntCodecHelper.*;
 
-class StoredFieldsInts {
-
-  private static final int BLOCK_SIZE = 128;
-  private static final int BLOCK_SIZE_MINUS_ONE = BLOCK_SIZE - 1;
+public class StoredFieldsInts {
 
   private StoredFieldsInts() {}
 
@@ -57,63 +55,6 @@ class StoredFieldsInts {
     }
   }
 
-  private static void writeInts8(DataOutput out, int count, int[] values, int offset)
-      throws IOException {
-    int k = 0;
-    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
-      int step = offset + k;
-      for (int i = 0; i < 16; ++i) {
-        long l =
-            ((long) values[step + i] << 56)
-                | ((long) values[step + 16 + i] << 48)
-                | ((long) values[step + 32 + i] << 40)
-                | ((long) values[step + 48 + i] << 32)
-                | ((long) values[step + 64 + i] << 24)
-                | ((long) values[step + 80 + i] << 16)
-                | ((long) values[step + 96 + i] << 8)
-                | (long) values[step + 112 + i];
-        out.writeLong(l);
-      }
-    }
-    for (; k < count; k++) {
-      out.writeByte((byte) values[offset + k]);
-    }
-  }
-
-  private static void writeInts16(DataOutput out, int count, int[] values, int offset)
-      throws IOException {
-    int k = 0;
-    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
-      int step = offset + k;
-      for (int i = 0; i < 32; ++i) {
-        long l =
-            ((long) values[step + i] << 48)
-                | ((long) values[step + 32 + i] << 32)
-                | ((long) values[step + 64 + i] << 16)
-                | (long) values[step + 96 + i];
-        out.writeLong(l);
-      }
-    }
-    for (; k < count; k++) {
-      out.writeShort((short) values[offset + k]);
-    }
-  }
-
-  private static void writeInts32(DataOutput out, int count, int[] values, int offset)
-      throws IOException {
-    int k = 0;
-    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
-      int step = offset + k;
-      for (int i = 0; i < 64; ++i) {
-        long l = ((long) values[step + i] << 32) | (long) values[step + 64 + i];
-        out.writeLong(l);
-      }
-    }
-    for (; k < count; k++) {
-      out.writeInt(values[offset + k]);
-    }
-  }
-
   /** Read {@code count} integers into {@code values}. */
   static void readInts(IndexInput in, int count, long[] values, int offset) throws IOException {
     final int bpv = in.readByte();
@@ -132,65 +73,6 @@ class StoredFieldsInts {
         break;
       default:
         throw new IOException("Unsupported number of bits per value: " + bpv);
-    }
-  }
-
-  private static void readInts8(IndexInput in, int count, long[] values, int offset)
-      throws IOException {
-    int k = 0;
-    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
-      final int step = offset + k;
-      in.readLongs(values, step, 16);
-      for (int i = 0; i < 16; ++i) {
-        final long l = values[step + i];
-        values[step + i] = (l >>> 56) & 0xFFL;
-        values[step + 16 + i] = (l >>> 48) & 0xFFL;
-        values[step + 32 + i] = (l >>> 40) & 0xFFL;
-        values[step + 48 + i] = (l >>> 32) & 0xFFL;
-        values[step + 64 + i] = (l >>> 24) & 0xFFL;
-        values[step + 80 + i] = (l >>> 16) & 0xFFL;
-        values[step + 96 + i] = (l >>> 8) & 0xFFL;
-        values[step + 112 + i] = l & 0xFFL;
-      }
-    }
-    for (; k < count; k++) {
-      values[offset + k] = Byte.toUnsignedInt(in.readByte());
-    }
-  }
-
-  private static void readInts16(IndexInput in, int count, long[] values, int offset)
-      throws IOException {
-    int k = 0;
-    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
-      int step = offset + k;
-      in.readLongs(values, step, 32);
-      for (int i = 0; i < 32; ++i) {
-        final long l = values[step + i];
-        values[step + i] = (l >>> 48) & 0xFFFFL;
-        values[step + 32 + i] = (l >>> 32) & 0xFFFFL;
-        values[step + 64 + i] = (l >>> 16) & 0xFFFFL;
-        values[step + 96 + i] = l & 0xFFFFL;
-      }
-    }
-    for (; k < count; k++) {
-      values[offset + k] = Short.toUnsignedInt(in.readShort());
-    }
-  }
-
-  private static void readInts32(IndexInput in, int count, long[] values, int offset)
-      throws IOException {
-    int k = 0;
-    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
-      final int step = offset + k;
-      in.readLongs(values, step, 64);
-      for (int i = 0; i < 64; ++i) {
-        final long l = values[step + i];
-        values[step + i] = l >>> 32;
-        values[step + 64 + i] = l & 0xFFFFFFFFL;
-      }
-    }
-    for (; k < count; k++) {
-      values[offset + k] = in.readInt();
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/StoredFieldsInts.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/StoredFieldsInts.java
@@ -16,11 +16,12 @@
  */
 package org.apache.lucene.codecs.lucene90.compressing;
 
+import static org.apache.lucene.util.IntCodecHelper.*;
+
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.IndexInput;
-import static org.apache.lucene.util.IntCodecHelper.*;
 
 public class StoredFieldsInts {
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/StoredFieldsInts.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/StoredFieldsInts.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.IndexInput;
 
-public class StoredFieldsInts {
+class StoredFieldsInts {
 
   private StoredFieldsInts() {}
 

--- a/lucene/core/src/java/org/apache/lucene/util/IntCodecHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntCodecHelper.java
@@ -1,0 +1,128 @@
+package org.apache.lucene.util;
+
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.IndexInput;
+
+import java.io.IOException;
+
+public class IntCodecHelper {
+
+  private static final int BLOCK_SIZE = 128;
+  private static final int BLOCK_SIZE_MINUS_ONE = BLOCK_SIZE - 1;
+
+  public static void writeInts8(DataOutput out, int count, int[] values, int offset)
+          throws IOException {
+    int k = 0;
+    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
+      int step = offset + k;
+      for (int i = 0; i < 16; ++i) {
+        long l =
+                ((long) values[step + i] << 56)
+                        | ((long) values[step + 16 + i] << 48)
+                        | ((long) values[step + 32 + i] << 40)
+                        | ((long) values[step + 48 + i] << 32)
+                        | ((long) values[step + 64 + i] << 24)
+                        | ((long) values[step + 80 + i] << 16)
+                        | ((long) values[step + 96 + i] << 8)
+                        | (long) values[step + 112 + i];
+        out.writeLong(l);
+      }
+    }
+    for (; k < count; k++) {
+      out.writeByte((byte) values[offset + k]);
+    }
+  }
+
+  public static void writeInts16(DataOutput out, int count, int[] values, int offset)
+          throws IOException {
+    int k = 0;
+    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
+      int step = offset + k;
+      for (int i = 0; i < 32; ++i) {
+        long l =
+                ((long) values[step + i] << 48)
+                        | ((long) values[step + 32 + i] << 32)
+                        | ((long) values[step + 64 + i] << 16)
+                        | (long) values[step + 96 + i];
+        out.writeLong(l);
+      }
+    }
+    for (; k < count; k++) {
+      out.writeShort((short) values[offset + k]);
+    }
+  }
+
+  public static void writeInts32(DataOutput out, int count, int[] values, int offset)
+          throws IOException {
+    int k = 0;
+    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
+      int step = offset + k;
+      for (int i = 0; i < 64; ++i) {
+        long l = ((long) values[step + i] << 32) | (long) values[step + 64 + i];
+        out.writeLong(l);
+      }
+    }
+    for (; k < count; k++) {
+      out.writeInt(values[offset + k]);
+    }
+  }
+
+  public static void readInts8(IndexInput in, int count, long[] values, int offset)
+          throws IOException {
+    int k = 0;
+    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
+      final int step = offset + k;
+      in.readLongs(values, step, 16);
+      for (int i = 0; i < 16; ++i) {
+        final long l = values[step + i];
+        values[step + i] = (l >>> 56) & 0xFFL;
+        values[step + 16 + i] = (l >>> 48) & 0xFFL;
+        values[step + 32 + i] = (l >>> 40) & 0xFFL;
+        values[step + 48 + i] = (l >>> 32) & 0xFFL;
+        values[step + 64 + i] = (l >>> 24) & 0xFFL;
+        values[step + 80 + i] = (l >>> 16) & 0xFFL;
+        values[step + 96 + i] = (l >>> 8) & 0xFFL;
+        values[step + 112 + i] = l & 0xFFL;
+      }
+    }
+    for (; k < count; k++) {
+      values[offset + k] = Byte.toUnsignedInt(in.readByte());
+    }
+  }
+
+  public static void readInts16(IndexInput in, int count, long[] values, int offset)
+          throws IOException {
+    int k = 0;
+    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
+      int step = offset + k;
+      in.readLongs(values, step, 32);
+      for (int i = 0; i < 32; ++i) {
+        final long l = values[step + i];
+        values[step + i] = (l >>> 48) & 0xFFFFL;
+        values[step + 32 + i] = (l >>> 32) & 0xFFFFL;
+        values[step + 64 + i] = (l >>> 16) & 0xFFFFL;
+        values[step + 96 + i] = l & 0xFFFFL;
+      }
+    }
+    for (; k < count; k++) {
+      values[offset + k] = Short.toUnsignedInt(in.readShort());
+    }
+  }
+
+  public static void readInts32(IndexInput in, int count, long[] values, int offset)
+          throws IOException {
+    int k = 0;
+    for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
+      final int step = offset + k;
+      in.readLongs(values, step, 64);
+      for (int i = 0; i < 64; ++i) {
+        final long l = values[step + i];
+        values[step + i] = l >>> 32;
+        values[step + 64 + i] = l & 0xFFFFFFFFL;
+      }
+    }
+    for (; k < count; k++) {
+      values[offset + k] = in.readInt();
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/IntCodecHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntCodecHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.util;
 
 import java.io.IOException;

--- a/lucene/core/src/java/org/apache/lucene/util/IntCodecHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntCodecHelper.java
@@ -1,9 +1,8 @@
 package org.apache.lucene.util;
 
+import java.io.IOException;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.IndexInput;
-
-import java.io.IOException;
 
 public class IntCodecHelper {
 
@@ -11,20 +10,20 @@ public class IntCodecHelper {
   private static final int BLOCK_SIZE_MINUS_ONE = BLOCK_SIZE - 1;
 
   public static void writeInts8(DataOutput out, int count, int[] values, int offset)
-          throws IOException {
+      throws IOException {
     int k = 0;
     for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
       int step = offset + k;
       for (int i = 0; i < 16; ++i) {
         long l =
-                ((long) values[step + i] << 56)
-                        | ((long) values[step + 16 + i] << 48)
-                        | ((long) values[step + 32 + i] << 40)
-                        | ((long) values[step + 48 + i] << 32)
-                        | ((long) values[step + 64 + i] << 24)
-                        | ((long) values[step + 80 + i] << 16)
-                        | ((long) values[step + 96 + i] << 8)
-                        | (long) values[step + 112 + i];
+            ((long) values[step + i] << 56)
+                | ((long) values[step + 16 + i] << 48)
+                | ((long) values[step + 32 + i] << 40)
+                | ((long) values[step + 48 + i] << 32)
+                | ((long) values[step + 64 + i] << 24)
+                | ((long) values[step + 80 + i] << 16)
+                | ((long) values[step + 96 + i] << 8)
+                | (long) values[step + 112 + i];
         out.writeLong(l);
       }
     }
@@ -34,16 +33,16 @@ public class IntCodecHelper {
   }
 
   public static void writeInts16(DataOutput out, int count, int[] values, int offset)
-          throws IOException {
+      throws IOException {
     int k = 0;
     for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
       int step = offset + k;
       for (int i = 0; i < 32; ++i) {
         long l =
-                ((long) values[step + i] << 48)
-                        | ((long) values[step + 32 + i] << 32)
-                        | ((long) values[step + 64 + i] << 16)
-                        | (long) values[step + 96 + i];
+            ((long) values[step + i] << 48)
+                | ((long) values[step + 32 + i] << 32)
+                | ((long) values[step + 64 + i] << 16)
+                | (long) values[step + 96 + i];
         out.writeLong(l);
       }
     }
@@ -53,7 +52,7 @@ public class IntCodecHelper {
   }
 
   public static void writeInts32(DataOutput out, int count, int[] values, int offset)
-          throws IOException {
+      throws IOException {
     int k = 0;
     for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
       int step = offset + k;
@@ -68,7 +67,7 @@ public class IntCodecHelper {
   }
 
   public static void readInts8(IndexInput in, int count, long[] values, int offset)
-          throws IOException {
+      throws IOException {
     int k = 0;
     for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
       final int step = offset + k;
@@ -91,7 +90,7 @@ public class IntCodecHelper {
   }
 
   public static void readInts16(IndexInput in, int count, long[] values, int offset)
-          throws IOException {
+      throws IOException {
     int k = 0;
     for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
       int step = offset + k;
@@ -110,7 +109,7 @@ public class IntCodecHelper {
   }
 
   public static void readInts32(IndexInput in, int count, long[] values, int offset)
-          throws IOException {
+      throws IOException {
     int k = 0;
     for (; k < count - BLOCK_SIZE_MINUS_ONE; k += BLOCK_SIZE) {
       final int step = offset + k;

--- a/lucene/core/src/java/org/apache/lucene/util/IntCodecHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntCodecHelper.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.IndexInput;
 
+/** encode ints 8/16/32 and decode them with auto-vectorization optimization */
 public class IntCodecHelper {
 
   private static final int BLOCK_SIZE = 128;

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -168,6 +168,7 @@ public class BKDReader extends PointValues {
         scratchMaxIndexPackedValue;
     private final int[] commonPrefixLengths;
     private final BKDReaderDocIDSetIterator scratchIterator;
+    private final long[] scratch;
 
     private BKDPointTree(
         IndexInput innerNodes,
@@ -248,6 +249,7 @@ public class BKDReader extends PointValues {
       this.scratchDataPackedValue = scratchDataPackedValue;
       this.scratchMinIndexPackedValue = scratchMinIndexPackedValue;
       this.scratchMaxIndexPackedValue = scratchMaxIndexPackedValue;
+      this.scratch = scratchIterator.scratch;
     }
 
     @Override
@@ -514,7 +516,7 @@ public class BKDReader extends PointValues {
         // How many points are stored in this leaf cell:
         int count = leafNodes.readVInt();
         // No need to call grow(), it has been called up-front
-        DocIdsWriter.readInts(leafNodes, count, visitor);
+        DocIdsWriter.readInts(leafNodes, count, visitor, scratch);
       } else {
         pushLeft();
         addAll(visitor, grown);
@@ -577,7 +579,7 @@ public class BKDReader extends PointValues {
       // How many points are stored in this leaf cell:
       int count = in.readVInt();
 
-      DocIdsWriter.readInts(in, count, iterator.docIDs);
+      DocIdsWriter.readInts(in, count, iterator.docIDs, iterator.scratch);
 
       return count;
     }
@@ -946,9 +948,11 @@ public class BKDReader extends PointValues {
     private int offset;
     private int docID;
     final int[] docIDs;
+    final long[] scratch;
 
     public BKDReaderDocIDSetIterator(int maxPointsInLeafNode) {
       this.docIDs = new int[maxPointsInLeafNode];
+      this.scratch = new long[maxPointsInLeafNode];
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
@@ -79,11 +79,11 @@ class DocIdsWriter {
       if (max <= 0xff) {
         out.writeByte((byte) 1);
         out.writeVInt(docIds[start]);
-        writeInts8(out, count, delta, start);
+        writeInts8(out, count, delta, 0);
       } else if (max <= 0xffff) {
         out.writeByte((byte) 2);
         out.writeVInt(docIds[start]);
-        writeInts16(out, count, delta, start);
+        writeInts16(out, count, delta, 0);
       } else {
         out.writeByte((byte) 0);
         out.writeVInt(docIds[start]);

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
@@ -291,8 +291,7 @@ class DocIdsWriter {
    * Read {@code count} integers and feed the result directly to {@link
    * IntersectVisitor#visit(int)}.
    */
-  static void readInts(IndexInput in, int count, IntersectVisitor visitor, long[] scratch)
-      throws IOException {
+  static void readInts(IndexInput in, int count, IntersectVisitor visitor, long[] scratch) throws IOException {
     final int bpv = in.readByte();
     switch (bpv) {
       case -2:
@@ -337,8 +336,7 @@ class DocIdsWriter {
     }
   }
 
-  private static void readInts24(IndexInput in, int count, IntersectVisitor visitor)
-      throws IOException {
+  private static void readInts24(IndexInput in, int count, IntersectVisitor visitor) throws IOException {
     int i;
     for (i = 0; i < count - 7; i += 8) {
       long l1 = in.readLong();

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
@@ -70,12 +70,13 @@ class DocIdsWriter {
     if (sorted) {
       int[] delta = new int[count];
       int previous = docIds[start];
+      long max = 0;
       for (int i = 1; i < count; ++i) {
         int doc = docIds[start + i];
         delta[i] = doc - previous;
+        max |= Integer.toUnsignedLong(delta[i]);
         previous = doc;
       }
-      long max = getMax(delta, 0, count);
       if (max <= 0xff) {
         out.writeByte((byte) 1);
         out.writeVInt(docIds[start]);
@@ -92,7 +93,10 @@ class DocIdsWriter {
         }
       }
     } else {
-      long max = getMax(docIds, start, count);
+      long max = 0;
+      for (int i = 0; i < count; ++i) {
+        max |= Integer.toUnsignedLong(docIds[start + i]);
+      }
       if (max <= 0xffffff) {
         out.writeByte((byte) 24);
         // write them the same way we are reading them.
@@ -128,14 +132,6 @@ class DocIdsWriter {
         }
       }
     }
-  }
-
-  private static long getMax(int[] arr, int start, int count) {
-    long max = 0;
-    for (int i = 0; i < count; ++i) {
-      max |= Integer.toUnsignedLong(arr[start + i]);
-    }
-    return max;
   }
 
   private static void writeIdsAsBitSet(int[] docIds, int start, int count, DataOutput out)

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
@@ -200,7 +200,7 @@ class DocIdsWriter {
         readInts32(in, count, docIDs);
         break;
       case 24:
-        readInts24(in, count, docIDs, scratch);
+        readInts24(in, count, docIDs);
         break;
       default:
         throw new IOException("Unsupported number of bits per value: " + bpv);
@@ -266,15 +266,13 @@ class DocIdsWriter {
     }
   }
 
-  private static void readInts24(IndexInput in, int count, int[] docIDs, long[] scratch)
+  private static void readInts24(IndexInput in, int count, int[] docIDs)
       throws IOException {
-    in.readLongs(scratch, 0, (count >> 3) * 3);
     int i;
-    int pos = 0;
     for (i = 0; i < count - 7; i += 8) {
-      long l1 = scratch[pos++];
-      long l2 = scratch[pos++];
-      long l3 = scratch[pos++];
+      long l1 = in.readLong();
+      long l2 = in.readLong();
+      long l3 = in.readLong();
       docIDs[i] = (int) (l1 >>> 40);
       docIDs[i + 1] = (int) (l1 >>> 16) & 0xffffff;
       docIDs[i + 2] = (int) (((l1 & 0xffff) << 8) | (l2 >>> 56));
@@ -316,7 +314,7 @@ class DocIdsWriter {
         readInts32(in, count, visitor);
         break;
       case 24:
-        readInts24(in, count, visitor, scratch);
+        readInts24(in, count, visitor);
         break;
       default:
         throw new IOException("Unsupported number of bits per value: " + bpv);
@@ -339,15 +337,13 @@ class DocIdsWriter {
     }
   }
 
-  private static void readInts24(IndexInput in, int count, IntersectVisitor visitor, long[] scratch)
+  private static void readInts24(IndexInput in, int count, IntersectVisitor visitor)
       throws IOException {
-    in.readLongs(scratch, 0, (count >> 3) * 3);
     int i;
-    int pos = 0;
     for (i = 0; i < count - 7; i += 8) {
-      long l1 = scratch[pos++];
-      long l2 = scratch[pos++];
-      long l3 = scratch[pos++];
+      long l1 = in.readLong();
+      long l2 = in.readLong();
+      long l3 = in.readLong();
       visitor.visit((int) (l1 >>> 40));
       visitor.visit((int) (l1 >>> 16) & 0xffffff);
       visitor.visit((int) (((l1 & 0xffff) << 8) | (l2 >>> 56)));

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
@@ -197,7 +197,7 @@ class DocIdsWriter {
         readDelta16(in, count, docIDs, scratch);
         break;
       case 32:
-        readInts32BE(in, count, docIDs);
+        readInts32(in, count, docIDs);
         break;
       case 24:
         readInts24(in, count, docIDs, scratch);
@@ -260,7 +260,7 @@ class DocIdsWriter {
     }
   }
 
-  private static void readInts32BE(IndexInput in, int count, int[] docIDs) throws IOException {
+  private static void readInts32(IndexInput in, int count, int[] docIDs) throws IOException {
     for (int i = 0; i < count; i++) {
       docIDs[i] = in.readInt();
     }
@@ -313,7 +313,7 @@ class DocIdsWriter {
         readDelta16(in, count, visitor, scratch);
         break;
       case 32:
-        readInts32BE(in, count, visitor);
+        readInts32(in, count, visitor);
         break;
       case 24:
         readInts24(in, count, visitor, scratch);
@@ -332,7 +332,7 @@ class DocIdsWriter {
     }
   }
 
-  private static void readInts32BE(IndexInput in, int count, IntersectVisitor visitor)
+  private static void readInts32(IndexInput in, int count, IntersectVisitor visitor)
       throws IOException {
     for (int i = 0; i < count; i++) {
       visitor.visit(in.readInt());

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
@@ -266,8 +266,7 @@ class DocIdsWriter {
     }
   }
 
-  private static void readInts24(IndexInput in, int count, int[] docIDs)
-      throws IOException {
+  private static void readInts24(IndexInput in, int count, int[] docIDs) throws IOException {
     int i;
     for (i = 0; i < count - 7; i += 8) {
       long l1 = in.readLong();
@@ -291,7 +290,8 @@ class DocIdsWriter {
    * Read {@code count} integers and feed the result directly to {@link
    * IntersectVisitor#visit(int)}.
    */
-  static void readInts(IndexInput in, int count, IntersectVisitor visitor, long[] scratch) throws IOException {
+  static void readInts(IndexInput in, int count, IntersectVisitor visitor, long[] scratch)
+      throws IOException {
     final int bpv = in.readByte();
     switch (bpv) {
       case -2:
@@ -336,7 +336,8 @@ class DocIdsWriter {
     }
   }
 
-  private static void readInts24(IndexInput in, int count, IntersectVisitor visitor) throws IOException {
+  private static void readInts24(IndexInput in, int count, IntersectVisitor visitor)
+      throws IOException {
     int i;
     for (i = 0; i < count - 7; i += 8) {
       long l1 = in.readLong();

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/Run.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/Run.java
@@ -1,0 +1,167 @@
+package org.apache.lucene.util.bkd;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.CollectionTerminatedException;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+
+/** java doc */
+public class Run {
+
+  private static final String FIELD = "field";
+  private static final boolean BASELINE = false;
+  private static final boolean INDEX = false;
+  private static final boolean SEARCH = true;
+  private static final Random RANDOM = new Random(578136438746182L);
+
+  public static void main(String[] args) throws IOException {
+    index(32, 100000000);
+    search(32, 100000000, 1);
+    search(32, 100000000, 2);
+    search(32, 100000000, 4);
+    search(32, 100000000, 8);
+    search(32, 100000000, 16);
+
+    index(128, 100000000);
+    search(128, 100000000, 1);
+    search(128, 100000000, 8);
+    search(128, 100000000, 16);
+    search(128, 100000000, 32);
+    search(128, 100000000, 64);
+
+    index(1024, 100000000);
+    search(1024, 100000000, 1);
+    search(1024, 100000000, 8);
+    search(1024, 100000000, 32);
+    search(1024, 100000000, 128);
+    search(1024, 100000000, 512);
+
+    index(8192, 100000000);
+    search(8192, 100000000, 1);
+    search(8192, 100000000, 16);
+    search(8192, 100000000, 64);
+    search(8192, 100000000, 512);
+    search(8192, 100000000, 2048);
+//
+//    index(1024 * 1024, 100000000);
+//    search(1024 * 1024, 100000000, 1);
+//    search(1024 * 1024, 100000000, 16);
+//    search(1024 * 1024, 100000000, 64);
+//    search(1024 * 1024, 100000000, 512);
+//    search(1024 * 1024, 100000000, 2048);
+  }
+
+  private static void index(int cardinality, int docCount) throws IOException {
+    if (INDEX == false) {
+      return;
+    }
+    Directory directory = FSDirectory.open(Paths.get("./" + dictName(cardinality, docCount)));
+    IndexWriter writer =
+        new IndexWriter(
+            directory, new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.CREATE));
+    for (int i = 0; i < docCount; i++) {
+      Document document = new Document();
+      long point = RANDOM.nextInt(cardinality);
+      document.add(new LongPoint(FIELD, point));
+      writer.addDocument(document);
+    }
+    writer.flush();
+    writer.commit();
+    writer.close();
+  }
+
+  private static String dictName(int cardinality, int docCount) throws IOException {
+    return "index_"
+        + docCount
+        + "_doc_"
+        + cardinality
+        + "_cardinality_"
+        + (BASELINE ? "baseline" : "candidate");
+  }
+
+  private static void search(int cardinality, int docCount, int termCount) throws IOException {
+    if (SEARCH == false) {
+      return;
+    }
+    String fileName = dictName(cardinality, docCount);
+    Directory directory = FSDirectory.open(Paths.get("./" + fileName));
+    IndexReader indexReader = DirectoryReader.open(directory);
+    IndexSearcher searcher = new IndexSearcher(indexReader);
+    searcher.setQueryCachingPolicy(
+        new QueryCachingPolicy() {
+          @Override
+          public void onUse(Query query) {}
+
+          @Override
+          public boolean shouldCache(Query query) throws IOException {
+            return false;
+          }
+        });
+    long total = 0;
+    for (int i = 0; i < 100; i++) {
+      Query query = getQuery(cardinality, termCount);
+      long start = System.currentTimeMillis();
+      doSearch(searcher, query);
+      long end = System.currentTimeMillis();
+      total += end - start;
+    }
+    System.out.println(
+        "task: " + fileName + ", term count: " + termCount + ", took: " + total / 100);
+  }
+
+  private static Query getQuery(int cardinality, int termCount) {
+    assert termCount < cardinality;
+    Set<Integer> set = new HashSet<>(cardinality);
+    while (set.size() < termCount) {
+      set.add(RANDOM.nextInt(cardinality));
+    }
+    long[] terms = new long[termCount];
+    int pos = 0;
+    for (long l : set) {
+      terms[pos++] = l;
+    }
+    return LongPoint.newSetQuery(FIELD, terms);
+  }
+
+  private static void doSearch(IndexSearcher searcher, Query query) throws IOException {
+    searcher.search(
+        query,
+        new Collector() {
+          @Override
+          public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+            return new LeafCollector() {
+              @Override
+              public void setScorer(Scorable scorer) throws IOException {}
+
+              @Override
+              public void collect(int doc) throws IOException {
+                throw new CollectionTerminatedException();
+              }
+            };
+          }
+
+          @Override
+          public ScoreMode scoreMode() {
+            return ScoreMode.COMPLETE_NO_SCORES;
+          }
+        });
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -93,6 +93,10 @@ public class TestDocIdsWriter extends LuceneTestCase {
 
   private void test(Directory dir, int[] ints) throws Exception {
     final long len;
+    final long[] scratch = new long[ints.length];
+    for (int i=0;i<scratch.length;i++) {
+      scratch[i] = random().nextLong();
+    }
     try (IndexOutput out = dir.createOutput("tmp", IOContext.DEFAULT)) {
       DocIdsWriter.writeDocIds(ints, 0, ints.length, out);
       len = out.getFilePointer();
@@ -102,7 +106,7 @@ public class TestDocIdsWriter extends LuceneTestCase {
     }
     try (IndexInput in = dir.openInput("tmp", IOContext.READONCE)) {
       int[] read = new int[ints.length];
-      DocIdsWriter.readInts(in, ints.length, read);
+      DocIdsWriter.readInts(in, ints.length, read, scratch);
       assertArrayEquals(ints, read);
       assertEquals(len, in.getFilePointer());
     }
@@ -128,7 +132,7 @@ public class TestDocIdsWriter extends LuceneTestCase {
             public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
               throw new UnsupportedOperationException();
             }
-          });
+          }, scratch);
       assertArrayEquals(ints, read);
       assertEquals(len, in.getFilePointer());
     }

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -94,7 +94,7 @@ public class TestDocIdsWriter extends LuceneTestCase {
   private void test(Directory dir, int[] ints) throws Exception {
     final long len;
     final long[] scratch = new long[ints.length];
-    for (int i=0;i<scratch.length;i++) {
+    for (int i = 0; i < scratch.length; i++) {
       scratch[i] = random().nextLong();
     }
     try (IndexOutput out = dir.createOutput("tmp", IOContext.DEFAULT)) {
@@ -132,7 +132,8 @@ public class TestDocIdsWriter extends LuceneTestCase {
             public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
               throw new UnsupportedOperationException();
             }
-          }, scratch);
+          },
+          scratch);
       assertArrayEquals(ints, read);
       assertEquals(len, in.getFilePointer());
     }


### PR DESCRIPTION
We introduced a bitset optimization for extremly low cardinality fields in https://issues.apache.org/jira/browse/LUCENE-10233, but medium cardinality fields (like 32/128) can rarely trigger this optimization, I'm trying to find out a way to speed up them.

In https://github.com/apache/lucene-solr/pull/1538, we made some effort to use readLELongs to speed up BKD id blocks, but did not get a obvious gain on this approach. I think the reason could probably be that we were trying to optimize the unsorted situation (typically happens for high cardinality fields) and the bottleneck of queries on high cardinality fields is `visitDocValues` but not `readDocIds`.

However, medium cardinality fields may be tempted for this optimization because they need to read lots of ids for each term. The basic idea is that we can compute the delta of the sorted ids and encode/decode them like what we do in `StoredFieldsInts`. I benchmarked the optimization by mocking some random longPoint and querying them with `PointInSetQuery`. As expected, the medium cardinality fields got spped up and high cardinality fields get even results.

**Benchmark Result**

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/gf/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/gf/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-number-format:General;
	text-align:general;
	vertical-align:middle;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{color:#172B4D;
	font-size:14.0pt;}
.xl66
	{color:#172B4D;
	font-size:14.0pt;
	mso-number-format:Percent;}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-char-type:none;
	display:none;}
-->

</head>

<body link="#0563C1" vlink="#954F72">
<meta charset=utf-8>



doc count | field   cardinality | query   point | baseline(ms) | candidate(ms) | diff   percentage | baseline(QPS) | candidate(QPS) | diff   percentage
-- | -- | -- | -- | -- | -- | -- | -- | --
100000000 | 32 | 1 | 19 | 16 | -15.79% | 52.63 | 62.5 | 18.75%
100000000 | 32 | 2 | 34 | 14 | -58.82% | 29.41 | 71.43 | 142.86%
100000000 | 32 | 4 | 76 | 22 | -71.05% | 13.16 | 45.45 | 245.45%
100000000 | 32 | 8 | 139 | 42 | -69.78% | 7.19 | 23.81 | 230.95%
100000000 | 32 | 16 | 279 | 82 | -70.61% | 3.58 | 12.2 | 240.24%
100000000 | 128 | 1 | 17 | 11 | -35.29% | 58.82 | 90.91 | 54.55%
100000000 | 128 | 8 | 75 | 23 | -69.33% | 13.33 | 43.48 | 226.09%
100000000 | 128 | 16 | 126 | 25 | -80.16% | 7.94 | 40 | 404.00%
100000000 | 128 | 32 | 245 | 50 | -79.59% | 4.08 | 20 | 390.00%
100000000 | 128 | 64 | 528 | 97 | -81.63% | 1.89 | 10.31 | 444.33%
100000000 | 1024 | 1 | 3 | 2 | -33.33% | 333.33 | 500 | 50.00%
100000000 | 1024 | 8 | 13 | 8 | -38.46% | 76.92 | 125 | 62.50%
100000000 | 1024 | 32 | 31 | 19 | -38.71% | 32.26 | 52.63 | 63.16%
100000000 | 1024 | 128 | 120 | 67 | -44.17% | 8.33 | 14.93 | 79.10%
100000000 | 1024 | 512 | 480 | 133 | -72.29% | 2.08 | 7.52 | 260.90%
100000000 | 8192 | 1 | 3 | 3 | 0.00% | 333.33 | 333.33 | 0.00%
100000000 | 8192 | 16 | 18 | 15 | -16.67% | 55.56 | 66.67 | 20.00%
100000000 | 8192 | 64 | 19 | 14 | -26.32% | 52.63 | 71.43 | 35.71%
100000000 | 8192 | 512 | 69 | 43 | -37.68% | 14.49 | 23.26 | 60.47%
100000000 | 8192 | 2048 | 236 | 134 | -43.22% | 4.24 | 7.46 | 76.12%
100000000 | 1048576 | 1 | 3 | 2 | -33.33% | 333.33 | 500 | 50.00%
100000000 | 1048576 | 16 | 18 | 19 | 5.56% | 55.56 | 52.63 | -5.26%
100000000 | 1048576 | 64 | 17 | 17 | 0.00% | 58.82 | 58.82 | 0.00%
100000000 | 1048576 | 512 | 34 | 32 | -5.88% | 29.41 | 31.25 | 6.25%
100000000 | 1048576 | 2048 | 89 | 93 | 4.49% | 11.24 | 10.75 | -4.30%



</body>

</html>
