### PR TITLE
LUCENE-10413: Make default Ukrainian stopword set available

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -267,6 +267,8 @@ Other
   and discover classes to check from module system. The test now checks all analyzer modules,
   so it may discover new bugs outside of analysis:common module.  (Uwe Schindler, Robert Muir)
 
+* LUCENE-10413: Make Ukrainian default stop words list available as a public getter. (Alan Woodward)
+
 ======================= Lucene 9.0.0 =======================
 
 New Features

--- a/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
+++ b/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
@@ -115,7 +115,7 @@ public final class UkrainianMorfologikAnalyzer extends StopwordAnalyzerBase {
 
   private record DefaultResources(CharArraySet stopSet, Dictionary dictionary) {}
 
-  /** @return the default stopword set for this analyzer */
+  /** Returns the default stopword set for this analyzer */
   public static CharArraySet getDefaultStopwords() {
     return getDefaultResources().stopSet;
   }

--- a/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
+++ b/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
@@ -113,14 +113,13 @@ public final class UkrainianMorfologikAnalyzer extends StopwordAnalyzerBase {
     return defaultResources;
   }
 
-  private static class DefaultResources {
-    final CharArraySet stopSet;
-    final Dictionary dictionary;
+  private record DefaultResources(CharArraySet stopSet, Dictionary dictionary) { }
 
-    private DefaultResources(CharArraySet stopSet, Dictionary dictionary) {
-      this.stopSet = stopSet;
-      this.dictionary = dictionary;
-    }
+  /**
+   * @return the default stopword set for this analyzer
+   */
+  public static CharArraySet getDefaultStopwords() {
+    return getDefaultResources().stopSet;
   }
 
   /** Builds an analyzer with the default stop words. */

--- a/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
+++ b/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
@@ -113,11 +113,9 @@ public final class UkrainianMorfologikAnalyzer extends StopwordAnalyzerBase {
     return defaultResources;
   }
 
-  private record DefaultResources(CharArraySet stopSet, Dictionary dictionary) { }
+  private record DefaultResources(CharArraySet stopSet, Dictionary dictionary) {}
 
-  /**
-   * @return the default stopword set for this analyzer
-   */
+  /** @return the default stopword set for this analyzer */
   public static CharArraySet getDefaultStopwords() {
     return getDefaultResources().stopSet;
   }

--- a/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
+++ b/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
@@ -117,7 +117,7 @@ public final class UkrainianMorfologikAnalyzer extends StopwordAnalyzerBase {
 
   /** Returns the default stopword set for this analyzer */
   public static CharArraySet getDefaultStopwords() {
-    return getDefaultResources().stopSet;
+    return CharArraySet.unmodifiableSet(getDefaultResources().stopSet);
   }
 
   /** Builds an analyzer with the default stop words. */

--- a/lucene/analysis/morfologik/src/test/org/apache/lucene/analysis/uk/TestUkrainianAnalyzer.java
+++ b/lucene/analysis/morfologik/src/test/org/apache/lucene/analysis/uk/TestUkrainianAnalyzer.java
@@ -104,5 +104,7 @@ public class TestUkrainianAnalyzer extends BaseTokenStreamTestCase {
   public void testDefaultStopWords() {
     CharArraySet stopwords = UkrainianMorfologikAnalyzer.getDefaultStopwords();
     assertTrue(stopwords.contains("аби"));
+    stopwords.remove("аби");
+    assertTrue(UkrainianMorfologikAnalyzer.getDefaultStopwords().contains("аби"));
   }
 }

--- a/lucene/analysis/morfologik/src/test/org/apache/lucene/analysis/uk/TestUkrainianAnalyzer.java
+++ b/lucene/analysis/morfologik/src/test/org/apache/lucene/analysis/uk/TestUkrainianAnalyzer.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.uk;
 
 import java.io.IOException;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 
 /** Test case for UkrainianAnalyzer. */
@@ -98,5 +99,10 @@ public class TestUkrainianAnalyzer extends BaseTokenStreamTestCase {
     Analyzer analyzer = new UkrainianMorfologikAnalyzer();
     checkRandomData(random(), analyzer, 200 * RANDOM_MULTIPLIER);
     analyzer.close();
+  }
+
+  public void testDefaultStopWords() {
+    CharArraySet stopwords = UkrainianMorfologikAnalyzer.getDefaultStopwords();
+    assertTrue(stopwords.contains("аби"));
   }
 }


### PR DESCRIPTION
This commit adds a new `getDefaultStopwords()` static method to 
UkrainianMorfologikAnalyzer, which makes it possible to create an
analyzer with the default stop word set but a custom stem exclusion
set.