### PR TITLE
LUCENE-10002: Replaces usages of FacetsCollector with FacetsCollectorManager

### DIFF
--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/DistanceFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/DistanceFacetsExample.java
@@ -31,6 +31,7 @@ import org.apache.lucene.facet.DrillSideways;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.range.DoubleRange;
 import org.apache.lucene.facet.range.DoubleRangeFacetCounts;
@@ -213,9 +214,7 @@ public class DistanceFacetsExample implements Closeable {
   /** User runs a query and counts facets. */
   public FacetResult search() throws IOException {
 
-    FacetsCollector fc = new FacetsCollector();
-
-    searcher.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets =
         new DoubleRangeFacetCounts(

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleFacetsExample.java
@@ -28,6 +28,7 @@ import org.apache.lucene.facet.FacetField;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts;
 import org.apache.lucene.facet.taxonomy.TaxonomyReader;
@@ -125,12 +126,10 @@ public class SimpleFacetsExample {
     IndexSearcher searcher = new IndexSearcher(indexReader);
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
 
-    FacetsCollector fc = new FacetsCollector();
-
     // MatchAllDocsQuery is for "browsing" (counts facets
     // for all non-deleted docs in the index); normally
     // you'd use a "normal" query:
-    searcher.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     // Retrieve results
     List<FacetResult> results = new ArrayList<>();

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestFacetUtils.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestFacetUtils.java
@@ -73,8 +73,7 @@ public class TestFacetUtils extends LuceneTestCase {
     }
 
     IndexSearcher searcher = newSearcher(writer.getReader());
-    FacetsCollector fc = new FacetsCollector();
-    searcher.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     int visitedDocs = 0;
     DocIdSetIterator disi;

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestFacetsConfig.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestFacetsConfig.java
@@ -73,8 +73,7 @@ public class TestFacetsConfig extends FacetTestCase {
     DirectoryReader indexReader = DirectoryReader.open(indexDir);
     DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
     IndexSearcher searcher = newSearcher(indexReader);
-    FacetsCollector fc = new FacetsCollector();
-    searcher.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets = getTaxonomyFacetCounts(taxoReader, facetsConfig, fc);
     FacetResult res = facets.getTopChildren(10, "a");

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -59,9 +59,8 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     LongValueFacetCounts facets = new LongValueFacetCounts("field", fc);
 
@@ -111,9 +110,8 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     LongValueFacetCounts facets = new LongValueFacetCounts("field", fc);
 
@@ -143,9 +141,8 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets = new LongValueFacetCounts("field", fc);
 
@@ -204,7 +201,6 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
 
     int iters = atLeast(100);
     for (int iter = 0; iter < iters; iter++) {
-      FacetsCollector fc = new FacetsCollector();
       if (VERBOSE) {
         System.out.println("\nTEST: iter=" + iter);
         System.out.println("  test all docs");
@@ -231,7 +227,7 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
 
       LongValueFacetCounts facetCounts;
       if (random().nextBoolean()) {
-        s.search(new MatchAllDocsQuery(), fc);
+        FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
         if (random().nextBoolean()) {
           if (VERBOSE) {
             System.out.println("  use value source");
@@ -331,8 +327,8 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
         System.out.println("  test id range " + minId + "-" + maxId);
       }
 
-      fc = new FacetsCollector();
-      s.search(IntPoint.newRangeQuery("id", minId, maxId), fc);
+      FacetsCollector fc =
+          s.search(IntPoint.newRangeQuery("id", minId, maxId), new FacetsCollectorManager());
       if (random().nextBoolean()) {
         if (VERBOSE) {
           System.out.println("  use doc values");
@@ -481,7 +477,6 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
 
     int iters = atLeast(100);
     for (int iter = 0; iter < iters; iter++) {
-      FacetsCollector fc = new FacetsCollector();
       if (VERBOSE) {
         System.out.println("\nTEST: iter=" + iter);
         System.out.println("  test all docs");
@@ -505,7 +500,7 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
 
       LongValueFacetCounts facetCounts;
       if (random().nextBoolean()) {
-        s.search(new MatchAllDocsQuery(), fc);
+        FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
         if (VERBOSE) {
           System.out.println("  use doc values");
         }
@@ -577,8 +572,8 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
         System.out.println("  test id range " + minId + "-" + maxId);
       }
 
-      fc = new FacetsCollector();
-      s.search(IntPoint.newRangeQuery("id", minId, maxId), fc);
+      FacetsCollector fc =
+          s.search(IntPoint.newRangeQuery("id", minId, maxId), new FacetsCollectorManager());
       if (random().nextBoolean()) {
         facetCounts = new LongValueFacetCounts("field", fc);
       } else {

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
@@ -260,8 +260,7 @@ public class TestStringValueFacetCounts extends FacetTestCase {
     IndexSearcher searcher = newSearcher(writer.getReader());
     writer.close();
 
-    FacetsCollector c = new FacetsCollector();
-    searcher.search(new MatchAllDocsQuery(), c);
+    FacetsCollector c = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     // using a stale state
     expectThrows(IllegalStateException.class, () -> new StringValueFacetCounts(state, c));
@@ -339,8 +338,7 @@ public class TestStringValueFacetCounts extends FacetTestCase {
     StringDocValuesReaderState state =
         new StringDocValuesReaderState(searcher.getIndexReader(), "field");
 
-    FacetsCollector c = new FacetsCollector();
-    searcher.search(new MatchAllDocsQuery(), c);
+    FacetsCollector c = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     for (int topN : topNs) {
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -36,6 +36,7 @@ import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.facet.MultiDoubleValuesSource;
@@ -85,9 +86,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets =
         new LongRangeFacetCounts(
@@ -131,9 +131,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets =
         new LongRangeFacetCounts(
@@ -182,9 +181,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets =
         new LongRangeFacetCounts(
@@ -223,9 +221,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets =
         new LongRangeFacetCounts(
@@ -287,9 +284,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets =
         new LongRangeFacetCounts(
@@ -327,9 +323,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets =
         new LongRangeFacetCounts(
@@ -363,9 +358,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets = new LongRangeFacetCounts("field", fc);
 
@@ -393,9 +387,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets = new LongRangeFacetCounts("field", fc);
 
@@ -539,10 +532,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
 
     IndexReader r = w.getReader();
 
-    FacetsCollector fc = new FacetsCollector();
-
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
     Facets facets =
         new DoubleRangeFacetCounts(
             "field",
@@ -577,10 +568,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
 
     IndexReader r = w.getReader();
 
-    FacetsCollector fc = new FacetsCollector();
-
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
     Facets facets =
         new DoubleRangeFacetCounts(
             "field",
@@ -626,9 +615,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    FacetsCollector fc = new FacetsCollector();
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets =
         new DoubleRangeFacetCounts(
@@ -756,8 +744,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
         }
       }
 
-      FacetsCollector sfc = new FacetsCollector();
-      s.search(new MatchAllDocsQuery(), sfc);
+      FacetsCollector sfc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
       Query fastMatchQuery;
       if (random().nextBoolean()) {
         if (random().nextBoolean()) {
@@ -953,8 +940,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
         }
       }
 
-      FacetsCollector sfc = new FacetsCollector();
-      s.search(new MatchAllDocsQuery(), sfc);
+      FacetsCollector sfc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
       Query fastMatchQuery;
       if (random().nextBoolean()) {
         if (random().nextBoolean()) {
@@ -1106,8 +1092,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
         }
       }
 
-      FacetsCollector sfc = new FacetsCollector();
-      s.search(new MatchAllDocsQuery(), sfc);
+      FacetsCollector sfc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
       Query fastMatchFilter;
       if (random().nextBoolean()) {
         if (random().nextBoolean()) {
@@ -1276,8 +1261,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
         }
       }
 
-      FacetsCollector sfc = new FacetsCollector();
-      s.search(new MatchAllDocsQuery(), sfc);
+      FacetsCollector sfc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
       Query fastMatchFilter;
       if (random().nextBoolean()) {
         if (random().nextBoolean()) {
@@ -1352,10 +1336,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
 
     IndexReader r = w.getReader();
 
-    FacetsCollector fc = new FacetsCollector();
-
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
     Facets facets =
         new LongRangeFacetCounts(
             "field",
@@ -1396,10 +1378,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
 
     IndexReader r = w.getReader();
 
-    FacetsCollector fc = new FacetsCollector();
-
     IndexSearcher s = newSearcher(r);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
     Facets facets =
         new LongRangeFacetCounts(
             "field",
@@ -1544,12 +1524,10 @@ public class TestRangeFacetCounts extends FacetTestCase {
 
     FacetsConfig config = new FacetsConfig();
 
-    FacetsCollector fc = new FacetsCollector();
-
     IndexReader r = writer.getReader();
 
     IndexSearcher s = newSearcher(r, false, false);
-    s.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     final DoubleRange[] ranges =
         new DoubleRange[] {

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -39,6 +39,7 @@ import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.index.IndexReader;
@@ -660,9 +661,8 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
         try (IndexReader r2 = writer.getReader()) {
           IndexSearcher searcher = newSearcher(r2);
 
-          FacetsCollector c = new FacetsCollector();
-
-          searcher.search(new MatchAllDocsQuery(), c);
+          FacetsCollector c =
+              searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
           expectThrows(
               IllegalStateException.class,
@@ -1392,8 +1392,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
       IndexSearcher searcher, SortedSetDocValuesReaderState state, ExecutorService exec)
       throws IOException, InterruptedException {
     if (random().nextBoolean()) {
-      FacetsCollector c = new FacetsCollector();
-      searcher.search(new MatchAllDocsQuery(), c);
+      FacetsCollector c = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
       if (exec != null) {
         return new ConcurrentSortedSetDocValuesFacetCounts(state, c, exec);
       } else {

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
@@ -28,6 +28,7 @@ import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
@@ -184,8 +185,8 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
         SearcherAndTaxonomy pair = mgr.acquire();
         try {
           // System.out.println("search maxOrd=" + pair.taxonomyReader.getSize());
-          FacetsCollector sfc = new FacetsCollector();
-          pair.searcher.search(new MatchAllDocsQuery(), sfc);
+          FacetsCollector sfc =
+              pair.searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
           Facets facets = getTaxonomyFacetCounts(pair.taxonomyReader, config, sfc);
           FacetResult result = facets.getTopChildren(10, "field");
           if (pair.searcher.getIndexReader().numDocs() > 0) {
@@ -239,8 +240,8 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
         SearcherAndTaxonomy pair = mgr.acquire();
         try {
           // System.out.println("search maxOrd=" + pair.taxonomyReader.getSize());
-          FacetsCollector sfc = new FacetsCollector();
-          pair.searcher.search(new MatchAllDocsQuery(), sfc);
+          FacetsCollector sfc =
+              pair.searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
           Facets facets = getTaxonomyFacetCounts(pair.taxonomyReader, config, sfc);
           FacetResult result = facets.getTopChildren(10, "field");
           if (pair.searcher.getIndexReader().numDocs() > 0) {

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
@@ -21,6 +21,7 @@ import org.apache.lucene.facet.DrillDownQuery;
 import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
@@ -96,10 +97,8 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
 
   public void testIntSumAssociation() throws Exception {
 
-    FacetsCollector fc = new FacetsCollector();
-
     IndexSearcher searcher = newSearcher(reader);
-    searcher.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets = new TaxonomyFacetSumIntAssociations("$facets.int", taxoReader, config, fc);
     assertEquals(
@@ -112,10 +111,8 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
   }
 
   public void testFloatSumAssociation() throws Exception {
-    FacetsCollector fc = new FacetsCollector();
-
     IndexSearcher searcher = newSearcher(reader);
-    searcher.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets = new TaxonomyFacetSumFloatAssociations("$facets.float", taxoReader, config, fc);
     assertEquals(
@@ -138,10 +135,8 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
    * different field.
    */
   public void testIntAndFloatAssocation() throws Exception {
-    FacetsCollector fc = new FacetsCollector();
-
     IndexSearcher searcher = newSearcher(reader);
-    searcher.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets = new TaxonomyFacetSumFloatAssociations("$facets.float", taxoReader, config, fc);
     assertEquals(
@@ -163,10 +158,8 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
   }
 
   public void testWrongIndexFieldName() throws Exception {
-    FacetsCollector fc = new FacetsCollector();
-
     IndexSearcher searcher = newSearcher(reader);
-    searcher.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
     Facets facets = new TaxonomyFacetSumFloatAssociations(taxoReader, config, fc);
     expectThrows(
         IllegalArgumentException.class,
@@ -244,12 +237,10 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
   }
 
   public void testIntSumAssociationDrillDown() throws Exception {
-    FacetsCollector fc = new FacetsCollector();
-
     IndexSearcher searcher = newSearcher(reader);
     DrillDownQuery q = new DrillDownQuery(config);
     q.add("int", "b");
-    searcher.search(q, fc);
+    FacetsCollector fc = searcher.search(q, new FacetsCollectorManager());
 
     Facets facets = new TaxonomyFacetSumIntAssociations("$facets.int", taxoReader, config, fc);
     assertEquals(

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts2.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts2.java
@@ -32,6 +32,7 @@ import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
@@ -274,9 +275,8 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
     IndexSearcher searcher = newSearcher(indexReader);
 
-    FacetsCollector sfc = new FacetsCollector();
     TermQuery q = new TermQuery(A);
-    searcher.search(q, sfc);
+    FacetsCollector sfc = searcher.search(q, new FacetsCollectorManager());
     Facets facets = getTaxonomyFacetCounts(taxoReader, getConfig(), sfc);
     FacetResult result = facets.getTopChildren(NUM_CHILDREN_CP_A, CP_A);
     assertEquals(-1, result.value.intValue());
@@ -298,8 +298,7 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
     IndexSearcher searcher = newSearcher(indexReader);
 
-    FacetsCollector sfc = new FacetsCollector();
-    searcher.search(new MatchAllDocsQuery(), sfc);
+    FacetsCollector sfc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets = getTaxonomyFacetCounts(taxoReader, getConfig(), sfc);
 
@@ -340,8 +339,7 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
     IndexSearcher searcher = newSearcher(indexReader);
 
-    FacetsCollector sfc = new FacetsCollector();
-    searcher.search(new MatchAllDocsQuery(), sfc);
+    FacetsCollector sfc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets = getTaxonomyFacetCounts(taxoReader, getConfig(), sfc);
 
@@ -365,8 +363,7 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
     IndexSearcher searcher = newSearcher(indexReader);
 
-    FacetsCollector sfc = new FacetsCollector();
-    searcher.search(new MatchAllDocsQuery(), sfc);
+    FacetsCollector sfc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     Facets facets = getTaxonomyFacetCounts(taxoReader, getConfig(), sfc);
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetLabels.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetLabels.java
@@ -27,6 +27,7 @@ import org.apache.lucene.facet.FacetField;
 import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.facet.FacetsCollector.MatchingDocs;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
@@ -148,8 +149,7 @@ public class TestTaxonomyFacetLabels extends FacetTestCase {
     // NRT open
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
 
-    FacetsCollector fc = new FacetsCollector();
-    searcher.search(new MatchAllDocsQuery(), fc);
+    FacetsCollector fc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     TaxonomyFacetLabels taxoLabels =
         new TaxonomyFacetLabels(taxoReader, FacetsConfig.DEFAULT_INDEX_FIELD_NAME);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
@@ -30,6 +30,7 @@ import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
@@ -104,14 +105,11 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
     taxoWriter.close();
 
-    // Aggregate the facet counts:
-    FacetsCollector c = new FacetsCollector();
-
     // MatchAllDocsQuery is for "browsing" (counts facets
     // for all non-deleted docs in the index); normally
     // you'd use a "normal" query and one of the
     // Facets.search utility methods:
-    searcher.search(new MatchAllDocsQuery(), c);
+    FacetsCollector c = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     TaxonomyFacetSumValueSource facets =
         new TaxonomyFacetSumValueSource(
@@ -175,8 +173,7 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
     taxoWriter.close();
 
-    FacetsCollector c = new FacetsCollector();
-    searcher.search(new MatchAllDocsQuery(), c);
+    FacetsCollector c = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     TaxonomyFacetSumValueSource facets =
         new TaxonomyFacetSumValueSource(
@@ -226,8 +223,7 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
     taxoWriter.close();
 
-    FacetsCollector c = new FacetsCollector();
-    searcher.search(new MatchAllDocsQuery(), c);
+    FacetsCollector c = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     TaxonomyFacetSumValueSource facets =
         new TaxonomyFacetSumValueSource(
@@ -305,8 +301,8 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     DirectoryReader r = DirectoryReader.open(iw);
     DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
 
-    FacetsCollector sfc = new FacetsCollector();
-    newSearcher(r).search(new MatchAllDocsQuery(), sfc);
+    FacetsCollector sfc =
+        newSearcher(r).search(new MatchAllDocsQuery(), new FacetsCollectorManager());
     Facets facets =
         new TaxonomyFacetSumValueSource(
             taxoReader, config, sfc, DoubleValuesSource.fromLongField("price"));
@@ -372,8 +368,8 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     DirectoryReader r = DirectoryReader.open(iw);
     DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
 
-    FacetsCollector sfc = new FacetsCollector();
-    newSearcher(r).search(new MatchAllDocsQuery(), sfc);
+    FacetsCollector sfc =
+        newSearcher(r).search(new MatchAllDocsQuery(), new FacetsCollectorManager());
     Facets facets =
         new TaxonomyFacetSumValueSource(
             taxoReader, config, sfc, DoubleValuesSource.fromLongField("price"));

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/TestIndexAndTaxonomyReplicationClient.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/TestIndexAndTaxonomyReplicationClient.java
@@ -30,6 +30,7 @@ import org.apache.lucene.facet.DrillDownQuery;
 import org.apache.lucene.facet.FacetField;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts;
 import org.apache.lucene.facet.taxonomy.TaxonomyReader;
@@ -109,8 +110,7 @@ public class TestIndexAndTaxonomyReplicationClient extends ReplicatorTestCase {
         // verify faceted search
         int id = Integer.parseInt(indexReader.getIndexCommit().getUserData().get(VERSION_ID), 16);
         IndexSearcher searcher = new IndexSearcher(indexReader);
-        FacetsCollector fc = new FacetsCollector();
-        searcher.search(new MatchAllDocsQuery(), fc);
+        FacetsCollector fc = searcher.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
         Facets facets = new FastTaxonomyFacetCounts(taxoReader, config, fc);
         assertEquals(1, facets.getSpecificValue("A", Integer.toString(id, 16)).intValue());
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1955,7 +1955,7 @@ public abstract class LuceneTestCase extends Assert {
    */
   public static IndexSearcher newSearcher(
       IndexReader r, boolean maybeWrap, boolean wrapWithAssertions) {
-    return newSearcher(r, maybeWrap, wrapWithAssertions, true);//TODO revert
+    return newSearcher(r, maybeWrap, wrapWithAssertions, rarely());
   }
 
   /**

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1955,7 +1955,7 @@ public abstract class LuceneTestCase extends Assert {
    */
   public static IndexSearcher newSearcher(
       IndexReader r, boolean maybeWrap, boolean wrapWithAssertions) {
-    return newSearcher(r, maybeWrap, wrapWithAssertions, rarely());
+    return newSearcher(r, maybeWrap, wrapWithAssertions, true);//TODO revert
   }
 
   /**


### PR DESCRIPTION
In the effort of decreasing usages of IndexSearcher#search(query, Collector) by using the corresponding method that accepts a collector manager, this commit replaces many usages of FacetsCollector with its corresponding existing collector manager.

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes. (not applicable, modifying existing tests)
