### PR TITLE
LUCENE-10424: Optimize the "everything matches" case for count query in PointRangeQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -229,6 +229,8 @@ Optimizations
 
 * LUCENE-10408 Better encoding of doc Ids in vectors. (Mayya Sharipova, Julie Tibshirani, Adrien Grand)
 
+* LUCENE-10424 Optimize the "everything matches" case for count query in PointRangeQuery. (Ignacio Vera, Lu Xugang)
+
 * LUCENE-10084: Rewrite DocValuesFieldExistsQuery to MatchAllDocsQuery whenever terms
   or points have a docCount that is equal to maxDoc. (Vigya Sharma)
 

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -391,6 +391,10 @@ public abstract class PointRangeQuery extends Query {
             && numDims == 1
             && values.getDocCount() == values.size()) {
           // if all documents have at-most one point
+          if (relate(values.getMinPackedValue(), values.getMaxPackedValue())
+              == Relation.CELL_INSIDE_QUERY) {
+            return values.getDocCount();
+          }
           return (int) pointCount(values.getPointTree(), this::relate, this::matches);
         }
         return super.count(context);


### PR DESCRIPTION
In Implement of Weight#count in PointRangeQuery, Whether additional consideration is needed that when PointValues#getDocCount() == IndexReader#maxDoc() and the range's lower bound is less that the field's min value and the range's upper bound is greater than the field's max value, then return reader.maxDoc() directly?