### PR TITLE
LUCENE-10216: Use MergeScheduler and MergePolicy to run addIndexes(CodecReader[]) merges.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -132,6 +132,9 @@ New Features
 Improvements
 ---------------------
 
+* LUCENE-10216: Use MergePolicy to define and MergeScheduler to trigger the reader merges
+  required by addIndexes(CodecReader[]) API. (Vigya Sharma, Michael McCandless)
+
 * LUCENE-10229: return -1 for unknown offsets in ExtendedIntervalsSource. Modify highlighting to
   work properly with or without offsets. (Dawid Weiss)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -38,6 +38,9 @@ Improvements
 * LUCENE-10416: Update Korean Dictionary to mecab-ko-dic-2.1.1-20180720 for Nori.
   (Uihyun Kim)
 
+* LUCENE-10216: Use MergePolicy to define and MergeScheduler to trigger the reader merges
+  required by addIndexes(CodecReader[]) API. (Vigya Sharma, Michael McCandless)
+
 Optimizations
 ---------------------
 (No changes)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -132,9 +132,6 @@ New Features
 Improvements
 ---------------------
 
-* LUCENE-10216: Use MergePolicy to define and MergeScheduler to trigger the reader merges
-  required by addIndexes(CodecReader[]) API. (Vigya Sharma, Michael McCandless)
-
 * LUCENE-10229: return -1 for unknown offsets in ExtendedIntervalsSource. Modify highlighting to
   work properly with or without offsets. (Dawid Weiss)
 

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -352,6 +352,14 @@ public class FieldInfos implements Iterable<FieldInfo> {
       this.softDeletesFieldName = softDeletesFieldName;
     }
 
+    public void verifyField(FieldInfo fi) {
+      String fieldName = fi.getName();
+      verifySoftDeletedFieldName(fieldName, fi.isSoftDeletesField());
+      if (nameToNumber.containsKey(fieldName)) {
+        verifySameSchema(fi);
+      }
+    }
+
     /**
      * Returns the global field number for the given field name. If the name does not exist yet it
      * tries to add it with the given preferred field number assigned if possible otherwise the

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -352,7 +352,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
       this.softDeletesFieldName = softDeletesFieldName;
     }
 
-    public void verifyField(FieldInfo fi) {
+    public void verifyFieldInfo(FieldInfo fi) {
       String fieldName = fi.getName();
       verifySoftDeletedFieldName(fieldName, fi.isSoftDeletesField());
       if (nameToNumber.containsKey(fieldName)) {

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -352,7 +352,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
       this.softDeletesFieldName = softDeletesFieldName;
     }
 
-    public void verifyFieldInfo(FieldInfo fi) {
+    void verifyFieldInfo(FieldInfo fi) {
       String fieldName = fi.getName();
       verifySoftDeletedFieldName(fieldName, fi.isSoftDeletesField());
       if (nameToNumber.containsKey(fieldName)) {

--- a/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
@@ -49,7 +49,7 @@ public class FilterMergePolicy extends MergePolicy implements Unwrappable<MergeP
   }
 
   @Override
-  public MergeSpecification findMerges(List<CodecReader> readers) throws IOException {
+  public MergeSpecification findMerges(CodecReader... readers) throws IOException {
     return in.findMerges(readers);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.apache.lucene.util.IOSupplier;
 import org.apache.lucene.util.Unwrappable;
@@ -45,6 +46,11 @@ public class FilterMergePolicy extends MergePolicy implements Unwrappable<MergeP
       MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext)
       throws IOException {
     return in.findMerges(mergeTrigger, segmentInfos, mergeContext);
+  }
+
+  @Override
+  public MergeSpecification findMerges(List<CodecReader> readers) throws IOException {
+    return in.findMerges(readers);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import org.apache.lucene.util.IOSupplier;
 import org.apache.lucene.util.Unwrappable;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3352,8 +3352,6 @@ public class IndexWriter
         new IOContext(
             new MergeInfo(Math.toIntExact(numDocs), -1, false, UNBOUNDED_MAX_MERGE_SEGMENTS));
 
-    // TODO: somehow we should fix this merge so it's
-    // abortable so that IW.close(false) is able to stop it
     TrackingDirectoryWrapper trackingDir = new TrackingDirectoryWrapper(mergeDirectory);
     Codec codec = config.getCodec();
     // We set the min version to null for now, it will be set later by SegmentMerger

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -2337,8 +2337,9 @@ public class IndexWriter
           spec = mergePolicy.findFullFlushMerges(trigger, segmentInfos, this);
           break;
         case ADD_INDEXES:
-          throw new IllegalStateException("Merges with ADD_INDEXES trigger should be " +
-            "called from within the addIndexes() API flow");
+          throw new IllegalStateException(
+              "Merges with ADD_INDEXES trigger should be "
+                  + "called from within the addIndexes() API flow");
         case EXPLICIT:
         case FULL_FLUSH:
         case MERGE_FINISHED:
@@ -3137,9 +3138,9 @@ public class IndexWriter
 
     try {
       // Best effort up front validations
-      for (CodecReader leaf: readers) {
+      for (CodecReader leaf : readers) {
         validateMergeReader(leaf);
-        for (FieldInfo fi: leaf.getFieldInfos()) {
+        for (FieldInfo fi : leaf.getFieldInfos()) {
           globalFieldNumberMap.verifyFieldInfo(fi);
         }
         numDocs += leaf.numDocs();
@@ -3149,8 +3150,9 @@ public class IndexWriter
       synchronized (this) {
         ensureOpen();
         if (merges.areEnabled() == false) {
-          throw new AlreadyClosedException("Merges are disabled on current writer. " +
-            "Cannot execute addIndexes(CodecReaders...) API");
+          throw new AlreadyClosedException(
+              "Merges are disabled on current writer. "
+                  + "Cannot execute addIndexes(CodecReaders...) API");
         }
       }
 
@@ -3162,10 +3164,11 @@ public class IndexWriter
           spec.merges.forEach(addIndexesMergeSource::registerMerge);
           mergeScheduler.merge(addIndexesMergeSource, MergeTrigger.ADD_INDEXES);
           spec.await();
-          mergeSuccess = spec.merges.stream().allMatch(m -> m.hasCompletedSuccessfully().orElse(false));
+          mergeSuccess =
+              spec.merges.stream().allMatch(m -> m.hasCompletedSuccessfully().orElse(false));
         } finally {
           if (mergeSuccess == false) {
-            for (MergePolicy.OneMerge merge: spec.merges) {
+            for (MergePolicy.OneMerge merge : spec.merges) {
               if (merge.getMergeInfo() != null) {
                 deleteNewFiles(merge.getMergeInfo().files());
               }
@@ -3175,11 +3178,13 @@ public class IndexWriter
       } else {
         if (infoStream.isEnabled("IW")) {
           if (spec == null) {
-            infoStream.message("addIndexes(CodecReaders...)",
-              "received null mergeSpecification from MergePolicy. No indexes to add, returning..");
+            infoStream.message(
+                "addIndexes(CodecReaders...)",
+                "received null mergeSpecification from MergePolicy. No indexes to add, returning..");
           } else {
-            infoStream.message("addIndexes(CodecReaders...)",
-              "received empty mergeSpecification from MergePolicy. No indexes to add, returning..");
+            infoStream.message(
+                "addIndexes(CodecReaders...)",
+                "received empty mergeSpecification from MergePolicy. No indexes to add, returning..");
           }
         }
         return docWriter.getNextSequenceNumber();
@@ -3188,7 +3193,7 @@ public class IndexWriter
       if (mergeSuccess) {
         List<SegmentCommitInfo> infos = new ArrayList<>();
         long totalDocs = 0;
-        for (MergePolicy.OneMerge merge: spec.merges) {
+        for (MergePolicy.OneMerge merge : spec.merges) {
           totalDocs += merge.totalMaxDoc;
           if (merge.getMergeInfo() != null) {
             infos.add(merge.getMergeInfo());
@@ -3217,7 +3222,8 @@ public class IndexWriter
           seqNo = docWriter.getNextSequenceNumber();
         }
       } else {
-        throw new MergePolicy.MergeException("failed to successfully merge all provided readers in addIndexes(CodecReader...)");
+        throw new MergePolicy.MergeException(
+            "failed to successfully merge all provided readers in addIndexes(CodecReader...)");
       }
     } catch (VirtualMachineError tragedy) {
       tragicEvent(tragedy, "addIndexes(CodecReader...)");
@@ -3263,15 +3269,15 @@ public class IndexWriter
 
     public synchronized void abortPendingMerges() throws IOException {
       IOUtils.applyToAll(
-        pendingAddIndexesMerges,
-        merge -> {
-          if (infoStream.isEnabled("IW")) {
-            infoStream.message("IW", "now abort pending addIndexes merge");
-          }
-          merge.setAborted();
-          merge.close(false, false, mr -> {});
-          onMergeFinished(merge);
-        });
+          pendingAddIndexesMerges,
+          merge -> {
+            if (infoStream.isEnabled("IW")) {
+              infoStream.message("IW", "now abort pending addIndexes merge");
+            }
+            merge.setAborted();
+            merge.close(false, false, mr -> {});
+            onMergeFinished(merge);
+          });
       pendingAddIndexesMerges.clear();
     }
 
@@ -3297,8 +3303,8 @@ public class IndexWriter
   /**
    * Runs a single merge operation for {@link IndexWriter#addIndexes(CodecReader...)}.
    *
-   * Merges and creates a SegmentInfo, for the readers grouped together in
-   * provided OneMerge.
+   * <p>Merges and creates a SegmentInfo, for the readers grouped together in provided OneMerge.
+   *
    * @param merge OneMerge object initialized from readers.
    * @throws IOException if there is a low-level IO error
    */
