### PR TITLE
LUCENE-10325: Add getTopDims functionality to Facets

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/Facets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/Facets.java
@@ -48,4 +48,13 @@ public abstract class Facets {
    * indexed, for example depending on the type of document.
    */
   public abstract List<FacetResult> getAllDims(int topN) throws IOException;
+
+  /**
+   * Returns labels for topN dimensions and their topNChildren sorted by the number of hits that
+   * dimension matched
+   */
+  public List<FacetResult> getTopDims(int topNDims, int topNChildren) throws IOException {
+    List<FacetResult> allResults = getAllDims(topNChildren);
+    return allResults.subList(0, Math.min(topNDims, allResults.size()));
+  }
 }

--- a/lucene/facet/src/java/org/apache/lucene/facet/Facets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/Facets.java
@@ -50,9 +50,9 @@ public abstract class Facets {
   public abstract List<FacetResult> getAllDims(int topN) throws IOException;
 
   /**
-   * Returns labels for topN dimensions and their topNChildren sorted by the number of hits/aggregated values
-   * that dimension matched; Sub-classes may want to override this implementation with a more efficient one
-   * if they are able.
+   * Returns labels for topN dimensions and their topNChildren sorted by the number of
+   * hits/aggregated values that dimension matched; Sub-classes may want to override this
+   * implementation with a more efficient one if they are able.
    */
   public List<FacetResult> getTopDims(int topNDims, int topNChildren) throws IOException {
     List<FacetResult> allResults = getAllDims(topNChildren);

--- a/lucene/facet/src/java/org/apache/lucene/facet/Facets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/Facets.java
@@ -51,8 +51,9 @@ public abstract class Facets {
 
   /**
    * Returns labels for topN dimensions and their topNChildren sorted by the number of
-   * hits/aggregated values that dimension matched; Sub-classes may want to override this
-   * implementation with a more efficient one if they are able.
+   * hits/aggregated values that dimension matched; Results should be the same as calling getAllDims
+   * and then only using the first topNDims; Sub-classes may want to override this implementation
+   * with a more efficient one if they are able.
    */
   public List<FacetResult> getTopDims(int topNDims, int topNChildren) throws IOException {
     List<FacetResult> allResults = getAllDims(topNChildren);

--- a/lucene/facet/src/java/org/apache/lucene/facet/Facets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/Facets.java
@@ -50,8 +50,9 @@ public abstract class Facets {
   public abstract List<FacetResult> getAllDims(int topN) throws IOException;
 
   /**
-   * Returns labels for topN dimensions and their topNChildren sorted by the number of hits that
-   * dimension matched
+   * Returns labels for topN dimensions and their topNChildren sorted by the number of hits/aggregated values
+   * that dimension matched; Sub-classes may want to override this implementation with a more efficient one
+   * if they are able.
    */
   public List<FacetResult> getTopDims(int topNDims, int topNChildren) throws IOException {
     List<FacetResult> allResults = getAllDims(topNChildren);

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -168,8 +168,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     ChildOrdsResult childOrdsResult;
 
     // if getTopDims is called, get results from previously stored dimToChildOrdsResult, otherwise
-    // call
-    // getChildOrdsResult to get dimCount, childCount and the queue for the dimension's top children
+    // call getChildOrdsResult to get dimCount, childCount and the queue for the dimension's top
+    // children
     if (dimToChildOrdsResult != null) {
       childOrdsResult = dimToChildOrdsResult;
     } else {
@@ -198,9 +198,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
       PrimitiveIterator.OfInt childOrds, int topN, FacetsConfig.DimConfig dimConfig, int pathOrd) {
 
     TopOrdAndIntQueue q = null;
-
     int bottomCount = 0;
-
     int dimCount = 0;
     int childCount = 0;
 
@@ -275,10 +273,9 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     // if dimCount was not aggregated at indexing time, iterate over childOrds to get dimCount
     ChildOrdsResult childOrdsResult = getChildOrdsResult(childOrds, topN, dimConfig, dimOrd);
 
-    // if no early termination, store dim and childOrdsResult into hashmap
-    if (dimToChildOrdsResult != null) {
-      dimToChildOrdsResult.put(dim, childOrdsResult);
-    }
+    // if no early termination, store dim and childOrdsResult into a hashmap to avoid calling
+    // getChildOrdsResult again in getPathResult
+    dimToChildOrdsResult.put(dim, childOrdsResult);
 
     return childOrdsResult.dimCount;
   }
@@ -445,7 +442,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
 
   /** Returns FacetResult for a dimension. */
   private FacetResult getFacetResultForDim(
-      String dim, int topNChildren, ChildOrdsResult cacheChildOrdsResult) throws IOException {
+      String dim, int topNChildren, ChildOrdsResult dimToChildOrdsResult) throws IOException {
 
     FacetsConfig.DimConfig dimConfig = stateConfig.getDimConfig(dim);
 
@@ -459,7 +456,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
           dimOrd,
           dimTree.iterator(),
           topNChildren,
-          cacheChildOrdsResult);
+          dimToChildOrdsResult);
     } else {
       OrdRange ordRange = state.getOrdRange(dim);
       int dimOrd = ordRange.start;
@@ -471,7 +468,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
         childIt.next();
       }
       return getPathResult(
-          dimConfig, dim, emptyPath, dimOrd, childIt, topNChildren, cacheChildOrdsResult);
+          dimConfig, dim, emptyPath, dimOrd, childIt, topNChildren, dimToChildOrdsResult);
     }
   }
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -183,7 +183,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     LabelAndValue[] labelValues = getLabelValuesFromTopOrdAndIntQueue(childOrdsResult.q);
 
     if (dimConfig.hierarchical == true) {
-      return new FacetResult(dim, path, counts[pathOrd], labelValues, childOrdsResult.childCount);
+      return new FacetResult(
+          dim, path, childOrdsResult.dimCount, labelValues, childOrdsResult.childCount);
     } else {
       return new FacetResult(
           dim, emptyPath, childOrdsResult.dimCount, labelValues, childOrdsResult.childCount);
@@ -227,7 +228,9 @@ public class SortedSetDocValuesFacetCounts extends Facets {
       }
     }
 
-    if (dimConfig.hierarchical == false) {
+    if (dimConfig.hierarchical == true) {
+      dimCount = counts[pathOrd];
+    } else {
       // see if dimCount is actually reliable or needs to be reset
       if (dimConfig.multiValued) {
         if (dimConfig.requireDimCount) {

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -436,13 +436,24 @@ public class SortedSetDocValuesFacetCounts extends Facets {
   }
 
   /** Returns FacetResult for a dimension. */
-  private FacetResult getFacetResultForDim(String dim, int topNChildren, HashMap<String, SortedSetDocValuesChildOrdsResult> cacheChildOrdsResult) throws IOException {
+  private FacetResult getFacetResultForDim(
+      String dim,
+      int topNChildren,
+      HashMap<String, SortedSetDocValuesChildOrdsResult> cacheChildOrdsResult)
+      throws IOException {
     FacetsConfig.DimConfig dimConfig = stateConfig.getDimConfig(dim);
     if (dimConfig.hierarchical) {
       DimTree dimTree = state.getDimTree(dim);
       int dimOrd = dimTree.dimStartOrd;
       FacetResult fr =
-          getPathResult(dimConfig, dim, emptyPath, dimOrd, dimTree.iterator(), topNChildren, cacheChildOrdsResult);
+          getPathResult(
+              dimConfig,
+              dim,
+              emptyPath,
+              dimOrd,
+              dimTree.iterator(),
+              topNChildren,
+              cacheChildOrdsResult);
       if (fr != null) {
         return fr;
       }
@@ -456,7 +467,9 @@ public class SortedSetDocValuesFacetCounts extends Facets {
         // child:
         childIt.next();
       }
-      FacetResult fr = getPathResult(dimConfig, dim, emptyPath, dimOrd, childIt, topNChildren, cacheChildOrdsResult);
+      FacetResult fr =
+          getPathResult(
+              dimConfig, dim, emptyPath, dimOrd, childIt, topNChildren, cacheChildOrdsResult);
       if (fr != null) {
         return fr;
       }
@@ -495,19 +508,22 @@ public class SortedSetDocValuesFacetCounts extends Facets {
 
   @Override
   public List<FacetResult> getTopDims(int topNDims, int topNChildren) throws IOException {
-    // Creates priority queue to store top dimensions and sort by their aggregated values/hits and string values.
-    PriorityQueue<SortedSetDocValuesDimValueResult> pq = new PriorityQueue<>(topNDims) {
-      @Override
-      protected boolean lessThan(SortedSetDocValuesDimValueResult a, SortedSetDocValuesDimValueResult b) {
-        if (a.value.intValue() > b.value.intValue()) {
-          return false;
-        } else if (a.value.intValue() < b.value.intValue()) {
-          return true;
-        } else {
-          return a.dim.compareTo(b.dim) > 0;
-        }
-      }
-    };
+    // Creates priority queue to store top dimensions and sort by their aggregated values/hits and
+    // string values.
+    PriorityQueue<SortedSetDocValuesDimValueResult> pq =
+        new PriorityQueue<>(topNDims) {
+          @Override
+          protected boolean lessThan(
+              SortedSetDocValuesDimValueResult a, SortedSetDocValuesDimValueResult b) {
+            if (a.value.intValue() > b.value.intValue()) {
+              return false;
+            } else if (a.value.intValue() < b.value.intValue()) {
+              return true;
+            } else {
+              return a.dim.compareTo(b.dim) > 0;
+            }
+          }
+        };
 
     HashMap<String, SortedSetDocValuesChildOrdsResult> cacheChildOrdsResult = new HashMap<>();
 
@@ -517,7 +533,9 @@ public class SortedSetDocValuesFacetCounts extends Facets {
         DimTree dimTree = state.getDimTree(dim);
         int dimOrd = dimTree.dimStartOrd;
         // get dim value
-        int dimCount = getDimValue(dimConfig, dim, dimOrd, dimTree.iterator(), topNChildren, cacheChildOrdsResult);
+        int dimCount =
+            getDimValue(
+                dimConfig, dim, dimOrd, dimTree.iterator(), topNChildren, cacheChildOrdsResult);
         if (dimCount != 0) {
           // use priority queue to store SortedSetDocValuesDimValueResult for topNDims
           pq.insertWithOverflow(new SortedSetDocValuesDimValueResult(dim, dimCount));
@@ -532,7 +550,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
           // child:
           childIt.next();
         }
-        int dimCount = getDimValue(dimConfig, dim, dimOrd, childIt, topNChildren, cacheChildOrdsResult);
+        int dimCount =
+            getDimValue(dimConfig, dim, dimOrd, childIt, topNChildren, cacheChildOrdsResult);
         if (dimCount != 0) {
           pq.insertWithOverflow(new SortedSetDocValuesDimValueResult(dim, dimCount));
         }
@@ -544,7 +563,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     while (pq.size() > 0) {
       SortedSetDocValuesDimValueResult dimValueResult = pq.pop();
       if (dimValueResult != null) {
-        FacetResult factResult = getFacetResultForDim(dimValueResult.dim, topNChildren, cacheChildOrdsResult);
+        FacetResult factResult =
+            getFacetResultForDim(dimValueResult.dim, topNChildren, cacheChildOrdsResult);
         if (factResult != null) {
           results.add(0, factResult);
         }

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -152,7 +152,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
 
     SortedSetDocValuesChildOrdsResult childOrdsResult = null;
 
-    // if getTopDims is called, get results from cacheChildOrdsResult, otherwise call getChildOrdsResult to get
+    // if getTopDims is called, get results from cacheChildOrdsResult, otherwise call
+    // getChildOrdsResult to get
     // dimCount, childCount and TopOrdAndIntQueue q
     if (cacheChildOrdsResult != null && cacheChildOrdsResult.containsKey(dim)) {
       childOrdsResult = cacheChildOrdsResult.get(dim);
@@ -182,9 +183,12 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     }
   }
 
-  /** Returns SortedSetDocValuesChildOrdsResult that contains results of dimCount, childCount, and TopOrdAndIntQueue q
-   * to populate FacetResult in getPathResult. */
-  private SortedSetDocValuesChildOrdsResult getChildOrdsResult(PrimitiveIterator.OfInt childOrds, int topN) {
+  /**
+   * Returns SortedSetDocValuesChildOrdsResult that contains results of dimCount, childCount, and
+   * TopOrdAndIntQueue q to populate FacetResult in getPathResult.
+   */
+  private SortedSetDocValuesChildOrdsResult getChildOrdsResult(
+      PrimitiveIterator.OfInt childOrds, int topN) {
 
     TopOrdAndIntQueue q = null;
 
@@ -221,7 +225,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
   }
 
   /** Returns label values for dims. */
-  private LabelAndValue[] getLabelValuesFromTopOrdAndIntQueue(TopOrdAndIntQueue q) throws IOException {
+  private LabelAndValue[] getLabelValuesFromTopOrdAndIntQueue(TopOrdAndIntQueue q)
+      throws IOException {
     LabelAndValue[] labelValues = new LabelAndValue[q.size()];
     for (int i = labelValues.length - 1; i >= 0; i--) {
       TopOrdAndIntQueue.OrdAndValue ordAndValue = q.pop();
@@ -235,12 +240,12 @@ public class SortedSetDocValuesFacetCounts extends Facets {
 
   /** Returns value/count of a dimension. */
   private Number getDimValue(
-          FacetsConfig.DimConfig dimConfig,
-          String dim,
-          int pathOrd,
-          PrimitiveIterator.OfInt childOrds,
-          int topN)
-          throws IOException {
+      FacetsConfig.DimConfig dimConfig,
+      String dim,
+      int pathOrd,
+      PrimitiveIterator.OfInt childOrds,
+      int topN)
+      throws IOException {
 
     // if dimConfig.hierarchical == true, return dimCount directly
     if (dimConfig.hierarchical == true && pathOrd >= 0) {
@@ -437,7 +442,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     if (dimConfig.hierarchical) {
       DimTree dimTree = state.getDimTree(dim);
       int dimOrd = dimTree.dimStartOrd;
-      FacetResult fr = getPathResult(dimConfig, dim, emptyPath, dimOrd, dimTree.iterator(), topNChildren);
+      FacetResult fr =
+          getPathResult(dimConfig, dim, emptyPath, dimOrd, dimTree.iterator(), topNChildren);
       if (fr != null) {
         return fr;
       }
@@ -458,7 +464,6 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     }
     return null;
   }
-
 
   @Override
   public List<FacetResult> getAllDims(int topN) throws IOException {
@@ -492,7 +497,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
   @Override
   public List<FacetResult> getTopDims(int topNDims, int topNChildren) throws IOException {
     // get topNDims by their values
-    SortedSetDocValueDimValuePriorityQueue pq = new SortedSetDocValueDimValuePriorityQueue(topNDims);
+    SortedSetDocValueDimValuePriorityQueue pq =
+        new SortedSetDocValueDimValuePriorityQueue(topNDims);
     cacheChildOrdsResult = new HashMap<>();
     for (String dim : state.getDims()) {
       FacetsConfig.DimConfig dimConfig = stateConfig.getDimConfig(dim);
@@ -538,7 +544,10 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     return results;
   }
 
-  /** Creates SortedSetDocValuesChildOrdsResult to store dimCount, childCount, and TopOrdAndIntQueue q for getPathResult. */
+  /**
+   * Creates SortedSetDocValuesChildOrdsResult to store dimCount, childCount, and TopOrdAndIntQueue
+   * q for getPathResult.
+   */
   private class SortedSetDocValuesChildOrdsResult {
     final int dimCount;
     final int childCount;
@@ -551,7 +560,10 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     }
   }
 
-  /** Creates SortedSetDocValuesDimValueResult to store the label and count of dim in order to sort by these two fields. */
+  /**
+   * Creates SortedSetDocValuesDimValueResult to store the label and count of dim in order to sort
+   * by these two fields.
+   */
   private class SortedSetDocValuesDimValueResult {
     final String dim;
     final Number value;
@@ -562,14 +574,19 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     }
   }
 
-  /** Creates priority queue to store top dimensions and sort by their aggregated values/hits and string values. */
-  private class SortedSetDocValueDimValuePriorityQueue extends PriorityQueue<SortedSetDocValuesDimValueResult> {
+  /**
+   * Creates priority queue to store top dimensions and sort by their aggregated values/hits and
+   * string values.
+   */
+  private class SortedSetDocValueDimValuePriorityQueue
+      extends PriorityQueue<SortedSetDocValuesDimValueResult> {
     public SortedSetDocValueDimValuePriorityQueue(int maxSize) {
       super(maxSize);
     }
 
     @Override
-    protected boolean lessThan(SortedSetDocValuesDimValueResult a, SortedSetDocValuesDimValueResult b) {
+    protected boolean lessThan(
+        SortedSetDocValuesDimValueResult a, SortedSetDocValuesDimValueResult b) {
       if (a.value.intValue() > b.value.intValue()) {
         return false;
       } else if (a.value.intValue() < b.value.intValue()) {

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -276,7 +276,6 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     // if no early termination, store dim and childOrdsResult into a hashmap to avoid calling
     // getChildOrdsResult again in getPathResult
     dimToChildOrdsResult.put(dim, childOrdsResult);
-
     return childOrdsResult.dimCount;
   }
 
@@ -440,6 +439,14 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     return counts[ord];
   }
 
+  /**
+   * Overloaded method to allow getFacetResultForDim be called without passing in the
+   * dimToChildOrdsResult parameter
+   */
+  private FacetResult getFacetResultForDim(String dim, int topNChildren) throws IOException {
+    return getFacetResultForDim(dim, topNChildren, null);
+  }
+
   /** Returns FacetResult for a dimension. */
   private FacetResult getFacetResultForDim(
       String dim, int topNChildren, ChildOrdsResult dimToChildOrdsResult) throws IOException {
@@ -476,7 +483,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
   public List<FacetResult> getAllDims(int topN) throws IOException {
     List<FacetResult> results = new ArrayList<>();
     for (String dim : state.getDims()) {
-      FacetResult factResult = getFacetResultForDim(dim, topN, null);
+      FacetResult factResult = getFacetResultForDim(dim, topN);
       if (factResult != null) {
         results.add(factResult);
       }

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -168,7 +168,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     if (dimConfig.hierarchical == true) {
       return new FacetResult(dim, path, counts[pathOrd], labelValues, childOrdsResult.childCount);
     } else {
-      return new FacetResult(dim, emptyPath, childOrdsResult.dimCount, labelValues, childOrdsResult.childCount);
+      return new FacetResult(
+          dim, emptyPath, childOrdsResult.dimCount, labelValues, childOrdsResult.childCount);
     }
   }
 
@@ -248,7 +249,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
       int topN,
       HashMap<String, ChildOrdsResult> cacheChildOrdsResult) {
 
-    // if dimConfig.hierarchical == true || dim is multiValued and dim count has been aggregated at indexing time,
+    // if dimConfig.hierarchical == true || dim is multiValued and dim count has been aggregated at
+    // indexing time,
     // return dimCount directly
     if (dimConfig.hierarchical == true || (dimConfig.multiValued && dimConfig.requireDimCount)) {
       return counts[dimOrd];
@@ -427,10 +429,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
 
   /** Returns FacetResult for a dimension. */
   private FacetResult getFacetResultForDim(
-      String dim,
-      int topNChildren,
-      ChildOrdsResult cacheChildOrdsResult)
-      throws IOException {
+      String dim, int topNChildren, ChildOrdsResult cacheChildOrdsResult) throws IOException {
 
     FacetsConfig.DimConfig dimConfig = stateConfig.getDimConfig(dim);
 
@@ -438,13 +437,13 @@ public class SortedSetDocValuesFacetCounts extends Facets {
       DimTree dimTree = state.getDimTree(dim);
       int dimOrd = dimTree.dimStartOrd;
       return getPathResult(
-              dimConfig,
-              dim,
-              emptyPath,
-              dimOrd,
-              dimTree.iterator(),
-              topNChildren,
-              cacheChildOrdsResult);
+          dimConfig,
+          dim,
+          emptyPath,
+          dimOrd,
+          dimTree.iterator(),
+          topNChildren,
+          cacheChildOrdsResult);
     } else {
       OrdRange ordRange = state.getOrdRange(dim);
       int dimOrd = ordRange.start;
@@ -456,8 +455,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
         childIt.next();
       }
       return getPathResult(
-              dimConfig, dim, emptyPath, dimOrd, childIt, topNChildren, cacheChildOrdsResult);
-
+          dimConfig, dim, emptyPath, dimOrd, childIt, topNChildren, cacheChildOrdsResult);
     }
   }
 
@@ -496,8 +494,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     PriorityQueue<DimValueResult> pq =
         new PriorityQueue<>(topNDims) {
           @Override
-          protected boolean lessThan(
-              DimValueResult a, DimValueResult b) {
+          protected boolean lessThan(DimValueResult a, DimValueResult b) {
             if (a.value > b.value) {
               return false;
             } else if (a.value < b.value) {
@@ -507,7 +504,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
             }
           }
         };
-    
+
     HashMap<String, ChildOrdsResult> cacheChildOrdsResult = new HashMap<>();
     int dimCount;
 
@@ -517,7 +514,9 @@ public class SortedSetDocValuesFacetCounts extends Facets {
         DimTree dimTree = state.getDimTree(dim);
         int dimOrd = dimTree.dimStartOrd;
         // get dim value
-        dimCount = getDimValue(dimConfig, dim, dimOrd, dimTree.iterator(), topNChildren, cacheChildOrdsResult);
+        dimCount =
+            getDimValue(
+                dimConfig, dim, dimOrd, dimTree.iterator(), topNChildren, cacheChildOrdsResult);
       } else {
         OrdRange ordRange = state.getOrdRange(dim);
         int dimOrd = ordRange.start;
@@ -536,7 +535,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
         if (pq.size() < topNDims) {
           pq.insertWithOverflow(new DimValueResult(dim, dimCount));
         } else {
-          if (dimCount > pq.top().value || (dimCount == pq.top().value && dim.compareTo(pq.top().dim) < 0)) {
+          if (dimCount > pq.top().value
+              || (dimCount == pq.top().value && dim.compareTo(pq.top().dim) < 0)) {
             DimValueResult bottomDim = pq.pop();
             bottomDim.dim = dim;
             bottomDim.value = dimCount;
@@ -553,14 +553,16 @@ public class SortedSetDocValuesFacetCounts extends Facets {
     while (pq.size() > 0) {
       DimValueResult dimValueResult = pq.pop();
       FacetResult facetResult =
-          getFacetResultForDim(dimValueResult.dim, topNChildren, cacheChildOrdsResult.get(dimValueResult.dim));
+          getFacetResultForDim(
+              dimValueResult.dim, topNChildren, cacheChildOrdsResult.get(dimValueResult.dim));
       results[--resultSize] = facetResult;
     }
     return Arrays.asList(results);
   }
 
   /**
-   * Creates ChildOrdsResult to store dimCount, childCount, and TopOrdAndIntQueue q for getPathResult.
+   * Creates ChildOrdsResult to store dimCount, childCount, and TopOrdAndIntQueue q for
+   * getPathResult.
    */
   private static class ChildOrdsResult {
     final int dimCount;
@@ -575,7 +577,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
   }
 
   /**
-   * Creates DimValueResult to store the label and value of dim in order to sort by these two fields.
+   * Creates DimValueResult to store the label and value of dim in order to sort by these two
+   * fields.
    */
   private static class DimValueResult {
     String dim;

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -601,6 +601,10 @@ public class TestDrillSideways extends FacetTestCase {
         "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n  Susan (1)\n",
         topNDimsResult.get(0).toString());
 
+    // test getTopDims(10, 10) and expect same results from getAllDims(10)
+    List<FacetResult> allDimsResults = r.facets.getTopDims(10, 10);
+    assertEquals(allResults, allDimsResults);
+
     // More interesting case: drill-down on two fields
     ddq = new DrillDownQuery(config);
     ddq.add("Author", "Lisa");

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -358,6 +358,20 @@ public class TestDrillSideways extends FacetTestCase {
         "dim=Publish Date path=[] value=3 childCount=2\n  2010 (2)\n  2012 (1)\n",
         allResults.get(1).toString());
 
+    // test default implementation of getTopDims
+    List<FacetResult> topNDimsResult = r.facets.getTopDims(2, 1);
+    assertEquals(2, topNDimsResult.size());
+    assertEquals(
+            "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n",
+            topNDimsResult.get(0).toString());
+    assertEquals(
+            "dim=Publish Date path=[] value=3 childCount=2\n  2010 (2)\n",
+            topNDimsResult.get(1).toString());
+
+    // test getTopDims(0, 1)
+    List<FacetResult> topDimsResults2 = r.facets.getTopDims(0, 1);
+    assertEquals(0, topDimsResults2.size());
+
     // More interesting case: drill-down on two fields
     ddq = new DrillDownQuery(config);
     ddq.add("Author", "Lisa");
@@ -580,6 +594,13 @@ public class TestDrillSideways extends FacetTestCase {
     assertEquals(
         "dim=Publish Date path=[] value=3 childCount=2\n  2010 (2)\n  2012 (1)\n",
         allResults.get(1).toString());
+
+    // test default implementation of getTopDims
+    List<FacetResult> topNDimsResult = r.facets.getTopDims(1, 2);
+    assertEquals(1, topNDimsResult.size());
+    assertEquals(
+            "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n  Susan (1)\n",
+            topNDimsResult.get(0).toString());
 
     // More interesting case: drill-down on two fields
     ddq = new DrillDownQuery(config);
@@ -1842,6 +1863,13 @@ public class TestDrillSideways extends FacetTestCase {
     assertEquals(
         "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n  Bob (1)\n  Susan (1)\n  Frank (1)\n",
         allResults.get(0).toString());
+
+    // test default implementation of getTopDims
+    List<FacetResult> topNDimsResult = facets.getTopDims(1, 2);
+    assertEquals(1, topNDimsResult.size());
+    assertEquals(
+            "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n  Susan (1)\n",
+            topNDimsResult.get(0).toString());
 
     // More interesting case: drill-down on two fields
     ddq = new DrillDownQuery(config);

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -362,11 +362,10 @@ public class TestDrillSideways extends FacetTestCase {
     List<FacetResult> topNDimsResult = r.facets.getTopDims(2, 1);
     assertEquals(2, topNDimsResult.size());
     assertEquals(
-            "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n",
-            topNDimsResult.get(0).toString());
+        "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n", topNDimsResult.get(0).toString());
     assertEquals(
-            "dim=Publish Date path=[] value=3 childCount=2\n  2010 (2)\n",
-            topNDimsResult.get(1).toString());
+        "dim=Publish Date path=[] value=3 childCount=2\n  2010 (2)\n",
+        topNDimsResult.get(1).toString());
 
     // test getTopDims(0, 1)
     List<FacetResult> topDimsResults2 = r.facets.getTopDims(0, 1);
@@ -599,8 +598,8 @@ public class TestDrillSideways extends FacetTestCase {
     List<FacetResult> topNDimsResult = r.facets.getTopDims(1, 2);
     assertEquals(1, topNDimsResult.size());
     assertEquals(
-            "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n  Susan (1)\n",
-            topNDimsResult.get(0).toString());
+        "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n  Susan (1)\n",
+        topNDimsResult.get(0).toString());
 
     // More interesting case: drill-down on two fields
     ddq = new DrillDownQuery(config);
@@ -1868,8 +1867,8 @@ public class TestDrillSideways extends FacetTestCase {
     List<FacetResult> topNDimsResult = facets.getTopDims(1, 2);
     assertEquals(1, topNDimsResult.size());
     assertEquals(
-            "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n  Susan (1)\n",
-            topNDimsResult.get(0).toString());
+        "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n  Susan (1)\n",
+        topNDimsResult.get(0).toString());
 
     // More interesting case: drill-down on two fields
     ddq = new DrillDownQuery(config);

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -155,6 +155,18 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
         "dim=field path=[] value=101 childCount=6\n  0 (20)\n  1 (20)\n  2 (20)\n  "
             + "3 (20)\n  4 (20)\n  9223372036854775807 (1)\n",
         result.get(0).toString());
+
+    // test default implementation of getTopDims
+    List<FacetResult> getTopDimResult = facets.getTopDims(1, 1);
+    assertEquals(1, getTopDimResult.size());
+    assertEquals(
+            "dim=field path=[] value=101 childCount=6\n  0 (20)\n",
+            getTopDimResult.get(0).toString());
+
+    // test getTopDims(0, 1)
+    List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
+    assertEquals(0, topDimsResults2.size());
+
     r.close();
     d.close();
   }

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -162,6 +162,10 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     assertEquals(
         "dim=field path=[] value=101 childCount=6\n  0 (20)\n", getTopDimResult.get(0).toString());
 
+    // test getTopDims(10, 10) and expect same results from getAllDims(10)
+    List<FacetResult> allDimsResults = facets.getTopDims(10, 10);
+    assertEquals(result, allDimsResults);
+
     // test getTopDims(0, 1)
     List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
     assertEquals(0, topDimsResults2.size());

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -160,8 +160,7 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     List<FacetResult> getTopDimResult = facets.getTopDims(1, 1);
     assertEquals(1, getTopDimResult.size());
     assertEquals(
-            "dim=field path=[] value=101 childCount=6\n  0 (20)\n",
-            getTopDimResult.get(0).toString());
+        "dim=field path=[] value=101 childCount=6\n  0 (20)\n", getTopDimResult.get(0).toString());
 
     // test getTopDims(0, 1)
     List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
@@ -387,6 +387,11 @@ public class TestStringValueFacetCounts extends FacetTestCase {
       assertEquals(1, allDims.size());
       assertEquals(facetResult, allDims.get(0));
 
+      // test default implementation of getTopDims
+      List<FacetResult> topNDimsResult = facets.getTopDims(2, topN);
+      assertEquals(1, topNDimsResult.size());
+      assertEquals(facetResult, topNDimsResult.get(0));
+
       // This is a little strange, but we request all labels at this point so that when we
       // secondarily sort by label value in order to compare to the expected results, we have
       // all the values. See LUCENE-9991:

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -252,10 +252,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
 
     // test default implementation of getTopDims
     List<FacetResult> topNDimsResult = facets.getTopDims(1, 1);
-    assertEquals(1, topNDimsResult.size());
-    assertEquals(
-        "dim=field path=[] value=22 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (1)\n",
-        topNDimsResult.get(0).toString());
+    assertEquals(test1Child, topNDimsResult);
 
     // test getTopDims(0, 1)
     List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -243,6 +243,24 @@ public class TestRangeFacetCounts extends FacetTestCase {
         "dim=field path=[] value=22 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (1)\n",
         result.get(0).toString());
 
+    // test getAllDims(1)
+    List<FacetResult> test1Child = facets.getAllDims(1);
+    assertEquals(1, test1Child.size());
+    assertEquals(
+            "dim=field path=[] value=22 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (1)\n",
+            test1Child.get(0).toString());
+
+    // test default implementation of getTopDims
+    List<FacetResult> topNDimsResult = facets.getTopDims(1, 1);
+    assertEquals(1, topNDimsResult.size());
+    assertEquals(
+            "dim=field path=[] value=22 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (1)\n",
+            topNDimsResult.get(0).toString());
+
+    // test getTopDims(0, 1)
+    List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
+    assertEquals(0, topDimsResults2.size());
+
     r.close();
     d.close();
   }

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -247,15 +247,15 @@ public class TestRangeFacetCounts extends FacetTestCase {
     List<FacetResult> test1Child = facets.getAllDims(1);
     assertEquals(1, test1Child.size());
     assertEquals(
-            "dim=field path=[] value=22 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (1)\n",
-            test1Child.get(0).toString());
+        "dim=field path=[] value=22 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (1)\n",
+        test1Child.get(0).toString());
 
     // test default implementation of getTopDims
     List<FacetResult> topNDimsResult = facets.getTopDims(1, 1);
     assertEquals(1, topNDimsResult.size());
     assertEquals(
-            "dim=field path=[] value=22 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (1)\n",
-            topNDimsResult.get(0).toString());
+        "dim=field path=[] value=22 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (1)\n",
+        topNDimsResult.get(0).toString());
 
     // test getTopDims(0, 1)
     List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -152,8 +152,8 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
     }
   }
 
-  // test tricky combinations of the three config: MultiValued, Hierarchical, and RequireDimCount of a
-  // dim
+  // test tricky combinations of the three config: MultiValued, Hierarchical, and RequireDimCount of
+  // a dim
   public void testCombinationsOfConfig() throws Exception {
     FacetsConfig config = new FacetsConfig();
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -108,60 +108,56 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
           List<FacetResult> results = facets.getAllDims(10);
           assertEquals(2, results.size());
           assertEquals(
-                  "dim=b path=[] value=2 childCount=2\n  buzz (2)\n  baz (1)\n",
-                  results.get(0).toString());
+              "dim=b path=[] value=2 childCount=2\n  buzz (2)\n  baz (1)\n",
+              results.get(0).toString());
           assertEquals(
-                  "dim=a path=[] value=-1 childCount=3\n  foo (2)\n  bar (1)\n  zoo (1)\n",
-                  results.get(1).toString());
+              "dim=a path=[] value=-1 childCount=3\n  foo (2)\n  bar (1)\n  zoo (1)\n",
+              results.get(1).toString());
 
           // test getAllDims(1, 0) with topN = 0
           expectThrows(
-                  NullPointerException.class,
-                  () -> {
-                    facets.getAllDims(0);
-                  });
+              NullPointerException.class,
+              () -> {
+                facets.getAllDims(0);
+              });
 
           // test getTopDims(10, 10) and expect same results from getAllDims(10)
           List<FacetResult> allDimsResults = facets.getTopDims(10, 10);
           assertEquals(2, results.size());
           assertEquals(
-                  "dim=b path=[] value=2 childCount=2\n  buzz (2)\n  baz (1)\n",
-                  allDimsResults.get(0).toString());
+              "dim=b path=[] value=2 childCount=2\n  buzz (2)\n  baz (1)\n",
+              allDimsResults.get(0).toString());
           assertEquals(
-                  "dim=a path=[] value=-1 childCount=3\n  foo (2)\n  bar (1)\n  zoo (1)\n",
-                  allDimsResults.get(1).toString());
-
+              "dim=a path=[] value=-1 childCount=3\n  foo (2)\n  bar (1)\n  zoo (1)\n",
+              allDimsResults.get(1).toString());
 
           // test getTopDims(2, 1)
           List<FacetResult> topDimsResults = facets.getTopDims(2, 1);
           assertEquals(2, topDimsResults.size());
           assertEquals(
-                  "dim=b path=[] value=2 childCount=2\n  buzz (2)\n",
-                  topDimsResults.get(0).toString());
+              "dim=b path=[] value=2 childCount=2\n  buzz (2)\n", topDimsResults.get(0).toString());
           assertEquals(
-                  "dim=a path=[] value=-1 childCount=3\n  foo (2)\n",
-                  topDimsResults.get(1).toString());
+              "dim=a path=[] value=-1 childCount=3\n  foo (2)\n", topDimsResults.get(1).toString());
 
           // test getAllDims
           List<FacetResult> results2 = facets.getAllDims(1);
           assertEquals(2, results2.size());
           assertEquals(
-                  "dim=b path=[] value=2 childCount=2\n  buzz (2)\n",
-                  results2.get(0).toString());
+              "dim=b path=[] value=2 childCount=2\n  buzz (2)\n", results2.get(0).toString());
 
           // test getTopDims(1, 1)
           List<FacetResult> topDimsResults1 = facets.getTopDims(1, 1);
           assertEquals(1, topDimsResults1.size());
           assertEquals(
-                  "dim=b path=[] value=2 childCount=2\n  buzz (2)\n",
-                  topDimsResults1.get(0).toString());
+              "dim=b path=[] value=2 childCount=2\n  buzz (2)\n",
+              topDimsResults1.get(0).toString());
 
           // test getTopDims(1, 0) with topNChildren = 0
           expectThrows(
-                  NullPointerException.class,
-                  () -> {
-                    facets.getTopDims(1, 0);
-                  });
+              NullPointerException.class,
+              () -> {
+                facets.getTopDims(1, 0);
+              });
 
           // test getTopDims(0, 1)
           List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
@@ -795,8 +791,8 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               "dim=b path=[] value=2 childCount=2\n  bar1 (1)\n  bar2 (1)\n",
               results.get(1).toString());
           assertEquals(
-                  "dim=d path=[] value=2 childCount=2\n  biz1 (1)\n  biz2 (1)\n",
-                  results.get(2).toString());
+              "dim=d path=[] value=2 childCount=2\n  biz1 (1)\n  biz2 (1)\n",
+              results.get(2).toString());
           assertEquals(
               "dim=c path=[] value=1 childCount=1\n  baz1 (1)\n", results.get(3).toString());
 
@@ -804,38 +800,33 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
           List<FacetResult> top1results = facets.getAllDims(1);
           assertEquals(4, results.size());
           assertEquals(
-                  "dim=a path=[] value=3 childCount=3\n  foo1 (1)\n",
-                  top1results.get(0).toString());
+              "dim=a path=[] value=3 childCount=3\n  foo1 (1)\n", top1results.get(0).toString());
           assertEquals(
-                  "dim=b path=[] value=2 childCount=2\n  bar1 (1)\n",
-                  top1results.get(1).toString());
+              "dim=b path=[] value=2 childCount=2\n  bar1 (1)\n", top1results.get(1).toString());
           assertEquals(
-                  "dim=d path=[] value=2 childCount=2\n  biz1 (1)\n",
-                  top1results.get(2).toString());
+              "dim=d path=[] value=2 childCount=2\n  biz1 (1)\n", top1results.get(2).toString());
           assertEquals(
-                  "dim=c path=[] value=1 childCount=1\n  baz1 (1)\n", top1results.get(3).toString());
-
+              "dim=c path=[] value=1 childCount=1\n  baz1 (1)\n", top1results.get(3).toString());
 
           // test getTopDims(1, 1)
           List<FacetResult> topDimsResults1 = facets.getTopDims(1, 1);
           assertEquals(1, topDimsResults1.size());
           assertEquals(
-                  "dim=a path=[] value=3 childCount=3\n  foo1 (1)\n",
-                  topDimsResults1.get(0).toString());
+              "dim=a path=[] value=3 childCount=3\n  foo1 (1)\n",
+              topDimsResults1.get(0).toString());
 
           // test top 2 dims that have the same counts, expect to sort by dim names
           List<FacetResult> topDimsResults2 = facets.getTopDims(3, 2);
           assertEquals(3, topDimsResults2.size());
           assertEquals(
-                  "dim=a path=[] value=3 childCount=3\n  foo1 (1)\n  foo2 (1)\n",
-                  topDimsResults2.get(0).toString());
+              "dim=a path=[] value=3 childCount=3\n  foo1 (1)\n  foo2 (1)\n",
+              topDimsResults2.get(0).toString());
           assertEquals(
-                  "dim=b path=[] value=2 childCount=2\n  bar1 (1)\n  bar2 (1)\n",
-                  topDimsResults2.get(1).toString());
+              "dim=b path=[] value=2 childCount=2\n  bar1 (1)\n  bar2 (1)\n",
+              topDimsResults2.get(1).toString());
           assertEquals(
-                  "dim=d path=[] value=2 childCount=2\n  biz1 (1)\n  biz2 (1)\n",
-                  topDimsResults2.get(2).toString());
-
+              "dim=d path=[] value=2 childCount=2\n  biz1 (1)\n  biz2 (1)\n",
+              topDimsResults2.get(2).toString());
 
           Collection<Accountable> resources = state.getChildResources();
           assertTrue(state.toString().contains(FacetsConfig.DEFAULT_INDEX_FIELD_NAME));
@@ -907,7 +898,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
           List<FacetResult> topDimsResults1 = facets.getTopDims(1, 1);
           assertEquals(1, topDimsResults1.size());
           assertEquals(
-                  "dim=d path=[] value=2 childCount=1\n  foo (2)\n", results.get(0).toString());
+              "dim=d path=[] value=2 childCount=1\n  foo (2)\n", results.get(0).toString());
 
           Collection<Accountable> resources = state.getChildResources();
           assertTrue(state.toString().contains(FacetsConfig.DEFAULT_INDEX_FIELD_NAME));
@@ -1132,7 +1123,6 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
                 List<FacetResult> topDimsResults1 = facets.getTopDims(1, 10);
                 assertEquals(actual.get(0), topDimsResults1.get(0));
               }
-
             }
           } finally {
             if (exec != null) exec.shutdownNow();

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -114,13 +114,6 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               "dim=a path=[] value=-1 childCount=3\n  foo (2)\n  bar (1)\n  zoo (1)\n",
               results.get(1).toString());
 
