### PR TITLE
LUCENE-10351 Correct knn search failure with deleted docs

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -236,6 +236,9 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
   @Override
   public TopDocs search(String field, float[] target, int k, Bits acceptDocs) throws IOException {
     FieldEntry fieldEntry = fields.get(field);
+    if (fieldEntry == null || fieldEntry.dimension == 0) {
+      return null;
+    }
     if (fieldEntry.size() == 0) {
       return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -239,6 +239,9 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
     if (fieldEntry == null || fieldEntry.dimension == 0) {
       return null;
     }
+    if (fieldEntry.size() == 0) {
+      return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+    }
 
     // bound k by total number of vectors to prevent oversizing data structures
     k = Math.min(k, fieldEntry.size());

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -236,9 +236,6 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
   @Override
   public TopDocs search(String field, float[] target, int k, Bits acceptDocs) throws IOException {
     FieldEntry fieldEntry = fields.get(field);
-    if (fieldEntry == null || fieldEntry.dimension == 0) {
-      return null;
-    }
     if (fieldEntry.size() == 0) {
       return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -42,6 +42,8 @@ import org.apache.lucene.index.RandomAccessVectorValuesProducer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnVectorQuery;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
@@ -559,6 +561,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         VectorValues values = getOnlyLeafReader(r).getVectorValues("v");
         assertNotNull(values);
         assertEquals(0, values.size());
+
+        // assert that knn search doesn't fail on a field with all deleted docs
+        IndexSearcher searcher = newSearcher(r);
+        KnnVectorQuery query = new KnnVectorQuery("v", randomVector(3), 1);
+        TopDocs results = searcher.search(query, 1);
+        assertEquals(0, results.scoreDocs.length);
       }
     }
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -569,29 +569,6 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     }
   }
 
-  public void testNonVectorField() throws IOException {
-    try (Directory dir = newDirectory();
-        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
-      Document doc = new Document();
-      doc.add(new StringField("id", "0", Field.Store.NO));
-      w.addDocument(doc);
-      w.commit();
-
-      try (DirectoryReader r = DirectoryReader.open(w)) {
-        LeafReader leafReader = getOnlyLeafReader(r);
-        // knn search on non-vector field returns null
-        TopDocs results =
-            leafReader.searchNearestVectors("id", randomVector(3), 1, leafReader.getLiveDocs());
-        assertNull(results);
-        // knn search on non-existent field returns null
-        TopDocs results2 =
-            leafReader.searchNearestVectors(
-                "non-existent", randomVector(3), 1, leafReader.getLiveDocs());
-        assertNull(results2);
-      }
-    }
-  }
-
   public void testKnnVectorFieldMissingFromOneSegment() throws Exception {
     try (Directory dir = FSDirectory.open(createTempDir());
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -569,6 +569,29 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     }
   }
 
+  public void testNonVectorField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      Document doc = new Document();
+      doc.add(new StringField("id", "0", Field.Store.NO));
+      w.addDocument(doc);
+      w.commit();
+
+      try (DirectoryReader r = DirectoryReader.open(w)) {
+        LeafReader leafReader = getOnlyLeafReader(r);
+        // knn search on non-vector field returns null
+        TopDocs results =
+            leafReader.searchNearestVectors("id", randomVector(3), 1, leafReader.getLiveDocs());
+        assertNull(results);
+        // knn search on non-existent field returns null
+        TopDocs results2 =
+            leafReader.searchNearestVectors(
+                "non-existent", randomVector(3), 1, leafReader.getLiveDocs());
+        assertNull(results2);
+      }
+    }
+  }
+
   public void testKnnVectorFieldMissingFromOneSegment() throws Exception {
     try (Directory dir = FSDirectory.open(createTempDir());
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {


### PR DESCRIPTION
Currently when doing knn search on an segment where all documents
with knn field were deleted, we get the following error:

```
maxSize must be > 0 and < 2147483630; got: 0
java.lang.IllegalArgumentException: maxSize must be > 0 and < 2147483630; got: 0
	at __randomizedtesting.SeedInfo.seed([43F1F124D7076A4E:1B860BFCCB9B0BB5]:0)
	at org.apache.lucene.util.LongHeap.<init>(LongHeap.java:57)
	at org.apache.lucene.util.LongHeap$1.<init>(LongHeap.java:69)
	at org.apache.lucene.util.LongHeap.create(LongHeap.java:69)
	at org.apache.lucene.util.hnsw.NeighborQueue.<init>(NeighborQueue.java:41)
	at org.apache.lucene.util.hnsw.HnswGraph.search(HnswGraph.java:105)#
```

This patch fixes this error and ensures empty TopDocs are returned when
knn field doesn't have any documents left.