### PR TITLE
supress Actions jobs when only text files are changed

### DIFF
--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -4,11 +4,19 @@ on:
   pull_request:
     branches:
     - '*'
+    paths-ignore:
+    - '**.md'
+    - '**.txt'
+    - '**.adoc'
 
   push:
     branches:
     - main
     - branch_9x
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '**.adoc'
 
 jobs:
   # This runs all validation checks without tests.

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -14,9 +14,9 @@ on:
     - main
     - branch_9x
     paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - '**.adoc'
+    - '**.md'
+    - '**.txt'
+    - '**.adoc'
 
 jobs:
   # This runs all validation checks without tests.
@@ -81,7 +81,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt-hotspot'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
         java-package: jdk
 


### PR DESCRIPTION
- A follow-up of #674 
- It wouldn't be needed to run check jobs when only text files (CHANGES, etc.) are changed.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths