### PR TITLE
LUCENE-10288: Check BKD tree shape for lucene pre-8.6 1D indexes

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -109,7 +109,7 @@ public class BKDReader extends PointValues {
     this.in = dataIn;
     this.isTreeBalanced = isTreeBalanced();
   }
-  
+
   private boolean isTreeBalanced() throws IOException {
     if (version >= BKDWriter.VERSION_META_FILE) {
       // Since lucene 8.6 all trees are unbalanced.
@@ -123,27 +123,29 @@ public class BKDReader extends PointValues {
     final int lastLeafNodePointCount = Math.toIntExact(pointCount % config.maxPointsInLeafNode);
     // navigate to last node
     PointTree pointTree = getPointTree();
-    do  {
-      while (pointTree.moveToSibling()) {};
+    do {
+      while (pointTree.moveToSibling()) {}
+      ;
     } while (pointTree.moveToChild());
     // count number of docs in the node
     final int[] count = new int[] {0};
-    pointTree.visitDocIDs(new IntersectVisitor() {
-      @Override
-      public void visit(int docID) {
-        count[0]++;
-      }
+    pointTree.visitDocIDs(
+        new IntersectVisitor() {
+          @Override
+          public void visit(int docID) {
+            count[0]++;
+          }
 
-      @Override
-      public void visit(int docID, byte[] packedValue) {
-        throw new AssertionError();
-      }
+          @Override
+          public void visit(int docID, byte[] packedValue) {
+            throw new AssertionError();
+          }
 
-      @Override
-      public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
-        throw new AssertionError();
-      }
-    });
+          @Override
+          public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+            throw new AssertionError();
+          }
+        });
     return count[0] != lastLeafNodePointCount;
   }
 
@@ -157,7 +159,7 @@ public class BKDReader extends PointValues {
         version,
         pointCount,
         minPackedValue,
-        maxPackedValue, 
+        maxPackedValue,
         isTreeBalanced);
   }
 
