### PR TITLE
LUCENE-10382: Support filtering in KnnVectorQuery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,3 +183,5 @@ apply from: file('gradle/hacks/turbocharge-jvm-opts.gradle')
 apply from: file('gradle/hacks/dummy-outputs.gradle')
 
 apply from: file('gradle/pylucene/pylucene.gradle')
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16

--- a/build.gradle
+++ b/build.gradle
@@ -183,5 +183,3 @@ apply from: file('gradle/hacks/turbocharge-jvm-opts.gradle')
 apply from: file('gradle/hacks/dummy-outputs.gradle')
 
 apply from: file('gradle/pylucene/pylucene.gradle')
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -140,6 +140,9 @@ New Features
 * LUCENE-10385: Implement Weight#count on IndexSortSortedNumericDocValuesRangeQuery
   to speed up computing the number of hits when possible. (Luca Cavanna, Adrien Grand)
 
+* LUCENE-10382: Add support for filtering in KnnVectorQuery. This allows for finding the
+  nearest k documents that also match a query. (Julie Tibshirani, Joel Bernstein)
+
 Improvements
 ---------------------
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -229,7 +229,8 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
   }
 
   @Override
-  public TopDocs search(String field, float[] target, int k, Bits acceptDocs) throws IOException {
+  public TopDocs search(String field, float[] target, int k, Bits acceptDocs, int visitedLimit)
+      throws IOException {
     FieldEntry fieldEntry = fields.get(field);
 
     if (fieldEntry.size() == 0) {

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
@@ -144,7 +144,8 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
   }
 
   @Override
-  public TopDocs search(String field, float[] target, int k, Bits acceptDocs) throws IOException {
+  public TopDocs search(String field, float[] target, int k, Bits acceptDocs, int visitedLimit)
+      throws IOException {
     VectorValues values = getVectorValues(field);
     if (target.length != values.dimension()) {
       throw new IllegalArgumentException(

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -100,7 +100,8 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
             }
 
             @Override
-            public TopDocs search(String field, float[] target, int k, Bits acceptDocs) {
+            public TopDocs search(
+                String field, float[] target, int k, Bits acceptDocs, int visitedLimit) {
               return TopDocsCollector.EMPTY_TOPDOCS;
             }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
@@ -21,8 +21,9 @@ import java.io.Closeable;
 import java.io.IOException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.VectorValues;
-import org.apache.lucene.search.CollectionTerminatedException;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Bits;
 
@@ -59,6 +60,12 @@ public abstract class KnnVectorsReader implements Closeable, Accountable {
    * true k closest neighbors. For large values of k (for example when k is close to the total
    * number of documents), the search may also retrieve fewer than k documents.
    *
+   * <p>The returned {@link TopDocs} will contain a {@link ScoreDoc} for each nearest neighbor, in
+   * order of their similarity to the query vector (decreasing scores). The {@link TotalHits}
+   * contains the number of documents visited during the search. If the search stopped early because
+   * it hit {@code visitedLimit}, it is indicated through the relation {@code
+   * TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO}.
+   *
    * <p>The behavior is undefined if the given field doesn't have KNN vectors enabled on its {@link
    * FieldInfo}. The return value is never {@code null}.
    *
@@ -68,7 +75,6 @@ public abstract class KnnVectorsReader implements Closeable, Accountable {
    * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
    *     if they are all allowed to match.
    * @param visitedLimit the maximum number of nodes that the search is allowed to visit
-   * @throws CollectionTerminatedException if search stops early because it hit {@code visitedLimit}
    * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
    */
   public abstract TopDocs search(

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Bits;
@@ -66,10 +67,12 @@ public abstract class KnnVectorsReader implements Closeable, Accountable {
    * @param k the number of docs to return
    * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
    *     if they are all allowed to match.
+   * @param visitedLimit the maximum number of nodes that the search is allowed to visit
+   * @throws CollectionTerminatedException if search stops early because it hit {@code visitedLimit}
    * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
    */
-  public abstract TopDocs search(String field, float[] target, int k, Bits acceptDocs)
-      throws IOException;
+  public abstract TopDocs search(
+      String field, float[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException;
 
   /**
    * Returns an instance optimized for merging. This instance may only be consumed in the thread

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -86,7 +86,8 @@ public abstract class KnnVectorsWriter implements Closeable {
               }
 
               @Override
-              public TopDocs search(String field, float[] target, int k, Bits acceptDocs) {
+              public TopDocs search(
+                  String field, float[] target, int k, Bits acceptDocs, int visitedLimit) {
                 throw new UnsupportedOperationException();
               }
             });

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene91/Lucene91HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene91/Lucene91HnswVectorsReader.java
@@ -35,12 +35,16 @@ import org.apache.lucene.index.RandomAccessVectorValuesProducer;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.HitQueue;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
@@ -227,8 +231,21 @@ public final class Lucene91HnswVectorsReader extends KnnVectorsReader {
 
     // bound k by total number of vectors to prevent oversizing data structures
     k = Math.min(k, fieldEntry.size());
-
     OffHeapVectorValues vectorValues = getOffHeapVectorValues(fieldEntry);
+
+    DocIdSetIterator acceptIterator = null;
+    int visitedLimit = Integer.MAX_VALUE;
+
+    if (acceptDocs instanceof BitSet acceptBitSet) {
+      visitedLimit = acceptBitSet.cardinality();
+      acceptIterator = new BitSetIterator(acceptBitSet, visitedLimit);
+      // If there <= k possible matches, short-circuit and perform exact search, since HNSW must
+      // always visit at least k documents.
+      if (visitedLimit <= k) {
+        return exactSearch(target, k, fieldEntry.similarityFunction, vectorValues, acceptIterator);
+      }
+    }
+
     NeighborQueue results =
         HnswGraphSearcher.search(
             target,
@@ -236,7 +253,14 @@ public final class Lucene91HnswVectorsReader extends KnnVectorsReader {
             vectorValues,
             fieldEntry.similarityFunction,
             getGraph(fieldEntry),
-            getAcceptOrds(acceptDocs, fieldEntry));
+            getAcceptOrds(acceptDocs, fieldEntry),
+            visitedLimit);
+
+    // If we stopped HNSW search early because it visited too many nodes, fall back to exact search
+    if (results.incomplete()) {
+      assert acceptIterator != null;
+      return exactSearch(target, k, fieldEntry.similarityFunction, vectorValues, acceptIterator);
+    }
 
     int i = 0;
     ScoreDoc[] scoreDocs = new ScoreDoc[Math.min(results.size(), k)];
@@ -251,6 +275,36 @@ public final class Lucene91HnswVectorsReader extends KnnVectorsReader {
     return new TopDocs(
         new TotalHits(results.visitedCount(), TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
         scoreDocs);
+  }
+
+  private TopDocs exactSearch(
+      float[] target,
+      int k,
+      VectorSimilarityFunction similarityFunction,
+      VectorValues vectorValues,
+      DocIdSetIterator acceptIterator)
+      throws IOException {
+    HitQueue topK = new HitQueue(k, false);
+
+    int doc;
+    while ((doc = acceptIterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+      if (vectorValues.docID() > doc) {
+        continue;
+      }
+      int vectorDoc = vectorValues.advance(doc);
+      if (vectorDoc == doc) {
+        float[] vector = vectorValues.vectorValue();
+        float score = similarityFunction.convertToScore(similarityFunction.compare(vector, target));
+        topK.insertWithOverflow(new ScoreDoc(doc, score));
+      }
+    }
+    ScoreDoc[] topScoreDocs = new ScoreDoc[topK.size()];
+    for (int i = topScoreDocs.length - 1; i >= 0; i--) {
+      topScoreDocs[i] = topK.pop();
+    }
+
+    TotalHits totalHits = new TotalHits(acceptIterator.cost(), TotalHits.Relation.EQUAL_TO);
+    return new TopDocs(totalHits, topScoreDocs);
   }
 
   private OffHeapVectorValues getOffHeapVectorValues(FieldEntry fieldEntry) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene91/Lucene91HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene91/Lucene91HnswVectorsReader.java
@@ -248,11 +248,12 @@ public final class Lucene91HnswVectorsReader extends KnnVectorsReader {
       results.pop();
       scoreDocs[scoreDocs.length - ++i] = new ScoreDoc(fieldEntry.ordToDoc[node], score);
     }
-    // always return >= the case where we can assert == is only when there are fewer than topK
-    // vectors in the index
-    return new TopDocs(
-        new TotalHits(results.visitedCount(), TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
-        scoreDocs);
+
+    TotalHits.Relation relation =
+        results.incomplete()
+            ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
+            : TotalHits.Relation.EQUAL_TO;
+    return new TopDocs(new TotalHits(results.visitedCount(), relation), scoreDocs);
   }
 
   private OffHeapVectorValues getOffHeapVectorValues(FieldEntry fieldEntry) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
@@ -263,12 +263,13 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
     }
 
     @Override
-    public TopDocs search(String field, float[] target, int k, Bits acceptDocs) throws IOException {
+    public TopDocs search(String field, float[] target, int k, Bits acceptDocs, int visitedLimit)
+        throws IOException {
       KnnVectorsReader knnVectorsReader = fields.get(field);
       if (knnVectorsReader == null) {
         return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
       } else {
-        return knnVectorsReader.search(field, target, k, acceptDocs);
+        return knnVectorsReader.search(field, target, k, acceptDocs, visitedLimit);
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
@@ -223,8 +223,8 @@ public abstract class CodecReader extends LeafReader {
   }
 
   @Override
-  public final TopDocs searchNearestVectors(String field, float[] target, int k, Bits acceptDocs)
-      throws IOException {
+  public final TopDocs searchNearestVectors(
+      String field, float[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException {
     ensureOpen();
     FieldInfo fi = getFieldInfos().fieldInfo(field);
     if (fi == null || fi.getVectorDimension() == 0) {
@@ -232,7 +232,7 @@ public abstract class CodecReader extends LeafReader {
       return null;
     }
 
-    return getVectorReader().search(field, target, k, acceptDocs);
+    return getVectorReader().search(field, target, k, acceptDocs, visitedLimit);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
@@ -53,8 +53,8 @@ abstract class DocValuesLeafReader extends LeafReader {
   }
 
   @Override
-  public TopDocs searchNearestVectors(String field, float[] target, int k, Bits acceptDocs)
-      throws IOException {
+  public TopDocs searchNearestVectors(
+      String field, float[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException {
     throw new UnsupportedOperationException();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
@@ -352,9 +352,9 @@ public abstract class FilterLeafReader extends LeafReader {
   }
 
   @Override
-  public TopDocs searchNearestVectors(String field, float[] target, int k, Bits acceptDocs)
-      throws IOException {
-    return in.searchNearestVectors(field, target, k, acceptDocs);
+  public TopDocs searchNearestVectors(
+      String field, float[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException {
+    return in.searchNearestVectors(field, target, k, acceptDocs, visitedLimit);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -17,8 +17,9 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
-import org.apache.lucene.search.CollectionTerminatedException;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.Bits;
 
 /**
@@ -216,9 +217,19 @@ public abstract class LeafReader extends IndexReader {
 
   /**
    * Return the k nearest neighbor documents as determined by comparison of their vector values for
-   * this field, to the given vector, by the field's search strategy. If the search strategy is
-   * reversed, lower values indicate nearer vectors, otherwise higher scores indicate nearer
-   * vectors. Unlike relevance scores, vector scores may be negative.
+   * this field, to the given vector, by the field's similarity function. The score of each document
+   * is derived from the vector similarity in a way that ensures scores are positive and that a
+   * larger score corresponds to a higher ranking.
+   *
+   * <p>The search is allowed to be approximate, meaning the results are not guaranteed to be the
+   * true k closest neighbors. For large values of k (for example when k is close to the total
+   * number of documents), the search may also retrieve fewer than k documents.
+   *
+   * <p>The returned {@link TopDocs} will contain a {@link ScoreDoc} for each nearest neighbor,
+   * sorted in order of their similarity to the query vector (decreasing scores). The {@link
+   * TotalHits} contains the number of documents visited during the search. If the search stopped
+   * early because it hit {@code visitedLimit}, it is indicated through the relation {@code
+   * TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO}.
    *
    * @param field the vector field to search
    * @param target the vector-valued query
@@ -227,7 +238,6 @@ public abstract class LeafReader extends IndexReader {
    *     if they are all allowed to match.
    * @param visitedLimit the maximum number of nodes that the search is allowed to visit
    * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
-   * @throws CollectionTerminatedException if search stops early because it hit {@code visitedLimit}
    * @lucene.experimental
    */
   public abstract TopDocs searchNearestVectors(

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
 
@@ -224,11 +225,13 @@ public abstract class LeafReader extends IndexReader {
    * @param k the number of docs to return
    * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
    *     if they are all allowed to match.
+   * @param visitedLimit the maximum number of nodes that the search is allowed to visit
    * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
+   * @throws CollectionTerminatedException if search stops early because it hit {@code visitedLimit}
    * @lucene.experimental
    */
-  public abstract TopDocs searchNearestVectors(String field, float[] target, int k, Bits acceptDocs)
-      throws IOException;
+  public abstract TopDocs searchNearestVectors(
+      String field, float[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException;
 
   /**
    * Get the {@link FieldInfos} describing all fields in this reader.

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -393,11 +393,14 @@ public class ParallelLeafReader extends LeafReader {
   }
 
   @Override
-  public TopDocs searchNearestVectors(String fieldName, float[] target, int k, Bits acceptDocs)
+  public TopDocs searchNearestVectors(
+      String fieldName, float[] target, int k, Bits acceptDocs, int visitedLimit)
       throws IOException {
     ensureOpen();
     LeafReader reader = fieldToReader.get(fieldName);
-    return reader == null ? null : reader.searchNearestVectors(fieldName, target, k, acceptDocs);
+    return reader == null
+        ? null
+        : reader.searchNearestVectors(fieldName, target, k, acceptDocs, visitedLimit);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
@@ -167,9 +167,9 @@ public final class SlowCodecReaderWrapper {
       }
 
       @Override
-      public TopDocs search(String field, float[] target, int k, Bits acceptDocs)
+      public TopDocs search(String field, float[] target, int k, Bits acceptDocs, int visitedLimit)
           throws IOException {
-        return reader.searchNearestVectors(field, target, k, acceptDocs);
+        return reader.searchNearestVectors(field, target, k, acceptDocs, visitedLimit);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -384,7 +384,8 @@ public final class SortingCodecReader extends FilterCodecReader {
       }
 
       @Override
-      public TopDocs search(String field, float[] target, int k, Bits acceptDocs) {
+      public TopDocs search(
+          String field, float[] target, int k, Bits acceptDocs, int visitedLimit) {
         throw new UnsupportedOperationException();
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
@@ -30,7 +30,7 @@ import org.apache.lucene.util.BytesRef;
 public abstract class VectorValues extends DocIdSetIterator {
 
   /** The maximum length of a vector */
-  public static int MAX_DIMENSIONS = 1024;
+  public static final int MAX_DIMENSIONS = 1024;
 
   /** Sole constructor */
   protected VectorValues() {}

--- a/lucene/core/src/java/org/apache/lucene/index/VectorValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorValuesWriter.java
@@ -135,7 +135,8 @@ class VectorValuesWriter {
           }
 
           @Override
-          public TopDocs search(String field, float[] target, int k, Bits acceptDocs)
+          public TopDocs search(
+              String field, float[] target, int k, Bits acceptDocs, int visitedLimit)
               throws IOException {
             throw new UnsupportedOperationException();
           }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorFieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorFieldExistsQuery.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.apache.lucene.index.LeafReaderContext;
+
+/**
+ * A {@link Query} that matches documents that contain a {@link
+ * org.apache.lucene.document.KnnVectorField}.
+ */
+public class KnnVectorFieldExistsQuery extends Query {
+
+  private final String field;
+
+  /** Create a query that will match documents which have a value for the given {@code field}. */
+  public KnnVectorFieldExistsQuery(String field) {
+    this.field = Objects.requireNonNull(field);
+  }
+
+  public String getField() {
+    return field;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return sameClassAs(other) && field.equals(((KnnVectorFieldExistsQuery) other).field);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * classHash() + field.hashCode();
+  }
+
+  @Override
+  public String toString(String field) {
+    return "KnnVectorFieldExistsQuery [field=" + this.field + "]";
+  }
+
+  @Override
+  public void visit(QueryVisitor visitor) {
+    if (visitor.acceptField(field)) {
+      visitor.visitLeaf(this);
+    }
+  }
+
+  @Override
+  public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+    return new ConstantScoreWeight(this, boost) {
+      @Override
+      public Scorer scorer(LeafReaderContext context) throws IOException {
+        DocIdSetIterator iterator = context.reader().getVectorValues(field);
+        if (iterator == null) {
+          return null;
+        }
+        return new ConstantScoreScorer(this, score(), scoreMode, iterator);
+      }
+
+      @Override
+      public boolean isCacheable(LeafReaderContext ctx) {
+        return true;
+      }
+    };
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -204,6 +204,11 @@ public class KnnVectorQuery extends Query {
       this.cost = new int[bitSets.length];
     }
 
+    /**
+     * Return an iterator whose {@link BitSet} contains the matching documents,
+     * and whose {@link BitSetIterator#cost()} is the exact cardinality. If the
+     * leaf was never visited, then return null.
+     **/
     public BitSetIterator getIterator(int contextOrd) {
       if (bitSets[contextOrd] == null) {
         return null;

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -160,7 +160,8 @@ public class KnnVectorQuery extends Query {
     return results != null ? results : NO_RESULTS;
   }
 
-  private TopDocs exactSearch(LeafReaderContext context, DocIdSetIterator acceptIterator)
+  // We allow this to be overridden so that tests can check what search strategy is used
+  protected TopDocs exactSearch(LeafReaderContext context, DocIdSetIterator acceptIterator)
       throws IOException {
     FieldInfo fi = context.reader().getFieldInfos().fieldInfo(field);
     if (fi == null || fi.getVectorDimension() == 0) {

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -43,7 +43,7 @@ import org.apache.lucene.util.FixedBitSet;
  * <ul>
  *   <li>If the filter cost is less than k, just execute an exact search
  *   <li>Otherwise run a kNN search subject to the filter
- *   <li>the kNN search visits too many vectors without completing, stop and run an exact search
+ *   <li>If the kNN search visits too many vectors without completing, stop and run an exact search
  * </ul>
  */
 public class KnnVectorQuery extends Query {

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -114,7 +114,6 @@ public class KnnVectorQuery extends Query {
 
     private final BitSet[] bitSets;
     private BitSet leafBits;
-    private int docBase;
 
     private BitSetCollector(BitSet[] bitSets) {
       this.bitSets = bitSets;

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -139,14 +139,14 @@ public class KnnVectorQuery extends Query {
         return exactSearch(ctx, filterIterator);
       }
 
-      try {
-        // The filter iterator already incorporates live docs
-        Bits acceptDocs = filterIterator.getBitSet();
-        int visitedLimit = (int) filterIterator.cost();
-        return approximateSearch(ctx, acceptDocs, visitedLimit);
-      } catch (
-          @SuppressWarnings("unused")
-          CollectionTerminatedException e) {
+      // Perform the approximate kNN search
+      Bits acceptDocs =
+          filterIterator.getBitSet(); // The filter iterator already incorporates live docs
+      int visitedLimit = (int) filterIterator.cost();
+      TopDocs results = approximateSearch(ctx, acceptDocs, visitedLimit);
+      if (results.totalHits.relation == TotalHits.Relation.EQUAL_TO) {
+        return results;
+      } else {
         // We stopped the kNN search because it visited too many nodes, so fall back to exact search
         return exactSearch(ctx, filterIterator);
       }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -97,8 +97,8 @@ public class KnnVectorQuery extends Query {
   }
 
   private TopDocs searchLeaf(LeafReaderContext ctx, int kPerLeaf, Bits bitsFilter) throws IOException {
-    Bits liveDocs = ctx.reader().getLiveDocs();
-    TopDocs results = ctx.reader().searchNearestVectors(field, target, kPerLeaf, bitsFilter != null ? bitsFilter : liveDocs);
+
+    TopDocs results = ctx.reader().searchNearestVectors(field, target, kPerLeaf, bitsFilter != null ? bitsFilter : ctx.reader().getLiveDocs());
     if (results == null) {
       return NO_RESULTS;
     }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -78,7 +78,7 @@ public class KnnVectorQuery extends Query {
   public Query rewrite(IndexReader reader) throws IOException {
     BitSet[] bitSets = null;
 
-    if(filter != null) {
+    if (filter != null) {
       IndexSearcher indexSearcher = new IndexSearcher(reader);
       bitSets = new BitSet[reader.leaves().size()];
       indexSearcher.search(filter, new BitSetCollector(bitSets));
@@ -96,9 +96,14 @@ public class KnnVectorQuery extends Query {
     return createRewrittenQuery(reader, topK);
   }
 
-  private TopDocs searchLeaf(LeafReaderContext ctx, int kPerLeaf, Bits bitsFilter) throws IOException {
+  private TopDocs searchLeaf(LeafReaderContext ctx, int kPerLeaf, Bits bitsFilter)
+      throws IOException {
+    // If the filter is non-null, then it already handles live docs
+    if (bitsFilter == null) {
+      bitsFilter = ctx.reader().getLiveDocs();
+    }
 
-    TopDocs results = ctx.reader().searchNearestVectors(field, target, kPerLeaf, bitsFilter != null ? bitsFilter : ctx.reader().getLiveDocs());
+    TopDocs results = ctx.reader().searchNearestVectors(field, target, kPerLeaf, bitsFilter);
     if (results == null) {
       return NO_RESULTS;
     }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -134,8 +134,8 @@ public class KnnVectorQuery extends Query {
       }
 
       if (filterIterator.cost() <= k) {
-        // If there <= k possible matches, short-circuit and perform exact search, since HNSW must
-        // always visit at least k documents
+        // If there are <= k possible matches, short-circuit and perform exact search, since HNSW
+        // must always visit at least k documents
         return exactSearch(ctx, filterIterator);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -151,13 +151,12 @@ public final class HnswGraphBuilder {
 
     // for levels > nodeLevel search with topk = 1
     for (int level = curMaxLevel; level > nodeLevel; level--) {
-      candidates = graphSearcher.searchLevel(value, 1, level, eps, vectorValues, hnsw, null);
+      candidates = graphSearcher.searchLevel(value, 1, level, eps, vectorValues, hnsw);
       eps = new int[] {candidates.pop()};
     }
     // for levels <= nodeLevel search with topk = beamWidth, and add connections
     for (int level = Math.min(nodeLevel, curMaxLevel); level >= 0; level--) {
-      candidates =
-          graphSearcher.searchLevel(value, beamWidth, level, eps, vectorValues, hnsw, null);
+      candidates = graphSearcher.searchLevel(value, beamWidth, level, eps, vectorValues, hnsw);
       eps = candidates.nodes();
       hnsw.addNode(level, node);
       addDiverseNeighbors(level, node, candidates);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -53,6 +53,8 @@ public class NeighborQueue {
 
   // Used to track the number of neighbors visited during a single graph traversal
   private int visitedCount;
+  // Whether the search stopped early because it reached the visited nodes limit
+  private boolean incomplete;
 
   public NeighborQueue(int initialSize, boolean reversed) {
     this.heap = new LongHeap(initialSize);
@@ -126,6 +128,14 @@ public class NeighborQueue {
 
   public void setVisitedCount(int visitedCount) {
     this.visitedCount = visitedCount;
+  }
+
+  public boolean incomplete() {
+    return incomplete;
+  }
+
+  public void markIncomplete() {
+    this.incomplete = true;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -54,9 +54,6 @@ public class NeighborQueue {
   // Used to track the number of neighbors visited during a single graph traversal
   private int visitedCount;
 
-  // Whether the greedy search stopped early because it reached the visited nodes limit
-  private boolean isIncomplete;
-
   public NeighborQueue(int initialSize, boolean reversed) {
     this.heap = new LongHeap(initialSize);
     this.order = reversed ? Order.REVERSED : Order.NATURAL;
@@ -129,14 +126,6 @@ public class NeighborQueue {
 
   public void setVisitedCount(int visitedCount) {
     this.visitedCount = visitedCount;
-  }
-
-  public boolean incomplete() {
-    return isIncomplete;
-  }
-
-  public void markIncomplete() {
-    this.isIncomplete = true;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -54,6 +54,9 @@ public class NeighborQueue {
   // Used to track the number of neighbors visited during a single graph traversal
   private int visitedCount;
 
+  // Whether the greedy search stopped early because it reached the visited nodes limit
+  private boolean isIncomplete;
+
   public NeighborQueue(int initialSize, boolean reversed) {
     this.heap = new LongHeap(initialSize);
     this.order = reversed ? Order.REVERSED : Order.NATURAL;
@@ -126,6 +129,14 @@ public class NeighborQueue {
 
   public void setVisitedCount(int visitedCount) {
     this.visitedCount = visitedCount;
+  }
+
+  public boolean incomplete() {
+    return isIncomplete;
+  }
+
+  public void markIncomplete() {
+    this.isIncomplete = true;
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
@@ -104,11 +104,13 @@ public class TestPerFieldKnnVectorsFormat extends BaseKnnVectorsFormatTestCase {
       try (IndexReader ireader = DirectoryReader.open(directory)) {
         LeafReader reader = ireader.leaves().get(0).reader();
         TopDocs hits1 =
-            reader.searchNearestVectors("field1", new float[] {1, 2, 3}, 10, reader.getLiveDocs());
+            reader.searchNearestVectors(
+                "field1", new float[] {1, 2, 3}, 10, reader.getLiveDocs(), Integer.MAX_VALUE);
         assertEquals(1, hits1.scoreDocs.length);
 
         TopDocs hits2 =
-            reader.searchNearestVectors("field2", new float[] {1, 2, 3}, 10, reader.getLiveDocs());
+            reader.searchNearestVectors(
+                "field2", new float[] {1, 2, 3}, 10, reader.getLiveDocs(), Integer.MAX_VALUE);
         assertEquals(1, hits2.scoreDocs.length);
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -397,7 +397,9 @@ public class TestKnnGraph extends LuceneTestCase {
     TopDocs[] results = new TopDocs[reader.leaves().size()];
     for (LeafReaderContext ctx : reader.leaves()) {
       Bits liveDocs = ctx.reader().getLiveDocs();
-      results[ctx.ord] = ctx.reader().searchNearestVectors(KNN_GRAPH_FIELD, vector, k, liveDocs);
+      results[ctx.ord] =
+          ctx.reader()
+              .searchNearestVectors(KNN_GRAPH_FIELD, vector, k, liveDocs, Integer.MAX_VALUE);
       if (ctx.docBase > 0) {
         for (ScoreDoc doc : results[ctx.ord].scoreDocs) {
           doc.doc += ctx.docBase;

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
@@ -112,7 +112,8 @@ public class TestSegmentToThreadMapping extends LuceneTestCase {
       }
 
       @Override
-      public TopDocs searchNearestVectors(String field, float[] target, int k, Bits acceptDocs) {
+      public TopDocs searchNearestVectors(
+          String field, float[] target, int k, Bits acceptDocs, int visitedLimit) {
         return null;
       }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorFieldExistsQuery.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.KnnVectorField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.VectorUtil;
+
+public class TestKnnVectorFieldExistsQuery extends LuceneTestCase {
+
+  public void testRandom() throws IOException {
+    int iters = atLeast(10);
+    for (int iter = 0; iter < iters; ++iter) {
+      try (Directory dir = newDirectory();
+          RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+        int numDocs = atLeast(100);
+        for (int i = 0; i < numDocs; ++i) {
+          Document doc = new Document();
+          boolean hasValue = random().nextBoolean();
+          if (hasValue) {
+            doc.add(new KnnVectorField("vector", randomVector(5)));
+            doc.add(new StringField("has_value", "yes", Store.NO));
+          }
+          doc.add(new StringField("field", "value", Store.NO));
+          iw.addDocument(doc);
+        }
+        if (random().nextBoolean()) {
+          iw.deleteDocuments(new TermQuery(new Term("f", "no")));
+        }
+        iw.commit();
+
+        try (IndexReader reader = iw.getReader()) {
+          IndexSearcher searcher = newSearcher(reader);
+
+          assertSameMatches(
+              searcher,
+              new TermQuery(new Term("has_value", "yes")),
+              new KnnVectorFieldExistsQuery("vector"),
+              false);
+
+          float boost = random().nextFloat() * 10;
+          assertSameMatches(
+              searcher,
+              new BoostQuery(
+                  new ConstantScoreQuery(new TermQuery(new Term("has_value", "yes"))), boost),
+              new BoostQuery(new KnnVectorFieldExistsQuery("vector"), boost),
+              true);
+        }
+      }
+    }
+  }
+
+  public void testMissingField() throws IOException {
+    try (Directory dir = newDirectory();
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+      iw.addDocument(new Document());
+      iw.commit();
+      try (IndexReader reader = iw.getReader()) {
+        IndexSearcher searcher = newSearcher(reader);
+        assertEquals(0, searcher.count(new KnnVectorFieldExistsQuery("f")));
+      }
+    }
+  }
+
+  public void testAllDocsHaveField() throws IOException {
+    try (Directory dir = newDirectory();
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+      Document doc = new Document();
+      doc.add(new KnnVectorField("vector", randomVector(3)));
+      iw.addDocument(doc);
+      iw.commit();
+      try (IndexReader reader = iw.getReader()) {
+        IndexSearcher searcher = newSearcher(reader);
+        assertEquals(1, searcher.count(new KnnVectorFieldExistsQuery("vector")));
+      }
+    }
+  }
+
+  public void testFieldExistsButNoDocsHaveField() throws IOException {
+    try (Directory dir = newDirectory();
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+      // 1st segment has the field, but 2nd one does not
+      Document doc = new Document();
+      doc.add(new KnnVectorField("vector", randomVector(3)));
+      iw.addDocument(doc);
+      iw.commit();
+      iw.addDocument(new Document());
+      iw.commit();
+      try (IndexReader reader = iw.getReader()) {
+        IndexSearcher searcher = newSearcher(reader);
+        assertEquals(1, searcher.count(new KnnVectorFieldExistsQuery("vector")));
+      }
+    }
+  }
+
+  private float[] randomVector(int dim) {
+    float[] v = new float[dim];
+    for (int i = 0; i < dim; i++) {
+      v[i] = random().nextFloat();
+    }
+    VectorUtil.l2normalize(v);
+    return v;
+  }
+
+  private void assertSameMatches(IndexSearcher searcher, Query q1, Query q2, boolean scores)
+      throws IOException {
+    final int maxDoc = searcher.getIndexReader().maxDoc();
+    final TopDocs td1 = searcher.search(q1, maxDoc, scores ? Sort.RELEVANCE : Sort.INDEXORDER);
+    final TopDocs td2 = searcher.search(q2, maxDoc, scores ? Sort.RELEVANCE : Sort.INDEXORDER);
+    assertEquals(td1.totalHits.value, td2.totalHits.value);
+    for (int i = 0; i < td1.scoreDocs.length; ++i) {
+      assertEquals(td1.scoreDocs[i].doc, td2.scoreDocs[i].doc);
+      if (scores) {
+        assertEquals(td1.scoreDocs[i].score, td2.scoreDocs[i].score, 10e-7);
+      }
+    }
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -115,13 +115,13 @@ public class TestKnnVectorQuery extends LuceneTestCase {
     }
   }
 
-  public void testMatchNoneFilter() throws IOException {
+  public void testFilterWithNoVectorMatches() throws IOException {
     try (Directory indexStore =
             getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
 
-      Query filter = new TermQuery(new Term("id", "nonexistent"));
+      Query filter = new TermQuery(new Term("other", "value"));
       Query kvq = new KnnVectorQuery("field", new float[] {0, 0}, 10, filter);
       TopDocs topDocs = searcher.search(kvq, 3);
       assertEquals(0, topDocs.totalHits.value);

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -486,7 +486,7 @@ public class TestKnnVectorQuery extends LuceneTestCase {
 
   /** Tests with random vectors and a random filter. Uses RandomIndexWriter. */
   public void testRandomWithFilter() throws IOException {
-    int numDocs = 100;
+    int numDocs = 200;
     int dimension = atLeast(5);
     int numIters = atLeast(10);
     try (Directory d = newDirectory()) {
@@ -503,14 +503,14 @@ public class TestKnnVectorQuery extends LuceneTestCase {
       try (IndexReader reader = DirectoryReader.open(d)) {
         IndexSearcher searcher = newSearcher(reader);
         for (int i = 0; i < numIters; i++) {
-          int lower = random().nextInt(numDocs / 2);
+          int lower = random().nextInt(50);
 
           // Check that when filter is restrictive, we use exact search
-          Query filter = IntPoint.newRangeQuery("tag", lower, lower + 39);
-          KnnVectorQuery query = new KnnVectorQuery("field", randomVector(dimension), 50, filter);
+          Query filter = IntPoint.newRangeQuery("tag", lower, lower + 6);
+          KnnVectorQuery query = new KnnVectorQuery("field", randomVector(dimension), 5, filter);
           TopDocs results = searcher.search(query, numDocs);
           assertEquals(TotalHits.Relation.EQUAL_TO, results.totalHits.relation);
-          assertEquals(results.totalHits.value, 40);
+          assertEquals(results.totalHits.value, 5);
 
           // Check that when filter cost is less than k, we use exact search
           filter = IntPoint.newRangeQuery("tag", lower, lower + 2);
@@ -520,19 +520,19 @@ public class TestKnnVectorQuery extends LuceneTestCase {
           assertEquals(results.totalHits.value, 3);
 
           // Check results when k is small and filter is not restrictive
-          filter = IntPoint.newRangeQuery("tag", lower, lower + 50);
+          filter = IntPoint.newRangeQuery("tag", lower, lower + 150);
           query = new KnnVectorQuery("field", randomVector(dimension), 5, filter);
           results =
               searcher.search(query, numDocs, new Sort(new SortField("tag", SortField.Type.INT)));
-          assertEquals(5, results.scoreDocs.length);
           assertTrue(results.totalHits.value >= results.scoreDocs.length);
+          assertEquals(5, results.scoreDocs.length);
 
           for (ScoreDoc scoreDoc : results.scoreDocs) {
             FieldDoc fieldDoc = (FieldDoc) scoreDoc;
             assertEquals(1, fieldDoc.fields.length);
 
             int tag = (int) fieldDoc.fields[0];
-            assertTrue(lower <= tag && tag <= lower + 50);
+            assertTrue(lower <= tag && tag <= lower + 150);
           }
         }
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -99,6 +99,23 @@ public class TestKnnVectorQuery extends LuceneTestCase {
     }
   }
 
+
+  /**
+   * Tests that a KnnVectorQuery applies the filter query
+   */
+  public void testFindWithFilter() throws IOException {
+    try (Directory indexStore =
+             getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+         IndexReader reader = DirectoryReader.open(indexStore)) {
+      IndexSearcher searcher = newSearcher(reader);
+      TermQuery filter = new TermQuery(new Term("id", "id0"));
+      KnnVectorQuery kvq = new KnnVectorQuery("field", new float[] {0, 0}, 10, filter);
+      assertMatches(searcher, kvq, 1);
+      TopDocs topDocs = searcher.search(kvq, 3);
+      assertEquals(0, topDocs.scoreDocs[0].doc);
+    }
+  }
+
   /** testDimensionMismatch */
   public void testDimensionMismatch() throws IOException {
     try (Directory indexStore =

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -99,14 +99,11 @@ public class TestKnnVectorQuery extends LuceneTestCase {
     }
   }
 
-
-  /**
-   * Tests that a KnnVectorQuery applies the filter query
-   */
+  /** Tests that a KnnVectorQuery applies the filter query */
   public void testFindWithFilter() throws IOException {
     try (Directory indexStore =
-             getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
-         IndexReader reader = DirectoryReader.open(indexStore)) {
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+        IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
       TermQuery filter = new TermQuery(new Term("id", "id0"));
       KnnVectorQuery kvq = new KnnVectorQuery("field", new float[] {0, 0}, 10, filter);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
@@ -435,7 +435,8 @@ public class KnnGraphTester {
     TopDocs[] results = new TopDocs[reader.leaves().size()];
     for (LeafReaderContext ctx : reader.leaves()) {
       Bits liveDocs = ctx.reader().getLiveDocs();
-      results[ctx.ord] = ctx.reader().searchNearestVectors(field, vector, k + fanout, liveDocs);
+      results[ctx.ord] =
+          ctx.reader().searchNearestVectors(field, vector, k + fanout, liveDocs, Integer.MAX_VALUE);
       int docBase = ctx.docBase;
       for (ScoreDoc scoreDoc : results[ctx.ord].scoreDocs) {
         scoreDoc.doc += docBase;

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
@@ -161,7 +161,8 @@ public class TermVectorLeafReader extends LeafReader {
   }
 
   @Override
-  public TopDocs searchNearestVectors(String field, float[] target, int k, Bits acceptDocs) {
+  public TopDocs searchNearestVectors(
+      String field, float[] target, int k, Bits acceptDocs, int visitedLimit) {
     return null;
   }
 

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -1351,7 +1351,8 @@ public class MemoryIndex {
     }
 
     @Override
-    public TopDocs searchNearestVectors(String field, float[] target, int k, Bits acceptDocs) {
+    public TopDocs searchNearestVectors(
+        String field, float[] target, int k, Bits acceptDocs, int visitedLimit) {
       return null;
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
@@ -114,10 +114,11 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
     }
 
     @Override
-    public TopDocs search(String field, float[] target, int k, Bits acceptDocs) throws IOException {
+    public TopDocs search(String field, float[] target, int k, Bits acceptDocs, int visitedLimit)
+        throws IOException {
       FieldInfo fi = fis.fieldInfo(field);
       assert fi != null && fi.getVectorDimension() > 0;
-      TopDocs hits = delegate.search(field, target, k, acceptDocs);
+      TopDocs hits = delegate.search(field, target, k, acceptDocs, visitedLimit);
       assert hits != null;
       assert hits.scoreDocs.length <= k;
       return hits;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -561,7 +561,8 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
 
         // assert that knn search doesn't fail on a field with all deleted docs
         TopDocs results =
-            leafReader.searchNearestVectors("v", randomVector(3), 1, leafReader.getLiveDocs());
+            leafReader.searchNearestVectors(
+                "v", randomVector(3), 1, leafReader.getLiveDocs(), Integer.MAX_VALUE);
         assertEquals(0, results.scoreDocs.length);
       }
     }
@@ -885,7 +886,9 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
             k = numLiveDocsWithVectors;
           }
           TopDocs results =
-              ctx.reader().searchNearestVectors(fieldName, randomVector(dimension), k, liveDocs);
+              ctx.reader()
+                  .searchNearestVectors(
+                      fieldName, randomVector(dimension), k, liveDocs, Integer.MAX_VALUE);
           assertEquals(Math.min(k, size), results.scoreDocs.length);
           for (int i = 0; i < k - 1; i++) {
             assertTrue(results.scoreDocs[i].score >= results.scoreDocs[i + 1].score);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MergeReaderWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MergeReaderWrapper.java
@@ -223,9 +223,9 @@ class MergeReaderWrapper extends LeafReader {
   }
 
   @Override
-  public TopDocs searchNearestVectors(String field, float[] target, int k, Bits acceptDocs)
-      throws IOException {
-    return in.searchNearestVectors(field, target, k, acceptDocs);
+  public TopDocs searchNearestVectors(
+      String field, float[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException {
+    return in.searchNearestVectors(field, target, k, acceptDocs, visitedLimit);
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
@@ -228,7 +228,8 @@ public class QueryUtils {
       }
 
       @Override
-      public TopDocs searchNearestVectors(String field, float[] target, int k, Bits acceptDocs) {
+      public TopDocs searchNearestVectors(
+          String field, float[] target, int k, Bits acceptDocs, int visitedLimit) {
         return null;
       }
 


### PR DESCRIPTION
This PR adds support for a query filter in KnnVectorQuery. First, we gather the
query results for each leaf as a bit set. Then the HNSW search skips over the
non-matching documents (using the same approach as for live docs). To prevent
HNSW search from visiting too many documents when the filter is very selective,
we short-circuit if HNSW has already visited more than the number of documents
that match the filter, and execute an exact search instead. This bounds the
number of visited documents at roughly 2x the cost of just running the exact
filter, while in most cases HNSW completes successfully and does a lot better.

Co-authored-by: Joel Bernstein <jbernste@apache.org>