### PR TITLE
Add custom composite action to set up CI environments

### DIFF
--- a/.github/actions/setup-action/action.yml
+++ b/.github/actions/setup-action/action.yml
@@ -13,4 +13,5 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
+        distribution: 'temurin'
         java-version: ${{ inputs.java-version }}

--- a/.github/actions/setup-action/action.yml
+++ b/.github/actions/setup-action/action.yml
@@ -11,6 +11,6 @@ runs:
   using: 'composite'
   steps:
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: ${{ inputs.java-version }}

--- a/.github/actions/setup-action/action.yml
+++ b/.github/actions/setup-action/action.yml
@@ -1,0 +1,16 @@
+name: 'Setup'
+description: 'Setup environment for CI jobs'
+
+inputs:
+  java-version:
+    description: 'JDK version'
+    required: false
+    default: '17'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -26,12 +26,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK
-      uses: actions/setup-java@v2
+    - uses: ./.github/actions/setup-action
       with:
-        distribution: 'adopt-hotspot'
         java-version: ${{ matrix.java }}
-        java-package: jdk
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/.github/workflows/hunspell.yml
+++ b/.github/workflows/hunspell.yml
@@ -16,10 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 17
+    - uses: ./.github/actions/setup-action
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - uses: actions/cache@v2


### PR DESCRIPTION
It may be possible to set up CI environments (e.g. JDK) in a shared custom action with all workflows.