### PR TITLE
LUCENE-10194 Buffer KNN vectors on disk

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
@@ -586,7 +586,7 @@ public class KnnGraphTester {
           }
         });
     // iwc.setMergePolicy(NoMergePolicy.INSTANCE);
-    iwc.setRAMBufferSizeMB(1994d);
+    // iwc.setRAMBufferSizeMB(1994d);
     // iwc.setMaxBufferedDocs(10000);
 
     FieldType fieldType = KnnVectorField.createFieldType(dim, similarityFunction);


### PR DESCRIPTION
Currently VectorValuesWriter buffers vectors in memory.
The  problem is that as multi-dimensional vectors consume a lot of memory,
a lot of flushes are triggered. Each flush is a very expensive involving
the construction of an HNSW graph.

This patch instead buffers KNN vectors on disk, which prevents
construction of new segments only because RAM is full.

Also unset RAMBufferSizeMB in KnnGraphTester, now defaults to  16Mb