### PR TITLE
Fix default alphabetSize of NFARunAutomaton

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/automaton/NFARunAutomaton.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/NFARunAutomaton.java
@@ -54,7 +54,7 @@ public class NFARunAutomaton implements ByteRunnable, TransitionAccessor {
    *     better efficiency
    */
   public NFARunAutomaton(Automaton automaton) {
-    this(automaton, Character.MAX_CODE_POINT);
+    this(automaton, Character.MAX_CODE_POINT + 1);
   }
 
   /**


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/projects/LUCENE

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>

LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

The test NFARunAutomaton is using default max codepoint as alphabet size, and the assertion `c < alphabetSize` failed, which means `c` is `MAX_CODEPOINT`

### Stacktrace
```
java.lang.AssertionError
	at __randomizedtesting.SeedInfo.seed([75637BDB16D0FDF0:1030A407D690701]:0)
	at org.apache.lucene.util.automaton.NFARunAutomaton.getCharClass(NFARunAutomaton.java:161)
	at org.apache.lucene.util.automaton.NFARunAutomaton.step(NFARunAutomaton.java:133)
	at org.apache.lucene.util.automaton.NFARunAutomaton.step(NFARunAutomaton.java:98)
	at org.apache.lucene.util.automaton.NFARunAutomaton.run(NFARunAutomaton.java:121)
	at org.apache.lucene.util.automaton.TestNFARunAutomaton.testAcceptedString(TestNFARunAutomaton.java:161)
	at org.apache.lucene.util.automaton.TestNFARunAutomaton.testWithRandomRegex(TestNFARunAutomaton.java:70)
...

NOTE: reproduce with: gradlew test --tests TestNFARunAutomaton.testWithRandomRegex -Dtests.seed=75637BDB16D0FDF0 -Dtests.multiplier=3 -Dtests.slow=true -Dtests.locale=ff-Latn-BF -Dtests.timezone=Europe/Gibraltar -Dtests.asserts=true -Dtests.file.encoding=UTF-8
NOTE: test params are: codec=Asserting(Lucene90): {field=PostingsFormat(name=LuceneVarGapDocFreqInterval)}, docValues:{}, maxPointsInLeafNode=1344, maxMBSortInHeap=6.120921628968405, sim=Asserting(RandomSimilarity(queryNorm=true): {field=org.apache.lucene.search.similarities.BooleanSimilarity@64e5ef99}), locale=ff-Latn-BF, timezone=Europe/Gibraltar
NOTE: Linux 5.11.0-41-generic amd64/Oracle Corporation 16 (64-bit)/cpus=16,threads=1,free=134519392,total=259588096
NOTE: All tests run in this JVM: [TestBKD, TestWeakIdentityMap, TestDaciukMihovAutomatonBuilder, TestCompiledAutomaton, TestNFARunAutomaton]
```
