### PR TITLE
LUCENE-10448: Avoid instant rate write bursts by writing bytes buffer in chunks

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/RateLimitedIndexOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RateLimitedIndexOutput.java
@@ -70,6 +70,7 @@ public final class RateLimitedIndexOutput extends IndexOutput {
   public void writeBytes(byte[] b, int offset, int length) throws IOException {
     while (length > 0) {
       int chunk = (int) Math.min(currentMinPauseCheckBytes + 1, length);
+      assert chunk > 0 && chunk <= length : "currentMinPauseCheckBytes " + currentMinPauseCheckBytes + " < 0";
       bytesSinceLastPause += chunk;
       checkRate();
       delegate.writeBytes(b, offset, chunk);

--- a/lucene/core/src/java/org/apache/lucene/store/RateLimitedIndexOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RateLimitedIndexOutput.java
@@ -70,7 +70,8 @@ public final class RateLimitedIndexOutput extends IndexOutput {
   public void writeBytes(byte[] b, int offset, int length) throws IOException {
     while (length > 0) {
       int chunk = (int) Math.min(currentMinPauseCheckBytes + 1, length);
-      assert chunk > 0 && chunk <= length : "currentMinPauseCheckBytes " + currentMinPauseCheckBytes + " < 0";
+      assert chunk > 0 && chunk <= length
+          : "currentMinPauseCheckBytes " + currentMinPauseCheckBytes + " < 0";
       bytesSinceLastPause += chunk;
       checkRate();
       delegate.writeBytes(b, offset, chunk);

--- a/lucene/core/src/test/org/apache/lucene/store/TestRateLimitedIndexOutput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestRateLimitedIndexOutput.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.store;
 
 import org.apache.lucene.tests.util.LuceneTestCase;

--- a/lucene/core/src/test/org/apache/lucene/store/TestRateLimitedIndexOutput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestRateLimitedIndexOutput.java
@@ -16,38 +16,34 @@
  */
 package org.apache.lucene.store;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
-
 import java.io.IOException;
+import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestRateLimitedIndexOutput extends LuceneTestCase {
 
   public void testWriteBytesChunking() throws Exception {
 
-    IndexOutput delegate = new IndexOutput("mock delegate for tests", "test-index-output") {
-      @Override
-      public void close() throws IOException {
-      }
+    IndexOutput delegate =
+        new IndexOutput("mock delegate for tests", "test-index-output") {
+          @Override
+          public void close() throws IOException {}
 
-      @Override
-      public long getFilePointer() {
-        return 0;
-      }
+          @Override
+          public long getFilePointer() {
+            return 0;
+          }
 
-      @Override
-      public long getChecksum() throws IOException {
-        return 0;
-      }
+          @Override
+          public long getChecksum() throws IOException {
+            return 0;
+          }
 
-      @Override
-      public void writeByte(byte b) throws IOException {
-      }
+          @Override
+          public void writeByte(byte b) throws IOException {}
 
-      @Override
-      public void writeBytes(byte[] b, int offset, int length) throws IOException {
-
-      }
-    };
+          @Override
+          public void writeBytes(byte[] b, int offset, int length) throws IOException {}
+        };
 
     final int minPauseCheckBytes = 10;
     final int chunk = minPauseCheckBytes + 1;

--- a/lucene/core/src/test/org/apache/lucene/store/TestRateLimitedIndexOutput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestRateLimitedIndexOutput.java
@@ -1,0 +1,78 @@
+package org.apache.lucene.store;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+import java.io.IOException;
+
+public class TestRateLimitedIndexOutput extends LuceneTestCase {
+
+  public void testWriteBytesChunking() throws Exception {
+
+    IndexOutput delegate = new IndexOutput("mock delegate for tests", "test-index-output") {
+      @Override
+      public void close() throws IOException {
+      }
+
+      @Override
+      public long getFilePointer() {
+        return 0;
+      }
+
+      @Override
+      public long getChecksum() throws IOException {
+        return 0;
+      }
+
+      @Override
+      public void writeByte(byte b) throws IOException {
+      }
+
+      @Override
+      public void writeBytes(byte[] b, int offset, int length) throws IOException {
+
+      }
+    };
+
+    final int minPauseCheckBytes = 10;
+    final int chunk = minPauseCheckBytes + 1;
+    MockRateLimiter rateLimiter = new MockRateLimiter(minPauseCheckBytes);
+    RateLimitedIndexOutput output = new RateLimitedIndexOutput(rateLimiter, delegate);
+
+    final int length = 90;
+    byte[] buf = new byte[length];
+    output.writeBytes(buf, 0, length);
+    assertEquals(length / chunk, rateLimiter.pauseCallCount);
+  }
+
+  public static class MockRateLimiter extends RateLimiter {
+    public int pauseCallCount = 0;
+
+    private double mbPerSec;
+    private long minPauseCheckBytes;
+
+    public MockRateLimiter(long minPauseCheckBytes) {
+      this.minPauseCheckBytes = minPauseCheckBytes;
+    }
+
+    @Override
+    public void setMBPerSec(double mbPerSec) {
+      this.mbPerSec = mbPerSec;
+    }
+
+    @Override
+    public double getMBPerSec() {
+      return mbPerSec;
+    }
+
+    @Override
+    public long pause(long bytes) throws IOException {
+      pauseCallCount++;
+      return 0;
+    }
+
+    @Override
+    public long getMinPauseCheckBytes() {
+      return minPauseCheckBytes;
+    }
+  }
+}


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene:

* https://issues.apache.org/jira/projects/LUCENE

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>

LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


## Description

`RateLimitedIndexOutput#writeBytes()` checks for rate only at the start of writing the byte buffer. This can result in large instant rate write bursts if the provided byte buffer is large.
To avoid this, we write bytes in chunks and check for rate between each chunk.

## Tests

Added `TestRateLimitedIndexOutput` to verify rate check between chunks.

## Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
