### PR TITLE
LUCENE-10488: Optimize Facets#getTopDims in IntTaxonomyFacets

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
@@ -182,14 +182,18 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
       return null;
     }
 
-    LabelAndValue[] labelValues = getLabelValues(childOrdsResult.q, cp);
+    LabelAndValue[] labelValues = getLabelValues(childOrdsResult.q, cp.length);
     return new FacetResult(
         dim, path, childOrdsResult.aggregatedValue, labelValues, childOrdsResult.childCount);
   }
 
-  /** Returns label and values for dims */
-  private LabelAndValue[] getLabelValues(TopOrdAndIntQueue q, FacetLabel facetLabel)
-      throws IOException {
+  /**
+   * Return label and values for top dimensions and children
+   *
+   * @param q the queue for the dimension's top children
+   * @param pathLength the length of a dimension's children paths
+   */
+  private LabelAndValue[] getLabelValues(TopOrdAndIntQueue q, int pathLength) throws IOException {
     LabelAndValue[] labelValues = new LabelAndValue[q.size()];
     int[] ordinals = new int[labelValues.length];
     int[] values = new int[labelValues.length];
@@ -202,15 +206,14 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
 
     FacetLabel[] bulkPath = taxoReader.getBulkPath(ordinals);
     for (int i = 0; i < labelValues.length; i++) {
-      labelValues[i] = new LabelAndValue(bulkPath[i].components[facetLabel.length], values[i]);
+      labelValues[i] = new LabelAndValue(bulkPath[i].components[pathLength], values[i]);
     }
     return labelValues;
   }
 
   /**
-   * Returns ChildOrdsResult that contains results of dimCount(totalValue), childCount, and the
-   * queue for the dimension's top children to populate FacetResult in getPathResult. This portion
-   * of code is moved from getTopChildren because getTopDims needs to reuse it
+   * Return ChildOrdsResult that contains results of dimCount, childCount, and the queue for the
+   * dimension's top children to populate FacetResult in getPathResult.
    */
   private ChildOrdsResult getChildOrdsResult(DimConfig dimConfig, int dimOrd, int topN)
       throws IOException {
@@ -278,7 +281,7 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
     return new ChildOrdsResult(aggregatedValue, childCount, q);
   }
 
-  /** Returns value/count of a dimension. */
+  /** Return value/count of a dimension. */
   private int getDimValue(
       FacetsConfig.DimConfig dimConfig,
       String dim,
@@ -376,14 +379,14 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
         childOrdsResult = getChildOrdsResult(dimConfig, dimValueResult.dimOrd, topNChildren);
       }
       // FacetResult requires String[] path, and path is always empty for getTopDims.
-      // FacetLabelLength is always equal to 1 when FacetLabel is constructed with
+      // pathLength is always equal to 1 when FacetLabel is constructed with
       // FacetLabel(dim, emptyPath), and therefore, 1 is passed in when calling getLabelValues
       FacetResult facetResult =
           new FacetResult(
               dimValueResult.dim,
               emptyPath,
               dimValueResult.value,
-              getLabelValues(childOrdsResult.q, new FacetLabel(dim, emptyPath)),
+              getLabelValues(childOrdsResult.q, 1),
               childOrdsResult.childCount);
       results[pq.size()] = facetResult;
     }