-          // test getAllDims(0) with topN = 0
-          expectThrows(
-              NullPointerException.class,
-              () -> {
-                facets.getAllDims(0);
-              });
-
           // test getTopDims(10, 10) and expect same results from getAllDims(10)
           List<FacetResult> allDimsResults = facets.getTopDims(10, 10);
           assertEquals(results, allDimsResults);
@@ -145,17 +138,6 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
           assertEquals(
               "dim=b path=[] value=2 childCount=2\n  buzz (2)\n",
               topDimsResults1.get(0).toString());
-
-          // test getTopDims(1, 0) with topNChildren = 0
-          expectThrows(
-              NullPointerException.class,
-              () -> {
-                facets.getTopDims(1, 0);
-              });
-
-          // test getTopDims(0, 1)
-          List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
-          assertEquals(0, topDimsResults2.size());
 
           // DrillDown:
           DrillDownQuery q = new DrillDownQuery(config);
@@ -1326,10 +1308,11 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
               assertEquals(expectedAllDims, actualAllDims);
 
-              // test getTopDims(1, 10)
+              // test getTopDims(n, 10)
               if (actualAllDims.size() > 0) {
-                List<FacetResult> topDimsResults1 = facets.getTopDims(1, 10);
-                assertEquals(actualAllDims.get(0), topDimsResults1.get(0));
+                for (int i = 1; i < actualAllDims.size(); i++) {
+                  assertEquals(actualAllDims.subList(0, i), facets.getTopDims(i, 10));
+                }
               }
 
               // Dfs through top children

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -114,7 +114,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               "dim=a path=[] value=-1 childCount=3\n  foo (2)\n  bar (1)\n  zoo (1)\n",
               results.get(1).toString());
 
