### PR TITLE
LUCENE-10497: add a base Token class to analysis-common

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/morph/Token.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/morph/Token.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.analysis.morph;
+
+/** Analyzed token with morphological data. */
+public abstract class Token {
+  protected final char[] surfaceForm;
+  protected final int offset;
+  protected final int length;
+
+  protected final int startOffset;
+  protected final int endOffset;
+  protected int posIncr = 1;
+  protected int posLen = 1;
+
+  protected Token(char[] surfaceForm, int offset, int length, int startOffset, int endOffset) {
+    this.surfaceForm = surfaceForm;
+    this.offset = offset;
+    this.length = length;
+    this.startOffset = startOffset;
+    this.endOffset = endOffset;
+  }
+
+  /** @return surfaceForm */
+  public char[] getSurfaceForm() {
+    return surfaceForm;
+  }
+
+  /** @return offset into surfaceForm */
+  public int getOffset() {
+    return offset;
+  }
+
+  /** @return length of surfaceForm */
+  public int getLength() {
+    return length;
+  }
+
+  /** @return surfaceForm as a String */
+  public String getSurfaceFormString() {
+    return new String(surfaceForm, offset, length);
+  }
+
+  /** Get the start offset of the term in the analyzed text. */
+  public int getStartOffset() {
+    return startOffset;
+  }
+
+  /** Get the end offset of the term in the analyzed text. */
+  public int getEndOffset() {
+    return endOffset;
+  }
+
+  public void setPositionIncrement(int posIncr) {
+    this.posIncr = posIncr;
+  }
+
+  public int getPositionIncrement() {
+    return posIncr;
+  }
+
+  /**
+   * Set the position length (in tokens) of this token. For normal tokens this is 1; for compound
+   * tokens it's &gt; 1.
+   */
+  public void setPositionLength(int posLen) {
+    this.posLen = posLen;
+  }
+
+  /**
+   * Get the length (in tokens) of this token. For normal tokens this is 1; for compound tokens it's
+   * &gt; 1.
+   */
+  public int getPositionLength() {
+    return posLen;
+  }
+}

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/Token.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/Token.java
@@ -20,104 +20,75 @@ import org.apache.lucene.analysis.ja.JapaneseTokenizer.Type;
 import org.apache.lucene.analysis.ja.dict.JaMorphData;
 
 /** Analyzed token with morphological data from its dictionary. */
