### PR TITLE
Lucene-10336: DirectDocValueFormat: use RandomAccessSlice instead of loading giant byte[] arrays

### DIFF
--- a/lucene/codecs/src/java/module-info.java
+++ b/lucene/codecs/src/java/module-info.java
@@ -36,4 +36,6 @@ module org.apache.lucene.codecs {
       org.apache.lucene.codecs.uniformsplit.sharedterms.STUniformSplitPostingsFormat;
   provides org.apache.lucene.codecs.Codec with
       org.apache.lucene.codecs.simpletext.SimpleTextCodec;
+  provides org.apache.lucene.codecs.DocValuesFormat with
+      org.apache.lucene.codecs.memory.DirectDocValuesFormat;
 }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectDocValuesConsumer.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectDocValuesConsumer.java
@@ -1,0 +1,1155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.memory;
+
+import static org.apache.lucene.codecs.memory.DirectDocValuesProducer.BYTES;
+import static org.apache.lucene.codecs.memory.DirectDocValuesProducer.NUMBER;
+import static org.apache.lucene.codecs.memory.DirectDocValuesProducer.SORTED;
+import static org.apache.lucene.codecs.memory.DirectDocValuesProducer.SORTED_NUMERIC;
+import static org.apache.lucene.codecs.memory.DirectDocValuesProducer.SORTED_NUMERIC_SINGLETON;
+import static org.apache.lucene.codecs.memory.DirectDocValuesProducer.SORTED_SET;
+import static org.apache.lucene.codecs.memory.DirectDocValuesProducer.SORTED_SET_SINGLETON;
+import static org.apache.lucene.codecs.memory.DirectDocValuesProducer.VERSION_CURRENT;
+import static org.apache.lucene.index.SortedSetDocValues.NO_MORE_ORDS;
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BaseTermsEnum;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.EmptyDocValuesProducer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.ImpactsEnum;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.LongsRef;
+
+/** Writer for {@link DirectDocValuesFormat} */
+class DirectDocValuesConsumer extends DocValuesConsumer {
+  final int maxDoc;
+  IndexOutput data, meta;
+
+  DirectDocValuesConsumer(
+      SegmentWriteState state,
+      String dataCodec,
+      String dataExtension,
+      String metaCodec,
+      String metaExtension)
+      throws IOException {
+    maxDoc = state.segmentInfo.maxDoc();
+    boolean success = false;
+    try {
+      String dataName =
+          IndexFileNames.segmentFileName(
+              state.segmentInfo.name, state.segmentSuffix, dataExtension);
+      data = state.directory.createOutput(dataName, state.context);
+      CodecUtil.writeIndexHeader(
+          data, dataCodec, VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
+      String metaName =
+          IndexFileNames.segmentFileName(
+              state.segmentInfo.name, state.segmentSuffix, metaExtension);
+      meta = state.directory.createOutput(metaName, state.context);
+      CodecUtil.writeIndexHeader(
+          meta, metaCodec, VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
+      success = true;
+    } finally {
+      if (!success) {
+        IOUtils.closeWhileHandlingException(this);
+      }
+    }
+  }
+
+  @Override
+  public void addNumericField(FieldInfo field, DocValuesProducer valuesProducer)
+      throws IOException {
+    meta.writeVInt(field.number);
+    meta.writeByte(NUMBER);
+    addNumericFieldValues(
+        field,
+        new EmptyDocValuesProducer() {
+          @Override
+          public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+            return new SortedNumericDocNullableValues() {
+              final NumericDocValues in = valuesProducer.getNumeric(field);
+              long[] values = LongsRef.EMPTY_LONGS;
+              long[] nullValues = LongsRef.EMPTY_LONGS;
+              int docIDUpto, i, docValueCount;
+
+              @Override
+              public boolean isNextValueNull() {
+                return nullValues[i - 1] == 1;
+              }
+
+              @Override
+              public long nextValue() {
+                return values[i++];
+              }
+
+              @Override
+              public int docValueCount() {
+                return docValueCount;
+              }
+
+              @Override
+              public boolean advanceExact(int target) {
+                throw new UnsupportedOperationException();
+              }
+
+              @Override
+              public int docID() {
+                throw new UnsupportedOperationException();
+              }
+
+              @Override
+              public int nextDoc() throws IOException {
+                if (docIDUpto == maxDoc) {
+                  return NO_MORE_DOCS;
+                }
+                int docID = in.nextDoc();
+                if (docID == NO_MORE_DOCS) {
+                  docID = -1;
+                }
+                docValueCount = 0;
+                nullValues = LongsRef.EMPTY_LONGS;
+                while (docIDUpto <= in.docID() && docIDUpto < maxDoc) {
+                  values = ArrayUtil.grow(values, docValueCount + 1);
+                  nullValues = ArrayUtil.grow(nullValues, docValueCount + 1);
+                  if (docIDUpto++ == in.docID()) {
+                    values[docValueCount++] = in.longValue();
+                  } else {
+                    nullValues[docValueCount++] = 1;
+                  }
+                }
+                i = 0;
+                return docID;
+              }
+
+              @Override
+              public int advance(int target) {
+                throw new UnsupportedOperationException();
+              }
+
+              @Override
+              public long cost() {
+                throw new UnsupportedOperationException();
+              }
+            };
+          }
+        });
+  }
+
+  private abstract static class SortedNumericDocNullableValues extends SortedNumericDocValues {
+    public boolean isNextValueNull() {
+      return false;
+    }
+  }
+
+  private abstract static class DocNullableValuesIterator extends DocIdSetIterator {
+    public abstract boolean isValueNull();
+  }
+
+  private void addNumericFieldValues(FieldInfo field, final DocValuesProducer valuesProducer)
+      throws IOException {
+    meta.writeLong(data.getFilePointer());
+    long minValue = Long.MAX_VALUE;
+    long maxValue = Long.MIN_VALUE;
+    boolean missing = false;
+
+    long count = 0;
+    SortedNumericDocNullableValues values =
+        (SortedNumericDocNullableValues) valuesProducer.getSortedNumeric(field);
+    for (int docID = values.nextDoc();
+        docID != DocIdSetIterator.NO_MORE_DOCS;
+        docID = values.nextDoc()) {
+      for (int i = 0, docValueCount = values.docValueCount(); i < docValueCount; ++i) {
+        long v = values.nextValue();
+        if (values.isNextValueNull()) {
+          missing = true;
+        } else {
+          minValue = Math.min(minValue, v);
+          maxValue = Math.max(maxValue, v);
+        }
+        count++;
+        if (count >= DirectDocValuesFormat.MAX_SORTED_SET_ORDS) {
+          throw new IllegalArgumentException(
+              "DocValuesField \""
+                  + field.name
+                  + "\" is too large, must be <= "
+                  + DirectDocValuesFormat.MAX_SORTED_SET_ORDS
+                  + " values/total ords");
+        }
+      }
+    }
+
+    meta.writeInt((int) count);
+
+    if (missing) {
+      long start = data.getFilePointer();
+      writeMissingBitset(
+          new DocNullableValuesIterator() {
+            final SortedNumericDocNullableValues values =
+                (SortedNumericDocNullableValues) valuesProducer.getSortedNumeric(field);
+            int docID = values.nextDoc();
+            int i;
+            int docValueCount = values.docValueCount();
+            boolean isValueMissing = false;
+
+            @Override
+            public boolean isValueNull() {
+              return isValueMissing;
+            }
+
+            @Override
+            public int docID() {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+              isValueMissing = false;
+              if (i < docValueCount) {
+                i++;
+              } else {
+                docID = values.nextDoc();
+                if (docID == NO_MORE_DOCS) return NO_MORE_DOCS;
+                i = 1;
+                docValueCount = values.docValueCount();
+              }
+              values.nextValue();
+              if (values.isNextValueNull()) {
+                isValueMissing = true;
+              }
+              return docID;
+            }
+
+            @Override
+            public int advance(int target) {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long cost() {
+              throw new UnsupportedOperationException();
+            }
+          });
+
+      meta.writeLong(start);
+      meta.writeLong(data.getFilePointer() - start);
+    } else {
+      meta.writeLong(-1L);
+    }
+
+    byte byteWidth;
+    if (minValue >= Byte.MIN_VALUE && maxValue <= Byte.MAX_VALUE) {
+      byteWidth = 1;
+    } else if (minValue >= Short.MIN_VALUE && maxValue <= Short.MAX_VALUE) {
+      byteWidth = 2;
+    } else if (minValue >= Integer.MIN_VALUE && maxValue <= Integer.MAX_VALUE) {
+      byteWidth = 4;
+    } else {
+      byteWidth = 8;
+    }
+    meta.writeByte(byteWidth);
+
+    values = (SortedNumericDocNullableValues) valuesProducer.getSortedNumeric(field);
+    for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+      for (int i = 0, docValueCount = values.docValueCount(); i < docValueCount; ++i) {
+        long v = values.nextValue();
+        if (values.isNextValueNull()) {
+          v = 0;
+        }
+
+        switch (byteWidth) {
+          case 1:
+            data.writeByte((byte) v);
+            break;
+          case 2:
+            data.writeShort((short) v);
+            break;
+          case 4:
+            data.writeInt((int) v);
+            break;
+          case 8:
+            data.writeLong(v);
+            break;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    boolean success = false;
+    try {
+      if (meta != null) {
+        meta.writeVInt(-1); // write EOF marker
+        CodecUtil.writeFooter(meta); // write checksum
+      }
+      if (data != null) {
+        CodecUtil.writeFooter(data);
+      }
+      success = true;
+    } finally {
+      if (success) {
+        IOUtils.close(data, meta);
+      } else {
+        IOUtils.closeWhileHandlingException(data, meta);
+      }
+      data = meta = null;
+    }
+  }
+
+  @Override
+  public void addBinaryField(FieldInfo field, final DocValuesProducer valuesProducer)
+      throws IOException {
+    meta.writeVInt(field.number);
+    meta.writeByte(BYTES);
+    addBinaryFieldValues(
+        field,
+        new EmptyDocValuesProducer() {
+          @Override
+          public SortedSetDocValues getSortedSet(FieldInfo field) throws IOException {
+            return new SortedSetDocValues() {
+              final BinaryDocValues values = valuesProducer.getBinary(field);
+
+              @Override
+              public long nextOrd() {
+                throw new UnsupportedOperationException();
+              }
+
+              @Override
+              public BytesRef lookupOrd(long ord) throws IOException {
+                if (ord > values.docID()) {
+                  values.nextDoc();
+                }
+                BytesRef result;
+                if (ord == values.docID()) {
+                  result = values.binaryValue();
+                } else {
+                  result = new BytesRef();
+                  result.bytes = null;
+                }
+                return result;
+              }
+
+              @Override
+              public long getValueCount() {
+                return maxDoc;
+              }
+
+              @Override
+              public boolean advanceExact(int target) {
+                return false;
+              }
+
+              @Override
+              public int docID() {
+                return values.docID();
+              }
+
+              @Override
+              public int nextDoc() {
+                throw new UnsupportedOperationException();
+              }
+
+              @Override
+              public int advance(int target) {
+                throw new UnsupportedOperationException();
+              }
+
+              @Override
+              public long cost() {
+                throw new UnsupportedOperationException();
+              }
+            };
+          }
+        });
+  }
+
+  private void addBinaryFieldValues(FieldInfo field, final DocValuesProducer valuesProducer)
+      throws IOException {
+    // write the byte[] data
+    final long startFP = data.getFilePointer();
+    boolean missing = false;
+    long totalBytes = 0;
+    int count = 0;
+    TermsEnum iterator = new SortedSetDocValuesTermsEnum(valuesProducer.getSortedSet(field));
+    for (BytesRef term = iterator.next(); term != null; term = iterator.next()) {
+      if (term.bytes != null) {
+        data.writeBytes(term.bytes, term.offset, term.length);
+        totalBytes += term.length;
+        if (totalBytes > DirectDocValuesFormat.MAX_TOTAL_BYTES_LENGTH) {
+          throw new IllegalArgumentException(
+              "DocValuesField \""
+                  + field.name
+                  + "\" is too large, cannot have more than DirectDocValuesFormat.MAX_TOTAL_BYTES_LENGTH ("
+                  + DirectDocValuesFormat.MAX_TOTAL_BYTES_LENGTH
+                  + ") bytes");
+        }
+      } else {
+        missing = true;
+      }
+      count++;
+    }
+
+    meta.writeLong(startFP);
+    meta.writeInt((int) totalBytes);
+    meta.writeInt(count);
+    if (missing) {
+      long start = data.getFilePointer();
+      writeMissingBitset(
+          new DocNullableValuesIterator() {
+            final SortedSetDocValues values = valuesProducer.getSortedSet(field);
+            long currentOrd = -1;
+            boolean isValueMissing = false;
+
+            @Override
+            public boolean isValueNull() {
+              return isValueMissing;
+            }
+
+            @Override
+            public int docID() {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+              isValueMissing = false;
+              currentOrd++;
+              if (currentOrd >= values.getValueCount()) {
+                return NO_MORE_DOCS;
+              }
+              BytesRef bytesRef = values.lookupOrd(currentOrd);
+              if (bytesRef.bytes == null) {
+                isValueMissing = true;
+              }
+              if (values.docID() == NO_MORE_DOCS) {
+                return -1;
+              }
+              return values.docID();
+            }
+
+            @Override
+            public int advance(int target) {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long cost() {
+              throw new UnsupportedOperationException();
+            }
+          });
+      meta.writeLong(start);
+      meta.writeLong(data.getFilePointer() - start);
+    } else {
+      meta.writeLong(-1L);
+    }
+
+    int addr = 0;
+    iterator = new SortedSetDocValuesTermsEnum(valuesProducer.getSortedSet(field));
+    for (BytesRef term = iterator.next(); term != null; term = iterator.next()) {
+      data.writeInt(addr);
+      if (term.bytes != null) {
+        addr += term.length;
+      }
+    }
+    data.writeInt(addr);
+  }
+
+  // TODO: in some cases representing missing with minValue-1 wouldn't take up additional space and
+  // so on,
+  // but this is very simple, and algorithms only check this for values of 0 anyway (doesnt slow
+  // down normal decode)
+  private void writeMissingBitset(DocNullableValuesIterator values) throws IOException {
+    long bits = 0;
+    int count = 0;
+    while (values.nextDoc() != NO_MORE_DOCS) {
+      if (count == 64) {
+        data.writeLong(bits);
+        count = 0;
+        bits = 0;
+      }
+      if (!values.isValueNull()) {
+        bits |= 1L << count;
+      }
+      count++;
+    }
+    if (count > 0) {
+      data.writeLong(bits);
+    }
+  }
+
+  @Override
+  public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+    meta.writeVInt(field.number);
+    meta.writeByte(SORTED);
+
+    // write the ordinals as numerics
+    addNumericFieldValues(
+        field,
+        new EmptyDocValuesProducer() {
+          @Override
+          public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+            return new SortedNumericDocNullableValues() {
+              final SortedDocValues in = valuesProducer.getSorted(field);
+              long[] values = LongsRef.EMPTY_LONGS;
+              int docIDUpto, i, docValueCount;
+
+              @Override
+              public boolean isNextValueNull() {
+                return false;
+              }
+
+              @Override
+              public long nextValue() {
+                return values[i++];
+              }
+
+              @Override
+              public int docValueCount() {
+                return docValueCount;
+              }
+
+              @Override
+              public boolean advanceExact(int target) {
+                throw new UnsupportedOperationException();
+              }
+
+              @Override
+              public int docID() {
+                return in.docID();
+              }
+
+              @Override
+              public int nextDoc() throws IOException {
+                if (docIDUpto == maxDoc) {
+                  return NO_MORE_DOCS;
+                }
+                int docID = in.nextDoc();
+                if (docID == NO_MORE_DOCS) {
+                  docID = -1;
+                }
+                docValueCount = 0;
+                while (docIDUpto <= in.docID() && docIDUpto < maxDoc) {
+                  values = ArrayUtil.grow(values, docValueCount + 1);
+                  if (docIDUpto++ == in.docID()) {
+                    values[docValueCount++] = in.ordValue();
+                  } else {
+                    values[docValueCount++] = -1L;
+                  }
+                }
+                i = 0;
+                return docID;
+              }
+
+              @Override
+              public int advance(int target) {
+                throw new UnsupportedOperationException();
+              }
+
+              @Override
+              public long cost() {
+                return in.cost();
+              }
+            };
+          }
+        });
+
+    // write the values as binary
+    addBinaryFieldValues(
+        field,
+        new EmptyDocValuesProducer() {
+          @Override
+          public SortedSetDocValues getSortedSet(FieldInfo field) throws IOException {
+            return DocValues.singleton(valuesProducer.getSorted(field));
+          }
+        });
+  }
+
+  @Override
+  public void addSortedNumericField(FieldInfo field, final DocValuesProducer valuesProducer)
+      throws IOException {
+    meta.writeVInt(field.number);
+    if (isSingleValued(valuesProducer.getSortedNumeric(field))) {
+      meta.writeByte(SORTED_NUMERIC_SINGLETON);
+      addNumericFieldValues(
+          field,
+          new EmptyDocValuesProducer() {
+            @Override
+            public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+              return new SortedNumericDocNullableValues() {
+                final SortedNumericDocValues in = valuesProducer.getSortedNumeric(field);
+                long[] values = LongsRef.EMPTY_LONGS;
+                long[] nullValues = LongsRef.EMPTY_LONGS;
+                int docIDUpto, i, docValueCount;
+
+                @Override
+                public boolean isNextValueNull() {
+                  return nullValues[i - 1] == 1;
+                }
+
+                @Override
+                public long nextValue() {
+                  return values[i++];
+                }
+
+                @Override
+                public int docValueCount() {
+                  return docValueCount;
+                }
+
+                @Override
+                public boolean advanceExact(int target) {
+                  throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public int docID() {
+                  return in.docID();
+                }
+
+                @Override
+                public int nextDoc() throws IOException {
+                  if (docIDUpto == maxDoc) {
+                    return NO_MORE_DOCS;
+                  }
+                  int docID = in.nextDoc();
+                  if (docID == NO_MORE_DOCS) {
+                    docID = -1;
+                  }
+                  docValueCount = 0;
+                  nullValues = LongsRef.EMPTY_LONGS;
+                  while (docIDUpto <= in.docID() && docIDUpto < maxDoc) {
+                    values = ArrayUtil.grow(values, docValueCount + 1);
+                    nullValues = ArrayUtil.grow(nullValues, docValueCount + 1);
+                    if (docIDUpto++ == in.docID()) {
+                      values[docValueCount++] = in.nextValue();
+                    } else {
+                      nullValues[docValueCount++] = 1;
+                    }
+                  }
+                  i = 0;
+                  return docID;
+                }
+
+                @Override
+                public int advance(int target) {
+                  throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public long cost() {
+                  return in.cost();
+                }
+              };
+            }
+          });
+    } else {
+      meta.writeByte(SORTED_NUMERIC);
+
+      // First write docToValueCounts, except we "aggregate" the
+      // counts, so they turn into addresses, and add a final
+      // value = the total aggregate:
+      addNumericFieldValues(
+          field,
+          new EmptyDocValuesProducer() {
+            @Override
+            public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+              return new SortedNumericDocNullableValues() {
+                final SortedNumericDocValues in = valuesProducer.getSortedNumeric(field);
+                long[] values = LongsRef.EMPTY_LONGS;
+                int docIDUpto, i, docValueCount;
+                boolean ended;
+                long sum;
+
+                @Override
+                public boolean isNextValueNull() {
+                  return false;
+                }
+
+                @Override
+                public long nextValue() {
+                  return values[i++];
+                }
+
+                @Override
+                public int docValueCount() {
+                  return docValueCount;
+                }
+
+                @Override
+                public boolean advanceExact(int target) {
+                  throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public int docID() {
+                  return in.docID();
+                }
+
+                @Override
+                public int nextDoc() throws IOException {
+                  if (docIDUpto == maxDoc) {
+                    if (!ended) {
+                      values[0] = sum;
+                      docValueCount = 1;
+                      i = 0;
+                      ended = true;
+                      return -1;
+                    } else {
+                      return NO_MORE_DOCS;
+                    }
+                  }
+                  int docID = in.nextDoc();
+
+                  docValueCount = 0;
+                  while (docIDUpto <= docID && docIDUpto < maxDoc) {
+                    values = ArrayUtil.grow(values, docValueCount + 1);
+                    values[docValueCount++] = sum;
+                    if (docIDUpto++ == in.docID()) {
+                      sum += in.docValueCount();
+                    }
+                  }
+                  i = 0;
+                  if (docID == NO_MORE_DOCS) {
+                    return -1;
+                  }
+                  return docID;
+                }
+
+                @Override
+                public int advance(int target) {
+                  throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public long cost() {
+                  return in.cost();
+                }
+              };
+            }
+          });
+
+      // Write values for all docs, appended into one big
+      // numerics:
+      addNumericFieldValues(
+          field,
+          new EmptyDocValuesProducer() {
+            @Override
+            public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+              return new SortedNumericDocNullableValues() {
+                final SortedNumericDocValues in = valuesProducer.getSortedNumeric(field);
+
+                @Override
+                public boolean isNextValueNull() {
+                  return false;
+                }
+
+                @Override
+                public long nextValue() throws IOException {
+                  return in.nextValue();
+                }
+
+                @Override
+                public int docValueCount() {
+                  return in.docValueCount();
+                }
+
+                @Override
+                public boolean advanceExact(int target) throws IOException {
+                  return in.advanceExact(target);
+                }
+
+                @Override
+                public int docID() {
+                  return in.docID();
+                }
+
+                @Override
+                public int nextDoc() throws IOException {
+                  return in.nextDoc();
+                }
+
+                @Override
+                public int advance(int target) throws IOException {
+                  return in.advance(target);
+                }
+
+                @Override
+                public long cost() {
+                  return in.cost();
+                }
+              };
+            }
+          });
+    }
+  }
+
+  private boolean isSingleValued(SortedNumericDocValues values) throws IOException {
+    if (DocValues.unwrapSingleton(values) != null) {
+      return true;
+    }
+
+    for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+      if (values.docValueCount() > 1) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // note: this might not be the most efficient... but it's fairly simple
+  @Override
+  public void addSortedSetField(FieldInfo field, DocValuesProducer valuesProducer)
+      throws IOException {
+    meta.writeVInt(field.number);
+
+    if (isSingleValued(valuesProducer.getSortedSet(field))) {
+      meta.writeByte(SORTED_SET_SINGLETON);
+      // Write ordinals for all docs, appended into one big
+      // numerics:
+      addNumericFieldValues(
+          field,
+          new EmptyDocValuesProducer() {
+            @Override
+            public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+              return new SortedNumericDocNullableValues() {
+                final SortedSetDocValues in = valuesProducer.getSortedSet(field);
+                long[] values = LongsRef.EMPTY_LONGS;
+                int docIDUpto, i, docValueCount;
+
+                @Override
+                public boolean isNextValueNull() {
+                  return false;
+                }
+
+                @Override
+                public long nextValue() {
+                  return values[i++];
+                }
+
+                @Override
+                public int docValueCount() {
+                  return docValueCount;
+                }
+
+                @Override
+                public boolean advanceExact(int target) {
+                  throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public int docID() {
+                  return in.docID();
+                }
+
+                @Override
+                public int nextDoc() throws IOException {
+                  if (docIDUpto == maxDoc) {
+                    return NO_MORE_DOCS;
+                  }
+                  int docID = in.nextDoc();
+                  if (docID == NO_MORE_DOCS) {
+                    docID = -1;
+                  }
+                  docValueCount = 0;
+                  while (docIDUpto <= in.docID() && docIDUpto < maxDoc) {
+                    values = ArrayUtil.grow(values, docValueCount + 1);
+                    if (docID == docIDUpto++) {
+                      values[docValueCount++] = in.nextOrd();
+                    } else {
+                      values[docValueCount++] = -1L;
+                    }
+                  }
+                  i = 0;
+                  return docID;
+                }
+
+                @Override
+                public int advance(int target) {
+                  throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public long cost() {
+                  return in.cost();
+                }
+              };
+            }
+          });
+    } else {
+      meta.writeByte(SORTED_SET);
+
+      // First write docToOrdCounts, except we "aggregate" the
+      // counts, so they turn into addresses, and add a final
+      // value = the total aggregate:
+      addNumericFieldValues(
+          field,
+          new EmptyDocValuesProducer() {
+            @Override
+            public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+              return new SortedNumericDocNullableValues() {
+                final SortedSetDocValues in = valuesProducer.getSortedSet(field);
+                long[] values = LongsRef.EMPTY_LONGS;
+                int i, docValueCount, docIDUpto, ordCount;
+                boolean ended;
+                long sum;
+
+                @Override
+                public boolean isNextValueNull() {
+                  return false;
+                }
+
+                @Override
+                public long nextValue() {
+                  return values[i++];
+                }
+
+                @Override
+                public int docValueCount() {
+                  return docValueCount;
+                }
+
+                @Override
+                public boolean advanceExact(int target) {
+                  throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public int docID() {
+                  return in.docID();
+                }
+
+                @Override
+                public int nextDoc() throws IOException {
+                  if (docIDUpto == maxDoc) {
+                    if (!ended) {
+                      values[0] = sum;
+                      docValueCount = 1;
+                      i = 0;
+                      ended = true;
+                      return -1;
+                    } else {
+                      return NO_MORE_DOCS;
+                    }
+                  }
+                  int docID = in.nextDoc();
+                  if (docID != NO_MORE_DOCS) {
+                    ordCount = 0;
+                    while (in.nextOrd() != NO_MORE_ORDS) {
+                      ordCount++;
+                    }
+                  }
+
+                  docValueCount = 0;
+                  while (docIDUpto <= docID && docIDUpto < maxDoc) {
+                    values = ArrayUtil.grow(values, docValueCount + 1);
+                    values[docValueCount++] = sum;
+                    if (docIDUpto++ == docID) {
+                      sum += ordCount;
+                    }
+                  }
+                  i = 0;
+                  if (docID == NO_MORE_DOCS) {
+                    return -1;
+                  }
+                  return docID;
+                }
+
+                @Override
+                public int advance(int target) {
+                  throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public long cost() {
+                  return in.cost();
+                }
+              };
+            }
+          });
+
+      // Write ordinals for all docs, appended into one big
+      // numerics:
+      addNumericFieldValues(
+          field,
+          new EmptyDocValuesProducer() {
+            @Override
+            public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+              return new SortedNumericDocNullableValues() {
+                final SortedSetDocValues in = valuesProducer.getSortedSet(field);
+                long[] values = LongsRef.EMPTY_LONGS;
+                int i, docValueCount;
+
+                @Override
+                public boolean isNextValueNull() {
+                  return false;
+                }
+
+                @Override
+                public long nextValue() {
+                  return values[i++];
+                }
+
+                @Override
+                public int docValueCount() {
+                  return docValueCount;
+                }
+
+                @Override
+                public boolean advanceExact(int target) {
+                  throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public int docID() {
+                  return in.docID();
+                }
+
+                @Override
+                public int nextDoc() throws IOException {
+                  int docID = in.nextDoc();
+                  if (docID != NO_MORE_DOCS) {
+                    docValueCount = 0;
+                    for (long ord = in.nextOrd();
+                        ord != SortedSetDocValues.NO_MORE_ORDS;
+                        ord = in.nextOrd()) {
+                      values = ArrayUtil.grow(values, docValueCount + 1);
+                      values[docValueCount++] = ord;
+                    }
+                    i = 0;
+                  }
+                  return docID;
+                }
+
+                @Override
+                public int advance(int target) {
+                  throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public long cost() {
+                  return in.cost();
+                }
+              };
+            }
+          });
+    }
+
+    // write the values as binary
+    addBinaryFieldValues(field, valuesProducer);
+  }
+
+  private boolean isSingleValued(SortedSetDocValues values) throws IOException {
+    if (DocValues.unwrapSingleton(values) != null) {
+      return true;
+    }
+
+    while (values.nextDoc() != NO_MORE_DOCS) {
+      int ordCount = 0;
+      while (values.nextOrd() != NO_MORE_ORDS) {
+        ordCount++;
+        if (ordCount > 1) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  private static class SortedSetDocValuesTermsEnum extends BaseTermsEnum {
+    final SortedSetDocValues values;
+    final BytesRefBuilder scratch;
+    long currentOrd = -1;
+
+    private SortedSetDocValuesTermsEnum(SortedSetDocValues in) {
+      values = in;
+      scratch = new BytesRefBuilder();
+    }
+
+    @Override
+    public SeekStatus seekCeil(BytesRef text) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void seekExact(long ord) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BytesRef term() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long ord() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int docFreq() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long totalTermFreq() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PostingsEnum postings(PostingsEnum reuse, int flags) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ImpactsEnum impacts(int flags) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BytesRef next() throws IOException {
+      currentOrd++;
+      if (currentOrd >= values.getValueCount()) {
+        return null;
+      }
+      BytesRef bytesRef = values.lookupOrd(currentOrd);
+      if (bytesRef.bytes == null) {
+        return bytesRef;
+      }
+      scratch.copyBytes(bytesRef);
+      return scratch.get();
+    }
+  }
+}

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectDocValuesConsumer.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectDocValuesConsumer.java
@@ -280,6 +280,7 @@ class DirectDocValuesConsumer extends DocValuesConsumer {
     }
     meta.writeByte(byteWidth);
 
+    long startOffset = data.getFilePointer();
     values = (SortedNumericDocNullableValues) valuesProducer.getSortedNumeric(field);
     for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
       for (int i = 0, docValueCount = values.docValueCount(); i < docValueCount; ++i) {
@@ -304,6 +305,7 @@ class DirectDocValuesConsumer extends DocValuesConsumer {
         }
       }
     }
+    meta.writeLong(data.getFilePointer() - startOffset);
   }
 
   @Override

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectDocValuesFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectDocValuesFormat.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.memory;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.util.ArrayUtil;
+
+/**
+ * In-memory docvalues format that does no (or very little) compression. Indexed values are stored
+ * on disk, but then at search time all values are loaded into memory as simple java arrays. For
+ * numeric values, it uses byte[], short[], int[], long[] as necessary to fit the range of the
+ * values. For binary values, there is an int (4 bytes) overhead per value.
+ *
+ * <p>Limitations:
+ *
+ * <ul>
+ *   <li>For binary and sorted fields the total space required for all binary values cannot exceed
+ *       about 2.1 GB (see #MAX_TOTAL_BYTES_LENGTH).
+ *   <li>For sorted set fields, the sum of the size of each document's set of values cannot exceed
+ *       about 2.1 B values (see #MAX_SORTED_SET_ORDS). For example, if every document has 10 values
+ *       (10 instances of {@link SortedSetDocValuesField}) added, then no more than ~210 M documents
+ *       can be added to one segment.
+ * </ul>
+ */
+public class DirectDocValuesFormat extends DocValuesFormat {
+
+  /**
+   * The sum of all byte lengths for binary field, or for the unique values in sorted or sorted set
+   * fields, cannot exceed this.
+   */
+  public static final int MAX_TOTAL_BYTES_LENGTH = ArrayUtil.MAX_ARRAY_LENGTH;
+
+  /**
+   * The sum of the number of values across all documents in a sorted set field cannot exceed this.
+   */
+  public static final int MAX_SORTED_SET_ORDS = ArrayUtil.MAX_ARRAY_LENGTH;
+
+  /** Sole constructor. */
+  public DirectDocValuesFormat() {
+    super("Direct");
+  }
+
+  @Override
+  public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+    return new DirectDocValuesConsumer(
+        state, DATA_CODEC, DATA_EXTENSION, METADATA_CODEC, METADATA_EXTENSION);
+  }
+
+  @Override
+  public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
+    return new DirectDocValuesProducer(
+        state, DATA_CODEC, DATA_EXTENSION, METADATA_CODEC, METADATA_EXTENSION);
+  }
+
+  static final String DATA_CODEC = "DirectDocValuesData";
+  static final String DATA_EXTENSION = "dvdd";
+  static final String METADATA_CODEC = "DirectDocValuesMetadata";
+  static final String METADATA_EXTENSION = "dvdm";
+}

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectDocValuesProducer.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectDocValuesProducer.java
@@ -1,0 +1,1000 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.memory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IOUtils;
+
+/** Reader for {@link DirectDocValuesFormat} */
+class DirectDocValuesProducer extends DocValuesProducer {
+  static final byte NUMBER = 0;
+  static final byte BYTES = 1;
+  static final byte SORTED = 2;
+  static final byte SORTED_SET = 3;
+  static final byte SORTED_SET_SINGLETON = 4;
+  static final byte SORTED_NUMERIC = 5;
+  static final byte SORTED_NUMERIC_SINGLETON = 6;
+  static final int VERSION_START = 3;
+  static final int VERSION_CURRENT = VERSION_START;
+  // metadata maps (just file pointers and minimal stuff)
+  private final Map<String, NumericEntry> numerics = new HashMap<>();
+  private final Map<String, BinaryEntry> binaries = new HashMap<>();
+  private final Map<String, SortedEntry> sorteds = new HashMap<>();
+  private final Map<String, SortedSetEntry> sortedSets = new HashMap<>();
+  private final Map<String, SortedNumericEntry> sortedNumerics = new HashMap<>();
+  private final IndexInput data;
+  // ram instances we have already loaded
+  private final Map<String, NumericRawValues> numericInstances = new HashMap<>();
+  private final Map<String, BinaryRawValues> binaryInstances = new HashMap<>();
+  private final Map<String, SortedRawValues> sortedInstances = new HashMap<>();
+  private final Map<String, SortedSetRawValues> sortedSetInstances = new HashMap<>();
+  private final Map<String, SortedNumericRawValues> sortedNumericInstances = new HashMap<>();
+  private final Map<String, FixedBitSet> docsWithFieldInstances = new HashMap<>();
+  private final int numEntries;
+  private final int maxDoc;
+  private final int version;
+  private final boolean merging;
+
+  // clone for merge: when merging we don't do any instances.put()s
+  DirectDocValuesProducer(DirectDocValuesProducer original) {
+    assert Thread.holdsLock(original);
+    numerics.putAll(original.numerics);
+    binaries.putAll(original.binaries);
+    sorteds.putAll(original.sorteds);
+    sortedSets.putAll(original.sortedSets);
+    sortedNumerics.putAll(original.sortedNumerics);
+    data = original.data.clone();
+
+    numericInstances.putAll(original.numericInstances);
+    binaryInstances.putAll(original.binaryInstances);
+    sortedInstances.putAll(original.sortedInstances);
+    sortedSetInstances.putAll(original.sortedSetInstances);
+    sortedNumericInstances.putAll(original.sortedNumericInstances);
+    docsWithFieldInstances.putAll(original.docsWithFieldInstances);
+
+    numEntries = original.numEntries;
+    maxDoc = original.maxDoc;
+    version = original.version;
+    merging = true;
+  }
+
+  DirectDocValuesProducer(
+      SegmentReadState state,
+      String dataCodec,
+      String dataExtension,
+      String metaCodec,
+      String metaExtension)
+      throws IOException {
+    maxDoc = state.segmentInfo.maxDoc();
+    merging = false;
+    String metaName =
+        IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, metaExtension);
+    // read in the entries from the metadata file.
+    ChecksumIndexInput in = state.directory.openChecksumInput(metaName, state.context);
+    boolean success = false;
+    try {
+      version =
+          CodecUtil.checkIndexHeader(
+              in,
+              metaCodec,
+              VERSION_START,
+              VERSION_CURRENT,
+              state.segmentInfo.getId(),
+              state.segmentSuffix);
+      numEntries = readFields(in, state.fieldInfos);
+
+      CodecUtil.checkFooter(in);
+      success = true;
+    } finally {
+      if (success) {
+        IOUtils.close(in);
+      } else {
+        IOUtils.closeWhileHandlingException(in);
+      }
+    }
+
+    String dataName =
+        IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, dataExtension);
+    data = state.directory.openInput(dataName, state.context);
+    success = false;
+    try {
+      final int version2 =
+          CodecUtil.checkIndexHeader(
+              data,
+              dataCodec,
+              VERSION_START,
+              VERSION_CURRENT,
+              state.segmentInfo.getId(),
+              state.segmentSuffix);
+      if (version != version2) {
+        throw new CorruptIndexException(
+            "Format versions mismatch: meta=" + version + ", data=" + version2, data);
+      }
+
+      // NOTE: data file is too costly to verify checksum against all the bytes on open,
+      // but for now we at least verify proper structure of the checksum footer: which looks
+      // for FOOTER_MAGIC + algorithmID. This is cheap and can detect some forms of corruption
+      // such as file truncation.
+      CodecUtil.retrieveChecksum(data);
+
+      success = true;
+    } finally {
+      if (!success) {
+        IOUtils.closeWhileHandlingException(this.data);
+      }
+    }
+  }
+
+  private NumericEntry readNumericEntry(IndexInput meta) throws IOException {
+    NumericEntry entry = new NumericEntry();
+    entry.offset = meta.readLong();
+    entry.count = meta.readInt();
+    entry.missingOffset = meta.readLong();
+    if (entry.missingOffset != -1) {
+      entry.missingBytes = meta.readLong();
+    } else {
+      entry.missingBytes = 0;
+    }
+    entry.byteWidth = meta.readByte();
+
+    return entry;
+  }
+
+  private BinaryEntry readBinaryEntry(IndexInput meta) throws IOException {
+    BinaryEntry entry = new BinaryEntry();
+    entry.offset = meta.readLong();
+    entry.numBytes = meta.readInt();
+    entry.count = meta.readInt();
+    entry.missingOffset = meta.readLong();
+    if (entry.missingOffset != -1) {
+      entry.missingBytes = meta.readLong();
+    } else {
+      entry.missingBytes = 0;
+    }
+
+    return entry;
+  }
+
+  private SortedEntry readSortedEntry(IndexInput meta) throws IOException {
+    SortedEntry entry = new SortedEntry();
+    entry.docToOrd = readNumericEntry(meta);
+    entry.values = readBinaryEntry(meta);
+    return entry;
+  }
+
+  private SortedSetEntry readSortedSetEntry(IndexInput meta, boolean singleton) throws IOException {
+    SortedSetEntry entry = new SortedSetEntry();
+    if (!singleton) {
+      entry.docToOrdAddress = readNumericEntry(meta);
+    }
+    entry.ords = readNumericEntry(meta);
+    entry.values = readBinaryEntry(meta);
+    return entry;
+  }
+
+  private SortedNumericEntry readSortedNumericEntry(IndexInput meta, boolean singleton)
+      throws IOException {
+    SortedNumericEntry entry = new SortedNumericEntry();
+    if (!singleton) {
+      entry.docToAddress = readNumericEntry(meta);
+    }
+    entry.values = readNumericEntry(meta);
+    return entry;
+  }
+
+  private int readFields(IndexInput meta, FieldInfos infos) throws IOException {
+    int numEntries = 0;
+    int fieldNumber = meta.readVInt();
+    while (fieldNumber != -1) {
+      numEntries++;
+      FieldInfo info = infos.fieldInfo(fieldNumber);
+      int fieldType = meta.readByte();
+      if (fieldType == NUMBER) {
+        numerics.put(info.name, readNumericEntry(meta));
+      } else if (fieldType == BYTES) {
+        binaries.put(info.name, readBinaryEntry(meta));
+      } else if (fieldType == SORTED) {
+        SortedEntry entry = readSortedEntry(meta);
+        sorteds.put(info.name, entry);
+        binaries.put(info.name, entry.values);
+      } else if (fieldType == SORTED_SET) {
+        SortedSetEntry entry = readSortedSetEntry(meta, false);
+        sortedSets.put(info.name, entry);
+        binaries.put(info.name, entry.values);
+      } else if (fieldType == SORTED_SET_SINGLETON) {
+        SortedSetEntry entry = readSortedSetEntry(meta, true);
+        sortedSets.put(info.name, entry);
+        binaries.put(info.name, entry.values);
+      } else if (fieldType == SORTED_NUMERIC) {
+        SortedNumericEntry entry = readSortedNumericEntry(meta, false);
+        sortedNumerics.put(info.name, entry);
+      } else if (fieldType == SORTED_NUMERIC_SINGLETON) {
+        SortedNumericEntry entry = readSortedNumericEntry(meta, true);
+        sortedNumerics.put(info.name, entry);
+      } else {
+        throw new CorruptIndexException(
+            "invalid entry type: " + fieldType + ", field= " + info.name, meta);
+      }
+      fieldNumber = meta.readVInt();
+    }
+    return numEntries;
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + "(entries=" + numEntries + ")";
+  }
+
+  @Override
+  public void checkIntegrity() throws IOException {
+    CodecUtil.checksumEntireFile(data.clone());
+  }
+
+  @Override
+  public synchronized NumericDocValues getNumeric(FieldInfo field) throws IOException {
+    NumericRawValues instance = numericInstances.get(field.name);
+    NumericEntry entry = numerics.get(field.name);
+    if (instance == null) {
+      // Lazy load
+      instance = loadNumeric(entry);
+      if (!merging) {
+        numericInstances.put(field.name, instance);
+      }
+    }
+    return new NumericDocValuesSub(
+        getMissingBits(field, entry.missingOffset, entry.missingBytes), instance);
+  }
+
+  private NumericRawValues loadNumeric(NumericEntry entry) throws IOException {
+    IndexInput data = this.data.clone();
+    data.seek(entry.offset + entry.missingBytes);
+    switch (entry.byteWidth) {
+      case 1:
+        {
+          final byte[] values = new byte[entry.count];
+          data.readBytes(values, 0, entry.count);
+          return new NumericRawValues() {
+            @Override
+            public long get(int docID) {
+              return values[docID];
+            }
+          };
+        }
+
+      case 2:
+        {
+          final short[] values = new short[entry.count];
+          for (int i = 0; i < entry.count; i++) {
+            values[i] = data.readShort();
+          }
+          return new NumericRawValues() {
+            @Override
+            public long get(int docID) {
+              return values[docID];
+            }
+          };
+        }
+
+      case 4:
+        {
+          final int[] values = new int[entry.count];
+          for (int i = 0; i < entry.count; i++) {
+            values[i] = data.readInt();
+          }
+          return new NumericRawValues() {
+            @Override
+            public long get(int docID) {
+              return values[docID];
+            }
+          };
+        }
+
+      case 8:
+        {
+          final long[] values = new long[entry.count];
+          for (int i = 0; i < entry.count; i++) {
+            values[i] = data.readLong();
+          }
+          return new NumericRawValues() {
+            @Override
+            public long get(int docID) {
+              return values[docID];
+            }
+          };
+        }
+
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  private synchronized BinaryRawValues getBinaryRawValues(FieldInfo field) throws IOException {
+    BinaryRawValues instance = binaryInstances.get(field.name);
+    if (instance == null) {
+      // Lazy load
+      instance = loadBinary(binaries.get(field.name));
+      if (!merging) {
+        binaryInstances.put(field.name, instance);
+      }
+    }
+
+    return new BinaryRawValues(instance.bytes, instance.address);
+  }
+
+  @Override
+  public synchronized BinaryDocValues getBinary(FieldInfo field) throws IOException {
+    BinaryEntry be = binaries.get(field.name);
+    Bits docsWithField = getMissingBits(field, be.missingOffset, be.missingBytes);
+    BinaryRawValues values = getBinaryRawValues(field);
+    int maxDoc = docsWithField.length();
+    return new BinaryDocValues() {
+      int docID = -1;
+      long cost = -1;
+
+      @Override
+      public BytesRef binaryValue() {
+        return values.get(docID);
+      }
+
+      @Override
+      public boolean advanceExact(int target) {
+        docID = target;
+        return docsWithField.get(target);
+      }
+
+      @Override
+      public int docID() {
+        return docID;
+      }
+
+      @Override
+      public int nextDoc() {
+        docID++;
+        while (docID < maxDoc) {
+          if (docsWithField.get(docID)) {
+            return docID;
+          }
+          docID++;
+        }
+        docID = NO_MORE_DOCS;
+        return NO_MORE_DOCS;
+      }
+
+      @Override
+      public int advance(int target) {
+        if (target < docID) {
+          throw new IllegalArgumentException(
+              "cannot advance backwards: docID=" + docID + " target=" + target);
+        }
+        if (target == NO_MORE_DOCS) {
+          this.docID = NO_MORE_DOCS;
+        } else {
+          this.docID = target - 1;
+          nextDoc();
+        }
+        return docID;
+      }
+
+      @Override
+      public long cost() {
+        if (cost != -1) {
+          return cost;
+        }
+        for (int docID = 0; docID < maxDoc; docID++) {
+          if (docsWithField.get(docID)) {
+            cost++;
+          }
+        }
+        return cost;
+      }
+    };
+  }
+
+  private BinaryRawValues loadBinary(BinaryEntry entry) throws IOException {
+    IndexInput data = this.data.clone();
+    data.seek(entry.offset);
+    final byte[] bytes = new byte[entry.numBytes];
+    data.readBytes(bytes, 0, entry.numBytes);
+    data.seek(entry.offset + entry.numBytes + entry.missingBytes);
+
+    final int[] address = new int[entry.count + 1];
+    for (int i = 0; i < entry.count; i++) {
+      address[i] = data.readInt();
+    }
+
+    address[entry.count] = data.readInt();
+    return new BinaryRawValues(bytes, address);
+  }
+
+  @Override
+  public SortedDocValues getSorted(FieldInfo field) throws IOException {
+    final SortedEntry entry = sorteds.get(field.name);
+    SortedRawValues instance;
+    synchronized (this) {
+      instance = sortedInstances.get(field.name);
+      if (instance == null) {
+        // Lazy load
+        instance = loadSorted(field);
+        if (!merging) {
+          sortedInstances.put(field.name, instance);
+        }
+      }
+    }
+    return new SortedDocValuesSub(
+        instance.docToOrd, getBinaryRawValues(field), entry.values.count, maxDoc);
+  }
+
+  private SortedRawValues loadSorted(FieldInfo field) throws IOException {
+    final SortedEntry entry = sorteds.get(field.name);
+    final NumericRawValues docToOrd = loadNumeric(entry.docToOrd);
+    final SortedRawValues values = new SortedRawValues();
+    values.docToOrd = docToOrd;
+    return values;
+  }
+
+  @Override
+  public synchronized SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+    SortedNumericRawValues instance = sortedNumericInstances.get(field.name);
+    final SortedNumericEntry entry = sortedNumerics.get(field.name);
+    if (instance == null) {
+      // Lazy load
+      instance = loadSortedNumeric(entry);
+      if (!merging) {
+        sortedNumericInstances.put(field.name, instance);
+      }
+    }
+
+    if (entry.docToAddress == null) {
+      final Bits docsWithField =
+          getMissingBits(field, entry.values.missingOffset, entry.values.missingBytes);
+      return DocValues.singleton(new NumericDocValuesSub(docsWithField, instance.values));
+    } else {
+      final NumericRawValues docToAddress = instance.docToAddress;
+      final NumericRawValues values = instance.values;
+
+      return new SortedNumericDocValues() {
+        int valueStart;
+        int valueLimit;
+        int docID = -1;
+        int upto;
+        long cost = -1;
+
+        private void setDocument(int docID) {
+          valueStart = (int) docToAddress.get(docID);
+          valueLimit = (int) docToAddress.get(docID + 1);
+        }
+
+        @Override
+        public long nextValue() {
+          return values.get(valueStart + upto++);
+        }
+
+        @Override
+        public int docValueCount() {
+          return valueLimit - valueStart;
+        }
+
+        @Override
+        public boolean advanceExact(int target) {
+          docID = target;
+          setDocument(docID);
+          upto = 0;
+          return docValueCount() != 0;
+        }
+
+        @Override
+        public int docID() {
+          return docID;
+        }
+
+        @Override
+        public int nextDoc() {
+          assert docID != NO_MORE_DOCS;
+          while (true) {
+            docID++;
+            if (docID == maxDoc) {
+              docID = NO_MORE_DOCS;
+              break;
+            }
+            setDocument(docID);
+            if (docValueCount() != 0) {
+              break;
+            }
+          }
+          upto = 0;
+          return docID;
+        }
+
+        @Override
+        public int advance(int target) {
+          if (target < docID) {
+            throw new IllegalArgumentException(
+                "cannot advance backwards: docID=" + docID + " target=" + target);
+          }
+          if (target >= maxDoc) {
+            docID = NO_MORE_DOCS;
+          } else {
+            docID = target - 1;
+            nextDoc();
+          }
+          return docID;
+        }
+
+        @Override
+        public long cost() {
+          if (cost != -1) {
+            return cost;
+          }
+          for (int docID = 0; docID < maxDoc; docID++) {
+            setDocument(docID);
+            if (docValueCount() != 0) {
+              cost++;
+            }
+          }
+          return cost;
+        }
+      };
+    }
+  }
+
+  private SortedNumericRawValues loadSortedNumeric(SortedNumericEntry entry) throws IOException {
+    SortedNumericRawValues instance = new SortedNumericRawValues();
+    if (entry.docToAddress != null) {
+      instance.docToAddress = loadNumeric(entry.docToAddress);
+    }
+    instance.values = loadNumeric(entry.values);
+    return instance;
+  }
+
+  @Override
+  public synchronized SortedSetDocValues getSortedSet(FieldInfo field) throws IOException {
+    SortedSetRawValues instance = sortedSetInstances.get(field.name);
+    final SortedSetEntry entry = sortedSets.get(field.name);
+    if (instance == null) {
+      // Lazy load
+      instance = loadSortedSet(entry);
+      if (!merging) {
+        sortedSetInstances.put(field.name, instance);
+      }
+    }
+
+    if (instance.docToOrdAddress == null) {
+      return DocValues.singleton(
+          new SortedDocValuesSub(
+              instance.ords, getBinaryRawValues(field), entry.values.count, maxDoc));
+    } else {
+      final NumericRawValues docToOrdAddress = instance.docToOrdAddress;
+      final NumericRawValues ords = instance.ords;
+      final BinaryRawValues values = getBinaryRawValues(field);
+
+      return new SortedSetDocValues() {
+        int ordUpto;
+        int ordLimit;
+        int docID = -1;
+        long ord;
+        long cost = -1;
+
+        private long innerNextOrd() {
+          if (ordUpto == ordLimit) {
+            return NO_MORE_ORDS;
+          } else {
+            return ords.get(ordUpto++);
+          }
+        }
+
+        private void setDocument(int docID) {
+          ordUpto = (int) docToOrdAddress.get(docID);
+          ordLimit = (int) docToOrdAddress.get(docID + 1);
+        }
+
+        @Override
+        public long nextOrd() {
+          long result = ord;
+          if (result != NO_MORE_ORDS) {
+            ord = innerNextOrd();
+          }
+          return result;
+        }
+
+        @Override
+        public BytesRef lookupOrd(long ord) {
+          return values.get((int) ord);
+        }
+
+        @Override
+        public long getValueCount() {
+          return entry.values.count;
+        }
+
+        @Override
+        public boolean advanceExact(int target) {
+          docID = target;
+          setDocument(docID);
+          ord = innerNextOrd();
+          return ord != NO_MORE_ORDS;
+        }
+
+        @Override
+        public int docID() {
+          return docID;
+        }
+
+        @Override
+        public int nextDoc() {
+          assert docID != NO_MORE_DOCS;
+          docID++;
+          while (docID < maxDoc) {
+            setDocument(docID);
+            ord = innerNextOrd();
+            if (ord != NO_MORE_ORDS) {
+              return docID;
+            }
+            docID++;
+          }
+          docID = NO_MORE_DOCS;
+          return NO_MORE_DOCS;
+        }
+
+        @Override
+        public int advance(int target) {
+          if (target < docID) {
+            throw new IllegalArgumentException(
+                "cannot advance backwards: docID=" + docID + " target=" + target);
+          }
+          if (target >= maxDoc) {
+            this.docID = NO_MORE_DOCS;
+          } else {
+            this.docID = target - 1;
+            nextDoc();
+          }
+          return docID;
+        }
+
+        @Override
+        public long cost() {
+          if (cost != -1) {
+            return cost;
+          }
+          for (int docID = 0; docID < maxDoc; docID++) {
+            setDocument(docID);
+            if (innerNextOrd() != NO_MORE_ORDS) {
+              cost++;
+            }
+          }
+          return cost;
+        }
+      };
+    }
+  }
+
+  private SortedSetRawValues loadSortedSet(SortedSetEntry entry) throws IOException {
+    SortedSetRawValues instance = new SortedSetRawValues();
+    if (entry.docToOrdAddress != null) {
+      instance.docToOrdAddress = loadNumeric(entry.docToOrdAddress);
+    }
+    instance.ords = loadNumeric(entry.ords);
+    return instance;
+  }
+
+  private Bits getMissingBits(FieldInfo field, final long offset, final long length)
+      throws IOException {
+    if (offset == -1) {
+      return new Bits.MatchAllBits(maxDoc);
+    } else {
+      FixedBitSet instance;
+      synchronized (this) {
+        instance = docsWithFieldInstances.get(field.name);
+        if (instance == null) {
+          IndexInput data = this.data.clone();
+          data.seek(offset);
+          assert length % 8 == 0;
+          long[] bits = new long[(int) length >> 3];
+          for (int i = 0; i < bits.length; i++) {
+            bits[i] = data.readLong();
+          }
+          instance = new FixedBitSet(bits, maxDoc);
+          if (!merging) {
+            docsWithFieldInstances.put(field.name, instance);
+          }
+        }
+      }
+      return instance;
+    }
+  }
+
+  @Override
+  public synchronized DocValuesProducer getMergeInstance() {
+    return new DirectDocValuesProducer(this);
+  }
+
+  @Override
+  public void close() throws IOException {
+    data.close();
+  }
+
+  private static class NumericDocValuesSub extends NumericDocValues {
+    final Bits docsWithField;
+    final NumericRawValues values;
+    final int maxDoc;
+    int docID = -1;
+    long value;
+    long cost = -1;
+
+    public NumericDocValuesSub(Bits docsWithField, NumericRawValues values) {
+      this.docsWithField = docsWithField;
+      this.values = values;
+      this.maxDoc = docsWithField.length();
+    }
+
+    @Override
+    public int docID() {
+      return docID;
+    }
+
+    @Override
+    public int nextDoc() {
+      docID++;
+      while (docID < maxDoc) {
+        value = values.get(docID);
+        if (value != 0 || docsWithField.get(docID)) {
+          return docID;
+        }
+        docID++;
+      }
+      docID = NO_MORE_DOCS;
+      return NO_MORE_DOCS;
+    }
+
+    @Override
+    public int advance(int target) {
+      assert target >= docID : "target=" + target + " docID=" + docID;
+      if (target == NO_MORE_DOCS) {
+        this.docID = NO_MORE_DOCS;
+      } else {
+        this.docID = target - 1;
+        nextDoc();
+      }
+      return docID;
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+      docID = target;
+      value = values.get(docID);
+      return value != 0 || docsWithField.get(docID);
+    }
+
+    @Override
+    public long cost() {
+      if (cost != -1) {
+        return cost;
+      }
+      for (int docID = 0; docID < maxDoc; docID++) {
+        if (values.get(docID) != 0 || docsWithField.get(docID)) {
+          cost++;
+        }
+      }
+      return cost;
+    }
+
+    @Override
+    public long longValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return "NumericDocValuesSub(" + values + ")";
+    }
+  }
+
+  private static class SortedDocValuesSub extends SortedDocValues {
+    final NumericRawValues numericRawValues;
+    final BinaryRawValues binaryRawValues;
+    final int count;
+    final int maxDoc;
+    int docID = -1;
+    int ord;
+    long cost = -1;
+
+    public SortedDocValuesSub(
+        NumericRawValues numericRawValues, BinaryRawValues binaryRawValues, int count, int maxDoc) {
+      this.numericRawValues = numericRawValues;
+      this.binaryRawValues = binaryRawValues;
+      this.count = count;
+      this.maxDoc = maxDoc;
+    }
+
+    @Override
+    public int docID() {
+      return docID;
+    }
+
+    @Override
+    public int nextDoc() {
+      assert docID != NO_MORE_DOCS;
+      docID++;
+      while (docID < maxDoc) {
+        ord = (int) numericRawValues.get(docID);
+        if (ord != -1) {
+          return docID;
+        }
+        docID++;
+      }
+      docID = NO_MORE_DOCS;
+      return NO_MORE_DOCS;
+    }
+
+    @Override
+    public int advance(int target) {
+      if (target < docID) {
+        throw new IllegalArgumentException(
+            "cannot advance backwards: docID=" + docID + " target=" + target);
+      }
+      if (target >= maxDoc) {
+        this.docID = NO_MORE_DOCS;
+      } else {
+        this.docID = target - 1;
+        nextDoc();
+      }
+      return docID;
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+      docID = target;
+      ord = (int) numericRawValues.get(docID);
+      return ord != -1;
+    }
+
+    @Override
+    public long cost() {
+      if (cost != -1) {
+        return cost;
+      }
+      for (int docID = 0; docID < maxDoc; docID++) {
+        if ((int) numericRawValues.get(docID) != -1) {
+          cost++;
+        }
+      }
+      return cost;
+    }
+
+    @Override
+    public int ordValue() {
+      return ord;
+    }
+
+    @Override
+    public BytesRef lookupOrd(int ord) {
+      return binaryRawValues.get(ord);
+    }
+
+    @Override
+    public int getValueCount() {
+      return count;
+    }
+  }
+
+  static class BinaryRawValues {
+    final BytesRef term = new BytesRef();
+    byte[] bytes;
+    int[] address;
+
+    public BinaryRawValues(byte[] bytes, int[] address) {
+      this.bytes = bytes;
+      this.address = address;
+    }
+
+    public BytesRef get(int docID) {
+      term.bytes = bytes;
+      term.offset = address[docID];
+      term.length = address[docID + 1] - term.offset;
+      return term;
+    }
+
+    @Override
+    public String toString() {
+      return getClass().getSimpleName();
+    }
+  }
+
+  abstract static class NumericRawValues {
+    public abstract long get(int docID);
+  }
+
+  static class SortedRawValues {
+    NumericRawValues docToOrd;
+
+    @Override
+    public String toString() {
+      return getClass().getSimpleName();
+    }
+  }
+
+  static class SortedNumericRawValues {
+    NumericRawValues docToAddress;
+    NumericRawValues values;
+
+    @Override
+    public String toString() {
+      return getClass().getSimpleName();
+    }
+  }
+
+  static class SortedSetRawValues {
+    NumericRawValues docToOrdAddress;
+    NumericRawValues ords;
+
+    @Override
+    public String toString() {
+      return getClass().getSimpleName();
+    }
+  }
+
+  static class NumericEntry {
+    long offset;
+    int count;
+    long missingOffset;
+    long missingBytes;
+    byte byteWidth;
+  }
+
+  static class BinaryEntry {
+    long offset;
+    long missingOffset;
+    long missingBytes;
+    int count;
+    int numBytes;
+  }
+
+  static class SortedEntry {
+    NumericEntry docToOrd;
+    BinaryEntry values;
+  }
+
+  static class SortedSetEntry {
+    NumericEntry docToOrdAddress;
+    NumericEntry ords;
+    BinaryEntry values;
+  }
+
+  static class SortedNumericEntry {
+    NumericEntry docToAddress;
+    NumericEntry values;
+  }
+}

--- a/lucene/codecs/src/resources/META-INF/services/org.apache.lucene.codecs.DocValuesFormat
+++ b/lucene/codecs/src/resources/META-INF/services/org.apache.lucene.codecs.DocValuesFormat
@@ -1,0 +1,16 @@
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+org.apache.lucene.codecs.memory.DirectDocValuesFormat

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/memory/TestDirectDocValuesFormat.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/memory/TestDirectDocValuesFormat.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.memory;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.tests.index.BaseDocValuesFormatTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+
+/** Tests DirectDocValuesFormat */
+public class TestDirectDocValuesFormat extends BaseDocValuesFormatTestCase {
+  private final Codec codec = TestUtil.alwaysDocValuesFormat(new DirectDocValuesFormat());
+
+  @Override
+  protected Codec getCodec() {
+    return codec;
+  }
+}

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
@@ -34,6 +34,7 @@ import org.apache.lucene.codecs.blocktreeords.BlockTreeOrdsPostingsFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90PointsReader;
 import org.apache.lucene.codecs.lucene90.Lucene90PointsWriter;
+import org.apache.lucene.codecs.memory.DirectDocValuesFormat;
 import org.apache.lucene.codecs.memory.DirectPostingsFormat;
 import org.apache.lucene.codecs.memory.FSTPostingsFormat;
 import org.apache.lucene.index.FieldInfo;
@@ -231,6 +232,7 @@ public class RandomCodec extends AssertingCodec {
 
     addDocValues(
         avoidCodecs,
+        new DirectDocValuesFormat(),
         TestUtil.getDefaultDocValuesFormat(),
         new Lucene90DocValuesFormat(),
         new AssertingDocValuesFormat());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-10336

P.S. Sorry for the changes messed with non-related codes since this pull request is based on https://github.com/apache/lucene/pull/464

#11372