### PR TITLE
LUCENE-10420: Remove deprecated interfaces and methods in IOUtils in main

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/IOConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOConsumer.java
@@ -25,14 +25,12 @@ import java.io.IOException;
  * @param <T> the consumer's input type.
  */
 @FunctionalInterface
-@SuppressWarnings("removal")
-public interface IOConsumer<T> extends IOUtils.IOConsumer<T> {
+public interface IOConsumer<T> {
   /**
    * Performs this operation on the given argument.
    *
    * @param input the input argument
    * @throws IOException if producing the result throws an {@link IOException}
    */
-  @Override
   void accept(T input) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/util/IOFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOFunction.java
@@ -26,8 +26,7 @@ import java.io.IOException;
  * @param <R> the type of the result of the function
  */
 @FunctionalInterface
-@SuppressWarnings("removal")
-public interface IOFunction<T, R> extends IOUtils.IOFunction<T, R> {
+public interface IOFunction<T, R> {
   /**
    * Applies this function to the given argument.
    *
@@ -35,6 +34,5 @@ public interface IOFunction<T, R> extends IOUtils.IOFunction<T, R> {
    * @return the function result
    * @throws IOException if producing the result throws an {@link IOException}
    */
-  @Override
   R apply(T t) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
@@ -175,43 +175,6 @@ public final class IOUtils {
   }
 
   /**
-   * Opens a Reader for the given resource using a {@link CharsetDecoder}. Unlike Java's defaults
-   * this reader will throw an exception if your it detects the read charset doesn't match the
-   * expected {@link Charset}.
-   *
-   * <p>Decoding readers are useful to load configuration files, stopword lists or synonym files to
-   * detect character set problems. However, it's not recommended to use as a common purpose reader.
-   *
-   * @param clazz the class used to locate the resource
-   * @param resource the resource name to load
-   * @param charSet the expected charset
-   * @return a reader to read the given file
-   * @deprecated {@link Class#getResourceAsStream(String)} is caller sensitive and cannot load
-   *     resources across Java Modules. Please call the {@code getResourceAsStream()} directly and
-   *     use {@link #requireResourceNonNull(Object,String)} to signal missing resources {@code null}
-   */
-  @Deprecated(forRemoval = true, since = "9.1")
-  public static Reader getDecodingReader(Class<?> clazz, String resource, Charset charSet)
-      throws IOException {
-    var argModule = clazz.getModule();
-    if (argModule.isNamed() && argModule != IOUtils.class.getModule()) {
-      throw new UnsupportedOperationException(
-          "getDecodingReader(class,...) does not work when Java Module System is enabled.");
-    }
-    InputStream stream = requireResourceNonNull(clazz.getResourceAsStream(resource), resource);
-    boolean success = false;
-    try {
-      final Reader reader = getDecodingReader(stream, charSet);
-      success = true;
-      return reader;
-    } finally {
-      if (!success) {
-        IOUtils.close(stream);
-      }
-    }
-  }
-
-  /**
    * Deletes all given files, suppressing all thrown IOExceptions.
    *
    * <p>Note that the files should not be null.
@@ -504,31 +467,5 @@ public final class IOUtils {
     IOUtils.close(
         collection.stream().filter(Objects::nonNull).map(t -> (Closeable) () -> consumer.accept(t))
             ::iterator);
-  }
-
-  /**
-   * An IO operation with a single input.
-   *
-   * @see java.util.function.Consumer
-   * @deprecated was replaced by {@link org.apache.lucene.util.IOConsumer}.
-   */
-  @FunctionalInterface
-  @Deprecated(forRemoval = true, since = "9.1")
-  public interface IOConsumer<T> {
-    /** Performs this operation on the given argument. */
-    void accept(T input) throws IOException;
-  }
-
-  /**
-   * A Function that may throw an IOException
-   *
-   * @see java.util.function.Function
-   * @deprecated was replaced by {@link org.apache.lucene.util.IOFunction}.
-   */
-  @FunctionalInterface
-  @Deprecated(forRemoval = true, since = "9.1")
-  public interface IOFunction<T, R> {
-    /** Applies this function to the given argument. */
-    R apply(T t) throws IOException;
   }
 }


### PR DESCRIPTION
Followup of #673 

This removes the interfaces but also removes a method I forgot when cleaning up for module system. Thiscould be a separate issue, but I will do it together with this one.