### PR TITLE
LUCENE-10486: Avoid unnecessary overhead in TopScoreDoc and TopField collector manager

### DIFF
--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/ReadTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/ReadTask.java
@@ -24,12 +24,15 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TopFieldCollector;
+import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TopScoreDocCollector;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Bits;
@@ -108,10 +111,14 @@ public abstract class ReadTask extends PerfTask {
             // the IndexSearcher search methods that take
             // Weight public again, we can go back to
             // pulling the Weight ourselves:
-            TopFieldCollector collector =
-                TopFieldCollector.create(sort, numHits, withTotalHits() ? Integer.MAX_VALUE : 1);
-            searcher.search(q, collector);
-            hits = collector.topDocs();
+            CollectorManager<TopFieldCollector, TopFieldDocs> manager =
+                TopFieldCollector.createManager(
+                    sort,
+                    numHits,
+                    null,
+                    withTotalHits() ? Integer.MAX_VALUE : 1,
+                    TopDocsCollector.isSearcherMultiThreaded(searcher));
+            hits = searcher.search(q, manager);
           } else {
             hits = searcher.search(q, numHits);
           }

--- a/lucene/core/src/java/org/apache/lucene/search/HitsThresholdChecker.java
+++ b/lucene/core/src/java/org/apache/lucene/search/HitsThresholdChecker.java
@@ -86,7 +86,7 @@ abstract class HitsThresholdChecker {
    * can never be reached. This is useful for cases where early termination is never desired, so
    * that the overhead of counting hits can be avoided.
    */
-  private static final HitsThresholdChecker NO_OP_THRESHOLD_CHECKER =
+  private static final HitsThresholdChecker EXACT_HITS_COUNT_THRESHOLD_CHECKER =
       new HitsThresholdChecker(Integer.MAX_VALUE) {
         @Override
         void incrementHitCount() {
@@ -111,7 +111,7 @@ abstract class HitsThresholdChecker {
 
   static HitsThresholdChecker create(final int totalHitsThreshold, boolean multiThreaded) {
     if (totalHitsThreshold == Integer.MAX_VALUE) {
-      return NO_OP_THRESHOLD_CHECKER;
+      return EXACT_HITS_COUNT_THRESHOLD_CHECKER;
     }
     return multiThreaded
         ? new GlobalHitsThresholdChecker(totalHitsThreshold)

--- a/lucene/core/src/java/org/apache/lucene/search/HitsThresholdChecker.java
+++ b/lucene/core/src/java/org/apache/lucene/search/HitsThresholdChecker.java
@@ -23,96 +23,134 @@ import java.util.concurrent.atomic.AtomicLong;
 abstract class HitsThresholdChecker {
   /** Implementation of HitsThresholdChecker which allows global hit counting */
   private static class GlobalHitsThresholdChecker extends HitsThresholdChecker {
-    private final int totalHitsThreshold;
-    private final AtomicLong globalHitCount;
+    private final AtomicLong globalHitCount = new AtomicLong();
 
-    public GlobalHitsThresholdChecker(int totalHitsThreshold) {
-
-      if (totalHitsThreshold < 0) {
-        throw new IllegalArgumentException(
-            "totalHitsThreshold must be >= 0, got " + totalHitsThreshold);
-      }
-
-      this.totalHitsThreshold = totalHitsThreshold;
-      this.globalHitCount = new AtomicLong();
+    GlobalHitsThresholdChecker(int totalHitsThreshold) {
+      super(totalHitsThreshold);
+      assert totalHitsThreshold != Integer.MAX_VALUE;
     }
 
     @Override
-    public void incrementHitCount() {
+    void incrementHitCount() {
       globalHitCount.incrementAndGet();
     }
 
     @Override
-    public boolean isThresholdReached() {
-      return globalHitCount.getAcquire() > totalHitsThreshold;
+    boolean isThresholdReached() {
+      return globalHitCount.getAcquire() > getHitsThreshold();
     }
 
     @Override
-    public ScoreMode scoreMode() {
-      return totalHitsThreshold == Integer.MAX_VALUE ? ScoreMode.COMPLETE : ScoreMode.TOP_SCORES;
+    ScoreMode scoreMode() {
+      return ScoreMode.TOP_SCORES;
     }
 
     @Override
-    public int getHitsThreshold() {
-      return totalHitsThreshold;
+    boolean supportsConcurrency() {
+      return true;
     }
   }
 
   /** Default implementation of HitsThresholdChecker to be used for single threaded execution */
   private static class LocalHitsThresholdChecker extends HitsThresholdChecker {
-    private final int totalHitsThreshold;
     private int hitCount;
 
-    public LocalHitsThresholdChecker(int totalHitsThreshold) {
-
-      if (totalHitsThreshold < 0) {
-        throw new IllegalArgumentException(
-            "totalHitsThreshold must be >= 0, got " + totalHitsThreshold);
-      }
-
-      this.totalHitsThreshold = totalHitsThreshold;
+    LocalHitsThresholdChecker(int totalHitsThreshold) {
+      super(totalHitsThreshold);
+      assert totalHitsThreshold != Integer.MAX_VALUE;
     }
 
     @Override
-    public void incrementHitCount() {
+    void incrementHitCount() {
       ++hitCount;
     }
 
     @Override
-    public boolean isThresholdReached() {
-      return hitCount > totalHitsThreshold;
+    boolean isThresholdReached() {
+      return hitCount > getHitsThreshold();
     }
 
     @Override
-    public ScoreMode scoreMode() {
-      return totalHitsThreshold == Integer.MAX_VALUE ? ScoreMode.COMPLETE : ScoreMode.TOP_SCORES;
+    ScoreMode scoreMode() {
+      return ScoreMode.TOP_SCORES;
     }
 
     @Override
-    public int getHitsThreshold() {
-      return totalHitsThreshold;
+    boolean supportsConcurrency() {
+      return false;
     }
+  }
+
+  /**
+   * No-op implementation of {@link HitsThresholdChecker} that does no counting, as the threshold
+   * can never be reached. This is useful for cases where early termination is never desired, so
+   * that the overhead of counting hits can be avoided.
+   */
+  private static final HitsThresholdChecker NO_OP_THRESHOLD_CHECKER =
+      new HitsThresholdChecker(Integer.MAX_VALUE) {
+        @Override
+        void incrementHitCount() {
+          // noop
+        }
+
+        @Override
+        boolean isThresholdReached() {
+          return false;
+        }
+
+        @Override
+        ScoreMode scoreMode() {
+          return ScoreMode.COMPLETE;
+        }
+
+        @Override
+        boolean supportsConcurrency() {
+          return true;
+        }
+      };
+
+  static HitsThresholdChecker create(final int totalHitsThreshold, boolean multiThreaded) {
+    if (totalHitsThreshold == Integer.MAX_VALUE) {
+      return NO_OP_THRESHOLD_CHECKER;
+    }
+    return multiThreaded
+        ? new GlobalHitsThresholdChecker(totalHitsThreshold)
+        : new LocalHitsThresholdChecker(totalHitsThreshold);
   }
 
   /*
    * Returns a threshold checker that is useful for single threaded searches
    */
-  public static HitsThresholdChecker create(final int totalHitsThreshold) {
-    return new LocalHitsThresholdChecker(totalHitsThreshold);
+  static HitsThresholdChecker create(final int totalHitsThreshold) {
+    return create(totalHitsThreshold, false);
   }
 
   /*
    * Returns a threshold checker that is based on a shared counter
    */
-  public static HitsThresholdChecker createShared(final int totalHitsThreshold) {
-    return new GlobalHitsThresholdChecker(totalHitsThreshold);
+  static HitsThresholdChecker createShared(final int totalHitsThreshold) {
+    return create(totalHitsThreshold, true);
   }
 
-  public abstract void incrementHitCount();
+  private final int totalHitsThreshold;
 
-  public abstract ScoreMode scoreMode();
+  HitsThresholdChecker(int totalHitsThreshold) {
+    if (totalHitsThreshold < 0) {
+      throw new IllegalArgumentException(
+          "totalHitsThreshold must be >= 0, got " + totalHitsThreshold);
+    }
+    this.totalHitsThreshold = totalHitsThreshold;
+  }
 
-  public abstract int getHitsThreshold();
+  final int getHitsThreshold() {
+    return totalHitsThreshold;
+  }
 
-  public abstract boolean isThresholdReached();
+  abstract boolean isThresholdReached();
+
+  abstract ScoreMode scoreMode();
+
+  abstract void incrementHitCount();
+
+  abstract boolean supportsConcurrency();
 }

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreAccumulator.java
@@ -22,6 +22,17 @@ import java.util.concurrent.atomic.LongAccumulator;
 
 /** Maintains the maximum score and its corresponding document id concurrently */
 final class MaxScoreAccumulator {
+
+  /**
+   * Returns the appropriate global accumulator given the arguments. Returns null when globally
+   * accumulating the max score does not apply,
+   */
+  static MaxScoreAccumulator createOrNull(long totalHitsThreshold, boolean multiThreaded) {
+    return totalHitsThreshold == Integer.MAX_VALUE || multiThreaded == false
+        ? null
+        : new MaxScoreAccumulator();
+  }
+
   // we use 2^10-1 to check the remainder with a bitwise operation
   static final int DEFAULT_INTERVAL = 0x3ff;
 

--- a/lucene/core/src/java/org/apache/lucene/search/TopDocsCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopDocsCollector.java
@@ -29,6 +29,10 @@ import org.apache.lucene.util.PriorityQueue;
  */
 public abstract class TopDocsCollector<T extends ScoreDoc> implements Collector {
 
+  public static boolean isSearcherMultiThreaded(IndexSearcher searcher) {
+    return searcher.getSlices() != null && searcher.getSlices().length > 1;
+  }
+
   /**
    * This is used in case topDocs() is called with illegal parameters, or there simply aren't
    * (enough) results.

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -483,8 +483,8 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
 
   /**
    * Create a {@link CollectorManager} which uses a shared hit counter as well as a shared {@link
-   * MaxScoreAccumulator} when needed, depending on the provided leaf slices argument provided. When
-   * the searcher does not support concurrency, the returned manager will not incur the overhead of
+   * MaxScoreAccumulator} when needed, depending on the provided arguments. When
+   * the searcher is not multi-threaded, the returned manager will not incur the overhead of
    * the shared data structures.
    */
   public static CollectorManager<TopFieldCollector, TopFieldDocs> createManager(

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -483,9 +483,8 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
 
   /**
    * Create a {@link CollectorManager} which uses a shared hit counter as well as a shared {@link
-   * MaxScoreAccumulator} when needed, depending on the provided arguments. When
-   * the searcher is not multi-threaded, the returned manager will not incur the overhead of
-   * the shared data structures.
+   * MaxScoreAccumulator} when needed, depending on the provided arguments. When the searcher is not
+   * multi-threaded, the returned manager will not incur the overhead of the shared data structures.
    */
   public static CollectorManager<TopFieldCollector, TopFieldDocs> createManager(
       Sort sort, int numHits, FieldDoc after, int totalHitsThreshold, boolean multiThreaded) {

--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
@@ -251,9 +251,8 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
 
   /**
    * Create a {@link CollectorManager} which uses a shared hit counter as well as a shared {@link
-   * MaxScoreAccumulator} when needed, depending on the provided arguments. When
-   * the searcher is not multi-threaded, the returned manager will not incur the overhead of
-   * the shared data structures.
+   * MaxScoreAccumulator} when needed, depending on the provided arguments. When the searcher is not
+   * multi-threaded, the returned manager will not incur the overhead of the shared data structures.
    */
   public static CollectorManager<TopScoreDocCollector, TopDocs> createManager(
       int numHits, ScoreDoc after, int totalHitsThreshold, boolean multiThreaded) {

--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
@@ -251,8 +251,8 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
 
   /**
    * Create a {@link CollectorManager} which uses a shared hit counter as well as a shared {@link
-   * MaxScoreAccumulator} when needed, depending on the provided leaf slices argument provided. When
-   * the searcher does not support concurrency, the returned manager will not incur the overhead of
+   * MaxScoreAccumulator} when needed, depending on the provided arguments. When
+   * the searcher is not multi-threaded, the returned manager will not incur the overhead of
    * the shared data structures.
    */
   public static CollectorManager<TopScoreDocCollector, TopDocs> createManager(

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -694,7 +694,6 @@ public class TestTopDocsCollector extends LuceneTestCase {
   }
 
   public void testCreateManager() throws IOException {
-    Sort sort = new Sort(SortField.FIELD_SCORE, SortField.FIELD_DOC);
     Executor executor = Executors.newSingleThreadScheduledExecutor();
     try (Directory dir = newDirectory();
         IndexWriter w =

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -693,9 +693,10 @@ public class TestTopDocsCollector extends LuceneTestCase {
   }
 
   public void testCreateManager() throws IOException {
-    Executor executor = command -> {
-      //no-op
-    };
+    Executor executor =
+        command -> {
+          // no-op
+        };
     try (Directory dir = newDirectory();
         IndexWriter w =
             new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -694,7 +694,9 @@ public class TestTopDocsCollector extends LuceneTestCase {
   }
 
   public void testCreateManager() throws IOException {
-    Executor executor = Executors.newSingleThreadScheduledExecutor();
+    Executor executor = command -> {
+      //no-op
+    };
     try (Directory dir = newDirectory();
         IndexWriter w =
             new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -743,7 +743,9 @@ public class TestTopFieldCollector extends LuceneTestCase {
 
   public void testCreateManager() throws IOException {
     Sort sort = new Sort(SortField.FIELD_SCORE, SortField.FIELD_DOC);
-    Executor executor = Executors.newSingleThreadScheduledExecutor();
+    Executor executor = command -> {
+      //no-op
+    };
     try (Directory dir = newDirectory();
         IndexWriter w =
             new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -742,9 +742,10 @@ public class TestTopFieldCollector extends LuceneTestCase {
 
   public void testCreateManager() throws IOException {
     Sort sort = new Sort(SortField.FIELD_SCORE, SortField.FIELD_DOC);
-    Executor executor = command -> {
-      //no-op
-    };
+    Executor executor =
+        command -> {
+          // no-op
+        };
     try (Directory dir = newDirectory();
         IndexWriter w =
             new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -844,10 +844,6 @@ public class TestTopFieldCollector extends LuceneTestCase {
     }
   }
 
-  private static boolean isMultiThreaded(IndexSearcher searcher) {
-    return searcher.getSlices() != null && searcher.getSlices().length > 1;
-  }
-
   private static void assertNoCounting(CollectorManager<TopFieldCollector, TopFieldDocs> manager)
       throws IOException {
     TopFieldCollector topFieldCollector = manager.newCollector();

--- a/lucene/facet/src/java/org/apache/lucene/facet/DrillSideways.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/DrillSideways.java
@@ -18,7 +18,6 @@ package org.apache.lucene.facet;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -198,23 +197,7 @@ public class DrillSideways {
       final int fTopN = Math.min(topN, limit);
 
       final CollectorManager<TopFieldCollector, TopFieldDocs> collectorManager =
-          new CollectorManager<>() {
-
-            @Override
-            public TopFieldCollector newCollector() {
-              return TopFieldCollector.create(sort, fTopN, after, Integer.MAX_VALUE);
-            }
-
-            @Override
-            public TopFieldDocs reduce(Collection<TopFieldCollector> collectors) {
-              final TopFieldDocs[] topFieldDocs = new TopFieldDocs[collectors.size()];
-              int pos = 0;
-              for (TopFieldCollector collector : collectors)
-                topFieldDocs[pos++] = collector.topDocs();
-              return TopDocs.merge(sort, topN, topFieldDocs);
-            }
-          };
-
+          TopFieldCollector.createSharedManager(sort, fTopN, after, Integer.MAX_VALUE);
       final ConcurrentDrillSidewaysResult<TopFieldDocs> r = search(query, collectorManager);
 
       TopFieldDocs topDocs = r.collectorResult;
@@ -247,24 +230,7 @@ public class DrillSideways {
     final int fTopN = Math.min(topN, limit);
 
     final CollectorManager<TopScoreDocCollector, TopDocs> collectorManager =
-        new CollectorManager<>() {
-
-          @Override
-          public TopScoreDocCollector newCollector() {
-            return TopScoreDocCollector.create(fTopN, after, Integer.MAX_VALUE);
-          }
-
-          @Override
-          public TopDocs reduce(Collection<TopScoreDocCollector> collectors) {
-            final TopDocs[] topDocs = new TopDocs[collectors.size()];
-            int pos = 0;
-            for (TopScoreDocCollector collector : collectors) {
-              topDocs[pos++] = collector.topDocs();
-            }
-            return TopDocs.merge(topN, topDocs);
-          }
-        };
-
+        TopScoreDocCollector.createSharedManager(fTopN, after, Integer.MAX_VALUE);
     final ConcurrentDrillSidewaysResult<TopDocs> r = search(query, collectorManager);
     return new DrillSidewaysResult(
         r.facets,


### PR DESCRIPTION
The createSharedManager static methods exposed by TopFieldCollector and TopScoreDocCollector rely unconditionally on a shared global counter as well as a shared max score accumulator. These can cause needless overhead when the search is not executed concurrently. This commit adds a new createManager method to both collectors that creates the proper hits threshold checker and max score accumulator depending on the provided arguments, specifically the total hits threshold and whether the search is multi-threaded or not. The searcher is considered multi-threaded when its leafSlices are set (meaning the executor was provided at contruction time) and there's more than one of them. Also, when totalHitsThreshold is Integer.MAX_VALUE a special hits threshold checker is used which does no counting, and no shared max score accumulator is used, regardless of whether the searcher is multi-threaded or not.

#11522

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.