### PR TITLE
Fix testMinimalCodec

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/codecs/TestMinimalCodec.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/TestMinimalCodec.java
@@ -49,6 +49,8 @@ public class TestMinimalCodec extends LuceneTestCase {
               .setCodec(useCompoundFile ? new MinimalCompoundCodec() : new MinimalCodec())
               .setUseCompoundFile(useCompoundFile);
       if (!useCompoundFile) {
+        // Avoid using MockMP as it randomly enables compound file creation
+        writerConfig.setMergePolicy(newMergePolicy(random(), false));
         writerConfig.getMergePolicy().setNoCFSRatio(0.0);
         writerConfig.getMergePolicy().setMaxCFSSegmentSizeMB(Double.POSITIVE_INFINITY);
       }


### PR DESCRIPTION
Follow-up to LUCENE-10291

This test was occasionally [failing on CI](https://elasticsearch-ci.elastic.co/job/apache+lucene+branch_9x/lastCompletedBuild/testReport/org.apache.lucene.codecs/TestMinimalCodec/testMinimalCodec/), as the test randomly installed a merge policy
that would force compound file creation while the goal of the test was not to do so.

Apologies for the noise.