### PR TITLE
LUCENE-10407: Set bpos flag to true when containing filter is exhausted

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -223,6 +223,9 @@ Bug Fixes
 * LUCENE-10402: Prefix intervals should declare their automaton as binary, otherwise prefixes
   containing multibyte characters will not correctly match. (Alan Woodward)
 
+* LUCENE-10407: Containing intervals could sometimes yield incorrect matches when wrapped
+  in a disjunction. (Alan Woodward, Dawid Weiss)
+
 Other
 ---------------------
 

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/ContainingIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/ContainingIntervalsSource.java
@@ -51,8 +51,10 @@ class ContainingIntervalsSource extends ConjunctionIntervalsSource {
         }
         while (a.nextInterval() != IntervalIterator.NO_MORE_INTERVALS) {
           while (b.start() < a.start() && b.end() < a.end()) {
-            if (b.nextInterval() == IntervalIterator.NO_MORE_INTERVALS)
+            if (b.nextInterval() == IntervalIterator.NO_MORE_INTERVALS) {
+              bpos = false;
               return IntervalIterator.NO_MORE_INTERVALS;
+            }
           }
           if (a.start() <= b.start() && a.end() >= b.end()) {
             return a.start();

--- a/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestIntervalQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestIntervalQuery.java
@@ -17,6 +17,11 @@
 
 package org.apache.lucene.queries.intervals;
 
+import static org.apache.lucene.queries.intervals.Intervals.containing;
+import static org.apache.lucene.queries.intervals.Intervals.extend;
+import static org.apache.lucene.queries.intervals.Intervals.or;
+import static org.apache.lucene.queries.intervals.Intervals.term;
+
 import java.io.IOException;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -32,11 +37,6 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.CheckHits;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
-
-import static org.apache.lucene.queries.intervals.Intervals.containing;
-import static org.apache.lucene.queries.intervals.Intervals.extend;
-import static org.apache.lucene.queries.intervals.Intervals.or;
-import static org.apache.lucene.queries.intervals.Intervals.term;
 
 public class TestIntervalQuery extends LuceneTestCase {
 
@@ -430,7 +430,9 @@ public class TestIntervalQuery extends LuceneTestCase {
   }
 
   public void testExtendDisjunctions() throws IOException {
-    Query q = new IntervalQuery(field, or(term("XXX"), containing(extend(term("message"), 0, 10), term("intend"))));
+    Query q =
+        new IntervalQuery(
+            field, or(term("XXX"), containing(extend(term("message"), 0, 10), term("intend"))));
     checkHits(q, new int[] {});
   }
 }


### PR DESCRIPTION
ContainedByIntervalIterator and OverlappingIntervalIterator set their 'is the filter 
interval exhausted' flag to `false` once it has returned NO_MORE_POSITIONS on 
a document, so that subsequent calls to `startPosition()` will also return 
NO_MORE_POSITIONS.  ContainingIntervalIterator omits to do this, and so it can 
incorrectly report matches, for example when used in a disjunction.