### PR TITLE
Don't store graph offsets for HNSW graph

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -498,7 +498,7 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
       this.entryNode = numLevels > 1 ? nodesByLevel[numLevels - 1][0] : 0;
       this.size = entry.size();
       this.graphOffsetsByLevel = entry.graphOffsetsByLevel;
-      this.bytesForConns = (entry.maxConn + 1) * 4;
+      this.bytesForConns = ((long) entry.maxConn + 1) * 4;
     }
 
     @Override


### PR DESCRIPTION
Currently we store for each node an offset in the graph
neighbours file from where to read this node's neighbours.
We also load these offsets into the heap.

This patch instead of storing offsets calculates them when needed.
This allows to save heap space and disk space for offsets.

To make offsets calculable:
1) we write neighbours as Int instead of the current VInt to
 have predictable offsets (some extra space here)
2) for each node we allocate ((maxConn + 1) * 4) bytes for
storing the node's neighbours, where "maxConn" is the maximum number
of connections the node can have. If a node has less than maxConn we
add extra padding to fill the leftover space (some extra space here).
In big graphs most nodes have "maxConn" of neighbours so there
should not be much of a waste space.
