### PR TITLE
Adapt release smoke tester for 9.1

### DIFF
--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -574,10 +574,11 @@ def verifyUnpacked(java, artifact, unpackPath, gitRevision, version, testArgs):
   #       raise RuntimeError('lucene: file "%s" is missing from artifact %s' % (fileName, artifact))
   #     in_root_folder.remove(fileName)
 
-  expected_folders = ['analysis', 'backward-codecs', 'benchmark', 'classification', 'codecs', 'core',
-                      'demo', 'expressions', 'facet', 'grouping', 'highlighter', 'join',
-                      'luke', 'memory', 'misc', 'monitor', 'queries', 'queryparser', 'replicator',
-                      'sandbox', 'spatial-extras', 'spatial3d', 'suggest', 'test-framework', 'licenses']
+  expected_folders = ['analysis', 'analysis.tests', 'backward-codecs', 'benchmark', 'classification', 'codecs',
+                      'core', 'core.tests',  'demo', 'distribution.tests', 'expressions', 'facet', 'grouping',
+                      'highlighter', 'join', 'luke', 'memory', 'misc', 'monitor', 'queries', 'queryparser',
+                      'replicator', 'sandbox', 'spatial-extras', 'spatial-test-fixtures', 'spatial3d', 'suggest',
+                      'test-framework', 'licenses']
   if isSrc:
     expected_src_root_files = ['build.gradle', 'buildSrc', 'dev-docs', 'dev-tools', 'gradle', 'gradlew',
                                'gradlew.bat', 'help', 'lucene', 'settings.gradle', 'versions.lock', 'versions.props']
@@ -588,7 +589,7 @@ def verifyUnpacked(java, artifact, unpackPath, gitRevision, version, testArgs):
     if len(in_lucene_folder) > 0:
       raise RuntimeError('lucene: unexpected files/dirs in artifact %s lucene/ folder: %s' % (artifact, in_lucene_folder))
   else:
-    is_in_list(in_root_folder, ['bin', 'docs', 'licenses', 'modules', 'modules-thirdparty'])
+    is_in_list(in_root_folder, ['bin', 'docs', 'licenses', 'modules', 'modules-thirdparty', 'modules-test-framework'])
 
   if len(in_root_folder) > 0:
     raise RuntimeError('lucene: unexpected files/dirs in artifact %s: %s' % (artifact, in_root_folder))
@@ -658,7 +659,7 @@ def testDemo(run_java, isSrc, version, jdk):
     searchFilesCmd = 'java -cp "%s" org.apache.lucene.demo.SearchFiles -index index -query lucene' % cp
   else:
     # For binary release, set up classpath as modules.
-    cp = "--module-path modules"
+    cp = "--module-path modules:modules-thirdparty"
     docsDir = 'docs'
     checkIndexCmd = 'java -ea %s --module org.apache.lucene.core/org.apache.lucene.index.CheckIndex index' % cp
     indexFilesCmd = 'java -Dsmoketester=true %s --module org.apache.lucene.demo/org.apache.lucene.demo.IndexFiles -index index -docs %s' % (cp, docsDir)

--- a/lucene/distribution/binary-release.gradle
+++ b/lucene/distribution/binary-release.gradle
@@ -56,7 +56,9 @@ configure(project(":lucene:distribution")) {
     // The third-party JARs consist of all the transitive dependencies from these modules.
     // Not sure whether we have to include all the thirdparty JARs from across all the modules.
     for (Project module : [
-        project(":lucene:luke")
+        project(":lucene:expressions"),
+        project(":lucene:facet"),
+        project(":lucene:luke"),
     ]) {
       jarsThirdParty(module, {
         transitive = true


### PR DESCRIPTION
This PR shows what parts of the smoke tester break when run on 9.1:
* We ship a new directory `module-test-framework`. Do we mean to be including this in the binary distribution?
* There are several new test folders like `analysis.tests`, `core.tests`, etc. that we could also omit.
* The demo can't be launched because it's missing external dependencies (org.carrotsearch.hppc for `:lucene:facets` and antlr/ asm for `:lucene:expressions`). How should we make these available?


NOTE: this PR is very hacky and is not meant to be merged, it just demonstrates the problems.