### PR TITLE
LUCENE-10450: IndexSortSortedNumericDocValuesRangeQuery could be rewrite to MatchAllDocsQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -243,6 +243,8 @@ Optimizations
 * LUCENE-10442: When indexQuery or/and dvQuery be a MatchAllDocsQuery
   then IndexOrDocValuesQuery should be rewrite to MatchAllDocsQuery. (Lu Xugang)
 
+* LUCENE-10450: IndexSortSortedNumericDocValuesRangeQuery could be rewrite to MatchAllDocsQuery. (Lu Xugang)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LeafFieldComparator;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
@@ -140,6 +141,9 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
     }
 
     Query rewrittenFallback = fallbackQuery.rewrite(reader);
+    if (rewrittenFallback.getClass() == MatchAllDocsQuery.class) {
+      return new MatchAllDocsQuery();
+    }
     if (rewrittenFallback == fallbackQuery) {
       return this;
     } else {


### PR DESCRIPTION
I see IndexOrDocValuesQuery as a fallbackQuery of IndexSortSortedNumericDocValuesRangeQuery in Elasticsearch, so After [LUCENE-10442](https://issues.apache.org/jira/browse/LUCENE-10442), we should rewrite IndexSortSortedNumericDocValuesRangeQuery to MatchAllDocsQuery if fallbackQuery could be as MatchAllDocsQuery?