### PR TITLE
LUCENE-10440: Reduce visibility of TaxonomyFacets and FloatTaxonomyFacets

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -17,6 +17,9 @@ API Changes
 
 * LUCENE-10400: Remove deprecated dictionary constructors in Kuromoji and Nori (Tomoko Uchida)
 
+* LUCENE-10440: TaxonomyFacets and FloatTaxonomyFacets have been made pkg-private and only serve
+  as internal implementation details of taxonomy-faceting. (Greg Miller)
+
 New Features
 ---------------------
 
@@ -92,6 +95,9 @@ API Changes
   (David Smiley, Uwe Schindler, Dawid Weiss, Tomoko Uchida)
 
 * LUCENE-10398: Add static method for getting Terms from LeafReader. (Spike Liu)
+
+* LUCENE-10440: TaxonomyFacets and FloatTaxonomyFacets have been deprecated and are no longer
+  supported extension points for user-created faceting implementations. (Greg Miller)
 
 New Features
 ---------------------

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
@@ -25,22 +25,22 @@ import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.facet.TopOrdAndFloatQueue;
 
 /** Base class for all taxonomy-based facets that aggregate to a per-ords float[]. */
-public abstract class FloatTaxonomyFacets extends TaxonomyFacets {
+abstract class FloatTaxonomyFacets extends TaxonomyFacets {
 
   // TODO: also use native hash map for sparse collection, like IntTaxonomyFacets
 
   /** Per-ordinal value. */
-  protected final float[] values;
+  final float[] values;
 
   /** Sole constructor. */
-  protected FloatTaxonomyFacets(
-      String indexFieldName, TaxonomyReader taxoReader, FacetsConfig config) throws IOException {
+  FloatTaxonomyFacets(String indexFieldName, TaxonomyReader taxoReader, FacetsConfig config)
+      throws IOException {
     super(indexFieldName, taxoReader, config);
     values = new float[taxoReader.getSize()];
   }
 
   /** Rolls up any single-valued hierarchical dimensions. */
-  protected void rollup() throws IOException {
+  void rollup() throws IOException {
     // Rollup any necessary dims:
     int[] children = getChildren();
     for (Map.Entry<String, DimConfig> ent : config.getDimConfigs().entrySet()) {

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -29,7 +29,7 @@ import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.FacetsConfig.DimConfig;
 
 /** Base class for all taxonomy-based facets impls. */
-public abstract class TaxonomyFacets extends Facets {
+abstract class TaxonomyFacets extends Facets {
 
   private static final Comparator<FacetResult> BY_VALUE_THEN_DIM =
       new Comparator<FacetResult>() {
@@ -46,13 +46,13 @@ public abstract class TaxonomyFacets extends Facets {
       };
 
   /** Index field name provided to the constructor. */
-  protected final String indexFieldName;
+  final String indexFieldName;
 
   /** {@code TaxonomyReader} provided to the constructor. */
-  protected final TaxonomyReader taxoReader;
+  final TaxonomyReader taxoReader;
 
   /** {@code FacetsConfig} provided to the constructor. */
-  protected final FacetsConfig config;
+  final FacetsConfig config;
 
   /** Maps parent ordinal to its child, or -1 if the parent is childless. */
   private int[] children;
@@ -61,10 +61,10 @@ public abstract class TaxonomyFacets extends Facets {
   private int[] siblings;
 
   /** Maps an ordinal to its parent, or -1 if there is no parent (root node). */
-  protected final int[] parents;
+  final int[] parents;
 
   /** Sole constructor. */
-  protected TaxonomyFacets(String indexFieldName, TaxonomyReader taxoReader, FacetsConfig config)
+  TaxonomyFacets(String indexFieldName, TaxonomyReader taxoReader, FacetsConfig config)
       throws IOException {
     this.indexFieldName = indexFieldName;
     this.taxoReader = taxoReader;
@@ -76,7 +76,7 @@ public abstract class TaxonomyFacets extends Facets {
    * Returns int[] mapping each ordinal to its first child; this is a large array and is computed
    * (and then saved) the first time this method is invoked.
    */
-  protected int[] getChildren() throws IOException {
+  int[] getChildren() throws IOException {
     if (children == null) {
       children = taxoReader.getParallelTaxonomyArrays().children();
     }
@@ -87,7 +87,7 @@ public abstract class TaxonomyFacets extends Facets {
    * Returns int[] mapping each ordinal to its next sibling; this is a large array and is computed
    * (and then saved) the first time this method is invoked.
    */
-  protected int[] getSiblings() throws IOException {
+  int[] getSiblings() throws IOException {
     if (siblings == null) {
       siblings = taxoReader.getParallelTaxonomyArrays().siblings();
     }
@@ -120,7 +120,7 @@ public abstract class TaxonomyFacets extends Facets {
    * @throws IllegalArgumentException if the provided dimension was manually configured, but its
    *     {@link DimConfig#indexFieldName} does not match {@link #indexFieldName}.
    */
-  protected DimConfig verifyDim(String dim) {
+  DimConfig verifyDim(String dim) {
     FacetsConfig.DimConfig dimConfig = config.getDimConfig(dim);
     if (config.isDimConfigured(dim) == true
         && dimConfig.indexFieldName.equals(indexFieldName) == false) {


### PR DESCRIPTION
# Description

These two classes are really implementation details, meant to hold common logic for our faceting implementations, but they are `public` and could be extended by users. It would be nice to reduce visibility to shrink our API surface area.

# Solution

Make pkg-private. Also reduce visibility of `protected` methods/fields to pkg-private as a little extra cleanup. Note that I will mark these as `@Deprecated` on the 9x branch to provide advanced notice to any users that might be extending these.

# Tests

No new testing needed.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
