### PR TITLE
LUCENE-10467: Throws IllegalArgumentException for getAllDims and getTopChildren if topN <= 0

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/Facets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/Facets.java
@@ -59,4 +59,16 @@ public abstract class Facets {
     List<FacetResult> allResults = getAllDims(topNChildren);
     return allResults.subList(0, Math.min(topNDims, allResults.size()));
   }
+
+  /**
+   * This helper method checks if topN is valid for getTopChildren and getAllDims. Throws
+   * IllegalArgumentException if topN is invalid.
+   *
+   * @lucene.experimental it may not exist in future versions of Lucene
+   */
+  protected static void validateTopN(int topN) {
+    if (topN <= 0) {
+      throw new IllegalArgumentException("topN must be > 0 (got: " + topN + ")");
+    }
+  }
 }

--- a/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
@@ -348,6 +348,7 @@ public class LongValueFacetCounts extends Facets {
 
   @Override
   public FacetResult getTopChildren(int topN, String dim, String... path) {
+    validateTopN(topN);
     if (dim.equals(field) == false) {
       throw new IllegalArgumentException(
           "invalid dim \"" + dim + "\"; should be \"" + field + "\"");
@@ -489,6 +490,7 @@ public class LongValueFacetCounts extends Facets {
 
   @Override
   public List<FacetResult> getAllDims(int topN) {
+    validateTopN(topN);
     return Collections.singletonList(getTopChildren(topN, field));
   }
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/MultiFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/MultiFacets.java
@@ -42,6 +42,7 @@ public class MultiFacets extends Facets {
 
   @Override
   public FacetResult getTopChildren(int topN, String dim, String... path) throws IOException {
+    validateTopN(topN);
     Facets facets = dimToFacets.get(dim);
     if (facets == null) {
       if (defaultFacets == null) {
@@ -66,7 +67,7 @@ public class MultiFacets extends Facets {
 
   @Override
   public List<FacetResult> getAllDims(int topN) throws IOException {
-
+    validateTopN(topN);
     List<FacetResult> results = new ArrayList<FacetResult>();
 
     // First add the specific dim's facets:

--- a/lucene/facet/src/java/org/apache/lucene/facet/StringValueFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/StringValueFacetCounts.java
@@ -132,9 +132,7 @@ public class StringValueFacetCounts extends Facets {
 
   @Override
   public FacetResult getTopChildren(int topN, String dim, String... path) throws IOException {
-    if (topN <= 0) {
-      throw new IllegalArgumentException("topN must be > 0 (got: " + topN + ")");
-    }
+    validateTopN(topN);
     if (dim.equals(field) == false) {
       throw new IllegalArgumentException(
           "invalid dim \"" + dim + "\"; should be \"" + field + "\"");
@@ -223,6 +221,7 @@ public class StringValueFacetCounts extends Facets {
 
   @Override
   public List<FacetResult> getAllDims(int topN) throws IOException {
+    validateTopN(topN);
     return Collections.singletonList(getTopChildren(topN, field));
   }
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
@@ -218,6 +218,7 @@ abstract class RangeFacetCounts extends Facets {
 
   @Override
   public FacetResult getTopChildren(int topN, String dim, String... path) {
+    validateTopN(topN);
     if (dim.equals(field) == false) {
       throw new IllegalArgumentException(
           "invalid dim \"" + dim + "\"; should be \"" + field + "\"");
@@ -240,6 +241,7 @@ abstract class RangeFacetCounts extends Facets {
 
   @Override
   public List<FacetResult> getAllDims(int topN) throws IOException {
+    validateTopN(topN);
     return Collections.singletonList(getTopChildren(topN, field));
   }
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/ConcurrentSortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/ConcurrentSortedSetDocValuesFacetCounts.java
@@ -98,10 +98,7 @@ public class ConcurrentSortedSetDocValuesFacetCounts extends Facets {
 
   @Override
   public FacetResult getTopChildren(int topN, String dim, String... path) throws IOException {
-    if (topN <= 0) {
-      throw new IllegalArgumentException("topN must be > 0 (got: " + topN + ")");
-    }
-
+    validateTopN(topN);
     FacetsConfig.DimConfig dimConfig = stateConfig.getDimConfig(dim);
 
     if (dimConfig.hierarchical) {
@@ -411,7 +408,7 @@ public class ConcurrentSortedSetDocValuesFacetCounts extends Facets {
 
   @Override
   public List<FacetResult> getAllDims(int topN) throws IOException {
-
+    validateTopN(topN);
     List<FacetResult> results = new ArrayList<>();
     for (String dim : state.getDims()) {
       FacetsConfig.DimConfig dimConfig = stateConfig.getDimConfig(dim);

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -509,9 +509,8 @@ public class SortedSetDocValuesFacetCounts extends Facets {
 
   @Override
   public List<FacetResult> getTopDims(int topNDims, int topNChildren) throws IOException {
-    if (topNDims <= 0 || topNChildren <= 0) {
-      throw new IllegalArgumentException("topN must be > 0");
-    }
+    validateTopN(topNDims);
+    validateTopN(topNChildren);
 
     // Creates priority queue to store top dimensions and sort by their aggregated values/hits and
     // string values.

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -194,7 +194,6 @@ public class SortedSetDocValuesFacetCounts extends Facets {
    */
   private ChildOrdsResult getChildOrdsResult(
       PrimitiveIterator.OfInt childOrds, int topN, FacetsConfig.DimConfig dimConfig, int pathOrd) {
-
     TopOrdAndIntQueue q = null;
     int bottomCount = 0;
     int dimCount = 0;

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -103,10 +103,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
 
   @Override
   public FacetResult getTopChildren(int topN, String dim, String... path) throws IOException {
-    if (topN <= 0) {
-      throw new IllegalArgumentException("topN must be > 0 (got: " + topN + ")");
-    }
-
+    validateTopN(topN);
     FacetsConfig.DimConfig dimConfig = stateConfig.getDimConfig(dim);
 
     if (dimConfig.hierarchical) {
@@ -484,6 +481,7 @@ public class SortedSetDocValuesFacetCounts extends Facets {
 
   @Override
   public List<FacetResult> getAllDims(int topN) throws IOException {
+    validateTopN(topN);
     List<FacetResult> results = new ArrayList<>();
     for (String dim : state.getDims()) {
       FacetResult factResult = getFacetResultForDim(dim, topN);

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
@@ -89,9 +89,7 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
 
   @Override
   public FacetResult getTopChildren(int topN, String dim, String... path) throws IOException {
-    if (topN <= 0) {
-      throw new IllegalArgumentException("topN must be > 0 (got: " + topN + ")");
-    }
+    validateTopN(topN);
     DimConfig dimConfig = verifyDim(dim);
     FacetLabel cp = new FacetLabel(dim, path);
     int dimOrd = taxoReader.getOrdinal(cp);

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
@@ -149,9 +149,7 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
 
   @Override
   public FacetResult getTopChildren(int topN, String dim, String... path) throws IOException {
-    if (topN <= 0) {
-      throw new IllegalArgumentException("topN must be > 0 (got: " + topN + ")");
-    }
+    validateTopN(topN);
     DimConfig dimConfig = verifyDim(dim);
     FacetLabel cp = new FacetLabel(dim, path);
     int dimOrd = taxoReader.getOrdinal(cp);

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -138,6 +138,7 @@ abstract class TaxonomyFacets extends Facets {
 
   @Override
   public List<FacetResult> getAllDims(int topN) throws IOException {
+    validateTopN(topN);
     int[] children = getChildren();
     int[] siblings = getSiblings();
     int ord = children[TaxonomyReader.ROOT_ORDINAL];

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -236,10 +236,10 @@ public class TestDrillSideways extends FacetTestCase {
 
     // test getTopChildren(0, dim)
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              concurrentResult.facets.getTopChildren(0, "Color");
-            });
+        IllegalArgumentException.class,
+        () -> {
+          concurrentResult.facets.getTopChildren(0, "Color");
+        });
 
     writer.close();
     IOUtils.close(searcher.getIndexReader(), taxoReader, taxoWriter, dir, taxoDir);
@@ -381,10 +381,10 @@ public class TestDrillSideways extends FacetTestCase {
     // test getAllDims(0)
     DrillSidewaysResult finalR1 = r;
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              finalR1.facets.getAllDims(0);
-            });
+        IllegalArgumentException.class,
+        () -> {
+          finalR1.facets.getAllDims(0);
+        });
 
     // More interesting case: drill-down on two fields
     ddq = new DrillDownQuery(config);
@@ -475,11 +475,10 @@ public class TestDrillSideways extends FacetTestCase {
     // test getTopChildren(0, dim)
     DrillSidewaysResult finalR = r;
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              finalR.facets.getTopChildren(0, "Author");
-            });
-
+        IllegalArgumentException.class,
+        () -> {
+          finalR.facets.getTopChildren(0, "Author");
+        });
 
     writer.close();
     IOUtils.close(searcher.getIndexReader(), taxoReader, taxoWriter, dir, taxoDir);

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -1900,10 +1900,10 @@ public class TestDrillSideways extends FacetTestCase {
 
     // test getAllDims(0)
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getAllDims(0);
-            });
+        IllegalArgumentException.class,
+        () -> {
+          facets.getAllDims(0);
+        });
     // More interesting case: drill-down on two fields
     ddq = new DrillDownQuery(config);
     ddq.add("Author", "Lisa");

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -234,6 +234,13 @@ public class TestDrillSideways extends FacetTestCase {
         "dim=Size path=[] value=2 childCount=2\n  Small (1)\n  Medium (1)\n",
         concurrentResult.facets.getTopChildren(10, "Size").toString());
 
+    // test getTopChildren(0, dim)
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              concurrentResult.facets.getTopChildren(0, "Color");
+            });
+
     writer.close();
     IOUtils.close(searcher.getIndexReader(), taxoReader, taxoWriter, dir, taxoDir);
   }
@@ -371,6 +378,14 @@ public class TestDrillSideways extends FacetTestCase {
     List<FacetResult> topDimsResults2 = r.facets.getTopDims(0, 1);
     assertEquals(0, topDimsResults2.size());
 
+    // test getAllDims(0)
+    DrillSidewaysResult finalR1 = r;
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              finalR1.facets.getAllDims(0);
+            });
+
     // More interesting case: drill-down on two fields
     ddq = new DrillDownQuery(config);
     ddq.add("Author", "Lisa");
@@ -456,6 +471,16 @@ public class TestDrillSideways extends FacetTestCase {
     assertEquals(0, r.hits.totalHits.value);
     assertNull(r.facets.getTopChildren(10, "Publish Date"));
     assertNull(r.facets.getTopChildren(10, "Author"));
+
+    // test getTopChildren(0, dim)
+    DrillSidewaysResult finalR = r;
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              finalR.facets.getTopChildren(0, "Author");
+            });
+
+
     writer.close();
     IOUtils.close(searcher.getIndexReader(), taxoReader, taxoWriter, dir, taxoDir);
   }
@@ -1874,6 +1899,12 @@ public class TestDrillSideways extends FacetTestCase {
         "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n  Susan (1)\n",
         topNDimsResult.get(0).toString());
 
+    // test getAllDims(0)
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getAllDims(0);
+            });
     // More interesting case: drill-down on two fields
     ddq = new DrillDownQuery(config);
     ddq.add("Author", "Lisa");

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -169,6 +169,12 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     // test getTopDims(0, 1)
     List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
     assertEquals(0, topDimsResults2.size());
+    // test getAllDims(0)
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getAllDims(0);
+            });
 
     r.close();
     d.close();

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -171,10 +171,10 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     assertEquals(0, topDimsResults2.size());
     // test getAllDims(0)
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getAllDims(0);
-            });
+        IllegalArgumentException.class,
+        () -> {
+          facets.getAllDims(0);
+        });
 
     r.close();
     d.close();

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
@@ -394,10 +394,10 @@ public class TestStringValueFacetCounts extends FacetTestCase {
 
       // test getAllDims(0)
       expectThrows(
-              IllegalArgumentException.class,
-              () -> {
-                facets.getAllDims(0);
-              });
+          IllegalArgumentException.class,
+          () -> {
+            facets.getAllDims(0);
+          });
 
       // This is a little strange, but we request all labels at this point so that when we
       // secondarily sort by label value in order to compare to the expected results, we have

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
@@ -392,6 +392,13 @@ public class TestStringValueFacetCounts extends FacetTestCase {
       assertEquals(1, topNDimsResult.size());
       assertEquals(facetResult, topNDimsResult.get(0));
 
+      // test getAllDims(0)
+      expectThrows(
+              IllegalArgumentException.class,
+              () -> {
+                facets.getAllDims(0);
+              });
+
       // This is a little strange, but we request all labels at this point so that when we
       // secondarily sort by label value in order to compare to the expected results, we have
       // all the values. See LUCENE-9991:

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -106,10 +106,10 @@ public class TestRangeFacetCounts extends FacetTestCase {
 
     // test getTopChildren(0, dim)
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getTopChildren(0, "field");
-            });
+        IllegalArgumentException.class,
+        () -> {
+          facets.getTopChildren(0, "field");
+        });
 
     r.close();
     d.close();

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -104,6 +104,13 @@ public class TestRangeFacetCounts extends FacetTestCase {
         "dim=field path=[] value=22 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (1)\n",
         result.toString());
 
+    // test getTopChildren(0, dim)
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getTopChildren(0, "field");
+            });
+
     r.close();
     d.close();
   }
@@ -257,6 +264,13 @@ public class TestRangeFacetCounts extends FacetTestCase {
     // test getTopDims(0, 1)
     List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
     assertEquals(0, topDimsResults2.size());
+
+    // test getAllDims(0)
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getAllDims(0);
+            });
 
     r.close();
     d.close();

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -267,10 +267,10 @@ public class TestRangeFacetCounts extends FacetTestCase {
 
     // test getAllDims(0)
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getAllDims(0);
-            });
+        IllegalArgumentException.class,
+        () -> {
+          facets.getAllDims(0);
+        });
 
     r.close();
     d.close();
@@ -373,7 +373,6 @@ public class TestRangeFacetCounts extends FacetTestCase {
     assertEquals(
         "dim=field path=[] value=41 childCount=4\n  0-10 (11)\n  10-20 (11)\n  20-30 (11)\n  30-40 (11)\n",
         result.toString());
-
     r.close();
     d.close();
   }

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -139,12 +139,12 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               "dim=b path=[] value=2 childCount=2\n  buzz (2)\n",
               topDimsResults1.get(0).toString());
 
-          // test getTopDims(1, 0) with topNChildren = 0
+          // test getTopDims(0)
           expectThrows(
-                  IllegalArgumentException.class,
-                  () -> {
-                    facets.getAllDims(0);
-                  });
+              IllegalArgumentException.class,
+              () -> {
+                facets.getAllDims(0);
+              });
 
           // DrillDown:
           DrillDownQuery q = new DrillDownQuery(config);
@@ -357,7 +357,6 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
           assertEquals(
               "dim=c path=[buzz, bif] value=2 childCount=1\n  baf (2)\n",
               facets.getTopChildren(10, "c", "buzz", "bif").toString());
-
           // DrillDown:
           DrillDownQuery q = new DrillDownQuery(config);
           q.add("a", "foo");
@@ -416,10 +415,10 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
         // test topNChildren = 0
         Facets finalFacets = facets;
         expectThrows(
-                IllegalArgumentException.class,
-                () -> {
-                  finalFacets.getTopChildren(0, "a");
-                });
+            IllegalArgumentException.class,
+            () -> {
+              finalFacets.getTopChildren(0, "a");
+            });
 
         ExecutorService exec =
             new ThreadPoolExecutor(
@@ -478,6 +477,15 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
         assertEquals(
             "dim=b path=[buzz] value=1 childCount=1\n  baz (1)\n",
             facets.getTopChildren(10, "b", "buzz").toString());
+
+        // test topNChildren = 0
+        Facets finalFacets = facets;
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              finalFacets.getTopChildren(0, "a");
+            });
+
         ExecutorService exec =
             new ThreadPoolExecutor(
                 1,
@@ -540,6 +548,14 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
           assertEquals(
               "dim=b path=[] value=1 childCount=1\n  bar (1)\n",
               facets.getTopChildren(10, "b").toString());
+
+          // test topNChildren = 0
+          Facets finalFacets = facets;
+          expectThrows(
+              IllegalArgumentException.class,
+              () -> {
+                finalFacets.getTopChildren(0, "a");
+              });
 
           // DrillDown:
           DrillDownQuery q = new DrillDownQuery(config);
@@ -1245,7 +1261,6 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               sortFacetResults(expected);
 
               List<FacetResult> actual = facets.getAllDims(10);
-
               // Messy: fixup ties
               // sortTies(actual);
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -139,6 +139,13 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               "dim=b path=[] value=2 childCount=2\n  buzz (2)\n",
               topDimsResults1.get(0).toString());
 
+          // test getTopDims(1, 0) with topNChildren = 0
+          expectThrows(
+                  IllegalArgumentException.class,
+                  () -> {
+                    facets.getAllDims(0);
+                  });
+
           // DrillDown:
           DrillDownQuery q = new DrillDownQuery(config);
           q.add("a", "foo");
@@ -406,6 +413,14 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
             "dim=a path=[] value=1 childCount=1\n  bar (1)\n",
             facets.getTopChildren(10, "a").toString());
 
+        // test topNChildren = 0
+        Facets finalFacets = facets;
+        expectThrows(
+                IllegalArgumentException.class,
+                () -> {
+                  finalFacets.getTopChildren(0, "a");
+                });
+
         ExecutorService exec =
             new ThreadPoolExecutor(
                 1,
@@ -463,7 +478,6 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
         assertEquals(
             "dim=b path=[buzz] value=1 childCount=1\n  baz (1)\n",
             facets.getTopChildren(10, "b", "buzz").toString());
-
         ExecutorService exec =
             new ThreadPoolExecutor(
                 1,

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -477,15 +477,6 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
         assertEquals(
             "dim=b path=[buzz] value=1 childCount=1\n  baz (1)\n",
             facets.getTopChildren(10, "b", "buzz").toString());
-
-        // test topNChildren = 0
-        Facets finalFacets = facets;
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              finalFacets.getTopChildren(0, "a");
-            });
-
         ExecutorService exec =
             new ThreadPoolExecutor(
                 1,
@@ -548,14 +539,6 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
           assertEquals(
               "dim=b path=[] value=1 childCount=1\n  bar (1)\n",
               facets.getTopChildren(10, "b").toString());
-
-          // test topNChildren = 0
-          Facets finalFacets = facets;
-          expectThrows(
-              IllegalArgumentException.class,
-              () -> {
-                finalFacets.getTopChildren(0, "a");
-              });
 
           // DrillDown:
           DrillDownQuery q = new DrillDownQuery(config);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -111,6 +111,14 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     assertTrue(((TaxonomyFacets) facets).siblingsLoaded());
     assertTrue(((TaxonomyFacets) facets).childrenLoaded());
 
+    // test getTopChildren(0, dim)
+    Facets finalFacets = facets;
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              finalFacets.getTopChildren(0, "Author");
+            });
+
     // Retrieve & verify results:
     assertEquals(
         "dim=Publish Date path=[] value=5 childCount=3\n  2010 (2)\n  2012 (2)\n  1999 (1)\n",
@@ -193,6 +201,13 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
 
     Facets facets =
         getAllFacets(FacetsConfig.DEFAULT_INDEX_FIELD_NAME, searcher, taxoReader, config);
+
+    // test getAllDims(0)
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getAllDims(0);
+            });
 
     // Ask for top 10 labels for any dims that have counts:
     List<FacetResult> results = facets.getAllDims(10);
@@ -628,6 +643,7 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
       assertEquals(r.numDocs(), result.value.intValue());
     }
 
+
     // test default implementation of getTopDims
     if (allDimsResult.size() > 0) {
       List<FacetResult> topNDimsResult = facets.getTopDims(1, 10);
@@ -644,6 +660,13 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
         () -> {
           facets.getTopDims(1, 0);
         });
+
+    // test getAllDims(0)
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getAllDims(0);
+            });
 
     iw.close();
     IOUtils.close(taxoWriter, taxoReader, taxoDir, r, indexDir);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -288,14 +288,6 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     // Ask for top 10 labels for any dims that have counts:
     List<FacetResult> results = facets.getAllDims(10);
     assertTrue(results.isEmpty());
