### PR TITLE
LUCENE-10491: Fix correctness bug in TaxonomyFacetSumValueSource score providing

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -93,6 +93,9 @@ Bug Fixes
 * LUCENE-10477: Highlighter: WeightedSpanTermExtractor.extractWeightedSpanTerms to Query#rewrite
   multiple times if necessary. (Christine Poerschke, Adrien Grand)
 
+* LUCENE-10491: A correctness bug in the way scores are provided within TaxonomyFacetSumValueSource
+  was fixed. (Michael McCandless, Greg Miller)
+
 Build
 ---------------------
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumValueSource.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetSumValueSource.java
@@ -75,7 +75,7 @@ public class TaxonomyFacetSumValueSource extends FloatTaxonomyFacets {
 
       @Override
       public boolean advanceExact(int doc) throws IOException {
-        index++;
+        index = doc;
         return true;
       }
     };

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetSumValueSource.java
@@ -353,8 +353,13 @@ public class TestTaxonomyFacetSumValueSource extends FacetTestCase {
     IndexWriter iw = new IndexWriter(indexDir, newIndexWriterConfig(new MockAnalyzer(random())));
 
     FacetsConfig config = new FacetsConfig();
+
+    // Add a doc without the price field to exercise the bug found in LUCENE-10491:
+    Document doc = new Document();
+    iw.addDocument(config.build(taxoWriter, doc));
+
     for (int i = 0; i < 4; i++) {
-      Document doc = new Document();
+      doc = new Document();
       doc.add(new NumericDocValuesField("price", (i + 1)));
       doc.add(new FacetField("a", Integer.toString(i % 2)));
       iw.addDocument(config.build(taxoWriter, doc));


### PR DESCRIPTION
# Description

Fixes a bug in TaxonomyFacetSumValueSource score providing

# Solution

Fixed the bug

# Tests

Added to an existing test case to demonstrate the bug

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
