### PR TITLE
LUCENE-10474: Avoid throwing StackOverflowError when creating RegExp

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -475,7 +475,13 @@ public class RegExp {
     RegExp e;
     if (s.length() == 0) e = makeString(flags, "");
     else {
-      e = parseUnionExp();
+      try {
+        e = parseUnionExp();
+      } catch (
+          @SuppressWarnings("unused")
+          StackOverflowError soe) {
+        throw new IllegalArgumentException("stack overflow during parsing at position " + pos);
+      }
       if (pos < originalString.length())
         throw new IllegalArgumentException("end-of-string expected at position " + pos);
     }

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
@@ -245,4 +245,8 @@ public class TestRegExp extends LuceneTestCase {
     }
     return regexPattern;
   }
+
+  public void testTooLongRegexp() {
+    expectThrows(IllegalArgumentException.class, () -> new RegExp(randomDocValue(10000)));
+  }
 }


### PR DESCRIPTION
Creating a regular expression using the RegExp class can easily result
in a StackOverflowError being thrown, for example when the input is
larger than the maximum stack depth. Throwing a StackOverflowError
isn't something a user would expect, and it isn't documented either.
StackOverflowError is a user-unfriendly exception as it does not
convey any intent that the user has done something wrong, but suggests
a bug in the implementation.

Instead of letting StackOverflowError bubble up, we now throw an
IllegalArgumentException instead to clearly mark this as an input
that the implementation can't handle.

#11510