@@ -211,7 +213,7 @@ public class BKDReader extends PointValues {
     private final BKDReaderDocIDSetIterator scratchIterator;
     // if true the tree is balanced, otherwise unbalanced
     private final boolean isTreeBalanced;
-    
+
     private BKDPointTree(
         IndexInput innerNodes,
         IndexInput leafNodes,
@@ -316,7 +318,7 @@ public class BKDReader extends PointValues {
               scratchMinIndexPackedValue,
               scratchMaxIndexPackedValue,
               commonPrefixLengths,
-               isTreeBalanced);
+              isTreeBalanced);
       index.leafBlockFPStack[index.level] = leafBlockFPStack[level];
       if (isLeafNode() == false) {
         // copy node data
@@ -501,7 +503,8 @@ public class BKDReader extends PointValues {
       }
       assert numLeaves == getNumLeavesSlow(nodeID) : numLeaves + " " + getNumLeavesSlow(nodeID);
       if (isTreeBalanced) {
-        // before lucene 8.6, high dimensional trees might have been constructed as fully balanced trees.
+        // before lucene 8.6, high dimensional trees might have been constructed as fully balanced
+        // trees.
         return sizeFromBalancedTree(leftMostLeafNode, rightMostLeafNode);
       }
       // size for an unbalanced tree.

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -44,6 +44,8 @@ public class BKDReader extends PointValues {
   final long minLeafBlockFP;
 
   final IndexInput packedIndex;
+  // if true, the tree is a legacy balanced tree
+  private final boolean isTreeBalanced;
 
   /**
    * Caller must pre-seek the provided {@link IndexInput} to the index location that {@link
@@ -105,6 +107,44 @@ public class BKDReader extends PointValues {
     }
     this.packedIndex = indexIn.slice("packedIndex", indexStartPointer, numIndexBytes);
     this.in = dataIn;
+    this.isTreeBalanced = isTreeBalanced();
+  }
+  
+  private boolean isTreeBalanced() throws IOException {
+    if (version >= BKDWriter.VERSION_META_FILE) {
+      // Since lucene 8.6 all trees are unbalanced.
+      return false;
+    }
+    if (config.numDims > 1) {
+      // High dimensional tree in pre-8.6 indices are balanced.
+      return true;
+    }
+    // count of the last node for unbalanced trees
+    final int lastLeafNodePointCount = Math.toIntExact(pointCount % config.maxPointsInLeafNode);
+    // navigate to last node
+    PointTree pointTree = getPointTree();
+    do  {
+      while (pointTree.moveToSibling()) {};
+    } while (pointTree.moveToChild());
+    // count number of docs in the node
+    final int[] count = new int[] {0};
+    pointTree.visitDocIDs(new IntersectVisitor() {
+      @Override
+      public void visit(int docID) {
+        count[0]++;
+      }
+
+      @Override
+      public void visit(int docID, byte[] packedValue) {
+        throw new AssertionError();
+      }
+
+      @Override
+      public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+        throw new AssertionError();
+      }
+    });
+    return count[0] != lastLeafNodePointCount;
   }
 
   @Override
@@ -117,7 +157,8 @@ public class BKDReader extends PointValues {
         version,
         pointCount,
         minPackedValue,
-        maxPackedValue);
+        maxPackedValue, 
+        isTreeBalanced);
   }
 
   private static class BKDPointTree implements PointTree {
@@ -168,7 +209,9 @@ public class BKDReader extends PointValues {
         scratchMaxIndexPackedValue;
     private final int[] commonPrefixLengths;
     private final BKDReaderDocIDSetIterator scratchIterator;
-
+    // if true the tree is balanced, otherwise unbalanced
+    private final boolean isTreeBalanced;
+    
     private BKDPointTree(
         IndexInput innerNodes,
         IndexInput leafNodes,
@@ -177,7 +220,8 @@ public class BKDReader extends PointValues {
         int version,
         long pointCount,
         byte[] minPackedValue,
-        byte[] maxPackedValue)
+        byte[] maxPackedValue,
+        boolean isTreeBalanced)
         throws IOException {
       this(
           innerNodes,
@@ -194,7 +238,8 @@ public class BKDReader extends PointValues {
           new byte[config.packedBytesLength],
           new byte[config.packedIndexBytesLength],
           new byte[config.packedIndexBytesLength],
-          new int[config.numDims]);
+          new int[config.numDims],
+          isTreeBalanced);
       // read root node
       readNodeData(false);
     }
@@ -214,12 +259,14 @@ public class BKDReader extends PointValues {
         byte[] scratchDataPackedValue,
         byte[] scratchMinIndexPackedValue,
         byte[] scratchMaxIndexPackedValue,
-        int[] commonPrefixLengths) {
+        int[] commonPrefixLengths,
+        boolean isTreeBalanced) {
       this.config = config;
       this.version = version;
       this.nodeID = nodeID;
       this.nodeRoot = nodeID;
       this.level = level;
+      this.isTreeBalanced = isTreeBalanced;
       leafNodeOffset = numLeaves;
       this.innerNodes = innerNodes;
       this.leafNodes = leafNodes;
@@ -268,7 +315,8 @@ public class BKDReader extends PointValues {
               scratchDataPackedValue,
               scratchMinIndexPackedValue,
               scratchMaxIndexPackedValue,
-              commonPrefixLengths);
+              commonPrefixLengths,
+               isTreeBalanced);
       index.leafBlockFPStack[index.level] = leafBlockFPStack[level];
       if (isLeafNode() == false) {
         // copy node data
@@ -452,8 +500,8 @@ public class BKDReader extends PointValues {
         numLeaves = rightMostLeafNode - leftMostLeafNode + 1 + leafNodeOffset;
       }
       assert numLeaves == getNumLeavesSlow(nodeID) : numLeaves + " " + getNumLeavesSlow(nodeID);
-      if (version < BKDWriter.VERSION_META_FILE && config.numDims > 1) {
-        // before lucene 8.6, high dimensional trees were constructed as fully balanced trees.
+      if (isTreeBalanced) {
+        // before lucene 8.6, high dimensional trees might have been constructed as fully balanced trees.
         return sizeFromBalancedTree(leftMostLeafNode, rightMostLeafNode);
       }
       // size for an unbalanced tree.

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -509,8 +509,7 @@ public class BKDReader extends PointValues {
       }
       assert numLeaves == getNumLeavesSlow(nodeID) : numLeaves + " " + getNumLeavesSlow(nodeID);
       if (isTreeBalanced) {
-        // before lucene 8.6, high dimensional trees might have been constructed as fully balanced
-        // trees.
+        // before lucene 8.6, trees might have been constructed as fully balanced trees.
         return sizeFromBalancedTree(leftMostLeafNode, rightMostLeafNode);
       }
       // size for an unbalanced tree.

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -107,13 +107,14 @@ public class BKDReader extends PointValues {
     }
     this.packedIndex = indexIn.slice("packedIndex", indexStartPointer, numIndexBytes);
     this.in = dataIn;
-    this.isTreeBalanced = isTreeBalanced();
+    // for only one leaf, balanced and unbalanced trees are the same
+    // we set it to unbalanced.
+    this.isTreeBalanced = numLeaves != 1 && isTreeBalanced();
   }
 
   private boolean isTreeBalanced() throws IOException {
-    if (version >= BKDWriter.VERSION_META_FILE || numLeaves == 1) {
+    if (version >= BKDWriter.VERSION_META_FILE) {
       // since lucene 8.6 all trees are unbalanced.
-      // for only one leaf we can assume unbalanced.
       return false;
     }
     if (config.numDims > 1) {

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -107,7 +107,7 @@ public class BKDReader extends PointValues {
     }
     this.packedIndex = indexIn.slice("packedIndex", indexStartPointer, numIndexBytes);
     this.in = dataIn;
-    // for only one leaf, balanced and unbalanced trees are the same
+    // for only one leaf, balanced and unbalanced trees can be handled the same way
     // we set it to unbalanced.
     this.isTreeBalanced = numLeaves != 1 && isTreeBalanced();
   }


### PR DESCRIPTION
In LUCENE-9820 we changed the API for PointValues to expose methods to navigate the BKD tree. One important change is the ability to compute the number of points below any node of the tree. In order to compute this value efficiently we need to know the shape of the tree. 

Since Lucene 8.6, all trees are built as unbalanced trees but in previous version there were specialised cases where trees where built as balanced trees. This was always the case for trees with dimensions >1 and some edge cases for 1D. In order to know the tree shape for these specialised cases we need to look into the tree itself.

This change looks into how many points are in the last node of the tree for 1D lucene pre-8.6 indices.  If the value is equal to the reminder of the number of points divided by the number of points per leaf the the tree is unbalanced, otherwise is balanced.