### PR TITLE
Update github hunspell regression test to use JDK 17

### DIFF
--- a/.github/workflows/hunspell.yml
+++ b/.github/workflows/hunspell.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - uses: actions/cache@v2


### PR DESCRIPTION
Not entirely sure how to test this outside of opening a PR with the change, so apologies if I have to iterate a bit to get this right in the PR.