### PR TITLE
LUCENE-10400: cleanup obsolete APIs in kuromoji

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -15,6 +15,8 @@ API Changes
 * LUCENE-10368: IntTaxonomyFacets has been make pkg-private and serves only as an internal
   implementation detail of taxonomy-faceting. (Greg Miller)
 
+* LUCENE-10400: Remove deprecated dictionary constructors in Kuromoji (Tomoko Uchida)
+
 New Features
 ---------------------
 

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
@@ -25,23 +25,13 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.InputStreamDataInput;
-import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.IntsRef;
 
 /** Base class for a binary-encoded in-memory dictionary. */
 public abstract class BinaryDictionary implements Dictionary {
-
-  /** Used to specify where (dictionary) resources get loaded from. */
-  @Deprecated(forRemoval = true, since = "9.1")
-  public enum ResourceScheme {
-    CLASSPATH,
-    FILE
-  }
 
   public static final String DICT_FILENAME_SUFFIX = "$buffer.dat";
   public static final String TARGETMAP_FILENAME_SUFFIX = "$targetMap.dat";
@@ -134,24 +124,6 @@ public abstract class BinaryDictionary implements Dictionary {
         inflFormDict[j] = null;
       }
     }
-  }
-
-  @Deprecated(forRemoval = true, since = "9.1")
-  public static final InputStream getResource(ResourceScheme scheme, String path)
-      throws IOException {
-    switch (scheme) {
-      case CLASSPATH:
-        return getClassResource(path);
-      case FILE:
-        return Files.newInputStream(Paths.get(path));
-      default:
-        throw new IllegalStateException("unknown resource scheme " + scheme);
-    }
-  }
-
-  @Deprecated(forRemoval = true, since = "9.1")
-  private static InputStream getClassResource(String path) throws IOException {
-    return IOUtils.requireResourceNonNull(BinaryDictionary.class.getResourceAsStream(path), path);
   }
 
   public void lookupWordIds(int sourceId, IntsRef ref) {

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/ConnectionCosts.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/ConnectionCosts.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.InputStreamDataInput;
@@ -39,20 +38,6 @@ public final class ConnectionCosts {
 
   private final ByteBuffer buffer;
   private final int forwardSize;
-
-  /**
-   * @param scheme - scheme for loading resources (FILE or CLASSPATH).
-   * @param path - where to load resources from, without the ".dat" suffix
-   * @deprecated replaced by {@link #ConnectionCosts(Path)}
-   */
-  @Deprecated(forRemoval = true, since = "9.1")
-  @SuppressWarnings("removal")
-  public ConnectionCosts(BinaryDictionary.ResourceScheme scheme, String path) throws IOException {
-    this(
-        scheme == BinaryDictionary.ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(path + FILENAME_SUFFIX))
-            : ConnectionCosts::getClassResource);
-  }
 
   /**
    * Create a {@link ConnectionCosts} from an external resource path.

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.InputStreamDataInput;
 import org.apache.lucene.util.IOUtils;
@@ -39,31 +38,6 @@ public final class TokenInfoDictionary extends BinaryDictionary {
   public static final String FST_FILENAME_SUFFIX = "$fst.dat";
 
   private final TokenInfoFST fst;
-
-  /**
-   * @param resourceScheme - scheme for loading resources (FILE or CLASSPATH).
-   * @param resourcePath - where to load resources (dictionaries) from. If null, with CLASSPATH
-   *     scheme only, use this class's name as the path.
-   * @deprecated replaced by {@link #TokenInfoDictionary(Path, Path, Path, Path)}
-   */
-  @Deprecated(forRemoval = true, since = "9.1")
-  @SuppressWarnings("removal")
-  public TokenInfoDictionary(ResourceScheme resourceScheme, String resourcePath)
-      throws IOException {
-    this(
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + TARGETMAP_FILENAME_SUFFIX))
-            : () -> getClassResource(TARGETMAP_FILENAME_SUFFIX),
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + POSDICT_FILENAME_SUFFIX))
-            : () -> getClassResource(POSDICT_FILENAME_SUFFIX),
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + DICT_FILENAME_SUFFIX))
-            : () -> getClassResource(DICT_FILENAME_SUFFIX),
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + FST_FILENAME_SUFFIX))
-            : () -> getClassResource(FST_FILENAME_SUFFIX));
-  }
 
   /**
    * Create a {@link TokenInfoDictionary} from an external resource path.

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionary.java
@@ -20,34 +20,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.lucene.util.IOUtils;
 
 /** Dictionary for unknown-word handling. */
 public final class UnknownDictionary extends BinaryDictionary {
 
   private final CharacterDefinition characterDefinition = CharacterDefinition.getInstance();
-
-  /**
-   * @param scheme scheme for loading resources (FILE or CLASSPATH).
-   * @param path where to load resources from; a path, including the file base name without
-   *     extension; this is used to match multiple files with the same base name.
-   * @deprecated replaced by {@link #UnknownDictionary(Path, Path, Path)}
-   */
-  @Deprecated(forRemoval = true, since = "9.1")
-  @SuppressWarnings("removal")
-  public UnknownDictionary(ResourceScheme scheme, String path) throws IOException {
-    super(
-        scheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(path + TARGETMAP_FILENAME_SUFFIX))
-            : () -> getClassResource(TARGETMAP_FILENAME_SUFFIX),
-        scheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(path + POSDICT_FILENAME_SUFFIX))
-            : () -> getClassResource(POSDICT_FILENAME_SUFFIX),
-        scheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(path + DICT_FILENAME_SUFFIX))
-            : () -> getClassResource(DICT_FILENAME_SUFFIX));
-  }
 
   /**
    * Create a {@link UnknownDictionary} from an external resource path.

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseTokenizer.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseTokenizer.java
@@ -30,10 +30,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.ja.JapaneseTokenizer.Mode;
-import org.apache.lucene.analysis.ja.dict.BinaryDictionary.ResourceScheme;
 import org.apache.lucene.analysis.ja.dict.ConnectionCosts;
-import org.apache.lucene.analysis.ja.dict.TokenInfoDictionary;
-import org.apache.lucene.analysis.ja.dict.UnknownDictionary;
 import org.apache.lucene.analysis.ja.dict.UserDictionary;
 import org.apache.lucene.analysis.ja.tokenattributes.*;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -488,32 +485,6 @@ public class TestJapaneseTokenizer extends BaseTokenStreamTestCase {
         new int[] {0, 1, 2},
         new int[] {1, 2, 4},
         4);
-  }
-
-  // Make sure loading custom dictionaries from classpath works:
-  @SuppressWarnings("removal")
-  public void testCustomDictionary() throws Exception {
-    Tokenizer tokenizer =
-        new JapaneseTokenizer(
-            newAttributeFactory(),
-            new TokenInfoDictionary(
-                ResourceScheme.CLASSPATH, "org/apache/lucene/analysis/ja/dict/TokenInfoDictionary"),
-            new UnknownDictionary(
-                ResourceScheme.CLASSPATH, "org/apache/lucene/analysis/ja/dict/UnknownDictionary"),
-            new ConnectionCosts(
-                ResourceScheme.CLASSPATH, "org/apache/lucene/analysis/ja/dict/ConnectionCosts"),
-            readDict(),
-            true,
-            false,
-            Mode.SEARCH);
-    try (Analyzer a = makeAnalyzer(tokenizer)) {
-      assertTokenStreamContents(
-          a.tokenStream("foo", "abcd"),
-          new String[] {"a", "b", "cd"},
-          new int[] {0, 1, 2},
-          new int[] {1, 2, 4},
-          4);
-    }
   }
 
   // HMM: fails (segments as a/b/cd/efghij)... because the

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestExternalDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestExternalDictionary.java
@@ -1,0 +1,85 @@
+package org.apache.lucene.analysis.ja.dict;
+
+import static org.apache.lucene.analysis.ja.dict.BinaryDictionary.DICT_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ja.dict.BinaryDictionary.POSDICT_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ja.dict.BinaryDictionary.TARGETMAP_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ja.dict.TokenInfoDictionary.FST_FILENAME_SUFFIX;
+
+import java.io.BufferedWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.lucene.analysis.ja.util.DictionaryBuilder;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.Before;
+
+public class TestExternalDictionary extends LuceneTestCase {
+
+  private Path dir;
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    dir = createTempDir("systemDict");
+    try (BufferedWriter writer =
+        Files.newBufferedWriter(dir.resolve("unk.def"), StandardCharsets.UTF_8)) {
+      writer.write("DEFAULT,5,5,4769,記号,一般,*,*,*,*,*");
+      writer.newLine();
+      writer.write("SPACE,9,9,8903,記号,空白,*,*,*,*,*");
+      writer.newLine();
+    }
+    try (BufferedWriter writer =
+        Files.newBufferedWriter(dir.resolve("char.def"), StandardCharsets.UTF_8)) {
+      writer.write("0x0021..0x002F SYMBOL");
+      writer.newLine();
+      writer.write("0x0030..0x0039 NUMERIC");
+      writer.newLine();
+    }
+    try (BufferedWriter writer =
+        Files.newBufferedWriter(dir.resolve("matrix.def"), StandardCharsets.UTF_8)) {
+      writer.write("3 3");
+      writer.newLine();
+      writer.write("0 1 1");
+      writer.newLine();
+      writer.write("0 2 -1630");
+      writer.newLine();
+    }
+    try (BufferedWriter writer =
+        Files.newBufferedWriter(dir.resolve("noun.csv"), StandardCharsets.UTF_8)) {
+      writer.write("白昼夢,1285,1285,5622,名詞,一般,*,*,*,*,白昼夢,ハクチュウム,ハクチューム");
+      writer.newLine();
+      writer.write("デバッギング,1285,1285,3657,名詞,一般,*,*,*,*,デバッギング,デバッギング,デバッギング");
+      writer.newLine();
+    }
+    DictionaryBuilder.build(DictionaryBuilder.DictionaryFormat.IPADIC, dir, dir, "utf-8", true);
+  }
+
+  public void testLoadExternalTokenInfoDictionary() throws Exception {
+    String dictionaryPath = TokenInfoDictionary.class.getName().replace('.', '/');
+    TokenInfoDictionary dict =
+        new TokenInfoDictionary(
+            dir.resolve(dictionaryPath + TARGETMAP_FILENAME_SUFFIX),
+            dir.resolve(dictionaryPath + POSDICT_FILENAME_SUFFIX),
+            dir.resolve(dictionaryPath + DICT_FILENAME_SUFFIX),
+            dir.resolve(dictionaryPath + FST_FILENAME_SUFFIX));
+    assertNotNull(dict.getFST());
+  }
+
+  public void testLoadExternalUnknownDictionary() throws Exception {
+    String dictionaryPath = UnknownDictionary.class.getName().replace('.', '/');
+    UnknownDictionary dict =
+        new UnknownDictionary(
+            dir.resolve(dictionaryPath + TARGETMAP_FILENAME_SUFFIX),
+            dir.resolve(dictionaryPath + POSDICT_FILENAME_SUFFIX),
+            dir.resolve(dictionaryPath + DICT_FILENAME_SUFFIX));
+    assertNotNull(dict.getCharacterDefinition());
+  }
+
+  public void testLoadExternalConnectionCosts() throws Exception {
+    String dictionaryPath = ConnectionCosts.class.getName().replace('.', '/');
+    ConnectionCosts cc =
+        new ConnectionCosts(dir.resolve(dictionaryPath + ConnectionCosts.FILENAME_SUFFIX));
+    assertEquals(1, cc.get(0, 1));
+  }
+}

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestExternalDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestExternalDictionary.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.analysis.ja.dict;
 
 import static org.apache.lucene.analysis.ja.dict.BinaryDictionary.DICT_FILENAME_SUFFIX;

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestTokenInfoDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestTokenInfoDictionary.java
@@ -61,7 +61,6 @@ public class TestTokenInfoDictionary extends LuceneTestCase {
     assertEquals(2, dict.getWordCost(wordId));
   }
 
-  @SuppressWarnings("removal")
   private TokenInfoDictionary newDictionary(String... entries) throws Exception {
     Path dir = createTempDir();
     try (OutputStream out = Files.newOutputStream(dir.resolve("test.csv"));

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestTokenInfoDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestTokenInfoDictionary.java
@@ -16,7 +16,10 @@
  */
 package org.apache.lucene.analysis.ja.dict;
 
