### PR TITLE
LUCENE-10490: Query implement Cloneable interface

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/Query.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Query.java
@@ -43,7 +43,7 @@ import org.apache.lucene.index.IndexReader;
  * <p>See also additional queries available in the <a
  * href="{@docRoot}/../queries/overview-summary.html">Queries module</a>
  */
-public abstract class Query {
+public abstract class Query implements Cloneable{
 
   /**
    * Prints a query to a string, with <code>field</code> assumed to be the default field and
@@ -135,5 +135,14 @@ public abstract class Query {
    */
   protected final int classHash() {
     return CLASS_NAME_HASH;
+  }
+
+  @Override
+  public Query clone() {
+    try {
+      return (Query) super.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new Error("This cannot happen: Failing to clone Query", e);
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/Query.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Query.java
@@ -43,7 +43,7 @@ import org.apache.lucene.index.IndexReader;
  * <p>See also additional queries available in the <a
  * href="{@docRoot}/../queries/overview-summary.html">Queries module</a>
  */
-public abstract class Query implements Cloneable{
+public abstract class Query implements Cloneable {
 
   /**
    * Prints a query to a string, with <code>field</code> assumed to be the default field and

--- a/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanContainQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanContainQuery.java
@@ -29,7 +29,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 
-abstract class SpanContainQuery extends SpanQuery implements Cloneable {
+abstract class SpanContainQuery extends SpanQuery {
 
   SpanQuery big;
   SpanQuery little;

--- a/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanContainQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanContainQuery.java
@@ -113,14 +113,12 @@ abstract class SpanContainQuery extends SpanQuery implements Cloneable {
     SpanQuery rewrittenBig = (SpanQuery) big.rewrite(reader);
     SpanQuery rewrittenLittle = (SpanQuery) little.rewrite(reader);
     if (big != rewrittenBig || little != rewrittenLittle) {
-      try {
+
         SpanContainQuery clone = (SpanContainQuery) super.clone();
         clone.big = rewrittenBig;
         clone.little = rewrittenLittle;
         return clone;
-      } catch (CloneNotSupportedException e) {
-        throw new AssertionError(e);
-      }
+
     }
     return super.rewrite(reader);
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanContainQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanContainQuery.java
@@ -114,11 +114,10 @@ abstract class SpanContainQuery extends SpanQuery implements Cloneable {
     SpanQuery rewrittenLittle = (SpanQuery) little.rewrite(reader);
     if (big != rewrittenBig || little != rewrittenLittle) {
 
-        SpanContainQuery clone = (SpanContainQuery) super.clone();
-        clone.big = rewrittenBig;
-        clone.little = rewrittenLittle;
-        return clone;
-
+      SpanContainQuery clone = (SpanContainQuery) super.clone();
+      clone.big = rewrittenBig;
+      clone.little = rewrittenLittle;
+      return clone;
     }
     return super.rewrite(reader);
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanNearQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanNearQuery.java
@@ -39,7 +39,7 @@ import org.apache.lucene.search.Weight;
  * Matches spans which are near one another. One can specify <i>slop</i>, the maximum number of
  * intervening unmatched positions, as well as whether matches are required to be in-order.
  */
-public class SpanNearQuery extends SpanQuery implements Cloneable {
+public class SpanNearQuery extends SpanQuery {
 
   /** A builder for SpanNearQueries */
   public static class Builder {

--- a/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanNearQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanNearQuery.java
@@ -253,10 +253,9 @@ public class SpanNearQuery extends SpanQuery implements Cloneable {
     }
     if (actuallyRewritten) {
 
-        SpanNearQuery rewritten = (SpanNearQuery) clone();
-        rewritten.clauses = rewrittenClauses;
-        return rewritten;
-
+      SpanNearQuery rewritten = (SpanNearQuery) clone();
+      rewritten.clauses = rewrittenClauses;
+      return rewritten;
     }
     return super.rewrite(reader);
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanNearQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanNearQuery.java
@@ -252,13 +252,11 @@ public class SpanNearQuery extends SpanQuery implements Cloneable {
       rewrittenClauses.add(query);
     }
     if (actuallyRewritten) {
-      try {
+
         SpanNearQuery rewritten = (SpanNearQuery) clone();
         rewritten.clauses = rewrittenClauses;
         return rewritten;
-      } catch (CloneNotSupportedException e) {
-        throw new AssertionError(e);
-      }
+
     }
     return super.rewrite(reader);
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanPositionCheckQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanPositionCheckQuery.java
@@ -31,7 +31,7 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 
 /** Base class for filtering a SpanQuery based on the position of a match. */
-public abstract class SpanPositionCheckQuery extends SpanQuery implements Cloneable {
+public abstract class SpanPositionCheckQuery extends SpanQuery {
   protected SpanQuery match;
 
   public SpanPositionCheckQuery(SpanQuery match) {

--- a/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanPositionCheckQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanPositionCheckQuery.java
@@ -114,13 +114,11 @@ public abstract class SpanPositionCheckQuery extends SpanQuery implements Clonea
   public Query rewrite(IndexReader reader) throws IOException {
     SpanQuery rewritten = (SpanQuery) match.rewrite(reader);
     if (rewritten != match) {
-      try {
+
         SpanPositionCheckQuery clone = (SpanPositionCheckQuery) this.clone();
         clone.match = rewritten;
         return clone;
-      } catch (CloneNotSupportedException e) {
-        throw new AssertionError(e);
-      }
+
     }
 
     return super.rewrite(reader);

--- a/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanPositionCheckQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanPositionCheckQuery.java
@@ -115,10 +115,9 @@ public abstract class SpanPositionCheckQuery extends SpanQuery implements Clonea
     SpanQuery rewritten = (SpanQuery) match.rewrite(reader);
     if (rewritten != match) {
 
-        SpanPositionCheckQuery clone = (SpanPositionCheckQuery) this.clone();
-        clone.match = rewritten;
-        return clone;
-
+      SpanPositionCheckQuery clone = (SpanPositionCheckQuery) this.clone();
+      clone.match = rewritten;
+      return clone;
     }
 
     return super.rewrite(reader);


### PR DESCRIPTION
Query should implement Cloneable interface, so that subClass of Query can clone itself to create a new instance when only minor modifications are needed especially in Query#rewrite method.

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