-          // test getAllDims(1, 0) with topN = 0
+          // test getAllDims(0) with topN = 0
           expectThrows(
               NullPointerException.class,
               () -> {
@@ -123,13 +123,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
           // test getTopDims(10, 10) and expect same results from getAllDims(10)
           List<FacetResult> allDimsResults = facets.getTopDims(10, 10);
-          assertEquals(2, results.size());
-          assertEquals(
-              "dim=b path=[] value=2 childCount=2\n  buzz (2)\n  baz (1)\n",
-              allDimsResults.get(0).toString());
-          assertEquals(
-              "dim=a path=[] value=-1 childCount=3\n  foo (2)\n  bar (1)\n  zoo (1)\n",
-              allDimsResults.get(1).toString());
+          assertEquals(results, allDimsResults);
 
           // test getTopDims(2, 1)
           List<FacetResult> topDimsResults = facets.getTopDims(2, 1);
@@ -154,7 +148,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
           // test getTopDims(1, 0) with topNChildren = 0
           expectThrows(
-              NullPointerException.class,
+                  NullPointerException.class,
               () -> {
                 facets.getTopDims(1, 0);
               });

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -148,7 +148,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
 
           // test getTopDims(1, 0) with topNChildren = 0
           expectThrows(
-                  NullPointerException.class,
+              NullPointerException.class,
               () -> {
                 facets.getTopDims(1, 0);
               });

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -222,6 +222,10 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     assertEquals(
         "dim=b path=[] value=3 childCount=3\n  bar2 (1)\n", topNDimsResult.get(1).toString());
 
+    // test getTopDims(10, 10) and expect same results from getAllDims(10)
+    List<FacetResult> allDimsResults = facets.getTopDims(10, 10);
+    assertEquals(results, allDimsResults);
+
     // test getTopDims(0, 1)
     List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
     assertEquals(0, topDimsResults2.size());

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -163,6 +163,7 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
 
     Document doc = new Document();
     doc.add(new FacetField("a", "foo1"));
+    doc.add(new FacetField("b", "aar1"));
     writer.addDocument(config.build(taxoWriter, doc));
 
     if (random().nextBoolean()) {
@@ -201,8 +202,40 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
         "dim=a path=[] value=3 childCount=3\n  foo1 (1)\n  foo2 (1)\n  foo3 (1)\n",
         results.get(0).toString());
     assertEquals(
-        "dim=b path=[] value=2 childCount=2\n  bar1 (1)\n  bar2 (1)\n", results.get(1).toString());
+        "dim=b path=[] value=3 childCount=3\n  aar1 (1)\n  bar1 (1)\n  bar2 (1)\n", results.get(1).toString());
     assertEquals("dim=c path=[] value=1 childCount=1\n  baz1 (1)\n", results.get(2).toString());
+
+    // test getAllDims with topN = 1, sort by dim names when values are equal
+    List<FacetResult> top1results = facets.getAllDims(1);
+
+    assertEquals(3, results.size());
+    assertEquals(
+            "dim=a path=[] value=3 childCount=3\n  foo3 (1)\n",
+            top1results.get(0).toString());
+    assertEquals(
+            "dim=b path=[] value=3 childCount=3\n  bar2 (1)\n", top1results.get(1).toString());
+    assertEquals("dim=c path=[] value=1 childCount=1\n  baz1 (1)\n", top1results.get(2).toString());
+
+    // test default implementation of getTopDims
+    List<FacetResult> topNDimsResult = facets.getTopDims(2, 1);
+    assertEquals(2, topNDimsResult.size());
+    assertEquals(
+            "dim=a path=[] value=3 childCount=3\n  foo3 (1)\n",
+            topNDimsResult.get(0).toString());
+    assertEquals(
+            "dim=b path=[] value=3 childCount=3\n  bar2 (1)\n", topNDimsResult.get(1).toString());
+
+    // test getTopDims(0, 1)
+    List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
+    assertEquals(0, topDimsResults2.size());
+
+    // test getTopDims(1, 0) with topNChildren = 0
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getTopDims(1, 0);
+            });
+
 
     writer.close();
     IOUtils.close(taxoWriter, searcher.getIndexReader(), taxoReader, taxoDir, dir);
