### PR TITLE
LUCENE-10431: Don't include rewriteMethod in MTQ hash calculation

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -260,6 +260,10 @@ Bug Fixes
   infinite loops in their parent BooleanQuery.
   (Ankit Jain, Daniel Doubrovkine, Adrien Grand)
 
+* LUCENE-10431: MultiTermQuery no longer includes its rewrite method in its hashcode
+  calculation, as this could cause problems with wrapper queries like BooleanQuery which
+  expect their child queries hashcodes to be stable. (Alan Woodward)
+
 Other
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -302,7 +302,11 @@ public abstract class MultiTermQuery extends Query {
   public int hashCode() {
     final int prime = 31;
     int result = classHash();
-    result = prime * result + rewriteMethod.hashCode();
+    // rewriteMethod is mutable in 9x so we exclude it from hashcode
+    // calculates to ensure that the hash is stable; otherwise we
+    // can get assertion errors from wrapper queries like BQ that
+    // store their subqueries in Sets
+    // result = prime * result + rewriteMethod.hashCode();
     result = prime * result + field.hashCode();
     return result;
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiTermQueryRewrites.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiTermQueryRewrites.java
@@ -269,4 +269,12 @@ public class TestMultiTermQueryRewrites extends LuceneTestCase {
     checkNoMaxClauseLimitation(new MultiTermQuery.TopTermsScoringBooleanQueryRewrite(1024));
     checkNoMaxClauseLimitation(new MultiTermQuery.TopTermsBoostOnlyBooleanQueryRewrite(1024));
   }
+
+  public void testHashCodeStability() {
+    PrefixQuery pq = new PrefixQuery(new Term("field", "test"));
+    pq.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    int hash = pq.hashCode();
+    pq.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+    assertEquals(hash, pq.hashCode());
+  }
 }


### PR DESCRIPTION
BooleanQuery assumes that its children's hashcodes are stable, and has some
assertions to this effect.  This did not apply to MultiTermQuery, which has a 
mutable RewriteMethod member variable that was included in its hash calculation.
Changing the rewrite method would change the hash, leading to assertion failures
being tripped.  This commit removes rewriteMethod from the hash calculation,
meaning that the hashcode will be stable even under mutability.