### PR TITLE
Implement method to bulk add all collection elements to a PriorityQueue

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -69,7 +69,8 @@ have readonly `Monitor` instances. (Niko Usai)
 
 Improvements
 ---------------------
-* Implement method to bulk add all collection elements to a PriorityQueue.
+
+* LUCENE-10494: Implement method to bulk add all collection elements to a PriorityQueue.
   (Bauyrzhan Sakhariyev)
 
 Optimizations

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -69,7 +69,8 @@ have readonly `Monitor` instances. (Niko Usai)
 
 Improvements
 ---------------------
-(No changes)
+* Implement method to bulk add all collection elements to a PriorityQueue.
+  (Bauyrzhan Sakhariyev)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/ExactPhraseMatcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ExactPhraseMatcher.java
@@ -269,6 +269,7 @@ public final class ExactPhraseMatcher extends PhraseMatcher {
 
             boolean hasImpacts = false;
             List<Impact> onlyImpactList = null;
+            List<SubIterator> subIterators = new ArrayList<>(impacts.length);
             for (int i = 0; i < impacts.length; ++i) {
               int impactsLevel = getLevel(impacts[i], docIdUpTo);
               if (impactsLevel == -1) {
@@ -284,7 +285,7 @@ public final class ExactPhraseMatcher extends PhraseMatcher {
               }
 
               SubIterator subIterator = new SubIterator(impactList);
-              pq.add(subIterator);
+              subIterators.add(subIterator);
               if (hasImpacts == false) {
                 hasImpacts = true;
                 onlyImpactList = impactList;
@@ -308,6 +309,7 @@ public final class ExactPhraseMatcher extends PhraseMatcher {
             // We walk impacts in parallel through a PQ ordered by freq. At any time,
             // the competitive impact consists of the lowest freq among all entries of
             // the PQ (the top) and the highest norm (tracked separately).
+            pq.addAll(subIterators);
             List<Impact> mergedImpacts = new ArrayList<>();
             SubIterator top = pq.top();
             int currentFreq = top.current.freq;

--- a/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
@@ -110,16 +110,21 @@ public abstract class PriorityQueue<T> implements Iterable<T> {
 
   /**
    * Adds all elements of the collection into the queue. This method should be preferred over
-   * calling add() in loop if all elements are known in advance as it builds queue faster.
+   * calling {@link #add(Object)} in loop if all elements are known in advance as it builds queue
+   * faster.
+   *
+   * <p>If one tries to add more objects than the maxSize passed in the constructor, an {@link
+   * ArrayIndexOutOfBoundsException} is thrown.
    */
   public void addAll(Collection<T> elements) {
     if (this.size + elements.size() > this.maxSize) {
-      throw new IllegalArgumentException(
+      throw new ArrayIndexOutOfBoundsException(
           "Cannot add "
               + elements.size()
               + " elements to a queue with remaining capacity: "
               + (maxSize - size));
     }
+
     // Heap with size S always takes first S elements of the array,
     // and thus it's safe to fill array further - no actual non-sentinel value will be overwritten.
     Iterator<T> iterator = elements.iterator();

--- a/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.util;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
@@ -104,6 +105,32 @@ public abstract class PriorityQueue<T> implements Iterable<T> {
         heap[i] = sentinelObjectSupplier.get();
       }
       size = maxSize;
+    }
+  }
+
+  /**
+   * Adds all elements of the collection into the queue. This method should be preferred over
+   * calling add() in loop if all elements are known in advance as it builds queue faster.
+   */
+  public void addAll(Collection<T> elements) {
+    if (this.size + elements.size() > this.maxSize) {
+      throw new IllegalArgumentException(
+          "Cannot add "
+              + elements.size()
+              + " elements to a queue with remaining capacity: "
+              + (maxSize - size));
+    }
+    // Heap with size S always takes first S elements of the array,
+    // and thus it's safe to fill array further - no actual non-sentinel value will be overwritten.
+    Iterator<T> iterator = elements.iterator();
+    while (iterator.hasNext()) {
+      this.heap[size + 1] = iterator.next();
+      this.size++;
+    }
+
+    // The loop goes down to 1 as heap is 1-based not 0-based.
+    for (int i = (size >>> 1); i >= 1; i--) {
+      downHeap(i);
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestPriorityQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestPriorityQueue.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.util;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -163,6 +164,55 @@ public class TestPriorityQueue extends LuceneTestCase {
     assertEquals((Integer) 2, pq.top());
   }
 
+  public void testAddAllToEmptyQueue() {
+    Random random = random();
+    int size = 10;
+    List<Integer> list = new ArrayList<>();
+    for (int i = 0; i < size; i++) {
+      list.add(random.nextInt());
+    }
+    IntegerQueue pq = new IntegerQueue(size);
+    pq.addAll(list);
+
+    pq.checkValidity();
+    assertOrderedWhenDrained(pq, list);
+  }
+
+  public void testAddAllToPartiallyFilledQueue() {
+    IntegerQueue pq = new IntegerQueue(20);
+    List<Integer> oneByOne = new ArrayList<>();
+    List<Integer> bulkAdded = new ArrayList<>();
+    Random random = random();
+    for (int i = 0; i < 10; i++) {
+      bulkAdded.add(random.nextInt());
+
+      int x = random.nextInt();
+      pq.add(x);
+      oneByOne.add(x);
+    }
+
+    pq.addAll(bulkAdded);
+    pq.checkValidity();
+
+    oneByOne.addAll(bulkAdded); // Gather all "reference" data.
+    assertOrderedWhenDrained(pq, oneByOne);
+  }
+
+  public void testAddAllDoesNotFitIntoQueue() {
+    IntegerQueue pq = new IntegerQueue(20);
+    List<Integer> list = new ArrayList<>();
+    Random random = random();
+    for (int i = 0; i < 11; i++) {
+      list.add(random.nextInt());
+      pq.add(random.nextInt());
+    }
+
+    assertThrows(
+        "Cannot add 11 elements to a queue with remaining capacity: 9",
+        IllegalArgumentException.class,
+        () -> pq.addAll(list));
+  }
+
   public void testRemovalsAndInsertions() {
     Random random = random();
     int numDocsInPQ = TestUtil.nextInt(random, 1, 100);
@@ -296,5 +346,14 @@ public class TestPriorityQueue extends LuceneTestCase {
             }
           };
         });
+  }
+
+  private void assertOrderedWhenDrained(IntegerQueue pq, List<Integer> referenceDataList) {
+    Collections.sort(referenceDataList);
+    int i = 0;
+    while (pq.size() > 0) {
+      assertEquals(pq.pop(), referenceDataList.get(i));
+      i++;
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestPriorityQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestPriorityQueue.java
@@ -209,7 +209,7 @@ public class TestPriorityQueue extends LuceneTestCase {
 
     assertThrows(
         "Cannot add 11 elements to a queue with remaining capacity: 9",
-        IllegalArgumentException.class,
+        ArrayIndexOutOfBoundsException.class,
         () -> pq.addAll(list));
   }
 


### PR DESCRIPTION
Hi!

This PR doesn't have a link to a Jira Issue as according to contribution guidelines I can either create a patch and attach it to an issue on Jira or open a pull request - let me know if I misunderstood things and have to create a Jira issue anyway.


# Description

`PriorityQueue` class doesn't have a constructor accepting array/collection and I created one for the cases, when heap elements are known in advance to save some time on queue creation: `O(N)` ([heapify](https://en.wikipedia.org/wiki/Binary_heap#Building_a_heap)) vs `Nlog(N)` (calling add() in loop).

# Solution

JDK `PriorityQueue` has a constructor, accepting Collection and it internally uses `heapify` - this PR is basically adaptation of this method (index is not 0 but 1 based and no need to check comparator presence).

# Tests

I added a test creating a queue filled by random elements with the new method and checking its validity. Also added a potential usage (just took randomly first usage of `add`) and it didn't cause any failures. 

Tried to run benchmarks using https://github.com/mikemccand/luceneutil but 
got an error 
```
src/python/competition.py", line 302
    raise ValueError(f'mode must be "cpu" or "heap" but got: {mode}')
```
may I ask is there any detailed guide on running Lucene benchmarks? 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
