### PR TITLE
LUCENE-10321: Tweak MultiRangeQuery interval tree creation logic

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -97,6 +97,8 @@ Optimizations
 
 * LUCENE-10225: Improve IntroSelector with 3-ways partitioning. (Bruno Roustant, Adrien Grand)
 
+* LUCENE-10321: Tweak MultiRangeQuery interval tree creation to skip "pulling up" mins. (Greg Miller)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiRangeQuery.java
@@ -245,7 +245,7 @@ public abstract class MultiRangeQuery extends Query {
         if (rangeClauses.size() == 1) {
           range = getRange(rangeClauses.get(0), numDims, bytesPerDim, comparator);
         } else {
-          range = create(rangeClauses, numDims, bytesPerDim, comparator);
+          range = createTree(rangeClauses, numDims, bytesPerDim, comparator);
         }
 
         boolean allDocsMatch;
@@ -531,7 +531,7 @@ public abstract class MultiRangeQuery extends Query {
   }
 
   /** Creates a tree from provided clauses */
-  static RangeTree create(
+  static RangeTree createTree(
       List<RangeClause> clauses,
       int numIndexDim,
       int bytesPerDim,

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiRangeQuery.java
@@ -603,16 +603,6 @@ public abstract class MultiRangeQuery extends Query {
       for (int i = 0; i < numIndexDim; i++) {
         int offset = i * bytesPerDim;
         if (comparator.compare(
-                newNode.minPackedValue, offset, newNode.left.getMinPackedValue(), offset)
-            > 0) {
-          System.arraycopy(
-              newNode.left.getMinPackedValue(),
-              offset,
-              newNode.minPackedValue,
-              offset,
-              bytesPerDim);
-        }
-        if (comparator.compare(
                 newNode.maxPackedValue, offset, newNode.left.getMaxPackedValue(), offset)
             < 0) {
           System.arraycopy(
@@ -627,16 +617,6 @@ public abstract class MultiRangeQuery extends Query {
     if (newNode.right != null) {
       for (int i = 0; i < numIndexDim; i++) {
         int offset = i * bytesPerDim;
-        if (comparator.compare(
-                newNode.minPackedValue, offset, newNode.right.getMinPackedValue(), offset)
-            > 0) {
-          System.arraycopy(
-              newNode.right.getMinPackedValue(),
-              offset,
-              newNode.minPackedValue,
-              offset,
-              bytesPerDim);
-        }
         if (comparator.compare(
                 newNode.maxPackedValue, offset, newNode.right.getMaxPackedValue(), offset)
             < 0) {


### PR DESCRIPTION
# Description

Small tweak that makes the interval tree creation logic in MultiRangeQuery consistent with ComponentTree.

# Solution

Just remove the "roll up" of min values since internal node bounding boxes don't need consistent min values.

# Tests

All existing tests continue to pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
