### PR TITLE
LUCENE-10382: Allow KnnVectorQuery to operate over a subset of liveDo…

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -114,7 +114,6 @@ public class KnnVectorQuery extends Query {
 
     private final BitSet[] bitSets;
     private BitSet leafBits;
-    private int docBase;
 
     private BitSetCollector(BitSet[] bitSets) {
       this.bitSets = bitSets;

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -97,8 +97,8 @@ public class KnnVectorQuery extends Query {
   }
 
   private TopDocs searchLeaf(LeafReaderContext ctx, int kPerLeaf, Bits bitsFilter) throws IOException {
-    Bits liveDocs = ctx.reader().getLiveDocs();
-    TopDocs results = ctx.reader().searchNearestVectors(field, target, kPerLeaf, bitsFilter != null ? bitsFilter : liveDocs);
+
+    TopDocs results = ctx.reader().searchNearestVectors(field, target, kPerLeaf, bitsFilter != null ? bitsFilter : ctx.reader().getLiveDocs());
     if (results == null) {
       return NO_RESULTS;
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -99,6 +99,23 @@ public class TestKnnVectorQuery extends LuceneTestCase {
     }
   }
 
+
+  /**
+   * Tests that a KnnVectorQuery applies the filter query
+   */
+  public void testFindWithFilter() throws IOException {
+    try (Directory indexStore =
+             getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+         IndexReader reader = DirectoryReader.open(indexStore)) {
+      IndexSearcher searcher = newSearcher(reader);
+      TermQuery filter = new TermQuery(new Term("id", "id0"));
+      KnnVectorQuery kvq = new KnnVectorQuery("field", new float[] {0, 0}, 10, filter);
+      assertMatches(searcher, kvq, 1);
+      TopDocs topDocs = searcher.search(kvq, 3);
+      assertEquals(0, topDocs.scoreDocs[0].doc);
+    }
+  }
+
   /** testDimensionMismatch */
   public void testDimensionMismatch() throws IOException {
     try (Directory indexStore =


### PR DESCRIPTION
WIP for initial consideration ...


<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/projects/LUCENE

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>

LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

This PR adds a filter to the KnnVectorQuery


# Solution

Add a constructor that accepts a query, run the query and collect the bits. Use the bits as filter if present.

# Tests

One test so far which runs a vector search with the filter query applied and asserts the results are limited by the filter.


# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
