### PR TITLE
LUCENE-10333: Speed up BinaryDocValues with a batch reading on LongValues

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -763,11 +763,13 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
             DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData, merging);
         return new DenseBinaryDocValues(maxDoc) {
           final BytesRef bytes = new BytesRef(new byte[entry.maxLength], 0, entry.maxLength);
+          final LongValues.Twin twin = new LongValues.Twin();
 
           @Override
           public BytesRef binaryValue() throws IOException {
-            long startOffset = addresses.get(doc);
-            bytes.length = (int) (addresses.get(doc + 1L) - startOffset);
+            addresses.get(doc, twin);
+            long startOffset = twin.first;
+            bytes.length = (int) (twin.second - startOffset);
             bytesSlice.seek(startOffset);
             bytesSlice.readBytes(bytes.bytes, 0, bytes.length);
             return bytes;
@@ -805,12 +807,14 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
             DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData);
         return new SparseBinaryDocValues(disi) {
           final BytesRef bytes = new BytesRef(new byte[entry.maxLength], 0, entry.maxLength);
+          final LongValues.Twin twin = new LongValues.Twin();
 
           @Override
           public BytesRef binaryValue() throws IOException {
             final int index = disi.index();
-            long startOffset = addresses.get(index);
-            bytes.length = (int) (addresses.get(index + 1L) - startOffset);
+            addresses.get(index, twin);
+            long startOffset = twin.first;
+            bytes.length = (int) (twin.second - startOffset);
             bytesSlice.seek(startOffset);
             bytesSlice.readBytes(bytes.bytes, 0, bytes.length);
             return bytes;
@@ -1295,6 +1299,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
         int doc = -1;
         long start, end;
         int count;
+        final LongValues.Twin twin = new LongValues.Twin();
 
         @Override
         public int nextDoc() throws IOException {
@@ -1316,16 +1321,18 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
           if (target >= maxDoc) {
             return doc = NO_MORE_DOCS;
           }
-          start = addresses.get(target);
-          end = addresses.get(target + 1L);
+          addresses.get(target, twin);
+          start = twin.first;
+          end = twin.second;
           count = (int) (end - start);
           return doc = target;
         }
 
         @Override
         public boolean advanceExact(int target) throws IOException {
-          start = addresses.get(target);
-          end = addresses.get(target + 1L);
+          addresses.get(target, twin);
+          start = twin.first;
+          end = twin.second;
           count = (int) (end - start);
           doc = target;
           return true;
@@ -1356,6 +1363,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
         boolean set;
         long start, end;
         int count;
+        private final LongValues.Twin twin = new LongValues.Twin();
 
         @Override
         public int nextDoc() throws IOException {
@@ -1400,8 +1408,9 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
         private void set() {
           if (set == false) {
             final int index = disi.index();
-            start = addresses.get(index);
-            end = addresses.get(index + 1L);
+            addresses.get(index, twin);
+            start = twin.first;
+            end = twin.second;
             count = (int) (end - start);
             set = true;
           }

--- a/lucene/core/src/java/org/apache/lucene/util/LongValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/LongValues.java
@@ -23,6 +23,11 @@ package org.apache.lucene.util;
  */
 public abstract class LongValues {
 
+  public static class Twin {
+    public long first;
+    public long second;
+  }
+
   /** An instance that returns the provided value. */
   public static final LongValues IDENTITY =
       new LongValues() {
@@ -44,4 +49,13 @@ public abstract class LongValues {
 
   /** Get value at <code>index</code>. */
   public abstract long get(long index);
+
+  public void get(long index, Twin twin) {
+    twin.first = get(index);
+    twin.second = get(index + 1);
+  }
+
+  protected boolean twinImplementIsRight(long index, Twin twin) {
+    return twin.first == get(index) && twin.second == get(index + 1);
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/packed/DirectReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/DirectReader.java
@@ -235,7 +235,9 @@ public class DirectReader {
         int i = in.readShort(offset + (index >>> 3)) >>> shift;
         twin.first = i & 0x1;
         twin.second = (i >>> 1) & 0x1;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         super.get(index, twin);
       }
       assert twinImplementIsRight(index, twin);
@@ -268,7 +270,9 @@ public class DirectReader {
         int i = in.readShort(offset + (index >>> 2)) >>> shift;
         twin.first = i & 0x3;
         twin.second = (i >>> 2) & 0x3;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         super.get(index, twin);
       }
       assert twinImplementIsRight(index, twin);
@@ -301,7 +305,9 @@ public class DirectReader {
         int l = in.readShort(offset + (index >>> 1)) >>> shift;
         twin.first = l & 0xF;
         twin.second = (l >>> 4) & 0xF;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         super.get(index, twin);
       }
       assert twinImplementIsRight(index, twin);
@@ -332,7 +338,9 @@ public class DirectReader {
         short s = in.readShort(offset + index);
         twin.first = s & 0xFF;
         twin.second = (s >>> 8) & 0xFF;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         super.get(index, twin);
       }
       assert twinImplementIsRight(index, twin);
@@ -367,7 +375,9 @@ public class DirectReader {
         int i = in.readInt(this.offset + offset) >>> shift;
         twin.first = i & 0xFFF;
         twin.second = (i >>> 12) & 0xFFF;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         super.get(index, twin);
       }
       assert twinImplementIsRight(index, twin);
@@ -398,7 +408,9 @@ public class DirectReader {
         int i = in.readInt(offset + (index << 1));
         twin.first = i & 0xFFFF;
         twin.second = (i >>> 16) & 0xFFFF;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         super.get(index, twin);
       }
       assert twinImplementIsRight(index, twin);
@@ -433,7 +445,9 @@ public class DirectReader {
         long l = in.readLong(this.offset + offset) >>> shift;
         twin.first = l & 0xFFFFF;
         twin.second = (l >>> 20) & 0xFFFFF;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         super.get(index, twin);
       }
       assert twinImplementIsRight(index, twin);
@@ -464,7 +478,9 @@ public class DirectReader {
         long l = in.readLong(this.offset + index * 3);
         twin.first = l & 0xFFFFFF;
         twin.second = (l >>> 24) & 0xFFFFFF;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         super.get(index, twin);
       }
       assert twinImplementIsRight(index, twin);
@@ -491,6 +507,7 @@ public class DirectReader {
       }
     }
 
+    @Override
     public void get(long index, Twin twin) {
       try {
         long offset = (index * 28) >>> 3;
@@ -498,7 +515,9 @@ public class DirectReader {
         long l = in.readLong(this.offset + offset) >>> shift;
         twin.first = l & 0xFFFFFFF;
         twin.second = (l >>> 28) & 0xFFFFFFF;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         super.get(index, twin);
       }
       assert twinImplementIsRight(index, twin);
@@ -529,7 +548,9 @@ public class DirectReader {
         long l = in.readLong(this.offset + (index << 2));
         twin.first = l & 0xFFFFFFFFL;
         twin.second = (l >>> 32) & 0xFFFFFFFFL;
-      } catch (Exception e) {
+      } catch (
+          @SuppressWarnings("unused")
+          Exception e) {
         super.get(index, twin);
       }
       assert twinImplementIsRight(index, twin);

--- a/lucene/core/src/java/org/apache/lucene/util/packed/DirectReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/DirectReader.java
@@ -125,6 +125,29 @@ public class DirectReader {
         return buffer[(int) (index & MERGE_BUFFER_MASK)];
       }
 
+      @Override
+      public void get(long index, Twin twin) {
+        assert index < numValues;
+        final long blockIndex = index >>> MERGE_BUFFER_SHIFT;
+        if (this.blockIndex != blockIndex) {
+          try {
+            fillBuffer(blockIndex << MERGE_BUFFER_SHIFT);
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+          this.blockIndex = blockIndex;
+        }
+        int blockPos = (int) (index & MERGE_BUFFER_MASK);
+        if (blockPos == MERGE_BUFFER_MASK) {
+          twin.first = buffer[blockPos];
+          twin.second = get(index + 1);
+        } else {
+          twin.first = buffer[blockPos];
+          twin.second = buffer[blockPos + 1];
+        }
+        assert twinImplementIsRight(index, twin);
+      }
+
       private void fillBuffer(long index) throws IOException {
         // NOTE: we're not allowed to read more than 3 bytes past the last value
         if (index >= numValues - MERGE_BUFFER_SIZE) {
@@ -204,6 +227,19 @@ public class DirectReader {
         throw new RuntimeException(e);
       }
     }
+
+    @Override
+    public void get(long index, Twin twin) {
+      try {
+        int shift = (int) (index & 7);
+        int i = in.readShort(offset + (index >>> 3)) >>> shift;
+        twin.first = i & 0x1;
+        twin.second = (i >>> 1) & 0x1;
+      } catch (Exception e) {
+        super.get(index, twin);
+      }
+      assert twinImplementIsRight(index, twin);
+    }
   }
 
   static final class DirectPackedReader2 extends LongValues {
@@ -224,6 +260,19 @@ public class DirectReader {
         throw new RuntimeException(e);
       }
     }
+
+    @Override
+    public void get(long index, Twin twin) {
+      try {
+        int shift = ((int) (index & 3)) << 1;
+        int i = in.readShort(offset + (index >>> 2)) >>> shift;
+        twin.first = i & 0x3;
+        twin.second = (i >>> 2) & 0x3;
+      } catch (Exception e) {
+        super.get(index, twin);
+      }
+      assert twinImplementIsRight(index, twin);
+    }
   }
 
   static final class DirectPackedReader4 extends LongValues {
@@ -233,7 +282,6 @@ public class DirectReader {
     DirectPackedReader4(RandomAccessInput in, long offset) {
       this.in = in;
       this.offset = offset;
-      ;
     }
 
     @Override
@@ -244,6 +292,19 @@ public class DirectReader {
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
+    }
+
+    @Override
+    public void get(long index, Twin twin) {
+      try {
+        int shift = (int) (index & 1) << 2;
+        int l = in.readShort(offset + (index >>> 1)) >>> shift;
+        twin.first = l & 0xF;
+        twin.second = (l >>> 4) & 0xF;
+      } catch (Exception e) {
+        super.get(index, twin);
+      }
+      assert twinImplementIsRight(index, twin);
     }
   }
 
@@ -263,6 +324,18 @@ public class DirectReader {
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
+    }
+
+    @Override
+    public void get(long index, Twin twin) {
+      try {
+        short s = in.readShort(offset + index);
+        twin.first = s & 0xFF;
+        twin.second = (s >>> 8) & 0xFF;
+      } catch (Exception e) {
+        super.get(index, twin);
+      }
+      assert twinImplementIsRight(index, twin);
     }
   }
 
@@ -285,6 +358,20 @@ public class DirectReader {
         throw new RuntimeException(e);
       }
     }
+
+    @Override
+    public void get(long index, Twin twin) {
+      try {
+        long offset = (index * 12) >>> 3;
+        int shift = (int) (index & 1) << 2;
+        int i = in.readInt(this.offset + offset) >>> shift;
+        twin.first = i & 0xFFF;
+        twin.second = (i >>> 12) & 0xFFF;
+      } catch (Exception e) {
+        super.get(index, twin);
+      }
+      assert twinImplementIsRight(index, twin);
+    }
   }
 
   static final class DirectPackedReader16 extends LongValues {
@@ -303,6 +390,18 @@ public class DirectReader {
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
+    }
+
+    @Override
+    public void get(long index, Twin twin) {
+      try {
+        int i = in.readInt(offset + (index << 1));
+        twin.first = i & 0xFFFF;
+        twin.second = (i >>> 16) & 0xFFFF;
+      } catch (Exception e) {
+        super.get(index, twin);
+      }
+      assert twinImplementIsRight(index, twin);
     }
   }
 
@@ -325,6 +424,20 @@ public class DirectReader {
         throw new RuntimeException(e);
       }
     }
+
+    @Override
+    public void get(long index, Twin twin) {
+      try {
+        long offset = (index * 20) >>> 3;
+        int shift = (int) (index & 1) << 2;
+        long l = in.readLong(this.offset + offset) >>> shift;
+        twin.first = l & 0xFFFFF;
+        twin.second = (l >>> 20) & 0xFFFFF;
+      } catch (Exception e) {
+        super.get(index, twin);
+      }
+      assert twinImplementIsRight(index, twin);
+    }
   }
 
   static final class DirectPackedReader24 extends LongValues {
@@ -343,6 +456,18 @@ public class DirectReader {
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
+    }
+
+    @Override
+    public void get(long index, Twin twin) {
+      try {
+        long l = in.readLong(this.offset + index * 3);
+        twin.first = l & 0xFFFFFF;
+        twin.second = (l >>> 24) & 0xFFFFFF;
+      } catch (Exception e) {
+        super.get(index, twin);
+      }
+      assert twinImplementIsRight(index, twin);
     }
   }
 
@@ -365,6 +490,19 @@ public class DirectReader {
         throw new RuntimeException(e);
       }
     }
+
+    public void get(long index, Twin twin) {
+      try {
+        long offset = (index * 28) >>> 3;
+        int shift = (int) (index & 1) << 2;
+        long l = in.readLong(this.offset + offset) >>> shift;
+        twin.first = l & 0xFFFFFFF;
+        twin.second = (l >>> 28) & 0xFFFFFFF;
+      } catch (Exception e) {
+        super.get(index, twin);
+      }
+      assert twinImplementIsRight(index, twin);
+    }
   }
 
   static final class DirectPackedReader32 extends LongValues {
@@ -383,6 +521,18 @@ public class DirectReader {
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
+    }
+
+    @Override
+    public void get(long index, Twin twin) {
+      try {
+        long l = in.readLong(this.offset + (index << 2));
+        twin.first = l & 0xFFFFFFFFL;
+        twin.second = (l >>> 32) & 0xFFFFFFFFL;
+      } catch (Exception e) {
+        super.get(index, twin);
+      }
+      assert twinImplementIsRight(index, twin);
     }
   }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/LUCENE-10333
#11369

PS: I'm pushing these codes to quickly see if this approach makes sense to you, I'll add some more tests if this can pass the the first round review :)