### PR TITLE
LUCENE-10002: Replace simple usages of TotalHitCountCollector with IndexSearcher#count

### DIFF
--- a/lucene/classification/src/java/org/apache/lucene/classification/CachingNaiveBayesClassifier.java
+++ b/lucene/classification/src/java/org/apache/lucene/classification/CachingNaiveBayesClassifier.java
@@ -32,7 +32,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.TotalHitCountCollector;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -179,10 +178,8 @@ public class CachingNaiveBayesClassifier extends SimpleNaiveBayesClassifier {
         if (query != null) {
           booleanQuery.add(query, BooleanClause.Occur.MUST);
         }
-        TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
-        indexSearcher.search(booleanQuery.build(), totalHitCountCollector);
 
-        int ret = totalHitCountCollector.getTotalHits();
+        int ret = indexSearcher.count(booleanQuery.build());
         if (ret != 0) {
           searched.put(cclass, ret);
         }

--- a/lucene/classification/src/java/org/apache/lucene/classification/SimpleNaiveBayesClassifier.java
+++ b/lucene/classification/src/java/org/apache/lucene/classification/SimpleNaiveBayesClassifier.java
@@ -35,7 +35,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.TotalHitCountCollector;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 
@@ -169,7 +168,6 @@ public class SimpleNaiveBayesClassifier implements Classifier<BytesRef> {
     Terms terms = MultiTerms.getTerms(this.indexReader, this.classFieldName);
     int docCount;
     if (terms == null || terms.getDocCount() == -1) { // in case codec doesn't support getDocCount
-      TotalHitCountCollector classQueryCountCollector = new TotalHitCountCollector();
       BooleanQuery.Builder q = new BooleanQuery.Builder();
       q.add(
           new BooleanClause(
@@ -179,8 +177,7 @@ public class SimpleNaiveBayesClassifier implements Classifier<BytesRef> {
       if (query != null) {
         q.add(query, BooleanClause.Occur.MUST);
       }
-      indexSearcher.search(q.build(), classQueryCountCollector);
-      docCount = classQueryCountCollector.getTotalHits();
+      docCount = indexSearcher.count(q.build());
     } else {
       docCount = terms.getDocCount();
     }
@@ -276,9 +273,7 @@ public class SimpleNaiveBayesClassifier implements Classifier<BytesRef> {
     if (query != null) {
       booleanQuery.add(query, BooleanClause.Occur.MUST);
     }
-    TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
-    indexSearcher.search(booleanQuery.build(), totalHitCountCollector);
-    return totalHitCountCollector.getTotalHits();
+    return indexSearcher.count(booleanQuery.build());
   }
 
   private double calculateLogPrior(Term term, int docsWithClassSize) throws IOException {

--- a/lucene/classification/src/java/org/apache/lucene/classification/document/SimpleNaiveBayesDocumentClassifier.java
+++ b/lucene/classification/src/java/org/apache/lucene/classification/document/SimpleNaiveBayesDocumentClassifier.java
@@ -40,7 +40,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.TotalHitCountCollector;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -263,9 +262,7 @@ public class SimpleNaiveBayesDocumentClassifier extends SimpleNaiveBayesClassifi
     if (query != null) {
       booleanQuery.add(query, BooleanClause.Occur.MUST);
     }
-    TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
-    indexSearcher.search(booleanQuery.build(), totalHitCountCollector);
-    return totalHitCountCollector.getTotalHits();
+    return indexSearcher.count(booleanQuery.build());
   }
 
   private double calculateLogPrior(Term term, int docsWithClassSize) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
@@ -16,10 +16,11 @@
  */
 package org.apache.lucene.search;
 
-/** Just counts the total number of hits.
- * For cases when this is the only collector used, {@link IndexSearcher#count(Query)}
- * can be called instead of {@link IndexSearcher#search(Query, Collector)} which will
- * automatically create an instance of this collector internally */
+/**
+ * Just counts the total number of hits. For cases when this is the only collector used, {@link
+ * IndexSearcher#count(Query)} can be called instead of {@link IndexSearcher#search(Query,
+ * Collector)} which will automatically create an instance of this collector internally
+ */
 public class TotalHitCountCollector extends SimpleCollector {
   private int totalHits;
 

--- a/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
@@ -18,8 +18,9 @@ package org.apache.lucene.search;
 
 /**
  * Just counts the total number of hits. For cases when this is the only collector used, {@link
- * IndexSearcher#count(Query)} can be called instead of {@link IndexSearcher#search(Query,
- * Collector)} which will automatically create an instance of this collector internally
+ * IndexSearcher#count(Query)} should be called instead of {@link IndexSearcher#search(Query,
+ * Collector)} which is faster whenever the match can be returned directly from the index
+ * statistics.
  */
 public class TotalHitCountCollector extends SimpleCollector {
   private int totalHits;

--- a/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
@@ -19,7 +19,7 @@ package org.apache.lucene.search;
 /**
  * Just counts the total number of hits. For cases when this is the only collector used, {@link
  * IndexSearcher#count(Query)} should be called instead of {@link IndexSearcher#search(Query,
- * Collector)} as the former is faster whenever the match can be returned directly from the index
+ * Collector)} as the former is faster whenever the count can be returned directly from the index
  * statistics.
  */
 public class TotalHitCountCollector extends SimpleCollector {

--- a/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
@@ -19,7 +19,7 @@ package org.apache.lucene.search;
 /**
  * Just counts the total number of hits. For cases when this is the only collector used, {@link
  * IndexSearcher#count(Query)} should be called instead of {@link IndexSearcher#search(Query,
- * Collector)} which is faster whenever the match can be returned directly from the index
+ * Collector)} as the former is faster whenever the match can be returned directly from the index
  * statistics.
  */
 public class TotalHitCountCollector extends SimpleCollector {

--- a/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
@@ -16,7 +16,10 @@
  */
 package org.apache.lucene.search;
 
-/** Just counts the total number of hits. */
+/** Just counts the total number of hits.
+ * For cases when this is the only collector used, {@link IndexSearcher#count(Query)}
+ * can be called instead of {@link IndexSearcher#search(Query, Collector)} which will
+ * automatically create an instance of this collector internally */
 public class TotalHitCountCollector extends SimpleCollector {
   private int totalHits;
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestFuzzyTermOnShortTerms.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFuzzyTermOnShortTerms.java
@@ -62,9 +62,8 @@ public class TestFuzzyTermOnShortTerms extends LuceneTestCase {
     Directory d = getDirectory(analyzer, docs);
     IndexReader r = DirectoryReader.open(d);
     IndexSearcher s = new IndexSearcher(r);
-    TotalHitCountCollector c = new TotalHitCountCollector();
-    s.search(q, c);
-    assertEquals(q.toString(), expected, c.getTotalHits());
+    int totalHits = s.count(q);
+    assertEquals(q.toString(), expected, totalHits);
     r.close();
     d.close();
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -945,7 +945,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
 
     searcher.setQueryCache(queryCache);
     searcher.setQueryCachingPolicy(policy);
-    searcher.count(query.build());
+    searcher.search(query.build(), new TotalHitCountCollector());
 
     reader.close();
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -167,7 +167,9 @@ public class TestLRUQueryCache extends LuceneTestCase {
                         RandomPicks.randomFrom(
                             random(), new String[] {"blue", "red", "yellow", "green"});
                     final Query q = new TermQuery(new Term("color", value));
-                    final int totalHits1 = searcher.count(q); // will use the cache
+                    TotalHitCountCollector collector = new TotalHitCountCollector();
+                    searcher.search(q, collector); // will use the cache
+                    final int totalHits1 = collector.getTotalHits();
                     TotalHitCountCollector collector2 = new TotalHitCountCollector();
                     searcher.search(
                         q,
@@ -1167,12 +1169,12 @@ public class TestLRUQueryCache extends LuceneTestCase {
     searcher.setQueryCachingPolicy(ALWAYS_CACHE);
 
     BadQuery query = new BadQuery();
-    searcher.count(query);
+    searcher.search(query, new TotalHitCountCollector());
     query.i[0] += 1; // change the hashCode!
 
     try {
       // trigger an eviction
-      searcher.count(new MatchAllDocsQuery());
+      searcher.search(new MatchAllDocsQuery(), new TotalHitCountCollector());
       fail();
     } catch (
         @SuppressWarnings("unused")

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -167,9 +167,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
                         RandomPicks.randomFrom(
                             random(), new String[] {"blue", "red", "yellow", "green"});
                     final Query q = new TermQuery(new Term("color", value));
-                    TotalHitCountCollector collector = new TotalHitCountCollector();
-                    searcher.search(q, collector); // will use the cache
-                    final int totalHits1 = collector.getTotalHits();
+                    final int totalHits1 = searcher.count(q); // will use the cache
                     TotalHitCountCollector collector2 = new TotalHitCountCollector();
                     searcher.search(
                         q,
@@ -945,7 +943,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
 
     searcher.setQueryCache(queryCache);
     searcher.setQueryCachingPolicy(policy);
-    searcher.search(query.build(), new TotalHitCountCollector());
+    searcher.count(query.build());
 
     reader.close();
     dir.close();
@@ -1174,7 +1172,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
 
     try {
       // trigger an eviction
-      searcher.search(new MatchAllDocsQuery(), new TotalHitCountCollector());
+      searcher.count(new MatchAllDocsQuery());
       fail();
     } catch (
         @SuppressWarnings("unused")

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermQuery.java
@@ -91,12 +91,16 @@ public class TestTermQuery extends LuceneTestCase {
     IndexSearcher searcher = new IndexSearcher(reader);
     // use a collector rather than searcher.count() which would just read the
     // doc freq instead of creating a scorer
-    assertEquals(1, searcher.count(query));
+    TotalHitCountCollector collector = new TotalHitCountCollector();
+    searcher.search(query, collector);
+    assertEquals(1, collector.getTotalHits());
     TermQuery queryWithContext =
         new TermQuery(
             new Term("foo", "bar"),
             TermStates.build(reader.getContext(), new Term("foo", "bar"), true));
-    assertEquals(1, searcher.count(queryWithContext));
+    collector = new TotalHitCountCollector();
+    searcher.search(queryWithContext, collector);
+    assertEquals(1, collector.getTotalHits());
 
     IOUtils.close(reader, w, dir);
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermQuery.java
@@ -91,16 +91,12 @@ public class TestTermQuery extends LuceneTestCase {
     IndexSearcher searcher = new IndexSearcher(reader);
     // use a collector rather than searcher.count() which would just read the
     // doc freq instead of creating a scorer
-    TotalHitCountCollector collector = new TotalHitCountCollector();
-    searcher.search(query, collector);
-    assertEquals(1, collector.getTotalHits());
+    assertEquals(1, searcher.count(query));
     TermQuery queryWithContext =
         new TermQuery(
             new Term("foo", "bar"),
             TermStates.build(reader.getContext(), new Term("foo", "bar"), true));
-    collector = new TotalHitCountCollector();
-    searcher.search(queryWithContext, collector);
-    assertEquals(1, collector.getTotalHits());
+    assertEquals(1, searcher.count(queryWithContext));
 
     IOUtils.close(reader, w, dir);
   }

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
@@ -681,15 +681,14 @@ public class TestJoinUtil extends LuceneTestCase {
       Query joinQuery =
           JoinUtil.createJoinQuery(
               "join_field", fromQuery, toQuery, searcher, scoreMode, ordinalMap, min, max);
-      TotalHitCountCollector collector = new TotalHitCountCollector();
-      searcher.search(joinQuery, collector);
+      int totalHits = searcher.count(joinQuery);
       int expectedCount = 0;
       for (int numChildDocs : childDocsPerParent) {
         if (numChildDocs >= min && numChildDocs <= max) {
           expectedCount++;
         }
       }
-      assertEquals(expectedCount, collector.getTotalHits());
+      assertEquals(expectedCount, totalHits);
     }
     searcher.getIndexReader().close();
     dir.close();

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestHeatmapFacetCounter.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestHeatmapFacetCounter.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TotalHitCountCollector;
 import org.apache.lucene.spatial.StrategyTestCase;
 import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
@@ -282,13 +281,12 @@ public class TestHeatmapFacetCounter extends StrategyTestCase {
     Query filter =
         new IntersectsPrefixTreeQuery(
             pt, strategy.getFieldName(), grid, facetLevel, grid.getMaxLevels());
-    final TotalHitCountCollector collector = new TotalHitCountCollector();
-    indexSearcher.search(filter, collector);
+    int totalHits = indexSearcher.count(filter);
     cellsValidated++;
-    if (collector.getTotalHits() > 0) {
+    if (totalHits > 0) {
       cellValidatedNonZero++;
     }
-    return collector.getTotalHits();
+    return totalHits;
   }
 
   private Shape randomIndexedShape() {


### PR DESCRIPTION
This is one of the many steps required to resolve LUCENE-10002

In case only number of documents are collected, `IndexSearcher#search(Query, Collector)` is commonly used, which does not use the executor that's been eventually set to the searcher. Calling `IndexSearcher#count(Query)` makes the code more concise and is also more correct as it honours the executor that's been set to the searcher instance.


- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes. (refactoring, not needed)
