### PR TITLE
LUCENE-10435: Break loop early while checking whether DocValuesFieldExistsQuery can be rewrite to MatchAllDocsQuery

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesFieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesFieldExistsQuery.java
@@ -69,17 +69,18 @@ public final class DocValuesFieldExistsQuery extends Query {
 
   @Override
   public Query rewrite(IndexReader reader) throws IOException {
-    int rewritableReaders = 0;
+    boolean allReadersRewritable = true;
     for (LeafReaderContext context : reader.leaves()) {
       LeafReader leaf = context.reader();
       Terms terms = leaf.terms(field);
       PointValues pointValues = leaf.getPointValues(field);
-      if ((terms != null && terms.getDocCount() == leaf.maxDoc())
-          || (pointValues != null && pointValues.getDocCount() == leaf.maxDoc())) {
-        rewritableReaders++;
-      } else break;
+      if ((terms == null || terms.getDocCount() != leaf.maxDoc())
+          && (pointValues == null || pointValues.getDocCount() != leaf.maxDoc())) {
+        allReadersRewritable = false;
+        break;
+      }
     }
-    if (rewritableReaders == reader.leaves().size()) {
+    if (allReadersRewritable) {
       return new MatchAllDocsQuery();
     }
     return super.rewrite(reader);

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesFieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesFieldExistsQuery.java
@@ -77,7 +77,7 @@ public final class DocValuesFieldExistsQuery extends Query {
       if ((terms != null && terms.getDocCount() == leaf.maxDoc())
           || (pointValues != null && pointValues.getDocCount() == leaf.maxDoc())) {
         rewritableReaders++;
-      }
+      } else break;
     }
     if (rewritableReaders == reader.leaves().size()) {
       return new MatchAllDocsQuery();


### PR DESCRIPTION
In the implementation of Query#rewrite in DocValuesFieldExistsQuery, when one Segment can't match the condition occurs, maybe we should break loop directly.