-
-    // test getAllDims(0)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getAllDims(0);
-        });
-
     expectThrows(
         IllegalArgumentException.class,
         () -> {
@@ -306,13 +298,6 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
         IllegalArgumentException.class,
         () -> {
           facets.getTopChildren(10, "a");
-        });
-
-    // test getTopChildren(0)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopChildren(0, "Author");
         });
 
     writer.close();
@@ -497,14 +482,6 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
         IllegalArgumentException.class,
         () -> {
           facets.getSpecificValue("dim");
-        });
-
-    // test getTopChildren(0, dim)
-    Facets finalFacets = facets;
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          finalFacets.getTopChildren(0, "Author");
         });
 
     assertEquals(1, facets.getSpecificValue("dim2"));

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -114,10 +114,10 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     // test getTopChildren(0, dim)
     Facets finalFacets = facets;
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              finalFacets.getTopChildren(0, "Author");
-            });
+        IllegalArgumentException.class,
+        () -> {
+          finalFacets.getTopChildren(0, "Author");
+        });
 
     // Retrieve & verify results:
     assertEquals(
@@ -204,10 +204,10 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
 
     // test getAllDims(0)
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getAllDims(0);
-            });
+        IllegalArgumentException.class,
+        () -> {
+          facets.getAllDims(0);
+        });
 
     // Ask for top 10 labels for any dims that have counts:
     List<FacetResult> results = facets.getAllDims(10);
