### PR TITLE
revert LUCENE-10350

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -116,8 +116,6 @@ Optimizations
 
 * LUCENE-10346: Optimize facet counting for single-valued TaxonomyFacetCounts. (Guo Feng)
 
-* LUCENE-10350: Avoid some duplicate null check in facet counting for TaxonomyFacetCounts. (Guo Feng)
-
 * LUCENE-10356: Further optimize facet counting for single-valued TaxonomyFacetCounts. (Greg Miller)
 
 Changes in runtime behavior

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
@@ -70,7 +70,7 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
     countAll(reader);
   }
 
-  private void count(List<MatchingDocs> matchingDocs) throws IOException {
+  private final void count(List<MatchingDocs> matchingDocs) throws IOException {
     for (MatchingDocs hits : matchingDocs) {
       SortedNumericDocValues multiValued =
           FacetUtils.loadOrdinalValues(hits.context.reader(), indexFieldName);

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
@@ -85,27 +85,13 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
           ConjunctionUtils.intersectIterators(Arrays.asList(hits.bits.iterator(), valuesIt));
 
       if (singleValued != null) {
-        if (values != null) {
-          while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            values[(int) singleValued.longValue()]++;
-          }
-        } else {
-          while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            sparseValues.addTo((int) singleValued.longValue(), 1);
-          }
+        while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+          increment((int) singleValued.longValue());
         }
       } else {
-        if (values != null) {
-          while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            for (int i = 0; i < multiValued.docValueCount(); i++) {
-              values[(int) multiValued.nextValue()]++;
-            }
-          }
-        } else {
-          while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            for (int i = 0; i < multiValued.docValueCount(); i++) {
-              sparseValues.addTo((int) multiValued.nextValue(), 1);
-            }
+        while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+          for (int i = 0; i < multiValued.docValueCount(); i++) {
+            increment((int) multiValued.nextValue());
           }
         }
       }
@@ -115,7 +101,6 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
   }
 
   private final void countAll(IndexReader reader) throws IOException {
-    assert values != null;
     for (LeafReaderContext context : reader.leaves()) {
       SortedNumericDocValues multiValued =
           FacetUtils.loadOrdinalValues(context.reader(), indexFieldName);
@@ -129,14 +114,14 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
       if (singleValued != null) {
         if (liveDocs == null) {
           while (singleValued.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            values[(int) singleValued.longValue()]++;
+            increment((int) singleValued.longValue());
           }
         } else {
           for (int doc = singleValued.nextDoc();
               doc != DocIdSetIterator.NO_MORE_DOCS;
               doc = singleValued.nextDoc()) {
             if (liveDocs.get(doc)) {
-              values[(int) singleValued.longValue()]++;
+              increment((int) singleValued.longValue());
             }
           }
         }
@@ -145,7 +130,7 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
           while (multiValued.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
             final int dvCount = multiValued.docValueCount();
             for (int i = 0; i < dvCount; i++) {
-              values[(int) multiValued.nextValue()]++;
+              increment((int) multiValued.nextValue());
             }
           }
         } else {
@@ -155,7 +140,7 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
             if (liveDocs.get(doc)) {
               final int dvCount = multiValued.docValueCount();
               for (int i = 0; i < dvCount; i++) {
-                values[(int) multiValued.nextValue()]++;
+                increment((int) multiValued.nextValue());
               }
             }
           }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
@@ -31,21 +31,10 @@ import org.apache.lucene.facet.TopOrdAndIntQueue;
 /** Base class for all taxonomy-based facets that aggregate to a per-ords int[]. */
 public abstract class IntTaxonomyFacets extends TaxonomyFacets {
 
-  /**
-   * Dense ordinal values.
-   *
-   * <p>We are making this and {@link #sparseValues} protected for some expert usage. e.g. It can be
-   * checked which is being used before a loop instead of calling {@link #increment} for each
-   * iteration.
-   */
-  protected final int[] values;
+  /** Per-ordinal value. */
+  private final int[] values;
 
-  /**
-   * Sparse ordinal values.
-   *
-   * @see #values for why protected.
-   */
-  protected final IntIntHashMap sparseValues;
+  private final IntIntHashMap sparseValues;
 
   /** Sole constructor. */
   protected IntTaxonomyFacets(


### PR DESCRIPTION
This reverts LUCENE-10350 on 9.x as well given that it appears to be the cause of a performance regression (see #597)