@@ -590,9 +623,28 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     Facets facets =
         getAllFacets(FacetsConfig.DEFAULT_INDEX_FIELD_NAME, newSearcher(r), taxoReader, config);
 
-    for (FacetResult result : facets.getAllDims(10)) {
+    List<FacetResult> allDimsResult = facets.getAllDims(10);
+    for (FacetResult result : allDimsResult) {
       assertEquals(r.numDocs(), result.value.intValue());
     }
+
+    // test default implementation of getTopDims
+    if (allDimsResult.size() > 0) {
+      List<FacetResult> topNDimsResult = facets.getTopDims(1, 10);
+      assertEquals(allDimsResult.get(0), topNDimsResult.get(0));
+    }
+
+    // test getTopDims(0, 1)
+    List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
+    assertEquals(0, topDimsResults2.size());
+
+    // test getTopDims(1, 0) with topNChildren = 0
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getTopDims(1, 0);
+            });
+
 
     iw.close();
     IOUtils.close(taxoWriter, taxoReader, taxoDir, r, indexDir);
@@ -622,6 +674,12 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     List<FacetResult> res2 = facets.getAllDims(10);
     assertEquals(
         "calling getFacetResults twice should return the .equals()=true result", res1, res2);
+
+    // test default implementation of getTopDims
+    if (res1.size() > 0) {
+      List<FacetResult> topNDimsResult = facets.getTopDims(1, 10);
+      assertEquals(res1.get(0), topNDimsResult.get(0));
+    }
 
     iw.close();
     IOUtils.close(taxoWriter, taxoReader, taxoDir, r, indexDir);
