### PR TITLE
update javac flags for java 17

### DIFF
--- a/gradle/java/javac.gradle
+++ b/gradle/java/javac.gradle
@@ -28,14 +28,14 @@ allprojects {
     }
 
     // Configure warnings.
+    // Use 'javac --help-lint' to get the supported list
     tasks.withType(JavaCompile) {
       options.encoding = "UTF-8"
       options.compilerArgs += [
-        "-Xlint:-deprecation",
-        "-Xlint:-serial",
         "-Xlint:auxiliaryclass",
         "-Xlint:cast",
         "-Xlint:classfile",
+        "-Xlint:-deprecation",
         "-Xlint:dep-ann",
         "-Xlint:divzero",
         "-Xlint:empty",
@@ -43,19 +43,26 @@ allprojects {
         "-Xlint:-exports",
         "-Xlint:fallthrough",
         "-Xlint:finally",
+        // TODO: untested
+        "-Xlint:-missing-explicit-ctor",
+        "-Xlint:module",
         "-Xlint:opens",
         "-Xlint:options",
         "-Xlint:overloads",
         "-Xlint:overrides",
         // TODO: some tests seem to have bad classpaths?
         // this check seems to be a good sanity check for gradle?
-        // "-Xlint:path",
+        "-Xlint:-path",
         "-Xlint:processing",
         "-Xlint:rawtypes",
         "-Xlint:removal",
-        "-Xlint:static",
         "-Xlint:requires-automatic",
         "-Xlint:requires-transitive-automatic",
+        "-Xlint:-serial",
+        "-Xlint:static",
+        "-Xlint:strictfp",
+        "-Xlint:synchronization",
+        "-Xlint:text-blocks",
         "-Xlint:try",
         "-Xlint:unchecked",
         "-Xlint:varargs",
@@ -65,19 +72,6 @@ allprojects {
         "-Xdoclint:-accessibility",
         "-proc:none",  // proc:none was added because of LOG4J2-1925 / JDK-8186647
       ]
-
-      // enable some warnings only relevant to newer language features
-      if (rootProject.runtimeJavaVersion >= JavaVersion.VERSION_15) {
-        options.compilerArgs += [
-          "-Xlint:text-blocks",
-        ]
-      }
-
-      if (rootProject.runtimeJavaVersion >= JavaVersion.VERSION_16) {
-        options.compilerArgs += [
-          "-Xlint:synchronization",
-        ]
-      }
 
       if (propertyOrDefault("javac.failOnWarnings", true).toBoolean()) {
         options.compilerArgs += "-Werror"


### PR DESCRIPTION
Previously `-Xlint:text-blocks` and `-Xlint:text-blocks` were enabled conditionally, if the user had at least java 15 or java 16, respectively. Enable them always.

Add new options so that the warnings list is fully configured:
* `-Xlint:module` (new in java 17)
* `-Xlint:strictfp` (new in java 17)

Disable `path` with `-Xlint:-path` rather than commenting it out, for
consistency.

Disable `missing-explicit-ctor` (new in java 17), as it is unlikely to
succeed right now.

Alphasort the flags and doc how to get the updated list, this makes it
easy to compare and keep up to date.