@@ -289,6 +289,13 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     List<FacetResult> results = facets.getAllDims(10);
     assertTrue(results.isEmpty());
 
+    // test getAllDims(0)
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          facets.getAllDims(0);
+        });
+
     expectThrows(
         IllegalArgumentException.class,
         () -> {
@@ -299,6 +306,13 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
         IllegalArgumentException.class,
         () -> {
           facets.getTopChildren(10, "a");
+        });
+
+    // test getTopChildren(0)
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          facets.getTopChildren(0, "Author");
         });
 
     writer.close();
@@ -484,6 +498,15 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
         () -> {
           facets.getSpecificValue("dim");
         });
+
+    // test getTopChildren(0, dim)
+    Facets finalFacets = facets;
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          finalFacets.getTopChildren(0, "Author");
+        });
+
     assertEquals(1, facets.getSpecificValue("dim2"));
     assertEquals(1, facets.getSpecificValue("dim3"));
     writer.close();
@@ -663,10 +686,10 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
 
     // test getAllDims(0)
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getAllDims(0);
-            });
+        IllegalArgumentException.class,
+        () -> {
+          facets.getAllDims(0);
+        });
 
     iw.close();
     IOUtils.close(taxoWriter, taxoReader, taxoDir, r, indexDir);
@@ -883,7 +906,6 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
       sortFacetResults(expected);
 
       List<FacetResult> actual = facets.getAllDims(10);
