### PR TITLE
Add note for smoke tester --tmp-dir option in rc announcing

### DIFF
--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -740,10 +740,10 @@ groups:
 
       You can run the smoke tester directly with this command:
 
-      python3 -u dev-tools/scripts/smokeTestRelease.py --tmp-dir <tmp-working-dir-path> \
+      python3 -u dev-tools/scripts/smokeTestRelease.py \
       https://dist.apache.org/repos/dist/dev/lucene/lucene-{{ release_version }}-RC{{ rc_number }}-rev-{{ build_rc.git_rev | default("<git_rev>", True) }}
 
-      Some tests create large files (several gigabytes) in the temporary working directory, make sure there is enough available disk space on your device. 8GB+ free space is recommended.
+      Some tests can create large files in the tmpfs (temporary file system), make sure there is enough available disk space on your device. You can change the location for temporary files by --tmp-dir <tmp-working-dir-path> option.
 
       The vote will be open for at least 72 hours i.e. until {{ vote_close }}.
 

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -740,8 +740,10 @@ groups:
 
       You can run the smoke tester directly with this command:
 
-      python3 -u dev-tools/scripts/smokeTestRelease.py \
+      python3 -u dev-tools/scripts/smokeTestRelease.py --tmp-dir <tmp-working-dir-path> \
       https://dist.apache.org/repos/dist/dev/lucene/lucene-{{ release_version }}-RC{{ rc_number }}-rev-{{ build_rc.git_rev | default("<git_rev>", True) }}
+
+      Some tests create large files (several gigabytes) in the temporary working directory, make sure there is enough available disk space on your device. 8GB+ free space is recommended.
 
       The vote will be open for at least 72 hours i.e. until {{ vote_close }}.
 


### PR DESCRIPTION
I encountered several times a "disk full" error when running the smoke tester.
From my observation, there is a test that (intentionally) creates very large index files. It might be helpful to have a notice about that in the rc announcing mails and encourage to explicitly use `--tmp-dir` option to avoid unnecessary retries.

Here is a snapshot of the disk usage in a smoke tester run.
```
$ dust -b ~/tmp/smoketester/
  47M   ┌── lucene-9.1.0-src.tgz
  64M   ├── lucene-9.1.0.tgz
  37M   │     ┌── test-framework
  59M   │     │     ┌── lucene-9.1.0-SNAPSHOT-itests
  59M   │     │   ┌─┴ packages
  59M   │     │ ┌─┴ build
  59M   │     ├─┴ distribution
  51M   │     │ ┌── build
  63M   │     ├─┴ backward-codecs
 125M   │     │   ┌── site
 125M   │     │ ┌─┴ build
 125M   │     ├─┴ documentation
  55M   │     │ ┌── nori
 133M   │     ├─┴ analysis
 3.0G   │     │           ┌── _0.cfs
 4.0G   │     │           ├── _0.fdt
 7.1G   │     │         ┌─┴ 4GBStoredFields-001
 7.1G   │     │       ┌─┴ lucene.index.Test4GBStoredFields_1FCE4B52E7A84AF3-001
 7.1G   │     │     ┌─┴ tests-tmp
 7.1G   │     │   ┌─┴ tmp
 7.1G   │     │ ┌─┴ build
 7.1G   │     ├─┴ core
 7.6G   │   ┌─┴ lucene
 7.6G   │ ┌─┴ lucene-9.1.0
 7.6G   ├─┴ unpack
 7.7G ┌─┴ smoketester
```

I didn't (couldn't) test this but just grepped the scripts to find where to change; would you tell me the correct file if I'm modifying the wrong file.