### PR TITLE
LUCENE-10085: Fix flaky testQueryMatchesCount

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesFieldExistsQuery.java
@@ -222,7 +222,8 @@ public class TestDocValuesFieldExistsQuery extends LuceneTestCase {
 
     for (int i = 0; i < randomNumDocs; i++) {
       Document doc = new Document();
-      if (random().nextBoolean()) {
+      // ensure we index at least a document with long between 0 and 10
+      if (i == 0 || random().nextBoolean()) {
         doc.add(new LongPoint("long", i));
         doc.add(new NumericDocValuesField("long", i));
         doc.add(new StringField("string", "value", Store.NO));


### PR DESCRIPTION
Five times every 10 000 tests, we did not index any documents with i
between 0 and 10 (inclusive), which caused the deleted tests to fail.

With this commit, we make sure that we always index at least one
document between 0 and 10.