### PR TITLE
LUCENE-10301: extract constants to TestSecrets to spare stack inspection and make code more readable

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -38,6 +38,7 @@ public final class TestSecrets {
             // initialized.
             // This only happens once. We could just leverage the JLS and invoke a static
             // method (or a constructor) on the target class but the method below seems simpler.
+            // TODO: In Java 15 there's MethodHandles.lookup().ensureInitialized(clazz)
             Class.forName(clazz.getName());
           } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -42,6 +42,7 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.TermState;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.internal.tests.IndexPackageAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.Bits;
@@ -491,6 +492,9 @@ public class AssertingLeafReader extends FilterLeafReader {
   /** Wraps a {@link ImpactsEnum} with additional checks */
   public static class AssertingImpactsEnum extends ImpactsEnum {
 
+    private static final IndexPackageAccess INDEX_PACKAGE_ACCESS =
+        TestSecrets.getIndexPackageAccess();
+
     private final AssertingPostingsEnum assertingPostings;
     private final ImpactsEnum in;
     private int lastShallowTarget = -1;
@@ -518,8 +522,7 @@ public class AssertingLeafReader extends FilterLeafReader {
       assert docID() >= 0 || lastShallowTarget >= 0
           : "Cannot get impacts until the iterator is positioned or advanceShallow has been called";
       Impacts impacts = in.getImpacts();
-      TestSecrets.getIndexPackageAccess()
-          .checkImpacts(impacts, Math.max(docID(), lastShallowTarget));
+      INDEX_PACKAGE_ACCESS.checkImpacts(impacts, Math.max(docID(), lastShallowTarget));
       return new AssertingImpacts(impacts, this);
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
@@ -38,6 +38,7 @@ import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.internal.tests.IndexPackageAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -56,6 +57,9 @@ import org.apache.lucene.util.Version;
  */
 public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTestCase {
 
+  private static final IndexPackageAccess INDEX_PACKAGE_ACCESS =
+      TestSecrets.getIndexPackageAccess();
+
   /** Test field infos read/write with a single field */
   public void testOneField() throws Exception {
     Directory dir = newDirectory();
@@ -64,8 +68,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     FieldInfo fi = createFieldInfo();
     addAttributes(fi);
 
-    FieldInfos infos =
-        TestSecrets.getIndexPackageAccess().newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
 
     codec.fieldInfosFormat().write(dir, segmentInfo, "", infos, IOContext.DEFAULT);
 
@@ -93,8 +96,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     fi.putAttribute("foo", "bar");
     fi.putAttribute("bar", "baz");
 
-    FieldInfos infos =
-        TestSecrets.getIndexPackageAccess().newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
 
     codec.fieldInfosFormat().write(dir, segmentInfo, "", infos, IOContext.DEFAULT);
 
@@ -134,8 +136,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     FieldInfo fi = createFieldInfo();
     addAttributes(fi);
 
-    FieldInfos infos =
-        TestSecrets.getIndexPackageAccess().newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
 
     fail.setDoFail();
     expectThrows(
@@ -170,8 +171,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     FieldInfo fi = createFieldInfo();
     addAttributes(fi);
 
-    FieldInfos infos =
-        TestSecrets.getIndexPackageAccess().newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
 
     fail.setDoFail();
     expectThrows(
@@ -206,8 +206,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     FieldInfo fi = createFieldInfo();
     addAttributes(fi);
 
-    FieldInfos infos =
-        TestSecrets.getIndexPackageAccess().newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
 
     codec.fieldInfosFormat().write(dir, segmentInfo, "", infos, IOContext.DEFAULT);
 
@@ -244,8 +243,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     FieldInfo fi = createFieldInfo();
     addAttributes(fi);
 
-    FieldInfos infos =
-        TestSecrets.getIndexPackageAccess().newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
 
     codec.fieldInfosFormat().write(dir, segmentInfo, "", infos, IOContext.DEFAULT);
 
@@ -278,7 +276,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     String softDeletesField =
         random().nextBoolean() ? TestUtil.randomUnicodeString(random()) : null;
 
-    var builder = TestSecrets.getIndexPackageAccess().newFieldInfosBuilder(softDeletesField);
+    var builder = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(softDeletesField);
 
     for (String field : fieldNames) {
       IndexableFieldType fieldType = randomFieldType(random());

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
@@ -72,6 +72,7 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
+import org.apache.lucene.internal.tests.IndexWriterAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.ChecksumIndexInput;
@@ -97,6 +98,8 @@ import org.apache.lucene.util.Version;
 
 /** Common tests to all index formats. */
 abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
+
+  private static final IndexWriterAccess INDEX_WRITER_ACCESS = TestSecrets.getIndexWriterAccess();
 
   // metadata or Directory-level objects
   private static final Set<Class<?>> EXCLUDED_CLASSES =
@@ -626,7 +629,7 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
           // OK: writer was closed by abort; we just reopen now:
           dir.setRandomIOExceptionRateOnOpen(
               0.0); // disable exceptions on openInput until next iteration
-          assertTrue(TestSecrets.getIndexWriterAccess().isDeleterClosed(iw));
+          assertTrue(INDEX_WRITER_ACCESS.isDeleterClosed(iw));
           assertTrue(allowAlreadyClosed);
           allowAlreadyClosed = false;
           conf = newIndexWriterConfig(analyzer);
@@ -667,7 +670,7 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
             // OK: writer was closed by abort; we just reopen now:
             dir.setRandomIOExceptionRateOnOpen(
                 0.0); // disable exceptions on openInput until next iteration
-            assertTrue(TestSecrets.getIndexWriterAccess().isDeleterClosed(iw));
+            assertTrue(INDEX_WRITER_ACCESS.isDeleterClosed(iw));
             assertTrue(allowAlreadyClosed);
             allowAlreadyClosed = false;
             conf = newIndexWriterConfig(analyzer);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseMergePolicyTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseMergePolicyTestCase.java
@@ -42,6 +42,7 @@ import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.internal.tests.IndexWriterAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -58,6 +59,8 @@ import org.apache.lucene.util.Version;
 
 /** Base test case for {@link MergePolicy}. */
 public abstract class BaseMergePolicyTestCase extends LuceneTestCase {
+
+  private static final IndexWriterAccess INDEX_WRITER_ACCESS = TestSecrets.getIndexWriterAccess();
 
   /** Create a new {@link MergePolicy} instance. */
   protected abstract MergePolicy mergePolicy();
@@ -115,7 +118,7 @@ public abstract class BaseMergePolicyTestCase extends LuceneTestCase {
         DirectoryReader.open(writer).close();
       }
       for (int i = 5; i >= 0; --i) {
-        final int segmentCount = TestSecrets.getIndexWriterAccess().getSegmentCount(writer);
+        final int segmentCount = INDEX_WRITER_ACCESS.getSegmentCount(writer);
         final int maxNumSegments = i == 0 ? 1 : TestUtil.nextInt(random(), 1, 10);
         mayMerge.set(segmentCount > maxNumSegments);
         if (VERBOSE) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BasePointsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BasePointsFormatTestCase.java
@@ -47,6 +47,7 @@ import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.internal.tests.ConcurrentMergeSchedulerAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.Directory;
@@ -66,6 +67,9 @@ import org.apache.lucene.util.NumericUtils;
  * in a given PointsFormat that this test fails to catch then this test needs to be improved!
  */
 public abstract class BasePointsFormatTestCase extends BaseIndexFileFormatTestCase {
+
+  private static final ConcurrentMergeSchedulerAccess CONCURRENT_MERGE_SCHEDULER_ACCESS =
+      TestSecrets.getConcurrentMergeSchedulerAccess();
 
   @Override
   protected void addRandomFields(Document doc) {
@@ -654,8 +658,7 @@ public abstract class BasePointsFormatTestCase extends BaseIndexFileFormatTestCa
     if (expectExceptions) {
       MergeScheduler ms = iwc.getMergeScheduler();
       if (ms instanceof ConcurrentMergeScheduler) {
-        TestSecrets.getConcurrentMergeSchedulerAccess()
-            .setSuppressExceptions((ConcurrentMergeScheduler) ms);
+        CONCURRENT_MERGE_SCHEDULER_ACCESS.setSuppressExceptions((ConcurrentMergeScheduler) ms);
       }
     }
     RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
@@ -704,8 +707,7 @@ public abstract class BasePointsFormatTestCase extends BaseIndexFileFormatTestCa
       if (expectExceptions) {
         MergeScheduler ms = iwc.getMergeScheduler();
         if (ms instanceof ConcurrentMergeScheduler) {
-          TestSecrets.getConcurrentMergeSchedulerAccess()
-              .setSuppressExceptions((ConcurrentMergeScheduler) ms);
+          CONCURRENT_MERGE_SCHEDULER_ACCESS.setSuppressExceptions((ConcurrentMergeScheduler) ms);
         }
       }
       w = new RandomIndexWriter(random(), dir, iwc);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/DocHelper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/DocHelper.java
@@ -33,6 +33,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.internal.tests.IndexWriterAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.similarities.Similarity;
@@ -42,6 +43,8 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 
 /** Helper functions for tests that handles documents */
 public class DocHelper {
+
+  private static final IndexWriterAccess INDEX_WRITER_ACCESS = TestSecrets.getIndexWriterAccess();
 
   public static final FieldType customType;
   public static final String FIELD_1_TEXT = "field one text";
@@ -298,7 +301,7 @@ public class DocHelper {
     // writer.setNoCFSRatio(0.0);
     writer.addDocument(doc);
     writer.commit();
-    SegmentCommitInfo info = TestSecrets.getIndexWriterAccess().newestSegment(writer);
+    SegmentCommitInfo info = INDEX_WRITER_ACCESS.newestSegment(writer);
     writer.close();
     return info;
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/OwnCacheKeyMultiReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/OwnCacheKeyMultiReader.java
@@ -21,17 +21,21 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiReader;
+import org.apache.lucene.internal.tests.IndexPackageAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.util.IOUtils;
 
 /** A {@link MultiReader} that has its own cache key, occasionally useful for testing purposes. */
 public final class OwnCacheKeyMultiReader extends MultiReader {
 
+  private static final IndexPackageAccess INDEX_PACKAGE_ACCESS =
+      TestSecrets.getIndexPackageAccess();
+
   private final Set<ClosedListener> readerClosedListeners = new CopyOnWriteArraySet<>();
 
   private final CacheHelper cacheHelper =
       new CacheHelper() {
-        private final CacheKey cacheKey = TestSecrets.getIndexPackageAccess().newCacheKey();
+        private final CacheKey cacheKey = INDEX_PACKAGE_ACCESS.newCacheKey();
 
         @Override
         public CacheKey getKey() {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
@@ -63,6 +63,7 @@ import org.apache.lucene.index.TermState;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.internal.tests.IndexPackageAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.Directory;
@@ -84,6 +85,8 @@ import org.apache.lucene.util.automaton.Operations;
 /** Helper class extracted from BasePostingsFormatTestCase to exercise a postings format. */
 public class RandomPostingsTester {
 
+  private static final IndexPackageAccess INDEX_PACKAGE_ACCESS =
+      TestSecrets.getIndexPackageAccess();
   private static final IntToLongFunction DOC_TO_NORM = doc -> 1 + (doc & 0x0f);
 
   /** Which features to test. */
@@ -1243,7 +1246,7 @@ public class RandomPostingsTester {
         if (doc > max) {
           impactsEnum.advanceShallow(doc);
           Impacts impacts = impactsEnum.getImpacts();
-          TestSecrets.getIndexPackageAccess().checkImpacts(impacts, doc);
+          INDEX_PACKAGE_ACCESS.checkImpacts(impacts, doc);
           impactsCopy =
               impacts.getImpacts(0).stream()
                   .map(i -> new Impact(i.freq, i.norm))
@@ -1289,7 +1292,7 @@ public class RandomPostingsTester {
 
           impactsEnum.advanceShallow(target);
           Impacts impacts = impactsEnum.getImpacts();
-          TestSecrets.getIndexPackageAccess().checkImpacts(impacts, target);
+          INDEX_PACKAGE_ACCESS.checkImpacts(impacts, target);
           impactsCopy = Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
           for (int level = 0; level < impacts.numLevels(); ++level) {
             if (impacts.getDocIdUpTo(level) >= max) {
@@ -1330,7 +1333,7 @@ public class RandomPostingsTester {
           int delta = Math.min(1 + random.nextInt(512), DocIdSetIterator.NO_MORE_DOCS - doc);
           max = doc + delta;
           Impacts impacts = impactsEnum.getImpacts();
-          TestSecrets.getIndexPackageAccess().checkImpacts(impacts, doc);
+          INDEX_PACKAGE_ACCESS.checkImpacts(impacts, doc);
           impactsCopy = Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
           for (int level = 0; level < impacts.numLevels(); ++level) {
             if (impacts.getDocIdUpTo(level) >= max) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/ThreadedIndexingAndSearchingTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/ThreadedIndexingAndSearchingTestCase.java
@@ -42,6 +42,8 @@ import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.internal.tests.IndexWriterAccess;
+import org.apache.lucene.internal.tests.SegmentReaderAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PhraseQuery;
@@ -69,6 +71,10 @@ import org.apache.lucene.util.PrintStreamInfoStream;
 
 /** Utility class that spawns multiple indexing and searching threads. */
 public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCase {
+
+  private static final IndexWriterAccess INDEX_WRITER_ACCESS = TestSecrets.getIndexWriterAccess();
+  private static final SegmentReaderAccess SEGMENT_READER_ACCESS =
+      TestSecrets.getSegmentReaderAccess();
 
   protected final AtomicBoolean failed = new AtomicBoolean();
   protected final AtomicInteger addCount = new AtomicInteger();
@@ -408,8 +414,7 @@ public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCas
                                 + " si="
                                 + segReader.getSegmentInfo(),
                             !assertMergedSegmentsWarmed
-                                || warmed.containsKey(
-                                    TestSecrets.getSegmentReaderAccess().getCore(segReader)));
+                                || warmed.containsKey(SEGMENT_READER_ACCESS.getCore(segReader)));
                       }
                     }
                     if (s.getIndexReader().numDocs() > 0) {
@@ -515,7 +520,7 @@ public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCas
           if (VERBOSE) {
             System.out.println("TEST: now warm merged reader=" + reader);
           }
-          var core = TestSecrets.getSegmentReaderAccess().getCore((SegmentReader) reader);
+          var core = SEGMENT_READER_ACCESS.getCore((SegmentReader) reader);
           warmed.put(core, Boolean.TRUE);
           final int maxDoc = reader.maxDoc();
           final Bits liveDocs = reader.getLiveDocs();
@@ -716,7 +721,7 @@ public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCas
 
     assertEquals(
         "index="
-            + TestSecrets.getIndexWriterAccess().segString(writer)
+            + INDEX_WRITER_ACCESS.segString(writer)
             + " addCount="
             + addCount
             + " delCount="
@@ -729,7 +734,7 @@ public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCas
 
     assertEquals(
         "index="
-            + TestSecrets.getIndexWriterAccess().segString(writer)
+            + INDEX_WRITER_ACCESS.segString(writer)
             + " addCount="
             + addCount
             + " delCount="

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -110,6 +110,7 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.*;
 import org.apache.lucene.index.TermsEnum.SeekStatus;
+import org.apache.lucene.internal.tests.IndexPackageAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
@@ -736,13 +737,16 @@ public abstract class LuceneTestCase extends Assert {
    * one index; call {@link #restoreIndexWriterMaxDocs} once your test is done.
    */
   public void setIndexWriterMaxDocs(int limit) {
-    TestSecrets.getIndexPackageAccess().setIndexWriterMaxDocs(limit);
+    INDEX_PACKAGE_ACCESS.setIndexWriterMaxDocs(limit);
   }
 
   /** Returns to the default {@link IndexWriter#MAX_DOCS} limit. */
   public void restoreIndexWriterMaxDocs() {
-    TestSecrets.getIndexPackageAccess().setIndexWriterMaxDocs(IndexWriter.MAX_DOCS);
+    INDEX_PACKAGE_ACCESS.setIndexWriterMaxDocs(IndexWriter.MAX_DOCS);
   }
+
+  private static final IndexPackageAccess INDEX_PACKAGE_ACCESS =
+      TestSecrets.getIndexPackageAccess();
 
   // -----------------------------------------------------------------
   // Test facilities and facades for subclasses.


### PR DESCRIPTION
Followup to cleanup TestSecrets after https://issues.apache.org/jira/browse/LUCENE-10301