### PR TITLE
LUCENE-10381: Require users to provide FacetsConfig for SSDV faceting

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -67,6 +67,8 @@ API Changes
   a boolean indicating whether or not skipping should be enabled on the comparator. 
   (Alan Woodward)
 
+* LUCENE-10381: Require users to provide FacetsConfig for SSDV faceting. (Greg Miller)
+
 New Features
 ---------------------
 

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleSortedSetFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleSortedSetFacetsExample.java
@@ -88,7 +88,8 @@ public class SimpleSortedSetFacetsExample {
   private List<FacetResult> search() throws IOException {
     DirectoryReader indexReader = DirectoryReader.open(indexDir);
     IndexSearcher searcher = new IndexSearcher(indexReader);
-    SortedSetDocValuesReaderState state = new DefaultSortedSetDocValuesReaderState(indexReader);
+    SortedSetDocValuesReaderState state =
+        new DefaultSortedSetDocValuesReaderState(indexReader, config);
 
     // Aggregatses the facet counts
     FacetsCollector fc = new FacetsCollector();
@@ -113,7 +114,8 @@ public class SimpleSortedSetFacetsExample {
   private FacetResult drillDown() throws IOException {
     DirectoryReader indexReader = DirectoryReader.open(indexDir);
     IndexSearcher searcher = new IndexSearcher(indexReader);
-    SortedSetDocValuesReaderState state = new DefaultSortedSetDocValuesReaderState(indexReader);
+    SortedSetDocValuesReaderState state =
+        new DefaultSortedSetDocValuesReaderState(indexReader, config);
 
     // Now user drills down on Publish Year/2010:
     DrillDownQuery q = new DrillDownQuery(config);

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/ConcurrentSortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/ConcurrentSortedSetDocValuesFacetCounts.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.PrimitiveIterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -85,7 +84,7 @@ public class ConcurrentSortedSetDocValuesFacetCounts extends Facets {
       throws IOException, InterruptedException {
     this.state = state;
     this.field = state.getField();
-    this.stateConfig = Objects.requireNonNullElse(state.getFacetsConfig(), new FacetsConfig());
+    this.stateConfig = state.getFacetsConfig();
     this.exec = exec;
     dv = state.getDocValues();
     counts = new AtomicIntegerArray(state.getSize());

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/DefaultSortedSetDocValuesReaderState.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/DefaultSortedSetDocValuesReaderState.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Stack;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.index.DocValues;
@@ -71,25 +72,12 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
     this(reader, FacetsConfig.DEFAULT_INDEX_FIELD_NAME, config);
   }
 
-  /**
-   * Creates this without a config, pulling doc values from the default {@link
-   * FacetsConfig#DEFAULT_INDEX_FIELD_NAME}.
-   */
-  public DefaultSortedSetDocValuesReaderState(IndexReader reader) throws IOException {
-    this(reader, FacetsConfig.DEFAULT_INDEX_FIELD_NAME, null);
-  }
-
-  /** Creates this without a config, pulling doc values from the specified field. */
-  public DefaultSortedSetDocValuesReaderState(IndexReader reader, String field) throws IOException {
-    this(reader, field, null);
-  }
-
   /** Creates this, pulling doc values from the specified field. */
   public DefaultSortedSetDocValuesReaderState(IndexReader reader, String field, FacetsConfig config)
       throws IOException {
-    this.field = field;
-    this.reader = reader;
-    this.config = config;
+    this.field = Objects.requireNonNull(field);
+    this.reader = Objects.requireNonNull(reader);
+    this.config = Objects.requireNonNull(config);
 
     // We need this to create thread-safe MultiSortedSetDV
     // per collector:
@@ -109,7 +97,7 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
       BytesRef term = dv.lookupOrd(ord);
       String[] components = FacetsConfig.stringToPath(term.utf8ToString());
       String dim = components[0];
-      if (config != null && config.getDimConfig(dim).hierarchical) {
+      if (config.getDimConfig(dim).hierarchical) {
         ord = createOneHierarchicalFacetDimState(dv, ord) + 1;
       } else {
         ord = createOneFlatFacetDimState(dv, ord) + 1;
@@ -377,7 +365,7 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
 
   @Override
   public OrdRange getOrdRange(String dim) {
-    if (config != null && config.getDimConfig(dim).hierarchical) {
+    if (config.getDimConfig(dim).hierarchical) {
       throw new UnsupportedOperationException(
           "This operation is only supported for flat dimensions");
     }
@@ -388,7 +376,7 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
 
   @Override
   public DimTree getDimTree(String dim) {
-    if (config == null || config.getDimConfig(dim).hierarchical == false) {
+    if (config.getDimConfig(dim).hierarchical == false) {
       throw new UnsupportedOperationException(
           "This opperation is only supported for hierarchical facets");
     }

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.PrimitiveIterator;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.FacetUtils;
@@ -85,7 +84,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
       throws IOException {
     this.state = state;
     this.field = state.getField();
-    this.stateConfig = Objects.requireNonNullElse(state.getFacetsConfig(), new FacetsConfig());
+    this.stateConfig = state.getFacetsConfig();
     this.dv = state.getDocValues();
     this.counts = new int[state.getSize()];
     if (hits == null) {

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -1068,7 +1068,7 @@ public class TestDrillSideways extends FacetTestCase {
     IndexSearcher s = getNewSearcher(r);
 
     if (doUseDV) {
-      sortedSetDVState = new DefaultSortedSetDocValuesReaderState(s.getIndexReader());
+      sortedSetDVState = new DefaultSortedSetDocValuesReaderState(s.getIndexReader(), config);
     } else {
       sortedSetDVState = null;
     }

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -85,7 +85,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
         // Per-top-reader state:
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         ExecutorService exec = randomExecutorServiceOrNull();
         try {
@@ -214,7 +214,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
         // Per-top-reader state:
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         Facets facets = new SortedSetDocValuesFacetCounts(state);
 
@@ -330,7 +330,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
         // Per-top-reader state:
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         ExecutorService exec = randomExecutorServiceOrNull();
         try {
@@ -641,7 +641,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
       writer.addDocument(config.build(doc));
 
       try (IndexReader r = writer.getReader()) {
-        SortedSetDocValuesReaderState state = new DefaultSortedSetDocValuesReaderState(r);
+        SortedSetDocValuesReaderState state = new DefaultSortedSetDocValuesReaderState(r, config);
 
         doc = new Document();
         doc.add(new SortedSetDocValuesFacetField("a", "bar"));
@@ -704,7 +704,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
         // Per-top-reader state:
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         ExecutorService exec = randomExecutorServiceOrNull();
         try {
@@ -832,7 +832,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
         // Per-top-reader state:
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         ExecutorService exec = randomExecutorServiceOrNull();
         try {
@@ -936,7 +936,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
           // Per-top-reader state:
           SortedSetDocValuesReaderState state =
-              new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+              new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
           ExecutorService exec = randomExecutorServiceOrNull();
           try {
             int iters = atLeast(100);
@@ -1297,7 +1297,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
         IndexSearcher searcher = newSearcher(r);
 
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         ExecutorService exec = randomExecutorServiceOrNull();
         try {


### PR DESCRIPTION
# Description

SSDV faceting needs to know about facet configuration to ensure it properly handles hierarchical faceting and multivalue faceting, but currently allows users to instantiate `DefaultSortedSetDocValuesReaderState` without providing configuration. This is trappy and we should require users to provide their facets config in all cases.

# Solution

Remove ctors that don't require facets configuration.

# Tests

Updated all existing tests to provide config.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