@@ -391,7 +394,7 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
   }
 
   /**
-   * Creates DimValueResult to store the label, dim ordinal and dim count of a dim in priority queue
+   * Create DimValueResult to store the label, dim ordinal and dim count of a dim in priority queue
    */
   private static class DimValueResult {
     String dim;
@@ -406,7 +409,7 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
   }
 
   /**
-   * Creates ChildOrdsResult to store dimCount, childCount, and the queue for the dimension's top
+   * Create ChildOrdsResult to store dimCount, childCount, and the queue for the dimension's top
    * children
    */
   private static class ChildOrdsResult {

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
@@ -224,6 +224,8 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
     int childCount = 0;
     TopOrdAndIntQueue.OrdAndValue reuse = null;
 
+    // TODO: would be faster if we had a "get the following children" API?  then we
+    // can make a single pass over the hashmap
     if (sparseValues != null) {
       for (IntIntCursor c : sparseValues) {
         int value = c.value;

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
@@ -345,23 +345,23 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
         // if dimOrd = -1, we skip this dim, else call getDimValue
         if (dimOrd != -1) {
           dimCount = getDimValue(dimConfig, dim, dimOrd, topNChildren, dimToChildOrdsResult);
-        }
-        if (dimCount != 0) {
-          // use priority queue to store DimValueResult for topNDims
-          if (pq.size() < topNDims) {
-            pq.add(new DimValueResult(dim, dimOrd, dimCount));
-          } else {
-            if (dimCount > pq.top().value
-                    || (dimCount == pq.top().value && dim.compareTo(pq.top().dim) < 0)) {
-              DimValueResult bottomDim = pq.top();
-              bottomDim.dim = dim;
-              bottomDim.value = dimCount;
-              pq.updateTop();
+          if (dimCount != 0) {
+            // use priority queue to store DimValueResult for topNDims
+            if (pq.size() < topNDims) {
+              pq.add(new DimValueResult(dim, dimOrd, dimCount));
+            } else {
+              if (dimCount > pq.top().value
+                      || (dimCount == pq.top().value && dim.compareTo(pq.top().dim) < 0)) {
+                DimValueResult bottomDim = pq.top();
+                bottomDim.dim = dim;
+                bottomDim.value = dimCount;
+                pq.updateTop();
+              }
             }
           }
         }
-        ord = siblings[ord];
       }
+      ord = siblings[ord];
     }
 
     // get FacetResult for topNDims

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
@@ -176,22 +176,23 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
       return null;
     }
 
-    ChildOrdsResult childOrdsResult = getChildOrdsResult(dimConfig, dimOrd,topN);
+    ChildOrdsResult childOrdsResult = getChildOrdsResult(dimConfig, dimOrd, topN);
 
     if (childOrdsResult.q == null || childOrdsResult.aggregatedValue == 0) {
       return null;
     }
 
     LabelAndValue[] labelValues = getLabelValues(childOrdsResult.q, cp.length);
-    return new FacetResult(dim, path, childOrdsResult.aggregatedValue, labelValues, childOrdsResult.childCount);
+    return new FacetResult(
+        dim, path, childOrdsResult.aggregatedValue, labelValues, childOrdsResult.childCount);
   }
 
   /**
-   * Returns label values for dims
-   * This portion of code is moved from getTopChildren because getTopDims needs to reuse it
+   * Returns label values for dims This portion of code is moved from getTopChildren because
+   * getTopDims needs to reuse it
    */
   private LabelAndValue[] getLabelValues(TopOrdAndIntQueue q, int facetLabelLength)
-          throws IOException {
+      throws IOException {
     LabelAndValue[] labelValues = new LabelAndValue[q.size()];
     int[] ordinals = new int[labelValues.length];
     int[] values = new int[labelValues.length];
@@ -210,12 +211,12 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
   }
 
   /**
-   * Returns ChildOrdsResult that contains results of dimCount(totalValue), childCount, and
-   * the queue for the dimension's top children to populate FacetResult in getPathResult.
-   * This portion of code is moved from getTopChildren because getTopDims needs to reuse it
-   *
+   * Returns ChildOrdsResult that contains results of dimCount(totalValue), childCount, and the
+   * queue for the dimension's top children to populate FacetResult in getPathResult. This portion
+   * of code is moved from getTopChildren because getTopDims needs to reuse it
    */
-  private ChildOrdsResult getChildOrdsResult(DimConfig dimConfig, int dimOrd, int topN) throws IOException {
+  private ChildOrdsResult getChildOrdsResult(DimConfig dimConfig, int dimOrd, int topN)
+      throws IOException {
     TopOrdAndIntQueue q = new TopOrdAndIntQueue(Math.min(taxoReader.getSize(), topN));
     int bottomValue = 0;
 
@@ -280,14 +281,14 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
     return new ChildOrdsResult (aggregatedValue, childCount, q);
   }
 
-
   /** Returns value/count of a dimension. */
   private int getDimValue(
-          FacetsConfig.DimConfig dimConfig,
-          String dim,
-          int dimOrd,
-          int topN,
-          HashMap<String, ChildOrdsResult> dimToChildOrdsResult) throws IOException {
+      FacetsConfig.DimConfig dimConfig,
+      String dim,
+      int dimOrd,
+      int topN,
+      HashMap<String, ChildOrdsResult> dimToChildOrdsResult)
+      throws IOException {
 
     // if dimConfig.hierarchical == true || dim is multiValued and dim count has been aggregated at
     // indexing time, return dimCount directly
@@ -317,18 +318,18 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
     // Creates priority queue to store top dimensions and sort by their aggregated values/hits and
     // string values.
     PriorityQueue<DimValueResult> pq =
-            new PriorityQueue<>(topNDims) {
-              @Override
-              protected boolean lessThan(DimValueResult a, DimValueResult b) {
-                if (a.value > b.value) {
-                  return false;
-                } else if (a.value < b.value) {
-                  return true;
-                } else {
-                  return a.dim.compareTo(b.dim) > 0;
-                }
-              }
-            };
+        new PriorityQueue<>(topNDims) {
+          @Override
+          protected boolean lessThan(DimValueResult a, DimValueResult b) {
+            if (a.value > b.value) {
+              return false;
+            } else if (a.value < b.value) {
+              return true;
+            } else {
+              return a.dim.compareTo(b.dim) > 0;
+            }
+          }
+        };
 
     // create hashMap to store the ChildOrdsResult to avoid calling getChildOrdsResult for all dims
     HashMap<String, ChildOrdsResult> dimToChildOrdsResult = new HashMap<>();
@@ -351,7 +352,7 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
               pq.add(new DimValueResult(dim, dimOrd, dimCount));
             } else {
               if (dimCount > pq.top().value
-                      || (dimCount == pq.top().value && dim.compareTo(pq.top().dim) < 0)) {
+                  || (dimCount == pq.top().value && dim.compareTo(pq.top().dim) < 0)) {
                 DimValueResult bottomDim = pq.top();
                 bottomDim.dim = dim;
                 bottomDim.value = dimCount;
@@ -364,10 +365,8 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
       ord = siblings[ord];
     }
 
-    // get FacetResult for topNDims
-    int resultSize = pq.size();
     // use fixed-size array to reduce space usage
-    FacetResult[] results = new FacetResult[resultSize];
+    FacetResult[] results = new FacetResult[pq.size()];
 
     while (pq.size() > 0) {
       DimValueResult dimValueResult = pq.pop();
@@ -380,20 +379,25 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
         FacetsConfig.DimConfig dimConfig = config.getDimConfig(dim);
         childOrdsResult = getChildOrdsResult(dimConfig, dimValueResult.dimOrd, topNChildren);
       }
-      // FacetResult requires String[] path, and path is always empty for getTopDims. FacetLabelLength
-      // is always equal to 1 when FacetLabel is constructed with FacetLabel(dim, emptyPath), and therefore,
+      // FacetResult requires String[] path, and path is always empty for getTopDims.
+      // FacetLabelLength
+      // is always equal to 1 when FacetLabel is constructed with FacetLabel(dim, emptyPath), and
+      // therefore,
       // 1 is passed in when calling getLabelValues
-      FacetResult facetResult = new FacetResult(dimValueResult.dim, emptyPath, dimValueResult.value,
-              getLabelValues(childOrdsResult.q, 1), childOrdsResult.childCount);
-      resultSize--;
-      results[resultSize] = facetResult;
+      FacetResult facetResult =
+          new FacetResult(
+              dimValueResult.dim,
+              emptyPath,
+              dimValueResult.value,
+              getLabelValues(childOrdsResult.q, 1),
+              childOrdsResult.childCount);
+      results[pq.size()] = facetResult;
     }
     return Arrays.asList(results);
   }
 
   /**
    * Creates DimValueResult to store the label, dim ordinal and dim count of a dim in priority queue
-   *
    */
   private static class DimValueResult {
     String dim;

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -109,16 +109,16 @@ abstract class TaxonomyFacets extends Facets {
   }
 
   /**
-   * Returns existing int[] mapping each ordinal to its next sibling to avoid re-creating int[] for siblings in subclass
-   *
+   * Returns existing int[] mapping each ordinal to its next sibling to avoid re-creating int[] for
+   * siblings in subclass
    */
   public int[] getExistingSiblings() throws IOException {
     return childrenLoaded() ? this.siblings : getSiblings();
   }
 
   /**
-   * Returns existing int[] mapping each ordinal to its first child to avoid re-creating int[] for children in subclass
-   *
+   * Returns existing int[] mapping each ordinal to its first child to avoid re-creating int[] for
+   * children in subclass
    */
   public int[] getExistingChildren() throws IOException {
     return childrenLoaded() ? this.children : getChildren();

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -18,7 +18,11 @@
 package org.apache.lucene.facet.taxonomy;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsConfig;

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -18,11 +18,7 @@
 package org.apache.lucene.facet.taxonomy;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsConfig;
@@ -110,6 +106,22 @@ abstract class TaxonomyFacets extends Facets {
    */
   public boolean siblingsLoaded() {
     return siblings != null;
+  }
+
+  /**
+   * Returns existing int[] mapping each ordinal to its next sibling to avoid re-creating int[] for siblings in subclass
+   *
+   */
+  public int[] getExistingSiblings() throws IOException {
+    return childrenLoaded() ? this.siblings : getSiblings();
+  }
+
+  /**
+   * Returns existing int[] mapping each ordinal to its first child to avoid re-creating int[] for children in subclass
+   *
+   */
+  public int[] getExistingChildren() throws IOException {
+    return childrenLoaded() ? this.children : getChildren();
   }
 
   /**

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -113,22 +113,6 @@ abstract class TaxonomyFacets extends Facets {
   }
 
   /**
-   * Returns existing int[] mapping each ordinal to its next sibling to avoid re-creating int[] for
-   * siblings in subclass
-   */
-  public int[] getExistingSiblings() throws IOException {
-    return childrenLoaded() ? this.siblings : getSiblings();
-  }
-
-  /**
-   * Returns existing int[] mapping each ordinal to its first child to avoid re-creating int[] for
-   * children in subclass
-   */
-  public int[] getExistingChildren() throws IOException {
-    return childrenLoaded() ? this.children : getChildren();
-  }
-
-  /**
    * Verifies and returns {@link DimConfig} for the given dimension name.
    *
    * @return {@link DimConfig} for the given dim, or {@link FacetsConfig#DEFAULT_DIM_CONFIG} if it

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -128,6 +128,19 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
         "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n  Bob (1)\n  Susan (1)\n  Frank (1)\n",
         facets.getTopChildren(10, "Author").toString());
 
+    // test getAllDims
+    List<FacetResult> results = facets.getAllDims(10);
+    // test getTopDims(10, 10) and expect same results from getAllDims(10)
+    List<FacetResult> allTopDimsResults = facets.getTopDims(10, 10);
+    assertEquals(results, allTopDimsResults);
+
+    // test getTopDims(n, 10)
+    if (allTopDimsResults.size() > 0) {
+      for (int i = 1; i < results.size(); i++) {
+        assertEquals(results.subList(0, i), facets.getTopDims(i, 10));
+      }
+    }
+
     // Now user drills down on Publish Date/2010:
     DrillDownQuery q2 = new DrillDownQuery(config);
     q2.add("Publish Date", "2010");
@@ -290,6 +303,11 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     // Ask for top 10 labels for any dims that have counts:
     List<FacetResult> results = facets.getAllDims(10);
     assertTrue(results.isEmpty());
+
+    // test getTopDims(10, 10) and expect same results from getAllDims(10)
+    List<FacetResult> allTopDimsResults = facets.getTopDims(10, 10);
+    assertEquals(results, allTopDimsResults);
+
     expectThrows(
         IllegalArgumentException.class,
         () -> {
@@ -645,7 +663,7 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
       assertEquals(r.numDocs(), result.value.intValue());
     }
 
-    // test default implementation of getTopDims
+    // test override implementation of getTopDims
     if (allDimsResult.size() > 0) {
       List<FacetResult> topNDimsResult = facets.getTopDims(1, 10);
       assertEquals(allDimsResult.get(0), topNDimsResult.get(0));
@@ -701,7 +719,7 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     assertEquals(
         "calling getFacetResults twice should return the .equals()=true result", res1, res2);
 
-    // test default implementation of getTopDims
+    // test getTopDims
     if (res1.size() > 0) {
       List<FacetResult> topNDimsResult = facets.getTopDims(1, 10);
       assertEquals(res1.get(0), topNDimsResult.get(0));
@@ -1001,7 +1019,7 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
 
       assertEquals(expected, actual);
 
-      // test default implementation of getTopDims
+      // test getTopDims
       if (actual.size() > 0) {
         List<FacetResult> topNDimsResult = facets.getTopDims(actual.size(), 10);
         sortTies(topNDimsResult);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -249,10 +249,10 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
 
     // test getTopDims(0, 1)
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getTopDims(0, 1);
-            });
+        IllegalArgumentException.class,
+        () -> {
+          facets.getTopDims(0, 1);
+        });
 
     // test getTopDims(1, 0) with topNChildren = 0
     expectThrows(
@@ -664,10 +664,10 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
 
     // test getTopDims(0, 1)
     expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              facets.getTopDims(0, 1);
-            });
+        IllegalArgumentException.class,
+        () -> {
+          facets.getTopDims(0, 1);
+        });
 
     // test getTopDims(1, 0) with topNChildren = 0
     expectThrows(

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -134,13 +134,6 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     List<FacetResult> allTopDimsResults = facets.getTopDims(10, 10);
     assertEquals(results, allTopDimsResults);
 
-    // test getTopDims(n, 10)
-    if (allTopDimsResults.size() > 0) {
-      for (int i = 1; i < results.size(); i++) {
-        assertEquals(results.subList(0, i), facets.getTopDims(i, 10));
-      }
-    }
-
     // Now user drills down on Publish Date/2010:
     DrillDownQuery q2 = new DrillDownQuery(config);
     q2.add("Publish Date", "2010");
@@ -719,10 +712,11 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     assertEquals(
         "calling getFacetResults twice should return the .equals()=true result", res1, res2);
 
-    // test getTopDims
+    // test getTopDims(n, 10)
     if (res1.size() > 0) {
-      List<FacetResult> topNDimsResult = facets.getTopDims(1, 10);
-      assertEquals(res1.get(0), topNDimsResult.get(0));
+      for (int i = 1; i < res1.size(); i++) {
+        assertEquals(res1.subList(0, i), facets.getTopDims(i, 10));
+      }
     }
 
     iw.close();

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -242,8 +242,11 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     assertEquals(results, allDimsResults);
 
     // test getTopDims(0, 1)
-    List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
-    assertEquals(0, topDimsResults2.size());
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getTopDims(0, 1);
+            });
 
     // test getTopDims(1, 0) with topNChildren = 0
     expectThrows(
@@ -649,8 +652,11 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     }
 
     // test getTopDims(0, 1)
-    List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
-    assertEquals(0, topDimsResults2.size());
+    expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facets.getTopDims(0, 1);
+            });
 
     // test getTopDims(1, 0) with topNChildren = 0
     expectThrows(
@@ -996,10 +1002,11 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
       assertEquals(expected, actual);
 
       // test default implementation of getTopDims
-
-      List<FacetResult> topNDimsResult = facets.getTopDims(actual.size(), 10);
-      sortTies(topNDimsResult);
-      assertEquals(actual, topNDimsResult);
+      if (actual.size() > 0) {
+        List<FacetResult> topNDimsResult = facets.getTopDims(actual.size(), 10);
+        sortTies(topNDimsResult);
+        assertEquals(actual, topNDimsResult);
+      }
 
       // Test facet labels for each matching test doc
       List<List<FacetLabel>> actualLabels = getAllTaxonomyFacetLabels(null, tr, fc);


### PR DESCRIPTION
# Description

This change overrides and optimizes the default implementation of getTopDims in IntTaxonomyFacets which is extended by FastTaxonomyFacetCounts and TaxonomyFacetSumIntAssociations. 

# Solution

Override getTopDims and refactor the getTopChildren function in IntTaxonomyFacets to get dimCount (aggregated dim values) more efficiently by checking if dimCount has been populated in indexing time for a dim that is hierarchical or multiValued && requireDimCount, before aggregating dimCount by iterating its child ordinal.

# Tests

Added new testing for the overridden implementations of getTopDims in IntTaxonomyFacets

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/lucene/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