@@ -3323,8 +3329,10 @@ public class IndexWriter
       if (softDeletesEnabled) {
         Bits liveDocs = reader.hardLiveDocs;
         numSoftDeleted +=
-          PendingSoftDeletes.countSoftDeletes(
-            DocValuesFieldExistsQuery.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), leaf), liveDocs);
+            PendingSoftDeletes.countSoftDeletes(
+                DocValuesFieldExistsQuery.getDocValuesDocIdSetIterator(
+                    config.getSoftDeletesField(), leaf),
+                liveDocs);
       }
     }
 
@@ -3332,8 +3340,8 @@ public class IndexWriter
     testReserveDocs(numDocs);
 
     final IOContext context =
-      new IOContext(
-        new MergeInfo(Math.toIntExact(numDocs), -1, false, UNBOUNDED_MAX_MERGE_SEGMENTS));
+        new IOContext(
+            new MergeInfo(Math.toIntExact(numDocs), -1, false, UNBOUNDED_MAX_MERGE_SEGMENTS));
 
     // TODO: somehow we should fix this merge so it's
     // abortable so that IW.close(false) is able to stop it
@@ -3341,21 +3349,23 @@ public class IndexWriter
     Codec codec = config.getCodec();
     // We set the min version to null for now, it will be set later by SegmentMerger
     SegmentInfo segInfo =
-      new SegmentInfo(
-        directoryOrig,
-        Version.LATEST,
-        null,
-        mergedName,
-        -1,
-        false,
-        codec,
-        Collections.emptyMap(),
-        StringHelper.randomId(),
-        Collections.emptyMap(),
-        config.getIndexSort());
+        new SegmentInfo(
+            directoryOrig,
+            Version.LATEST,
+            null,
+            mergedName,
+            -1,
+            false,
+            codec,
+            Collections.emptyMap(),
+            StringHelper.randomId(),
+            Collections.emptyMap(),
+            config.getIndexSort());
 
-    List<CodecReader> readers = merge.getMergeReader().stream().map(r -> r.codecReader).collect(Collectors.toList());
-    SegmentMerger merger = new SegmentMerger(readers, segInfo, infoStream, trackingDir, globalFieldNumberMap, context);
+    List<CodecReader> readers =
+        merge.getMergeReader().stream().map(r -> r.codecReader).collect(Collectors.toList());
+    SegmentMerger merger =
+        new SegmentMerger(readers, segInfo, infoStream, trackingDir, globalFieldNumberMap, context);
 
     if (!merger.shouldMerge()) {
       return;
@@ -3375,8 +3385,8 @@ public class IndexWriter
       }
     }
 
-    merge.setMergeInfo(new SegmentCommitInfo(segInfo, 0, numSoftDeleted,
-        -1L, -1L, -1L, StringHelper.randomId()));
+    merge.setMergeInfo(
+        new SegmentCommitInfo(segInfo, 0, numSoftDeleted, -1L, -1L, -1L, StringHelper.randomId()));
     merge.getMergeInfo().info.setFiles(new HashSet<>(trackingDir.getCreatedFiles()));
     trackingDir.clearCreatedFiles();
 
@@ -3396,7 +3406,8 @@ public class IndexWriter
       // TODO: unlike merge, on exception we arent sniping any trash cfs files here?
       // createCompoundFile tries to cleanup, but it might not always be able to...
       try {
-        createCompoundFile(infoStream, trackingCFSDir, merge.getMergeInfo().info, context, this::deleteNewFiles);
+        createCompoundFile(
+            infoStream, trackingCFSDir, merge.getMergeInfo().info, context, this::deleteNewFiles);
       } finally {
         // delete new non cfs files directly: they were never
         // registered with IFD

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3341,7 +3341,7 @@ public class IndexWriter
         Bits liveDocs = reader.hardLiveDocs;
         numSoftDeleted +=
             PendingSoftDeletes.countSoftDeletes(
-                DocValuesFieldExistsQuery.getDocValuesDocIdSetIterator(
+                DocValuesIterator.getDocValuesDocIdSetIterator(
                     config.getSoftDeletesField(), leaf),
                 liveDocs);
       }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3116,7 +3116,7 @@ public class IndexWriter
    * <p><b>NOTE:</b> empty segments are dropped by this method and not added to this index.
    *
    * <p><b>NOTE:</b> provided {@link LeafReader}s are merged as specified by the
-   * {@link MergePolicy#findMerges(List<CodecReader>)} API. Default behavior is to merge
+   * {@link MergePolicy#findMerges(List)} API. Default behavior is to merge
    * all provided readers into a single segment. You can modify this by overriding the
    * <code>findMerge</code> API in your custom merge policy.
    *

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3129,6 +3129,9 @@ public class IndexWriter
     long numDocs = 0;
     for (CodecReader leaf: readers) {
       validateMergeReader(leaf);
+      for (FieldInfo fi: leaf.getFieldInfos()) {
+        globalFieldNumberMap.verifyField(fi);
+      }
       numDocs += leaf.numDocs();
     }
     testReserveDocs(numDocs);

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3115,13 +3115,10 @@ public class IndexWriter
    *
    * <p><b>NOTE:</b> empty segments are dropped by this method and not added to this index.
    *
-   * <p><b>NOTE:</b> this merges all given {@link LeafReader}s in one merge. If you intend to merge
-   * a large number of readers, it may be better to call this method multiple times, each time with
-   * a small set of readers. In principle, if you use a merge policy with a {@code mergeFactor} or
-   * {@code maxMergeAtOnce} parameter, you should pass that many readers in one call.
-   *
-   * <p><b>NOTE:</b> this method does not call or make use of the {@link MergeScheduler}, so any
-   * custom bandwidth throttling is at the moment ignored.
+   * <p><b>NOTE:</b> provided {@link LeafReader}s are merged as specified by the
+   * {@link MergePolicy#findMerges(List<CodecReader>)} API. Default behavior is to merge
+   * all provided readers into a single segment. You can modify this by overriding the
+   * <code>findMerge</code> API in your custom merge policy.
    *
    * @return The <a href="#sequence_number">sequence number</a> for this operation
    * @throws CorruptIndexException if the index is corrupt

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3339,7 +3339,7 @@ public class IndexWriter
         Bits liveDocs = reader.hardLiveDocs;
         numSoftDeleted +=
             PendingSoftDeletes.countSoftDeletes(
-                DocValuesIterator.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), leaf),
+                FieldExistsQuery.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), leaf),
                 liveDocs);
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3231,7 +3231,8 @@ public class IndexWriter
             IOUtils.rethrowAlways(t);
           }
         }
-        // If no merge hit an exception, and merge was not aborted, but we still failed to add indexes, fail the API
+        // If no merge hit an exception, and merge was not aborted, but we still failed to add
+        // indexes, fail the API
         throw new RuntimeException(
             "failed to successfully merge all provided readers in addIndexes(CodecReader...)");
       }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3223,7 +3223,8 @@ public class IndexWriter
         }
       } else {
         if (infoStream.isEnabled("IW")) {
-          infoStream.message("addIndexes(CodecReaders...)", "failed to successfully merge all provided readers.");
+          infoStream.message(
+              "addIndexes(CodecReaders...)", "failed to successfully merge all provided readers.");
         }
         for (MergePolicy.OneMerge merge : spec.merges) {
           Throwable t = merge.getException();
@@ -3232,7 +3233,8 @@ public class IndexWriter
           }
         }
         // If no merge hit an exception but we still failed to add indexes, fail the API
