### PR TITLE
LUCENE-10484: Add support for concurrent facets random sampling

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -34,7 +34,7 @@ Improvements
   (Uihyun Kim)
 
 * LUCENE-10484: Add support for concurrent random sampling by calling
-  RandomSamplingFacetsCollector#createManager
+  RandomSamplingFacetsCollector#createManager. (Luca Cavanna)
 
 Optimizations
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -33,6 +33,9 @@ Improvements
 * LUCENE-10416: Update Korean Dictionary to mecab-ko-dic-2.1.1-20180720 for Nori.
   (Uihyun Kim)
 
+* LUCENE-10484: Add support for concurrent random sampling by calling
+  RandomSamplingFacetsCollector#createManager
+
 Optimizations
 ---------------------
 (No changes)

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestRandomSamplingFacetsCollector.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestRandomSamplingFacetsCollector.java
@@ -27,9 +27,9 @@ import org.apache.lucene.facet.taxonomy.TaxonomyReader;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.MultiCollector;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
@@ -74,11 +74,11 @@ public class TestRandomSamplingFacetsCollector extends FacetTestCase {
     IOUtils.close(writer, taxoWriter);
 
     // Test empty results
-    RandomSamplingFacetsCollector collectRandomZeroResults =
-        new RandomSamplingFacetsCollector(numDocs / 10, random.nextLong());
-
+    CollectorManager<RandomSamplingFacetsCollector, RandomSamplingFacetsCollector> fcm =
+        RandomSamplingFacetsCollector.createManager(numDocs / 10, random.nextLong());
     // There should be no divisions by zero
-    searcher.search(new TermQuery(new Term("EvenOdd", "NeverMatches")), collectRandomZeroResults);
+    RandomSamplingFacetsCollector collectRandomZeroResults =
+        searcher.search(new TermQuery(new Term("EvenOdd", "NeverMatches")), fcm);
 
     // There should be no divisions by zero and no null result
     assertNotNull(collectRandomZeroResults.getMatchingDocs());
@@ -93,13 +93,9 @@ public class TestRandomSamplingFacetsCollector extends FacetTestCase {
     // Use a query to select half of the documents.
     TermQuery query = new TermQuery(new Term("EvenOdd", "even"));
 
-    RandomSamplingFacetsCollector random10Percent =
-        new RandomSamplingFacetsCollector(
-            numDocs / 10, random.nextLong()); // 10% of total docs, 20% of the hits
-
-    FacetsCollector fc = new FacetsCollector();
-
-    searcher.search(query, MultiCollector.wrap(fc, random10Percent));
+    // 10% of total docs, 20% of the hits
+    fcm = RandomSamplingFacetsCollector.createManager(numDocs / 10, random.nextLong());
+    RandomSamplingFacetsCollector random10Percent = searcher.search(query, fcm);
 
     final List<MatchingDocs> matchingDocs = random10Percent.getMatchingDocs();
 


### PR DESCRIPTION
This commit adds a new createManager static method to RandomSamplingFacetsCollector that allows users to perform random sampling concurrently. The returned collector manager is very similar to the existing FacetsCollectorManager but it exposes a specialized reduced RandomSamplingFacetsCollector.

This relates to [LUCENE-10002](https://issues.apache.org/jira/browse/LUCENE-10002). It allows users to use a collector manager instead of a collector when doing random sampling, in the effort of reducing usages of IndexSearcher#search(Query, Collector).

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
