### PR TITLE
LUCENE-10478: mark Test4GBStoredFields as @Monster

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/Test4GBStoredFields.java
+++ b/lucene/core/src/test/org/apache/lucene/index/Test4GBStoredFields.java
@@ -29,10 +29,12 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.tests.util.TimeUnits;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.tests.util.LuceneTestCase.Monster;
 
 /** This test creates an index with one segment that is a little larger than 4GB. */
 @SuppressCodecs({"SimpleText", "Compressing"})
 @TimeoutSuite(millis = 4 * TimeUnits.HOUR)
+@Monster("consumes a lot of disk space")
 public class Test4GBStoredFields extends LuceneTestCase {
 
   @Nightly

--- a/lucene/core/src/test/org/apache/lucene/index/Test4GBStoredFields.java
+++ b/lucene/core/src/test/org/apache/lucene/index/Test4GBStoredFields.java
@@ -26,10 +26,10 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.codecs.compressing.CompressingCodec;
 import org.apache.lucene.tests.store.MockDirectoryWrapper;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.LuceneTestCase.Monster;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.tests.util.TimeUnits;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.tests.util.LuceneTestCase.Monster;
 
 /** This test creates an index with one segment that is a little larger than 4GB. */
 @SuppressCodecs({"SimpleText", "Compressing"})

--- a/lucene/core/src/test/org/apache/lucene/index/Test4GBStoredFields.java
+++ b/lucene/core/src/test/org/apache/lucene/index/Test4GBStoredFields.java
@@ -37,7 +37,6 @@ import org.apache.lucene.util.BytesRef;
 @Monster("consumes a lot of disk space")
 public class Test4GBStoredFields extends LuceneTestCase {
 
-  @Nightly
   public void test() throws Exception {
     assumeWorkingMMapOnWindows();
 


### PR DESCRIPTION
Excludes `Test4GBStoredFields` from nightly tests.