### PR TITLE
LUCENE-10311: Different implementations of DocIdSetBuilder for points and terms

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceFeatureQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceFeatureQuery.java
@@ -38,8 +38,8 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 import org.apache.lucene.util.SloppyMath;
 
 final class LatLonPointDistanceFeatureQuery extends Query {
@@ -398,12 +398,12 @@ final class LatLonPointDistanceFeatureQuery extends Query {
       NumericUtils.intToSortableBytes(GeoEncodingUtils.encodeLongitude(box.minLon), minLon, 0);
       NumericUtils.intToSortableBytes(GeoEncodingUtils.encodeLongitude(box.maxLon), maxLon, 0);
 
-      DocIdSetBuilder result = new DocIdSetBuilder(maxDoc);
+      PointsDocIdSetBuilder result = new PointsDocIdSetBuilder(maxDoc, pointValues);
       final int doc = docID();
       IntersectVisitor visitor =
           new IntersectVisitor() {
 
-            DocIdSetBuilder.BulkAdder adder;
+            PointsDocIdSetBuilder.BulkAdder adder;
 
             @Override
             public void grow(int count) {

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -44,9 +44,9 @@ import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitSetIterator;
-import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 
 /** Distance query for {@link LatLonPoint}. */
 final class LatLonPointDistanceQuery extends Query {
@@ -148,7 +148,7 @@ final class LatLonPointDistanceQuery extends Query {
         LatLonPoint.checkCompatible(fieldInfo);
 
         // matching docids
-        DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+        PointsDocIdSetBuilder result = new PointsDocIdSetBuilder(reader.maxDoc(), values);
         final IntersectVisitor visitor = getIntersectVisitor(result);
 
         final Weight weight = this;
@@ -241,10 +241,10 @@ final class LatLonPointDistanceQuery extends Query {
       }
 
       /** Create a visitor that collects documents matching the range. */
-      private IntersectVisitor getIntersectVisitor(DocIdSetBuilder result) {
+      private IntersectVisitor getIntersectVisitor(PointsDocIdSetBuilder result) {
         return new IntersectVisitor() {
 
-          DocIdSetBuilder.BulkAdder adder;
+          PointsDocIdSetBuilder.BulkAdder adder;
 
           @Override
           public void grow(int count) {

--- a/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
@@ -35,7 +35,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 
 final class LongDistanceFeatureQuery extends Query {
 
@@ -384,12 +384,12 @@ final class LongDistanceFeatureQuery extends Query {
       final byte[] maxValueAsBytes = new byte[Long.BYTES];
       LongPoint.encodeDimension(maxValue, maxValueAsBytes, 0);
 
-      DocIdSetBuilder result = new DocIdSetBuilder(maxDoc);
+      PointsDocIdSetBuilder result = new PointsDocIdSetBuilder(maxDoc, pointValues);
       final int doc = docID();
       IntersectVisitor visitor =
           new IntersectVisitor() {
 
-            DocIdSetBuilder.BulkAdder adder;
+            PointsDocIdSetBuilder.BulkAdder adder;
 
             @Override
             public void grow(int count) {

--- a/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
@@ -35,7 +35,7 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 
 /**
  * Query class for searching {@code RangeField} types by a defined {@link Relation}.
@@ -452,9 +452,9 @@ public abstract class RangeFieldQuery extends Query {
       throws IOException {
     return new ConstantScoreWeight(this, boost) {
 
-      private IntersectVisitor getIntersectVisitor(DocIdSetBuilder result) {
+      private IntersectVisitor getIntersectVisitor(PointsDocIdSetBuilder result) {
         return new IntersectVisitor() {
-          DocIdSetBuilder.BulkAdder adder;
+          PointsDocIdSetBuilder.BulkAdder adder;
 
           @Override
           public void grow(int count) {
@@ -538,7 +538,7 @@ public abstract class RangeFieldQuery extends Query {
         } else {
           return new ScorerSupplier() {
 
-            final DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+            final PointsDocIdSetBuilder result = new PointsDocIdSetBuilder(reader.maxDoc(), values);
             final IntersectVisitor visitor = getIntersectVisitor(result);
             long cost = -1;
 

--- a/lucene/core/src/java/org/apache/lucene/document/XYPointInGeometryQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/XYPointInGeometryQuery.java
@@ -37,7 +37,7 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 
 /**
  * Finds all previously indexed points that fall within the specified XY geometries.
@@ -71,9 +71,9 @@ final class XYPointInGeometryQuery extends Query {
     }
   }
 
-  private IntersectVisitor getIntersectVisitor(DocIdSetBuilder result, Component2D tree) {
+  private IntersectVisitor getIntersectVisitor(PointsDocIdSetBuilder result, Component2D tree) {
     return new IntersectVisitor() {
-      DocIdSetBuilder.BulkAdder adder;
+      PointsDocIdSetBuilder.BulkAdder adder;
 
       @Override
       public void grow(int count) {
@@ -149,7 +149,7 @@ final class XYPointInGeometryQuery extends Query {
         return new ScorerSupplier() {
 
           long cost = -1;
-          DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+          PointsDocIdSetBuilder result = new PointsDocIdSetBuilder(reader.maxDoc(), values);
           final IntersectVisitor visitor = getIntersectVisitor(result, tree);
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
@@ -36,7 +36,7 @@ import org.apache.lucene.util.ArrayUtil.ByteArrayComparator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.BytesRefIterator;
-import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 import org.apache.lucene.util.RamUsageEstimator;
 
 /**
@@ -173,7 +173,7 @@ public abstract class PointInSetQuery extends Query implements Accountable {
                   + bytesPerDim);
         }
 
-        DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+        PointsDocIdSetBuilder result = new PointsDocIdSetBuilder(reader.maxDoc(), values);
 
         if (numDims == 1) {
 
@@ -211,14 +211,14 @@ public abstract class PointInSetQuery extends Query implements Accountable {
    */
   private class MergePointVisitor implements IntersectVisitor {
 
-    private final DocIdSetBuilder result;
+    private final PointsDocIdSetBuilder result;
     private TermIterator iterator;
     private BytesRef nextQueryPoint;
     private final BytesRef scratch = new BytesRef();
     private final PrefixCodedTerms sortedPackedPoints;
-    private DocIdSetBuilder.BulkAdder adder;
+    private PointsDocIdSetBuilder.BulkAdder adder;
 
-    public MergePointVisitor(PrefixCodedTerms sortedPackedPoints, DocIdSetBuilder result)
+    public MergePointVisitor(PrefixCodedTerms sortedPackedPoints, PointsDocIdSetBuilder result)
         throws IOException {
       this.result = result;
       this.sortedPackedPoints = sortedPackedPoints;
@@ -315,11 +315,11 @@ public abstract class PointInSetQuery extends Query implements Accountable {
   private class SinglePointVisitor implements IntersectVisitor {
 
     private final ByteArrayComparator comparator;
-    private final DocIdSetBuilder result;
+    private final PointsDocIdSetBuilder result;
     private final byte[] pointBytes;
-    private DocIdSetBuilder.BulkAdder adder;
+    private PointsDocIdSetBuilder.BulkAdder adder;
 
-    public SinglePointVisitor(DocIdSetBuilder result) {
+    public SinglePointVisitor(PointsDocIdSetBuilder result) {
       this.comparator = ArrayUtil.getUnsignedComparator(bytesPerDim);
       this.result = result;
       this.pointBytes = new byte[bytesPerDim * numDims];

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -30,8 +30,8 @@ import org.apache.lucene.index.PointValues.Relation;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.ArrayUtil.ByteArrayComparator;
 import org.apache.lucene.util.BitSetIterator;
-import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 
 /**
  * Abstract class for range queries against single or multidimensional points such as {@link
@@ -165,10 +165,10 @@ public abstract class PointRangeQuery extends Query {
         }
       }
 
-      private IntersectVisitor getIntersectVisitor(DocIdSetBuilder result) {
+      private IntersectVisitor getIntersectVisitor(PointsDocIdSetBuilder result) {
         return new IntersectVisitor() {
 
-          DocIdSetBuilder.BulkAdder adder;
+          PointsDocIdSetBuilder.BulkAdder adder;
 
           @Override
           public void grow(int count) {
@@ -331,7 +331,7 @@ public abstract class PointRangeQuery extends Query {
         } else {
           return new ScorerSupplier() {
 
-            final DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+            final PointsDocIdSetBuilder result = new PointsDocIdSetBuilder(reader.maxDoc(), values);
             final IntersectVisitor visitor = getIntersectVisitor(result);
             long cost = -1;
 

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -30,7 +30,7 @@ import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.ArrayUtil.ByteArrayComparator;
-import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 
 /**
  * Abstract numeric comparator for comparing numeric values. This comparator provides a skipping
@@ -204,10 +204,10 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
         }
       }
 
-      DocIdSetBuilder result = new DocIdSetBuilder(maxDoc);
+      PointsDocIdSetBuilder result = new PointsDocIdSetBuilder(maxDoc, pointValues);
       PointValues.IntersectVisitor visitor =
           new PointValues.IntersectVisitor() {
-            DocIdSetBuilder.BulkAdder adder;
+            PointsDocIdSetBuilder.BulkAdder adder;
 
             @Override
             public void grow(int count) {

--- a/lucene/core/src/java/org/apache/lucene/util/Buffers.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Buffers.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.packed.PackedInts;
+
+/** Sparse structure to collect docIds. The structure will grow until the provided threshold. */
+class Buffers {
+
+  private static class Buffer {
+    int[] array;
+    int length;
+
+    Buffer(int length) {
+      this.array = new int[length];
+      this.length = 0;
+    }
+
+    Buffer(int[] array, int length) {
+      this.array = array;
+      this.length = length;
+    }
+  }
+
+  private final List<Buffer> buffers;
+  private final int threshold;
+  private final int maxDoc;
+  private int totalAllocated; // accumulated size of the allocated buffers
+  private Buffer current;
+  // pkg-private for testing
+  final boolean multiValued;
+
+  Buffers(int maxDoc, boolean multiValued) {
+    this.maxDoc = maxDoc;
+    this.multiValued = multiValued;
+    this.buffers = new ArrayList<>();
+    // For ridiculously small sets, we'll just use a sorted int[]
+    // maxDoc >>> 7 is a good value if you want to save memory, lower values
+    // such as maxDoc >>> 11 should provide faster building but at the expense
+    // of using a full bitset even for quite sparse data
+    this.threshold = maxDoc >>> 7;
+  }
+
+  /** add doc to the buffer structure */
+  public void addDoc(int doc) {
+    current.array[current.length++] = doc;
+  }
+
+  /** return true if the buffer can allocate numDocs, otherwise false */
+  public boolean ensureBufferCapacity(int numDocs) {
+    if ((long) totalAllocated + numDocs > threshold) {
+      return false;
+    }
+    if (buffers.isEmpty()) {
+      addBuffer(additionalCapacity(numDocs));
+    } else if (current.array.length - current.length >= numDocs) {
+      // current buffer is large enough
+    } else if (current.length < current.array.length - (current.array.length >>> 3)) {
+      // current buffer is less than 7/8 full, resize rather than waste space
+      growBuffer(current, additionalCapacity(numDocs));
+    } else {
+      addBuffer(additionalCapacity(numDocs));
+    }
+    return true;
+  }
+
+  /**
+   * Fill the provided BitSet with the current dics. Returns the total number of docs this structure
+   * is holding.
+   */
+  public long toBitSet(BitSet bitSet) {
+    long counter = 0;
+    for (Buffer buffer : buffers) {
+      int[] array = buffer.array;
+      int length = buffer.length;
+      counter += length;
+      for (int i = 0; i < length; ++i) {
+        bitSet.set(array[i]);
+      }
+    }
+    return counter;
+  }
+
+  /** Build a {@link DocIdSet} with the documents in the data structure. */
+  public DocIdSet toDocIdSet() {
+    Buffer concatenated = concat(buffers);
+    LSBRadixSorter sorter = new LSBRadixSorter();
+    sorter.sort(PackedInts.bitsRequired(maxDoc - 1), concatenated.array, concatenated.length);
+    final int l;
+    if (multiValued) {
+      l = dedup(concatenated.array, concatenated.length);
+    } else {
+      assert noDups(concatenated.array, concatenated.length);
+      l = concatenated.length;
+    }
+    assert l <= concatenated.length;
+    concatenated.array[l] = DocIdSetIterator.NO_MORE_DOCS;
+    return new IntArrayDocIdSet(concatenated.array, l);
+  }
+
+  /**
+   * Concatenate the buffers in any order, leaving at least one empty slot in the end NOTE: this
+   * method might reuse one of the arrays
+   */
+  private static Buffer concat(List<Buffer> buffers) {
+    int totalLength = 0;
+    Buffer largestBuffer = null;
+    for (Buffer buffer : buffers) {
+      totalLength += buffer.length;
+      if (largestBuffer == null || buffer.array.length > largestBuffer.array.length) {
+        largestBuffer = buffer;
+      }
+    }
+    if (largestBuffer == null) {
+      return new Buffer(1);
+    }
+    int[] docs = largestBuffer.array;
+    if (docs.length < totalLength + 1) {
+      docs = ArrayUtil.growExact(docs, totalLength + 1);
+    }
+    totalLength = largestBuffer.length;
+    for (Buffer buffer : buffers) {
+      if (buffer != largestBuffer) {
+        System.arraycopy(buffer.array, 0, docs, totalLength, buffer.length);
+        totalLength += buffer.length;
+      }
+    }
+    return new Buffer(docs, totalLength);
+  }
+
+  private static boolean noDups(int[] a, int len) {
+    for (int i = 1; i < len; ++i) {
+      assert a[i - 1] < a[i];
+    }
+    return true;
+  }
+
+  private Buffer addBuffer(int len) {
+    Buffer buffer = new Buffer(len);
+    buffers.add(buffer);
+    this.current = buffer;
+    totalAllocated += buffer.length;
+    return buffer;
+  }
+
+  private void growBuffer(Buffer buffer, int additionalCapacity) {
+    buffer.array = ArrayUtil.growExact(buffer.array, buffer.length + additionalCapacity);
+    totalAllocated += additionalCapacity;
+  }
+
+  private int additionalCapacity(int numDocs) {
+    // exponential growth: the new array has a size equal to the sum of what
+    // has been allocated so far
+    int c = totalAllocated;
+    // but is also >= numDocs + 1 so that we can store the next batch of docs
+    // (plus an empty slot so that we are more likely to reuse the array in build())
+    c = Math.max(numDocs + 1, c);
+    // avoid cold starts
+    c = Math.max(32, c);
+    // do not go beyond the threshold
+    c = Math.min(threshold - totalAllocated, c);
+    return c;
+  }
+
+  private static int dedup(int[] arr, int length) {
+    if (length == 0) {
+      return 0;
+    }
+    int l = 1;
+    int previous = arr[0];
+    for (int i = 1; i < length; ++i) {
+      final int value = arr[i];
+      assert value >= previous;
+      if (value != previous) {
+        arr[l++] = value;
+        previous = value;
+      }
+    }
+    return l;
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestReqExclBulkScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestReqExclBulkScorer.java
@@ -38,13 +38,11 @@ public class TestReqExclBulkScorer extends LuceneTestCase {
     DocIdSetBuilder exclBuilder = new DocIdSetBuilder(maxDoc);
     final int numIncludedDocs = TestUtil.nextInt(random(), 1, maxDoc);
     final int numExcludedDocs = TestUtil.nextInt(random(), 1, maxDoc);
-    DocIdSetBuilder.BulkAdder reqAdder = reqBuilder.grow(numIncludedDocs);
     for (int i = 0; i < numIncludedDocs; ++i) {
-      reqAdder.add(random().nextInt(maxDoc));
+      reqBuilder.add(random().nextInt(maxDoc));
     }
-    DocIdSetBuilder.BulkAdder exclAdder = exclBuilder.grow(numExcludedDocs);
     for (int i = 0; i < numExcludedDocs; ++i) {
-      exclAdder.add(random().nextInt(maxDoc));
+      exclBuilder.add(random().nextInt(maxDoc));
     }
 
     final DocIdSet req = reqBuilder.build();

--- a/lucene/core/src/test/org/apache/lucene/util/TestBuffers.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestBuffers.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util;
+
+import java.io.IOException;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestBuffers extends LuceneTestCase {
+
+  public void testSingleValue() throws IOException {
+    int maxDoc = random().nextInt(10000) + 10000;
+    int currentDoc = 0;
+    Buffers buffers = new Buffers(maxDoc, false);
+    while (true) {
+      int batchsize = 1 + random().nextInt(10);
+      if (buffers.ensureBufferCapacity(batchsize) == false) {
+        break;
+      }
+      for (int i = 0; i < batchsize; i++) {
+        buffers.addDoc(currentDoc++);
+      }
+    }
+    FixedBitSet fixedBitSet = new FixedBitSet(maxDoc);
+    long counter = buffers.toBitSet(fixedBitSet);
+    DocIdSetIterator docIdSetIterator = buffers.toDocIdSet().iterator();
+    assertEquals(counter, fixedBitSet.cardinality());
+    assertEquals(currentDoc, counter);
+    for (int i = 0; i < currentDoc; i++) {
+      int doc = docIdSetIterator.nextDoc();
+      assertEquals(i, doc);
+      assertTrue(fixedBitSet.get(doc));
+    }
+    assertEquals(DocIdSetIterator.NO_MORE_DOCS, docIdSetIterator.nextDoc());
+  }
+
+  public void testMultiValue() throws IOException {
+    int maxDoc = random().nextInt(10000) + 10000;
+    int currentDoc = 0;
+    int totalDocs = 0;
+    Buffers buffers = new Buffers(maxDoc, true);
+    while (true) {
+      int batchsize = 1 + random().nextInt(10);
+      if (buffers.ensureBufferCapacity(batchsize) == false) {
+        break;
+      }
+      for (int i = 0; i < batchsize; i++) {
+        buffers.addDoc(currentDoc);
+        totalDocs++;
+      }
+      currentDoc++;
+    }
+    FixedBitSet fixedBitSet = new FixedBitSet(maxDoc);
+    long counter = buffers.toBitSet(fixedBitSet);
+    assertEquals(totalDocs, counter);
+    DocIdSetIterator docIdSetIterator = buffers.toDocIdSet().iterator();
+    for (int i = 0; i < currentDoc; i++) {
+      int doc = docIdSetIterator.nextDoc();
+      assertEquals(i, doc);
+      assertTrue(fixedBitSet.get(doc));
+    }
+    assertEquals(DocIdSetIterator.NO_MORE_DOCS, docIdSetIterator.nextDoc());
+  }
+
+  public void testRandomValues() throws IOException {
+    int maxDoc = random().nextInt(10000) + 10000;
+    int totalDocs = 0;
+    Buffers buffers = new Buffers(maxDoc, true);
+    while (true) {
+      int batchsize = 1 + random().nextInt(10);
+      if (buffers.ensureBufferCapacity(batchsize) == false) {
+        break;
+      }
+      for (int i = 0; i < batchsize; i++) {
+        int doc = random().nextInt(maxDoc);
+        buffers.addDoc(doc);
+        maxDoc = Math.max(maxDoc, doc);
+        totalDocs++;
+      }
+    }
+    FixedBitSet fixedBitSet = new FixedBitSet(maxDoc + 1);
+    long counter = buffers.toBitSet(fixedBitSet);
+    DocIdSetIterator docIdSetIterator = buffers.toDocIdSet().iterator();
+    assertEquals(totalDocs, counter);
+    int iteratedDocs = 0;
+    int doc;
+    while ((doc = docIdSetIterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+      assertTrue(fixedBitSet.get(doc));
+      iteratedDocs++;
+    }
+    assertEquals(iteratedDocs, fixedBitSet.cardinality());
+  }
+}

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollector.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollector.java
@@ -115,7 +115,7 @@ public class FacetsCollector extends SimpleCollector {
 
   @Override
   public final void collect(int doc) throws IOException {
-    docsBuilder.grow(1).add(doc);
+    docsBuilder.add(doc);
     if (keepScores) {
       if (totalHits >= scores.length) {
         float[] newScores = new float[ArrayUtil.oversize(totalHits + 1, 4)];

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiRangeQuery.java
@@ -37,7 +37,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 
 /**
  * Abstract class for range queries involving multiple ranges against physical points such as {@code
@@ -178,10 +178,10 @@ public abstract class MultiRangeQuery extends Query {
     return new ConstantScoreWeight(this, boost) {
 
       private PointValues.IntersectVisitor getIntersectVisitor(
-          DocIdSetBuilder result, Relatable range) {
+          PointsDocIdSetBuilder result, Relatable range) {
         return new PointValues.IntersectVisitor() {
 
-          DocIdSetBuilder.BulkAdder adder;
+          PointsDocIdSetBuilder.BulkAdder adder;
 
           @Override
           public void grow(int count) {
@@ -277,7 +277,7 @@ public abstract class MultiRangeQuery extends Query {
         } else {
           return new ScorerSupplier() {
 
-            final DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+            final PointsDocIdSetBuilder result = new PointsDocIdSetBuilder(reader.maxDoc(), values);
             final PointValues.IntersectVisitor visitor = getIntersectVisitor(result, range);
             long cost = -1;
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/PointInGeo3DShapeQuery.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/PointInGeo3DShapeQuery.java
@@ -31,7 +31,7 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.spatial3d.geom.GeoShape;
 import org.apache.lucene.spatial3d.geom.XYZBounds;
 import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 import org.apache.lucene.util.RamUsageEstimator;
 
 /**
@@ -103,7 +103,7 @@ final class PointInGeo3DShapeQuery extends Query implements Accountable {
         assert xyzSolid.getRelationship(shape) == GeoArea.WITHIN || xyzSolid.getRelationship(shape) == GeoArea.OVERLAPS: "expected WITHIN (1) or OVERLAPS (2) but got " + xyzSolid.getRelationship(shape) + "; shape="+shape+"; XYZSolid="+xyzSolid;
         */
 
-        DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+        PointsDocIdSetBuilder result = new PointsDocIdSetBuilder(reader.maxDoc(), values);
 
         values.intersect(new PointInShapeIntersectVisitor(result, shape, shapeBounds));
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/PointInShapeIntersectVisitor.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/PointInShapeIntersectVisitor.java
@@ -26,11 +26,11 @@ import org.apache.lucene.spatial3d.geom.GeoAreaFactory;
 import org.apache.lucene.spatial3d.geom.GeoShape;
 import org.apache.lucene.spatial3d.geom.PlanetModel.DocValueEncoder;
 import org.apache.lucene.spatial3d.geom.XYZBounds;
-import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 
 class PointInShapeIntersectVisitor implements IntersectVisitor {
-  private final DocIdSetBuilder hits;
+  private final PointsDocIdSetBuilder hits;
   private final GeoShape shape;
   private final double minimumX;
   private final double maximumX;
@@ -38,9 +38,10 @@ class PointInShapeIntersectVisitor implements IntersectVisitor {
   private final double maximumY;
   private final double minimumZ;
   private final double maximumZ;
-  private DocIdSetBuilder.BulkAdder adder;
+  private PointsDocIdSetBuilder.BulkAdder adder;
 
-  public PointInShapeIntersectVisitor(DocIdSetBuilder hits, GeoShape shape, XYZBounds bounds) {
+  public PointInShapeIntersectVisitor(
+      PointsDocIdSetBuilder hits, GeoShape shape, XYZBounds bounds) {
     this.hits = hits;
     this.shape = shape;
     DocValueEncoder docValueEncoder = shape.getPlanetModel().getDocValueEncoder();

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/TestGeo3DPoint.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/TestGeo3DPoint.java
@@ -47,6 +47,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MultiDocValues;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;
 import org.apache.lucene.index.ReaderUtil;
@@ -77,10 +78,10 @@ import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.PointsDocIdSetBuilder;
 
 public class TestGeo3DPoint extends LuceneTestCase {
 
@@ -1954,11 +1955,12 @@ public class TestGeo3DPoint extends LuceneTestCase {
     // First find the leaf reader that owns this doc:
     int subIndex = ReaderUtil.subIndex(docID, reader.leaves());
     LeafReader leafReader = reader.leaves().get(subIndex).reader();
+    PointValues pointValues = leafReader.getPointValues(fieldName);
 
     StringBuilder b = new StringBuilder();
     b.append("target is in leaf " + leafReader + " of full reader " + reader + "\n");
 
-    DocIdSetBuilder hits = new DocIdSetBuilder(leafReader.maxDoc());
+    PointsDocIdSetBuilder hits = new PointsDocIdSetBuilder(leafReader.maxDoc(), pointValues);
     ExplainingVisitor visitor =
         new ExplainingVisitor(
             shape,
@@ -1975,7 +1977,7 @@ public class TestGeo3DPoint extends LuceneTestCase {
 
     // Do second phase, where we we see how the wrapped visitor responded along that path:
     visitor.startSecondPhase();
-    leafReader.getPointValues(fieldName).intersect(visitor);
+    pointValues.intersect(visitor);
 
     return b.toString();
   }


### PR DESCRIPTION
The idea in this PR is the following:

1) Extract the sparse structure to collect docIds from docIdSetBuilder in a class called Buffers so it can be used by the different implementations.
2) Add a new DocIdSetBuilder implementation for points called `PointsDocIdSetBuilder` with the following API:

```
 /**
   * Utility class to efficiently add many docs in one go.
   *
   * @see PointsDocIdSetBuilder#grow
   */
  public abstract static class BulkAdder {
    public abstract void add(int doc);

    public void add(DocIdSetIterator iterator) throws IOException {
      int docID;
      while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
        add(docID);
      }
    }
  }

  /**
   * Reserve space and return a {@link BulkAdder} object that can be used to visit up to {@code
   * numPoints} points.
   */
  public BulkAdder grow(long numPoints);
```

3) DocIdSet builder API looks like that after the extraction of the points API:

```
/**
   * Add the content of the provided {@link DocIdSetIterator} to this builder. NOTE: if you need to
   * build a {@link DocIdSet} out of a single {@link DocIdSetIterator}, you should rather use {@link
   * RoaringDocIdSet.Builder}.
   */
public void add(DocIdSetIterator iter) throws IOException;


 /** Add a single document to this builder. */
  public void add(int doc);

```