### PR TITLE
LUCENE-10348: Make stopwords resources from analyzers modules visible to ClasspathResourceLoader and ModuleResourceLoader

### DIFF
--- a/lucene/analysis/common/src/java/module-info.java
+++ b/lucene/analysis/common/src/java/module-info.java
@@ -89,6 +89,61 @@ module org.apache.lucene.analysis.common {
   exports org.tartarus.snowball.ext;
   exports org.tartarus.snowball;
 
+  opens org.apache.lucene.analysis.ar to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.bg to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.bn to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.br to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.ca to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.cjk to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.ckb to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.cz to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.el to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.et to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.eu to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.fa to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.ga to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.gl to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.hi to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.hy to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.id to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.lt to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.lv to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.ne to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.ro to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.snowball to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.sr to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.ta to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.te to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.th to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.tr to
+      org.apache.lucene.core;
+
   provides org.apache.lucene.analysis.CharFilterFactory with
       org.apache.lucene.analysis.charfilter.HTMLStripCharFilterFactory,
       org.apache.lucene.analysis.charfilter.MappingCharFilterFactory,

--- a/lucene/analysis/icu/src/java/module-info.java
+++ b/lucene/analysis/icu/src/java/module-info.java
@@ -26,6 +26,9 @@ module org.apache.lucene.analysis.icu {
   exports org.apache.lucene.analysis.icu.segmentation;
   exports org.apache.lucene.analysis.icu.tokenattributes;
 
+  opens org.apache.lucene.analysis.icu.segmentation to
+      org.apache.lucene.core;
+
   provides org.apache.lucene.analysis.CharFilterFactory with
       org.apache.lucene.analysis.icu.ICUNormalizer2CharFilterFactory;
   provides org.apache.lucene.analysis.TokenizerFactory with

--- a/lucene/analysis/kuromoji/src/java/module-info.java
+++ b/lucene/analysis/kuromoji/src/java/module-info.java
@@ -26,6 +26,11 @@ module org.apache.lucene.analysis.kuromoji {
   exports org.apache.lucene.analysis.ja.tokenattributes;
   exports org.apache.lucene.analysis.ja.util;
 
+  opens org.apache.lucene.analysis.ja to
+      org.apache.lucene.core;
+  opens org.apache.lucene.analysis.ja.completion to
+      org.apache.lucene.core;
+
   provides org.apache.lucene.analysis.CharFilterFactory with
       org.apache.lucene.analysis.ja.JapaneseIterationMarkCharFilterFactory;
   provides org.apache.lucene.analysis.TokenizerFactory with

--- a/lucene/analysis/morfologik/src/java/module-info.java
+++ b/lucene/analysis/morfologik/src/java/module-info.java
@@ -27,6 +27,9 @@ module org.apache.lucene.analysis.morfologik {
   exports org.apache.lucene.analysis.morfologik;
   exports org.apache.lucene.analysis.uk;
 
+  opens org.apache.lucene.analysis.uk to
+      org.apache.lucene.core;
+
   provides org.apache.lucene.analysis.TokenFilterFactory with
       org.apache.lucene.analysis.morfologik.MorfologikFilterFactory;
 }

--- a/lucene/analysis/smartcn/src/java/module-info.java
+++ b/lucene/analysis/smartcn/src/java/module-info.java
@@ -23,6 +23,9 @@ module org.apache.lucene.analysis.smartcn {
   exports org.apache.lucene.analysis.cn.smart;
   exports org.apache.lucene.analysis.cn.smart.hhmm;
 
+  opens org.apache.lucene.analysis.cn.smart to
+      org.apache.lucene.core;
+
   provides org.apache.lucene.analysis.TokenizerFactory with
       org.apache.lucene.analysis.cn.smart.HMMChineseTokenizerFactory;
 }

--- a/lucene/analysis/stempel/src/java/module-info.java
+++ b/lucene/analysis/stempel/src/java/module-info.java
@@ -24,6 +24,9 @@ module org.apache.lucene.analysis.stempel {
   exports org.apache.lucene.analysis.stempel;
   exports org.egothor.stemmer;
 
+  opens org.apache.lucene.analysis.pl to
+      org.apache.lucene.core;
+
   provides org.apache.lucene.analysis.TokenFilterFactory with
       org.apache.lucene.analysis.stempel.StempelPolishStemFilterFactory;
 }

--- a/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
+++ b/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
@@ -296,7 +296,7 @@ public class TestModularLayer {
       }
 
       Assertions.assertThat(moduleExports)
-          .as("Packages in module: " + module.descriptor().name())
+          .as("Exported packages in module: " + module.descriptor().name())
           .allSatisfy(
               export -> {
                 Assertions.assertThat(export.targets())
@@ -324,7 +324,7 @@ public class TestModularLayer {
       Set<ModuleDescriptor.Opens> moduleOpens = module.descriptor().opens();
 
       Assertions.assertThat(moduleOpens)
-          .as("Packages in module: " + module.descriptor().name())
+          .as("Open packages in module: " + module.descriptor().name())
           .allSatisfy(
               export -> {
                 Assertions.assertThat(export.targets())


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/LUCENE-10348

For now I made the distribution test assert that all analysis modules open up all packages to lucene core if they contain at least one of those file types:
- stopwords (*.txt)
- ICU break iterator files (*.brk)

Those are the only files that can be used from within CustomAnalyzer. All others are hardcoded statically (like kuromoji dictionaries or stemmer files).