### PR TITLE
LUCENE-10431: Deprecate MultiTermQuery.setRewriteMethod()

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -99,6 +99,9 @@ API Changes
 * LUCENE-10440: TaxonomyFacets and FloatTaxonomyFacets have been deprecated and are no longer
   supported extension points for user-created faceting implementations. (Greg Miller)
 
+* LUCENE-10431: MultiTermQuery.setRewriteMethod() has been deprecated, and constructor
+  parameters for the various implementations added. (Alan Woodward)
+
 New Features
 ---------------------
 

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/EnwikiQueryMaker.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/EnwikiQueryMaker.java
@@ -130,8 +130,8 @@ public class EnwikiQueryMaker extends AbstractQueryMaker {
   };
 
   private static Query[] getPrebuiltQueries(String field) {
-    WildcardQuery wcq = new WildcardQuery(new Term(field, "fo*"));
-    wcq.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    WildcardQuery wcq =
+        new WildcardQuery(new Term(field, "fo*"), MultiTermQuery.CONSTANT_SCORE_REWRITE);
     // be wary of unanalyzed text
     return new Query[] {
       new SpanFirstQuery(new SpanTermQuery(new Term(field, "ford")), 5),

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/EnwikiQueryMaker.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/EnwikiQueryMaker.java
@@ -31,6 +31,7 @@ import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.automaton.Operations;
 
 /**
  * A QueryMaker that uses common and uncommon actual Wikipedia queries for searching the English
@@ -131,7 +132,10 @@ public class EnwikiQueryMaker extends AbstractQueryMaker {
 
   private static Query[] getPrebuiltQueries(String field) {
     WildcardQuery wcq =
-        new WildcardQuery(new Term(field, "fo*"), MultiTermQuery.CONSTANT_SCORE_REWRITE);
+        new WildcardQuery(
+            new Term(field, "fo*"),
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            MultiTermQuery.CONSTANT_SCORE_REWRITE);
     // be wary of unanalyzed text
     return new Query[] {
       new SpanFirstQuery(new SpanTermQuery(new Term(field, "ford")), 5),

--- a/lucene/core/src/java/org/apache/lucene/search/AutomatonQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AutomatonQuery.java
@@ -76,7 +76,22 @@ public class AutomatonQuery extends MultiTermQuery implements Accountable {
    *     UTF32ToUTF8 conversion
    */
   public AutomatonQuery(final Term term, Automaton automaton, boolean isBinary) {
-    super(term.field());
+    this(term, automaton, isBinary, CONSTANT_SCORE_REWRITE);
+  }
+
+  /**
+   * Create a new AutomatonQuery from an {@link Automaton}.
+   *
+   * @param term Term containing field and possibly some pattern structure. The term text is
+   *     ignored.
+   * @param automaton Automaton to run, terms that are accepted are considered a match.
+   * @param isBinary if true, this automaton is already binary and will not go through the
+   *     UTF32ToUTF8 conversion
+   * @param rewriteMethod the rewriteMethod to use to build the final query from the automaton
+   */
+  public AutomatonQuery(
+      final Term term, Automaton automaton, boolean isBinary, RewriteMethod rewriteMethod) {
+    super(term.field(), rewriteMethod);
     this.term = term;
     this.automaton = automaton;
     this.automatonIsBinary = isBinary;

--- a/lucene/core/src/java/org/apache/lucene/search/FuzzyQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FuzzyQuery.java
@@ -56,6 +56,7 @@ public class FuzzyQuery extends MultiTermQuery {
   public static final int defaultMaxExpansions = 50;
   public static final boolean defaultTranspositions = true;
 
+  /** Creates a default top-terms blended frequency scoring rewrite with the given max expansions */
   public static RewriteMethod defaultRewriteMethod(int maxExpansions) {
     return new MultiTermQuery.TopTermsBlendedFreqScoringRewrite(maxExpansions);
   }
@@ -138,38 +139,9 @@ public class FuzzyQuery extends MultiTermQuery {
     this(term, maxEdits, defaultPrefixLength);
   }
 
-  /**
-   * Calls {@link #FuzzyQuery(Term, int, int, int, boolean,
-   * org.apache.lucene.search.MultiTermQuery.RewriteMethod) FuzzyQuery(term, maxEdits,
-   * defaultPrefixLength, defaultMaxExpansions, defaultTransitions, defaultRewriteMethod)}.
-   */
-  public FuzzyQuery(Term term, int maxEdits, RewriteMethod rewriteMethod) {
-    this(
-        term,
-        maxEdits,
-        defaultPrefixLength,
-        defaultMaxExpansions,
-        defaultTranspositions,
-        rewriteMethod);
-  }
-
   /** Calls {@link #FuzzyQuery(Term, int) FuzzyQuery(term, defaultMaxEdits)}. */
   public FuzzyQuery(Term term) {
     this(term, defaultMaxEdits);
-  }
-
-  /**
-   * Creates a new FuzzyQuery with default max edits, prefix length, max expansions and
-   * transpositions
-   */
-  public FuzzyQuery(Term term, RewriteMethod rewriteMethod) {
-    this(
-        term,
-        defaultMaxEdits,
-        defaultPrefixLength,
-        defaultMaxExpansions,
-        defaultTranspositions,
-        rewriteMethod);
   }
 
   /** @return the maximum number of edit distances allowed for this query to match. */

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -52,7 +52,7 @@ import org.apache.lucene.util.AttributeSource;
  */
 public abstract class MultiTermQuery extends Query {
   protected final String field;
-  protected RewriteMethod rewriteMethod;
+  protected RewriteMethod rewriteMethod; // TODO make this final
 
   /** Abstract class that defines how the query is rewritten. */
   public abstract static class RewriteMethod {

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -36,10 +36,10 @@ import org.apache.lucene.util.AttributeSource;
  * #getTermsEnum(Terms,AttributeSource)} to provide a {@link FilteredTermsEnum} that iterates
  * through the terms to be matched.
  *
- * <p><b>NOTE</b>: if {@link #setRewriteMethod} is either {@link #CONSTANT_SCORE_BOOLEAN_REWRITE} or
+ * <p><b>NOTE</b>: if {@link RewriteMethod} is either {@link #CONSTANT_SCORE_BOOLEAN_REWRITE} or
  * {@link #SCORING_BOOLEAN_REWRITE}, you may encounter a {@link IndexSearcher.TooManyClauses}
  * exception during searching, which happens when the number of terms to be searched exceeds {@link
- * IndexSearcher#getMaxClauseCount()}. Setting {@link #setRewriteMethod} to {@link
+ * IndexSearcher#getMaxClauseCount()}. Setting {@link RewriteMethod} to {@link
  * #CONSTANT_SCORE_REWRITE} prevents this.
  *
  * <p>The recommended rewrite method is {@link #CONSTANT_SCORE_REWRITE}: it doesn't spend CPU
@@ -52,7 +52,7 @@ import org.apache.lucene.util.AttributeSource;
  */
 public abstract class MultiTermQuery extends Query {
   protected final String field;
-  protected RewriteMethod rewriteMethod = CONSTANT_SCORE_REWRITE;
+  protected RewriteMethod rewriteMethod;
 
   /** Abstract class that defines how the query is rewritten. */
   public abstract static class RewriteMethod {
@@ -77,8 +77,6 @@ public abstract class MultiTermQuery extends Query {
    * <p>This method is faster than the BooleanQuery rewrite methods when the number of matched terms
    * or matched documents is non-trivial. Also, it will never hit an errant {@link
    * IndexSearcher.TooManyClauses} exception.
-   *
-   * @see #setRewriteMethod
    */
   public static final RewriteMethod CONSTANT_SCORE_REWRITE =
       new RewriteMethod() {
@@ -96,8 +94,6 @@ public abstract class MultiTermQuery extends Query {
    *
    * <p><b>NOTE</b>: This rewrite method will hit {@link IndexSearcher.TooManyClauses} if the number
    * of terms exceeds {@link IndexSearcher#getMaxClauseCount}.
-   *
-   * @see #setRewriteMethod
    */
   public static final RewriteMethod SCORING_BOOLEAN_REWRITE =
       ScoringRewrite.SCORING_BOOLEAN_REWRITE;
@@ -108,8 +104,6 @@ public abstract class MultiTermQuery extends Query {
    *
    * <p><b>NOTE</b>: This rewrite method will hit {@link IndexSearcher.TooManyClauses} if the number
    * of terms exceeds {@link IndexSearcher#getMaxClauseCount}.
-   *
-   * @see #setRewriteMethod
    */
   public static final RewriteMethod CONSTANT_SCORE_BOOLEAN_REWRITE =
       ScoringRewrite.CONSTANT_SCORE_BOOLEAN_REWRITE;
@@ -120,8 +114,6 @@ public abstract class MultiTermQuery extends Query {
    *
    * <p>This rewrite method only uses the top scoring terms so it will not overflow the boolean max
    * clause count.
-   *
-   * @see #setRewriteMethod
    */
   public static final class TopTermsScoringBooleanQueryRewrite
       extends TopTermsRewrite<BooleanQuery.Builder> {
@@ -167,8 +159,6 @@ public abstract class MultiTermQuery extends Query {
    *
    * <p>This rewrite method only uses the top scoring terms so it will not overflow the boolean max
    * clause count.
-   *
-   * @see #setRewriteMethod
    */
   public static final class TopTermsBlendedFreqScoringRewrite
       extends TopTermsRewrite<BlendedTermQuery.Builder> {
@@ -217,8 +207,6 @@ public abstract class MultiTermQuery extends Query {
    *
    * <p>This rewrite method only uses the top scoring terms so it will not overflow the boolean max
    * clause count.
-   *
-   * @see #setRewriteMethod
    */
   public static final class TopTermsBoostOnlyBooleanQueryRewrite
       extends TopTermsRewrite<BooleanQuery.Builder> {
@@ -257,8 +245,9 @@ public abstract class MultiTermQuery extends Query {
   }
 
   /** Constructs a query matching terms that cannot be represented with a single Term. */
-  public MultiTermQuery(final String field) {
+  public MultiTermQuery(final String field, RewriteMethod rewriteMethod) {
     this.field = Objects.requireNonNull(field, "field must not be null");
+    this.rewriteMethod = Objects.requireNonNull(rewriteMethod, "rewriteMethod must not be null");
   }
 
   /** Returns the field name for this query */
@@ -294,7 +283,6 @@ public abstract class MultiTermQuery extends Query {
     return rewriteMethod.rewrite(reader, this);
   }
 
-  /** @see #setRewriteMethod */
   public RewriteMethod getRewriteMethod() {
     return rewriteMethod;
   }
@@ -302,7 +290,10 @@ public abstract class MultiTermQuery extends Query {
   /**
    * Sets the rewrite method to be used when executing the query. You can use one of the four core
    * methods, or implement your own subclass of {@link RewriteMethod}.
+   *
+   * @deprecated set this using a constructor instead
    */
+  @Deprecated
   public void setRewriteMethod(RewriteMethod method) {
     rewriteMethod = method;
   }

--- a/lucene/core/src/java/org/apache/lucene/search/PrefixQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PrefixQuery.java
@@ -30,7 +30,14 @@ public class PrefixQuery extends AutomatonQuery {
 
   /** Constructs a query for terms starting with <code>prefix</code>. */
   public PrefixQuery(Term prefix) {
-    super(prefix, toAutomaton(prefix.bytes()), true);
+    this(prefix, CONSTANT_SCORE_REWRITE);
+  }
+
+  /**
+   * Constructs a query for terms starting with <code>prefix</code> using a defined RewriteMethod
+   */
+  public PrefixQuery(Term prefix, RewriteMethod rewriteMethod) {
+    super(prefix, toAutomaton(prefix.bytes()), true, rewriteMethod);
   }
 
   /** Build an automaton accepting all terms with the specified prefix. */

--- a/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.search;
 
 import org.apache.lucene.index.Term;
-import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.AutomatonProvider;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
@@ -42,14 +41,9 @@ import org.apache.lucene.util.automaton.RegExp;
  * @lucene.experimental
  */
 public class RegexpQuery extends AutomatonQuery {
+
   /** A provider that provides no named automata */
-  private static AutomatonProvider defaultProvider =
-      new AutomatonProvider() {
-        @Override
-        public Automaton getAutomaton(String name) {
-          return null;
-        }
-      };
+  public static final AutomatonProvider DEFAULT_PROVIDER = name -> null;
 
   /**
    * Constructs a query for terms matching <code>term</code>.
@@ -65,40 +59,11 @@ public class RegexpQuery extends AutomatonQuery {
   /**
    * Constructs a query for terms matching <code>term</code>.
    *
-   * <p>By default, all regular expression features are enabled.
-   *
-   * @param term regular expression.
-   * @param rewriteMethod the rewrite method used to build the final query
-   */
-  public RegexpQuery(Term term, RewriteMethod rewriteMethod) {
-    this(
-        term,
-        RegExp.ALL,
-        0,
-        defaultProvider,
-        Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
-        rewriteMethod);
-  }
-
-  /**
-   * Constructs a query for terms matching <code>term</code>.
-   *
    * @param term regular expression.
    * @param flags optional RegExp features from {@link RegExp}
    */
   public RegexpQuery(Term term, int flags) {
-    this(term, flags, defaultProvider, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
-  }
-
-  /**
-   * Constructs a query for terms matching <code>term</code>.
-   *
-   * @param term regular expression.
-   * @param flags optional RegExp features from {@link RegExp}
-   * @param rewriteMethod the rewrite method to use to build the final query
-   */
-  public RegexpQuery(Term term, int flags, RewriteMethod rewriteMethod) {
-    this(term, flags, 0, defaultProvider, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, rewriteMethod);
+    this(term, flags, DEFAULT_PROVIDER, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
   }
 
   /**
@@ -112,22 +77,7 @@ public class RegexpQuery extends AutomatonQuery {
    *     otherwise know what to specify.
    */
   public RegexpQuery(Term term, int flags, int determinizeWorkLimit) {
-    this(term, flags, defaultProvider, determinizeWorkLimit);
-  }
-
-  /**
-   * Constructs a query for terms matching <code>term</code>.
-   *
-   * @param term regular expression.
-   * @param flags optional RegExp syntax features from {@link RegExp}
-   * @param determinizeWorkLimit maximum effort to spend while compiling the automaton from this
-   *     regexp. Set higher to allow more complex queries and lower to prevent memory exhaustion.
-   *     Use {@link Operations#DEFAULT_DETERMINIZE_WORK_LIMIT} as a decent default if you don't
-   *     otherwise know what to specify.
-   * @param rewriteMethod the rewrite method to use to build the final query
-   */
-  public RegexpQuery(Term term, int flags, int determinizeWorkLimit, RewriteMethod rewriteMethod) {
-    this(term, flags, 0, defaultProvider, determinizeWorkLimit, rewriteMethod);
+    this(term, flags, DEFAULT_PROVIDER, determinizeWorkLimit);
   }
 
   /**
@@ -148,7 +98,7 @@ public class RegexpQuery extends AutomatonQuery {
         term,
         syntax_flags,
         match_flags,
-        defaultProvider,
+        DEFAULT_PROVIDER,
         determinizeWorkLimit,
         CONSTANT_SCORE_REWRITE);
   }

--- a/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
@@ -65,11 +65,40 @@ public class RegexpQuery extends AutomatonQuery {
   /**
    * Constructs a query for terms matching <code>term</code>.
    *
+   * <p>By default, all regular expression features are enabled.
+   *
+   * @param term regular expression.
+   * @param rewriteMethod the rewrite method used to build the final query
+   */
+  public RegexpQuery(Term term, RewriteMethod rewriteMethod) {
+    this(
+        term,
+        RegExp.ALL,
+        0,
+        defaultProvider,
+        Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+        rewriteMethod);
+  }
+
+  /**
+   * Constructs a query for terms matching <code>term</code>.
+   *
    * @param term regular expression.
    * @param flags optional RegExp features from {@link RegExp}
    */
   public RegexpQuery(Term term, int flags) {
     this(term, flags, defaultProvider, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+  }
+
+  /**
+   * Constructs a query for terms matching <code>term</code>.
+   *
+   * @param term regular expression.
+   * @param flags optional RegExp features from {@link RegExp}
+   * @param rewriteMethod the rewrite method to use to build the final query
+   */
+  public RegexpQuery(Term term, int flags, RewriteMethod rewriteMethod) {
+    this(term, flags, 0, defaultProvider, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, rewriteMethod);
   }
 
   /**
@@ -90,6 +119,21 @@ public class RegexpQuery extends AutomatonQuery {
    * Constructs a query for terms matching <code>term</code>.
    *
    * @param term regular expression.
+   * @param flags optional RegExp syntax features from {@link RegExp}
+   * @param determinizeWorkLimit maximum effort to spend while compiling the automaton from this
+   *     regexp. Set higher to allow more complex queries and lower to prevent memory exhaustion.
+   *     Use {@link Operations#DEFAULT_DETERMINIZE_WORK_LIMIT} as a decent default if you don't
+   *     otherwise know what to specify.
+   * @param rewriteMethod the rewrite method to use to build the final query
+   */
+  public RegexpQuery(Term term, int flags, int determinizeWorkLimit, RewriteMethod rewriteMethod) {
+    this(term, flags, 0, defaultProvider, determinizeWorkLimit, rewriteMethod);
+  }
+
+  /**
+   * Constructs a query for terms matching <code>term</code>.
+   *
+   * @param term regular expression.
    * @param syntax_flags optional RegExp syntax features from {@link RegExp} automaton for the
    *     regexp can result in. Set higher to allow more complex queries and lower to prevent memory
    *     exhaustion.
@@ -100,7 +144,13 @@ public class RegexpQuery extends AutomatonQuery {
    *     otherwise know what to specify.
    */
   public RegexpQuery(Term term, int syntax_flags, int match_flags, int determinizeWorkLimit) {
-    this(term, syntax_flags, match_flags, defaultProvider, determinizeWorkLimit);
+    this(
+        term,
+        syntax_flags,
+        match_flags,
+        defaultProvider,
+        determinizeWorkLimit,
+        CONSTANT_SCORE_REWRITE);
   }
 
   /**
@@ -116,7 +166,7 @@ public class RegexpQuery extends AutomatonQuery {
    */
   public RegexpQuery(
       Term term, int syntax_flags, AutomatonProvider provider, int determinizeWorkLimit) {
-    this(term, syntax_flags, 0, provider, determinizeWorkLimit);
+    this(term, syntax_flags, 0, provider, determinizeWorkLimit, CONSTANT_SCORE_REWRITE);
   }
 
   /**
@@ -130,18 +180,22 @@ public class RegexpQuery extends AutomatonQuery {
    *     regexp. Set higher to allow more complex queries and lower to prevent memory exhaustion.
    *     Use {@link Operations#DEFAULT_DETERMINIZE_WORK_LIMIT} as a decent default if you don't
    *     otherwise know what to specify.
+   * @param rewriteMethod the rewrite method to use to build the final query
    */
   public RegexpQuery(
       Term term,
       int syntax_flags,
       int match_flags,
       AutomatonProvider provider,
-      int determinizeWorkLimit) {
+      int determinizeWorkLimit,
+      RewriteMethod rewriteMethod) {
     super(
         term,
         Operations.determinize(
             new RegExp(term.text(), syntax_flags, match_flags).toAutomaton(provider),
-            determinizeWorkLimit));
+            determinizeWorkLimit),
+        false,
+        rewriteMethod);
   }
 
   /** Returns the regexp of this query wrapped in a Term. */

--- a/lucene/core/src/java/org/apache/lucene/search/ScoringRewrite.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScoringRewrite.java
@@ -46,8 +46,6 @@ public abstract class ScoringRewrite<B> extends TermCollectingRewrite<B> {
    *
    * <p><b>NOTE</b>: This rewrite method will hit {@link IndexSearcher.TooManyClauses} if the number
    * of terms exceeds {@link IndexSearcher#getMaxClauseCount}.
-   *
-   * @see MultiTermQuery#setRewriteMethod
    */
   public static final ScoringRewrite<BooleanQuery.Builder> SCORING_BOOLEAN_REWRITE =
       new ScoringRewrite<BooleanQuery.Builder>() {
@@ -84,8 +82,6 @@ public abstract class ScoringRewrite<B> extends TermCollectingRewrite<B> {
    *
    * <p><b>NOTE</b>: This rewrite method will hit {@link IndexSearcher.TooManyClauses} if the number
    * of terms exceeds {@link IndexSearcher#getMaxClauseCount}.
-   *
-   * @see MultiTermQuery#setRewriteMethod
    */
   public static final RewriteMethod CONSTANT_SCORE_BOOLEAN_REWRITE =
       new RewriteMethod() {

--- a/lucene/core/src/java/org/apache/lucene/search/TermRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermRangeQuery.java
@@ -60,10 +60,36 @@ public class TermRangeQuery extends AutomatonQuery {
       BytesRef upperTerm,
       boolean includeLower,
       boolean includeUpper) {
+    this(field, lowerTerm, upperTerm, includeLower, includeUpper, CONSTANT_SCORE_REWRITE);
+  }
+
+  /**
+   * Constructs a query selecting all terms greater/equal than <code>lowerTerm</code> but less/equal
+   * than <code>upperTerm</code>.
+   *
+   * <p>If an endpoint is null, it is said to be "open". Either or both endpoints may be open. Open
+   * endpoints may not be exclusive (you can't select all but the first or last term without
+   * explicitly specifying the term to exclude.)
+   *
+   * @param field The field that holds both lower and upper terms.
+   * @param lowerTerm The term text at the lower end of the range
+   * @param upperTerm The term text at the upper end of the range
+   * @param includeLower If true, the <code>lowerTerm</code> is included in the range.
+   * @param includeUpper If true, the <code>upperTerm</code> is included in the range.
+   * @param rewriteMethod the rewrite method to use when building the final query
+   */
+  public TermRangeQuery(
+      String field,
+      BytesRef lowerTerm,
+      BytesRef upperTerm,
+      boolean includeLower,
+      boolean includeUpper,
+      RewriteMethod rewriteMethod) {
     super(
         new Term(field, lowerTerm),
         toAutomaton(lowerTerm, upperTerm, includeLower, includeUpper),
-        true);
+        true,
+        rewriteMethod);
     this.lowerTerm = lowerTerm;
     this.upperTerm = upperTerm;
     this.includeLower = includeLower;
@@ -93,9 +119,21 @@ public class TermRangeQuery extends AutomatonQuery {
       String upperTerm,
       boolean includeLower,
       boolean includeUpper) {
+    return newStringRange(
+        field, lowerTerm, upperTerm, includeLower, includeUpper, CONSTANT_SCORE_REWRITE);
+  }
+
+  /** Factory that creates a new TermRangeQuery using Strings for term text. */
+  public static TermRangeQuery newStringRange(
+      String field,
+      String lowerTerm,
+      String upperTerm,
+      boolean includeLower,
+      boolean includeUpper,
+      RewriteMethod rewriteMethod) {
     BytesRef lower = lowerTerm == null ? null : new BytesRef(lowerTerm);
     BytesRef upper = upperTerm == null ? null : new BytesRef(upperTerm);
-    return new TermRangeQuery(field, lower, upper, includeLower, includeUpper);
+    return new TermRangeQuery(field, lower, upper, includeLower, includeUpper, rewriteMethod);
   }
 
   /** Returns the lower value of this range query */

--- a/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
@@ -59,7 +59,25 @@ public class WildcardQuery extends AutomatonQuery {
    *     otherwise know what to specify.
    */
   public WildcardQuery(Term term, int determinizeWorkLimit) {
-    super(term, toAutomaton(term, determinizeWorkLimit));
+    this(term, determinizeWorkLimit, CONSTANT_SCORE_REWRITE);
+  }
+
+  /** Constructs a query for terms matching <code>term</code> using a defined rewrite method */
+  public WildcardQuery(Term term, RewriteMethod rewriteMethod) {
+    this(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, rewriteMethod);
+  }
+
+  /**
+   * Constructs a query for terms matching <code>term</code>.
+   *
+   * @param determinizeWorkLimit maximum effort to spend while compiling the automaton from this
+   *     wildcard. Set higher to allow more complex queries and lower to prevent memory exhaustion.
+   *     Use {@link Operations#DEFAULT_DETERMINIZE_WORK_LIMIT} as a decent default if you don't
+   *     otherwise know what to specify.
+   * @param rewriteMethod the rewrite method to use when building the final query
+   */
+  public WildcardQuery(Term term, int determinizeWorkLimit, RewriteMethod rewriteMethod) {
+    super(term, toAutomaton(term, determinizeWorkLimit), false, rewriteMethod);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
@@ -62,11 +62,6 @@ public class WildcardQuery extends AutomatonQuery {
     this(term, determinizeWorkLimit, CONSTANT_SCORE_REWRITE);
   }
 
-  /** Constructs a query for terms matching <code>term</code> using a defined rewrite method */
-  public WildcardQuery(Term term, RewriteMethod rewriteMethod) {
-    this(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, rewriteMethod);
-  }
-
   /**
    * Constructs a query for terms matching <code>term</code>.
    *

--- a/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQuery.java
@@ -91,16 +91,24 @@ public class TestAutomatonQuery extends LuceneTestCase {
   }
 
   private void assertAutomatonHits(int expected, Automaton automaton) throws IOException {
-    AutomatonQuery query = new AutomatonQuery(newTerm("bogus"), automaton);
-
-    query.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-    assertEquals(expected, automatonQueryNrHits(query));
-
-    query.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
-    assertEquals(expected, automatonQueryNrHits(query));
-
-    query.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE);
-    assertEquals(expected, automatonQueryNrHits(query));
+    assertEquals(
+        expected,
+        automatonQueryNrHits(
+            new AutomatonQuery(
+                newTerm("bogus"), automaton, false, MultiTermQuery.SCORING_BOOLEAN_REWRITE)));
+    assertEquals(
+        expected,
+        automatonQueryNrHits(
+            new AutomatonQuery(
+                newTerm("bogus"), automaton, false, MultiTermQuery.CONSTANT_SCORE_REWRITE)));
+    assertEquals(
+        expected,
+        automatonQueryNrHits(
+            new AutomatonQuery(
+                newTerm("bogus"),
+                automaton,
+                false,
+                MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE)));
   }
 
   /** Test some very simple automata. */

--- a/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQueryUnicode.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQueryUnicode.java
@@ -97,16 +97,24 @@ public class TestAutomatonQueryUnicode extends LuceneTestCase {
   }
 
   private void assertAutomatonHits(int expected, Automaton automaton) throws IOException {
-    AutomatonQuery query = new AutomatonQuery(newTerm("bogus"), automaton);
-
-    query.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-    assertEquals(expected, automatonQueryNrHits(query));
-
-    query.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
-    assertEquals(expected, automatonQueryNrHits(query));
-
-    query.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE);
-    assertEquals(expected, automatonQueryNrHits(query));
+    assertEquals(
+        expected,
+        automatonQueryNrHits(
+            new AutomatonQuery(
+                newTerm("bogus"), automaton, false, MultiTermQuery.SCORING_BOOLEAN_REWRITE)));
+    assertEquals(
+        expected,
+        automatonQueryNrHits(
+            new AutomatonQuery(
+                newTerm("bogus"), automaton, false, MultiTermQuery.CONSTANT_SCORE_REWRITE)));
+    assertEquals(
+        expected,
+        automatonQueryNrHits(
+            new AutomatonQuery(
+                newTerm("bogus"),
+                automaton,
+                false,
+                MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE)));
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -47,6 +47,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.NamedThreadFactory;
+import org.apache.lucene.util.automaton.Operations;
 
 public class TestBooleanQuery extends LuceneTestCase {
 
@@ -255,7 +256,10 @@ public class TestBooleanQuery extends LuceneTestCase {
     BooleanQuery.Builder query = new BooleanQuery.Builder(); // Query: +foo -ba*
     query.add(new TermQuery(new Term("field", "foo")), BooleanClause.Occur.MUST);
     WildcardQuery wildcardQuery =
-        new WildcardQuery(new Term("field", "ba*"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+        new WildcardQuery(
+            new Term("field", "ba*"),
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            MultiTermQuery.SCORING_BOOLEAN_REWRITE);
     query.add(wildcardQuery, BooleanClause.Occur.MUST_NOT);
 
     MultiReader multireader = new MultiReader(reader1, reader2);

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -254,8 +254,8 @@ public class TestBooleanQuery extends LuceneTestCase {
 
     BooleanQuery.Builder query = new BooleanQuery.Builder(); // Query: +foo -ba*
     query.add(new TermQuery(new Term("field", "foo")), BooleanClause.Occur.MUST);
-    WildcardQuery wildcardQuery = new WildcardQuery(new Term("field", "ba*"));
-    wildcardQuery.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+    WildcardQuery wildcardQuery =
+        new WildcardQuery(new Term("field", "ba*"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
     query.add(wildcardQuery, BooleanClause.Occur.MUST_NOT);
 
     MultiReader multireader = new MultiReader(reader1, reader2);

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRewriteMethod.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRewriteMethod.java
@@ -114,8 +114,8 @@ public class TestDocValuesRewriteMethod extends LuceneTestCase {
 
   /** check that the # of hits is the same as if the query is run against the inverted index */
   protected void assertSame(String regexp) throws IOException {
-    RegexpQuery docValues = new RegexpQuery(new Term(fieldName, regexp), RegExp.NONE);
-    docValues.setRewriteMethod(new DocValuesRewriteMethod());
+    RegexpQuery docValues =
+        new RegexpQuery(new Term(fieldName, regexp), RegExp.NONE, new DocValuesRewriteMethod());
     RegexpQuery inverted = new RegexpQuery(new Term(fieldName, regexp), RegExp.NONE);
 
     TopDocs invertedDocs = searcher1.search(inverted, 25);
@@ -125,17 +125,24 @@ public class TestDocValuesRewriteMethod extends LuceneTestCase {
   }
 
   public void testEquals() throws Exception {
-    RegexpQuery a1 = new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE);
-    RegexpQuery a2 = new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE);
-    RegexpQuery b = new RegexpQuery(new Term(fieldName, "[bB]"), RegExp.NONE);
-    assertEquals(a1, a2);
-    assertFalse(a1.equals(b));
+    {
+      RegexpQuery a1 = new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE);
+      RegexpQuery a2 = new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE);
+      RegexpQuery b = new RegexpQuery(new Term(fieldName, "[bB]"), RegExp.NONE);
+      assertEquals(a1, a2);
+      assertFalse(a1.equals(b));
+    }
 
-    a1.setRewriteMethod(new DocValuesRewriteMethod());
-    a2.setRewriteMethod(new DocValuesRewriteMethod());
-    b.setRewriteMethod(new DocValuesRewriteMethod());
-    assertEquals(a1, a2);
-    assertFalse(a1.equals(b));
-    QueryUtils.check(a1);
+    {
+      RegexpQuery a1 =
+          new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE, new DocValuesRewriteMethod());
+      RegexpQuery a2 =
+          new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE, new DocValuesRewriteMethod());
+      RegexpQuery b =
+          new RegexpQuery(new Term(fieldName, "[bB]"), RegExp.NONE, new DocValuesRewriteMethod());
+      assertEquals(a1, a2);
+      assertFalse(a1.equals(b));
+      QueryUtils.check(a1);
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRewriteMethod.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRewriteMethod.java
@@ -36,6 +36,7 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.tests.util.automaton.AutomatonTestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.UnicodeUtil;
+import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 
 /** Tests the DocValuesRewriteMethod */
@@ -115,7 +116,13 @@ public class TestDocValuesRewriteMethod extends LuceneTestCase {
   /** check that the # of hits is the same as if the query is run against the inverted index */
   protected void assertSame(String regexp) throws IOException {
     RegexpQuery docValues =
-        new RegexpQuery(new Term(fieldName, regexp), RegExp.NONE, new DocValuesRewriteMethod());
+        new RegexpQuery(
+            new Term(fieldName, regexp),
+            RegExp.NONE,
+            0,
+            name -> null,
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            new DocValuesRewriteMethod());
     RegexpQuery inverted = new RegexpQuery(new Term(fieldName, regexp), RegExp.NONE);
 
     TopDocs invertedDocs = searcher1.search(inverted, 25);
@@ -135,11 +142,29 @@ public class TestDocValuesRewriteMethod extends LuceneTestCase {
 
     {
       RegexpQuery a1 =
-          new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE, new DocValuesRewriteMethod());
+          new RegexpQuery(
+              new Term(fieldName, "[aA]"),
+              RegExp.NONE,
+              0,
+              name -> null,
+              Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+              new DocValuesRewriteMethod());
       RegexpQuery a2 =
-          new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE, new DocValuesRewriteMethod());
+          new RegexpQuery(
+              new Term(fieldName, "[aA]"),
+              RegExp.NONE,
+              0,
+              name -> null,
+              Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+              new DocValuesRewriteMethod());
       RegexpQuery b =
-          new RegexpQuery(new Term(fieldName, "[bB]"), RegExp.NONE, new DocValuesRewriteMethod());
+          new RegexpQuery(
+              new Term(fieldName, "[bB]"),
+              RegExp.NONE,
+              0,
+              name -> null,
+              Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+              new DocValuesRewriteMethod());
       assertEquals(a1, a2);
       assertFalse(a1.equals(b));
       QueryUtils.check(a1);

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldCacheRewriteMethod.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldCacheRewriteMethod.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.tests.search.CheckHits;
 import org.apache.lucene.tests.search.QueryUtils;
+import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 
 /** Tests the FieldcacheRewriteMethod with random regular expressions */
@@ -29,11 +30,22 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
   @Override
   protected void assertSame(String regexp) throws IOException {
     RegexpQuery fieldCache =
-        new RegexpQuery(new Term(fieldName, regexp), RegExp.NONE, new DocValuesRewriteMethod());
+        new RegexpQuery(
+            new Term(fieldName, regexp),
+            RegExp.NONE,
+            0,
+            name -> null,
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            new DocValuesRewriteMethod());
 
     RegexpQuery filter =
         new RegexpQuery(
-            new Term(fieldName, regexp), RegExp.NONE, MultiTermQuery.CONSTANT_SCORE_REWRITE);
+            new Term(fieldName, regexp),
+            RegExp.NONE,
+            0,
+            name -> null,
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            MultiTermQuery.CONSTANT_SCORE_REWRITE);
 
     TopDocs fieldCacheDocs = searcher1.search(fieldCache, 25);
     TopDocs filterDocs = searcher2.search(filter, 25);
@@ -53,11 +65,29 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
 
     {
       RegexpQuery a1 =
-          new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE, new DocValuesRewriteMethod());
+          new RegexpQuery(
+              new Term(fieldName, "[aA]"),
+              RegExp.NONE,
+              0,
+              name -> null,
+              Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+              new DocValuesRewriteMethod());
       RegexpQuery a2 =
-          new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE, new DocValuesRewriteMethod());
+          new RegexpQuery(
+              new Term(fieldName, "[aA]"),
+              RegExp.NONE,
+              0,
+              name -> null,
+              Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+              new DocValuesRewriteMethod());
       RegexpQuery b =
-          new RegexpQuery(new Term(fieldName, "[bB]"), RegExp.NONE, new DocValuesRewriteMethod());
+          new RegexpQuery(
+              new Term(fieldName, "[bB]"),
+              RegExp.NONE,
+              0,
+              name -> null,
+              Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+              new DocValuesRewriteMethod());
       assertEquals(a1, a2);
       assertFalse(a1.equals(b));
       QueryUtils.check(a1);

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldCacheRewriteMethod.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldCacheRewriteMethod.java
@@ -28,11 +28,12 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
   /** Test fieldcache rewrite against filter rewrite */
   @Override
   protected void assertSame(String regexp) throws IOException {
-    RegexpQuery fieldCache = new RegexpQuery(new Term(fieldName, regexp), RegExp.NONE);
-    fieldCache.setRewriteMethod(new DocValuesRewriteMethod());
+    RegexpQuery fieldCache =
+        new RegexpQuery(new Term(fieldName, regexp), RegExp.NONE, new DocValuesRewriteMethod());
 
-    RegexpQuery filter = new RegexpQuery(new Term(fieldName, regexp), RegExp.NONE);
-    filter.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    RegexpQuery filter =
+        new RegexpQuery(
+            new Term(fieldName, regexp), RegExp.NONE, MultiTermQuery.CONSTANT_SCORE_REWRITE);
 
     TopDocs fieldCacheDocs = searcher1.search(fieldCache, 25);
     TopDocs filterDocs = searcher2.search(filter, 25);
@@ -41,17 +42,25 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
   }
 
   public void testEquals() throws Exception {
-    RegexpQuery a1 = new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE);
-    RegexpQuery a2 = new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE);
-    RegexpQuery b = new RegexpQuery(new Term(fieldName, "[bB]"), RegExp.NONE);
-    assertEquals(a1, a2);
-    assertFalse(a1.equals(b));
+    {
+      RegexpQuery a1 = new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE);
+      RegexpQuery a2 = new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE);
+      RegexpQuery b = new RegexpQuery(new Term(fieldName, "[bB]"), RegExp.NONE);
+      assertEquals(a1, a2);
+      assertFalse(a1.equals(b));
+      QueryUtils.check(a1);
+    }
 
-    a1.setRewriteMethod(new DocValuesRewriteMethod());
-    a2.setRewriteMethod(new DocValuesRewriteMethod());
-    b.setRewriteMethod(new DocValuesRewriteMethod());
-    assertEquals(a1, a2);
-    assertFalse(a1.equals(b));
-    QueryUtils.check(a1);
+    {
+      RegexpQuery a1 =
+          new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE, new DocValuesRewriteMethod());
+      RegexpQuery a2 =
+          new RegexpQuery(new Term(fieldName, "[aA]"), RegExp.NONE, new DocValuesRewriteMethod());
+      RegexpQuery b =
+          new RegexpQuery(new Term(fieldName, "[bB]"), RegExp.NONE, new DocValuesRewriteMethod());
+      assertEquals(a1, a2);
+      assertFalse(a1.equals(b));
+      QueryUtils.check(a1);
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestFuzzyQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFuzzyQuery.java
@@ -436,8 +436,10 @@ public class TestFuzzyQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
     writer.close();
 
-    FuzzyQuery query = new FuzzyQuery(new Term("field", "lucene"));
-    query.setRewriteMethod(new MultiTermQuery.TopTermsBoostOnlyBooleanQueryRewrite(50));
+    FuzzyQuery query =
+        new FuzzyQuery(
+            new Term("field", "lucene"),
+            new MultiTermQuery.TopTermsBoostOnlyBooleanQueryRewrite(50));
     ScoreDoc[] hits = searcher.search(query, 1000).scoreDocs;
     assertEquals(3, hits.length);
     // normally, 'Lucenne' would be the first result as IDF will skew the score.

--- a/lucene/core/src/test/org/apache/lucene/search/TestFuzzyQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFuzzyQuery.java
@@ -439,6 +439,10 @@ public class TestFuzzyQuery extends LuceneTestCase {
     FuzzyQuery query =
         new FuzzyQuery(
             new Term("field", "lucene"),
+            FuzzyQuery.defaultMaxEdits,
+            FuzzyQuery.defaultPrefixLength,
+            FuzzyQuery.defaultMaxExpansions,
+            FuzzyQuery.defaultTranspositions,
             new MultiTermQuery.TopTermsBoostOnlyBooleanQueryRewrite(50));
     ScoreDoc[] hits = searcher.search(query, 1000).scoreDocs;
     assertEquals(3, hits.length);

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
@@ -28,6 +28,7 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.QueryUtils;
+import org.apache.lucene.util.automaton.Operations;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -118,7 +119,8 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
   /** macro for readability */
   public static Query cswcq(Term wild) {
-    return new WildcardQuery(wild, MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    return new WildcardQuery(
+        wild, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.CONSTANT_SCORE_REWRITE);
   }
 
   @Test

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
@@ -94,8 +94,8 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
   /** macro for readability */
   public static Query csrq(String f, String l, String h, boolean il, boolean ih) {
-    TermRangeQuery query = TermRangeQuery.newStringRange(f, l, h, il, ih);
-    query.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    TermRangeQuery query =
+        TermRangeQuery.newStringRange(f, l, h, il, ih, MultiTermQuery.CONSTANT_SCORE_REWRITE);
     if (VERBOSE) {
       System.out.println("TEST: query=" + query);
     }
@@ -104,8 +104,7 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
   public static Query csrq(
       String f, String l, String h, boolean il, boolean ih, MultiTermQuery.RewriteMethod method) {
-    TermRangeQuery query = TermRangeQuery.newStringRange(f, l, h, il, ih);
-    query.setRewriteMethod(method);
+    TermRangeQuery query = TermRangeQuery.newStringRange(f, l, h, il, ih, method);
     if (VERBOSE) {
       System.out.println("TEST: query=" + query + " method=" + method);
     }
@@ -114,16 +113,12 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
   /** macro for readability */
   public static Query cspq(Term prefix) {
-    PrefixQuery query = new PrefixQuery(prefix);
-    query.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
-    return query;
+    return new PrefixQuery(prefix, MultiTermQuery.CONSTANT_SCORE_REWRITE);
   }
 
   /** macro for readability */
   public static Query cswcq(Term wild) {
-    WildcardQuery query = new WildcardQuery(wild);
-    query.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
-    return query;
+    return new WildcardQuery(wild, MultiTermQuery.CONSTANT_SCORE_REWRITE);
   }
 
   @Test

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiTermQueryRewrites.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiTermQueryRewrites.java
@@ -120,8 +120,7 @@ public class TestMultiTermQueryRewrites extends LuceneTestCase {
   }
 
   private void checkDuplicateTerms(MultiTermQuery.RewriteMethod method) throws Exception {
-    final MultiTermQuery mtq = TermRangeQuery.newStringRange("data", "2", "7", true, true);
-    mtq.setRewriteMethod(method);
+    final MultiTermQuery mtq = TermRangeQuery.newStringRange("data", "2", "7", true, true, method);
     final Query q1 = searcher.rewrite(mtq);
     final Query q2 = multiSearcher.rewrite(mtq);
     final Query q3 = multiSearcherDupls.rewrite(mtq);
@@ -163,7 +162,7 @@ public class TestMultiTermQueryRewrites extends LuceneTestCase {
 
   private void checkBoosts(MultiTermQuery.RewriteMethod method) throws Exception {
     final MultiTermQuery mtq =
-        new MultiTermQuery("data") {
+        new MultiTermQuery("data", method) {
           @Override
           protected TermsEnum getTermsEnum(Terms terms, AttributeSource atts) throws IOException {
             return new FilteredTermsEnum(terms.iterator()) {
@@ -198,7 +197,6 @@ public class TestMultiTermQueryRewrites extends LuceneTestCase {
           @Override
           public void visit(QueryVisitor visitor) {}
         };
-    mtq.setRewriteMethod(method);
     final Query q1 = searcher.rewrite(mtq);
     final Query q2 = multiSearcher.rewrite(mtq);
     final Query q3 = multiSearcherDupls.rewrite(mtq);
@@ -233,8 +231,7 @@ public class TestMultiTermQueryRewrites extends LuceneTestCase {
     int savedMaxClauseCount = IndexSearcher.getMaxClauseCount();
     IndexSearcher.setMaxClauseCount(3);
 
-    final MultiTermQuery mtq = TermRangeQuery.newStringRange("data", "2", "7", true, true);
-    mtq.setRewriteMethod(method);
+    final MultiTermQuery mtq = TermRangeQuery.newStringRange("data", "2", "7", true, true, method);
     try {
       IndexSearcher.TooManyClauses expected =
           expectThrows(
@@ -256,8 +253,7 @@ public class TestMultiTermQueryRewrites extends LuceneTestCase {
     int savedMaxClauseCount = IndexSearcher.getMaxClauseCount();
     IndexSearcher.setMaxClauseCount(3);
 
-    final MultiTermQuery mtq = TermRangeQuery.newStringRange("data", "2", "7", true, true);
-    mtq.setRewriteMethod(method);
+    final MultiTermQuery mtq = TermRangeQuery.newStringRange("data", "2", "7", true, true, method);
     try {
       multiSearcherDupls.rewrite(mtq);
     } finally {

--- a/lucene/core/src/test/org/apache/lucene/search/TestPrefixRandom.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPrefixRandom.java
@@ -81,7 +81,7 @@ public class TestPrefixRandom extends LuceneTestCase {
     private final BytesRef prefix;
 
     DumbPrefixQuery(Term term) {
-      super(term.field());
+      super(term.field(), CONSTANT_SCORE_REWRITE);
       prefix = term.bytes();
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestRegexpRandom2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRegexpRandom2.java
@@ -110,7 +110,7 @@ public class TestRegexpRandom2 extends LuceneTestCase {
     private final Automaton automaton;
 
     DumbRegexpQuery(Term term, int flags) {
-      super(term.field());
+      super(term.field(), MultiTermQuery.CONSTANT_SCORE_REWRITE);
       RegExp re = new RegExp(term.text(), flags);
       automaton =
           Operations.determinize(re.toAutomaton(), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermRangeQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermRangeQuery.java
@@ -128,7 +128,10 @@ public class TestTermRangeQuery extends LuceneTestCase {
 
     IndexReader reader = DirectoryReader.open(dir);
     IndexSearcher searcher = newSearcher(reader);
-    TermRangeQuery query = TermRangeQuery.newStringRange("content", "B", "J", true, true);
+    MultiTermQuery.RewriteMethod rewriteMethod =
+        new MultiTermQuery.TopTermsScoringBooleanQueryRewrite(50);
+    TermRangeQuery query =
+        TermRangeQuery.newStringRange("content", "B", "J", true, true, rewriteMethod);
     checkBooleanTerms(searcher, query, "B", "C", "D", "E", "F", "G", "H", "I", "J");
 
     final int savedClauseCount = IndexSearcher.getMaxClauseCount();
@@ -143,7 +146,6 @@ public class TestTermRangeQuery extends LuceneTestCase {
 
   private void checkBooleanTerms(IndexSearcher searcher, TermRangeQuery query, String... terms)
       throws IOException {
-    query.setRewriteMethod(new MultiTermQuery.TopTermsScoringBooleanQueryRewrite(50));
     final BooleanQuery bq = (BooleanQuery) searcher.rewrite(query);
     final Set<String> allowedTerms = asSet(terms);
     assertEquals(allowedTerms.size(), bq.clauses().size());

--- a/lucene/core/src/test/org/apache/lucene/search/TestWildcard.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestWildcard.java
@@ -28,6 +28,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.automaton.Operations;
 
 /** TestWildcard tests the '*' and '?' wildcard characters. */
 public class TestWildcard extends LuceneTestCase {
@@ -69,19 +70,25 @@ public class TestWildcard extends LuceneTestCase {
     Query q =
         searcher.rewrite(
             new WildcardQuery(
-                new Term("field", "nowildcard"), MultiTermQuery.SCORING_BOOLEAN_REWRITE));
+                new Term("field", "nowildcard"),
+                Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+                MultiTermQuery.SCORING_BOOLEAN_REWRITE));
     assertTrue(q instanceof TermQuery);
 
     q =
         searcher.rewrite(
             new WildcardQuery(
-                new Term("field", "nowildcard"), MultiTermQuery.CONSTANT_SCORE_REWRITE));
+                new Term("field", "nowildcard"),
+                Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+                MultiTermQuery.CONSTANT_SCORE_REWRITE));
     assertTrue(q instanceof MultiTermQueryConstantScoreWrapper);
 
     q =
         searcher.rewrite(
             new WildcardQuery(
-                new Term("field", "nowildcard"), MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE));
+                new Term("field", "nowildcard"),
+                Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+                MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE));
     assertTrue(q instanceof ConstantScoreQuery);
     reader.close();
     indexStore.close();
@@ -94,7 +101,10 @@ public class TestWildcard extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     MultiTermQuery wq =
-        new WildcardQuery(new Term("field", ""), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+        new WildcardQuery(
+            new Term("field", ""),
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            MultiTermQuery.SCORING_BOOLEAN_REWRITE);
     assertMatches(searcher, wq, 0);
     Query q = searcher.rewrite(wq);
     assertTrue(q instanceof MatchNoDocsQuery);

--- a/lucene/core/src/test/org/apache/lucene/search/TestWildcard.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestWildcard.java
@@ -66,16 +66,22 @@ public class TestWildcard extends LuceneTestCase {
     MultiTermQuery wq = new WildcardQuery(new Term("field", "nowildcard"));
     assertMatches(searcher, wq, 1);
 
-    wq.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-    Query q = searcher.rewrite(wq);
+    Query q =
+        searcher.rewrite(
+            new WildcardQuery(
+                new Term("field", "nowildcard"), MultiTermQuery.SCORING_BOOLEAN_REWRITE));
     assertTrue(q instanceof TermQuery);
 
-    wq.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
-    q = searcher.rewrite(wq);
+    q =
+        searcher.rewrite(
+            new WildcardQuery(
+                new Term("field", "nowildcard"), MultiTermQuery.CONSTANT_SCORE_REWRITE));
     assertTrue(q instanceof MultiTermQueryConstantScoreWrapper);
 
-    wq.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE);
-    q = searcher.rewrite(wq);
+    q =
+        searcher.rewrite(
+            new WildcardQuery(
+                new Term("field", "nowildcard"), MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE));
     assertTrue(q instanceof ConstantScoreQuery);
     reader.close();
     indexStore.close();
@@ -87,8 +93,8 @@ public class TestWildcard extends LuceneTestCase {
     IndexReader reader = DirectoryReader.open(indexStore);
     IndexSearcher searcher = newSearcher(reader);
 
-    MultiTermQuery wq = new WildcardQuery(new Term("field", ""));
-    wq.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+    MultiTermQuery wq =
+        new WildcardQuery(new Term("field", ""), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
     assertMatches(searcher, wq, 0);
     Query q = searcher.rewrite(wq);
     assertTrue(q instanceof MatchNoDocsQuery);

--- a/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
@@ -985,8 +985,9 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
           @Override
           public void run() throws Exception {
             numHighlights = 0;
-            FuzzyQuery fuzzyQuery = new FuzzyQuery(new Term(FIELD_NAME, "kinnedy"), 2);
-            fuzzyQuery.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+            FuzzyQuery fuzzyQuery =
+                new FuzzyQuery(
+                    new Term(FIELD_NAME, "kinnedy"), 2, MultiTermQuery.SCORING_BOOLEAN_REWRITE);
             doSearching(fuzzyQuery);
             doStandardHighlights(analyzer, searcher, hits, query, TestHighlighter.this, true);
             assertTrue(
@@ -1005,8 +1006,9 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
           @Override
           public void run() throws Exception {
             numHighlights = 0;
-            WildcardQuery wildcardQuery = new WildcardQuery(new Term(FIELD_NAME, "k?nnedy"));
-            wildcardQuery.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+            WildcardQuery wildcardQuery =
+                new WildcardQuery(
+                    new Term(FIELD_NAME, "k?nnedy"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
             doSearching(wildcardQuery);
             doStandardHighlights(analyzer, searcher, hits, query, TestHighlighter.this);
             assertTrue(
@@ -1025,8 +1027,9 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
           @Override
           public void run() throws Exception {
             numHighlights = 0;
-            WildcardQuery wildcardQuery = new WildcardQuery(new Term(FIELD_NAME, "k*dy"));
-            wildcardQuery.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+            WildcardQuery wildcardQuery =
+                new WildcardQuery(
+                    new Term(FIELD_NAME, "k*dy"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
             doSearching(wildcardQuery);
             doStandardHighlights(analyzer, searcher, hits, query, TestHighlighter.this);
             assertTrue(
@@ -1050,12 +1053,14 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
             // rather
             // than RangeFilters
 
-            TermRangeQuery rangeQuery =
+            query =
                 new TermRangeQuery(
-                    FIELD_NAME, new BytesRef("kannedy"), new BytesRef("kznnedy"), true, true);
-            rangeQuery.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-
-            query = rangeQuery;
+                    FIELD_NAME,
+                    new BytesRef("kannedy"),
+                    new BytesRef("kznnedy"),
+                    true,
+                    true,
+                    MultiTermQuery.SCORING_BOOLEAN_REWRITE);
             doSearching(query);
 
             doStandardHighlights(analyzer, searcher, hits, query, TestHighlighter.this);
@@ -1072,8 +1077,7 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
 
     numHighlights = 0;
 
-    query = new WildcardQuery(new Term(FIELD_NAME, "ken*"));
-    ((WildcardQuery) query).setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    query = new WildcardQuery(new Term(FIELD_NAME, "ken*"), MultiTermQuery.CONSTANT_SCORE_REWRITE);
     searcher = newSearcher(reader);
     // can't rewrite ConstantScore if you want to highlight it -
     // it rewrites to ConstantScoreQuery which cannot be highlighted
@@ -1288,8 +1292,9 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
             numHighlights = 0;
             BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
             booleanQuery.add(new TermQuery(new Term(FIELD_NAME, "john")), Occur.SHOULD);
-            PrefixQuery prefixQuery = new PrefixQuery(new Term(FIELD_NAME, "kenn"));
-            prefixQuery.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+            PrefixQuery prefixQuery =
+                new PrefixQuery(
+                    new Term(FIELD_NAME, "kenn"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
             booleanQuery.add(prefixQuery, Occur.SHOULD);
 
             doSearching(booleanQuery.build());

--- a/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
@@ -92,6 +92,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -987,7 +988,12 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
             numHighlights = 0;
             FuzzyQuery fuzzyQuery =
                 new FuzzyQuery(
-                    new Term(FIELD_NAME, "kinnedy"), 2, MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+                    new Term(FIELD_NAME, "kinnedy"),
+                    2,
+                    FuzzyQuery.defaultPrefixLength,
+                    FuzzyQuery.defaultMaxExpansions,
+                    FuzzyQuery.defaultTranspositions,
+                    MultiTermQuery.SCORING_BOOLEAN_REWRITE);
             doSearching(fuzzyQuery);
             doStandardHighlights(analyzer, searcher, hits, query, TestHighlighter.this, true);
             assertTrue(
@@ -1008,7 +1014,9 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
             numHighlights = 0;
             WildcardQuery wildcardQuery =
                 new WildcardQuery(
-                    new Term(FIELD_NAME, "k?nnedy"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+                    new Term(FIELD_NAME, "k?nnedy"),
+                    Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+                    MultiTermQuery.SCORING_BOOLEAN_REWRITE);
             doSearching(wildcardQuery);
             doStandardHighlights(analyzer, searcher, hits, query, TestHighlighter.this);
             assertTrue(
@@ -1029,7 +1037,9 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
             numHighlights = 0;
             WildcardQuery wildcardQuery =
                 new WildcardQuery(
-                    new Term(FIELD_NAME, "k*dy"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+                    new Term(FIELD_NAME, "k*dy"),
+                    Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+                    MultiTermQuery.SCORING_BOOLEAN_REWRITE);
             doSearching(wildcardQuery);
             doStandardHighlights(analyzer, searcher, hits, query, TestHighlighter.this);
             assertTrue(
@@ -1077,7 +1087,11 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
 
     numHighlights = 0;
 
-    query = new WildcardQuery(new Term(FIELD_NAME, "ken*"), MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    query =
+        new WildcardQuery(
+            new Term(FIELD_NAME, "ken*"),
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            MultiTermQuery.CONSTANT_SCORE_REWRITE);
     searcher = newSearcher(reader);
     // can't rewrite ConstantScore if you want to highlight it -
     // it rewrites to ConstantScoreQuery which cannot be highlighted

--- a/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
@@ -63,7 +63,7 @@ class TermsQuery extends MultiTermQuery implements Accountable {
       String fromField,
       Query fromQuery,
       Object indexReaderContextId) {
-    super(toField);
+    super(toField, CONSTANT_SCORE_REWRITE);
     this.terms = terms;
     ords = terms.sort();
     this.fromField = fromField;

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
@@ -541,9 +541,7 @@ public abstract class QueryParserBase extends QueryBuilder
    * @return new PrefixQuery instance
    */
   protected Query newPrefixQuery(Term prefix) {
-    PrefixQuery query = new PrefixQuery(prefix);
-    query.setRewriteMethod(multiTermRewriteMethod);
-    return query;
+    return new PrefixQuery(prefix, multiTermRewriteMethod);
   }
 
   /**
@@ -553,9 +551,7 @@ public abstract class QueryParserBase extends QueryBuilder
    * @return new RegexpQuery instance
    */
   protected Query newRegexpQuery(Term regexp) {
-    RegexpQuery query = new RegexpQuery(regexp, RegExp.ALL, determinizeWorkLimit);
-    query.setRewriteMethod(multiTermRewriteMethod);
-    return query;
+    return new RegexpQuery(regexp, RegExp.ALL, determinizeWorkLimit, multiTermRewriteMethod);
   }
 
   /**
@@ -601,11 +597,8 @@ public abstract class QueryParserBase extends QueryBuilder
       end = getAnalyzer().normalize(field, part2);
     }
 
-    final TermRangeQuery query =
-        new TermRangeQuery(field, start, end, startInclusive, endInclusive);
-
-    query.setRewriteMethod(multiTermRewriteMethod);
-    return query;
+    return new TermRangeQuery(
+        field, start, end, startInclusive, endInclusive, multiTermRewriteMethod);
   }
 
   /**
@@ -624,9 +617,7 @@ public abstract class QueryParserBase extends QueryBuilder
    * @return new WildcardQuery instance
    */
   protected Query newWildcardQuery(Term t) {
-    WildcardQuery query = new WildcardQuery(t, determinizeWorkLimit);
-    query.setRewriteMethod(multiTermRewriteMethod);
-    return query;
+    return new WildcardQuery(t, determinizeWorkLimit, multiTermRewriteMethod);
   }
 
   /**

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
@@ -551,7 +551,13 @@ public abstract class QueryParserBase extends QueryBuilder
    * @return new RegexpQuery instance
    */
   protected Query newRegexpQuery(Term regexp) {
-    return new RegexpQuery(regexp, RegExp.ALL, determinizeWorkLimit, multiTermRewriteMethod);
+    return new RegexpQuery(
+        regexp,
+        RegExp.ALL,
+        0,
+        RegexpQuery.DEFAULT_PROVIDER,
+        determinizeWorkLimit,
+        multiTermRewriteMethod);
   }
 
   /**

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/PrefixWildcardQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/PrefixWildcardQueryNodeBuilder.java
@@ -36,16 +36,15 @@ public class PrefixWildcardQueryNodeBuilder implements StandardQueryBuilder {
 
     PrefixWildcardQueryNode wildcardNode = (PrefixWildcardQueryNode) queryNode;
 
-    String text =
-        wildcardNode.getText().subSequence(0, wildcardNode.getText().length() - 1).toString();
-    PrefixQuery q = new PrefixQuery(new Term(wildcardNode.getFieldAsString(), text));
-
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
-    if (method != null) {
-      q.setRewriteMethod(method);
+    if (method == null) {
+      method = MultiTermQuery.CONSTANT_SCORE_REWRITE;
     }
 
-    return q;
+    String text =
+        wildcardNode.getText().subSequence(0, wildcardNode.getText().length() - 1).toString();
+
+    return new PrefixQuery(new Term(wildcardNode.getFieldAsString(), text), method);
   }
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/RegexpQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/RegexpQueryNodeBuilder.java
@@ -23,6 +23,8 @@ import org.apache.lucene.queryparser.flexible.standard.nodes.RegexpQueryNode;
 import org.apache.lucene.queryparser.flexible.standard.processors.MultiTermRewriteMethodProcessor;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.RegexpQuery;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.RegExp;
 
 /** Builds a {@link RegexpQuery} object from a {@link RegexpQueryNode} object. */
 public class RegexpQueryNodeBuilder implements StandardQueryBuilder {
@@ -43,6 +45,11 @@ public class RegexpQueryNodeBuilder implements StandardQueryBuilder {
 
     // TODO: make the maxStates configurable w/ a reasonable default (QueryParserBase uses 10000)
     return new RegexpQuery(
-        new Term(regexpNode.getFieldAsString(), regexpNode.textToBytesRef()), method);
+        new Term(regexpNode.getFieldAsString(), regexpNode.textToBytesRef()),
+        RegExp.ALL,
+        0,
+        name -> null,
+        Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+        method);
   }
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/RegexpQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/RegexpQueryNodeBuilder.java
@@ -35,16 +35,14 @@ public class RegexpQueryNodeBuilder implements StandardQueryBuilder {
   public RegexpQuery build(QueryNode queryNode) throws QueryNodeException {
     RegexpQueryNode regexpNode = (RegexpQueryNode) queryNode;
 
-    // TODO: make the maxStates configurable w/ a reasonable default (QueryParserBase uses 10000)
-    RegexpQuery q =
-        new RegexpQuery(new Term(regexpNode.getFieldAsString(), regexpNode.textToBytesRef()));
-
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
-    if (method != null) {
-      q.setRewriteMethod(method);
+    if (method == null) {
+      method = MultiTermQuery.CONSTANT_SCORE_REWRITE;
     }
 
-    return q;
+    // TODO: make the maxStates configurable w/ a reasonable default (QueryParserBase uses 10000)
+    return new RegexpQuery(
+        new Term(regexpNode.getFieldAsString(), regexpNode.textToBytesRef()), method);
   }
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/TermRangeQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/TermRangeQueryNodeBuilder.java
@@ -50,20 +50,18 @@ public class TermRangeQueryNodeBuilder implements StandardQueryBuilder {
       upperText = null;
     }
 
-    TermRangeQuery rangeQuery =
-        TermRangeQuery.newStringRange(
-            field,
-            lowerText,
-            upperText,
-            rangeNode.isLowerInclusive(),
-            rangeNode.isUpperInclusive());
-
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
-    if (method != null) {
-      rangeQuery.setRewriteMethod(method);
+    if (method == null) {
+      method = MultiTermQuery.CONSTANT_SCORE_REWRITE;
     }
 
-    return rangeQuery;
+    return TermRangeQuery.newStringRange(
+        field,
+        lowerText,
+        upperText,
+        rangeNode.isLowerInclusive(),
+        rangeNode.isUpperInclusive(),
+        method);
   }
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/WildcardQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/WildcardQueryNodeBuilder.java
@@ -35,16 +35,13 @@ public class WildcardQueryNodeBuilder implements StandardQueryBuilder {
   public WildcardQuery build(QueryNode queryNode) throws QueryNodeException {
     WildcardQueryNode wildcardNode = (WildcardQueryNode) queryNode;
 
-    WildcardQuery q =
-        new WildcardQuery(
-            new Term(wildcardNode.getFieldAsString(), wildcardNode.getTextAsString()));
-
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
-    if (method != null) {
-      q.setRewriteMethod(method);
+    if (method == null) {
+      method = MultiTermQuery.CONSTANT_SCORE_REWRITE;
     }
 
-    return q;
+    return new WildcardQuery(
+        new Term(wildcardNode.getFieldAsString(), wildcardNode.getTextAsString()), method);
   }
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/WildcardQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/WildcardQueryNodeBuilder.java
@@ -23,6 +23,7 @@ import org.apache.lucene.queryparser.flexible.standard.nodes.WildcardQueryNode;
 import org.apache.lucene.queryparser.flexible.standard.processors.MultiTermRewriteMethodProcessor;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.automaton.Operations;
 
 /** Builds a {@link WildcardQuery} object from a {@link WildcardQueryNode} object. */
 public class WildcardQueryNodeBuilder implements StandardQueryBuilder {
@@ -42,6 +43,8 @@ public class WildcardQueryNodeBuilder implements StandardQueryBuilder {
     }
 
     return new WildcardQuery(
-        new Term(wildcardNode.getFieldAsString(), wildcardNode.getTextAsString()), method);
+        new Term(wildcardNode.getFieldAsString(), wildcardNode.getTextAsString()),
+        Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+        method);
   }
 }

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestQPHelper.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestQPHelper.java
@@ -77,6 +77,7 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -1191,7 +1192,14 @@ public class TestQPHelper extends LuceneTestCase {
     assertEquals(two.build(), qp.parse("/foo/ /bar/", df));
 
     qp.setMultiTermRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-    q = new RegexpQuery(new Term("field", "[a-z][123]"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+    q =
+        new RegexpQuery(
+            new Term("field", "[a-z][123]"),
+            RegExp.ALL,
+            0,
+            name -> null,
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            MultiTermQuery.SCORING_BOOLEAN_REWRITE);
     assertEquals(new BoostQuery(q, 0.5f), qp.parse("/[A-Z][123]/^0.5", df));
     assertEquals(
         MultiTermQuery.SCORING_BOOLEAN_REWRITE,

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestQPHelper.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestQPHelper.java
@@ -1151,14 +1151,6 @@ public class TestQPHelper extends LuceneTestCase {
     assertEquals(q, qp.parse("/[a-z][123]/", df));
     assertEquals(q, qp.parse("/[A-Z][123]/", df));
     assertEquals(new BoostQuery(q, 0.5f), qp.parse("/[A-Z][123]/^0.5", df));
-    qp.setMultiTermRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-    q.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-    assertEquals(new BoostQuery(q, 0.5f), qp.parse("/[A-Z][123]/^0.5", df));
-    assertEquals(
-        MultiTermQuery.SCORING_BOOLEAN_REWRITE,
-        ((RegexpQuery) (((BoostQuery) qp.parse("/[A-Z][123]/^0.5", df)).getQuery()))
-            .getRewriteMethod());
-    qp.setMultiTermRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
 
     Query escaped = new RegexpQuery(new Term("field", "[a-z]\\/[123]"));
     assertEquals(escaped, qp.parse("/[a-z]\\/[123]/", df));
@@ -1197,6 +1189,15 @@ public class TestQPHelper extends LuceneTestCase {
     two.add(new RegexpQuery(new Term("field", "bar")), Occur.SHOULD);
     assertEquals(two.build(), qp.parse("field:/foo/ field:/bar/", df));
     assertEquals(two.build(), qp.parse("/foo/ /bar/", df));
+
+    qp.setMultiTermRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+    q = new RegexpQuery(new Term("field", "[a-z][123]"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+    assertEquals(new BoostQuery(q, 0.5f), qp.parse("/[A-Z][123]/^0.5", df));
+    assertEquals(
+        MultiTermQuery.SCORING_BOOLEAN_REWRITE,
+        ((RegexpQuery) (((BoostQuery) qp.parse("/[A-Z][123]/^0.5", df)).getQuery()))
+            .getRewriteMethod());
+    qp.setMultiTermRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
   }
 
   public void testStopwords() throws Exception {

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
@@ -1035,16 +1035,6 @@ public abstract class QueryParserTestBase extends LuceneTestCase {
     assertEquals(q, getQuery("/[a-z][123]/", qp));
     assertEquals(q, getQuery("/[A-Z][123]/", qp));
     assertEquals(new BoostQuery(q, 0.5f), getQuery("/[A-Z][123]/^0.5", qp));
-    qp.setMultiTermRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-    q.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-    assertTrue(getQuery("/[A-Z][123]/^0.5", qp) instanceof BoostQuery);
-    assertTrue(((BoostQuery) getQuery("/[A-Z][123]/^0.5", qp)).getQuery() instanceof RegexpQuery);
-    assertEquals(
-        MultiTermQuery.SCORING_BOOLEAN_REWRITE,
-        ((RegexpQuery) ((BoostQuery) getQuery("/[A-Z][123]/^0.5", qp)).getQuery())
-            .getRewriteMethod());
-    assertEquals(new BoostQuery(q, 0.5f), getQuery("/[A-Z][123]/^0.5", qp));
-    qp.setMultiTermRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
 
     Query escaped = new RegexpQuery(new Term("field", "[a-z]\\/[123]"));
     assertEquals(escaped, getQuery("/[a-z]\\/[123]/", qp));
@@ -1080,6 +1070,16 @@ public abstract class QueryParserTestBase extends LuceneTestCase {
     two.add(new RegexpQuery(new Term("field", "bar")), Occur.SHOULD);
     assertEquals(two.build(), getQuery("field:/foo/ field:/bar/", qp));
     assertEquals(two.build(), getQuery("/foo/ /bar/", qp));
+
+    qp.setMultiTermRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+    q = new RegexpQuery(new Term("field", "[a-z][123]"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+    assertTrue(getQuery("/[A-Z][123]/^0.5", qp) instanceof BoostQuery);
+    assertTrue(((BoostQuery) getQuery("/[A-Z][123]/^0.5", qp)).getQuery() instanceof RegexpQuery);
+    assertEquals(
+        MultiTermQuery.SCORING_BOOLEAN_REWRITE,
+        ((RegexpQuery) ((BoostQuery) getQuery("/[A-Z][123]/^0.5", qp)).getQuery())
+            .getRewriteMethod());
+    assertEquals(new BoostQuery(q, 0.5f), getQuery("/[A-Z][123]/^0.5", qp));
   }
 
   public void testStopwords() throws Exception {

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
@@ -66,6 +66,7 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -1072,7 +1073,14 @@ public abstract class QueryParserTestBase extends LuceneTestCase {
     assertEquals(two.build(), getQuery("/foo/ /bar/", qp));
 
     qp.setMultiTermRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-    q = new RegexpQuery(new Term("field", "[a-z][123]"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+    q =
+        new RegexpQuery(
+            new Term("field", "[a-z][123]"),
+            RegExp.ALL,
+            0,
+            name -> null,
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            MultiTermQuery.SCORING_BOOLEAN_REWRITE);
     assertTrue(getQuery("/[A-Z][123]/^0.5", qp) instanceof BoostQuery);
     assertTrue(((BoostQuery) getQuery("/[A-Z][123]/^0.5", qp)).getQuery() instanceof RegexpQuery);
     assertEquals(


### PR DESCRIPTION
Allowing users to mutate MultiTermQuery can give rise to odd bugs, for example
in wrapper queries such as BooleanQuery which lazily calculate their hashcodes
and then cache the result.  This commit deprecates the `setRewriteMethod()`
method on `MultiTermQuery`, in preparation for removing it entirely, and adds
constructor parameters to the various MTQ implementations as a preferred
way to set the rewrite method.