-
       // Messy: fixup ties
       sortTies(actual);
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -643,7 +643,6 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
       assertEquals(r.numDocs(), result.value.intValue());
     }
 
-
     // test default implementation of getTopDims
     if (allDimsResult.size() > 0) {
       List<FacetResult> topNDimsResult = facets.getTopDims(1, 10);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
@@ -124,10 +124,10 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
 
     // test getTopChildren(0, dim)
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getTopChildren(0, "Author");
-            });
+        IllegalArgumentException.class,
+        () -> {
+          facets.getTopChildren(0, "Author");
+        });
 
     taxoReader.close();
     searcher.getIndexReader().close();
@@ -194,10 +194,10 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
 
     // test getAllDims(0)
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getAllDims(0);
-            });
+        IllegalArgumentException.class,
+        () -> {
+          facets.getAllDims(0);
+        });
 
     assertEquals(3, results.size());
     assertEquals(

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
@@ -274,11 +274,9 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     List<FacetResult> results = facets.getAllDims(10);
     assertTrue(results.isEmpty());
 
-
     // test default implementation of getTopDims
     List<FacetResult> topDimsResults = facets.getTopDims(10, 10);
     assertTrue(topDimsResults.isEmpty());
-
     expectThrows(
         IllegalArgumentException.class,
         () -> {
@@ -388,7 +386,6 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     assertEquals(
         "dim=a path=[] value=10.0 childCount=2\n  1 (6.0)\n  0 (4.0)\n",
         facets.getTopChildren(10, "a").toString());
-
     iw.close();
     IOUtils.close(taxoWriter, taxoReader, taxoDir, r, indexDir);
   }
@@ -549,13 +546,11 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
       sortFacetResults(expected);
 
       List<FacetResult> actual = facets.getAllDims(10);
-
       // test default implementation of getTopDims
       if (actual.size() > 0) {
         List<FacetResult> topDimsResults1 = facets.getTopDims(1, 10);
         assertEquals(actual.get(0), topDimsResults1.get(0));
       }
-
       // Messy: fixup ties
       sortTies(actual);
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
@@ -274,6 +274,7 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     List<FacetResult> results = facets.getAllDims(10);
     assertTrue(results.isEmpty());
 
+
     // test default implementation of getTopDims
     List<FacetResult> topDimsResults = facets.getTopDims(10, 10);
     assertTrue(topDimsResults.isEmpty());
@@ -354,7 +355,6 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     assertEquals(
         "dim=a path=[] value=10.0 childCount=2\n  1 (6.0)\n  0 (4.0)\n",
         facets.getTopChildren(10, "a").toString());
-
     iw.close();
     IOUtils.close(taxoWriter, taxoReader, taxoDir, r, indexDir);
   }
@@ -422,7 +422,6 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     assertEquals(
         "dim=a path=[] value=10.0 childCount=2\n  1 (6.0)\n  0 (4.0)\n",
         facets.getTopChildren(10, "a").toString());
-
     iw.close();
     IOUtils.close(taxoWriter, taxoReader, taxoDir, r, indexDir);
   }

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
@@ -122,6 +122,13 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
         "dim=Author path=[] value=145.0 childCount=4\n  Lisa (50.0)\n  Frank (45.0)\n  Susan (40.0)\n  Bob (10.0)\n",
         facets.getTopChildren(10, "Author").toString());
 