@@ -808,6 +866,12 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
       sortTies(actual);
 
       assertEquals(expected, actual);
+
+      // test default implementation of getTopDims
+
+      List<FacetResult> topNDimsResult = facets.getTopDims(actual.size(), 10);
+      sortTies(topNDimsResult);
+      assertEquals(actual, topNDimsResult);
 
       // Test facet labels for each matching test doc
       List<List<FacetLabel>> actualLabels = getAllTaxonomyFacetLabels(null, tr, fc);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -202,28 +202,25 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
         "dim=a path=[] value=3 childCount=3\n  foo1 (1)\n  foo2 (1)\n  foo3 (1)\n",
         results.get(0).toString());
     assertEquals(
-        "dim=b path=[] value=3 childCount=3\n  aar1 (1)\n  bar1 (1)\n  bar2 (1)\n", results.get(1).toString());
+        "dim=b path=[] value=3 childCount=3\n  aar1 (1)\n  bar1 (1)\n  bar2 (1)\n",
+        results.get(1).toString());
     assertEquals("dim=c path=[] value=1 childCount=1\n  baz1 (1)\n", results.get(2).toString());
 
     // test getAllDims with topN = 1, sort by dim names when values are equal
     List<FacetResult> top1results = facets.getAllDims(1);
 
     assertEquals(3, results.size());
