### PR TITLE
LUCENE-10372: Performance of TaxoFacets in Nightly benchmark decreased, revert LUCENE-10350

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -154,8 +154,6 @@ Optimizations
 
 * LUCENE-10346: Optimize facet counting for single-valued TaxonomyFacetCounts. (Guo Feng)
 
-* LUCENE-10350: Avoid some duplicate null check in facet counting for TaxonomyFacetCounts. (Guo Feng)
-
 * LUCENE-10356: Further optimize facet counting for single-valued TaxonomyFacetCounts. (Greg Miller)
 
 Changes in runtime behavior

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
@@ -84,27 +84,13 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
           ConjunctionUtils.intersectIterators(Arrays.asList(hits.bits.iterator(), valuesIt));
 
       if (singleValued != null) {
-        if (values != null) {
-          while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            values[(int) singleValued.longValue()]++;
-          }
-        } else {
-          while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            sparseValues.addTo((int) singleValued.longValue(), 1);
-          }
+        while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+          increment((int) singleValued.longValue());
         }
       } else {
-        if (values != null) {
-          while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            for (int i = 0; i < multiValued.docValueCount(); i++) {
-              values[(int) multiValued.nextValue()]++;
-            }
-          }
-        } else {
-          while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            for (int i = 0; i < multiValued.docValueCount(); i++) {
-              sparseValues.addTo((int) multiValued.nextValue(), 1);
-            }
+        while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+          for (int i = 0; i < multiValued.docValueCount(); i++) {
+            increment((int) multiValued.nextValue());
           }
         }
       }
@@ -113,8 +99,7 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
     rollup();
   }
 
-  private final void countAll(IndexReader reader) throws IOException {
-    assert values != null;
+  private void countAll(IndexReader reader) throws IOException {
     for (LeafReaderContext context : reader.leaves()) {
       SortedNumericDocValues multiValued =
           context.reader().getSortedNumericDocValues(indexFieldName);
@@ -123,41 +108,28 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
       }
 
       Bits liveDocs = context.reader().getLiveDocs();
-      NumericDocValues singleValued = DocValues.unwrapSingleton(multiValued);
 
+      NumericDocValues singleValued = DocValues.unwrapSingleton(multiValued);
       if (singleValued != null) {
-        if (liveDocs == null) {
-          while (singleValued.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            values[(int) singleValued.longValue()]++;
+        for (int doc = singleValued.nextDoc();
+            doc != DocIdSetIterator.NO_MORE_DOCS;
+            doc = singleValued.nextDoc()) {
+          if (liveDocs != null && liveDocs.get(doc) == false) {
+            continue;
           }
-        } else {
-          for (int doc = singleValued.nextDoc();
-              doc != DocIdSetIterator.NO_MORE_DOCS;
-              doc = singleValued.nextDoc()) {
-            if (liveDocs.get(doc)) {
-              values[(int) singleValued.longValue()]++;
-            }
-          }
+          increment((int) singleValued.longValue());
         }
-      } else {
-        if (liveDocs == null) {
-          while (multiValued.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            final int dvCount = multiValued.docValueCount();
-            for (int i = 0; i < dvCount; i++) {
-              values[(int) multiValued.nextValue()]++;
-            }
-          }
-        } else {
-          for (int doc = multiValued.nextDoc();
-              doc != DocIdSetIterator.NO_MORE_DOCS;
-              doc = multiValued.nextDoc()) {
-            if (liveDocs.get(doc)) {
-              final int dvCount = multiValued.docValueCount();
-              for (int i = 0; i < dvCount; i++) {
-                values[(int) multiValued.nextValue()]++;
-              }
-            }
-          }
+        continue;
+      }
+
+      for (int doc = multiValued.nextDoc();
+          doc != DocIdSetIterator.NO_MORE_DOCS;
+          doc = multiValued.nextDoc()) {
+        if (liveDocs != null && liveDocs.get(doc) == false) {
+          continue;
+        }
+        for (int i = 0; i < multiValued.docValueCount(); i++) {
+          increment((int) multiValued.nextValue());
         }
       }
     }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
@@ -31,21 +31,10 @@ import org.apache.lucene.facet.TopOrdAndIntQueue;
 /** Base class for all taxonomy-based facets that aggregate to a per-ords int[]. */
 public abstract class IntTaxonomyFacets extends TaxonomyFacets {
 
-  /**
-   * Dense ordinal values.
-   *
-   * <p>We are making this and {@link #sparseValues} protected for some expert usage. e.g. It can be
-   * checked which is being used before a loop instead of calling {@link #increment} for each
-   * iteration.
-   */
-  protected final int[] values;
+  /** Per-ordinal value. */
+  private final int[] values;
 
-  /**
-   * Sparse ordinal values.
-   *
-   * @see #values for why protected.
-   */
-  protected final IntIntHashMap sparseValues;
+  private final IntIntHashMap sparseValues;
 
   /** Sole constructor. */
   protected IntTaxonomyFacets(


### PR DESCRIPTION
link: https://home.apache.org/~mikemccand/lucenebench/2022.01.10.18.03.12.html
```
BrowseDayOfYearTaxoFacets	7.6	(12.1%)	6.3	(26.7%)	0.8 X	0.010
BrowseDateTaxoFacets	        7.6	(11.9%)	6.3	(26.4%)	0.8 X	0.010
BrowseRandomLabelTaxoFacets	6.4	(7.5%)	5.7	(16.2%)	0.9 X	0.004

BrowseMonthTaxoFacets	        6.6	(2.6%)	8.2	(87.0%)	1.2 X	0.218
```
It should be related to https://issues.apache.org/jira/browse/LUCENE-10350, so revert it.