### PR TITLE
LUCENE-10002: move MemoryIndex to search(Query, CollectorManager)

### DIFF
--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -35,6 +35,8 @@ import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.*;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
@@ -725,29 +727,38 @@ public class MemoryIndex {
 
     IndexSearcher searcher = createSearcher();
     try {
-      final float[] scores = new float[1]; // inits to 0.0f (no match)
-      searcher.search(
+      return searcher.search(
           query,
-          new SimpleCollector() {
-            private Scorable scorer;
+          new CollectorManager<>() {
+            final float[] scores = new float[1]; // inits to 0.0f (no match)
 
             @Override
-            public void collect(int doc) throws IOException {
-              scores[0] = scorer.score();
+            public Collector newCollector() {
+              return new SimpleCollector() {
+                private Scorable scorer;
+
+                @Override
+                public void collect(int doc) throws IOException {
+                  scores[0] = scorer.score();
+                }
+
+                @Override
+                public void setScorer(Scorable scorer) {
+                  this.scorer = scorer;
+                }
+
+                @Override
+                public ScoreMode scoreMode() {
+                  return ScoreMode.COMPLETE;
+                }
+              };
             }
 
             @Override
-            public void setScorer(Scorable scorer) {
-              this.scorer = scorer;
-            }
-
-            @Override
-            public ScoreMode scoreMode() {
-              return ScoreMode.COMPLETE;
+            public Float reduce(Collection<Collector> collectors) {
+              return scores[0];
             }
           });
-      float score = scores[0];
-      return score;
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
MemoryIndex exposes a search method that returns the score of the matching doc if it does match, otherwise 0.0f. It internally uses a custom collector and calls IndexSearcher#search(Query, Collector). We can easily replace that with a collector manager, that does not need to handle concurrency as the memory index will only ever hold a single document.

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