-    assertEquals(
-            "dim=a path=[] value=3 childCount=3\n  foo3 (1)\n",
-            top1results.get(0).toString());
-    assertEquals(
-            "dim=b path=[] value=3 childCount=3\n  bar2 (1)\n", top1results.get(1).toString());
+    assertEquals("dim=a path=[] value=3 childCount=3\n  foo3 (1)\n", top1results.get(0).toString());
+    assertEquals("dim=b path=[] value=3 childCount=3\n  bar2 (1)\n", top1results.get(1).toString());
     assertEquals("dim=c path=[] value=1 childCount=1\n  baz1 (1)\n", top1results.get(2).toString());
 
     // test default implementation of getTopDims
     List<FacetResult> topNDimsResult = facets.getTopDims(2, 1);
     assertEquals(2, topNDimsResult.size());
     assertEquals(
-            "dim=a path=[] value=3 childCount=3\n  foo3 (1)\n",
-            topNDimsResult.get(0).toString());
+        "dim=a path=[] value=3 childCount=3\n  foo3 (1)\n", topNDimsResult.get(0).toString());
     assertEquals(
-            "dim=b path=[] value=3 childCount=3\n  bar2 (1)\n", topNDimsResult.get(1).toString());
+        "dim=b path=[] value=3 childCount=3\n  bar2 (1)\n", topNDimsResult.get(1).toString());
 
     // test getTopDims(0, 1)
     List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
