### PR TITLE
LUCENE-10415: FunctionScoreQuery and IndexOrDocValuesQuery delegate Weight#count.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -154,6 +154,8 @@ New Features
   the number of matching range docs when each doc has at-most one point and the points are 1-dimensional.
   (Gautam Worah, Ignacio Vera, Adrien Grand)
 
+* LUCENE-10415: FunctionScoreQuery and IndexOrDocValuesQuery delegate Weight#count. (Ignacio Vera)     
+
 Improvements
 ---------------------
 
@@ -181,7 +183,7 @@ Improvements
 
 * LUCENE-10371: Make IndexRearranger able to arrange segment in a determined order.
   (Patrick Zhai)
-
+  
 Optimizations
 ---------------------
 
@@ -614,9 +616,7 @@ Improvements
   (David Smiley)
 
 * LUCENE-10062: Switch taxonomy faceting to use numeric doc values for storing ordinals instead of binary doc values
-  with its own custom encoding. (Greg Miller)
- 
-* LUCENE-10415: FunctionScoreQuery and IndexOrDocValuesQuery delegate Weight#count. (Ignacio Vera)  
+  with its own custom encoding. (Greg Miller) 
 
 Bug fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -615,6 +615,8 @@ Improvements
 
 * LUCENE-10062: Switch taxonomy faceting to use numeric doc values for storing ordinals instead of binary doc values
   with its own custom encoding. (Greg Miller)
+ 
+* LUCENE-10415: FunctionScoreQuery and IndexOrDocValuesQuery delegate Weight#count. (Ignacio Vera)  
 
 Bug fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
@@ -143,6 +143,15 @@ public final class IndexOrDocValuesQuery extends Query {
       }
 
       @Override
+      public int count(LeafReaderContext context) throws IOException {
+        final int count = indexWeight.count(context);
+        if (count != -1) {
+          return count;
+        }
+        return dvWeight.count(context);
+      }
+
+      @Override
       public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
         final ScorerSupplier indexScorerSupplier = indexWeight.scorerSupplier(context);
         final ScorerSupplier dvScorerSupplier = dvWeight.scorerSupplier(context);

--- a/lucene/core/src/test/org/apache/lucene/search/TestIndexOrDocValuesQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestIndexOrDocValuesQuery.java
@@ -187,12 +187,12 @@ public class TestIndexOrDocValuesQuery extends LuceneTestCase {
   // Weight#count is delegated to the inner weight
   public void testQueryMatchesCount() throws Exception {
     Directory dir = newDirectory();
-    IndexWriter w = 
-            new IndexWriter(
-                    dir,
-                    newIndexWriterConfig()
-                            // relies on costs and PointValues.estimateCost so we need the default codec
-                            .setCodec(TestUtil.getDefaultCodec()));
+    IndexWriter w =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig()
+                // relies on costs and PointValues.estimateCost so we need the default codec
+                .setCodec(TestUtil.getDefaultCodec()));
     final int numDocs = random().nextInt(5000);
     for (int i = 0; i < numDocs; ++i) {
       Document doc = new Document();
@@ -203,11 +203,11 @@ public class TestIndexOrDocValuesQuery extends LuceneTestCase {
     w.forceMerge(1);
     IndexReader reader = DirectoryReader.open(w);
     IndexSearcher searcher = newSearcher(reader);
-    
+
     final IndexOrDocValuesQuery query =
-            new IndexOrDocValuesQuery(
-                    LongPoint.newExactQuery("f2", 42),
-                    SortedNumericDocValuesField.newSlowRangeQuery("f2", 42, 42L));
+        new IndexOrDocValuesQuery(
+            LongPoint.newExactQuery("f2", 42),
+            SortedNumericDocValuesField.newSlowRangeQuery("f2", 42, 42L));
 
     final int searchCount = searcher.count(query);
     final Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE, 1);

--- a/lucene/core/src/test/org/apache/lucene/search/TestIndexOrDocValuesQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestIndexOrDocValuesQuery.java
@@ -26,6 +26,7 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.store.Directory;
@@ -177,6 +178,44 @@ public class TestIndexOrDocValuesQuery extends LuceneTestCase {
     final Weight w3 = searcher.createWeight(searcher.rewrite(q3), ScoreMode.COMPLETE, 1);
     final Scorer s3 = w3.scorer(searcher.getIndexReader().leaves().get(0));
     assertNotNull(s3.twoPhaseIterator()); // means we use doc values
+
+    reader.close();
+    w.close();
+    dir.close();
+  }
+
+  // Weight#count is delegated to the inner weight
+  public void testQueryMatchesCount() throws Exception {
+    Directory dir = newDirectory();
+    IndexWriter w = 
+            new IndexWriter(
+                    dir,
+                    newIndexWriterConfig()
+                            // relies on costs and PointValues.estimateCost so we need the default codec
+                            .setCodec(TestUtil.getDefaultCodec()));
+    final int numDocs = random().nextInt(5000);
+    for (int i = 0; i < numDocs; ++i) {
+      Document doc = new Document();
+      doc.add(new LongPoint("f2", 42L));
+      doc.add(new SortedNumericDocValuesField("f2", 42L));
+      w.addDocument(doc);
+    }
+    w.forceMerge(1);
+    IndexReader reader = DirectoryReader.open(w);
+    IndexSearcher searcher = newSearcher(reader);
+    
+    final IndexOrDocValuesQuery query =
+            new IndexOrDocValuesQuery(
+                    LongPoint.newExactQuery("f2", 42),
+                    SortedNumericDocValuesField.newSlowRangeQuery("f2", 42, 42L));
+
+    final int searchCount = searcher.count(query);
+    final Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE, 1);
+    int weightCount = 0;
+    for (LeafReaderContext leafReaderContext : reader.leaves()) {
+      weightCount += weight.count(leafReaderContext);
+    }
+    assertEquals(searchCount, weightCount);
 
     reader.close();
     w.close();

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
@@ -254,6 +254,11 @@ public final class FunctionScoreQuery extends Query {
     }
 
     @Override
+    public int count(LeafReaderContext context) throws IOException {
+      return inner.count(context);
+    }
+
+    @Override
     public boolean isCacheable(LeafReaderContext ctx) {
       return inner.isCacheable(ctx) && valueSource.isCacheable(ctx);
     }


### PR DESCRIPTION
These query wrappers do not modify the set of matching documents so they can delegate Weight#count.