### PR TITLE
LUCENE-10313: minor clean-ups and follow-ups

### DIFF
--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CreateIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CreateIndexDialogFactory.java
@@ -339,7 +339,7 @@ public class CreateIndexDialogFactory implements DialogOpener.DialogFactory {
                   }
 
                   log.log(Level.SEVERE, "Cannot create index", ex);
-                  String message = "See Logs tab or log file for more details.";
+                  String message = "See Logs tab for more details.";
                   JOptionPane.showMessageDialog(
                       dialog, message, "Cannot create index", JOptionPane.ERROR_MESSAGE);
                 } finally {

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OpenIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OpenIndexDialogFactory.java
@@ -337,7 +337,7 @@ public final class OpenIndexDialogFactory implements DialogOpener.DialogFactory 
         closeDialog();
       } catch (LukeException ex) {
         String message =
-            ex.getMessage() + System.lineSeparator() + "See Logs tab or log file for more details.";
+            ex.getMessage() + System.lineSeparator() + "See Logs tab for more details.";
         JOptionPane.showMessageDialog(
             dialog, message, "Invalid index path", JOptionPane.ERROR_MESSAGE);
       } catch (Throwable cause) {

--- a/lucene/luke/src/java/org/apache/lucene/luke/util/CircularLogBufferHandler.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/util/CircularLogBufferHandler.java
@@ -106,9 +106,9 @@ public class CircularLogBufferHandler extends Handler {
   }
 
   /** @return Return a clone of the buffered records so far. */
-  public Collection<ImmutableLogRecord> getLogRecords() {
+  public List<ImmutableLogRecord> getLogRecords() {
     synchronized (buffer) {
-      return new ArrayDeque<>(buffer);
+      return List.copyOf(buffer);
     }
   }
 }

--- a/lucene/luke/src/java/org/apache/lucene/luke/util/LogRecordFormatter.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/util/LogRecordFormatter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.luke.util;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.function.Function;
+
+public class LogRecordFormatter
+    implements Function<CircularLogBufferHandler.ImmutableLogRecord, String> {
+  @Override
+  public String apply(CircularLogBufferHandler.ImmutableLogRecord record) {
+    return String.format(
+        Locale.ROOT,
+        "%s [%s] %s: %s",
+        DateTimeFormatter.ofPattern("HH:mm:ss", Locale.ROOT)
+            .format(record.getInstant().atZone(ZoneId.systemDefault())),
+        record.getLevel(),
+        record.getLoggerName(),
+        record.getMessage()
+            + (record.getThrown() == null ? "" : "\n" + toString(record.getThrown())));
+  }
+
+  private String toString(Throwable t) {
+    try (StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw)) {
+      t.printStackTrace(pw);
+      pw.flush();
+      return sw.toString();
+    } catch (IOException e) {
+      return "Could not dump stack trace: " + e.getMessage();
+    }
+  }
+}


### PR DESCRIPTION
- Fix the inequality sign for filtering log records.
- Move the log formatter class to util package.
- Allow to copy the displayed log string to the system clipboard.
- other small changes.