### PR TITLE
LUCENE-10190: Ensure changes are visible before advancing seqno

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThread.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThread.java
@@ -209,7 +209,8 @@ final class DocumentsWriterPerThread implements Accountable {
   long updateDocuments(
       Iterable<? extends Iterable<? extends IndexableField>> docs,
       DocumentsWriterDeleteQueue.Node<?> deleteNode,
-      DocumentsWriter.FlushNotifications flushNotifications)
+      DocumentsWriter.FlushNotifications flushNotifications,
+      Runnable onNewDocOnRAM)
       throws IOException {
     try {
       testPoint("DocumentsWriterPerThread addDocuments start");
@@ -236,7 +237,11 @@ final class DocumentsWriterPerThread implements Accountable {
           // it's very hard to fix (we can't easily distinguish aborting
           // vs non-aborting exceptions):
           reserveOneDoc();
-          indexingChain.processDocument(numDocsInRAM++, doc);
+          try {
+            indexingChain.processDocument(numDocsInRAM++, doc);
+          } finally {
+            onNewDocOnRAM.run();
+          }
         }
         allDocsIndexed = true;
         return finishDocuments(deleteNode, docsInRamBefore);


### PR DESCRIPTION
`DocumentWriter#anyChanges()` can return false after we process and
generate a sequence number for an update operation; but before we adjust
the `numDocsInRAM`. In this window of time, refreshes are noop, although
the `maxCompletedSequenceNumber` has advanced.