### PR TITLE
LUCENE-10440: Mark TaxonomyFacets and FloatTaxonomyFacets as deprecated

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -51,6 +51,9 @@ API Changes
 
 * LUCENE-10398: Add static method for getting Terms from LeafReader. (Spike Liu)
 
+* LUCENE-10440: TaxonomyFacets and FloatTaxonomyFacets have been deprecated and are no longer
+  supported extension points for user-created faceting implementations. (Greg Miller)
+
 New Features
 ---------------------
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
@@ -24,7 +24,16 @@ import org.apache.lucene.facet.FacetsConfig.DimConfig;
 import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.facet.TopOrdAndFloatQueue;
 
-/** Base class for all taxonomy-based facets that aggregate to a per-ords float[]. */
+/**
+ * Base class for all taxonomy-based facets that aggregate to a per-ords float[].
+ *
+ * @deprecated Visibility of this class will be reduced to pkg-private in a future version. This
+ *     class is meant to host common code as an internal implementation detail to taxonomy
+ *     faceting,and is not intended as an extension point for user-created {@code Facets}
+ *     implementations. If your code is relying on this, please migrate necessary functionality down
+ *     into your own class.
+ */
+@Deprecated
 public abstract class FloatTaxonomyFacets extends TaxonomyFacets {
 
   // TODO: also use native hash map for sparse collection, like IntTaxonomyFacets

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -28,7 +28,16 @@ import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.FacetsConfig.DimConfig;
 
-/** Base class for all taxonomy-based facets impls. */
+/**
+ * Base class for all taxonomy-based facets impls.
+ *
+ * @deprecated Visibility of this class will be reduced to pkg-private in a future version. This
+ *     class is meant to host common code as an internal implementation detail to taxonomy
+ *     faceting,and is not intended as an extension point for user-created {@code Facets}
+ *     implementations. If your code is relying on this, please migrate necessary functionality down
+ *     into your own class.
+ */
+@Deprecated
 public abstract class TaxonomyFacets extends Facets {
 
   private static final Comparator<FacetResult> BY_VALUE_THEN_DIM =


### PR DESCRIPTION
This is a "backport" of #712, providing early `@Deprecation` notice.