-public class Token {
-  private final JaMorphData morphAtts;
+public class Token extends org.apache.lucene.analysis.morph.Token {
+  private final JaMorphData morphData;
 
-  private final int wordId;
-
-  private final char[] surfaceForm;
-  private final int offset;
-  private final int length;
-
-  private final int position;
-  private int positionLength;
+  private final int morphId;
 
   private final Type type;
 
   public Token(
-      int wordId,
       char[] surfaceForm,
       int offset,
       int length,
+      int startOffset,
+      int endOffset,
+      int morphId,
       Type type,
-      int position,
-      JaMorphData morphAtts) {
-    this.wordId = wordId;
-    this.surfaceForm = surfaceForm;
-    this.offset = offset;
-    this.length = length;
+      JaMorphData morphData) {
+    super(surfaceForm, offset, length, startOffset, endOffset);
+    this.morphId = morphId;
     this.type = type;
-    this.position = position;
-    this.morphAtts = morphAtts;
+    this.morphData = morphData;
   }
 
   @Override
   public String toString() {
     return "Token(\""
         + new String(surfaceForm, offset, length)
-        + "\" pos="
-        + position
+        + "\" offset="
+        + startOffset
         + " length="
         + length
         + " posLen="
-        + positionLength
+        + posLen
         + " type="
         + type
-        + " wordId="
-        + wordId
+        + " morphId="
+        + morphId
         + " leftID="
-        + morphAtts.getLeftId(wordId)
+        + morphData.getLeftId(morphId)
         + ")";
-  }
-
-  /** @return surfaceForm */
-  public char[] getSurfaceForm() {
-    return surfaceForm;
-  }
-
-  /** @return offset into surfaceForm */
-  public int getOffset() {
-    return offset;
-  }
-
-  /** @return length of surfaceForm */
-  public int getLength() {
-    return length;
-  }
-
-  /** @return surfaceForm as a String */
-  public String getSurfaceFormString() {
-    return new String(surfaceForm, offset, length);
   }
 
   /** @return reading. null if token doesn't have reading. */
   public String getReading() {
-    return morphAtts.getReading(wordId, surfaceForm, offset, length);
+    return morphData.getReading(morphId, surfaceForm, offset, length);
   }
 
   /** @return pronunciation. null if token doesn't have pronunciation. */
   public String getPronunciation() {
-    return morphAtts.getPronunciation(wordId, surfaceForm, offset, length);
+    return morphData.getPronunciation(morphId, surfaceForm, offset, length);
   }
 
   /** @return part of speech. */
   public String getPartOfSpeech() {
-    return morphAtts.getPartOfSpeech(wordId);
+    return morphData.getPartOfSpeech(morphId);
   }
 
   /** @return inflection type or null */
   public String getInflectionType() {
-    return morphAtts.getInflectionType(wordId);
+    return morphData.getInflectionType(morphId);
   }
 
   /** @return inflection form or null */
   public String getInflectionForm() {
-    return morphAtts.getInflectionForm(wordId);
+    return morphData.getInflectionForm(morphId);
   }
 
   /** @return base form or null if token is not inflected */
   public String getBaseForm() {
-    return morphAtts.getBaseForm(wordId, surfaceForm, offset, length);
+    return morphData.getBaseForm(morphId, surfaceForm, offset, length);
   }
 
   /**
@@ -154,32 +125,5 @@ public class Token {
    */
   public boolean isUser() {
     return type == Type.USER;
-  }
-
-  /**
-   * Get index of this token in input text
-   *
-   * @return position of token
-   */
-  public int getPosition() {
-    return position;
-  }
-
-  /**
-   * Set the position length (in tokens) of this token. For normal tokens this is 1; for compound
-   * tokens it's &gt; 1.
-   */
-  public void setPositionLength(int positionLength) {
-    this.positionLength = positionLength;
-  }
-
-  /**
-   * Get the length (in tokens) of this token. For normal tokens this is 1; for compound tokens it's
-   * &gt; 1.
-   *
-   * @return position length of token
-   */
-  public int getPositionLength() {
-    return positionLength;
   }
 }

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/Token.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/Token.java
@@ -19,43 +19,10 @@ package org.apache.lucene.analysis.ko;
 import org.apache.lucene.analysis.ko.dict.KoMorphData;
 
 /** Analyzed token with morphological data. */
-public abstract class Token {
-  private final char[] surfaceForm;
-  private final int offset;
-  private final int length;
+public abstract class Token extends org.apache.lucene.analysis.morph.Token {
 
-  private final int startOffset;
-  private final int endOffset;
-  private int posIncr = 1;
-  private int posLen = 1;
-
-  public Token(char[] surfaceForm, int offset, int length, int startOffset, int endOffset) {
-    this.surfaceForm = surfaceForm;
-    this.offset = offset;
-    this.length = length;
-
-    this.startOffset = startOffset;
-    this.endOffset = endOffset;
-  }
-
-  /** @return surfaceForm */
-  public char[] getSurfaceForm() {
-    return surfaceForm;
-  }
-
-  /** @return offset into surfaceForm */
-  public int getOffset() {
-    return offset;
-  }
-
-  /** @return length of surfaceForm */
-  public int getLength() {
-    return length;
-  }
-
-  /** @return surfaceForm as a String */
-  public String getSurfaceFormString() {
-    return new String(surfaceForm, offset, length);
+  protected Token(char[] surfaceForm, int offset, int length, int startOffset, int endOffset) {
+    super(surfaceForm, offset, length, startOffset, endOffset);
   }
 
   /** Get the {@link POS.Type} of the token. */
@@ -75,30 +42,4 @@ public abstract class Token {
    * token.
    */
   public abstract KoMorphData.Morpheme[] getMorphemes();
-
-  /** Get the start offset of the term in the analyzed text. */
-  public int getStartOffset() {
-    return startOffset;
-  }
-
-  /** Get the end offset of the term in the analyzed text. */
-  public int getEndOffset() {
-    return endOffset;
-  }
-
-  public void setPositionIncrement(int posIncr) {
-    this.posIncr = posIncr;
-  }
-
-  public int getPositionIncrement() {
-    return posIncr;
-  }
-
-  public void setPositionLength(int posLen) {
-    this.posLen = posLen;
-  }
-
-  public int getPositionLength() {
-    return posLen;
-  }
 }


### PR DESCRIPTION
This adds a base `Token` class (internal data object for emitting token attributes) to analysis-common that is based on current Nori's `Token` class. Each `Token` in Kuromoji and Nori is now an extension of it. 
An interface change: Kuromoji's `Token.getPosition()` method was changed to `Token.getStartOffset()` to align it with the base class - this property is actually a token's "start offset" and it'd sound correct in terms of Lucene's general terminology.

This minor refactoring alone would not be very meaningful, though, I think this is inevitable to break up https://issues.apache.org/jira/browse/LUCENE-10493 into small tasks; I'd like to proceed with it in small steps.