@@ -231,11 +228,10 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
 
     // test getTopDims(1, 0) with topNChildren = 0
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getTopDims(1, 0);
-            });
-
+        IllegalArgumentException.class,
+        () -> {
+          facets.getTopDims(1, 0);
+        });
 
     writer.close();
     IOUtils.close(taxoWriter, searcher.getIndexReader(), taxoReader, taxoDir, dir);
@@ -640,11 +636,10 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
 
     // test getTopDims(1, 0) with topNChildren = 0
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getTopDims(1, 0);
-            });
-
+        IllegalArgumentException.class,
+        () -> {
+          facets.getTopDims(1, 0);
+        });
 
     iw.close();
     IOUtils.close(taxoWriter, taxoReader, taxoDir, r, indexDir);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
@@ -199,11 +199,9 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     List<FacetResult> topNDimsResult = facets.getTopDims(2, 1);
     assertEquals(2, topNDimsResult.size());
     assertEquals(
-            "dim=a path=[] value=60.0 childCount=3\n  foo3 (30.0)\n",
-            topNDimsResult.get(0).toString());
+        "dim=a path=[] value=60.0 childCount=3\n  foo3 (30.0)\n", topNDimsResult.get(0).toString());
     assertEquals(
-            "dim=b path=[] value=50.0 childCount=2\n  bar2 (30.0)\n",
-            topNDimsResult.get(1).toString());
+        "dim=b path=[] value=50.0 childCount=2\n  bar2 (30.0)\n", topNDimsResult.get(1).toString());
 
     // test getTopDims(0, 1)
     List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
