### PR TITLE
LUCENE-10329: Use computed mask

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -96,6 +96,8 @@ Improvements
 Optimizations
 ---------------------
 
+* LUCENE-10329: Use computed block mask for DirectMonotonicReader#get. (Guo Feng)
+
 * LUCENE-10280: Optimize BKD leaves' doc IDs codec when they are continuous. (Guo Feng)
 
 * LUCENE-10233: Store BKD leaves' doc IDs as bitset in some cases (typically for low cardinality fields

--- a/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicReader.java
@@ -127,6 +127,7 @@ public final class DirectMonotonicReader extends LongValues implements Accountab
   }
 
   private final int blockShift;
+  private final long blockMask;
   private final LongValues[] readers;
   private final long[] mins;
   private final float[] avgs;
@@ -136,6 +137,7 @@ public final class DirectMonotonicReader extends LongValues implements Accountab
   private DirectMonotonicReader(
       int blockShift, LongValues[] readers, long[] mins, float[] avgs, byte[] bpvs) {
     this.blockShift = blockShift;
+    this.blockMask = (1L << blockShift) - 1;
     this.readers = readers;
     this.mins = mins;
     this.avgs = avgs;
@@ -157,7 +159,7 @@ public final class DirectMonotonicReader extends LongValues implements Accountab
   @Override
   public long get(long index) {
     final int block = (int) (index >>> blockShift);
-    final long blockIndex = index & ((1 << blockShift) - 1);
+    final long blockIndex = index & blockMask;
     final long delta = readers[block].get(blockIndex);
     return mins[block] + (long) (avgs[block] * blockIndex) + delta;
   }


### PR DESCRIPTION
Use a computed mask for `DirectMonotonicReader#get` instead of computing it for every call.

see https://issues.apache.org/jira/browse/LUCENE-10329 for more details