### PR TITLE
LUCENE-10448: avoid the instant writing rate bigger than the limited rate in merge process

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/MergeRateLimiter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeRateLimiter.java
@@ -91,7 +91,7 @@ public class MergeRateLimiter extends RateLimiter {
     while ((delta = maybePause(bytes, System.nanoTime(), itera, lastedTime)) >= 0) {
       // Keep waiting.
       paused += delta;
-      itera ++;
+      itera++;
     }
 
     return paused;
@@ -112,7 +112,8 @@ public class MergeRateLimiter extends RateLimiter {
    * applied. If the thread needs pausing, this method delegates to the linked {@link
    * OneMergeProgress}.
    */
-  private long maybePause(long bytes, long curNS, int itera, long lastedTime) throws MergePolicy.MergeAbortedException {
+  private long maybePause(long bytes, long curNS, int itera, long lastedTime)
+      throws MergePolicy.MergeAbortedException {
     // Now is a good time to abort the merge:
     if (mergeProgress.isAborted()) {
       throw new MergePolicy.MergeAbortedException("Merge aborted.");

--- a/lucene/core/src/java/org/apache/lucene/index/MergeRateLimiter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeRateLimiter.java
@@ -86,12 +86,10 @@ public class MergeRateLimiter extends RateLimiter {
     // While loop because we may wake up and check again when our rate limit
     // is changed while we were pausing:
     long paused = 0;
-    int itera = 0;
     long delta;
-    while ((delta = maybePause(bytes, System.nanoTime(), itera, lastedTime)) >= 0) {
+    while ((delta = maybePause(bytes, System.nanoTime(), lastedTime)) >= 0) {
       // Keep waiting.
       paused += delta;
-      itera++;
     }
 
     return paused;
@@ -112,7 +110,7 @@ public class MergeRateLimiter extends RateLimiter {
    * applied. If the thread needs pausing, this method delegates to the linked {@link
    * OneMergeProgress}.
    */
-  private long maybePause(long bytes, long curNS, int itera, long lastedTime)
+  private long maybePause(long bytes, long curNS, long lastedTime)
       throws MergePolicy.MergeAbortedException {
     // Now is a good time to abort the merge:
     if (mergeProgress.isAborted()) {
@@ -130,16 +128,7 @@ public class MergeRateLimiter extends RateLimiter {
 
     // We don't bother with thread pausing if the pause is smaller than 2 msec.
     if (curPauseNS <= MIN_PAUSE_NS) {
-      if (itera == 0) {
-        curPauseNS = (long) (1000000000 * secondsToPause) - lastedTime;
-        if (curPauseNS <= MIN_PAUSE_NS) {
-          return -1;
-        }
-      } else {
-        // Set to curNS, not targetNS, to enforce the instant rate, not
-        // the "averaged over all history" rate:
         return -1;
-      }
     }
 
     // Defensive: don't sleep for too long; the loop above will call us again if

--- a/lucene/core/src/java/org/apache/lucene/index/MergeRateLimiter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeRateLimiter.java
@@ -128,7 +128,7 @@ public class MergeRateLimiter extends RateLimiter {
 
     // We don't bother with thread pausing if the pause is smaller than 2 msec.
     if (curPauseNS <= MIN_PAUSE_NS) {
-        return -1;
+      return -1;
     }
 
     // Defensive: don't sleep for too long; the loop above will call us again if

--- a/lucene/core/src/java/org/apache/lucene/index/MergeRateLimiter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeRateLimiter.java
@@ -87,7 +87,7 @@ public class MergeRateLimiter extends RateLimiter {
     // is changed while we were pausing:
     long paused = 0;
     long delta;
-    long pauseStartingTime =  System.nanoTime();
+    long pauseStartingTime = System.nanoTime();
     while ((delta = maybePause(bytes, System.nanoTime(), pauseStartingTime, lastedTime)) >= 0) {
       // Keep waiting.
       paused += delta;
@@ -111,7 +111,7 @@ public class MergeRateLimiter extends RateLimiter {
    * applied. If the thread needs pausing, this method delegates to the linked {@link
    * OneMergeProgress}.
    */
-  private long maybePause(long bytes, long curNS, long pauseStartingTime , long lastedTime)
+  private long maybePause(long bytes, long curNS, long pauseStartingTime, long lastedTime)
       throws MergePolicy.MergeAbortedException {
     // Now is a good time to abort the merge:
     if (mergeProgress.isAborted()) {

--- a/lucene/core/src/java/org/apache/lucene/store/RateLimiter.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RateLimiter.java
@@ -43,7 +43,7 @@ public abstract class RateLimiter {
    *
    * @return the pause time in nano seconds
    */
-  public abstract long pause(long bytes) throws IOException;
+  public abstract long pause(long bytes, long lastedTime) throws IOException;
 
   /**
    * How many bytes caller should add up itself before invoking {@link #pause}. NOTE: The value
@@ -94,7 +94,7 @@ public abstract class RateLimiter {
      * @return the pause time in nano seconds
      */
     @Override
-    public long pause(long bytes) {
+    public long pause(long bytes, long lastedTime) {
 
       long startNS = System.nanoTime();
 

--- a/lucene/core/src/test/org/apache/lucene/store/TestRateLimitedIndexOutput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestRateLimitedIndexOutput.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.store;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.MergeRateLimiter;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+public class TestRateLimitedIndexOutput  extends LuceneTestCase {
+
+    public void testCheckInstanthighRate ()  throws Exception {
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput in = dir.createOutput("RateLimitedIndexOutputTest", IOContext.DEFAULT)) {
+                final List<SegmentCommitInfo> segments = new LinkedList<SegmentCommitInfo>();
+                SegmentInfo si =
+                        new SegmentInfo(
+                                dir,
+                                Version.LATEST,
+                                Version.LATEST,
+                                "test",
+                                10,
+                                false,
+                                Codec.getDefault(),
+                                Collections.emptyMap(),
+                                StringHelper.randomId(),
+                                new HashMap<>(),
+                                null);
+                segments.add(new SegmentCommitInfo(si, 0, 0, 0, 0, 0, StringHelper.randomId()));
+
+                MergePolicy.OneMerge oneMerge = new MergePolicy.OneMerge(segments);
+                oneMerge.mergeInit();
+
+                MergeRateLimiter rateLimiter = new MergeRateLimiter(oneMerge.getMergeProgress());
+                rateLimiter.setMBPerSec(0.0001);
+                RateLimitedIndexOutput rateLimitedIndexOutput = new RateLimitedIndexOutput(rateLimiter, in);
+                byte[] bytes = new byte[]{1,2,3};
+                assertTrue(bytes.length > rateLimiter.getMinPauseCheckBytes());
+                rateLimitedIndexOutput.writeBytes(bytes, 0, bytes.length);
+                Thread.sleep(100);
+
+                bytes = new byte[]{1,2,3,4};
+                assertTrue(bytes.length > rateLimiter.getMinPauseCheckBytes());
+                long start = System.nanoTime();
+                rateLimitedIndexOutput.writeBytes(bytes, 0, bytes.length);
+                long end = System.nanoTime() - start;
+                double pauseTimes = bytes.length/1024./1024./rateLimiter.getMBPerSec()*1000000000;
+                assertTrue(end > pauseTimes);
+            }
+        }
+    }
+}

--- a/lucene/core/src/test/org/apache/lucene/store/TestRateLimiter.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestRateLimiter.java
@@ -36,7 +36,7 @@ public final class TestRateLimiter extends LuceneTestCase {
                 ThreadInterruptedException.class,
                 () -> {
                   new SimpleRateLimiter(1)
-                      .pause((long) (1.5 * Integer.MAX_VALUE * 1024 * 1024 / 1000));
+                      .pause((long) (1.5 * Integer.MAX_VALUE * 1024 * 1024 / 1000), 0);
                 });
           }
         };
@@ -70,7 +70,7 @@ public final class TestRateLimiter extends LuceneTestCase {
                 totBytes.addAndGet(numBytes);
                 bytesSinceLastPause += numBytes;
                 if (bytesSinceLastPause > limiter.getMinPauseCheckBytes()) {
-                  limiter.pause(bytesSinceLastPause);
+                  limiter.pause(bytesSinceLastPause, 0);
                   bytesSinceLastPause = 0;
                 }
               }


### PR DESCRIPTION
# Description

In the merge process, if there is a long interval between two chunks writing, then the second chunk write will be not paused, as the result, the instant writing rate of the second chunk is high, which is far more than the limited rate.

# Tests

Added TestRateLimitedIndexOutput. 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
