### PR TITLE
LUCENE-10002: Replace test usages of TopScoreDocCollector with a corresponding collector manager

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/document/TestLatLonPointDistanceFeatureQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLatLonPointDistanceFeatureQuery.java
@@ -101,7 +101,8 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 10, 10, pivotDistance);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(2, null, 1);
     TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
@@ -197,7 +198,8 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 0, 179, pivotDistance);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(2, null, 1);
     TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
@@ -263,7 +265,8 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 10, 10, 5);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(3, null, 1);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(3, null, 1);
     TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
@@ -342,7 +345,8 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 0, 0, 200);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(2, null, 1);
     TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 

--- a/lucene/core/src/test/org/apache/lucene/document/TestLatLonPointDistanceFeatureQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLatLonPointDistanceFeatureQuery.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.MultiReader;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
@@ -100,9 +101,8 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 10, 10, pivotDistance);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
-    searcher.search(q, collector);
-    TopDocs topHits = collector.topDocs();
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
     double distance1 =
@@ -140,9 +140,8 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
             9);
 
     q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 9, 9, pivotDistance);
-    collector = TopScoreDocCollector.create(2, null, 1);
-    searcher.search(q, collector);
-    topHits = collector.topDocs();
+    manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
     CheckHits.checkExplanations(q, "", searcher);
 
@@ -198,9 +197,8 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 0, 179, pivotDistance);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
-    searcher.search(q, collector);
-    TopDocs topHits = collector.topDocs();
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
     double distance1 =
@@ -265,9 +263,8 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 10, 10, 5);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(3, null, 1);
-    searcher.search(q, collector);
-    TopDocs topHits = collector.topDocs();
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(3, null, 1);
+    TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
     double distance1 =
@@ -345,9 +342,8 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 0, 0, 200);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
-    searcher.search(q, collector);
-    TopDocs topHits = collector.topDocs();
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
     double distance1 =
@@ -372,9 +368,8 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
         topHits.scoreDocs);
 
     q = LatLonPoint.newDistanceFeatureQuery("foo", 3, -90, 0, 10000.);
-    collector = TopScoreDocCollector.create(2, null, 1);
-    searcher.search(q, collector);
-    topHits = collector.topDocs();
+    manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
     CheckHits.checkExplanations(q, "", searcher);
 

--- a/lucene/core/src/test/org/apache/lucene/document/TestLongDistanceFeatureQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLongDistanceFeatureQuery.java
@@ -90,7 +90,8 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, 10, 5);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(2, null, 1);
     TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
@@ -158,7 +159,8 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, Long.MAX_VALUE - 1, 100);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(2, null, 1);
     TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
@@ -240,7 +242,8 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, 10, 5);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(3, null, 1);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(3, null, 1);
     TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
@@ -306,7 +309,8 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, 10, 5);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(2, null, 1);
     TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 

--- a/lucene/core/src/test/org/apache/lucene/document/TestLongDistanceFeatureQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLongDistanceFeatureQuery.java
@@ -21,6 +21,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.MultiReader;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
@@ -89,9 +90,8 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, 10, 5);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
-    searcher.search(q, collector);
-    TopDocs topHits = collector.topDocs();
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
     CheckHits.checkEqual(
@@ -103,9 +103,8 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
         topHits.scoreDocs);
 
     q = LongPoint.newDistanceFeatureQuery("foo", 3, 7, 5);
-    collector = TopScoreDocCollector.create(2, null, 1);
-    searcher.search(q, collector);
-    topHits = collector.topDocs();
+    manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
     CheckHits.checkExplanations(q, "", searcher);
 
@@ -159,9 +158,8 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, Long.MAX_VALUE - 1, 100);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
-    searcher.search(q, collector);
-    TopDocs topHits = collector.topDocs();
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
     CheckHits.checkEqual(
@@ -181,9 +179,7 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
         topHits.scoreDocs);
 
     q = LongPoint.newDistanceFeatureQuery("foo", 3, Long.MIN_VALUE + 1, 100);
-    collector = TopScoreDocCollector.create(2, null, 1);
-    searcher.search(q, collector);
-    topHits = collector.topDocs();
+    topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
     CheckHits.checkExplanations(q, "", searcher);
 
@@ -244,9 +240,8 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, 10, 5);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(3, null, 1);
-    searcher.search(q, collector);
-    TopDocs topHits = collector.topDocs();
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(3, null, 1);
+    TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
     CheckHits.checkEqual(
@@ -311,9 +306,8 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, 10, 5);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
-    searcher.search(q, collector);
-    TopDocs topHits = collector.topDocs();
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    TopDocs topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
 
     CheckHits.checkEqual(
@@ -325,9 +319,8 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
         topHits.scoreDocs);
 
     q = LongPoint.newDistanceFeatureQuery("foo", 3, 7, 5);
-    collector = TopScoreDocCollector.create(2, null, 1);
-    searcher.search(q, collector);
-    topHits = collector.topDocs();
+    manager = TopScoreDocCollector.createSharedManager(2, null, 1);
+    topHits = searcher.search(q, manager);
     assertEquals(2, topHits.scoreDocs.length);
     CheckHits.checkExplanations(q, "", searcher);
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
@@ -66,9 +67,8 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
       assertEquals(IndexWriter.MAX_DOCS, ir.maxDoc());
       assertEquals(IndexWriter.MAX_DOCS, ir.numDocs());
       IndexSearcher searcher = new IndexSearcher(ir);
-      TopScoreDocCollector collector = TopScoreDocCollector.create(10, Integer.MAX_VALUE);
-      searcher.search(new TermQuery(new Term("field", "text")), collector);
-      TopDocs hits = collector.topDocs();
+      CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
+      TopDocs hits = searcher.search(new TermQuery(new Term("field", "text")), manager);
       assertEquals(IndexWriter.MAX_DOCS, hits.totalHits.value);
 
       // Sort by docID reversed:

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
@@ -67,7 +67,8 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
       assertEquals(IndexWriter.MAX_DOCS, ir.maxDoc());
       assertEquals(IndexWriter.MAX_DOCS, ir.numDocs());
       IndexSearcher searcher = new IndexSearcher(ir);
