### PR TITLE
LUCENE-10442: When indexQuery or/and dvQuery be a MatchAllDocsQuery  then IndexOrDocValuesQuery should be rewrite to MatchAllDocsQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -234,6 +234,9 @@ Optimizations
 * LUCENE-10084, LUCENE-10435: Rewrite DocValuesFieldExistsQuery to MatchAllDocsQuery whenever
   terms or points have a docCount that is equal to maxDoc. (Vigya Sharma, Lu Xugang)
 
+* LUCENE-10442: When indexQuery or/and dvQuery be a MatchAllDocsQuery
+  then IndexOrDocValuesQuery should be rewrite to MatchAllDocsQuery. (Lu Xugang)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
@@ -104,6 +104,10 @@ public final class IndexOrDocValuesQuery extends Query {
   public Query rewrite(IndexReader reader) throws IOException {
     Query indexRewrite = indexQuery.rewrite(reader);
     Query dvRewrite = dvQuery.rewrite(reader);
+    if (indexRewrite.getClass() == MatchAllDocsQuery.class
+        || dvRewrite.getClass() == MatchAllDocsQuery.class) {
+      return new MatchAllDocsQuery();
+    }
     if (indexQuery != indexRewrite || dvQuery != dvRewrite) {
       return new IndexOrDocValuesQuery(indexRewrite, dvRewrite);
     }


### PR DESCRIPTION
IndexOrDocValuesQuery is typically useful for range queries, When indexQuery was rewrite to MatchAllDocsQuery and if IndexOrDocValuesQuery not be a lead iterator , it most likely that dvQuery will supply the Scorer not indexQuery.

