### PR TITLE
LUCENE-10381: Require users to provide FacetsConfig for SSDV faceting

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -29,6 +29,8 @@ API Changes
   a boolean indicating whether or not skipping should be enabled on the comparator. 
   (Alan Woodward)
 
+* LUCENE-10381: Require users to provide FacetsConfig for SSDV faceting. (Greg Miller)
+
 New Features
 ---------------------
 

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleSortedSetFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleSortedSetFacetsExample.java
@@ -88,7 +88,8 @@ public class SimpleSortedSetFacetsExample {
   private List<FacetResult> search() throws IOException {
     DirectoryReader indexReader = DirectoryReader.open(indexDir);
     IndexSearcher searcher = new IndexSearcher(indexReader);
-    SortedSetDocValuesReaderState state = new DefaultSortedSetDocValuesReaderState(indexReader);
+    SortedSetDocValuesReaderState state =
+        new DefaultSortedSetDocValuesReaderState(indexReader, config);
 
     // Aggregatses the facet counts
     FacetsCollector fc = new FacetsCollector();
@@ -113,7 +114,8 @@ public class SimpleSortedSetFacetsExample {
   private FacetResult drillDown() throws IOException {
     DirectoryReader indexReader = DirectoryReader.open(indexDir);
     IndexSearcher searcher = new IndexSearcher(indexReader);
-    SortedSetDocValuesReaderState state = new DefaultSortedSetDocValuesReaderState(indexReader);
+    SortedSetDocValuesReaderState state =
+        new DefaultSortedSetDocValuesReaderState(indexReader, config);
 
     // Now user drills down on Publish Year/2010:
     DrillDownQuery q = new DrillDownQuery(config);

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/DefaultSortedSetDocValuesReaderState.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/DefaultSortedSetDocValuesReaderState.java
@@ -74,12 +74,26 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
   /**
    * Creates this without a config, pulling doc values from the default {@link
    * FacetsConfig#DEFAULT_INDEX_FIELD_NAME}.
+   *
+   * @deprecated Users should explicitly provide facet configuration during instantiation. See
+   *     {@link #DefaultSortedSetDocValuesReaderState(IndexReader, FacetsConfig)}. To maintain all
+   *     existing behavior, a "default" facet configuration can be provided with {@link
+   *     FacetsConfig#FacetsConfig()}.
    */
+  @Deprecated
   public DefaultSortedSetDocValuesReaderState(IndexReader reader) throws IOException {
     this(reader, FacetsConfig.DEFAULT_INDEX_FIELD_NAME, null);
   }
 
-  /** Creates this without a config, pulling doc values from the specified field. */
+  /**
+   * Creates this without a config, pulling doc values from the specified field.
+   *
+   * @deprecated Users should explicitly provide facet configuration during instantiation. See
+   *     {@link #DefaultSortedSetDocValuesReaderState(IndexReader, String, FacetsConfig)}. To
+   *     maintain all existing behavior, a "default" facet configuration can be provided with {@link
+   *     FacetsConfig#FacetsConfig()}.
+   */
+  @Deprecated
   public DefaultSortedSetDocValuesReaderState(IndexReader reader, String field) throws IOException {
     this(reader, field, null);
   }

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -1068,7 +1068,7 @@ public class TestDrillSideways extends FacetTestCase {
     IndexSearcher s = getNewSearcher(r);
 
     if (doUseDV) {
-      sortedSetDVState = new DefaultSortedSetDocValuesReaderState(s.getIndexReader());
+      sortedSetDVState = new DefaultSortedSetDocValuesReaderState(s.getIndexReader(), config);
     } else {
       sortedSetDVState = null;
     }

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -85,7 +85,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
         // Per-top-reader state:
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         ExecutorService exec = randomExecutorServiceOrNull();
         try {
@@ -214,7 +214,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
         // Per-top-reader state:
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         Facets facets = new SortedSetDocValuesFacetCounts(state);
 
@@ -330,7 +330,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
         // Per-top-reader state:
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         ExecutorService exec = randomExecutorServiceOrNull();
         try {
@@ -641,7 +641,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
       writer.addDocument(config.build(doc));
 
       try (IndexReader r = writer.getReader()) {
-        SortedSetDocValuesReaderState state = new DefaultSortedSetDocValuesReaderState(r);
+        SortedSetDocValuesReaderState state = new DefaultSortedSetDocValuesReaderState(r, config);
 
         doc = new Document();
         doc.add(new SortedSetDocValuesFacetField("a", "bar"));
@@ -704,7 +704,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
         // Per-top-reader state:
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         ExecutorService exec = randomExecutorServiceOrNull();
         try {
@@ -832,7 +832,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
         // Per-top-reader state:
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         ExecutorService exec = randomExecutorServiceOrNull();
         try {
@@ -936,7 +936,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
           // Per-top-reader state:
           SortedSetDocValuesReaderState state =
-              new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+              new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
           ExecutorService exec = randomExecutorServiceOrNull();
           try {
             int iters = atLeast(100);
@@ -1297,7 +1297,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
         IndexSearcher searcher = newSearcher(r);
 
         SortedSetDocValuesReaderState state =
-            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader());
+            new DefaultSortedSetDocValuesReaderState(searcher.getIndexReader(), config);
 
         ExecutorService exec = randomExecutorServiceOrNull();
         try {


### PR DESCRIPTION
This is a backport of #613 that initially marks ctors as `@Deprecated` on 9.x before being removed on the `main` branch.