-      CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
+      CollectorManager<TopScoreDocCollector, TopDocs> manager =
+          TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
       TopDocs hits = searcher.search(new TermQuery(new Term("field", "text")), manager);
       assertEquals(IndexWriter.MAX_DOCS, hits.totalHits.value);
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
@@ -236,32 +236,28 @@ public class TestBoolean2 extends LuceneTestCase {
     // The asserting searcher will sometimes return the bulk scorer and
     // sometimes return a default impl around the scorer so that we can
     // compare BS1 and BS2
-    TopScoreDocCollector collector = TopScoreDocCollector.create(topDocsToCheck, Integer.MAX_VALUE);
-    searcher.search(query, collector);
-    ScoreDoc[] hits1 = collector.topDocs().scoreDocs;
-    collector = TopScoreDocCollector.create(topDocsToCheck, Integer.MAX_VALUE);
-    searcher.search(query, collector);
-    ScoreDoc[] hits2 = collector.topDocs().scoreDocs;
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(topDocsToCheck, null, Integer.MAX_VALUE);
+    ScoreDoc[] hits1 = searcher.search(query, manager).scoreDocs;
+    manager = TopScoreDocCollector.createSharedManager(topDocsToCheck, null, Integer.MAX_VALUE);
+    ScoreDoc[] hits2 = searcher.search(query, manager).scoreDocs;
 
     CheckHits.checkHitsQuery(query, hits1, hits2, expDocNrs);
 
     // Since we have no deleted docs, we should also be able to verify identical matches &
     // scores against an single segment copy of our index
-    collector = TopScoreDocCollector.create(topDocsToCheck, Integer.MAX_VALUE);
-    singleSegmentSearcher.search(query, collector);
-    hits2 = collector.topDocs().scoreDocs;
+    manager = TopScoreDocCollector.createSharedManager(topDocsToCheck, null, Integer.MAX_VALUE);
+    TopDocs topDocs = singleSegmentSearcher.search(query, manager);
+    hits2 = topDocs.scoreDocs;
     CheckHits.checkHitsQuery(query, hits1, hits2, expDocNrs);
 
     // sanity check expected num matches in bigSearcher
-    assertEquals(mulFactor * collector.totalHits, bigSearcher.count(query));
+    assertEquals(mulFactor * topDocs.totalHits.value, bigSearcher.count(query));
 
     // now check 2 diff scorers from the bigSearcher as well
-    collector = TopScoreDocCollector.create(topDocsToCheck, Integer.MAX_VALUE);
-    bigSearcher.search(query, collector);
-    hits1 = collector.topDocs().scoreDocs;
-    collector = TopScoreDocCollector.create(topDocsToCheck, Integer.MAX_VALUE);
-    bigSearcher.search(query, collector);
-    hits2 = collector.topDocs().scoreDocs;
+    manager = TopScoreDocCollector.createSharedManager(topDocsToCheck, null, Integer.MAX_VALUE);
+    hits1 = bigSearcher.search(query, manager).scoreDocs;
+    manager = TopScoreDocCollector.createSharedManager(topDocsToCheck, null, Integer.MAX_VALUE);
+    hits2 = bigSearcher.search(query, manager).scoreDocs;
 
     // NOTE: just comparing results, not vetting against expDocNrs
     // since we have dups in bigSearcher

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
@@ -236,7 +236,8 @@ public class TestBoolean2 extends LuceneTestCase {
     // The asserting searcher will sometimes return the bulk scorer and
     // sometimes return a default impl around the scorer so that we can
     // compare BS1 and BS2
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(topDocsToCheck, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(topDocsToCheck, null, Integer.MAX_VALUE);
     ScoreDoc[] hits1 = searcher.search(query, manager).scoreDocs;
     manager = TopScoreDocCollector.createSharedManager(topDocsToCheck, null, Integer.MAX_VALUE);
     ScoreDoc[] hits2 = searcher.search(query, manager).scoreDocs;

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanMinShouldMatch.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanMinShouldMatch.java
@@ -92,9 +92,8 @@ public class TestBooleanMinShouldMatch extends LuceneTestCase {
     assertEquals("result count", expected, h.length);
     // System.out.println("TEST: now check");
     // bs2
-    TopScoreDocCollector collector = TopScoreDocCollector.create(1000, Integer.MAX_VALUE);
-    s.search(q, collector);
-    ScoreDoc[] h2 = collector.topDocs().scoreDocs;
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(1000, null, Integer.MAX_VALUE);
+    ScoreDoc[] h2 = s.search(q, manager).scoreDocs;
     if (expected != h2.length) {
       printHits(getTestName(), h2, s);
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanMinShouldMatch.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanMinShouldMatch.java
@@ -92,7 +92,8 @@ public class TestBooleanMinShouldMatch extends LuceneTestCase {
     assertEquals("result count", expected, h.length);
     // System.out.println("TEST: now check");
     // bs2
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(1000, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(1000, null, Integer.MAX_VALUE);
     ScoreDoc[] h2 = s.search(q, manager).scoreDocs;
     if (expected != h2.length) {
       printHits(getTestName(), h2, s);

--- a/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreScorer.java
@@ -240,8 +240,10 @@ public class TestConstantScoreScorer extends LuceneTestCase {
 
     IndexSearcher is = newSearcher(ir);
 
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(10, null, 10);
-    TopDocs topDocs = is.search(new ConstantScoreQuery(new TermQuery(new Term("key", "foo"))), manager);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(10, null, 10);
+    TopDocs topDocs =
+        is.search(new ConstantScoreQuery(new TermQuery(new Term("key", "foo"))), manager);
     assertEquals(11, topDocs.totalHits.value);
     assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation);
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreScorer.java
@@ -240,20 +240,20 @@ public class TestConstantScoreScorer extends LuceneTestCase {
 
     IndexSearcher is = newSearcher(ir);
 
-    TopScoreDocCollector c = TopScoreDocCollector.create(10, null, 10);
-    is.search(new ConstantScoreQuery(new TermQuery(new Term("key", "foo"))), c);
-    assertEquals(11, c.totalHits);
-    assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, c.totalHitsRelation);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(10, null, 10);
+    TopDocs topDocs = is.search(new ConstantScoreQuery(new TermQuery(new Term("key", "foo"))), manager);
+    assertEquals(11, topDocs.totalHits.value);
+    assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation);
 
-    c = TopScoreDocCollector.create(10, null, 10);
+    manager = TopScoreDocCollector.createSharedManager(10, null, 10);
     Query query =
         new BooleanQuery.Builder()
             .add(new ConstantScoreQuery(new TermQuery(new Term("key", "foo"))), Occur.SHOULD)
             .add(new ConstantScoreQuery(new TermQuery(new Term("key", "bar"))), Occur.FILTER)
             .build();
-    is.search(query, c);
-    assertEquals(11, c.totalHits);
-    assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, c.totalHitsRelation);
+    topDocs = is.search(query, manager);
+    assertEquals(11, topDocs.totalHits.value);
+    assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation);
 
     iw.close();
     ir.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
@@ -118,7 +118,8 @@ public class TestMatchAllDocsQuery extends LuceneTestCase {
     IndexSearcher is = newSearcher(ir);
 
     final int totalHitsThreshold = 200;
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(10, null, totalHitsThreshold);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(10, null, totalHitsThreshold);
     TopDocs topDocs = is.search(new MatchAllDocsQuery(), manager);
     assertEquals(totalHitsThreshold + 1, topDocs.totalHits.value);
     assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation);

--- a/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
@@ -118,17 +118,15 @@ public class TestMatchAllDocsQuery extends LuceneTestCase {
     IndexSearcher is = newSearcher(ir);
 
     final int totalHitsThreshold = 200;
-    TopScoreDocCollector c = TopScoreDocCollector.create(10, null, totalHitsThreshold);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(10, null, totalHitsThreshold);
+    TopDocs topDocs = is.search(new MatchAllDocsQuery(), manager);
+    assertEquals(totalHitsThreshold + 1, topDocs.totalHits.value);
+    assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation);
 
-    is.search(new MatchAllDocsQuery(), c);
-    assertEquals(totalHitsThreshold + 1, c.totalHits);
-    assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, c.totalHitsRelation);
-
-    TopScoreDocCollector c1 = TopScoreDocCollector.create(10, null, numDocs);
-
-    is.search(new MatchAllDocsQuery(), c1);
-    assertEquals(numDocs, c1.totalHits);
-    assertEquals(TotalHits.Relation.EQUAL_TO, c1.totalHitsRelation);
+    manager = TopScoreDocCollector.createSharedManager(10, null, numDocs);
+    topDocs = is.search(new MatchAllDocsQuery(), manager);
+    assertEquals(numDocs, topDocs.totalHits.value);
+    assertEquals(TotalHits.Relation.EQUAL_TO, topDocs.totalHits.relation);
 
     iw.close();
     ir.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -772,13 +772,12 @@ public class TestPhraseQuery extends LuceneTestCase {
             new PhraseQuery("f", "d", "d") // repeated term
             )) {
       for (int topN = 1; topN <= 2; ++topN) {
-        TopScoreDocCollector collector1 =
-            TopScoreDocCollector.create(topN, null, Integer.MAX_VALUE);
-        searcher.search(query, collector1);
-        ScoreDoc[] hits1 = collector1.topDocs().scoreDocs;
-        TopScoreDocCollector collector2 = TopScoreDocCollector.create(topN, null, 1);
-        searcher.search(query, collector2);
-        ScoreDoc[] hits2 = collector2.topDocs().scoreDocs;
+        CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(topN, null, Integer.MAX_VALUE);
+        TopDocs topDocs = searcher.search(query, manager);
+        ScoreDoc[] hits1 = topDocs.scoreDocs;
+        manager = TopScoreDocCollector.createSharedManager(topN, null, 1);
+        topDocs = searcher.search(query, manager);
+        ScoreDoc[] hits2 = topDocs.scoreDocs;
         assertTrue("" + query, hits1.length > 0);
         CheckHits.checkEqual(query, hits1, hits2);
       }
@@ -1029,13 +1028,12 @@ public class TestPhraseQuery extends LuceneTestCase {
       for (String secondTerm : new String[] {"a", "b", "c"}) {
         Query query = new PhraseQuery("foo", newBytesRef(firstTerm), newBytesRef(secondTerm));
 
-        TopScoreDocCollector collector1 =
-            TopScoreDocCollector.create(10, null, Integer.MAX_VALUE); // COMPLETE
-        TopScoreDocCollector collector2 = TopScoreDocCollector.create(10, null, 10); // TOP_SCORES
+        CollectorManager<TopScoreDocCollector, TopDocs> completeManager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);// COMPLETE
+        CollectorManager<TopScoreDocCollector, TopDocs> topScoresManager = TopScoreDocCollector.createSharedManager(10, null, 10);// TOP_SCORES
 
-        searcher.search(query, collector1);
-        searcher.search(query, collector2);
-        CheckHits.checkEqual(query, collector1.topDocs().scoreDocs, collector2.topDocs().scoreDocs);
+        TopDocs complete = searcher.search(query, completeManager);
+        TopDocs topScores = searcher.search(query, topScoresManager);
+        CheckHits.checkEqual(query, complete.scoreDocs, topScores.scoreDocs);
 
         Query filteredQuery =
             new BooleanQuery.Builder()
@@ -1043,11 +1041,11 @@ public class TestPhraseQuery extends LuceneTestCase {
                 .add(new TermQuery(new Term("foo", "b")), Occur.FILTER)
                 .build();
 
-        collector1 = TopScoreDocCollector.create(10, null, Integer.MAX_VALUE); // COMPLETE
-        collector2 = TopScoreDocCollector.create(10, null, 10); // TOP_SCORES
-        searcher.search(filteredQuery, collector1);
-        searcher.search(filteredQuery, collector2);
-        CheckHits.checkEqual(query, collector1.topDocs().scoreDocs, collector2.topDocs().scoreDocs);
+        completeManager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE); // COMPLETE
+        topScoresManager = TopScoreDocCollector.createSharedManager(10, null, 10); // TOP_SCORES
+        complete = searcher.search(filteredQuery, completeManager);
+        topScores = searcher.search(filteredQuery, topScoresManager);
+        CheckHits.checkEqual(query, complete.scoreDocs, topScores.scoreDocs);
       }
     }
     reader.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -772,7 +772,8 @@ public class TestPhraseQuery extends LuceneTestCase {
             new PhraseQuery("f", "d", "d") // repeated term
             )) {
       for (int topN = 1; topN <= 2; ++topN) {
-        CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(topN, null, Integer.MAX_VALUE);
+        CollectorManager<TopScoreDocCollector, TopDocs> manager =
+            TopScoreDocCollector.createSharedManager(topN, null, Integer.MAX_VALUE);
         TopDocs topDocs = searcher.search(query, manager);
         ScoreDoc[] hits1 = topDocs.scoreDocs;
         manager = TopScoreDocCollector.createSharedManager(topN, null, 1);
@@ -1028,8 +1029,10 @@ public class TestPhraseQuery extends LuceneTestCase {
       for (String secondTerm : new String[] {"a", "b", "c"}) {
         Query query = new PhraseQuery("foo", newBytesRef(firstTerm), newBytesRef(secondTerm));
 
-        CollectorManager<TopScoreDocCollector, TopDocs> completeManager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);// COMPLETE
-        CollectorManager<TopScoreDocCollector, TopDocs> topScoresManager = TopScoreDocCollector.createSharedManager(10, null, 10);// TOP_SCORES
+        CollectorManager<TopScoreDocCollector, TopDocs> completeManager =
+            TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE); // COMPLETE
+        CollectorManager<TopScoreDocCollector, TopDocs> topScoresManager =
+            TopScoreDocCollector.createSharedManager(10, null, 10); // TOP_SCORES
 
         TopDocs complete = searcher.search(query, completeManager);
         TopDocs topScores = searcher.search(query, topScoresManager);
@@ -1041,7 +1044,8 @@ public class TestPhraseQuery extends LuceneTestCase {
                 .add(new TermQuery(new Term("foo", "b")), Occur.FILTER)
                 .build();
 
-        completeManager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE); // COMPLETE
+        completeManager =
+            TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE); // COMPLETE
         topScoresManager = TopScoreDocCollector.createSharedManager(10, null, 10); // TOP_SCORES
         complete = searcher.search(filteredQuery, completeManager);
         topScores = searcher.search(filteredQuery, topScoresManager);

--- a/lucene/core/src/test/org/apache/lucene/search/TestReqOptSumScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestReqOptSumScorer.java
@@ -265,7 +265,8 @@ public class TestReqOptSumScorer extends LuceneTestCase {
     Query query =
         new BooleanQuery.Builder().add(mustTerm, Occur.MUST).add(shouldTerm, Occur.SHOULD).build();
 
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
     TopDocs topDocs = searcher.search(query, manager);
     ScoreDoc[] expected = topDocs.scoreDocs;
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestReqOptSumScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestReqOptSumScorer.java
@@ -265,9 +265,9 @@ public class TestReqOptSumScorer extends LuceneTestCase {
     Query query =
         new BooleanQuery.Builder().add(mustTerm, Occur.MUST).add(shouldTerm, Occur.SHOULD).build();
 
-    TopScoreDocCollector coll = TopScoreDocCollector.create(10, null, Integer.MAX_VALUE);
-    searcher.search(query, coll);
-    ScoreDoc[] expected = coll.topDocs().scoreDocs;
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
+    TopDocs topDocs = searcher.search(query, manager);
+    ScoreDoc[] expected = topDocs.scoreDocs;
 
     // Also test a filtered query, since it does not compute the score on all
     // matches.
@@ -277,9 +277,9 @@ public class TestReqOptSumScorer extends LuceneTestCase {
             .add(new TermQuery(new Term("f", "C")), Occur.FILTER)
             .build();
 
-    coll = TopScoreDocCollector.create(10, null, Integer.MAX_VALUE);
-    searcher.search(query, coll);
-    ScoreDoc[] expectedFiltered = coll.topDocs().scoreDocs;
+    manager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
+    topDocs = searcher.search(query, manager);
+    ScoreDoc[] expectedFiltered = topDocs.scoreDocs;
 
     CheckHits.checkTopScores(random(), query, searcher);
 
@@ -290,9 +290,9 @@ public class TestReqOptSumScorer extends LuceneTestCase {
               .add(shouldTerm, Occur.SHOULD)
               .build();
 
-      coll = TopScoreDocCollector.create(10, null, 1);
-      searcher.search(q, coll);
-      ScoreDoc[] actual = coll.topDocs().scoreDocs;
+      manager = TopScoreDocCollector.createSharedManager(10, null, 1);
+      topDocs = searcher.search(q, manager);
+      ScoreDoc[] actual = topDocs.scoreDocs;
       CheckHits.checkEqual(query, expected, actual);
 
       q =
@@ -300,9 +300,9 @@ public class TestReqOptSumScorer extends LuceneTestCase {
               .add(mustTerm, Occur.MUST)
               .add(new RandomApproximationQuery(shouldTerm, random()), Occur.SHOULD)
               .build();
-      coll = TopScoreDocCollector.create(10, null, 1);
-      searcher.search(q, coll);
-      actual = coll.topDocs().scoreDocs;
+      manager = TopScoreDocCollector.createSharedManager(10, null, 1);
+      topDocs = searcher.search(q, manager);
+      actual = topDocs.scoreDocs;
       CheckHits.checkEqual(q, expected, actual);
 
       q =
@@ -310,9 +310,9 @@ public class TestReqOptSumScorer extends LuceneTestCase {
               .add(new RandomApproximationQuery(mustTerm, random()), Occur.MUST)
               .add(new RandomApproximationQuery(shouldTerm, random()), Occur.SHOULD)
               .build();
-      coll = TopScoreDocCollector.create(10, null, 1);
-      searcher.search(q, coll);
-      actual = coll.topDocs().scoreDocs;
+      manager = TopScoreDocCollector.createSharedManager(10, null, 1);
+      topDocs = searcher.search(q, manager);
+      actual = topDocs.scoreDocs;
       CheckHits.checkEqual(q, expected, actual);
     }
 
@@ -332,9 +332,9 @@ public class TestReqOptSumScorer extends LuceneTestCase {
                   Occur.FILTER)
               .build();
 
-      coll = TopScoreDocCollector.create(10, null, 1);
-      searcher.search(nestedQ, coll);
-      ScoreDoc[] actualFiltered = coll.topDocs().scoreDocs;
+      manager = TopScoreDocCollector.createSharedManager(10, null, 1);
+      topDocs = searcher.search(nestedQ, manager);
+      ScoreDoc[] actualFiltered = topDocs.scoreDocs;
       CheckHits.checkEqual(nestedQ, expectedFiltered, actualFiltered);
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearchAfter.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearchAfter.java
@@ -266,17 +266,20 @@ public class TestSearchAfter extends LuceneTestCase {
         if (VERBOSE) {
           System.out.println("  iter lastBottom=" + lastBottom);
         }
-        pagedManager = TopScoreDocCollector.createSharedManager(pageSize, lastBottom, Integer.MAX_VALUE);
+        pagedManager =
+            TopScoreDocCollector.createSharedManager(pageSize, lastBottom, Integer.MAX_VALUE);
       } else {
         if (VERBOSE) {
           System.out.println("  iter lastBottom=" + lastBottom);
         }
         if (sort == Sort.RELEVANCE) {
           pagedManager =
-              TopFieldCollector.createSharedManager(sort, pageSize, (FieldDoc) lastBottom, Integer.MAX_VALUE);
+              TopFieldCollector.createSharedManager(
+                  sort, pageSize, (FieldDoc) lastBottom, Integer.MAX_VALUE);
         } else {
           pagedManager =
-              TopFieldCollector.createSharedManager(sort, pageSize, (FieldDoc) lastBottom, Integer.MAX_VALUE);
+              TopFieldCollector.createSharedManager(
+                  sort, pageSize, (FieldDoc) lastBottom, Integer.MAX_VALUE);
         }
       }
       paged = searcher.search(query, pagedManager);

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearchAfter.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearchAfter.java
@@ -228,19 +228,18 @@ public class TestSearchAfter extends LuceneTestCase {
               + pageSize);
     }
     final boolean doScores;
-    final TopDocsCollector<?> allCollector;
+    final CollectorManager<?, ? extends TopDocs> allManager;
     if (sort == null) {
-      allCollector = TopScoreDocCollector.create(maxDoc, null, Integer.MAX_VALUE);
+      allManager = TopScoreDocCollector.createSharedManager(maxDoc, null, Integer.MAX_VALUE);
       doScores = false;
     } else if (sort == Sort.RELEVANCE) {
-      allCollector = TopFieldCollector.create(sort, maxDoc, Integer.MAX_VALUE);
+      allManager = TopFieldCollector.createSharedManager(sort, maxDoc, null, Integer.MAX_VALUE);
       doScores = true;
     } else {
-      allCollector = TopFieldCollector.create(sort, maxDoc, Integer.MAX_VALUE);
+      allManager = TopFieldCollector.createSharedManager(sort, maxDoc, null, Integer.MAX_VALUE);
       doScores = random().nextBoolean();
     }
-    searcher.search(query, allCollector);
-    all = allCollector.topDocs();
+    all = searcher.search(query, allManager);
     if (doScores) {
       TopFieldCollector.populateScores(all.scoreDocs, searcher, query);
     }
@@ -262,26 +261,25 @@ public class TestSearchAfter extends LuceneTestCase {
     ScoreDoc lastBottom = null;
     while (pageStart < all.totalHits.value) {
       TopDocs paged;
-      final TopDocsCollector<?> pagedCollector;
+      final CollectorManager<?, ? extends TopDocs> pagedManager;
       if (sort == null) {
         if (VERBOSE) {
           System.out.println("  iter lastBottom=" + lastBottom);
         }
-        pagedCollector = TopScoreDocCollector.create(pageSize, lastBottom, Integer.MAX_VALUE);
+        pagedManager = TopScoreDocCollector.createSharedManager(pageSize, lastBottom, Integer.MAX_VALUE);
       } else {
         if (VERBOSE) {
           System.out.println("  iter lastBottom=" + lastBottom);
         }
         if (sort == Sort.RELEVANCE) {
-          pagedCollector =
-              TopFieldCollector.create(sort, pageSize, (FieldDoc) lastBottom, Integer.MAX_VALUE);
+          pagedManager =
+              TopFieldCollector.createSharedManager(sort, pageSize, (FieldDoc) lastBottom, Integer.MAX_VALUE);
         } else {
-          pagedCollector =
-              TopFieldCollector.create(sort, pageSize, (FieldDoc) lastBottom, Integer.MAX_VALUE);
+          pagedManager =
+              TopFieldCollector.createSharedManager(sort, pageSize, (FieldDoc) lastBottom, Integer.MAX_VALUE);
         }
       }
-      searcher.search(query, pagedCollector);
-      paged = pagedCollector.topDocs();
+      paged = searcher.search(query, pagedManager);
       if (doScores) {
         TopFieldCollector.populateScores(paged.scoreDocs, searcher, query);
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
@@ -167,11 +167,9 @@ public class TestSynonymQuery extends LuceneTestCase {
             .addTerm(new Term("f", "b"), boost == 0 ? 1f : boost)
             .build();
 
-    TopScoreDocCollector collector =
-        TopScoreDocCollector.create(
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(
             Math.min(reader.numDocs(), totalHitsThreshold), null, totalHitsThreshold);
-    searcher.search(query, collector);
-    TopDocs topDocs = collector.topDocs();
+    TopDocs topDocs = searcher.search(query, manager);
     if (topDocs.totalHits.value < totalHitsThreshold) {
       assertEquals(new TotalHits(11, TotalHits.Relation.EQUAL_TO), topDocs.totalHits);
     } else {
@@ -227,11 +225,9 @@ public class TestSynonymQuery extends LuceneTestCase {
             .addTerm(new Term("f", "c"))
             .build();
 
-    TopScoreDocCollector collector =
-        TopScoreDocCollector.create(
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(
             Math.min(reader.numDocs(), totalHitsThreshold), null, totalHitsThreshold);
-    searcher.search(query, collector);
-    TopDocs topDocs = collector.topDocs();
+    TopDocs topDocs = searcher.search(query, manager);
     if (topDocs.totalHits.value < totalHitsThreshold) {
       assertEquals(TotalHits.Relation.EQUAL_TO, topDocs.totalHits.relation);
       assertEquals(22, topDocs.totalHits.value);
@@ -445,13 +441,12 @@ public class TestSynonymQuery extends LuceneTestCase {
               .addTerm(new Term("foo", Integer.toString(term2)), boost2)
               .build();
 
-      TopScoreDocCollector collector1 =
-          TopScoreDocCollector.create(10, null, Integer.MAX_VALUE); // COMPLETE
-      TopScoreDocCollector collector2 = TopScoreDocCollector.create(10, null, 1); // TOP_SCORES
+      CollectorManager<TopScoreDocCollector, TopDocs> completeManager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
+      CollectorManager<TopScoreDocCollector, TopDocs> topScoresManager = TopScoreDocCollector.createSharedManager(10, null, 1);
 
-      searcher.search(query, collector1);
-      searcher.search(query, collector2);
-      CheckHits.checkEqual(query, collector1.topDocs().scoreDocs, collector2.topDocs().scoreDocs);
+      TopDocs complete = searcher.search(query, completeManager);
+      TopDocs topScores = searcher.search(query, topScoresManager);
+      CheckHits.checkEqual(query, complete.scoreDocs, topScores.scoreDocs);
 
       int filterTerm = random().nextInt(15);
       Query filteredQuery =
@@ -460,11 +455,11 @@ public class TestSynonymQuery extends LuceneTestCase {
               .add(new TermQuery(new Term("foo", Integer.toString(filterTerm))), Occur.FILTER)
               .build();
 
-      collector1 = TopScoreDocCollector.create(10, null, Integer.MAX_VALUE); // COMPLETE
-      collector2 = TopScoreDocCollector.create(10, null, 1); // TOP_SCORES
-      searcher.search(filteredQuery, collector1);
-      searcher.search(filteredQuery, collector2);
-      CheckHits.checkEqual(query, collector1.topDocs().scoreDocs, collector2.topDocs().scoreDocs);
+      completeManager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
+      topScoresManager = TopScoreDocCollector.createSharedManager(10, null, 1);
+      complete = searcher.search(filteredQuery, completeManager);
+      topScores = searcher.search(filteredQuery, topScoresManager);
+      CheckHits.checkEqual(query, complete.scoreDocs, topScores.scoreDocs);
     }
     reader.close();
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
@@ -167,7 +167,8 @@ public class TestSynonymQuery extends LuceneTestCase {
             .addTerm(new Term("f", "b"), boost == 0 ? 1f : boost)
             .build();
 
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(
             Math.min(reader.numDocs(), totalHitsThreshold), null, totalHitsThreshold);
     TopDocs topDocs = searcher.search(query, manager);
     if (topDocs.totalHits.value < totalHitsThreshold) {
@@ -225,7 +226,8 @@ public class TestSynonymQuery extends LuceneTestCase {
             .addTerm(new Term("f", "c"))
             .build();
 
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(
             Math.min(reader.numDocs(), totalHitsThreshold), null, totalHitsThreshold);
     TopDocs topDocs = searcher.search(query, manager);
     if (topDocs.totalHits.value < totalHitsThreshold) {
@@ -441,8 +443,10 @@ public class TestSynonymQuery extends LuceneTestCase {
               .addTerm(new Term("foo", Integer.toString(term2)), boost2)
               .build();
 
-      CollectorManager<TopScoreDocCollector, TopDocs> completeManager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
-      CollectorManager<TopScoreDocCollector, TopDocs> topScoresManager = TopScoreDocCollector.createSharedManager(10, null, 1);
+      CollectorManager<TopScoreDocCollector, TopDocs> completeManager =
+          TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
+      CollectorManager<TopScoreDocCollector, TopDocs> topScoresManager =
+          TopScoreDocCollector.createSharedManager(10, null, 1);
 
       TopDocs complete = searcher.search(query, completeManager);
       TopDocs topScores = searcher.search(query, topScoresManager);

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermScorer.java
@@ -242,8 +242,10 @@ public class TestTermScorer extends LuceneTestCase {
     for (int iter = 0; iter < 15; ++iter) {
       Query query = new TermQuery(new Term("foo", Integer.toString(iter)));
 
-      CollectorManager<TopScoreDocCollector, TopDocs> completeManager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
-      CollectorManager<TopScoreDocCollector, TopDocs> topScoresManager = TopScoreDocCollector.createSharedManager(10, null, 1);
+      CollectorManager<TopScoreDocCollector, TopDocs> completeManager =
+          TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
+      CollectorManager<TopScoreDocCollector, TopDocs> topScoresManager =
+          TopScoreDocCollector.createSharedManager(10, null, 1);
 
       TopDocs complete = searcher.search(query, completeManager);
       TopDocs topScores = searcher.search(query, topScoresManager);

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermScorer.java
@@ -242,13 +242,12 @@ public class TestTermScorer extends LuceneTestCase {
     for (int iter = 0; iter < 15; ++iter) {
       Query query = new TermQuery(new Term("foo", Integer.toString(iter)));
 
-      TopScoreDocCollector collector1 =
-          TopScoreDocCollector.create(10, null, Integer.MAX_VALUE); // COMPLETE
-      TopScoreDocCollector collector2 = TopScoreDocCollector.create(10, null, 1); // TOP_SCORES
+      CollectorManager<TopScoreDocCollector, TopDocs> completeManager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
+      CollectorManager<TopScoreDocCollector, TopDocs> topScoresManager = TopScoreDocCollector.createSharedManager(10, null, 1);
 
-      searcher.search(query, collector1);
-      searcher.search(query, collector2);
-      CheckHits.checkEqual(query, collector1.topDocs().scoreDocs, collector2.topDocs().scoreDocs);
+      TopDocs complete = searcher.search(query, completeManager);
+      TopDocs topScores = searcher.search(query, topScoresManager);
+      CheckHits.checkEqual(query, complete.scoreDocs, topScores.scoreDocs);
 
       int filterTerm = random().nextInt(15);
       Query filteredQuery =
@@ -257,11 +256,11 @@ public class TestTermScorer extends LuceneTestCase {
               .add(new TermQuery(new Term("foo", Integer.toString(filterTerm))), Occur.FILTER)
               .build();
 
-      collector1 = TopScoreDocCollector.create(10, null, Integer.MAX_VALUE); // COMPLETE
-      collector2 = TopScoreDocCollector.create(10, null, 1); // TOP_SCORES
-      searcher.search(filteredQuery, collector1);
-      searcher.search(filteredQuery, collector2);
-      CheckHits.checkEqual(query, collector1.topDocs().scoreDocs, collector2.topDocs().scoreDocs);
+      completeManager = TopScoreDocCollector.createSharedManager(10, null, Integer.MAX_VALUE);
+      topScoresManager = TopScoreDocCollector.createSharedManager(10, null, 1);
+      complete = searcher.search(filteredQuery, completeManager);
+      topScores = searcher.search(filteredQuery, topScoresManager);
+      CheckHits.checkEqual(query, complete.scoreDocs, topScores.scoreDocs);
     }
     reader.close();
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -41,11 +41,11 @@ import org.apache.lucene.util.BytesRef;
 
 public class TestTopDocsCollector extends LuceneTestCase {
 
-  private static final class MyTopsDocCollector extends TopDocsCollector<ScoreDoc> {
+  private static final class MyTopDocsCollector extends TopDocsCollector<ScoreDoc> {
 
     private int idx = 0;
 
-    public MyTopsDocCollector(int size) {
+    public MyTopDocsCollector(int size) {
       super(new HitQueue(size, false));
     }
 
@@ -130,20 +130,19 @@ public class TestTopDocsCollector extends LuceneTestCase {
 
   private TopDocsCollector<ScoreDoc> doSearch(int numResults, Query q) throws IOException {
     IndexSearcher searcher = newSearcher(reader);
-    TopDocsCollector<ScoreDoc> tdc = new MyTopsDocCollector(numResults);
+    TopDocsCollector<ScoreDoc> tdc = new MyTopDocsCollector(numResults);
     searcher.search(q, tdc);
     return tdc;
   }
 
-  private TopDocsCollector<ScoreDoc> doSearchWithThreshold(
+  private static TopDocs doSearchWithThreshold(
       int numResults, int thresHold, Query q, IndexReader indexReader) throws IOException {
     IndexSearcher searcher = newSearcher(indexReader, true, true, false);
-    TopDocsCollector<ScoreDoc> tdc = TopScoreDocCollector.create(numResults, thresHold);
-    searcher.search(q, tdc);
-    return tdc;
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(numResults, null, thresHold);
+    return searcher.search(q, manager);
   }
 
-  private TopDocs doConcurrentSearchWithThreshold(
+  private static TopDocs doConcurrentSearchWithThreshold(
       int numResults, int threshold, Query q, IndexReader indexReader) throws IOException {
     IndexSearcher searcher = newSearcher(indexReader, true, true, true);
     CollectorManager<TopScoreDocCollector, TopDocs> collectorManager =
@@ -205,7 +204,7 @@ public class TestTopDocsCollector extends LuceneTestCase {
   }
 
   public void testZeroResults() throws Exception {
-    TopDocsCollector<ScoreDoc> tdc = new MyTopsDocCollector(5);
+    TopDocsCollector<ScoreDoc> tdc = new MyTopDocsCollector(5);
     assertEquals(0, tdc.topDocs(0, 1).scoreDocs.length);
   }
 
@@ -382,9 +381,8 @@ public class TestTopDocsCollector extends LuceneTestCase {
     assertEquals(2, reader.leaves().size());
     w.close();
 
-    TopDocsCollector<ScoreDoc> collector = doSearchWithThreshold(5, 10, q, reader);
+    TopDocs tdc2 = doSearchWithThreshold(5, 10, q, reader);
     TopDocs tdc = doConcurrentSearchWithThreshold(5, 10, q, reader);
-    TopDocs tdc2 = collector.topDocs();
 
     CheckHits.checkEqual(q, tdc.scoreDocs, tdc2.scoreDocs);
 
@@ -460,20 +458,20 @@ public class TestTopDocsCollector extends LuceneTestCase {
 
       try (IndexReader reader = DirectoryReader.open(w)) {
         IndexSearcher searcher = new IndexSearcher(reader);
-        TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 10);
-        searcher.search(new TermQuery(new Term("f", "foo")), collector);
-        assertEquals(10, collector.totalHits);
-        assertEquals(TotalHits.Relation.EQUAL_TO, collector.totalHitsRelation);
+        CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 10);
+        TopDocs topDocs = searcher.search(new TermQuery(new Term("f", "foo")), manager);
+        assertEquals(10, topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocs.totalHits.relation);
 
-        collector = TopScoreDocCollector.create(2, null, 2);
-        searcher.search(new TermQuery(new Term("f", "foo")), collector);
-        assertTrue(10 >= collector.totalHits);
-        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, collector.totalHitsRelation);
+        manager = TopScoreDocCollector.createSharedManager(2, null, 2);
+        topDocs = searcher.search(new TermQuery(new Term("f", "foo")), manager);
+        assertTrue(10 >= topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation);
 
-        collector = TopScoreDocCollector.create(10, null, 2);
-        searcher.search(new TermQuery(new Term("f", "foo")), collector);
-        assertEquals(10, collector.totalHits);
-        assertEquals(TotalHits.Relation.EQUAL_TO, collector.totalHitsRelation);
+        manager = TopScoreDocCollector.createSharedManager(10, null, 2);
+        topDocs = searcher.search(new TermQuery(new Term("f", "foo")), manager);
+        assertEquals(10, topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocs.totalHits.relation);
       }
     }
   }
@@ -637,9 +635,8 @@ public class TestTopDocsCollector extends LuceneTestCase {
               .build()
         };
     for (Query query : queries) {
-      TopDocsCollector<ScoreDoc> collector = doSearchWithThreshold(5, 0, query, indexReader);
+      TopDocs tdc2 =  doSearchWithThreshold(5, 0, query, indexReader);
       TopDocs tdc = doConcurrentSearchWithThreshold(5, 0, query, indexReader);
-      TopDocs tdc2 = collector.topDocs();
 
       assertTrue(tdc.totalHits.value > 0);
       assertTrue(tdc2.totalHits.value > 0);
@@ -679,9 +676,8 @@ public class TestTopDocsCollector extends LuceneTestCase {
         BytesRef term = BytesRef.deepCopyOf(termsEnum.term());
         Query query = new TermQuery(new Term("body", term));
 
-        TopDocsCollector<ScoreDoc> collector = doSearchWithThreshold(5, 0, query, reader);
+        TopDocs tdc2 = doSearchWithThreshold(5, 0, query, reader);
         TopDocs tdc = doConcurrentSearchWithThreshold(5, 0, query, reader);
-        TopDocs tdc2 = collector.topDocs();
 
         CheckHits.checkEqual(query, tdc.scoreDocs, tdc2.scoreDocs);
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -138,7 +138,8 @@ public class TestTopDocsCollector extends LuceneTestCase {
   private static TopDocs doSearchWithThreshold(
       int numResults, int thresHold, Query q, IndexReader indexReader) throws IOException {
     IndexSearcher searcher = newSearcher(indexReader, true, true, false);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(numResults, null, thresHold);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(numResults, null, thresHold);
     return searcher.search(q, manager);
   }
 
@@ -458,7 +459,8 @@ public class TestTopDocsCollector extends LuceneTestCase {
 
       try (IndexReader reader = DirectoryReader.open(w)) {
         IndexSearcher searcher = new IndexSearcher(reader);
-        CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(2, null, 10);
+        CollectorManager<TopScoreDocCollector, TopDocs> manager =
+            TopScoreDocCollector.createSharedManager(2, null, 10);
         TopDocs topDocs = searcher.search(new TermQuery(new Term("f", "foo")), manager);
         assertEquals(10, topDocs.totalHits.value);
         assertEquals(TotalHits.Relation.EQUAL_TO, topDocs.totalHits.relation);
@@ -635,7 +637,7 @@ public class TestTopDocsCollector extends LuceneTestCase {
               .build()
         };
     for (Query query : queries) {
-      TopDocs tdc2 =  doSearchWithThreshold(5, 0, query, indexReader);
+      TopDocs tdc2 = doSearchWithThreshold(5, 0, query, indexReader);
       TopDocs tdc = doConcurrentSearchWithThreshold(5, 0, query, indexReader);
 
       assertTrue(tdc.totalHits.value > 0);

--- a/lucene/queries/src/test/org/apache/lucene/queries/spans/TestBasics.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/spans/TestBasics.java
@@ -512,7 +512,8 @@ public class TestBasics extends LuceneTestCase {
     SpanQuery sq2 = new SpanTermQuery(new Term(FIELD, "clckwork"));
     query.add(sq1, BooleanClause.Occur.SHOULD);
     query.add(sq2, BooleanClause.Occur.SHOULD);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(1000, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(1000, null, Integer.MAX_VALUE);
     TopDocs topDocs = searcher.search(query.build(), manager);
     hits = topDocs.scoreDocs.length;
     for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
@@ -547,7 +548,8 @@ public class TestBasics extends LuceneTestCase {
                 new SpanTermQuery(new Term(FIELD, "clockwork")),
                 new SpanTermQuery(new Term(FIELD, "clckwork"))),
             1.0f);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(1000, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(1000, null, Integer.MAX_VALUE);
     TopDocs topDocs = searcher.search(query, manager);
     hits = topDocs.scoreDocs.length;
     for (ScoreDoc scoreDoc : topDocs.scoreDocs) {

--- a/lucene/queries/src/test/org/apache/lucene/queries/spans/TestBasics.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/spans/TestBasics.java
@@ -31,12 +31,14 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopScoreDocCollector;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
@@ -510,10 +512,10 @@ public class TestBasics extends LuceneTestCase {
     SpanQuery sq2 = new SpanTermQuery(new Term(FIELD, "clckwork"));
     query.add(sq1, BooleanClause.Occur.SHOULD);
     query.add(sq2, BooleanClause.Occur.SHOULD);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(1000, Integer.MAX_VALUE);
-    searcher.search(query.build(), collector);
-    hits = collector.topDocs().scoreDocs.length;
-    for (ScoreDoc scoreDoc : collector.topDocs().scoreDocs) {
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(1000, null, Integer.MAX_VALUE);
+    TopDocs topDocs = searcher.search(query.build(), manager);
+    hits = topDocs.scoreDocs.length;
+    for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
       System.out.println(scoreDoc.doc);
     }
     indexReader.close();
@@ -545,10 +547,10 @@ public class TestBasics extends LuceneTestCase {
                 new SpanTermQuery(new Term(FIELD, "clockwork")),
                 new SpanTermQuery(new Term(FIELD, "clckwork"))),
             1.0f);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(1000, Integer.MAX_VALUE);
-    searcher.search(query, collector);
-    hits = collector.topDocs().scoreDocs.length;
-    for (ScoreDoc scoreDoc : collector.topDocs().scoreDocs) {
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(1000, null, Integer.MAX_VALUE);
+    TopDocs topDocs = searcher.search(query, manager);
+    hits = topDocs.scoreDocs.length;
+    for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
       System.out.println(scoreDoc.doc);
     }
     indexReader.close();

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
@@ -153,7 +153,8 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
             .addField("g", 1f)
             .addTerm(new BytesRef("a"))
             .build();
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(
             Math.min(reader.numDocs(), Integer.MAX_VALUE), null, Integer.MAX_VALUE);
     TopDocs topDocs = searcher.search(query, manager);
     assertEquals(new TotalHits(11, TotalHits.Relation.EQUAL_TO), topDocs.totalHits);
@@ -232,7 +233,8 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
             .addTerm(new BytesRef("zoo"))
             .build();
 
-    CollectorManager<TopScoreDocCollector, TopDocs> completeManager = TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> completeManager =
+        TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
     searcher.search(query, completeManager);
 
     reader.close();
@@ -265,7 +267,8 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
 
     Similarity searchSimilarity = randomCompatibleSimilarity();
     searcher.setSimilarity(searchSimilarity);
-    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(10, null, 10);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager =
+        TopScoreDocCollector.createSharedManager(10, null, 10);
 
     CombinedFieldQuery query =
         new CombinedFieldQuery.Builder()
@@ -283,8 +286,7 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
             .addTerm(new BytesRef("value"))
             .build();
     IllegalArgumentException e =
-        expectThrows(
-            IllegalArgumentException.class, () -> searcher.search(invalidQuery, manager));
+        expectThrows(IllegalArgumentException.class, () -> searcher.search(invalidQuery, manager));
     assertTrue(e.getMessage().contains("requires norms to be consistent across fields"));
 
     reader.close();
@@ -496,11 +498,13 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
 
   private void checkExpectedHits(
       IndexSearcher searcher, int numHits, Query firstQuery, Query secondQuery) throws IOException {
-    CollectorManager<TopScoreDocCollector, TopDocs> firstManager = TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> firstManager =
+        TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
     TopDocs firstTopDocs = searcher.search(firstQuery, firstManager);
     assertEquals(numHits, firstTopDocs.totalHits.value);
 
-    CollectorManager<TopScoreDocCollector, TopDocs> secondManager = TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> secondManager =
+        TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
     TopDocs secondTopDocs = searcher.search(secondQuery, secondManager);
     CheckHits.checkEqual(firstQuery, secondTopDocs.scoreDocs, firstTopDocs.scoreDocs);
   }

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestCombinedFieldQuery.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.CollectionStatistics;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -152,11 +153,9 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
             .addField("g", 1f)
             .addTerm(new BytesRef("a"))
             .build();
-    TopScoreDocCollector collector =
-        TopScoreDocCollector.create(
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(
             Math.min(reader.numDocs(), Integer.MAX_VALUE), null, Integer.MAX_VALUE);
-    searcher.search(query, collector);
-    TopDocs topDocs = collector.topDocs();
+    TopDocs topDocs = searcher.search(query, manager);
     assertEquals(new TotalHits(11, TotalHits.Relation.EQUAL_TO), topDocs.totalHits);
     // All docs must have the same score
     for (int i = 0; i < topDocs.scoreDocs.length; ++i) {
@@ -233,9 +232,8 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
             .addTerm(new BytesRef("zoo"))
             .build();
 
-    TopScoreDocCollector completeCollector =
-        TopScoreDocCollector.create(numHits, null, Integer.MAX_VALUE);
-    searcher.search(query, completeCollector);
+    CollectorManager<TopScoreDocCollector, TopDocs> completeManager = TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
+    searcher.search(query, completeManager);
 
     reader.close();
     w.close();
@@ -267,7 +265,7 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
 
     Similarity searchSimilarity = randomCompatibleSimilarity();
     searcher.setSimilarity(searchSimilarity);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(10, null, 10);
+    CollectorManager<TopScoreDocCollector, TopDocs> manager = TopScoreDocCollector.createSharedManager(10, null, 10);
 
     CombinedFieldQuery query =
         new CombinedFieldQuery.Builder()
@@ -275,8 +273,7 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
             .addField("b", 1.0f)
             .addTerm(new BytesRef("value"))
             .build();
-    searcher.search(query, collector);
-    TopDocs topDocs = collector.topDocs();
+    TopDocs topDocs = searcher.search(query, manager);
     assertEquals(new TotalHits(2, TotalHits.Relation.EQUAL_TO), topDocs.totalHits);
 
     CombinedFieldQuery invalidQuery =
@@ -287,7 +284,7 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
             .build();
     IllegalArgumentException e =
         expectThrows(
-            IllegalArgumentException.class, () -> searcher.search(invalidQuery, collector));
+            IllegalArgumentException.class, () -> searcher.search(invalidQuery, manager));
     assertTrue(e.getMessage().contains("requires norms to be consistent across fields"));
 
     reader.close();
@@ -499,16 +496,12 @@ public class TestCombinedFieldQuery extends LuceneTestCase {
 
   private void checkExpectedHits(
       IndexSearcher searcher, int numHits, Query firstQuery, Query secondQuery) throws IOException {
-    TopScoreDocCollector firstCollector =
-        TopScoreDocCollector.create(numHits, null, Integer.MAX_VALUE);
-    searcher.search(firstQuery, firstCollector);
-    TopDocs firstTopDocs = firstCollector.topDocs();
+    CollectorManager<TopScoreDocCollector, TopDocs> firstManager = TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
+    TopDocs firstTopDocs = searcher.search(firstQuery, firstManager);
     assertEquals(numHits, firstTopDocs.totalHits.value);
 
-    TopScoreDocCollector secondCollector =
-        TopScoreDocCollector.create(numHits, null, Integer.MAX_VALUE);
-    searcher.search(secondQuery, secondCollector);
-    TopDocs secondTopDocs = secondCollector.topDocs();
+    CollectorManager<TopScoreDocCollector, TopDocs> secondManager = TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
+    TopDocs secondTopDocs = searcher.search(secondQuery, secondManager);
     CheckHits.checkEqual(firstQuery, secondTopDocs.scoreDocs, firstTopDocs.scoreDocs);
   }
 

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestLargeNumHitsTopDocsCollector.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestLargeNumHitsTopDocsCollector.java
@@ -24,6 +24,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
@@ -83,13 +84,12 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
   public void testIllegalArguments() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
     LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(15);
-    TopScoreDocCollector regularCollector =
-        TopScoreDocCollector.create(15, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> regularManager = TopScoreDocCollector.createSharedManager(15, null, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
-    searcher.search(testQuery, regularCollector);
+    TopDocs regular = searcher.search(testQuery, regularManager);
 
-    assertEquals(largeCollector.totalHits, regularCollector.getTotalHits());
+    assertEquals(largeCollector.totalHits, regular.totalHits.value);
 
     IllegalArgumentException expected =
         expectThrows(
@@ -104,46 +104,43 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
   public void testNoPQBuild() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
     LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(250_000);
-    TopScoreDocCollector regularCollector =
-        TopScoreDocCollector.create(250_000, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> regularManager = TopScoreDocCollector.createSharedManager(250_000, null, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
-    searcher.search(testQuery, regularCollector);
+    TopDocs regular = searcher.search(testQuery, regularManager);
 
-    assertEquals(largeCollector.totalHits, regularCollector.getTotalHits());
+    assertEquals(largeCollector.totalHits, regular.totalHits.value);
 
-    assertEquals(largeCollector.pq, null);
-    assertEquals(largeCollector.pqTop, null);
+    assertNull(largeCollector.pq);
+    assertNull(largeCollector.pqTop);
   }
 
   public void testPQBuild() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
     LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(50);
-    TopScoreDocCollector regularCollector =
-        TopScoreDocCollector.create(50, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> regularManager = TopScoreDocCollector.createSharedManager(50, null, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
-    searcher.search(testQuery, regularCollector);
+    TopDocs regular = searcher.search(testQuery, regularManager);
 
-    assertEquals(largeCollector.totalHits, regularCollector.getTotalHits());
+    assertEquals(largeCollector.totalHits, regular.totalHits.value);
 
-    assertNotEquals(largeCollector.pq, null);
-    assertNotEquals(largeCollector.pqTop, null);
+    assertNotNull(largeCollector.pq);
+    assertNotNull(largeCollector.pqTop);
   }
 
   public void testNoPQHitsOrder() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
     LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(250_000);
-    TopScoreDocCollector regularCollector =
-        TopScoreDocCollector.create(250_000, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> regularManager = TopScoreDocCollector.createSharedManager(250_000, null, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
-    searcher.search(testQuery, regularCollector);
+    TopDocs regular = searcher.search(testQuery, regularManager);
 
-    assertEquals(largeCollector.totalHits, regularCollector.getTotalHits());
+    assertEquals(largeCollector.totalHits, regular.totalHits.value);
 
-    assertEquals(largeCollector.pq, null);
-    assertEquals(largeCollector.pqTop, null);
+    assertNull(largeCollector.pq);
+    assertNull(largeCollector.pqTop);
 
     TopDocs topDocs = largeCollector.topDocs();
 
@@ -159,16 +156,14 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
   private void runNumHits(int numHits) throws IOException {
     IndexSearcher searcher = newSearcher(reader);
     LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(numHits);
-    TopScoreDocCollector regularCollector =
-        TopScoreDocCollector.create(numHits, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> regularManager = TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
-    searcher.search(testQuery, regularCollector);
+    TopDocs secondTopDocs = searcher.search(testQuery, regularManager);
 
-    assertEquals(largeCollector.totalHits, regularCollector.getTotalHits());
+    assertEquals(largeCollector.totalHits, secondTopDocs.totalHits.value);
 
     TopDocs firstTopDocs = largeCollector.topDocs();
-    TopDocs secondTopDocs = regularCollector.topDocs();
 
     assertEquals(firstTopDocs.scoreDocs.length, secondTopDocs.scoreDocs.length);
 

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestLargeNumHitsTopDocsCollector.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestLargeNumHitsTopDocsCollector.java
@@ -84,7 +84,8 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
   public void testIllegalArguments() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
     LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(15);
-    CollectorManager<TopScoreDocCollector, TopDocs> regularManager = TopScoreDocCollector.createSharedManager(15, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> regularManager =
+        TopScoreDocCollector.createSharedManager(15, null, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
     TopDocs regular = searcher.search(testQuery, regularManager);
@@ -104,7 +105,8 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
   public void testNoPQBuild() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
     LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(250_000);
-    CollectorManager<TopScoreDocCollector, TopDocs> regularManager = TopScoreDocCollector.createSharedManager(250_000, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> regularManager =
+        TopScoreDocCollector.createSharedManager(250_000, null, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
     TopDocs regular = searcher.search(testQuery, regularManager);
@@ -118,7 +120,8 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
   public void testPQBuild() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
     LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(50);
-    CollectorManager<TopScoreDocCollector, TopDocs> regularManager = TopScoreDocCollector.createSharedManager(50, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> regularManager =
+        TopScoreDocCollector.createSharedManager(50, null, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
     TopDocs regular = searcher.search(testQuery, regularManager);
@@ -132,7 +135,8 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
   public void testNoPQHitsOrder() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
     LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(250_000);
-    CollectorManager<TopScoreDocCollector, TopDocs> regularManager = TopScoreDocCollector.createSharedManager(250_000, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> regularManager =
+        TopScoreDocCollector.createSharedManager(250_000, null, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
     TopDocs regular = searcher.search(testQuery, regularManager);
@@ -156,7 +160,8 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
   private void runNumHits(int numHits) throws IOException {
     IndexSearcher searcher = newSearcher(reader);
     LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(numHits);
-    CollectorManager<TopScoreDocCollector, TopDocs> regularManager = TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
+    CollectorManager<TopScoreDocCollector, TopDocs> regularManager =
+        TopScoreDocCollector.createSharedManager(numHits, null, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
     TopDocs secondTopDocs = searcher.search(testQuery, regularManager);


### PR DESCRIPTION
This is another one of many steps towards resolution of LUCENE-10002. In the effort or replacing usages of IndexSearcher#search(Query, Collector) with IndexSearcher#search(Query, CollectorManager), this commit replaces many test usages of TopScoreDocCollector with its corresponding CollectorManager created by calling TopScoreDocCollector#createSharedManager.


# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes. (not applicable)