### PR TITLE
LUCENE-10301: Place test-framework into separated modules folder.

### DIFF
--- a/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
+++ b/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
@@ -93,6 +93,14 @@ public class TestModularLayer {
               + modulesPath.toAbsolutePath());
     }
 
+    Path testModulesPath = Paths.get(modulesPropertyValue).resolve("modules-test-framework");
+    if (!Files.isDirectory(testModulesPath)) {
+      throw new AssertionError(
+          DISTRIBUTION_PROPERTY
+              + " property does not point to a directory where this path is present: "
+              + modulesPath.toAbsolutePath());
+    }
+
     Path thirdPartyModulesPath = Paths.get(modulesPropertyValue).resolve("modules-thirdparty");
     if (!Files.isDirectory(thirdPartyModulesPath)) {
       throw new AssertionError(
@@ -101,7 +109,7 @@ public class TestModularLayer {
               + thirdPartyModulesPath.toAbsolutePath());
     }
 
-    coreModulesFinder = ModuleFinder.of(modulesPath);
+    coreModulesFinder = ModuleFinder.of(modulesPath, testModulesPath);
     allCoreModules = coreModulesFinder.findAll();
   }
 

--- a/lucene/distribution/binary-release.gradle
+++ b/lucene/distribution/binary-release.gradle
@@ -26,6 +26,7 @@ configure(project(":lucene:distribution")) {
     docs
 
     jars
+    jarsTestFramework
     jarsThirdParty
 
     binaryDirForTests
@@ -36,13 +37,21 @@ configure(project(":lucene:distribution")) {
 
     // Maven-published submodule JARs are part of the binary distribution.
     // We don't copy their transitive dependencies.
-    def binaryModules = rootProject.ext.mavenProjects
+    def binaryModules = rootProject.ext.mavenProjects.findAll { p -> !(p in [
+      // Placed in a separate folder (module layer conflicts).
+      project(":lucene:test-framework"),
+    ]) }
     for (Project module : binaryModules) {
       jars(module, {
         transitive = false
       })
     }
 
+    // It's placed in a separate modules folder since it has service providers that are consumed by lucene-core for tests.
+    // We won't resolve it when running the Luke app.
+    jarsTestFramework(project(":lucene:test-framework"), {
+      transitive = false
+    })
 
     // The third-party JARs consist of all the transitive dependencies from these modules.
     // Not sure whether we have to include all the thirdparty JARs from across all the modules.
@@ -97,6 +106,9 @@ configure(project(":lucene:distribution")) {
     // Binary modules (Lucene).
     from(configurations.jars, {
       into 'modules'
+    })
+    from(configurations.jarsTestFramework, {
+      into 'modules-test-framework'
     })
 
     // Binary modules (with dependencies). Don't duplicate project artifacts.


### PR DESCRIPTION
test-framework module has to be placed in a separate folder in the binary distribution in order to run the Luke application.