@@ -211,11 +209,10 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
 
     // test getTopDims(1, 0) with topNChildren = 0
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getTopDims(1, 0);
-            });
-
+        IllegalArgumentException.class,
+        () -> {
+          facets.getTopDims(1, 0);
+        });
 
     IOUtils.close(searcher.getIndexReader(), taxoReader, dir, taxoDir);
   }
@@ -262,7 +259,6 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     // test default implementation of getTopDims
     List<FacetResult> topDimsResults = facets.getTopDims(10, 10);
     assertTrue(topDimsResults.isEmpty());
-
 
     expectThrows(
         IllegalArgumentException.class,

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
@@ -195,6 +195,28 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     assertEquals(
         "dim=c path=[] value=30.0 childCount=1\n  baz1 (30.0)\n", results.get(2).toString());
 
+    // test default implementation of getTopDims
+    List<FacetResult> topNDimsResult = facets.getTopDims(2, 1);
+    assertEquals(2, topNDimsResult.size());
+    assertEquals(
+            "dim=a path=[] value=60.0 childCount=3\n  foo3 (30.0)\n",
+            topNDimsResult.get(0).toString());
+    assertEquals(
+            "dim=b path=[] value=50.0 childCount=2\n  bar2 (30.0)\n",
+            topNDimsResult.get(1).toString());
+
+    // test getTopDims(0, 1)
+    List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
+    assertEquals(0, topDimsResults2.size());
+
+    // test getTopDims(1, 0) with topNChildren = 0
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getTopDims(1, 0);
+            });
+
+
     IOUtils.close(searcher.getIndexReader(), taxoReader, dir, taxoDir);
   }
 
@@ -236,6 +258,11 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     // Ask for top 10 labels for any dims that have counts:
     List<FacetResult> results = facets.getAllDims(10);
     assertTrue(results.isEmpty());
+
+    // test default implementation of getTopDims
+    List<FacetResult> topDimsResults = facets.getTopDims(10, 10);
+    assertTrue(topDimsResults.isEmpty());
+
 
     expectThrows(
         IllegalArgumentException.class,
@@ -509,6 +536,12 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
       sortFacetResults(expected);
 
       List<FacetResult> actual = facets.getAllDims(10);
+
+      // test default implementation of getTopDims
+      if (actual.size() > 0) {
+        List<FacetResult> topDimsResults1 = facets.getTopDims(1, 10);
+        assertEquals(actual.get(0), topDimsResults1.get(0));
+      }
 
       // Messy: fixup ties
       sortTies(actual);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
@@ -203,6 +203,10 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     assertEquals(
         "dim=b path=[] value=50.0 childCount=2\n  bar2 (30.0)\n", topNDimsResult.get(1).toString());
 
+    // test getTopDims(10, 10) and expect same results from getAllDims(10)
+    List<FacetResult> allDimsResults = facets.getTopDims(10, 10);
+    assertEquals(results, allDimsResults);
+
     // test getTopDims(0, 1)
     List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
     assertEquals(0, topDimsResults2.size());


### PR DESCRIPTION
# Description
This change 
* adds a new API - getTopDims in Facets to support users specify the number of dims and children they want to get, and return only these dims and children.
* overrides getTopDims in SortedSetDocValuesFacetCounts to optimize the current method of getting dimCount, return FacetResult and resolve child paths for only the requested dims.

# Solution

* Implement a default getTopDims function in the Facets class.
* Override getTopDims and refactor the getPathResult function in SortedSetDocValuesFacetCounts to get dimCount (aggregated dim values) more efficiently by checking if dimCount has been populated in indexing time for a dim that is hierarchical or multiValued && requireDimCount, before aggregating dimCount by iterating its child ordinal. 
* Use priority queue to store the requested top n dims and then call getPathResult to populate labels and return FacetResult for those dims.

# Tests

Added new testing for both default and overridden implementations of getTopDims
Added more testing for the getAllDims and getTopChildren to ensure the current design does not affect the existing functions that call getPathResult

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
