### PR TITLE
LUCENE-10380: Further optimize FastTaxonomyFacetCounts#countAll by moving the liveDocs null check outside the loops

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -164,7 +164,7 @@ Optimizations
   (Guo Feng, Greg Miller)
 
 * LUCENE-10380: Further optimize FastTaxonomyFacetCounts#countAll by moving the liveDocs null check
-  outside the loops. (Guo Feng, Greg Miller)
+  outside the loops and breaking out common functionality into separate methods. (Guo Feng, Greg Miller)
 
 Changes in runtime behavior
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -163,6 +163,9 @@ Optimizations
 * LUCENE-10379: Count directly into the dense values array in FastTaxonomyFacetCounts#countAll.
   (Guo Feng, Greg Miller)
 
+* LUCENE-10380: Further optimize FastTaxonomyFacetCounts#countAll by moving the liveDocs null check
+  outside the loops. (Guo Feng, Greg Miller)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
@@ -134,7 +134,7 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
 
   private static void accumulateSingleValuedDense(
       DocIdSetIterator it, NumericDocValues singleValued, int[] values) throws IOException {
-    while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+    for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
       values[(int) singleValued.longValue()]++;
     }
   }
@@ -142,14 +142,14 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
   private static void accumulateSingleValuedSparse(
       DocIdSetIterator it, NumericDocValues singleValued, IntIntHashMap sparseValues)
       throws IOException {
-    while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+    for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
       sparseValues.addTo((int) singleValued.longValue(), 1);
     }
   }
 
   private static void accumulateMultiValuedDense(
       DocIdSetIterator it, SortedNumericDocValues multiValued, int[] values) throws IOException {
-    while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+    for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
       for (int i = 0; i < multiValued.docValueCount(); i++) {
         values[(int) multiValued.nextValue()]++;
       }
@@ -159,7 +159,7 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
   private static void accumulateMultiValuedSparse(
       DocIdSetIterator it, SortedNumericDocValues multiValued, IntIntHashMap sparseValues)
       throws IOException {
-    while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+    for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
       for (int i = 0; i < multiValued.docValueCount(); i++) {
         sparseValues.addTo((int) multiValued.nextValue(), 1);
       }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
@@ -126,23 +126,39 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
 
       NumericDocValues singleValued = DocValues.unwrapSingleton(multiValued);
       if (singleValued != null) {
-        for (int doc = singleValued.nextDoc();
-            doc != DocIdSetIterator.NO_MORE_DOCS;
-            doc = singleValued.nextDoc()) {
-          if (liveDocs != null && liveDocs.get(doc) == false) {
-            continue;
+        if (liveDocs != null) {
+          for (int doc = singleValued.nextDoc();
+              doc != DocIdSetIterator.NO_MORE_DOCS;
+              doc = singleValued.nextDoc()) {
+            if (liveDocs.get(doc)) {
+              values[(int) singleValued.longValue()]++;
+            }
           }
-          values[(int) singleValued.longValue()]++;
+        } else {
+          for (int doc = singleValued.nextDoc();
+              doc != DocIdSetIterator.NO_MORE_DOCS;
+              doc = singleValued.nextDoc()) {
+            values[(int) singleValued.longValue()]++;
+          }
         }
       } else {
-        for (int doc = multiValued.nextDoc();
-            doc != DocIdSetIterator.NO_MORE_DOCS;
-            doc = multiValued.nextDoc()) {
-          if (liveDocs != null && liveDocs.get(doc) == false) {
-            continue;
+        if (liveDocs != null) {
+          for (int doc = multiValued.nextDoc();
+              doc != DocIdSetIterator.NO_MORE_DOCS;
+              doc = multiValued.nextDoc()) {
+            if (liveDocs.get(doc)) {
+              for (int i = 0; i < multiValued.docValueCount(); i++) {
+                values[(int) multiValued.nextValue()]++;
+              }
+            }
           }
-          for (int i = 0; i < multiValued.docValueCount(); i++) {
-            values[(int) multiValued.nextValue()]++;
+        } else {
+          for (int doc = multiValued.nextDoc();
+              doc != DocIdSetIterator.NO_MORE_DOCS;
+              doc = multiValued.nextDoc()) {
+            for (int i = 0; i < multiValued.docValueCount(); i++) {
+              values[(int) multiValued.nextValue()]++;
+            }
           }
         }
       }


### PR DESCRIPTION
This change attempts to bring in the other piece of the LUCENE-10350 change without the regressions. See LUCENE-10374 for more details.