### PR TITLE
LUCENE-10329: Use computed mask for DirectMonotonicReader#get

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -96,6 +96,8 @@ Improvements
 Optimizations
 ---------------------
 
+* LUCENE-10329: Use computed block mask for DirectMonotonicReader#get. (Guo Feng)
+
 * LUCENE-10280: Optimize BKD leaves' doc IDs codec when they are continuous. (Guo Feng)
 
 * LUCENE-10233: Store BKD leaves' doc IDs as bitset in some cases (typically for low cardinality fields

--- a/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicReader.java
@@ -167,7 +167,7 @@ public final class DirectMonotonicReader extends LongValues implements Accountab
   /** Get lower/upper bounds for the value at a given index without hitting the direct reader. */
   private long[] getBounds(long index) {
     final int block = Math.toIntExact(index >>> blockShift);
-    final long blockIndex = index & ((1 << blockShift) - 1);
+    final long blockIndex = index & blockMask;
     final long lowerBound = mins[block] + (long) (avgs[block] * blockIndex);
     final long upperBound = lowerBound + (1L << bpvs[block]) - 1;
     if (bpvs[block] == 64 || upperBound < lowerBound) { // overflow

--- a/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicReader.java
@@ -127,6 +127,7 @@ public final class DirectMonotonicReader extends LongValues implements Accountab
   }
 
   private final int blockShift;
+  private final long blockMask;
   private final LongValues[] readers;
   private final long[] mins;
   private final float[] avgs;
@@ -136,6 +137,7 @@ public final class DirectMonotonicReader extends LongValues implements Accountab
   private DirectMonotonicReader(
       int blockShift, LongValues[] readers, long[] mins, float[] avgs, byte[] bpvs) {
     this.blockShift = blockShift;
+    this.blockMask = (1L << blockShift) - 1;
     this.readers = readers;
     this.mins = mins;
     this.avgs = avgs;
@@ -157,7 +159,7 @@ public final class DirectMonotonicReader extends LongValues implements Accountab
   @Override
   public long get(long index) {
     final int block = (int) (index >>> blockShift);
-    final long blockIndex = index & ((1 << blockShift) - 1);
+    final long blockIndex = index & blockMask;
     final long delta = readers[block].get(blockIndex);
     return mins[block] + (long) (avgs[block] * blockIndex) + delta;
   }


### PR DESCRIPTION
I saw `DirectMonotonicReader#get` was the hot method during when running luceneutil test, So using a computed mask for DirectMonotonicReader#get instead of computing it for every call may make a bit sense. CPU profile shows the pct of `org.apache.lucene.util.packed.DirectMonotonicReader#get()` decreased from 12.86% to 10.93%

### Benchmark
```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
           HighTermDayOfYearSort       90.49     (18.0%)       88.62     (11.1%)   -2.1% ( -26% -   32%) 0.661
                      TermDTSort       86.84     (10.6%)       85.83      (8.7%)   -1.2% ( -18% -   20%) 0.705
                         Prefix3      140.90      (5.7%)      139.70      (7.0%)   -0.8% ( -12% -   12%) 0.675
               HighTermMonthSort      176.44     (14.0%)      175.30     (11.8%)   -0.6% ( -23% -   29%) 0.875
                      HighPhrase      430.23      (3.2%)      428.04      (3.6%)   -0.5% (  -7% -    6%) 0.635
                   OrNotHighHigh      676.66      (4.2%)      673.70      (3.2%)   -0.4% (  -7% -    7%) 0.711
                    OrHighNotLow      823.43      (3.5%)      822.17      (4.5%)   -0.2% (  -7% -    8%) 0.905
                        Wildcard      121.59      (2.0%)      121.41      (2.6%)   -0.2% (  -4% -    4%) 0.840
         AndHighMedDayTaxoFacets       55.32      (1.8%)       55.26      (1.9%)   -0.1% (  -3% -    3%) 0.851
                    HighSpanNear       14.79      (2.6%)       14.77      (2.5%)   -0.1% (  -5% -    5%) 0.899
           BrowseMonthSSDVFacets       17.99      (9.8%)       17.98      (9.6%)   -0.1% ( -17% -   21%) 0.982
            HighIntervalsOrdered       21.05      (3.1%)       21.04      (3.2%)   -0.0% (  -6% -    6%) 0.966
             MedIntervalsOrdered       18.57      (3.0%)       18.57      (2.9%)   -0.0% (  -5% -    6%) 0.983
                     MedSpanNear       88.82      (2.0%)       88.86      (2.1%)    0.0% (  -3% -    4%) 0.943
                     LowSpanNear      154.86      (1.9%)      154.95      (1.6%)    0.1% (  -3% -    3%) 0.916
                         Respell       65.43      (2.2%)       65.51      (2.3%)    0.1% (  -4% -    4%) 0.862
       BrowseDayOfYearSSDVFacets       16.76     (11.3%)       16.79     (11.6%)    0.2% ( -20% -   25%) 0.963
                       LowPhrase      513.12      (2.7%)      514.01      (3.1%)    0.2% (  -5% -    6%) 0.850
                          IntNRQ      288.28      (1.3%)      288.90      (1.2%)    0.2% (  -2% -    2%) 0.586
                 LowSloppyPhrase      214.50      (2.4%)      215.09      (2.2%)    0.3% (  -4% -    5%) 0.706
             LowIntervalsOrdered      202.73      (2.8%)      203.30      (2.9%)    0.3% (  -5% -    6%) 0.757
                      OrHighHigh       41.48      (1.8%)       41.64      (2.0%)    0.4% (  -3% -    4%) 0.524
                    OrNotHighMed      809.16      (5.0%)      812.45      (3.1%)    0.4% (  -7% -    8%) 0.757
                      AndHighLow      665.08      (3.1%)      668.14      (3.3%)    0.5% (  -5% -    7%) 0.649
                        PKLookup      211.67      (3.1%)      212.66      (3.3%)    0.5% (  -5% -    7%) 0.644
                       MedPhrase      304.39      (2.5%)      305.90      (2.3%)    0.5% (  -4% -    5%) 0.519
                      AndHighMed      157.06      (4.0%)      157.89      (4.0%)    0.5% (  -7% -    8%) 0.678
                     AndHighHigh       99.07      (2.6%)       99.69      (3.6%)    0.6% (  -5% -    7%) 0.534
                          Fuzzy2       36.32      (3.6%)       36.55      (3.7%)    0.6% (  -6% -    8%) 0.579
                       OrHighMed       80.10      (2.4%)       80.62      (1.8%)    0.6% (  -3% -    4%) 0.329
                         LowTerm     1411.61      (3.0%)     1421.53      (4.3%)    0.7% (  -6% -    8%) 0.549
        AndHighHighDayTaxoFacets       12.47      (2.6%)       12.56      (2.5%)    0.8% (  -4% -    6%) 0.343
                 MedSloppyPhrase       37.22      (1.6%)       37.51      (1.7%)    0.8% (  -2% -    4%) 0.138
                          Fuzzy1       60.37      (4.8%)       60.87      (4.3%)    0.8% (  -7% -   10%) 0.564
                       OrHighLow      565.69      (4.2%)      570.55      (4.3%)    0.9% (  -7% -    9%) 0.523
                        HighTerm     1167.96      (5.0%)     1178.00      (5.8%)    0.9% (  -9% -   12%) 0.615
                         MedTerm     1392.49      (4.3%)     1404.95      (4.0%)    0.9% (  -7% -    9%) 0.496
          OrHighMedDayTaxoFacets        4.17      (2.1%)        4.21      (2.4%)    1.0% (  -3% -    5%) 0.189
            MedTermDayTaxoFacets       21.41      (1.8%)       21.61      (2.0%)    1.0% (  -2% -    4%) 0.115
                HighSloppyPhrase        3.74      (2.8%)        3.77      (3.0%)    1.0% (  -4% -    6%) 0.298
                    OrNotHighLow     1020.98      (4.6%)     1034.25      (3.9%)    1.3% (  -6% -   10%) 0.334
                    OrHighNotMed      690.49      (3.0%)      701.12      (3.3%)    1.5% (  -4% -    8%) 0.125
                   OrHighNotHigh      923.13      (3.2%)      943.46      (3.2%)    2.2% (  -4% -    8%) 0.030
            HighTermTitleBDVSort      161.11     (12.8%)      165.00     (11.6%)    2.4% ( -19% -   30%) 0.532
            BrowseDateTaxoFacets        2.96      (2.6%)        3.05      (4.0%)    2.8% (  -3% -    9%) 0.009
       BrowseDayOfYearTaxoFacets        2.96      (2.7%)        3.05      (4.1%)    2.8% (  -3% -    9%) 0.009
           BrowseMonthTaxoFacets        3.12      (2.3%)        3.22      (4.1%)    3.0% (  -3% -    9%) 0.004
```

### baseline
```
PERCENT       CPU SAMPLES   STACK
12.86%        70257         org.apache.lucene.util.packed.DirectMonotonicReader#get()
5.38%         29376         org.apache.lucene.codecs.lucene90.Lucene90DocValuesProducer$17#binaryValue()
5.26%         28749         org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts#countAll()
5.23%         28560         org.apache.lucene.util.packed.DirectReader$DirectPackedReader12#get()
4.14%         22593         java.nio.ByteBuffer#get()
1.98%         10828         org.apache.lucene.codecs.lucene90.Lucene90PostingsReader$BlockImpactsPostingsEnum#advance()
1.75%         9533          java.nio.Buffer#position()
1.70%         9301          java.nio.Buffer#scope()
1.68%         9158          org.apache.lucene.store.ByteBufferGuard#ensureValid()
1.62%         8849          org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetCounts#countOneSegment()
1.48%         8065          org.apache.lucene.facet.taxonomy.IntTaxonomyFacets#increment()
1.35%         7398          java.nio.Buffer#nextGetIndex()
1.29%         7032          java.nio.Buffer#checkIndex()
1.27%         6959          org.apache.lucene.search.ConjunctionDISI#doNext()
1.22%         6643          jdk.internal.misc.ScopedMemoryAccess#getByteInternal()
1.18%         6469          org.apache.lucene.util.PriorityQueue#upHeap()
1.18%         6439          java.nio.DirectByteBuffer#ix()
1.12%         6118          jdk.internal.misc.Unsafe#convEndian()
1.08%         5910          org.apache.lucene.search.PhraseScorer$1#matches()
1.04%         5697          jdk.internal.misc.ScopedMemoryAccess#getShortUnalignedInternal()
1.03%         5600          org.apache.lucene.store.ByteBufferIndexInput$SingleBufferImpl#seek()
0.99%         5392          org.apache.lucene.store.ByteBufferGuard#getShort()
0.97%         5312          jdk.internal.util.Preconditions#checkFromIndexSize()
0.94%         5133          java.nio.DirectByteBuffer#get()
0.88%         4813          org.apache.lucene.search.similarities.BM25Similarity$BM25Scorer#score()
0.88%         4807          org.apache.lucene.search.SloppyPhraseMatcher#initSimple()
0.86%         4682          org.apache.lucene.codecs.lucene90.Lucene90PostingsReader$EverythingEnum#nextPosition()
0.85%         4618          org.apache.lucene.util.PriorityQueue#add()
0.83%         4525          org.apache.lucene.codecs.lucene90.Lucene90PostingsReader$EverythingEnum#advance()
0.81%         4443          org.apache.lucene.codecs.lucene90.Lucene90PostingsReader$BlockImpactsPostingsEnum#nextPosition()
```

### candidate
```
PERCENT       CPU SAMPLES   STACK
10.93%        58254         org.apache.lucene.util.packed.DirectMonotonicReader#get()
6.21%         33121         org.apache.lucene.codecs.lucene90.Lucene90DocValuesProducer$17#binaryValue()
5.38%         28683         org.apache.lucene.util.packed.DirectReader$DirectPackedReader12#get()
5.10%         27194         org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts#countAll()
4.33%         23074         java.nio.ByteBuffer#get()
2.14%         11407         java.nio.Buffer#scope()
2.05%         10928         org.apache.lucene.codecs.lucene90.Lucene90PostingsReader$BlockImpactsPostingsEnum#advance()
1.81%         9640          java.nio.Buffer#position()
1.71%         9125          org.apache.lucene.store.ByteBufferGuard#ensureValid()
1.63%         8678          org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetCounts#countOneSegment()
1.54%         8196          org.apache.lucene.facet.taxonomy.IntTaxonomyFacets#increment()
1.34%         7164          java.nio.Buffer#checkIndex()
1.32%         7017          org.apache.lucene.search.ConjunctionDISI#doNext()
1.29%         6858          jdk.internal.misc.ScopedMemoryAccess#getByteInternal()
1.27%         6746          java.nio.Buffer#nextGetIndex()
1.23%         6533          org.apache.lucene.util.PriorityQueue#upHeap()
1.17%         6234          jdk.internal.misc.Unsafe#convEndian()
1.12%         5960          org.apache.lucene.search.PhraseScorer$1#matches()
1.06%         5633          jdk.internal.misc.ScopedMemoryAccess#getShortUnalignedInternal()
0.98%         5246          jdk.internal.util.Preconditions#checkFromIndexSize()
0.94%         5002          org.apache.lucene.store.ByteBufferGuard#getShort()
0.92%         4904          org.apache.lucene.store.ByteBufferIndexInput$SingleBufferImpl#seek()
0.91%         4868          org.apache.lucene.search.SloppyPhraseMatcher#initSimple()
0.90%         4779          org.apache.lucene.util.PriorityQueue#add()
0.89%         4725          org.apache.lucene.codecs.lucene90.Lucene90PostingsReader$EverythingEnum#nextPosition()
0.86%         4568          org.apache.lucene.codecs.lucene90.Lucene90PostingsReader$BlockImpactsPostingsEnum#nextPosition()
0.84%         4487          org.apache.lucene.codecs.lucene90.Lucene90PostingsReader$EverythingEnum#advance()
0.84%         4476          java.nio.DirectByteBuffer#get()
0.83%         4423          org.apache.lucene.search.similarities.BM25Similarity$BM25Scorer#score()
0.83%         4408          org.apache.lucene.search.MultiCollector$MultiLeafCollector#collect()
```