### PR TITLE
LUCENE-10460: Delegating DocIdSetIterator could be replaced to DocIdSetIterator#range(int minDoc, int maxDoc) in IndexSortSortedNumericDocValuesRangeQuery

### DIFF
--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -278,6 +278,10 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
     }
 
     int lastDocIdExclusive = high + 1;
+    if (sortField.getMissingValue() == null && firstDocIdInclusive < lastDocIdExclusive) {
+      DocIdSetIterator disi = DocIdSetIterator.range(firstDocIdInclusive, lastDocIdExclusive);
+      return new BoundedDocSetIdIterator(firstDocIdInclusive, lastDocIdExclusive, disi);
+    }
     return new BoundedDocSetIdIterator(firstDocIdInclusive, lastDocIdExclusive, delegate);
   }
 


### PR DESCRIPTION
While taking advantage of of index sort In IndexSortSortedNumericDocValuesRangeQuery, if MissingValue disabled, all Documents between a range of firstDoc and lastDoc must contain docValues. So In BoundedDocSetIdIterator#advance(int), the delegating DocIdSetIterator could be replaced to DocIdSetIterator#range(int minDoc, int maxDoc)?