### PR TITLE
trivial updates on github actions

### DIFF
--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt-hotspot'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
         java-package: jdk
 

--- a/.github/workflows/hunspell.yml
+++ b/.github/workflows/hunspell.yml
@@ -17,9 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'temurin'
         java-version: 17
+        java-package: jdk
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - uses: actions/cache@v2


### PR DESCRIPTION
- upgrade actions/setup-java to v2 in the hunspell regression workflow (aligned with the main workflow)
- migrate the distribution to 'temurin' (recommended in [supported distributions](https://github.com/actions/setup-java#supported-distributions))