### PR TITLE
LUCENE-10310: Fix test error in TestXYDocValuesQueries#testRandomDistanceHuge

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -110,6 +110,11 @@ Other
 
 * LUCENE-10303: Upgrade log4j to 2.15.0. (Tomoko Uchida)
 
+* LUCENE-10310: TestXYDocValuesQueries#doRandomDistanceTest does not produce random circles with radius
+  with '0' value any longer.
+
+
+
 ======================= Lucene 9.0.0 =======================
 
 New Features

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -113,8 +113,6 @@ Other
 * LUCENE-10310: TestXYDocValuesQueries#doRandomDistanceTest does not produce random circles with radius
   with '0' value any longer.
 
-
-
 ======================= Lucene 9.0.0 =======================
 
 New Features

--- a/lucene/test-framework/src/java/org/apache/lucene/geo/BaseXYPointTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/geo/BaseXYPointTestCase.java
@@ -1341,9 +1341,10 @@ public abstract class BaseXYPointTestCase extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     for (int i = 0; i < numQueries; i++) {
-      float x = nextX();
-      float y = nextY();
-      float radius = (Float.MAX_VALUE / 2) * random().nextFloat();
+      XYCircle circle = ShapeTestUtil.nextCircle();
+      float x = circle.getX();
+      float y = circle.getY();
+      float radius = circle.getRadius();
 
       BitSet expected = new BitSet();
       for (int doc = 0; doc < reader.maxDoc(); doc++) {


### PR DESCRIPTION
TestXYDocValuesQueries#doRandomDistanceTest does not produce random circles with radius with '0' value any longer.  We create random circles using ShapeTestUtils which is safe.