### PR TITLE
LUCENE-10421: use Constant instead of relying upon timestamp

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswGraphBuilder.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswGraphBuilder.java
@@ -38,7 +38,7 @@ import org.apache.lucene.util.hnsw.NeighborQueue;
 public final class Lucene90HnswGraphBuilder {
 
   /** Default random seed for level generation * */
-  private static final long DEFAULT_RAND_SEED = System.currentTimeMillis();
+  private static final long DEFAULT_RAND_SEED = 42;
   /** A name for the HNSW component for the info-stream * */
   public static final String HNSW_COMPONENT = "HNSW";
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -36,7 +36,7 @@ import org.apache.lucene.util.InfoStream;
 public final class HnswGraphBuilder {
 
   /** Default random seed for level generation * */
-  private static final long DEFAULT_RAND_SEED = System.currentTimeMillis();
+  private static final long DEFAULT_RAND_SEED = 42;
   /** A name for the HNSW component for the info-stream * */
   public static final String HNSW_COMPONENT = "HNSW";
 


### PR DESCRIPTION
All the other uses of `System.currentTimeMillis` (both java and test code) are no good, but i'd rather tackle them in a followup issue (I will make a JIRA). Eventually, we can ban use of wall clock time with forbidden-apis.

But for now, I'd just like to have nightly benchmarks again :)