-import static org.apache.lucene.analysis.ja.dict.BinaryDictionary.ResourceScheme;
+import static org.apache.lucene.analysis.ja.dict.BinaryDictionary.DICT_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ja.dict.BinaryDictionary.POSDICT_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ja.dict.BinaryDictionary.TARGETMAP_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ja.dict.TokenInfoDictionary.FST_FILENAME_SUFFIX;
 
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -78,7 +81,11 @@ public class TestTokenInfoDictionary extends LuceneTestCase {
     DictionaryBuilder.build(DictionaryFormat.IPADIC, dir, dir, "utf-8", true);
     String dictionaryPath = TokenInfoDictionary.class.getName().replace('.', '/');
     // We must also load the other files (in BinaryDictionary) from the correct path
-    return new TokenInfoDictionary(ResourceScheme.FILE, dir.resolve(dictionaryPath).toString());
+    return new TokenInfoDictionary(
+        dir.resolve(dictionaryPath + TARGETMAP_FILENAME_SUFFIX),
+        dir.resolve(dictionaryPath + POSDICT_FILENAME_SUFFIX),
+        dir.resolve(dictionaryPath + DICT_FILENAME_SUFFIX),
+        dir.resolve(dictionaryPath + FST_FILENAME_SUFFIX));
   }
 
   public void testPutException() {


### PR DESCRIPTION
1. Remove deprecated constructors
2. Add / change tests for new constructors