### PR TITLE
LUCENE-10455: IndexSortSortedNumericDocValuesRangeQuery should implement Weight#scorerSupplier(LeafReaderContext)

### DIFF
--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -35,6 +35,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.Weight;
@@ -158,13 +159,34 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
     Weight fallbackWeight = fallbackQuery.createWeight(searcher, scoreMode, boost);
 
     return new ConstantScoreWeight(this, boost) {
+
       @Override
-      public Scorer scorer(LeafReaderContext context) throws IOException {
+      public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+        final Weight weight = this;
         DocIdSetIterator disi = getDocIdSetIteratorOrNull(context);
         if (disi != null) {
-          return new ConstantScoreScorer(this, score(), scoreMode, disi);
+          return new ScorerSupplier() {
+            @Override
+            public Scorer get(long leadCost) throws IOException {
+              return new ConstantScoreScorer(weight, score(), scoreMode, disi);
+            }
+
+            @Override
+            public long cost() {
+              return disi.cost();
+            }
+          };
         }
-        return fallbackWeight.scorer(context);
+        return fallbackWeight.scorerSupplier(context);
+      }
+
+      @Override
+      public Scorer scorer(LeafReaderContext context) throws IOException {
+        ScorerSupplier scorerSupplier = scorerSupplier(context);
+        if (scorerSupplier == null) {
+          return null;
+        }
+        return scorerSupplier.get(Long.MAX_VALUE);
       }
 
       @Override


### PR DESCRIPTION
IndexOrDocValuesQuery was used as a fallbackQuery of IndexSortSortedNumericDocValuesRangeQuery in Elasticsearch, but When IndexSortSortedNumericDocValuesRangeQuery can't take advantage of index sort, the fallbackQuery(IndexOrDocValuesQuery)  always only supply Scorer by indexQuery, beacuse IndexSortSortedNumericDocValuesRangeQuery did not implement Weight#scorerSupplier(LeafReaderContext).