### PR TITLE
Sanity check on start javaw

### DIFF
--- a/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestScripts.java
+++ b/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestScripts.java
@@ -134,7 +134,7 @@ public class TestScripts extends AbstractLuceneDistributionTest {
           throw new AssertionError("Forked process did not terminate in the expected time");
         }
 
-        // Wait until the log file is created by Luke.
+        // Wait until the log file is created by the descendant process.
         ExecutorService executor = Executors.newSingleThreadExecutor();
         executor.submit(() -> {
           while (Files.notExists(logFile)) {

--- a/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestScripts.java
+++ b/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestScripts.java
@@ -144,7 +144,10 @@ public class TestScripts extends AbstractLuceneDistributionTest {
           throw new AssertionError("Forked process did not terminate in the expected time");
         }
 
-        sleep(50000);
+        if (Files.size(logFile) == 0) {
+          sleep(5000);
+        }
+
         int exitStatus = p.exitValue();
 
         Assertions.assertThat(exitStatus)

--- a/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestScripts.java
+++ b/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestScripts.java
@@ -51,8 +51,9 @@ public class TestScripts extends AbstractLuceneDistributionTest {
       distributionPath = getDistributionPath();
     }
 
+    // Use "javaw" on Windows, "java" otherwise.
     Path currentJava =
-        Paths.get(System.getProperty("java.home"), "bin", WINDOWS ? "java.exe" : "java");
+        Paths.get(System.getProperty("java.home"), "bin", WINDOWS ? "javaw.exe" : "java");
     Assertions.assertThat(currentJava).exists();
 
     Path lukeScript = resolveScript(distributionPath.resolve("bin").resolve("luke"));
@@ -133,6 +134,7 @@ public class TestScripts extends AbstractLuceneDistributionTest {
           throw new AssertionError("Forked process did not terminate in the expected time");
         }
 
+        // Wait until the log file is created by Luke.
         ExecutorService executor = Executors.newSingleThreadExecutor();
         executor.submit(() -> {
           while (Files.notExists(logFile)) {
@@ -143,9 +145,9 @@ public class TestScripts extends AbstractLuceneDistributionTest {
         if (!executor.awaitTermination(timeoutInSeconds, TimeUnit.SECONDS)) {
           throw new AssertionError("Forked process did not terminate in the expected time");
         }
-
+        // Wait three more seconds if the log file is still empty.
         if (Files.size(logFile) == 0) {
-          sleep(5000);
+          sleep(3000);
         }
 
         int exitStatus = p.exitValue();
@@ -154,7 +156,6 @@ public class TestScripts extends AbstractLuceneDistributionTest {
             .as("forked process exit status")
             .isEqualTo(expectedExitCode);
 
-        //processOutputConsumer.accept(forkedProcess.getProcessOutputFile());
         processOutputConsumer.accept(logFile);
       } catch (Throwable t) {
         logSubprocessOutput(

--- a/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestScripts.java
+++ b/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestScripts.java
@@ -144,6 +144,7 @@ public class TestScripts extends AbstractLuceneDistributionTest {
           throw new AssertionError("Forked process did not terminate in the expected time");
         }
 
+        sleep(50000);
         int exitStatus = p.exitValue();
 
         Assertions.assertThat(exitStatus)

--- a/lucene/distribution/src/binary-release/bin/luke.cmd
+++ b/lucene/distribution/src/binary-release/bin/luke.cmd
@@ -32,7 +32,7 @@ REM For distribution testing we don't use start and pass an explicit java comman
 REM This is required because otherwise we can't block on luke invocation and can't intercept
 REM the return status. We also force UTF-8 encoding so that we don't have to interpret the output in
 REM an unknown local platform encoding.
-SET LAUNCH_START=
+SET LAUNCH_START=start "Lucene Luke"
 SET LAUNCH_OPTS=-Dfile.encoding=UTF-8
 
 :launch

--- a/lucene/distribution/src/binary-release/bin/luke.cmd
+++ b/lucene/distribution/src/binary-release/bin/luke.cmd
@@ -18,21 +18,17 @@
 SETLOCAL
 SET MODULES=%~dp0..
 
-IF DEFINED LAUNCH_CMD GOTO testing
 REM Windows 'start' command takes the first quoted argument to be the title of the started window. Since we
 REM quote the LAUNCH_CMD (because it can contain spaces), it misinterprets it as the title and fails to run.
 REM force the window title here.
 SET LAUNCH_START=start "Lucene Luke"
+
+IF DEFINED LAUNCH_CMD GOTO testing
 SET LAUNCH_CMD=javaw
 SET LAUNCH_OPTS=
 goto launch
 
 :testing
-REM For distribution testing we don't use start and pass an explicit java command path,
-REM This is required because otherwise we can't block on luke invocation and can't intercept
-REM the return status. We also force UTF-8 encoding so that we don't have to interpret the output in
-REM an unknown local platform encoding.
-SET LAUNCH_START=start "Lucene Luke"
 SET LAUNCH_OPTS=-Dfile.encoding=UTF-8
 
 :launch

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/LukeMain.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/LukeMain.java
@@ -23,8 +23,10 @@ import java.awt.*;
 import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.concurrent.SynchronousQueue;
+import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 import javax.swing.*;
 import org.apache.lucene.luke.app.desktop.components.LukeWindowProvider;
 import org.apache.lucene.luke.app.desktop.components.dialog.menubar.OpenIndexDialogFactory;
@@ -71,6 +73,16 @@ public class LukeMain {
 
   public static void main(String[] args) throws Exception {
     boolean sanityCheck = Arrays.asList(args).contains("--sanity-check");
+
+    if (sanityCheck) {
+      int idx = Arrays.binarySearch(args, "--sanity-check") + 1;
+      if (idx < args.length) {
+        String logFile = args[idx];
+        FileHandler fh = new FileHandler(logFile);
+        fh.setFormatter(new SimpleFormatter());
+        Logger.getGlobal().addHandler(fh);
+      }
+    }
 
     if (sanityCheck && GraphicsEnvironment.isHeadless()) {
       Logger.getGlobal().log(Level.SEVERE, "[Vader] Hello, Luke. Can't do much in headless mode.");

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/LukeMain.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/LukeMain.java
@@ -77,6 +77,7 @@ public class LukeMain {
     if (sanityCheck) {
       int idx = Arrays.binarySearch(args, "--sanity-check") + 1;
       if (idx < args.length) {
+        // add file handler for launch testing.
         String logFile = args[idx];
         FileHandler fh = new FileHandler(logFile);
         fh.setFormatter(new SimpleFormatter());


### PR DESCRIPTION
This checks if Luke process successfully starts on "java" on Mac/Linux or "start javaw" on Windows.
TestScripts now checks if the expected message is contained in a log file instead of the forked process's stdout.
I tested this works on Linux and Windows.