### PR TITLE
Revert "LUCENE-10289: Change DocIdSetBuilder#grow() from taking an int to a long (#520)"

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -41,8 +41,6 @@ API Changes
 
 * LUCENE-10244: MultiCollector::getCollectors is now public, allowing users to access the wrapped
   collectors. (Andriy Redko)
-  
-* LUCENE-10289: DocIdSetBuilder#grow() takes now a long instead of an int. (Ignacio Vera)  
 
 New Features
 ---------------------

--- a/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
@@ -128,9 +128,9 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
       for (j = 0; j < array.length; ) {
         final int l = TestUtil.nextInt(random(), 1, array.length - j);
         DocIdSetBuilder.BulkAdder adder = null;
-        for (long k = 0, budget = 0; k < l; ++k) {
+        for (int k = 0, budget = 0; k < l; ++k) {
           if (budget == 0 || rarely()) {
-            budget = TestUtil.nextLong(random(), 1, l - k + 5);
+            budget = TestUtil.nextInt(random(), 1, l - k + 5);
             adder = builder.grow(budget);
           }
           adder.add(array[j++]);
@@ -239,38 +239,6 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
     builder = new DocIdSetBuilder(100, terms);
     assertEquals(1d, builder.numValuesPerDoc, 0d);
     assertTrue(builder.multivalued);
-  }
-
-  @Nightly
-  public void testLotsOfDocs() throws IOException {
-    final int docCount = 1;
-    final long numDocs = (long) Integer.MAX_VALUE + 1;
-    PointValues values = new DummyPointValues(docCount, numDocs);
-    DocIdSetBuilder builder = new DocIdSetBuilder(100, values, "foo");
-    DocIdSetBuilder.BulkAdder adder = builder.grow(numDocs);
-    for (long i = 0; i < numDocs; ++i) {
-      adder.add(0);
-    }
-    DocIdSet result = builder.build();
-    assertTrue(result instanceof BitDocIdSet);
-    assertEquals(1, result.iterator().cost());
-  }
-
-  public void testLongOverflow() throws IOException {
-    {
-      DocIdSetBuilder builder = new DocIdSetBuilder(100);
-      builder.grow(1L);
-      Exception ex = expectThrows(ArithmeticException.class, () -> builder.grow(Long.MAX_VALUE));
-      assertEquals("long overflow", ex.getMessage());
-    }
-    {
-      DocIdSetBuilder builder = new DocIdSetBuilder(100);
-      builder.grow((long) Integer.MAX_VALUE + 1);
-      Exception ex =
-          expectThrows(
-              ArithmeticException.class, () -> builder.grow(Long.MAX_VALUE - Integer.MAX_VALUE));
-      assertEquals("long overflow", ex.getMessage());
-    }
   }
 
   private static class DummyTerms extends Terms {


### PR DESCRIPTION
This reverts commit af1e68b89197bd6399c0db18e478716951dd381c.

