### PR TITLE
LUCENE-10375: Write merged vectors to file before building graph

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -156,6 +156,9 @@ Optimizations
 
 * LUCENE-10356: Further optimize facet counting for single-valued TaxonomyFacetCounts. (Greg Miller)
 
+* LUCENE-10375: Speed up HNSW vectors merge by first writing combined vector
+  data to a file. (Julie Tibshirani, Adrien Grand)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -140,7 +140,7 @@ public abstract class KnnVectorsWriter implements Closeable {
    * reverse ordinal mapping for documents having values in order to support random access by dense
    * ordinal.
    */
-  private static class VectorValuesMerger extends VectorValues
+  public static class VectorValuesMerger extends VectorValues
       implements RandomAccessVectorValuesProducer {
     private final List<VectorValuesSub> subs;
     private final DocIDMerger<VectorValuesSub> docIdMerger;
@@ -156,7 +156,7 @@ public abstract class KnnVectorsWriter implements Closeable {
     private int[] ordMap;
     private int ord;
 
-    static VectorValuesMerger mergeVectorValues(FieldInfo fieldInfo, MergeState mergeState)
+    public static VectorValuesMerger mergeVectorValues(FieldInfo fieldInfo, MergeState mergeState)
         throws IOException {
       List<VectorValuesSub> subs = new ArrayList<>();
       int dimension = -1;

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -49,7 +49,7 @@ public abstract class KnnVectorsWriter implements Closeable {
   public abstract void finish() throws IOException;
 
   /** Merge the vector values from multiple segments, for all fields */
-  public void merge(MergeState mergeState) throws IOException {
+  public final void merge(MergeState mergeState) throws IOException {
     for (int i = 0; i < mergeState.fieldInfos.length; i++) {
       KnnVectorsReader reader = mergeState.knnVectorsReaders[i];
       assert reader != null || mergeState.fieldInfos[i].hasVectorValues() == false;
@@ -59,14 +59,18 @@ public abstract class KnnVectorsWriter implements Closeable {
     }
     for (FieldInfo fieldInfo : mergeState.mergeFieldInfos) {
       if (fieldInfo.hasVectorValues()) {
-        mergeVectors(fieldInfo, mergeState);
+        mergeField(fieldInfo, mergeState);
       }
     }
     finish();
   }
 
-  private void mergeVectors(FieldInfo mergeFieldInfo, final MergeState mergeState)
-      throws IOException {
+  /**
+   * Merges the vectors for the field specified in {@code mergeFieldInfo}. The default
+   * implementation calls {@link #writeField}, passing a {@link KnnVectorsReader} that combines the
+   * vector values and ignores deleted documents.
+   */
+  public void mergeField(FieldInfo mergeFieldInfo, final MergeState mergeState) throws IOException {
     if (mergeState.infoStream.isEnabled("VV")) {
       mergeState.infoStream.message("VV", "merging " + mergeState.segmentInfo);
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -43,9 +43,9 @@ public abstract class KnnVectorsWriter implements Closeable {
   public abstract void finish() throws IOException;
 
   /**
-   * Merges the segment vectors for all fields. across all fields. This default implementation
-   * delegates to {@link #writeField}, passing a {@link KnnVectorsReader} that combines the vector
-   * values and ignores deleted documents.
+   * Merges the segment vectors for all fields. This default implementation delegates to {@link
+   * #writeField}, passing a {@link KnnVectorsReader} that combines the vector values and ignores
+   * deleted documents.
    */
   public void merge(MergeState mergeState) throws IOException {
     for (int i = 0; i < mergeState.fieldInfos.length; i++) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -131,6 +131,7 @@ public abstract class KnnVectorsWriter implements Closeable {
     private int docId;
     private VectorValuesSub current;
 
+    /** Returns a merged view over all the segment's {@link VectorValues}. */
     public static MergedVectorValues mergeVectorValues(FieldInfo fieldInfo, MergeState mergeState)
         throws IOException {
       assert fieldInfo != null && fieldInfo.hasVectorValues();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -271,7 +271,7 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
   private OffHeapVectorValues getOffHeapVectorValues(FieldEntry fieldEntry) throws IOException {
     IndexInput bytesSlice =
         vectorData.slice("vector-data", fieldEntry.vectorDataOffset, fieldEntry.vectorDataLength);
-    return new OffHeapVectorValues(fieldEntry, bytesSlice);
+    return new OffHeapVectorValues(fieldEntry.dimension, fieldEntry.ordToDoc, bytesSlice);
   }
 
   private Bits getAcceptOrds(Bits acceptDocs, FieldEntry fieldEntry) {
@@ -354,10 +354,11 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
   }
 
   /** Read the vector values from the index input. This supports both iterated and random access. */
-  private static class OffHeapVectorValues extends VectorValues
+  public static class OffHeapVectorValues extends VectorValues
       implements RandomAccessVectorValues, RandomAccessVectorValuesProducer {
 
-    final FieldEntry fieldEntry;
+    final int dimension;
+    final int[] ordToDoc;
     final IndexInput dataIn;
 
     final BytesRef binaryValue;
@@ -368,23 +369,25 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
     int ord = -1;
     int doc = -1;
 
-    OffHeapVectorValues(FieldEntry fieldEntry, IndexInput dataIn) {
-      this.fieldEntry = fieldEntry;
+    OffHeapVectorValues(int dimension, int[] ordToDoc, IndexInput dataIn) {
+      this.dimension = dimension;
+      this.ordToDoc = ordToDoc;
       this.dataIn = dataIn;
-      byteSize = Float.BYTES * fieldEntry.dimension;
+
+      byteSize = Float.BYTES * dimension;
       byteBuffer = ByteBuffer.allocate(byteSize);
-      value = new float[fieldEntry.dimension];
+      value = new float[dimension];
       binaryValue = new BytesRef(byteBuffer.array(), byteBuffer.arrayOffset(), byteSize);
     }
 
     @Override
     public int dimension() {
-      return fieldEntry.dimension;
+      return dimension;
     }
 
     @Override
     public int size() {
-      return fieldEntry.size();
+      return ordToDoc.length;
     }
 
     @Override
@@ -411,7 +414,7 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
       if (++ord >= size()) {
         doc = NO_MORE_DOCS;
       } else {
-        doc = fieldEntry.ordToDoc[ord];
+        doc = ordToDoc[ord];
       }
       return doc;
     }
@@ -419,27 +422,27 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
     @Override
     public int advance(int target) {
       assert docID() < target;
-      ord = Arrays.binarySearch(fieldEntry.ordToDoc, ord + 1, fieldEntry.ordToDoc.length, target);
+      ord = Arrays.binarySearch(ordToDoc, ord + 1, ordToDoc.length, target);
       if (ord < 0) {
         ord = -(ord + 1);
       }
-      assert ord <= fieldEntry.ordToDoc.length;
-      if (ord == fieldEntry.ordToDoc.length) {
+      assert ord <= ordToDoc.length;
+      if (ord == ordToDoc.length) {
         doc = NO_MORE_DOCS;
       } else {
-        doc = fieldEntry.ordToDoc[ord];
+        doc = ordToDoc[ord];
       }
       return doc;
     }
 
     @Override
     public long cost() {
-      return fieldEntry.size();
+      return ordToDoc.length;
     }
 
     @Override
     public RandomAccessVectorValues randomAccess() {
-      return new OffHeapVectorValues(fieldEntry, dataIn.clone());
+      return new OffHeapVectorValues(dimension, ordToDoc, dataIn.clone());
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
@@ -163,7 +163,7 @@ public final class Lucene90HnswVectorsWriter extends KnnVectorsWriter {
     long vectorDataOffset = vectorData.getFilePointer();
 
     // write the merged vector data to a temporary file
-    VectorValues vectors = VectorValuesMerger.mergeVectorValues(fieldInfo, mergeState);
+    VectorValues vectors = MergedVectorValues.mergeVectorValues(fieldInfo, mergeState);
     IndexOutput tempVectorData =
         segmentWriteState.directory.createTempOutput(
             vectorData.getName(), "temp", segmentWriteState.context);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
@@ -149,7 +149,30 @@ public final class Lucene90HnswVectorsWriter extends KnnVectorsWriter {
   }
 
   @Override
-  public void mergeField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+  public void merge(MergeState mergeState) throws IOException {
+    for (int i = 0; i < mergeState.fieldInfos.length; i++) {
+      KnnVectorsReader reader = mergeState.knnVectorsReaders[i];
+      assert reader != null || mergeState.fieldInfos[i].hasVectorValues() == false;
+      if (reader != null) {
+        reader.checkIntegrity();
+      }
+    }
+
+    for (FieldInfo fieldInfo : mergeState.mergeFieldInfos) {
+      if (fieldInfo.hasVectorValues()) {
+        if (mergeState.infoStream.isEnabled("VV")) {
+          mergeState.infoStream.message("VV", "merging " + mergeState.segmentInfo);
+        }
+        mergeField(fieldInfo, mergeState);
+        if (mergeState.infoStream.isEnabled("VV")) {
+          mergeState.infoStream.message("VV", "merge done " + mergeState.segmentInfo);
+        }
+      }
+    }
+    finish();
+  }
+
+  private void mergeField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
     if (mergeState.infoStream.isEnabled("VV")) {
       mergeState.infoStream.message("VV", "merging " + mergeState.segmentInfo);
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
@@ -188,13 +188,15 @@ public final class Lucene90HnswVectorsWriter extends KnnVectorsWriter {
     try {
       // write the merged vector data to a temporary file
       int[] docIds = writeVectorData(tempVectorData, vectors);
+      CodecUtil.writeFooter(tempVectorData);
       IOUtils.close(tempVectorData);
 
       // copy the temporary file vectors to the actual data file
       vectorDataInput =
           segmentWriteState.directory.openInput(
               tempVectorData.getName(), segmentWriteState.context);
-      vectorData.copyBytes(vectorDataInput, vectorDataInput.length());
+      vectorData.copyBytes(vectorDataInput, vectorDataInput.length() - CodecUtil.footerLength());
+      CodecUtil.retrieveChecksum(vectorDataInput);
 
       // build the graph using the temporary vector data
       Lucene90HnswVectorsReader.OffHeapVectorValues offHeapVectors =

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
@@ -227,7 +227,6 @@ public final class Lucene90HnswVectorsWriter extends KnnVectorsWriter {
       IOUtils.close(vectorDataInput);
       if (success) {
         segmentWriteState.directory.deleteFile(tempVectorData.getName());
-        IOUtils.closeWhileHandlingException(tempVectorData);
       } else {
         IOUtils.closeWhileHandlingException(tempVectorData);
         IOUtils.deleteFilesIgnoringExceptions(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90HnswVectorsWriter.java
@@ -113,8 +113,7 @@ public final class Lucene90HnswVectorsWriter extends KnnVectorsWriter {
   @Override
   public void writeField(FieldInfo fieldInfo, KnnVectorsReader knnVectorsReader)
       throws IOException {
-    writeVectorDataPadding();
-    long vectorDataOffset = vectorData.getFilePointer();
+    long vectorDataOffset = vectorData.alignFilePointer(Float.BYTES);
 
     VectorValues vectors = knnVectorsReader.getVectorValues(fieldInfo.name);
     // TODO - use a better data structure; a bitset? DocsWithFieldSet is p.p. in o.a.l.index
@@ -159,8 +158,7 @@ public final class Lucene90HnswVectorsWriter extends KnnVectorsWriter {
       mergeState.infoStream.message("VV", "merging " + mergeState.segmentInfo);
     }
 
-    writeVectorDataPadding();
-    long vectorDataOffset = vectorData.getFilePointer();
+    long vectorDataOffset = vectorData.alignFilePointer(Float.BYTES);
 
     // write the merged vector data to a temporary file
     VectorValues vectors = MergedVectorValues.mergeVectorValues(fieldInfo, mergeState);
@@ -209,16 +207,6 @@ public final class Lucene90HnswVectorsWriter extends KnnVectorsWriter {
     writeGraphOffsets(meta, offsets);
     if (mergeState.infoStream.isEnabled("VV")) {
       mergeState.infoStream.message("VV", "merge done " + mergeState.segmentInfo);
-    }
-  }
-
-  private void writeVectorDataPadding() throws IOException {
-    long pos = vectorData.getFilePointer();
-    // write floats aligned at 4 bytes. This will not survive CFS, but it shows a small benefit when
-    // CFS is not used, eg for larger indexes
-    long padding = (4 - (pos & 0x3)) & 0x3;
-    for (int i = 0; i < padding; i++) {
-      vectorData.writeByte((byte) 0);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
@@ -27,6 +27,7 @@ import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.VectorValues;
@@ -101,6 +102,11 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
     public void writeField(FieldInfo fieldInfo, KnnVectorsReader knnVectorsReader)
         throws IOException {
       getInstance(fieldInfo).writeField(fieldInfo, knnVectorsReader);
+    }
+
+    @Override
+    public void mergeField(FieldInfo mergeFieldInfo, MergeState mergeState) throws IOException {
+      getInstance(mergeFieldInfo).mergeField(mergeFieldInfo, mergeState);
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
@@ -179,9 +179,11 @@ public class TestPerFieldKnnVectorsFormat extends BaseKnnVectorsFormatTestCase {
         }
 
         @Override
-        public void mergeField(FieldInfo mergeFieldInfo, MergeState mergeState) throws IOException {
-          fieldsWritten.add(mergeFieldInfo.name);
-          writer.mergeField(mergeFieldInfo, mergeState);
+        public void merge(MergeState mergeState) throws IOException {
+          for (FieldInfo fieldInfo : mergeState.mergeFieldInfos) {
+            fieldsWritten.add(fieldInfo.name);
+          }
+          writer.merge(mergeState);
         }
 
         @Override

--- a/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
@@ -36,6 +36,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
@@ -175,6 +176,12 @@ public class TestPerFieldKnnVectorsFormat extends BaseKnnVectorsFormatTestCase {
             throws IOException {
           fieldsWritten.add(fieldInfo.name);
           writer.writeField(fieldInfo, knnVectorsReader);
+        }
+
+        @Override
+        public void mergeField(FieldInfo mergeFieldInfo, MergeState mergeState) throws IOException {
+          fieldsWritten.add(mergeFieldInfo.name);
+          writer.mergeField(mergeFieldInfo, mergeState);
         }
 
         @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
@@ -71,9 +71,8 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
     }
 
     @Override
-    public void mergeField(FieldInfo mergeFieldInfo, MergeState mergeState) throws IOException {
-      assert mergeFieldInfo != null;
-      delegate.mergeField(mergeFieldInfo, mergeState);
+    public void merge(MergeState mergeState) throws IOException {
+      delegate.merge(mergeState);
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
@@ -23,6 +23,7 @@ import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.VectorValues;
@@ -67,6 +68,12 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
       assert knnVectorsReader.getVectorValues(fieldInfo.name)
           != knnVectorsReader.getVectorValues(fieldInfo.name);
       delegate.writeField(fieldInfo, knnVectorsReader);
+    }
+
+    @Override
+    public void mergeField(FieldInfo mergeFieldInfo, MergeState mergeState) throws IOException {
+      assert mergeFieldInfo != null;
+      delegate.mergeField(mergeFieldInfo, mergeState);
     }
 
     @Override


### PR DESCRIPTION
When merging segments together, the `KnnVectorsWriter` creates a `VectorValues`
instance with a merged view of all the segments' vectors. This merged instance
is used when constructing the new HNSW graph. Graph building needs random
access, and the merged VectorValues support this by mapping from merged
ordinals to segments and segment ordinals. This mapping can add significant
overhead when building the graph.

This change updates the HNSW merging logic to first write the combined segment
vectors to a file, then use that the file to build the graph. This helps speed
up segment merging, and also lets us simplify `VectorValuesMerger`, which
provides the merged view of vector values.