### PR TITLE
LUCENE-10429: Change how DocIdSetBuilder compute the cost of the dense iterator

### DIFF
--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextBKDReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextBKDReader.java
@@ -333,17 +333,11 @@ final class SimpleTextBKDReader extends PointValues {
 
     @Override
     public void visitDocIDs(PointValues.IntersectVisitor visitor) throws IOException {
-      addAll(visitor, false);
+      visitor.grow((int) Math.min(docCount, size()));
+      addAll(visitor);
     }
 
-    public void addAll(PointValues.IntersectVisitor visitor, boolean grown) throws IOException {
-      if (grown == false) {
-        final long size = size();
-        if (size <= Integer.MAX_VALUE) {
-          visitor.grow((int) size);
-          grown = true;
-        }
-      }
+    public void addAll(PointValues.IntersectVisitor visitor) throws IOException {
       if (isLeafNode()) {
         // Leaf node
         BytesRefBuilder scratch = new BytesRefBuilder();
@@ -356,10 +350,10 @@ final class SimpleTextBKDReader extends PointValues {
         }
       } else {
         pushLeft();
-        addAll(visitor, grown);
+        addAll(visitor);
         pop(true);
         pushRight();
-        addAll(visitor, grown);
+        addAll(visitor);
         pop(false);
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/PointValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValues.java
@@ -332,7 +332,7 @@ public abstract class PointValues {
    * Finds all documents and points matching the provided visitor. This method does not enforce live
    * documents, so it's up to the caller to test whether each document is deleted, if necessary.
    */
-  public final void intersect(IntersectVisitor visitor) throws IOException {
+  public void intersect(IntersectVisitor visitor) throws IOException {
     final PointTree pointTree = getPointTree();
     intersect(visitor, pointTree);
     assert pointTree.moveToParent() == false;

--- a/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
@@ -168,14 +168,14 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
   public void testEmptyPoints() throws IOException {
     PointValues values = new DummyPointValues(0, 0);
     DocIdSetBuilder builder = new DocIdSetBuilder(1, values, "foo");
-    assertEquals(1d, builder.numValuesPerDoc, 0d);
+    assertEquals(0, builder.docCount);
   }
 
   public void testLeverageStats() throws IOException {
     // single-valued points
     PointValues values = new DummyPointValues(42, 42);
     DocIdSetBuilder builder = new DocIdSetBuilder(100, values, "foo");
-    assertEquals(1d, builder.numValuesPerDoc, 0d);
+    assertEquals(42, builder.docCount);
     assertFalse(builder.multivalued);
     DocIdSetBuilder.BulkAdder adder = builder.grow(2);
     adder.add(5);
@@ -187,30 +187,30 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
     // multi-valued points
     values = new DummyPointValues(42, 63);
     builder = new DocIdSetBuilder(100, values, "foo");
-    assertEquals(1.5, builder.numValuesPerDoc, 0d);
+    assertEquals(42, builder.docCount);
     assertTrue(builder.multivalued);
-    adder = builder.grow(2);
+    adder = builder.grow(100);
     adder.add(5);
     adder.add(7);
     set = builder.build();
     assertTrue(set instanceof BitDocIdSet);
-    assertEquals(1, set.iterator().cost()); // it thinks the same doc was added twice
+    assertEquals(42, set.iterator().cost()); // it thinks all docs have been added
 
     // incomplete stats
     values = new DummyPointValues(42, -1);
     builder = new DocIdSetBuilder(100, values, "foo");
-    assertEquals(1d, builder.numValuesPerDoc, 0d);
+    assertEquals(1d, builder.docCount, 42);
     assertTrue(builder.multivalued);
 
     values = new DummyPointValues(-1, 84);
     builder = new DocIdSetBuilder(100, values, "foo");
-    assertEquals(1d, builder.numValuesPerDoc, 0d);
+    assertEquals(Integer.MAX_VALUE, builder.docCount);
     assertTrue(builder.multivalued);
 
     // single-valued terms
     Terms terms = new DummyTerms(42, 42);
     builder = new DocIdSetBuilder(100, terms);
-    assertEquals(1d, builder.numValuesPerDoc, 0d);
+    assertEquals(42, builder.docCount);
     assertFalse(builder.multivalued);
     adder = builder.grow(2);
     adder.add(5);
@@ -222,24 +222,24 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
     // multi-valued terms
     terms = new DummyTerms(42, 63);
     builder = new DocIdSetBuilder(100, terms);
-    assertEquals(1.5, builder.numValuesPerDoc, 0d);
+    assertEquals(42, builder.docCount);
     assertTrue(builder.multivalued);
-    adder = builder.grow(2);
+    adder = builder.grow(100);
     adder.add(5);
     adder.add(7);
     set = builder.build();
     assertTrue(set instanceof BitDocIdSet);
-    assertEquals(1, set.iterator().cost()); // it thinks the same doc was added twice
+    assertEquals(42, set.iterator().cost()); // it thinks all docs have been added
 
     // incomplete stats
     terms = new DummyTerms(42, -1);
     builder = new DocIdSetBuilder(100, terms);
-    assertEquals(1d, builder.numValuesPerDoc, 0d);
+    assertEquals(42, builder.docCount, 0d);
     assertTrue(builder.multivalued);
 
     terms = new DummyTerms(-1, 84);
     builder = new DocIdSetBuilder(100, terms);
-    assertEquals(1d, builder.numValuesPerDoc, 0d);
+    assertEquals(Integer.MAX_VALUE, builder.docCount);
     assertTrue(builder.multivalued);
   }
 


### PR DESCRIPTION
We currently compute the cost of the dense iterator using the following code:

```
final long cost = Math.round(counter / numValuesPerDoc);
```

Where counter is how many values have been added to the builder. This is inconsistent with the `#grow` method where the counter is increased as it expects grow to be called for documents and no values. Therefore in this PR is proposed to change the way  we compute the cost to reflect that counter refers to documents and not to values:

```
final long cost = Math.min(counter, docCount)
```
