### PR TITLE
LUCENE-10368: Mark IntTaxonomyFacets as deprecated

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -26,8 +26,11 @@ API Changes
 * LUCENE-10349: WordListLoader methods now return unmodifiable CharArraySets.  (Uwe Schindler)
 
 * LUCENE-10377: SortField.getComparator() has changed signature. The second parameter is now
-  a boolean indicating whether or not skipping should be enabled on the comparator. 
+  a boolean indicating whether or not skipping should be enabled on the comparator.
   (Alan Woodward)
+
+* LUCENE-10368: IntTaxonomyFacets has been deprecated and is no longer a supported extension point
+  for user-created faceting implementations. (Greg Miller)
 
 New Features
 ---------------------

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
@@ -28,7 +28,16 @@ import org.apache.lucene.facet.FacetsConfig.DimConfig;
 import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.facet.TopOrdAndIntQueue;
 
-/** Base class for all taxonomy-based facets that aggregate to a per-ords int[]. */
+/**
+ * Base class for all taxonomy-based facets that aggregate to a per-ords int[].
+ *
+ * @deprecated Visibility of this class will be reduced to pkg-private in a future version. This
+ *     class is meant to host common code as an internal implementation detail to {@link
+ *     FastTaxonomyFacetCounts} and {@link TaxonomyFacetSumIntAssociations},and is not intended as
+ *     an extension point for user-created {@code Facets} implementations. If your code is relying
+ *     on this, please migrate necessary functionality down into your own class.
+ */
+@Deprecated
 public abstract class IntTaxonomyFacets extends TaxonomyFacets {
 
   /**


### PR DESCRIPTION
# Description

IntTaxonomyFacets is intended as an internal implementation detail but has public visibility, so could also be serving as an extension point for user-created faceting implementations. We want to migrate this to pkg-private. The first step is marking it `deprecated` in 9.x.

# Solution

Add `@Deprecated` tag and javadoc.

# Tests

N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