+    // test getTopChildren(0, dim)
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getTopChildren(0, "Author");
+            });
+
     taxoReader.close();
     searcher.getIndexReader().close();
     dir.close();
@@ -184,6 +191,13 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
 
     // Ask for top 10 labels for any dims that have counts:
     List<FacetResult> results = facets.getAllDims(10);
+
+    // test getAllDims(0)
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getAllDims(0);
+            });
 
     assertEquals(3, results.size());
     assertEquals(


### PR DESCRIPTION
# Description

Currently, there are different behaviors from subclasses that implement and override `getAllDims` and `getTopChildren` when passing in an invalid TopN parameter (`topN <= 0`). Some overridden implementations throw a `NullPointerException`, some throw an `IllegalArgumentException`, and others do not throw any exception.

This change aligns the behaviors across all overridden implementations of `getAllDims` and `getTopChildren` by throwing an `IllegalArgumentException` and exiting the function earlier if the parameter `topN` is invalid.

# Solution

Added a condition checking if `topN <= 0` in the beginning of both functions. If `topN` is invalid, the function will be terminated by throwing an `IllegalArgumentException`. 

# Tests

Added new testing, `getAllDims(0)` and `getTopChildren(0, dim)`, for all Facet subclasses that implement `getAllDims` and `getTopChildren`.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
