### PR TITLE
LUCENE-9651 Update benchmark module docs

### DIFF
--- a/gradle/datasets/external-datasets.gradle
+++ b/gradle/datasets/external-datasets.gradle
@@ -24,7 +24,7 @@ configure(project(":lucene:benchmark")) {
   apply plugin: "de.undercouch.download"
 
   ext {
-    dataDir = file("data")
+    dataDir = file("work")
   }
 
   task getEnWiki(type: Download) {
@@ -120,10 +120,9 @@ configure(project(":lucene:benchmark")) {
   task getReuters(type: Download) {
     ext {
       name = "reuters21578"
-      // note: there is no HTTPS url and we don't care because this is merely test/perf data
-      src = "http://www.daviddlewis.com/resources/testcollections/reuters21578/${name}.tar.gz"
+      src = "https://kdd.ics.uci.edu/databases/${name}/${name}.tar.gz"
       intermediate = file("${dataDir}/${name}.tar.gz")
-      dst = file("${dataDir}/${name}")
+      dst = file("${dataDir}/reuters-out")
     }
 
     outputs.dir ext.dst

--- a/gradle/validation/validate-source-patterns.gradle
+++ b/gradle/validation/validate-source-patterns.gradle
@@ -108,6 +108,7 @@ allprojects {
 configure(project(':lucene:benchmark')) {
   project.tasks.withType(ValidateSourcePatternsTask) {
     sourceFiles.exclude 'data/**'
+    sourceFiles.exclude 'work/**'
 
     // Known .txt offenders.
     sourceFiles.exclude '**/reuters.first20.lines.txt', '**/trecQRels.txt'

--- a/lucene/benchmark/.gitignore
+++ b/lucene/benchmark/.gitignore
@@ -1,1 +1,2 @@
 /data
+/work

--- a/lucene/benchmark/conf/createLineFile.alg
+++ b/lucene/benchmark/conf/createLineFile.alg
@@ -20,9 +20,9 @@
 # This alg will process the Reuters documents feed to produce a
 # single file that contains all documents, one per line.
 #
-# To use this, first cd to benchmark and then run:
+# To use this run:
 #
-#   gradlew run -P task.alg=conf/createLineFile.alg
+#   gradlew :lucene:benchmark:run -Ptask.alg=conf/createLineFile.alg
 #
 # Then, to index the documents in the line file, see
 # indexLineFile.alg.

--- a/lucene/benchmark/conf/createLineFile.alg
+++ b/lucene/benchmark/conf/createLineFile.alg
@@ -22,7 +22,7 @@
 #
 # To use this, first cd to benchmark and then run:
 #
-#   ant run-task -Dtask.alg=conf/createLineFile.alg
+#   gradlew run -P task.alg=conf/createLineFile.alg
 #
 # Then, to index the documents in the line file, see
 # indexLineFile.alg.

--- a/lucene/benchmark/conf/extractWikipedia.alg
+++ b/lucene/benchmark/conf/extractWikipedia.alg
@@ -22,7 +22,7 @@
 #
 # To use this, first cd to benchmark and then run:
 #
-#   ant run-task -Dtask.alg=conf/extractWikipedia.alg
+#   gradlew run -P task.alg=conf/extractWikipedia.alg
 #
 # Then, to index the documents in the line file, see
 # indexLineFile.alg.

--- a/lucene/benchmark/conf/extractWikipedia.alg
+++ b/lucene/benchmark/conf/extractWikipedia.alg
@@ -20,9 +20,9 @@
 # This alg will process the Wikipedia documents feed to produce a
 # single file that contains all documents, one per line.
 #
-# To use this, first cd to benchmark and then run:
+# To use this run:
 #
-#   gradlew run -P task.alg=conf/extractWikipedia.alg
+#   gradlew :lucene:benchmark:run -Ptask.alg=conf/extractWikipedia.alg
 #
 # Then, to index the documents in the line file, see
 # indexLineFile.alg.

--- a/lucene/benchmark/conf/indexLineFile.alg
+++ b/lucene/benchmark/conf/indexLineFile.alg
@@ -26,7 +26,7 @@
 # To use this, you must first run the createLineFile.alg, then cd to
 # benchmark and then run:
 #
-#   ant run-task -Dtask.alg=conf/indexLineFile.alg
+#   gradlew run -P task.alg=conf/indexLineFile.alg
 #
 
 analyzer=org.apache.lucene.analysis.core.SimpleAnalyzer

--- a/lucene/benchmark/conf/indexLineFile.alg
+++ b/lucene/benchmark/conf/indexLineFile.alg
@@ -23,10 +23,9 @@
 # document to let you more accurately measure time spent analyzing and
 # indexing your documents vs time spent creating the documents.
 #
-# To use this, you must first run the createLineFile.alg, then cd to
-# benchmark and then run:
+# To use this, you must first run the createLineFile.alg, then run:
 #
-#   gradlew run -P task.alg=conf/indexLineFile.alg
+#   gradlew :lucene:benchmark:run -Ptask.alg=conf/indexLineFile.alg
 #
 
 analyzer=org.apache.lucene.analysis.core.SimpleAnalyzer

--- a/lucene/benchmark/conf/micro-standard.alg
+++ b/lucene/benchmark/conf/micro-standard.alg
@@ -30,8 +30,7 @@ doc.tokenized=true
 doc.term.vector=false
 log.step=500
 
-work.dir=data
-docs.dir=reuters21578
+docs.dir=reuters-out
 
 #content.source=org.apache.lucene.benchmark.byTask.feeds.SingleDocSource
 content.source=org.apache.lucene.benchmark.byTask.feeds.ReutersContentSource

--- a/lucene/benchmark/conf/readContentSource.alg
+++ b/lucene/benchmark/conf/readContentSource.alg
@@ -24,7 +24,7 @@
 #
 # To use this, first cd to benchmark and then run:
 #
-#   ant run-task -Dtask.alg=conf/readContentSource.alg
+#   gradlew run -P task.alg=conf/readContentSource.alg
 #
 
 # Where to get documents from:

--- a/lucene/benchmark/conf/readContentSource.alg
+++ b/lucene/benchmark/conf/readContentSource.alg
@@ -22,9 +22,9 @@
 # gather baselines for operations like indexing (if reading from the content 
 # source takes 'X' time, we cannot index faster).
 #
-# To use this, first cd to benchmark and then run:
+# To use this run:
 #
-#   gradlew run -P task.alg=conf/readContentSource.alg
+#   gradlew :lucene:benchmark:run -Ptask.alg=conf/readContentSource.alg
 #
 
 # Where to get documents from:

--- a/lucene/benchmark/conf/tokenize.alg
+++ b/lucene/benchmark/conf/tokenize.alg
@@ -22,7 +22,7 @@
 #
 # To use this, cd to benchmark and then run:
 #
-#   ant run-task -Dtask.alg=conf/tokenize.alg
+#   gradlew run -P task.alg=conf/tokenize.alg
 #
 
 content.source=org.apache.lucene.benchmark.byTask.feeds.ReutersContentSource

--- a/lucene/benchmark/conf/tokenize.alg
+++ b/lucene/benchmark/conf/tokenize.alg
@@ -20,9 +20,9 @@
 # This alg reads all tokens out of a document but does not index them.
 # This is useful for benchmarking tokenizers.
 #
-# To use this, cd to benchmark and then run:
+# To use this run:
 #
-#   gradlew run -P task.alg=conf/tokenize.alg
+#   gradlew :lucene:benchmark:run -Ptask.alg=conf/tokenize.alg
 #
 
 content.source=org.apache.lucene.benchmark.byTask.feeds.ReutersContentSource

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/package-info.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/package-info.java
@@ -81,9 +81,9 @@
  * <ul>
  *   <li>./gradlew -p lucene/benchmark getReuters run <br>
  *       - would run the <code>micro-standard.alg</code> "algorithm".
- *   <li>./gradlew -p lucene/benchmark getReuters run -P task.alg=conf/compound-penalty.alg <br>
+ *   <li>./gradlew -p lucene/benchmark getReuters run -Ptask.alg=conf/compound-penalty.alg <br>
  *       - would run the <code>compound-penalty.alg</code> "algorithm".
- *   <li>./gradlew -p lucene/benchmark getReuters run -P task.alg=[full-path-to-your-alg-file] <br>
+ *   <li>./gradlew -p lucene/benchmark getReuters run -Ptask.alg=[full-path-to-your-alg-file] <br>
  *       - would run <code>your perf test</code> "algorithm".
  *   <li>java org.apache.lucene.benchmark.byTask.programmatic.Sample <br>
  *       - would run a performance test programmatically - without using an alg file. This is less
@@ -131,7 +131,7 @@
  * benchmark.ext.classpath property:
  *
  * <ul>
- *   <li>./gradlew -p lucene/benchmark run -P task.alg=[full-path-to-your-alg-file] <span
+ *   <li>./gradlew -p lucene/benchmark run -Ptask.alg=[full-path-to-your-alg-file] <span
  *       style="color: #FF0000">-Dbenchmark.ext.classpath=/mydir/classes </span> -Dtask.mem=512M
  * </ul>
  *
@@ -494,7 +494,7 @@
  * </pre>
  *
  * <p>The command line for running this sample: <br>
- * <code>./gradlew -p lucene/benchmark getReuters run -P task.alg=conf/sample.alg</code>
+ * <code>./gradlew -p lucene/benchmark getReuters run -Ptask.alg=conf/sample.alg</code>
  *
  * <p>The output report from running this test contains the following:
  *

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/package-info.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/package-info.java
@@ -81,9 +81,9 @@
  * <ul>
  *   <li>./gradlew -p lucene/benchmark getReuters run <br>
  *       - would run the <code>micro-standard.alg</code> "algorithm".
- *   <li>ant run-task -Dtask.alg=conf/compound-penalty.alg <br>
+ *   <li>./gradlew -p lucene/benchmark getReuters run -P task.alg=conf/compound-penalty.alg <br>
  *       - would run the <code>compound-penalty.alg</code> "algorithm".
- *   <li>ant run-task -Dtask.alg=[full-path-to-your-alg-file] <br>
+ *   <li>./gradlew -p lucene/benchmark getReuters run -P task.alg=[full-path-to-your-alg-file] <br>
  *       - would run <code>your perf test</code> "algorithm".
  *   <li>java org.apache.lucene.benchmark.byTask.programmatic.Sample <br>
  *       - would run a performance test programmatically - without using an alg file. This is less
@@ -131,8 +131,8 @@
  * benchmark.ext.classpath property:
  *
  * <ul>
- *   <li>ant run-task -Dtask.alg=[full-path-to-your-alg-file] <span style="color:
- *       #FF0000">-Dbenchmark.ext.classpath=/mydir/classes </span> -Dtask.mem=512M
+ *   <li>./gradlew -p lucene/benchmark run -P task.alg=[full-path-to-your-alg-file] <span
+ *       style="color: #FF0000">-Dbenchmark.ext.classpath=/mydir/classes </span> -Dtask.mem=512M
  * </ul>
  *
  * <p><u>External tasks</u>: When writing your own tasks under a package other than
@@ -494,7 +494,7 @@
  * </pre>
  *
  * <p>The command line for running this sample: <br>
- * <code>ant run-task -Dtask.alg=conf/sample.alg</code>
+ * <code>./gradlew -p lucene/benchmark getReuters run -P task.alg=conf/sample.alg</code>
  *
  * <p>The output report from running this test contains the following:
  *

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/package-info.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/package-info.java
@@ -35,12 +35,12 @@
  * alternate views or to take in command line options. When reporting benchmarking runs you should
  * state any alterations you have made.
  *
- * <p>To run the short version of the StandardBenchmarker, call "ant run-micro-standard". This
- * should take a minute or so to complete and give you a preliminary idea of how your change affects
- * the code.
+ * <p>To run the short version of the StandardBenchmarker, call "./gradlew -p lucene/benchmark run".
+ * This should take a minute or so to complete and give you a preliminary idea of how your change
+ * affects the code.
  *
- * <p>To run the long version of the StandardBenchmarker, call "ant run-standard". This takes
- * considerably longer.
+ * <p>To run the long version of the StandardBenchmarker, call "./gradlew -p lucene/benchmark run -P
+ * taskAlg=conf/standard.alg". This takes considerably longer, maybe 10 minutes.
  *
  * <p>The original code for these classes was donated by Andrzej Bialecki at
  * http://issues.apache.org/jira/browse/LUCENE-675 and has been updated by Grant Ingersoll to make

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/package-info.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/package-info.java
@@ -39,8 +39,8 @@
  * This should take a minute or so to complete and give you a preliminary idea of how your change
  * affects the code.
  *
- * <p>To run the long version of the StandardBenchmarker, call "./gradlew -p lucene/benchmark run -P
- * taskAlg=conf/standard.alg". This takes considerably longer, maybe 10 minutes.
+ * <p>To run the long version of the StandardBenchmarker, call "./gradlew -p lucene/benchmark run
+ * -PtaskAlg=conf/standard.alg". This takes considerably longer, maybe 10 minutes.
  *
  * <p>The original code for these classes was donated by Andrzej Bialecki at
  * http://issues.apache.org/jira/browse/LUCENE-675 and has been updated by Grant Ingersoll to make


### PR DESCRIPTION
LUCENE-9651: Update javadoc and download tasks for benchmarks module

# Description

Update the Reuters download task to extract data where most of the benchmarks already expect it.
Update docs to have gradle commands instead of ant commands.
Switch Reuters download from personal site to archived institutional site, per maintainer's request.

# Tests

Manually ran several of the benchmark algorithms to verify.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
