### PR TITLE
LUCENE-10408: Fix vector values iteration bug

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene91/Lucene91HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene91/Lucene91HnswVectorsReader.java
@@ -475,11 +475,10 @@ public final class Lucene91HnswVectorsReader extends KnnVectorsReader {
         }
       }
 
-      assert ord <= size;
-      if (ord == size) {
-        doc = NO_MORE_DOCS;
-      } else {
+      if (ord < size) {
         doc = ordToDocOperator.applyAsInt(ord);
+      } else {
+        doc = NO_MORE_DOCS;
       }
       return doc;
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -486,7 +486,6 @@ public class TestKnnVectorQuery extends LuceneTestCase {
   }
 
   /** Tests with random vectors and a random filter. Uses RandomIndexWriter. */
-  @AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/LUCENE-10408")
   public void testRandomWithFilter() throws IOException {
     int numDocs = 200;
     int dimension = atLeast(5);


### PR DESCRIPTION
Now that there is special logic to handle the dense case, we need to adjust some
assertions in VectorValues#advance.