### PR TITLE
LUCENE-10472: Fix TestMatchAllDocsQuery#testEarlyTermination

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
@@ -115,15 +115,16 @@ public class TestMatchAllDocsQuery extends LuceneTestCase {
     }
     IndexReader ir = DirectoryReader.open(iw);
 
-    IndexSearcher is = newSearcher(ir);
 
+    IndexSearcher singleThreadedSearcher = newSearcher(ir, true, true, false);
     final int totalHitsThreshold = 200;
     CollectorManager<TopScoreDocCollector, TopDocs> manager =
         TopScoreDocCollector.createSharedManager(10, null, totalHitsThreshold);
-    TopDocs topDocs = is.search(new MatchAllDocsQuery(), manager);
-    assertTrue(topDocs.totalHits.value > totalHitsThreshold);
+    TopDocs topDocs = singleThreadedSearcher.search(new MatchAllDocsQuery(), manager);
+    assertEquals(totalHitsThreshold + 1, topDocs.totalHits.value);
     assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation);
 
+    IndexSearcher is = newSearcher(ir);
     manager = TopScoreDocCollector.createSharedManager(10, null, numDocs);
     topDocs = is.search(new MatchAllDocsQuery(), manager);
     assertEquals(numDocs, topDocs.totalHits.value);

--- a/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
@@ -121,7 +121,7 @@ public class TestMatchAllDocsQuery extends LuceneTestCase {
     CollectorManager<TopScoreDocCollector, TopDocs> manager =
         TopScoreDocCollector.createSharedManager(10, null, totalHitsThreshold);
     TopDocs topDocs = is.search(new MatchAllDocsQuery(), manager);
-    assertEquals(totalHitsThreshold + 1, topDocs.totalHits.value);
+    assertTrue(topDocs.totalHits.value > totalHitsThreshold);
     assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation);
 
     manager = TopScoreDocCollector.createSharedManager(10, null, numDocs);

--- a/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
@@ -115,7 +115,6 @@ public class TestMatchAllDocsQuery extends LuceneTestCase {
     }
     IndexReader ir = DirectoryReader.open(iw);
 
-
     IndexSearcher singleThreadedSearcher = newSearcher(ir, true, true, false);
     final int totalHitsThreshold = 200;
     CollectorManager<TopScoreDocCollector, TopDocs> manager =


### PR DESCRIPTION
As part of #716 I moved the test to use a collector manager, but I forgot to update one of the assertions.
We can't rely on totalHits being accurate when the search is executed my multiple threads and early terminated.