### PR TITLE
LUCENE-10379: Count directly into the dense values array in FastTaxonomyFacetCounts#countAll

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -156,6 +156,9 @@ Optimizations
 
 * LUCENE-10356: Further optimize facet counting for single-valued TaxonomyFacetCounts. (Greg Miller)
 
+* LUCENE-10379: Count directly into the dense values array in FastTaxonomyFacetCounts#countAll.
+  (Guo Feng, Greg Miller)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
@@ -31,10 +31,21 @@ import org.apache.lucene.facet.TopOrdAndIntQueue;
 /** Base class for all taxonomy-based facets that aggregate to a per-ords int[]. */
 public abstract class IntTaxonomyFacets extends TaxonomyFacets {
 
-  /** Per-ordinal value. */
-  private final int[] values;
+  /**
+   * Dense ordinal values.
+   *
+   * <p>We are making this and {@link #sparseValues} protected for some expert usage. e.g. It can be
+   * checked which is being used before a loop instead of calling {@link #increment} for each
+   * iteration.
+   */
+  protected final int[] values;
 
-  private final IntIntHashMap sparseValues;
+  /**
+   * Sparse ordinal values.
+   *
+   * @see #values for why protected.
+   */
+  protected final IntIntHashMap sparseValues;
 
   /** Sole constructor. */
   protected IntTaxonomyFacets(


### PR DESCRIPTION
This change just pulls out part of the optimization done (and subsequently reverted) in LUCENE-10350. The idea is to push only part of the optimization to see if we can isolate the performance regression observed in LUCENE-10350. See LUCENE-10374 for more.