### PR TITLE
LUCENE-10002: Replace some IndexSearcher#search(Collector, Query) in tests

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestOmitTf.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestOmitTf.java
@@ -26,10 +26,12 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.CollectionStatistics;
+import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SimpleCollector;
@@ -224,19 +226,7 @@ public class TestOmitTf extends LuceneTestCase {
         new CollectorManager<SimpleCollector, Void>() {
           @Override
           public SimpleCollector newCollector() {
-            return new SimpleCollector() {
-              private Scorable scorer;
-
-              @Override
-              public ScoreMode scoreMode() {
-                return ScoreMode.COMPLETE;
-              }
-
-              @Override
-              public void setScorer(Scorable scorer) {
-                this.scorer = scorer;
-              }
-
+            return new ScoreAssertingCollector() {
               @Override
               public void collect(int doc) throws IOException {
                 // System.out.println("Q1: Doc=" + doc + " score=" + score);
@@ -257,19 +247,7 @@ public class TestOmitTf extends LuceneTestCase {
         new CollectorManager<SimpleCollector, Void>() {
           @Override
           public SimpleCollector newCollector() {
-            return new SimpleCollector() {
-              private Scorable scorer;
-
-              @Override
-              public ScoreMode scoreMode() {
-                return ScoreMode.COMPLETE;
-              }
-
-              @Override
-              public void setScorer(Scorable scorer) {
-                this.scorer = scorer;
-              }
-
+            return new ScoreAssertingCollector() {
               @Override
               public void collect(int doc) throws IOException {
                 // System.out.println("Q2: Doc=" + doc + " score=" + score);
@@ -290,19 +268,7 @@ public class TestOmitTf extends LuceneTestCase {
         new CollectorManager<SimpleCollector, Void>() {
           @Override
           public SimpleCollector newCollector() {
-            return new SimpleCollector() {
-              private Scorable scorer;
-
-              @Override
-              public ScoreMode scoreMode() {
-                return ScoreMode.COMPLETE;
-              }
-
-              @Override
-              public void setScorer(Scorable scorer) {
-                this.scorer = scorer;
-              }
-
+            return new ScoreAssertingCollector() {
               @Override
               public void collect(int doc) throws IOException {
                 // System.out.println("Q1: Doc=" + doc + " score=" + score);
@@ -324,19 +290,7 @@ public class TestOmitTf extends LuceneTestCase {
         new CollectorManager<SimpleCollector, Void>() {
           @Override
           public SimpleCollector newCollector() {
-            return new SimpleCollector() {
-              private Scorable scorer;
-
-              @Override
-              public ScoreMode scoreMode() {
-                return ScoreMode.COMPLETE;
-              }
-
-              @Override
-              public void setScorer(Scorable scorer) {
-                this.scorer = scorer;
-              }
-
+            return new ScoreAssertingCollector() {
               @Override
               public void collect(int doc) throws IOException {
                 float score = scorer.score();
@@ -387,5 +341,18 @@ public class TestOmitTf extends LuceneTestCase {
     assertEquals(ir.getSumDocFreq("foo"), ir.getSumTotalTermFreq("foo"));
     ir.close();
     dir.close();
+  }
+
+  private static abstract class ScoreAssertingCollector extends SimpleCollector {
+      Scorable scorer;
+      @Override
+      public ScoreMode scoreMode() {
+          return ScoreMode.COMPLETE;
+      }
+
+      @Override
+      public void setScorer(Scorable scorer) throws IOException {
+          this.scorer = scorer;
+      }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestOmitTf.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestOmitTf.java
@@ -26,12 +26,10 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.CollectionStatistics;
-import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PhraseQuery;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SimpleCollector;
@@ -343,16 +341,17 @@ public class TestOmitTf extends LuceneTestCase {
     dir.close();
   }
 
-  private static abstract class ScoreAssertingCollector extends SimpleCollector {
-      Scorable scorer;
-      @Override
-      public ScoreMode scoreMode() {
-          return ScoreMode.COMPLETE;
-      }
+  private abstract static class ScoreAssertingCollector extends SimpleCollector {
+    Scorable scorer;
 
-      @Override
-      public void setScorer(Scorable scorer) throws IOException {
-          this.scorer = scorer;
-      }
+    @Override
+    public ScoreMode scoreMode() {
+      return ScoreMode.COMPLETE;
+    }
+
+    @Override
+    public void setScorer(Scorable scorer) throws IOException {
+      this.scorer = scorer;
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestOmitTf.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestOmitTf.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.util.Collection;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -25,6 +26,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.CollectionStatistics;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PhraseQuery;
@@ -219,158 +221,147 @@ public class TestOmitTf extends LuceneTestCase {
 
     searcher.search(
         q1,
-        new CountingHitCollector() {
-          private Scorable scorer;
-
+        new CollectorManager<SimpleCollector, Void>() {
           @Override
-          public ScoreMode scoreMode() {
-            return ScoreMode.COMPLETE;
+          public SimpleCollector newCollector() {
+            return new SimpleCollector() {
+              private Scorable scorer;
+
+              @Override
+              public ScoreMode scoreMode() {
+                return ScoreMode.COMPLETE;
+              }
+
+              @Override
+              public void setScorer(Scorable scorer) {
+                this.scorer = scorer;
+              }
+
+              @Override
+              public void collect(int doc) throws IOException {
+                // System.out.println("Q1: Doc=" + doc + " score=" + score);
+                float score = scorer.score();
+                assertTrue("got score=" + score, score == 1.0f);
+              }
+            };
           }
 
           @Override
-          public final void setScorer(Scorable scorer) {
-            this.scorer = scorer;
-          }
-
-          @Override
-          public final void collect(int doc) throws IOException {
-            // System.out.println("Q1: Doc=" + doc + " score=" + score);
-            float score = scorer.score();
-            assertTrue("got score=" + score, score == 1.0f);
-            super.collect(doc);
+          public Void reduce(Collection<SimpleCollector> collectors) {
+            return null;
           }
         });
-    // System.out.println(CountingHitCollector.getCount());
 
     searcher.search(
         q2,
-        new CountingHitCollector() {
-          private Scorable scorer;
-
+        new CollectorManager<SimpleCollector, Void>() {
           @Override
-          public ScoreMode scoreMode() {
-            return ScoreMode.COMPLETE;
+          public SimpleCollector newCollector() {
+            return new SimpleCollector() {
+              private Scorable scorer;
+
+              @Override
+              public ScoreMode scoreMode() {
+                return ScoreMode.COMPLETE;
+              }
+
+              @Override
+              public void setScorer(Scorable scorer) {
+                this.scorer = scorer;
+              }
+
+              @Override
+              public void collect(int doc) throws IOException {
+                // System.out.println("Q2: Doc=" + doc + " score=" + score);
+                float score = scorer.score();
+                assertEquals(1.0f + doc, score, 0.00001f);
+              }
+            };
           }
 
           @Override
-          public final void setScorer(Scorable scorer) {
-            this.scorer = scorer;
-          }
-
-          @Override
-          public final void collect(int doc) throws IOException {
-            // System.out.println("Q2: Doc=" + doc + " score=" + score);
-            float score = scorer.score();
-            assertEquals(1.0f + doc, score, 0.00001f);
-            super.collect(doc);
+          public Void reduce(Collection<SimpleCollector> collectors) {
+            return null;
           }
         });
-    // System.out.println(CountingHitCollector.getCount());
 
     searcher.search(
         q3,
-        new CountingHitCollector() {
-          private Scorable scorer;
-
+        new CollectorManager<SimpleCollector, Void>() {
           @Override
-          public ScoreMode scoreMode() {
-            return ScoreMode.COMPLETE;
+          public SimpleCollector newCollector() {
+            return new SimpleCollector() {
+              private Scorable scorer;
+
+              @Override
+              public ScoreMode scoreMode() {
+                return ScoreMode.COMPLETE;
+              }
+
+              @Override
+              public void setScorer(Scorable scorer) {
+                this.scorer = scorer;
+              }
+
+              @Override
+              public void collect(int doc) throws IOException {
+                // System.out.println("Q1: Doc=" + doc + " score=" + score);
+                float score = scorer.score();
+                assertTrue(score == 1.0f);
+                assertFalse(doc % 2 == 0);
+              }
+            };
           }
 
           @Override
-          public final void setScorer(Scorable scorer) {
-            this.scorer = scorer;
-          }
-
-          @Override
-          public final void collect(int doc) throws IOException {
-            // System.out.println("Q1: Doc=" + doc + " score=" + score);
-            float score = scorer.score();
-            assertTrue(score == 1.0f);
-            assertFalse(doc % 2 == 0);
-            super.collect(doc);
+          public Void reduce(Collection<SimpleCollector> collectors) {
+            return null;
           }
         });
-    // System.out.println(CountingHitCollector.getCount());
 
     searcher.search(
         q4,
-        new CountingHitCollector() {
-          private Scorable scorer;
-
+        new CollectorManager<SimpleCollector, Void>() {
           @Override
-          public ScoreMode scoreMode() {
-            return ScoreMode.COMPLETE;
+          public SimpleCollector newCollector() {
+            return new SimpleCollector() {
+              private Scorable scorer;
+
+              @Override
+              public ScoreMode scoreMode() {
+                return ScoreMode.COMPLETE;
+              }
+
+              @Override
+              public void setScorer(Scorable scorer) {
+                this.scorer = scorer;
+              }
+
+              @Override
+              public void collect(int doc) throws IOException {
+                float score = scorer.score();
+                // System.out.println("Q1: Doc=" + doc + " score=" + score);
+                assertTrue(score == 1.0f);
+                assertTrue(doc % 2 == 0);
+              }
+            };
           }
 
           @Override
-          public final void setScorer(Scorable scorer) {
-            this.scorer = scorer;
-          }
-
-          @Override
-          public final void collect(int doc) throws IOException {
-            float score = scorer.score();
-            // System.out.println("Q1: Doc=" + doc + " score=" + score);
-            assertTrue(score == 1.0f);
-            assertTrue(doc % 2 == 0);
-            super.collect(doc);
+          public Void reduce(Collection<SimpleCollector> collectors) {
+            return null;
           }
         });
-    // System.out.println(CountingHitCollector.getCount());
 
     BooleanQuery.Builder bq = new BooleanQuery.Builder();
     bq.add(q1, Occur.MUST);
     bq.add(q4, Occur.MUST);
 
-    searcher.search(
-        bq.build(),
-        new CountingHitCollector() {
-          @Override
-          public final void collect(int doc) throws IOException {
-            // System.out.println("BQ: Doc=" + doc + " score=" + score);
-            super.collect(doc);
-          }
-        });
-    assertEquals(15, CountingHitCollector.getCount());
+    int count = searcher.count(bq.build());
+    assertEquals(15, count);
 
     reader.close();
     dir.close();
-  }
-
-  public static class CountingHitCollector extends SimpleCollector {
-    static int count = 0;
-    static int sum = 0;
-    private int docBase = -1;
-
-    CountingHitCollector() {
-      count = 0;
-      sum = 0;
-    }
-
-    @Override
-    public void collect(int doc) throws IOException {
-      count++;
-      sum += doc + docBase; // use it to avoid any possibility of being merged away
-    }
-
-    public static int getCount() {
-      return count;
-    }
-
-    public static int getSum() {
-      return sum;
-    }
-
-    @Override
-    protected void doSetNextReader(LeafReaderContext context) throws IOException {
-      docBase = context.docBase;
-    }
-
-    @Override
-    public ScoreMode scoreMode() {
-      return ScoreMode.COMPLETE_NO_SCORES;
-    }
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -492,33 +493,43 @@ public class TestBooleanQuery extends LuceneTestCase {
     final AtomicBoolean matched = new AtomicBoolean();
     searcher.search(
         bq,
-        new SimpleCollector() {
-          int docBase;
-          Scorable scorer;
-
+        new CollectorManager<SimpleCollector, Boolean>() {
           @Override
-          protected void doSetNextReader(LeafReaderContext context) throws IOException {
-            super.doSetNextReader(context);
-            docBase = context.docBase;
+          public SimpleCollector newCollector() {
+            return new SimpleCollector() {
+              int docBase;
+              Scorable scorer;
+
+              @Override
+              protected void doSetNextReader(LeafReaderContext context) throws IOException {
+                super.doSetNextReader(context);
+                docBase = context.docBase;
+              }
+
+              @Override
+              public ScoreMode scoreMode() {
+                return ScoreMode.COMPLETE;
+              }
+
+              @Override
+              public void setScorer(Scorable scorer) {
+                this.scorer = scorer;
+              }
+
+              @Override
+              public void collect(int doc) throws IOException {
+                final float actualScore = scorer.score();
+                final float expectedScore =
+                    searcher.explain(bq2, docBase + doc).getValue().floatValue();
+                assertEquals(expectedScore, actualScore, 10e-5);
+                matched.set(true);
+              }
+            };
           }
 
           @Override
-          public ScoreMode scoreMode() {
-            return ScoreMode.COMPLETE;
-          }
-
-          @Override
-          public void setScorer(Scorable scorer) throws IOException {
-            this.scorer = scorer;
-          }
-
-          @Override
-          public void collect(int doc) throws IOException {
-            final float actualScore = scorer.score();
-            final float expectedScore =
-                searcher.explain(bq2, docBase + doc).getValue().floatValue();
-            assertEquals(expectedScore, actualScore, 10e-5);
-            matched.set(true);
+          public Boolean reduce(Collection<SimpleCollector> collectors) {
+            return null;
           }
         });
     assertTrue(matched.get());
@@ -538,10 +549,9 @@ public class TestBooleanQuery extends LuceneTestCase {
     w.commit();
 
     DirectoryReader reader = w.getReader();
-    final IndexSearcher searcher = new IndexSearcher(reader);
+    final IndexSearcher searcher = newSearcher(reader);
 
     BooleanQuery.Builder qBuilder = new BooleanQuery.Builder();
-    BooleanQuery q = qBuilder.build();
     qBuilder.add(new TermQuery(new Term("field", "a")), Occur.FILTER);
 
     // With a single clause, we will rewrite to the underlying
@@ -551,7 +561,7 @@ public class TestBooleanQuery extends LuceneTestCase {
     // Now with two clauses, we will get a conjunction scorer
     // Make sure it returns null scores
     qBuilder.add(new TermQuery(new Term("field", "b")), Occur.FILTER);
-    q = qBuilder.build();
+    BooleanQuery q = qBuilder.build();
     assertSameScoresWithoutFilters(searcher, q);
 
     // Now with a scoring clause, we need to make sure that

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -493,7 +493,7 @@ public class TestBooleanQuery extends LuceneTestCase {
     final AtomicBoolean matched = new AtomicBoolean();
     searcher.search(
         bq,
-        new CollectorManager<SimpleCollector, Boolean>() {
+        new CollectorManager<SimpleCollector, Void>() {
           @Override
           public SimpleCollector newCollector() {
             return new SimpleCollector() {
@@ -528,7 +528,7 @@ public class TestBooleanQuery extends LuceneTestCase {
           }
 
           @Override
-          public Boolean reduce(Collection<SimpleCollector> collectors) {
+          public Void reduce(Collection<SimpleCollector> collectors) {
             return null;
           }
         });

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQueryVisitSubscorers.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQueryVisitSubscorers.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQueryVisitSubscorers.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQueryVisitSubscorers.java
@@ -18,11 +18,14 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
@@ -70,10 +73,7 @@ public class TestBooleanQueryVisitSubscorers extends LuceneTestCase {
             "nutch is an internet search engine with web crawler and is using lucene and hadoop"));
     reader = writer.getReader();
     writer.close();
-    // we do not use newSearcher because the assertingXXX layers break
-    // the toString representations we are relying on
-    // TODO: clean that up
-    searcher = new IndexSearcher(reader);
+    searcher = newSearcher(reader, true, false);
     searcher.setSimilarity(new ClassicSimilarity());
     scorerSearcher = new ScorerIndexSearcher(reader);
     scorerSearcher.setSimilarity(new CountingSimilarity());
@@ -132,9 +132,23 @@ public class TestBooleanQueryVisitSubscorers extends LuceneTestCase {
 
   static Map<Integer, Integer> getDocCounts(IndexSearcher searcher, Query query)
       throws IOException {
-    MyCollector collector = new MyCollector();
-    searcher.search(query, collector);
-    return collector.docCounts;
+    return searcher.search(
+        query,
+        new CollectorManager<MyCollector, Map<Integer, Integer>>() {
+          @Override
+          public MyCollector newCollector() {
+            return new MyCollector();
+          }
+
+          @Override
+          public Map<Integer, Integer> reduce(Collection<MyCollector> collectors) {
+            Map<Integer, Integer> docCounts = new HashMap<>();
+            for (MyCollector myCollector : collectors) {
+              docCounts.putAll(myCollector.docCounts);
+            }
+            return docCounts;
+          }
+        });
   }
 
   static class MyCollector extends FilterCollector {
@@ -234,11 +248,11 @@ public class TestBooleanQueryVisitSubscorers extends LuceneTestCase {
     query.add(new TermQuery(new Term(F2, "crawler")), Occur.SHOULD);
     query.setMinimumNumberShouldMatch(2);
     query.add(new MatchAllDocsQuery(), Occur.MUST);
-    ScorerSummarizingCollector collector = new ScorerSummarizingCollector();
-    searcher.search(query.build(), collector);
-    assertEquals(1, collector.getNumHits());
-    assertFalse(collector.getSummaries().isEmpty());
-    for (String summary : collector.getSummaries()) {
+    ScoreSummary scoreSummary =
+        searcher.search(query.build(), new ScorerSummarizingCollectorManager());
+    assertEquals(1, scoreSummary.numHits.get());
+    assertFalse(scoreSummary.summaries.isEmpty());
+    for (String summary : scoreSummary.summaries) {
       assertEquals(
           "ConjunctionScorer\n"
               + "    MUST ConstantScoreScorer\n"
@@ -254,26 +268,41 @@ public class TestBooleanQueryVisitSubscorers extends LuceneTestCase {
     final BooleanQuery.Builder query = new BooleanQuery.Builder();
     query.add(new TermQuery(new Term(F2, "nutch")), Occur.SHOULD);
     query.add(new TermQuery(new Term(F2, "miss")), Occur.SHOULD);
-    ScorerSummarizingCollector collector = new ScorerSummarizingCollector();
-    scorerSearcher.search(query.build(), collector);
-    assertEquals(1, collector.getNumHits());
-    assertFalse(collector.getSummaries().isEmpty());
-    for (String summary : collector.getSummaries()) {
+    ScoreSummary scoreSummary =
+        scorerSearcher.search(query.build(), new ScorerSummarizingCollectorManager());
+    assertEquals(1, scoreSummary.numHits.get());
+    assertFalse(scoreSummary.summaries.isEmpty());
+    for (String summary : scoreSummary.summaries) {
       assertEquals("TermScorer body:nutch", summary);
     }
   }
 
-  private static class ScorerSummarizingCollector implements Collector {
+  private static class ScoreSummary {
     private final List<String> summaries = new ArrayList<>();
-    private int[] numHits = new int[1];
+    private final AtomicInteger numHits = new AtomicInteger();
+  }
 
-    public int getNumHits() {
-      return numHits[0];
+  private static class ScorerSummarizingCollectorManager
+      implements CollectorManager<ScorerSummarizingCollector, ScoreSummary> {
+    @Override
+    public ScorerSummarizingCollector newCollector() {
+      return new ScorerSummarizingCollector();
     }
 
-    public List<String> getSummaries() {
-      return summaries;
+    @Override
+    public ScoreSummary reduce(Collection<ScorerSummarizingCollector> collectors)
+        throws IOException {
+      ScoreSummary scoreSummary = new ScoreSummary();
+      for (ScorerSummarizingCollector collector : collectors) {
+        scoreSummary.summaries.addAll(collector.scoreSummary.summaries);
+        scoreSummary.numHits.addAndGet(collector.scoreSummary.numHits.get());
+      }
+      return scoreSummary;
     }
+  }
+
+  private static class ScorerSummarizingCollector implements Collector {
+    private final ScoreSummary scoreSummary = new ScoreSummary();
 
     @Override
     public ScoreMode scoreMode() {
@@ -288,12 +317,12 @@ public class TestBooleanQueryVisitSubscorers extends LuceneTestCase {
         public void setScorer(Scorable scorer) throws IOException {
           final StringBuilder builder = new StringBuilder();
           summarizeScorer(builder, scorer, 0);
-          summaries.add(builder.toString());
+          scoreSummary.summaries.add(builder.toString());
         }
 
         @Override
-        public void collect(int doc) throws IOException {
-          numHits[0]++;
+        public void collect(int doc) {
+          scoreSummary.numHits.incrementAndGet();
         }
       };
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestConjunctions.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConjunctions.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -123,37 +125,52 @@ public class TestConjunctions extends LuceneTestCase {
     b.add(new TermQuery(new Term("field", "b")), BooleanClause.Occur.FILTER);
     Query q = b.build();
     IndexSearcher s = new IndexSearcher(r);
-    final boolean[] setScorerCalled = new boolean[1];
     s.search(
-        q,
-        new SimpleCollector() {
-          @Override
-          public void setScorer(Scorable s) throws IOException {
-            Collection<Scorer.ChildScorable> childScorers = s.getChildren();
-            setScorerCalled[0] = true;
-            assertEquals(2, childScorers.size());
-            Set<String> terms = new HashSet<>();
-            for (Scorer.ChildScorable childScorer : childScorers) {
-              Query query = ((Scorer) childScorer.child).getWeight().getQuery();
-              assertTrue(query instanceof TermQuery);
-              Term term = ((TermQuery) query).getTerm();
-              assertEquals("field", term.field());
-              terms.add(term.text());
-            }
-            assertEquals(2, terms.size());
-            assertTrue(terms.contains("a"));
-            assertTrue(terms.contains("b"));
-          }
+            q,
+            new CollectorManager<TestCollector, Void>() {
+              @Override
+              public TestCollector newCollector() {
+                return new TestCollector();
+              }
 
-          @Override
-          public void collect(int doc) {}
-
-          @Override
-          public ScoreMode scoreMode() {
-            return ScoreMode.COMPLETE;
-          }
-        });
-    assertTrue(setScorerCalled[0]);
+              @Override
+              public Void reduce(Collection<TestCollector> collectors) {
+                for (TestCollector collector : collectors) {
+                  assertTrue(collector.setScorerCalled.get());
+                }
+                return null;
+              }
+            });
     IOUtils.close(r, w, dir);
+  }
+
+  private static class TestCollector extends SimpleCollector {
+    private final AtomicBoolean setScorerCalled = new AtomicBoolean(false);
+
+    @Override
+    public void setScorer(Scorable s) throws IOException {
+      Collection<Scorer.ChildScorable> childScorers = s.getChildren();
+      setScorerCalled.set(true);
+      assertEquals(2, childScorers.size());
+      Set<String> terms = new HashSet<>();
+      for (Scorer.ChildScorable childScorer : childScorers) {
+        Query query = ((Scorer) childScorer.child).getWeight().getQuery();
+        assertTrue(query instanceof TermQuery);
+        Term term = ((TermQuery) query).getTerm();
+        assertEquals("field", term.field());
+        terms.add(term.text());
+      }
+      assertEquals(2, terms.size());
+      assertTrue(terms.contains("a"));
+      assertTrue(terms.contains("b"));
+    }
+
+    @Override
+    public void collect(int doc) {}
+
+    @Override
+    public ScoreMode scoreMode() {
+      return ScoreMode.COMPLETE;
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestConjunctions.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConjunctions.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -126,21 +125,21 @@ public class TestConjunctions extends LuceneTestCase {
     Query q = b.build();
     IndexSearcher s = new IndexSearcher(r);
     s.search(
-            q,
-            new CollectorManager<TestCollector, Void>() {
-              @Override
-              public TestCollector newCollector() {
-                return new TestCollector();
-              }
+        q,
+        new CollectorManager<TestCollector, Void>() {
+          @Override
+          public TestCollector newCollector() {
+            return new TestCollector();
+          }
 
-              @Override
-              public Void reduce(Collection<TestCollector> collectors) {
-                for (TestCollector collector : collectors) {
-                  assertTrue(collector.setScorerCalled.get());
-                }
-                return null;
-              }
-            });
+          @Override
+          public Void reduce(Collection<TestCollector> collectors) {
+            for (TestCollector collector : collectors) {
+              assertTrue(collector.setScorerCalled.get());
+            }
+            return null;
+          }
+        });
     IOUtils.close(r, w, dir);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreQuery.java
@@ -18,6 +18,8 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.DirectoryReader;
@@ -58,36 +60,46 @@ public class TestConstantScoreQuery extends LuceneTestCase {
       final float expectedScore,
       final Class<? extends Scorable> innerScorerClass)
       throws IOException {
-    final int[] count = new int[1];
+    final AtomicInteger count = new AtomicInteger();
     searcher.search(
-        q,
-        new SimpleCollector() {
-          private Scorable scorer;
+            q,
+            new CollectorManager<SimpleCollector, Void>() {
+              @Override
+              public SimpleCollector newCollector() {
+                return new SimpleCollector() {
+                  private Scorable scorer;
 
-          @Override
-          public void setScorer(Scorable scorer) {
-            this.scorer = scorer;
-            if (innerScorerClass != null) {
-              Scorable innerScorer = rootScorer(scorer);
-              assertEquals(
-                  "inner Scorer is implemented by wrong class",
-                  innerScorerClass,
-                  innerScorer.getClass());
-            }
-          }
+                  @Override
+                  public void setScorer(Scorable scorer) {
+                    this.scorer = scorer;
+                    if (innerScorerClass != null) {
+                      Scorable innerScorer = rootScorer(scorer);
+                      assertEquals(
+                              "inner Scorer is implemented by wrong class",
+                              innerScorerClass,
+                              innerScorer.getClass());
+                    }
+                  }
 
-          @Override
-          public void collect(int doc) throws IOException {
-            assertEquals("Score differs from expected", expectedScore, this.scorer.score(), 0);
-            count[0]++;
-          }
+                  @Override
+                  public void collect(int doc) throws IOException {
+                    assertEquals("Score differs from expected", expectedScore, this.scorer.score(), 0);
+                    count.incrementAndGet();
+                  }
 
-          @Override
-          public ScoreMode scoreMode() {
-            return ScoreMode.COMPLETE;
-          }
-        });
-    assertEquals("invalid number of results", 1, count[0]);
+                  @Override
+                  public ScoreMode scoreMode() {
+                    return ScoreMode.COMPLETE;
+                  }
+                };
+              }
+
+              @Override
+              public Void reduce(Collection<SimpleCollector> collectors) {
+                return null;
+              }
+            });
+    assertEquals("invalid number of results", 1, count.get());
   }
 
   private Scorable rootScorer(Scorable s) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesSource.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesSource.java
@@ -19,6 +19,7 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoubleDocValuesField;
@@ -256,38 +257,49 @@ public class TestDoubleValuesSource extends LuceneTestCase {
   private void testExplanations(Query q, DoubleValuesSource vs) throws IOException {
     DoubleValuesSource rewritten = vs.rewrite(searcher);
     searcher.search(
-        q,
-        new SimpleCollector() {
+            q,
+            new CollectorManager<SimpleCollector, Void>() {
+              @Override
+              public SimpleCollector newCollector() {
+                return new SimpleCollector() {
 
-          DoubleValues v;
-          LeafReaderContext ctx;
+                  DoubleValues v;
+                  LeafReaderContext ctx;
 
-          @Override
-          protected void doSetNextReader(LeafReaderContext context) throws IOException {
-            this.ctx = context;
-          }
+                  @Override
+                  protected void doSetNextReader(LeafReaderContext context) {
+                    this.ctx = context;
+                  }
 
-          @Override
-          public void setScorer(Scorable scorer) throws IOException {
-            this.v = rewritten.getValues(this.ctx, DoubleValuesSource.fromScorer(scorer));
-          }
+                  @Override
+                  public void setScorer(Scorable scorer) throws IOException {
+                    this.v = rewritten.getValues(this.ctx, DoubleValuesSource.fromScorer(scorer));
+                  }
 
-          @Override
-          public void collect(int doc) throws IOException {
-            Explanation scoreExpl = searcher.explain(q, ctx.docBase + doc);
-            if (this.v.advanceExact(doc)) {
-              CheckHits.verifyExplanation(
-                  "", doc, (float) v.doubleValue(), true, rewritten.explain(ctx, doc, scoreExpl));
-            } else {
-              assertFalse(rewritten.explain(ctx, doc, scoreExpl).isMatch());
+                  @Override
+                  public void collect(int doc) throws IOException {
+                    Explanation scoreExpl = searcher.explain(q, ctx.docBase + doc);
+                    if (this.v.advanceExact(doc)) {
+                      CheckHits.verifyExplanation(
+                              "", doc, (float) v.doubleValue(), true, rewritten.explain(ctx, doc, scoreExpl));
+                    } else {
+                      assertFalse(rewritten.explain(ctx, doc, scoreExpl).isMatch());
+                    }
+                  }
+
+                  @Override
+                  public ScoreMode scoreMode() {
+                    return vs.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+                  }
+                };
+              }
+
+              @Override
+              public Void reduce(Collection<SimpleCollector> collectors) {
+                return null;
+              }
             }
-          }
-
-          @Override
-          public ScoreMode scoreMode() {
-            return vs.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
-          }
-        });
+    );
   }
 
   public void testQueryDoubleValuesSource() throws Exception {
@@ -310,34 +322,44 @@ public class TestDoubleValuesSource extends LuceneTestCase {
   private void doTestQueryDoubleValuesSources(Query q) throws Exception {
     DoubleValuesSource vs = DoubleValuesSource.fromQuery(q).rewrite(searcher);
     searcher.search(
-        q,
-        new SimpleCollector() {
+            q,
+            new CollectorManager<SimpleCollector, Void>() {
+              @Override
+              public SimpleCollector newCollector() {
+                return new SimpleCollector() {
 
-          DoubleValues v;
-          Scorable scorer;
-          LeafReaderContext ctx;
+                  DoubleValues v;
+                  Scorable scorer;
+                  LeafReaderContext ctx;
 
-          @Override
-          protected void doSetNextReader(LeafReaderContext context) throws IOException {
-            this.ctx = context;
-          }
+                  @Override
+                  protected void doSetNextReader(LeafReaderContext context) {
+                    this.ctx = context;
+                  }
 
-          @Override
-          public void setScorer(Scorable scorer) throws IOException {
-            this.scorer = scorer;
-            this.v = vs.getValues(this.ctx, DoubleValuesSource.fromScorer(scorer));
-          }
+                  @Override
+                  public void setScorer(Scorable scorer) throws IOException {
+                    this.scorer = scorer;
+                    this.v = vs.getValues(this.ctx, DoubleValuesSource.fromScorer(scorer));
+                  }
 
-          @Override
-          public void collect(int doc) throws IOException {
-            assertTrue(v.advanceExact(doc));
-            assertEquals(scorer.score(), v.doubleValue(), 0.00001);
-          }
+                  @Override
+                  public void collect(int doc) throws IOException {
+                    assertTrue(v.advanceExact(doc));
+                    assertEquals(scorer.score(), v.doubleValue(), 0.00001);
+                  }
 
-          @Override
-          public ScoreMode scoreMode() {
-            return ScoreMode.COMPLETE;
-          }
-        });
+                  @Override
+                  public ScoreMode scoreMode() {
+                    return ScoreMode.COMPLETE;
+                  }
+                };
+              }
+
+              @Override
+              public Void reduce(Collection<SimpleCollector> collectors) {
+                return null;
+              }
+            });
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestEarlyTermination.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestEarlyTermination.java
@@ -17,6 +17,8 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
+import java.util.Collection;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
@@ -56,37 +58,43 @@ public class TestEarlyTermination extends LuceneTestCase {
 
     for (int i = 0; i < iters; ++i) {
       final IndexSearcher searcher = newSearcher(reader);
-      final Collector collector =
-          new SimpleCollector() {
+      searcher.search(new MatchAllDocsQuery(), new CollectorManager<SimpleCollector, Void>() {
+          @Override
+          public SimpleCollector newCollector() {
+              return new SimpleCollector() {
+                  boolean collectionTerminated = true;
 
-            boolean collectionTerminated = true;
+                  @Override
+                  public void collect(int doc) {
+                      assertFalse(collectionTerminated);
+                      if (rarely()) {
+                          collectionTerminated = true;
+                          throw new CollectionTerminatedException();
+                      }
+                  }
 
-            @Override
-            public void collect(int doc) throws IOException {
-              assertFalse(collectionTerminated);
-              if (rarely()) {
-                collectionTerminated = true;
-                throw new CollectionTerminatedException();
-              }
-            }
+                  @Override
+                  protected void doSetNextReader(LeafReaderContext context) {
+                      if (random().nextBoolean()) {
+                          collectionTerminated = true;
+                          throw new CollectionTerminatedException();
+                      } else {
+                          collectionTerminated = false;
+                      }
+                  }
 
-            @Override
-            protected void doSetNextReader(LeafReaderContext context) throws IOException {
-              if (random().nextBoolean()) {
-                collectionTerminated = true;
-                throw new CollectionTerminatedException();
-              } else {
-                collectionTerminated = false;
-              }
-            }
+                  @Override
+                  public ScoreMode scoreMode() {
+                      return ScoreMode.COMPLETE_NO_SCORES;
+                  }
+              };
+          }
 
-            @Override
-            public ScoreMode scoreMode() {
-              return ScoreMode.COMPLETE_NO_SCORES;
-            }
-          };
-
-      searcher.search(new MatchAllDocsQuery(), collector);
+          @Override
+          public Void reduce(Collection<SimpleCollector> collectors) {
+              return null;
+          }
+      });
     }
     reader.close();
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestEarlyTermination.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestEarlyTermination.java
@@ -18,7 +18,6 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Collection;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
@@ -58,43 +57,45 @@ public class TestEarlyTermination extends LuceneTestCase {
 
     for (int i = 0; i < iters; ++i) {
       final IndexSearcher searcher = newSearcher(reader);
-      searcher.search(new MatchAllDocsQuery(), new CollectorManager<SimpleCollector, Void>() {
-          @Override
-          public SimpleCollector newCollector() {
+      searcher.search(
+          new MatchAllDocsQuery(),
+          new CollectorManager<SimpleCollector, Void>() {
+            @Override
+            public SimpleCollector newCollector() {
               return new SimpleCollector() {
-                  boolean collectionTerminated = true;
+                boolean collectionTerminated = true;
 
-                  @Override
-                  public void collect(int doc) {
-                      assertFalse(collectionTerminated);
-                      if (rarely()) {
-                          collectionTerminated = true;
-                          throw new CollectionTerminatedException();
-                      }
+                @Override
+                public void collect(int doc) {
+                  assertFalse(collectionTerminated);
+                  if (rarely()) {
+                    collectionTerminated = true;
+                    throw new CollectionTerminatedException();
                   }
+                }
 
-                  @Override
-                  protected void doSetNextReader(LeafReaderContext context) {
-                      if (random().nextBoolean()) {
-                          collectionTerminated = true;
-                          throw new CollectionTerminatedException();
-                      } else {
-                          collectionTerminated = false;
-                      }
+                @Override
+                protected void doSetNextReader(LeafReaderContext context) {
+                  if (random().nextBoolean()) {
+                    collectionTerminated = true;
+                    throw new CollectionTerminatedException();
+                  } else {
+                    collectionTerminated = false;
                   }
+                }
 
-                  @Override
-                  public ScoreMode scoreMode() {
-                      return ScoreMode.COMPLETE_NO_SCORES;
-                  }
+                @Override
+                public ScoreMode scoreMode() {
+                  return ScoreMode.COMPLETE_NO_SCORES;
+                }
               };
-          }
+            }
 
-          @Override
-          public Void reduce(Collection<SimpleCollector> collectors) {
+            @Override
+            public Void reduce(Collection<SimpleCollector> collectors) {
               return null;
-          }
-      });
+            }
+          });
     }
     reader.close();
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -1187,7 +1187,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     searcher.setQueryCachingPolicy(ALWAYS_CACHE);
 
     BadQuery query = new BadQuery();
-    searcher.search(query, new TotalHitCountCollector());
+    searcher.search(query, new TotalHitCountCollectorManager());
     query.i[0] += 1; // change the hashCode!
 
     try {

--- a/lucene/core/src/test/org/apache/lucene/search/TestSimilarity.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSimilarity.java
@@ -18,7 +18,6 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Collection;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexReader;
@@ -88,31 +87,31 @@ public class TestSimilarity extends LuceneTestCase {
     bq.add(new TermQuery(b), BooleanClause.Occur.SHOULD);
     // System.out.println(bq.toString("field"));
     searcher.search(
-            bq.build(),
-            new CollectorManager<SimpleCollector, Void>() {
-                @Override
-                public SimpleCollector newCollector() {
-                    return new ScoreAssertingCollector() {
-                        private int base = 0;
-                        @Override
-                        public void collect(int doc) throws IOException {
-                            // System.out.println("Doc=" + doc + " score=" + score);
-                            assertEquals((float) doc + base + 1, scorer.score(), 0);
-                        }
+        bq.build(),
+        new CollectorManager<SimpleCollector, Void>() {
+          @Override
+          public SimpleCollector newCollector() {
+            return new ScoreAssertingCollector() {
+              private int base = 0;
 
-                        @Override
-                        protected void doSetNextReader(LeafReaderContext context) {
-                            base = context.docBase;
-                        }
-                    };
-                }
+              @Override
+              public void collect(int doc) throws IOException {
+                // System.out.println("Doc=" + doc + " score=" + score);
+                assertEquals((float) doc + base + 1, scorer.score(), 0);
+              }
 
-                @Override
-                public Void reduce(Collection<SimpleCollector> collectors) {
-                    return null;
-                }
-            }
-    );
+              @Override
+              protected void doSetNextReader(LeafReaderContext context) {
+                base = context.docBase;
+              }
+            };
+          }
+
+          @Override
+          public Void reduce(Collection<SimpleCollector> collectors) {
+            return null;
+          }
+        });
 
     PhraseQuery pq = new PhraseQuery(a.field(), a.bytes(), c.bytes());
     // System.out.println(pq.toString("field"));
@@ -126,39 +125,40 @@ public class TestSimilarity extends LuceneTestCase {
     store.close();
   }
 
-  private static void assertScore(IndexSearcher searcher, Query query, float score) throws IOException {
-      searcher.search(
-              query,
-              new CollectorManager<SimpleCollector, Void>() {
-                  @Override
-                  public SimpleCollector newCollector() {
-                      return new ScoreAssertingCollector() {
-                          @Override
-                          public final void collect(int doc) throws IOException {
-                              // System.out.println("Doc=" + doc + " score=" + score);
-                              assertEquals(score, scorer.score(), 0);
-                          }
-                      };
-                  }
+  private static void assertScore(IndexSearcher searcher, Query query, float score)
+      throws IOException {
+    searcher.search(
+        query,
+        new CollectorManager<SimpleCollector, Void>() {
+          @Override
+          public SimpleCollector newCollector() {
+            return new ScoreAssertingCollector() {
+              @Override
+              public final void collect(int doc) throws IOException {
+                // System.out.println("Doc=" + doc + " score=" + score);
+                assertEquals(score, scorer.score(), 0);
+              }
+            };
+          }
 
-                  @Override
-                  public Void reduce(Collection<SimpleCollector> collectors) {
-                      return null;
-                  }
-              });
+          @Override
+          public Void reduce(Collection<SimpleCollector> collectors) {
+            return null;
+          }
+        });
   }
 
-  private static abstract class ScoreAssertingCollector extends SimpleCollector {
-      Scorable scorer;
+  private abstract static class ScoreAssertingCollector extends SimpleCollector {
+    Scorable scorer;
 
-      @Override
-      public final void setScorer(Scorable scorer) {
-          this.scorer = scorer;
-      }
+    @Override
+    public final void setScorer(Scorable scorer) {
+      this.scorer = scorer;
+    }
 
-      @Override
-      public final ScoreMode scoreMode() {
-          return ScoreMode.COMPLETE;
-      }
+    @Override
+    public final ScoreMode scoreMode() {
+      return ScoreMode.COMPLETE;
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSloppyPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSloppyPhraseQuery.java
@@ -18,7 +18,6 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Collection;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -242,35 +241,35 @@ public class TestSloppyPhraseQuery extends LuceneTestCase {
   /** checks that no scores are infinite */
   private void assertSaneScoring(PhraseQuery pq, IndexSearcher searcher) throws Exception {
     searcher.search(
-            pq,
-            new CollectorManager<SimpleCollector, Void>() {
+        pq,
+        new CollectorManager<SimpleCollector, Void>() {
+          @Override
+          public SimpleCollector newCollector() {
+            return new SimpleCollector() {
+              Scorer scorer;
+
               @Override
-              public SimpleCollector newCollector() {
-                return new SimpleCollector() {
-                  Scorer scorer;
-
-                  @Override
-                  public void setScorer(Scorable scorer) {
-                    this.scorer = (Scorer) AssertingScorable.unwrap(scorer);
-                  }
-
-                  @Override
-                  public void collect(int doc) throws IOException {
-                    assertFalse(Float.isInfinite(scorer.score()));
-                  }
-
-                  @Override
-                  public ScoreMode scoreMode() {
-                    return ScoreMode.COMPLETE;
-                  }
-                };
+              public void setScorer(Scorable scorer) {
+                this.scorer = (Scorer) AssertingScorable.unwrap(scorer);
               }
 
               @Override
-              public Void reduce(Collection<SimpleCollector> collectors) {
-                return null;
+              public void collect(int doc) throws IOException {
+                assertFalse(Float.isInfinite(scorer.score()));
               }
-            });
+
+              @Override
+              public ScoreMode scoreMode() {
+                return ScoreMode.COMPLETE;
+              }
+            };
+          }
+
+          @Override
+          public Void reduce(Collection<SimpleCollector> collectors) {
+            return null;
+          }
+        });
     QueryUtils.check(random(), pq, searcher);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestSloppyPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSloppyPhraseQuery.java
@@ -17,6 +17,8 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
+import java.util.Collection;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -157,12 +159,11 @@ public class TestSloppyPhraseQuery extends LuceneTestCase {
     IndexReader reader = writer.getReader();
 
     IndexSearcher searcher = newSearcher(reader);
-    MaxFreqCollector c = new MaxFreqCollector();
-    searcher.search(query, c);
+    Result result = searcher.search(query, new MaxFreqCollectorManager());
     assertEquals(
         "slop: " + slop + "  query: " + query + "  doc: " + doc + "  Wrong number of hits",
         expectedNumResults,
-        c.totalHits);
+        result.totalHits);
 
     // QueryUtils.check(query,searcher);
     writer.close();
@@ -172,7 +173,7 @@ public class TestSloppyPhraseQuery extends LuceneTestCase {
     // returns the max Scorer.freq() found, because even though norms are omitted, many index stats
     // are different
     // with these different tokens/distributions/lengths.. otherwise this test is very fragile.
-    return c.max;
+    return result.max;
   }
 
   private static Document makeDocument(String docText) {
@@ -187,6 +188,28 @@ public class TestSloppyPhraseQuery extends LuceneTestCase {
   private static PhraseQuery makePhraseQuery(String terms) {
     String[] t = terms.split(" +");
     return new PhraseQuery("f", t);
+  }
+
+  static class Result {
+    float max;
+    int totalHits;
+  }
+
+  static class MaxFreqCollectorManager implements CollectorManager<MaxFreqCollector, Result> {
+    @Override
+    public MaxFreqCollector newCollector() throws IOException {
+      return new MaxFreqCollector();
+    }
+
+    @Override
+    public Result reduce(Collection<MaxFreqCollector> collectors) throws IOException {
+      Result result = new Result();
+      for (MaxFreqCollector collector : collectors) {
+        result.max = Math.max(result.max, collector.max);
+        result.totalHits += collector.totalHits;
+      }
+      return result;
+    }
   }
 
   static class MaxFreqCollector extends SimpleCollector {
@@ -219,25 +242,35 @@ public class TestSloppyPhraseQuery extends LuceneTestCase {
   /** checks that no scores are infinite */
   private void assertSaneScoring(PhraseQuery pq, IndexSearcher searcher) throws Exception {
     searcher.search(
-        pq,
-        new SimpleCollector() {
-          Scorer scorer;
+            pq,
+            new CollectorManager<SimpleCollector, Void>() {
+              @Override
+              public SimpleCollector newCollector() {
+                return new SimpleCollector() {
+                  Scorer scorer;
 
-          @Override
-          public void setScorer(Scorable scorer) {
-            this.scorer = (Scorer) AssertingScorable.unwrap(scorer);
-          }
+                  @Override
+                  public void setScorer(Scorable scorer) {
+                    this.scorer = (Scorer) AssertingScorable.unwrap(scorer);
+                  }
 
-          @Override
-          public void collect(int doc) throws IOException {
-            assertFalse(Float.isInfinite(scorer.score()));
-          }
+                  @Override
+                  public void collect(int doc) throws IOException {
+                    assertFalse(Float.isInfinite(scorer.score()));
+                  }
 
-          @Override
-          public ScoreMode scoreMode() {
-            return ScoreMode.COMPLETE;
-          }
-        });
+                  @Override
+                  public ScoreMode scoreMode() {
+                    return ScoreMode.COMPLETE;
+                  }
+                };
+              }
+
+              @Override
+              public Void reduce(Collection<SimpleCollector> collectors) {
+                return null;
+              }
+            });
     QueryUtils.check(random(), pq, searcher);
   }
 


### PR DESCRIPTION
This is another one of many steps towards resolution of LUCENE-10002. In this PR I am replacing some usages of SimpleCollector extension in tests with a corresponding CollectorManager. In a few cases the test was not using LuceneTestCase#newSearcher hence I attempted addressing that too when applicable.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes. (not applicable)
