### PR TITLE
LUCENE-10400: revise binary dictionaries' constructor in nori

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -77,7 +77,7 @@ API Changes
 * LUCENE-10368: IntTaxonomyFacets has been deprecated and is no longer a supported extension point
   for user-created faceting implementations. (Greg Miller)
 
-* LUCENE-10400: Add constructors that take external resource Paths to dictionary classes in Kuromoji:
+* LUCENE-10400: Add constructors that take external resource Paths to dictionary classes in Kuromoji and Nori:
   ConnectionCosts, TokenInfoDictionary, and UnknownDictionary. Old constructors that take resource scheme and
   resource path in those classes are deprecated; These are replaced with the new constructors and planned to be
   removed in a future release. (Tomoko Uchida, Uwe Schindler, Mike Sokolov)

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/CharacterDefinition.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/CharacterDefinition.java
@@ -73,11 +73,7 @@ public final class CharacterDefinition {
   public static final byte HANJANUMERIC = (byte) CharacterClass.HANJANUMERIC.ordinal();
 
   private CharacterDefinition() throws IOException {
-    InputStream is = null;
-    boolean success = false;
-    try {
-      is = BinaryDictionary.getClassResource(getClass(), FILENAME_SUFFIX);
-      is = new BufferedInputStream(is);
+    try (InputStream is = new BufferedInputStream(getClassResource())) {
       final DataInput in = new InputStreamDataInput(is);
       CodecUtil.checkHeader(in, HEADER, VERSION, VERSION);
       in.readBytes(characterCategoryMap, 0, characterCategoryMap.length);
@@ -86,14 +82,13 @@ public final class CharacterDefinition {
         invokeMap[i] = (b & 0x01) != 0;
         groupMap[i] = (b & 0x02) != 0;
       }
-      success = true;
-    } finally {
-      if (success) {
-        IOUtils.close(is);
-      } else {
-        IOUtils.closeWhileHandlingException(is);
-      }
     }
+  }
+
+  private static InputStream getClassResource() throws IOException {
+    final String resourcePath = CharacterDefinition.class.getSimpleName() + FILENAME_SUFFIX;
+    return IOUtils.requireResourceNonNull(
+        CharacterDefinition.class.getResourceAsStream(resourcePath), resourcePath);
   }
 
   public byte getCharacterClass(char c) {

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UnknownDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UnknownDictionary.java
@@ -17,6 +17,11 @@
 package org.apache.lucene.analysis.ko.dict;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.lucene.util.IOUtils;
 
 /** Dictionary for unknown-word handling. */
 public final class UnknownDictionary extends BinaryDictionary {
@@ -27,12 +32,47 @@ public final class UnknownDictionary extends BinaryDictionary {
    * @param resourcePath where to load resources from; a path, including the file base name without
    *     extension; this is used to match multiple files with the same base name.
    */
+  @Deprecated(forRemoval = true, since = "9.1")
+  @SuppressWarnings("removal")
   public UnknownDictionary(ResourceScheme scheme, String resourcePath) throws IOException {
-    super(scheme, resourcePath);
+    super(
+        scheme == ResourceScheme.FILE
+            ? () -> Files.newInputStream(Paths.get(resourcePath + TARGETMAP_FILENAME_SUFFIX))
+            : () -> getClassResource(TARGETMAP_FILENAME_SUFFIX),
+        scheme == ResourceScheme.FILE
+            ? () -> Files.newInputStream(Paths.get(resourcePath + POSDICT_FILENAME_SUFFIX))
+            : () -> getClassResource(POSDICT_FILENAME_SUFFIX),
+        scheme == ResourceScheme.FILE
+            ? () -> Files.newInputStream(Paths.get(resourcePath + DICT_FILENAME_SUFFIX))
+            : () -> getClassResource(DICT_FILENAME_SUFFIX));
+  }
+
+  /**
+   * Create a {@link UnknownDictionary} from an external resource path.
+   *
+   * @param targetMapFile where to load target map resource
+   * @param posDictFile where to load POS dictionary resource
+   * @param dictFile where to load dictionary entries resource
+   * @throws IOException if resource was not found or broken
+   */
+  public UnknownDictionary(Path targetMapFile, Path posDictFile, Path dictFile) throws IOException {
+    super(
+        () -> Files.newInputStream(targetMapFile),
+        () -> Files.newInputStream(posDictFile),
+        () -> Files.newInputStream(dictFile));
   }
 
   private UnknownDictionary() throws IOException {
-    super();
+    super(
+        () -> getClassResource(TARGETMAP_FILENAME_SUFFIX),
+        () -> getClassResource(POSDICT_FILENAME_SUFFIX),
+        () -> getClassResource(DICT_FILENAME_SUFFIX));
+  }
+
+  private static InputStream getClassResource(String suffix) throws IOException {
+    final String resourcePath = UnknownDictionary.class.getSimpleName() + suffix;
+    return IOUtils.requireResourceNonNull(
+        UnknownDictionary.class.getResourceAsStream(resourcePath), resourcePath);
   }
 
   public CharacterDefinition getCharacterDefinition() {

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
@@ -473,6 +473,7 @@ public class TestKoreanTokenizer extends BaseTokenStreamTestCase {
   }
 
   // Make sure loading custom dictionaries from classpath works:
+  @SuppressWarnings("removal")
   public void testCustomDictionary() throws Exception {
     Tokenizer tokenizer =
         new KoreanTokenizer(

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestExternalDictionary.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestExternalDictionary.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.analysis.ko.dict;
+
+import static org.apache.lucene.analysis.ko.dict.BinaryDictionary.DICT_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ko.dict.BinaryDictionary.POSDICT_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ko.dict.BinaryDictionary.TARGETMAP_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ko.dict.TokenInfoDictionary.FST_FILENAME_SUFFIX;
+
+import java.io.BufferedWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.lucene.analysis.ko.util.DictionaryBuilder;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.Before;
+
+public class TestExternalDictionary extends LuceneTestCase {
+
+  private Path dir;
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    dir = createTempDir("systemDict");
+    try (BufferedWriter writer =
+        Files.newBufferedWriter(dir.resolve("unk.def"), StandardCharsets.UTF_8)) {
+      writer.write("DEFAULT,1798,3559,3677,SY,*,*,*,*,*,*,*");
+      writer.newLine();
+      writer.write("SPACE,1795,3556,1065,SP,*,*,*,*,*,*,*");
+      writer.newLine();
+    }
+    try (BufferedWriter writer =
+        Files.newBufferedWriter(dir.resolve("char.def"), StandardCharsets.UTF_8)) {
+      writer.write("0x0021..0x002F SYMBOL");
+      writer.newLine();
+      writer.write("0x0030..0x0039 NUMERIC");
+      writer.newLine();
+    }
+    try (BufferedWriter writer =
+        Files.newBufferedWriter(dir.resolve("matrix.def"), StandardCharsets.UTF_8)) {
+      writer.write("3 3");
+      writer.newLine();
+      writer.write("1 1 0");
+      writer.newLine();
+      writer.write("1 2 0");
+      writer.newLine();
+    }
+    try (BufferedWriter writer =
+        Files.newBufferedWriter(dir.resolve("noun.csv"), StandardCharsets.UTF_8)) {
+      writer.write("명사,1,1,2,NNG,*,*,*,*,*,*,*");
+      writer.newLine();
+      writer.write("일반,5000,5000,3,NNG,*,*,*,*,*,*,*");
+      writer.newLine();
+    }
+    DictionaryBuilder.build(dir, dir, "utf-8", true);
+  }
+
+  public void testLoadExternalTokenInfoDictionary() throws Exception {
+    String dictionaryPath = TokenInfoDictionary.class.getName().replace('.', '/');
+    TokenInfoDictionary dict =
+        new TokenInfoDictionary(
+            dir.resolve(dictionaryPath + TARGETMAP_FILENAME_SUFFIX),
+            dir.resolve(dictionaryPath + POSDICT_FILENAME_SUFFIX),
+            dir.resolve(dictionaryPath + DICT_FILENAME_SUFFIX),
+            dir.resolve(dictionaryPath + FST_FILENAME_SUFFIX));
+    assertNotNull(dict.getFST());
+  }
+
+  public void testLoadExternalUnknownDictionary() throws Exception {
+    String dictionaryPath = UnknownDictionary.class.getName().replace('.', '/');
+    UnknownDictionary dict =
+        new UnknownDictionary(
+            dir.resolve(dictionaryPath + TARGETMAP_FILENAME_SUFFIX),
+            dir.resolve(dictionaryPath + POSDICT_FILENAME_SUFFIX),
+            dir.resolve(dictionaryPath + DICT_FILENAME_SUFFIX));
+    assertNotNull(dict.getCharacterDefinition());
+  }
+
+  public void testLoadExternalConnectionCosts() throws Exception {
+    String dictionaryPath = ConnectionCosts.class.getName().replace('.', '/');
+    ConnectionCosts cc =
+        new ConnectionCosts(dir.resolve(dictionaryPath + ConnectionCosts.FILENAME_SUFFIX));
+    assertEquals(0, cc.get(1, 1));
+  }
+}

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestTokenInfoDictionary.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestTokenInfoDictionary.java
@@ -16,7 +16,10 @@
  */
 package org.apache.lucene.analysis.ko.dict;
 
-import static org.apache.lucene.analysis.ko.dict.BinaryDictionary.ResourceScheme;
+import static org.apache.lucene.analysis.ko.dict.BinaryDictionary.DICT_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ko.dict.BinaryDictionary.POSDICT_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ko.dict.BinaryDictionary.TARGETMAP_FILENAME_SUFFIX;
+import static org.apache.lucene.analysis.ko.dict.TokenInfoDictionary.FST_FILENAME_SUFFIX;
 
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -76,7 +79,11 @@ public class TestTokenInfoDictionary extends LuceneTestCase {
     DictionaryBuilder.build(dir, dir, "utf-8", true);
     String dictionaryPath = TokenInfoDictionary.class.getName().replace('.', '/');
     // We must also load the other files (in BinaryDictionary) from the correct path
-    return new TokenInfoDictionary(ResourceScheme.FILE, dir.resolve(dictionaryPath).toString());
+    return new TokenInfoDictionary(
+        dir.resolve(dictionaryPath + TARGETMAP_FILENAME_SUFFIX),
+        dir.resolve(dictionaryPath + POSDICT_FILENAME_SUFFIX),
+        dir.resolve(dictionaryPath + DICT_FILENAME_SUFFIX),
+        dir.resolve(dictionaryPath + FST_FILENAME_SUFFIX));
   }
 
   public void testPutException() {


### PR DESCRIPTION
This applies the same changes as #643 to Nori.

- Add new constructors that take Path objects to load external resources.
- Add tests for the new constructors.
- Deprecate the old constructors to switch the resource location (classpath/file path).
- Always use Class.getResourceAsStream() to load class resources.