### PR TITLE
LUCENE-10384: Simplify LongHeap small addition

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -100,7 +100,7 @@ public class NeighborQueue {
     int size = size();
     int[] nodes = new int[size];
     for (int i = 0; i < size; i++) {
-      nodes[i] = (int) heap.get(i + 1);
+      nodes[i] = (int) order.apply(heap.get(i + 1));
     }
     return nodes;
   }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswGraph.java
@@ -201,7 +201,7 @@ public class TestHnswGraph extends LuceneTestCase {
     CircularVectorValues vectors = new CircularVectorValues(nDoc);
     HnswGraphBuilder builder =
         new HnswGraphBuilder(
-            vectors, VectorSimilarityFunction.DOT_PRODUCT, 16, 100, random().nextInt());
+            vectors, VectorSimilarityFunction.EUCLIDEAN, 16, 100, random().nextInt());
     HnswGraph hnsw = builder.build(vectors);
 
     // Skip over half of the documents that are closest to the query vector
@@ -215,7 +215,7 @@ public class TestHnswGraph extends LuceneTestCase {
             10,
             10,
             vectors.randomAccess(),
-            VectorSimilarityFunction.DOT_PRODUCT,
+            VectorSimilarityFunction.EUCLIDEAN,
             hnsw,
             acceptOrds,
             new SplittableRandom(random().nextLong()));


### PR DESCRIPTION
LUCENE-10384 and PR #615 introduced encoding into NeighborQueue.
But one function `nodes()` the encoding was forgotten.

Also modify the test that would fail without this patch.