-        throw new RuntimeException("failed to successfully merge all provided readers in addIndexes(CodecReader...)");
+        throw new RuntimeException(
+            "failed to successfully merge all provided readers in addIndexes(CodecReader...)");
       }
     } catch (VirtualMachineError tragedy) {
       tragicEvent(tragedy, "addIndexes(CodecReader...)");

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3173,6 +3173,17 @@ public class IndexWriter
             }
           }
         }
+      } else {
+        if (infoStream.isEnabled("IW")) {
+          if (spec == null) {
+            infoStream.message("addIndexes(CodecReaders...)",
+              "received null mergeSpecification from MergePolicy. No indexes to add, returning..");
+          } else {
+            infoStream.message("addIndexes(CodecReaders...)",
+              "received empty mergeSpecification from MergePolicy. No indexes to add, returning..");
+          }
+        }
+        return docWriter.getNextSequenceNumber();
       }
 
       if (mergeSuccess) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3341,8 +3341,7 @@ public class IndexWriter
         Bits liveDocs = reader.hardLiveDocs;
         numSoftDeleted +=
             PendingSoftDeletes.countSoftDeletes(
-                DocValuesIterator.getDocValuesDocIdSetIterator(
-                    config.getSoftDeletesField(), leaf),
+                DocValuesIterator.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), leaf),
                 liveDocs);
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3222,8 +3222,17 @@ public class IndexWriter
           seqNo = docWriter.getNextSequenceNumber();
         }
       } else {
-        throw new MergePolicy.MergeException(
-            "failed to successfully merge all provided readers in addIndexes(CodecReader...)");
+        if (infoStream.isEnabled("IW")) {
+          infoStream.message("addIndexes(CodecReaders...)", "failed to successfully merge all provided readers.");
+        }
+        for (MergePolicy.OneMerge merge : spec.merges) {
+          Throwable t = merge.getException();
+          if (t != null) {
+            IOUtils.rethrowAlways(t);
+          }
+        }
+        // If no merge hit an exception but we still failed to add indexes, fail the API
+        throw new RuntimeException("failed to successfully merge all provided readers in addIndexes(CodecReader...)");
       }
     } catch (VirtualMachineError tragedy) {
       tragicEvent(tragedy, "addIndexes(CodecReader...)");

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3172,9 +3172,9 @@ public class IndexWriter
 
       if (mergesComplete) {
         List<SegmentCommitInfo> infos = new ArrayList<>();
-        long totalMaxDoc = 0;
+        long totalDocs = 0;
         for (MergePolicy.OneMerge merge: spec.merges) {
-          totalMaxDoc += merge.totalMaxDoc;
+          totalDocs += merge.totalMaxDoc;
           if (merge.getMergeInfo() != null) {
             infos.add(merge.getMergeInfo());
           }
@@ -3187,7 +3187,7 @@ public class IndexWriter
             try {
               ensureOpen();
               // Reserve the docs, just before we update SIS:
-              reserveDocs(totalMaxDoc);
+              reserveDocs(totalDocs);
               success = true;
             } finally {
               if (success == false) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3287,16 +3287,15 @@ public class IndexWriter
     public void abortPendingMerges() throws IOException {
       synchronized (IndexWriter.this) {
         IOUtils.applyToAll(
-          pendingAddIndexesMerges,
-          merge -> {
-            if (infoStream.isEnabled("IW")) {
-              infoStream.message("IW", "now abort pending addIndexes merge");
-            }
-            merge.setAborted();
-            merge.close(false, false, mr -> {
+            pendingAddIndexesMerges,
+            merge -> {
+              if (infoStream.isEnabled("IW")) {
+                infoStream.message("IW", "now abort pending addIndexes merge");
+              }
+              merge.setAborted();
+              merge.close(false, false, mr -> {});
+              onMergeFinished(merge);
             });
-            onMergeFinished(merge);
-          });
         pendingAddIndexesMerges.clear();
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3133,157 +3133,22 @@ public class IndexWriter
     }
     testReserveDocs(numDocs);
 
+    synchronized (this) {
+      ensureOpen();
+      if (merges.areEnabled() == false) {
+        return docWriter.getNextSequenceNumber();
+      }
+    }
+
     MergePolicy mergePolicy = config.getMergePolicy();
     MergePolicy.MergeSpecification spec = mergePolicy.findMerges(Arrays.asList(readers));
     if (spec != null && spec.merges.size() > 0) {
       spec.merges.forEach(addIndexesMergeSource::registerMerge);
       mergeScheduler.merge(addIndexesMergeSource, MergeTrigger.ADD_INDEXES);
+      spec.await(5, TimeUnit.MINUTES);
     }
     maybeMerge();
     return docWriter.getNextSequenceNumber();
-
-//    // =======
-//
-//    // long so we can detect int overflow:
-////    long numDocs = 0;
-//    long seqNo;
-//    try {
-//      if (infoStream.isEnabled("IW")) {
-//        infoStream.message("IW", "flush at addIndexes(CodecReader...)");
-//      }
-//      flush(false, true);
-//
-//      String mergedName = newSegmentName();
-//      int numSoftDeleted = 0;
-//      for (CodecReader leaf : readers) {
-//        numDocs += leaf.numDocs();
-////        validateMergeReader(leaf);
-//        if (softDeletesEnabled) {
-//          Bits liveDocs = leaf.getLiveDocs();
-//          numSoftDeleted +=
-//              PendingSoftDeletes.countSoftDeletes(
-//                  DocValuesFieldExistsQuery.getDocValuesDocIdSetIterator(
-//                      config.getSoftDeletesField(), leaf),
-//                  liveDocs);
-//        }
-//      }
-//
-//      // Best-effort up front check:
-//      testReserveDocs(numDocs);
-//
-//      final IOContext context =
-//          new IOContext(
-//              new MergeInfo(Math.toIntExact(numDocs), -1, false, UNBOUNDED_MAX_MERGE_SEGMENTS));
-//
-//      // TODO: somehow we should fix this merge so it's
-//      // abortable so that IW.close(false) is able to stop it
-//      TrackingDirectoryWrapper trackingDir = new TrackingDirectoryWrapper(directory);
-//      Codec codec = config.getCodec();
-//      // We set the min version to null for now, it will be set later by SegmentMerger
-//      SegmentInfo info =
-//          new SegmentInfo(
-//              directoryOrig,
-//              Version.LATEST,
-//              null,
-//              mergedName,
-//              -1,
-//              false,
-//              codec,
-//              Collections.emptyMap(),
-//              StringHelper.randomId(),
-//              Collections.emptyMap(),
-//              config.getIndexSort());
-//
-//      SegmentMerger merger =
-//          new SegmentMerger(
-//              Arrays.asList(readers), info, infoStream, trackingDir, globalFieldNumberMap, context);
-//
-//      if (!merger.shouldMerge()) {
-//        return docWriter.getNextSequenceNumber();
-//      }
-//
-//      synchronized (this) {
-//        ensureOpen();
-//        assert merges.areEnabled();
-//        runningAddIndexesMerges.add(merger);
-//      }
-//      try {
-//        merger.merge(); // merge 'em
-//      } finally {
-//        synchronized (this) {
-//          runningAddIndexesMerges.remove(merger);
-//          notifyAll();
-//        }
-//      }
-//      SegmentCommitInfo infoPerCommit =
-//          new SegmentCommitInfo(info, 0, numSoftDeleted, -1L, -1L, -1L, StringHelper.randomId());
-//
-//      info.setFiles(new HashSet<>(trackingDir.getCreatedFiles()));
-//      trackingDir.clearCreatedFiles();
-//
-//      setDiagnostics(info, SOURCE_ADDINDEXES_READERS);
-//
-//      final MergePolicy mergePolicy = config.getMergePolicy();
-//      boolean useCompoundFile;
-//      synchronized (this) { // Guard segmentInfos
-//        if (merges.areEnabled() == false) {
-//          // Safe: these files must exist
-//          deleteNewFiles(infoPerCommit.files());
-//
-//          return docWriter.getNextSequenceNumber();
-//        }
-//        ensureOpen();
-//        useCompoundFile = mergePolicy.useCompoundFile(segmentInfos, infoPerCommit, this);
-//      }
-//
-//      // Now create the compound file if needed
-//      if (useCompoundFile) {
-//        Collection<String> filesToDelete = infoPerCommit.files();
-//        TrackingDirectoryWrapper trackingCFSDir = new TrackingDirectoryWrapper(directory);
-//        // TODO: unlike merge, on exception we arent sniping any trash cfs files here?
-//        // createCompoundFile tries to cleanup, but it might not always be able to...
-//        try {
-//          createCompoundFile(infoStream, trackingCFSDir, info, context, this::deleteNewFiles);
-//        } finally {
-//          // delete new non cfs files directly: they were never
-//          // registered with IFD
-//          deleteNewFiles(filesToDelete);
-//        }
-//        info.setUseCompoundFile(true);
-//      }
-//
-//      // Have codec write SegmentInfo.  Must do this after
-//      // creating CFS so that 1) .si isn't slurped into CFS,
-//      // and 2) .si reflects useCompoundFile=true change
-//      // above:
-//      codec.segmentInfoFormat().write(trackingDir, info, context);
-//
-//      info.addFiles(trackingDir.getCreatedFiles());
-//
-//      // Register the new segment
-//      synchronized (this) {
-//        if (merges.areEnabled() == false) {
-//          // Safe: these files must exist
-//          deleteNewFiles(infoPerCommit.files());
-//
-//          return docWriter.getNextSequenceNumber();
-//        }
-//        ensureOpen();
-//
-//        // Now reserve the docs, just before we update SIS:
-//        reserveDocs(numDocs);
-//
-//        segmentInfos.add(infoPerCommit);
-//        seqNo = docWriter.getNextSequenceNumber();
-//        checkpoint();
-//      }
-//    } catch (VirtualMachineError tragedy) {
-//      tragicEvent(tragedy, "addIndexes(CodecReader...)");
-//      throw tragedy;
-//    }
-//    maybeMerge();
-//    return docWriter.getNextSequenceNumber();  // VIGYA added now
-//    return seqNo;
   }
 
   private class AddIndexesMergeSource implements MergeScheduler.MergeSource {
@@ -3297,8 +3162,6 @@ public class IndexWriter
 
     @Override
     public MergePolicy.OneMerge getNextMerge() {
-      System.out.println("VIGYA - getNextMerge: pendingAddIndexesMerges size = " + pendingAddIndexesMerges.size());
-      System.out.println("VIGYA - getNextMerge: pendingMerges size = " + pendingMerges.size());
       if (hasPendingMerges() == false) {
         return null;
       }
@@ -3320,139 +3183,147 @@ public class IndexWriter
 
     @Override
     public void merge(MergePolicy.OneMerge merge) throws IOException {
-      List<CodecReader> readers = merge.getMergeReader().stream().map(r -> r.reader).collect(Collectors.toList());
-
-      // long so we can detect int overflow:
-      long numDocs = 0;
-//      long seqNo;
+      boolean success = false;
       try {
-        if (infoStream.isEnabled("IW")) {
-          infoStream.message("IW", "flush at addIndexes(CodecReader...)");
-        }
-        flush(false, true);
-
-        String mergedName = newSegmentName();
-        int numSoftDeleted = 0;
-        for (CodecReader leaf : readers) {
-          numDocs += leaf.numDocs();
-          if (softDeletesEnabled) {
-            Bits liveDocs = leaf.getLiveDocs();
-            numSoftDeleted +=
-              PendingSoftDeletes.countSoftDeletes(
-                DocValuesFieldExistsQuery.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), leaf), liveDocs);
-          }
-        }
-
-        // Best-effort up front check:
-        testReserveDocs(numDocs);
-
-        final IOContext context =
-          new IOContext(
-            new MergeInfo(Math.toIntExact(numDocs), -1, false, UNBOUNDED_MAX_MERGE_SEGMENTS));
-
-        // TODO: somehow we should fix this merge so it's
-        // abortable so that IW.close(false) is able to stop it
-        TrackingDirectoryWrapper trackingDir = new TrackingDirectoryWrapper(directory);
-        Codec codec = config.getCodec();
-        // We set the min version to null for now, it will be set later by SegmentMerger
-        SegmentInfo info =
-          new SegmentInfo(
-            directoryOrig,
-            Version.LATEST,
-            null,
-            mergedName,
-            -1,
-            false,
-            codec,
-            Collections.emptyMap(),
-            StringHelper.randomId(),
-            Collections.emptyMap(),
-            config.getIndexSort());
-
-        SegmentMerger merger = new SegmentMerger(readers, info, infoStream, trackingDir, globalFieldNumberMap, context);
-
-        if (!merger.shouldMerge()) {
-          return;
-        }
-
-        synchronized (this) {
-          ensureOpen();
-          assert merges.areEnabled();
-          runningAddIndexesMerges.add(merger);
-        }
-        try {
-          merger.merge(); // merge 'em
-        } finally {
-          synchronized (this) {
-            runningAddIndexesMerges.remove(merger);
-            notifyAll();
-          }
-        }
-        SegmentCommitInfo infoPerCommit =
-          new SegmentCommitInfo(info, 0, numSoftDeleted, -1L, -1L, -1L, StringHelper.randomId());
-
-        info.setFiles(new HashSet<>(trackingDir.getCreatedFiles()));
-        trackingDir.clearCreatedFiles();
-
-        setDiagnostics(info, SOURCE_ADDINDEXES_READERS);
-
-        final MergePolicy mergePolicy = config.getMergePolicy();
-        boolean useCompoundFile;
-        synchronized (this) { // Guard segmentInfos
-          if (merges.areEnabled() == false) {
-            // Safe: these files must exist
-            deleteNewFiles(infoPerCommit.files());
-            return;
-          }
-          ensureOpen();
-          useCompoundFile = mergePolicy.useCompoundFile(segmentInfos, infoPerCommit, IndexWriter.this);
-        }
-
-        // Now create the compound file if needed
-        if (useCompoundFile) {
-          Collection<String> filesToDelete = infoPerCommit.files();
-          TrackingDirectoryWrapper trackingCFSDir = new TrackingDirectoryWrapper(directory);
-          // TODO: unlike merge, on exception we arent sniping any trash cfs files here?
-          // createCompoundFile tries to cleanup, but it might not always be able to...
-          try {
-            createCompoundFile(infoStream, trackingCFSDir, info, context, IndexWriter.this::deleteNewFiles);
-          } finally {
-            // delete new non cfs files directly: they were never
-            // registered with IFD
-            deleteNewFiles(filesToDelete);
-          }
-          info.setUseCompoundFile(true);
-        }
-
-        // Have codec write SegmentInfo.  Must do this after
-        // creating CFS so that 1) .si isn't slurped into CFS,
-        // and 2) .si reflects useCompoundFile=true change
-        // above:
-        codec.segmentInfoFormat().write(trackingDir, info, context);
-
-        info.addFiles(trackingDir.getCreatedFiles());
-
-        // Register the new segment
-        synchronized (this) {
-          if (merges.areEnabled() == false) {
-            // Safe: these files must exist
-            deleteNewFiles(infoPerCommit.files());
-            return;
-          }
-          ensureOpen();
-
-          // Now reserve the docs, just before we update SIS:
-          reserveDocs(numDocs);
-
-          segmentInfos.add(infoPerCommit);
-//          seqNo = docWriter.getNextSequenceNumber();
-          checkpoint();
-        }
+        doMerge(merge);
+        success = true;
       } catch (VirtualMachineError tragedy) {
         tragicEvent(tragedy, "addIndexes(CodecReader...)");
         throw tragedy;
+      } finally {
+        merge.close(success, false, mr -> {});
+        onMergeFinished(merge);
       }
-//      maybeMerge();
+    }
+
+    public void doMerge(MergePolicy.OneMerge merge) throws IOException {
+
+      // long so we can detect int overflow:
+      long numDocs = 0;
+      if (infoStream.isEnabled("IW")) {
+        infoStream.message("IW", "flush at addIndexes(CodecReader...)");
+      }
+      flush(false, true);
+
+      String mergedName = newSegmentName();
+      int numSoftDeleted = 0;
+      for (MergePolicy.MergeReader reader : merge.getMergeReader()) {
+        CodecReader leaf = reader.codecReader;
+        numDocs += leaf.numDocs();
+        if (softDeletesEnabled) {
+          Bits liveDocs = reader.hardLiveDocs;
+          numSoftDeleted +=
+            PendingSoftDeletes.countSoftDeletes(
+              DocValuesFieldExistsQuery.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), leaf), liveDocs);
+        }
+      }
+
+      // Best-effort up front check:
+      testReserveDocs(numDocs);
+
+      final IOContext context =
+        new IOContext(
+          new MergeInfo(Math.toIntExact(numDocs), -1, false, UNBOUNDED_MAX_MERGE_SEGMENTS));
+
+      // TODO: somehow we should fix this merge so it's
+      // abortable so that IW.close(false) is able to stop it
+      TrackingDirectoryWrapper trackingDir = new TrackingDirectoryWrapper(directory);
+      Codec codec = config.getCodec();
+      // We set the min version to null for now, it will be set later by SegmentMerger
+      SegmentInfo info =
+        new SegmentInfo(
+          directoryOrig,
+          Version.LATEST,
+          null,
+          mergedName,
+          -1,
+          false,
+          codec,
+          Collections.emptyMap(),
+          StringHelper.randomId(),
+          Collections.emptyMap(),
+          config.getIndexSort());
+
+      List<CodecReader> readers = merge.getMergeReader().stream().map(r -> r.codecReader).collect(Collectors.toList());
+      SegmentMerger merger = new SegmentMerger(readers, info, infoStream, trackingDir, globalFieldNumberMap, context);
+
+      if (!merger.shouldMerge()) {
+        return;
+      }
+
+      synchronized (this) {
+        ensureOpen();
+//          assert merges.areEnabled();
+        runningAddIndexesMerges.add(merger);
+      }
+      try {
+        merger.merge(); // merge 'em
+      } finally {
+        synchronized (this) {
+          runningAddIndexesMerges.remove(merger);
+          notifyAll();
+        }
+      }
+      SegmentCommitInfo infoPerCommit =
+        new SegmentCommitInfo(info, 0, numSoftDeleted, -1L, -1L, -1L, StringHelper.randomId());
+
+      info.setFiles(new HashSet<>(trackingDir.getCreatedFiles()));
+      trackingDir.clearCreatedFiles();
+
+      setDiagnostics(info, SOURCE_ADDINDEXES_READERS);
+
+      final MergePolicy mergePolicy = config.getMergePolicy();
+      boolean useCompoundFile;
+      synchronized (this) { // Guard segmentInfos
+//          if (merges.areEnabled() == false) {
+//            // Safe: these files must exist
+//            deleteNewFiles(infoPerCommit.files());
+//            return;
+//          }
+        ensureOpen();
+        useCompoundFile = mergePolicy.useCompoundFile(segmentInfos, infoPerCommit, IndexWriter.this);
+      }
+
+      // Now create the compound file if needed
+      if (useCompoundFile) {
+        Collection<String> filesToDelete = infoPerCommit.files();
+        TrackingDirectoryWrapper trackingCFSDir = new TrackingDirectoryWrapper(directory);
+        // TODO: unlike merge, on exception we arent sniping any trash cfs files here?
+        // createCompoundFile tries to cleanup, but it might not always be able to...
+        try {
+          createCompoundFile(infoStream, trackingCFSDir, info, context, IndexWriter.this::deleteNewFiles);
+        } finally {
+          // delete new non cfs files directly: they were never
+          // registered with IFD
+          deleteNewFiles(filesToDelete);
+        }
+        info.setUseCompoundFile(true);
+      }
+
+      // Have codec write SegmentInfo.  Must do this after
+      // creating CFS so that 1) .si isn't slurped into CFS,
+      // and 2) .si reflects useCompoundFile=true change
+      // above:
+      codec.segmentInfoFormat().write(trackingDir, info, context);
+
+      info.addFiles(trackingDir.getCreatedFiles());
+
+      // Register the new segment
+      synchronized (this) {
+//          if (merges.areEnabled() == false) {
+//            // Safe: these files must exist
+//            deleteNewFiles(infoPerCommit.files());
+//            return;
+//          }
+        ensureOpen();
+
+        // Now reserve the docs, just before we update SIS:
+        reserveDocs(numDocs);
+
+        segmentInfos.add(infoPerCommit);
+//          seqNo = docWriter.getNextSequenceNumber();
+        checkpoint();
+      }
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3116,7 +3116,7 @@ public class IndexWriter
    * <p><b>NOTE:</b> empty segments are dropped by this method and not added to this index.
    *
    * <p><b>NOTE:</b> provided {@link LeafReader}s are merged as specified by the {@link
-   * MergePolicy#findMerges(List)} API. Default behavior is to merge all provided readers into a
+   * MergePolicy#findMerges(CodecReader...)} API. Default behavior is to merge all provided readers into a
    * single segment. You can modify this by overriding the <code>findMerge</code> API in your custom
    * merge policy.
    *
@@ -3153,7 +3153,7 @@ public class IndexWriter
       }
 
       MergePolicy mergePolicy = config.getMergePolicy();
-      MergePolicy.MergeSpecification spec = mergePolicy.findMerges(Arrays.asList(readers));
+      MergePolicy.MergeSpecification spec = mergePolicy.findMerges(readers);
       boolean mergeSuccess = false;
       if (spec != null && spec.merges.size() > 0) {
         try {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3202,6 +3202,13 @@ public class IndexWriter
     }
   }
 
+  /**
+   * Runs merge on a OneMerge created from CodecReaders. This is used by to merge
+   * incoming readers in {@link IndexWriter#addIndexes(CodecReader...)}
+   * @param merge OneMerge object initialized from readers. This merge object has an empty
+   *              segments list
+   * @throws IOException
+   */
   public void addIndexesReaderMerge(MergePolicy.OneMerge merge) throws IOException {
 
     merge.mergeInit();

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3165,7 +3165,6 @@ public class IndexWriter
           mergeSuccess = spec.merges.stream().allMatch(m -> m.hasCompletedSuccessfully().orElse(false));
         } finally {
           if (mergeSuccess == false) {
-            // nocommit -- ensure all intermediate files are deleted
             for (MergePolicy.OneMerge merge: spec.merges) {
               if (merge.getMergeInfo() != null) {
                 deleteNewFiles(merge.getMergeInfo().files());
@@ -3196,7 +3195,6 @@ public class IndexWriter
           }
         }
 
-        // nocommit -- add tests for this transactional behavior
         synchronized (this) {
           if (infos.isEmpty() == false) {
             boolean registerSegmentSuccess = false;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3297,6 +3297,11 @@ public class IndexWriter
 
     @Override
     public MergePolicy.OneMerge getNextMerge() {
+      System.out.println("VIGYA - getNextMerge: pendingAddIndexesMerges size = " + pendingAddIndexesMerges.size());
+      System.out.println("VIGYA - getNextMerge: pendingMerges size = " + pendingMerges.size());
+      if (hasPendingMerges() == false) {
+        return null;
+      }
       MergePolicy.OneMerge merge = pendingAddIndexesMerges.remove();
       pendingMerges.removeFirst();
       runningMerges.add(merge);
@@ -3310,7 +3315,7 @@ public class IndexWriter
 
     @Override
     public boolean hasPendingMerges() {
-      return pendingMerges.size() > 0;
+      return pendingAddIndexesMerges.size() > 0;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3177,7 +3177,9 @@ public class IndexWriter
         long totalDocs = 0;
         for (MergePolicy.OneMerge merge: spec.merges) {
           totalDocs += merge.totalMaxDoc;
-          infos.add(merge.getMergeInfo());
+          if (merge.getMergeInfo() != null) {
+            infos.add(merge.getMergeInfo());
+          }
         }
 
         // nocommit -- add tests for this transactional behavior

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -2336,6 +2336,9 @@ public class IndexWriter
         case COMMIT:
           spec = mergePolicy.findFullFlushMerges(trigger, segmentInfos, this);
           break;
+        case ADD_INDEXES:
+          throw new IllegalStateException("Merges with ADD_INDEXES trigger should be " +
+            "called from within the addIndexes() API flow");
         case EXPLICIT:
         case FULL_FLUSH:
         case MERGE_FINISHED:
@@ -3266,7 +3269,7 @@ public class IndexWriter
    * incoming readers in {@link IndexWriter#addIndexes(CodecReader...)}
    * @param merge OneMerge object initialized from readers. This merge object has an empty
    *              segments list
-   * @throws IOException
+   * @throws IOException if there is a low-level IO error
    */
   public void addIndexesReaderMerge(MergePolicy.OneMerge merge) throws IOException {
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3116,9 +3116,9 @@ public class IndexWriter
    * <p><b>NOTE:</b> empty segments are dropped by this method and not added to this index.
    *
    * <p><b>NOTE:</b> provided {@link LeafReader}s are merged as specified by the {@link
-   * MergePolicy#findMerges(CodecReader...)} API. Default behavior is to merge all provided readers into a
-   * single segment. You can modify this by overriding the <code>findMerge</code> API in your custom
-   * merge policy.
+   * MergePolicy#findMerges(CodecReader...)} API. Default behavior is to merge all provided readers
+   * into a single segment. You can modify this by overriding the <code>findMerge</code> API in your
+   * custom merge policy.
    *
    * @return The <a href="#sequence_number">sequence number</a> for this operation
    * @throws CorruptIndexException if the index is corrupt

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3115,10 +3115,10 @@ public class IndexWriter
    *
    * <p><b>NOTE:</b> empty segments are dropped by this method and not added to this index.
    *
-   * <p><b>NOTE:</b> provided {@link LeafReader}s are merged as specified by the
-   * {@link MergePolicy#findMerges(List)} API. Default behavior is to merge
-   * all provided readers into a single segment. You can modify this by overriding the
-   * <code>findMerge</code> API in your custom merge policy.
+   * <p><b>NOTE:</b> provided {@link LeafReader}s are merged as specified by the {@link
+   * MergePolicy#findMerges(List)} API. Default behavior is to merge all provided readers into a
+   * single segment. You can modify this by overriding the <code>findMerge</code> API in your custom
+   * merge policy.
    *
    * @return The <a href="#sequence_number">sequence number</a> for this operation
    * @throws CorruptIndexException if the index is corrupt

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3151,8 +3151,7 @@ public class IndexWriter
         ensureOpen();
         if (merges.areEnabled() == false) {
           throw new AlreadyClosedException(
-              "Merges are disabled on current writer. "
-                  + "Cannot execute addIndexes(CodecReaders...) API");
+              "this IndexWriter is closed. Cannot execute addIndexes(CodecReaders...) API");
         }
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -248,7 +248,7 @@ public abstract class MergePolicy {
       codecReaders.forEach(r -> readers.add(readerFactory.apply(r)));
       mergeReaders = List.copyOf(readers);
       segments = List.of();
-      totalMaxDoc = codecReaders.stream().mapToInt(IndexReader::maxDoc).sum();
+      totalMaxDoc = codecReaders.stream().mapToInt(IndexReader::numDocs).sum();
       mergeProgress = new OneMergeProgress();
       usesPooledReaders = false;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -194,7 +194,7 @@ public abstract class MergePolicy {
     long mergeGen; // used by IndexWriter
     boolean isExternal; // used by IndexWriter
     int maxNumSegments = -1; // used by IndexWriter
-    boolean isAddIndexesMerge;
+    boolean usesPooledReaders; // used by IndexWriter to drop readers while closing
 
     /** Estimated size in bytes of the merged segment. */
     public volatile long estimatedMergeBytes; // used by IndexWriter
@@ -231,7 +231,7 @@ public abstract class MergePolicy {
       totalMaxDoc = segments.stream().mapToInt(i -> i.info.maxDoc()).sum();
       mergeProgress = new OneMergeProgress();
       mergeReaders = List.of();
-      isAddIndexesMerge = false;
+      usesPooledReaders = true;
     }
 
     /**
@@ -249,7 +249,7 @@ public abstract class MergePolicy {
       segments = List.of();
       totalMaxDoc = codecReaders.stream().mapToInt(IndexReader::maxDoc).sum();
       mergeProgress = new OneMergeProgress();
-      isAddIndexesMerge = true;
+      usesPooledReaders = false;
     }
 
     /**
@@ -281,9 +281,7 @@ public abstract class MergePolicy {
       } finally {
         final List<MergeReader> readers = mergeReaders;
         mergeReaders = List.of();
-        if (!isAddIndexesMerge) {
-          IOUtils.applyToAll(readers, readerConsumer);
-        }
+        IOUtils.applyToAll(readers, readerConsumer);
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -35,7 +35,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
 import org.apache.lucene.document.Field;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MergeInfo;
@@ -245,7 +244,7 @@ public abstract class MergePolicy {
     public OneMerge(CodecReader... codecReaders) {
       List<MergeReader> readers = new ArrayList<>(codecReaders.length);
       int totalDocs = 0;
-      for (CodecReader r: codecReaders) {
+      for (CodecReader r : codecReaders) {
         readers.add(new MergeReader(r, r.getLiveDocs()));
         totalDocs += r.numDocs();
       }

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -232,6 +232,14 @@ public abstract class MergePolicy {
       mergeReaders = List.of();
     }
 
+    /**
+     * Create a OneMerge directly from CodecReaders.
+     * Used to merge incoming readers in {@link IndexWriter#addIndexes(CodecReader...)}. This
+     * OneMerge works directly on readers and has an empty segments list.
+     *
+     * @param codecReaders Codec readers to merge
+     * @param readerFactory Function to create a MergeReader from a CodecReader.
+     */
     public OneMerge(List<CodecReader> codecReaders, Function<CodecReader, MergeReader> readerFactory) {
       List<MergeReader> readers = new ArrayList<>(codecReaders.size());
       codecReaders.forEach(r -> readers.add(readerFactory.apply(r)));

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -236,14 +236,15 @@ public abstract class MergePolicy {
     }
 
     /**
-     * Create a OneMerge directly from CodecReaders.
-     * Used to merge incoming readers in {@link IndexWriter#addIndexes(CodecReader...)}. This
-     * OneMerge works directly on readers and has an empty segments list.
+     * Create a OneMerge directly from CodecReaders. Used to merge incoming readers in {@link
+     * IndexWriter#addIndexes(CodecReader...)}. This OneMerge works directly on readers and has an
+     * empty segments list.
      *
      * @param codecReaders Codec readers to merge
      * @param readerFactory Function to create a MergeReader from a CodecReader.
      */
-    public OneMerge(List<CodecReader> codecReaders, Function<CodecReader, MergeReader> readerFactory) {
+    public OneMerge(
+        List<CodecReader> codecReaders, Function<CodecReader, MergeReader> readerFactory) {
       List<MergeReader> readers = new ArrayList<>(codecReaders.size());
       codecReaders.forEach(r -> readers.add(readerFactory.apply(r)));
       mergeReaders = List.copyOf(readers);
@@ -496,10 +497,10 @@ public abstract class MergePolicy {
 
     CompletableFuture<Void> getMergeCompletedFutures() {
       return CompletableFuture.allOf(
-        merges.stream()
-          .map(m -> m.mergeCompleted)
-          .collect(Collectors.toList())
-          .toArray(CompletableFuture<?>[]::new));
+          merges.stream()
+              .map(m -> m.mergeCompleted)
+              .collect(Collectors.toList())
+              .toArray(CompletableFuture<?>[]::new));
     }
 
     /** Waits, until interrupted, for all merges to complete. */
@@ -608,15 +609,14 @@ public abstract class MergePolicy {
       throws IOException;
 
   /**
-   * Define the set of merge operations to perform on provided codec readers
-   * in {@link IndexWriter#addIndexes(CodecReader...)}.
+   * Define the set of merge operations to perform on provided codec readers in {@link
+   * IndexWriter#addIndexes(CodecReader...)}.
    *
-   * The merge operation is required to convert provided readers into segments that can be added
-   * to the writer. This API can be overridden in custom merge policies to control the
-   * concurrency for addIndexes. Default implementation creates a single merge operation for
-   * all provided readers (lowest concurrency).
-   * Creating a merge for each reader, would provide the highest level of concurrency possible
-   * with the configured merge scheduler.
+   * <p>The merge operation is required to convert provided readers into segments that can be added
+   * to the writer. This API can be overridden in custom merge policies to control the concurrency
+   * for addIndexes. Default implementation creates a single merge operation for all provided
+   * readers (lowest concurrency). Creating a merge for each reader, would provide the highest level
+   * of concurrency possible with the configured merge scheduler.
    *
    * @param readers set of readers to merge into the main index
    */

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -608,10 +608,15 @@ public abstract class MergePolicy {
       throws IOException;
 
   /**
-   * Define {@link OneMerge} operations for a list of codec readers. This call is used to
-   * define merges for input readers in {@link IndexWriter#addIndexes(CodecReader...)}.
-   * Default implementation adds all readers to a single merge. This can be overridden in custom
-   * merge policies.
+   * Define the set of merge operations to perform on provided codec readers
+   * in {@link IndexWriter#addIndexes(CodecReader...)}.
+   *
+   * The merge operation is required to convert provided readers into segments that can be added
+   * to the writer. This API can be overridden in custom merge policies to control the
+   * concurrency for addIndexes. Default implementation creates a single merge operation for
+   * all provided readers (lowest concurrency).
+   * Creating a merge for each reader, would provide the highest level of concurrency possible
+   * with the configured merge scheduler.
    *
    * @param readers set of readers to merge into the main index
    */

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -194,6 +194,7 @@ public abstract class MergePolicy {
     long mergeGen; // used by IndexWriter
     boolean isExternal; // used by IndexWriter
     int maxNumSegments = -1; // used by IndexWriter
+    boolean isAddIndexesMerge;
 
     /** Estimated size in bytes of the merged segment. */
     public volatile long estimatedMergeBytes; // used by IndexWriter
@@ -230,6 +231,7 @@ public abstract class MergePolicy {
       totalMaxDoc = segments.stream().mapToInt(i -> i.info.maxDoc()).sum();
       mergeProgress = new OneMergeProgress();
       mergeReaders = List.of();
+      isAddIndexesMerge = false;
     }
 
     /**
@@ -247,6 +249,7 @@ public abstract class MergePolicy {
       segments = List.of();
       totalMaxDoc = codecReaders.stream().mapToInt(IndexReader::maxDoc).sum();
       mergeProgress = new OneMergeProgress();
+      isAddIndexesMerge = true;
     }
 
     /**
@@ -278,7 +281,9 @@ public abstract class MergePolicy {
       } finally {
         final List<MergeReader> readers = mergeReaders;
         mergeReaders = List.of();
-        IOUtils.applyToAll(readers, readerConsumer);
+        if (!isAddIndexesMerge) {
+          IOUtils.applyToAll(readers, readerConsumer);
+        }
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/MergeTrigger.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeTrigger.java
@@ -43,4 +43,6 @@ public enum MergeTrigger {
   COMMIT,
   /** Merge was triggered on opening NRT readers. */
   GET_READER,
+  /** Merge was triggered by an {@link IndexWriter#addIndexes(CodecReader...)} operation */
+  ADD_INDEXES,
 }

--- a/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
@@ -42,7 +42,12 @@ public final class NoMergePolicy extends MergePolicy {
 
   @Override
   public MergeSpecification findMerges(List<CodecReader> readers) throws IOException {
-    return null;
+    // addIndexes(CodecReader...) now uses MergePolicy and MergeScheduler to add
+    // provided readers (LUCENE-10216). We retain the default behavior here to enable
+    // addIndexes for consumers like IndexRearranger.
+    // This does not merge existing segments, but uses SegmentMerger to add
+    // new incoming readers to the index.
+    return super.findMerges(readers);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
@@ -41,7 +41,7 @@ public final class NoMergePolicy extends MergePolicy {
   }
 
   @Override
-  public MergeSpecification findMerges(List<CodecReader> readers) throws IOException {
+  public MergeSpecification findMerges(CodecReader... readers) throws IOException {
     // addIndexes(CodecReader...) now uses MergePolicy and MergeScheduler to add
     // provided readers (LUCENE-10216). We retain the default behavior here to enable
     // addIndexes for consumers like IndexRearranger.

--- a/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.apache.lucene.util.IOSupplier;
 
@@ -36,6 +37,11 @@ public final class NoMergePolicy extends MergePolicy {
   @Override
   public MergeSpecification findMerges(
       MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext) {
+    return null;
+  }
+
+  @Override
+  public MergeSpecification findMerges(List<CodecReader> readers) throws IOException {
     return null;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import org.apache.lucene.util.IOSupplier;
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -688,12 +688,11 @@ public class TestAddIndexes extends LuceneTestCase {
   private class ConcurrentAddIndexesMergePolicy extends TieredMergePolicy {
 
     @Override
-    public MergeSpecification findMerges(List<CodecReader> readers) throws IOException {
+    public MergeSpecification findMerges(CodecReader... readers) throws IOException {
       // create a oneMerge for each reader to let them get concurrently processed by addIndexes()
       MergeSpecification mergeSpec = new MergeSpecification();
       for (CodecReader reader : readers) {
-        mergeSpec.add(
-            new OneMerge(List.of(reader), leaf -> new MergeReader(leaf, leaf.getLiveDocs())));
+        mergeSpec.add(new OneMerge(reader));
       }
       if (VERBOSE) {
         System.out.println(
@@ -793,7 +792,7 @@ public class TestAddIndexes extends LuceneTestCase {
     ConcurrentAddIndexesMergePolicy mp =
         new ConcurrentAddIndexesMergePolicy() {
           @Override
-          public MergeSpecification findMerges(List<CodecReader> readers) throws IOException {
+          public MergeSpecification findMerges(CodecReader... readers) throws IOException {
             MergeSpecification spec = super.findMerges(readers);
             merges.addAll(spec.merges);
             return spec;
@@ -822,7 +821,7 @@ public class TestAddIndexes extends LuceneTestCase {
     MergePolicy mp =
         new TieredMergePolicy() {
           @Override
-          public MergeSpecification findMerges(List<CodecReader> readers) throws IOException {
+          public MergeSpecification findMerges(CodecReader... readers) throws IOException {
             return null;
           }
         };
@@ -840,7 +839,7 @@ public class TestAddIndexes extends LuceneTestCase {
     MergePolicy mp =
         new TieredMergePolicy() {
           @Override
-          public MergeSpecification findMerges(List<CodecReader> readers) throws IOException {
+          public MergeSpecification findMerges(CodecReader... readers) throws IOException {
             return new MergeSpecification();
           }
         };
@@ -1275,7 +1274,6 @@ public class TestAddIndexes extends LuceneTestCase {
       System.out.println("TEST: done join threads");
     }
     c.closeDir();
-
     assertTrue(c.failures.size() == 0);
   }
 
@@ -1304,6 +1302,7 @@ public class TestAddIndexes extends LuceneTestCase {
     }
 
     c.closeDir();
+    assertTrue(c.failures.size() == 0);
   }
 
   // LUCENE-2996: tests that addIndexes(IndexReader) applies existing deletes correctly.

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -1501,6 +1501,8 @@ public class TestAddIndexes extends LuceneTestCase {
       readers[i] = (CodecReader) reader.leaves().get(i).reader();
     }
     writer.addIndexes(readers);
+    System.out.printf("VIGYA - wrappedReader maxDocs: [%s], numDocs: [%s], delDocs: [%s]\n",
+      wrappedReader.maxDoc(), wrappedReader.numDocs(), wrappedReader.numDeletedDocs());
     assertEquals(wrappedReader.numDocs(), writer.getDocStats().numDocs);
     assertEquals(maxDoc, writer.getDocStats().maxDoc);
     writer.commit();

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -843,7 +842,6 @@ public class TestAddIndexes extends LuceneTestCase {
 
   private class CountingSerialMergeScheduler extends MergeScheduler {
 
-    int mergesTriggered = 0;
     int explicitMerges = 0;
     int addIndexesMerges = 0;
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -801,7 +801,7 @@ public class TestAddIndexes extends LuceneTestCase {
         };
     AddIndexesWithReadersSetup c = new AddIndexesWithReadersSetup(new PartialMergeScheduler(2), mp);
     assertThrows(
-        MergePolicy.MergeException.class, () -> TestUtil.addIndexesSlowly(c.destWriter, c.readers));
+        RuntimeException.class, () -> TestUtil.addIndexesSlowly(c.destWriter, c.readers));
     c.destWriter.commit();
 
     // verify no docs got added and all interim files from successful merges have been deleted from

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -696,7 +696,7 @@ public class TestAddIndexes extends LuceneTestCase {
         mergeSpec.add(new OneMerge(List.of(reader), leaf -> new MergeReader(leaf, leaf.getLiveDocs())));
       }
       if (VERBOSE) {
-        System.out.printf("[%s] merges found in mergeSpec\n", mergeSpec.merges.size());
+        System.out.println("No. of addIndexes merges returned by MergePolicy: " + mergeSpec.merges.size());
       }
       return mergeSpec;
     }
@@ -757,7 +757,8 @@ public class TestAddIndexes extends LuceneTestCase {
     public PartialMergeScheduler(int mergesToDo) {
       this.mergesToDo = mergesToDo;
       if (VERBOSE) {
-        System.out.printf("PartialMergeScheduler configured to mark all merges as failed, after triggering [%s] merges.\n", mergesToDo);
+        System.out.println("PartialMergeScheduler configured to mark all merges as failed, " +
+          "after triggering [" + mergesToDo + "] merges.");
       }
     }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -1501,8 +1501,6 @@ public class TestAddIndexes extends LuceneTestCase {
       readers[i] = (CodecReader) reader.leaves().get(i).reader();
     }
     writer.addIndexes(readers);
-    System.out.printf("VIGYA - wrappedReader maxDocs: [%s], numDocs: [%s], delDocs: [%s]\n",
-      wrappedReader.maxDoc(), wrappedReader.numDocs(), wrappedReader.numDeletedDocs());
     assertEquals(wrappedReader.numDocs(), writer.getDocStats().numDocs);
     assertEquals(maxDoc, writer.getDocStats().maxDoc);
     writer.commit();

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -953,7 +953,9 @@ public class TestAddIndexes extends LuceneTestCase {
       TestUtil.addIndexesSlowly(destWriter, readers);
       success = true;
     } catch (IllegalArgumentException e) {
-      assertTrue(e.getMessage().contains("number of documents in the index cannot exceed " + writerMaxDocs));
+      assertTrue(
+          e.getMessage()
+              .contains("number of documents in the index cannot exceed " + writerMaxDocs));
     }
     assertFalse(success);
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -800,8 +800,7 @@ public class TestAddIndexes extends LuceneTestCase {
           }
         };
     AddIndexesWithReadersSetup c = new AddIndexesWithReadersSetup(new PartialMergeScheduler(2), mp);
-    assertThrows(
-        RuntimeException.class, () -> TestUtil.addIndexesSlowly(c.destWriter, c.readers));
+    assertThrows(RuntimeException.class, () -> TestUtil.addIndexesSlowly(c.destWriter, c.readers));
     c.destWriter.commit();
 
     // verify no docs got added and all interim files from successful merges have been deleted from

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -853,7 +853,6 @@ public class TestAddIndexes extends LuceneTestCase {
           break;
         }
         mergeSource.merge(merge);
-        mergesTriggered++;
         if (trigger == MergeTrigger.EXPLICIT) {
           explicitMerges++;
         }

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -1793,7 +1793,10 @@ public class TestAddIndexes extends LuceneTestCase {
     assertEquals(wrappedReader.numDocs(), writer.getDocStats().numDocs);
     assertEquals(maxDoc, writer.getDocStats().maxDoc);
     writer.commit();
-    int softDeleteCount = writer.cloneSegmentInfos().asList().stream().mapToInt(SegmentCommitInfo::getSoftDelCount).sum();
+    int softDeleteCount =
+        writer.cloneSegmentInfos().asList().stream()
+            .mapToInt(SegmentCommitInfo::getSoftDelCount)
+            .sum();
     assertEquals(maxDoc - wrappedReader.numDocs(), softDeleteCount);
     writer.close();
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -803,8 +803,7 @@ public class TestAddIndexes extends LuceneTestCase {
     assertThrows(RuntimeException.class, () -> TestUtil.addIndexesSlowly(c.destWriter, c.readers));
     c.destWriter.commit();
 
-    // verify no docs got added and all interim files from successful merges have been deleted from
-    // dir
+    // verify no docs got added and all interim files from successful merges have been deleted
     try (IndexReader reader = DirectoryReader.open(c.destDir)) {
       assertEquals(c.INIT_DOCS, reader.numDocs());
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
@@ -352,7 +352,7 @@ public class TestIndexWriterOnDiskFull extends LuceneTestCase {
               done = true;
             }
 
-          } catch (IllegalStateException | IOException e) {
+          } catch (IllegalStateException | IOException | MergePolicy.MergeException e) {
             success = false;
             err = e;
             if (VERBOSE) {
@@ -360,7 +360,7 @@ public class TestIndexWriterOnDiskFull extends LuceneTestCase {
               e.printStackTrace(System.out);
             }
 
-            if (1 == x) {
+            if (1 == x && (e instanceof MergePolicy.MergeException == false)) {
               e.printStackTrace(System.out);
               fail(methodName + " hit IOException after disk space was freed up");
             }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
@@ -88,7 +88,7 @@ public class MockRandomMergePolicy extends MergePolicy {
 
   @Override
   public MergeSpecification findMerges(CodecReader... readers) throws IOException {
-    if (true || random.nextBoolean() == true) {
+    if (random.nextBoolean() == true) {
       return super.findMerges(readers);
     } else {
       // create a oneMerge for each reader to let them get concurrently processed by addIndexes()

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
@@ -88,7 +88,7 @@ public class MockRandomMergePolicy extends MergePolicy {
 
   @Override
   public MergeSpecification findMerges(CodecReader... readers) throws IOException {
-    if (false && random.nextBoolean() == true) {
+    if (true || random.nextBoolean() == true) {
       return super.findMerges(readers);
     } else {
       // create a oneMerge for each reader to let them get concurrently processed by addIndexes()

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
@@ -88,16 +88,16 @@ public class MockRandomMergePolicy extends MergePolicy {
 
   @Override
   public MergeSpecification findMerges(CodecReader... readers) throws IOException {
-//    if (random.nextBoolean() == true) {
-//      return super.findMerges(readers);
-//    } else {
+    if (false && random.nextBoolean() == true) {
+      return super.findMerges(readers);
+    } else {
       // create a oneMerge for each reader to let them get concurrently processed by addIndexes()
       MergeSpecification mergeSpec = new MergeSpecification();
       for (CodecReader reader : readers) {
         mergeSpec.add(new OneMerge(reader));
       }
       return mergeSpec;
-//    }
+    }
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
@@ -88,16 +88,16 @@ public class MockRandomMergePolicy extends MergePolicy {
 
   @Override
   public MergeSpecification findMerges(CodecReader... readers) throws IOException {
-    if (random.nextBoolean() == true) {
-      return super.findMerges(readers);
-    } else {
+//    if (random.nextBoolean() == true) {
+//      return super.findMerges(readers);
+//    } else {
       // create a oneMerge for each reader to let them get concurrently processed by addIndexes()
       MergeSpecification mergeSpec = new MergeSpecification();
       for (CodecReader reader : readers) {
         mergeSpec.add(new OneMerge(reader));
       }
       return mergeSpec;
-    }
+//    }
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
@@ -87,20 +87,6 @@ public class MockRandomMergePolicy extends MergePolicy {
   }
 
   @Override
-  public MergeSpecification findMerges(CodecReader... readers) throws IOException {
-    if (random.nextBoolean() == true) {
-      return super.findMerges(readers);
-    } else {
-      // create a oneMerge for each reader to let them get concurrently processed by addIndexes()
-      MergeSpecification mergeSpec = new MergeSpecification();
-      for (CodecReader reader : readers) {
-        mergeSpec.add(new OneMerge(reader));
-      }
-      return mergeSpec;
-    }
-  }
-
-  @Override
   public MergeSpecification findForcedMerges(
       SegmentInfos segmentInfos,
       int maxSegmentCount,

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MockRandomMergePolicy.java
@@ -87,6 +87,20 @@ public class MockRandomMergePolicy extends MergePolicy {
   }
 
   @Override
+  public MergeSpecification findMerges(CodecReader... readers) throws IOException {
+    if (random.nextBoolean() == true) {
+      return super.findMerges(readers);
+    } else {
+      // create a oneMerge for each reader to let them get concurrently processed by addIndexes()
+      MergeSpecification mergeSpec = new MergeSpecification();
+      for (CodecReader reader : readers) {
+        mergeSpec.add(new OneMerge(reader));
+      }
+      return mergeSpec;
+    }
+  }
+
+  @Override
   public MergeSpecification findForcedMerges(
       SegmentInfos segmentInfos,
       int maxSegmentCount,


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/projects/LUCENE

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>

LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

The addIndexes(CodecReader...) API today merges all provided readers into a single merge, in one large blocking call. We want to add concurrency here by invoking multiple parallel merges on subsets of readers, in a way that is configurable by users. The merged segments created, can later be merged further in the regular, non-blocking, background merges triggered by Lucene. Currently, users are responsible  for managing their API run times, by invoking it multiple times with subsets of readers. 
JIRA - https://issues.apache.org/jira/browse/LUCENE-10216


# Solution

In this change, we leverage the configured MergeScheduler to invoke all merges required by the addIndexes API. MergePolicy also exposes a `findMerges(List<CodecReader> readers)` API that users can override to configure how their readers should be clustered into merges. We add a default implementation that retains current behavior of adding all readers into a single merge.


# Tests

- Existing tests passing
- Pending: New tests to be added

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
