### PR TITLE
LUCENE-10499: reduce unnecessary copy data overhead when growing array size

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
@@ -204,7 +204,7 @@ public abstract class CompressionMode {
       // pad with extra "dummy byte": see javadocs for using Inflater(true)
       // we do it for compliance, but it's unnecessary for years in zlib.
       final int paddedLength = compressedLength + 1;
-      compressed = ArrayUtil.grow(compressed, paddedLength);
+      compressed = ArrayUtil.grow(compressed, paddedLength, false);
       in.readBytes(compressed, 0, compressedLength);
       compressed[compressedLength] = 0; // explicitly set dummy byte to 0
 
@@ -214,7 +214,7 @@ public abstract class CompressionMode {
         decompressor.setInput(compressed, 0, paddedLength);
 
         bytes.offset = bytes.length = 0;
-        bytes.bytes = ArrayUtil.grow(bytes.bytes, originalLength);
+        bytes.bytes = ArrayUtil.grow(bytes.bytes, originalLength, false);
         try {
           bytes.length = decompressor.inflate(bytes.bytes, bytes.length, originalLength);
         } catch (DataFormatException e) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
@@ -204,7 +204,7 @@ public abstract class CompressionMode {
       // pad with extra "dummy byte": see javadocs for using Inflater(true)
       // we do it for compliance, but it's unnecessary for years in zlib.
       final int paddedLength = compressedLength + 1;
-      compressed = ArrayUtil.grow(compressed, paddedLength, false);
+      compressed = ArrayUtil.growSizeOnly(compressed, paddedLength);
       in.readBytes(compressed, 0, compressedLength);
       compressed[compressedLength] = 0; // explicitly set dummy byte to 0
 
@@ -214,7 +214,7 @@ public abstract class CompressionMode {
         decompressor.setInput(compressed, 0, paddedLength);
 
         bytes.offset = bytes.length = 0;
-        bytes.bytes = ArrayUtil.grow(bytes.bytes, originalLength, false);
+        bytes.bytes = ArrayUtil.growSizeOnly(bytes.bytes, originalLength);
         try {
           bytes.length = decompressor.inflate(bytes.bytes, bytes.length, originalLength);
         } catch (DataFormatException e) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
@@ -204,7 +204,7 @@ public abstract class CompressionMode {
       // pad with extra "dummy byte": see javadocs for using Inflater(true)
       // we do it for compliance, but it's unnecessary for years in zlib.
       final int paddedLength = compressedLength + 1;
-      compressed = ArrayUtil.growSizeOnly(compressed, paddedLength);
+      compressed = ArrayUtil.growNoCopy(compressed, paddedLength);
       in.readBytes(compressed, 0, compressedLength);
       compressed[compressedLength] = 0; // explicitly set dummy byte to 0
 
@@ -214,7 +214,7 @@ public abstract class CompressionMode {
         decompressor.setInput(compressed, 0, paddedLength);
 
         bytes.offset = bytes.length = 0;
-        bytes.bytes = ArrayUtil.growSizeOnly(bytes.bytes, originalLength);
+        bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, originalLength);
         try {
           bytes.length = decompressor.inflate(bytes.bytes, bytes.length, originalLength);
         } catch (DataFormatException e) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
@@ -81,7 +81,7 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
       // pad with extra "dummy byte": see javadocs for using Inflater(true)
       // we do it for compliance, but it's unnecessary for years in zlib.
       final int paddedLength = compressedLength + 1;
-      compressed = ArrayUtil.grow(compressed, paddedLength);
+      compressed = ArrayUtil.grow(compressed, paddedLength, false);
       in.readBytes(compressed, 0, compressedLength);
       compressed[compressedLength] = 0; // explicitly set dummy byte to 0
 
@@ -113,7 +113,7 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
       }
       final int dictLength = in.readVInt();
       final int blockLength = in.readVInt();
-      bytes.bytes = ArrayUtil.grow(bytes.bytes, dictLength);
+      bytes.bytes = ArrayUtil.grow(bytes.bytes, dictLength, false);
       bytes.offset = bytes.length = 0;
 
       final Inflater decompressor = new Inflater(true);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
@@ -81,7 +81,7 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
       // pad with extra "dummy byte": see javadocs for using Inflater(true)
       // we do it for compliance, but it's unnecessary for years in zlib.
       final int paddedLength = compressedLength + 1;
-      compressed = ArrayUtil.growSizeOnly(compressed, paddedLength);
+      compressed = ArrayUtil.growNoCopy(compressed, paddedLength);
       in.readBytes(compressed, 0, compressedLength);
       compressed[compressedLength] = 0; // explicitly set dummy byte to 0
 
@@ -113,7 +113,7 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
       }
       final int dictLength = in.readVInt();
       final int blockLength = in.readVInt();
-      bytes.bytes = ArrayUtil.growSizeOnly(bytes.bytes, dictLength);
+      bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, dictLength);
       bytes.offset = bytes.length = 0;
 
       final Inflater decompressor = new Inflater(true);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
@@ -81,7 +81,7 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
       // pad with extra "dummy byte": see javadocs for using Inflater(true)
       // we do it for compliance, but it's unnecessary for years in zlib.
       final int paddedLength = compressedLength + 1;
-      compressed = ArrayUtil.grow(compressed, paddedLength, false);
+      compressed = ArrayUtil.growSizeOnly(compressed, paddedLength);
       in.readBytes(compressed, 0, compressedLength);
       compressed[compressedLength] = 0; // explicitly set dummy byte to 0
 
@@ -113,7 +113,7 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
       }
       final int dictLength = in.readVInt();
       final int blockLength = in.readVInt();
-      bytes.bytes = ArrayUtil.grow(bytes.bytes, dictLength, false);
+      bytes.bytes = ArrayUtil.growSizeOnly(bytes.bytes, dictLength);
       bytes.offset = bytes.length = 0;
 
       final Inflater decompressor = new Inflater(true);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -75,7 +75,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
       int totalLength = dictLength;
       int i = 0;
       compressedLengths =
-          ArrayUtil.growSizeOnly(compressedLengths, originalLength / blockLength + 1);
+          ArrayUtil.growNoCopy(compressedLengths, originalLength / blockLength + 1);
       while (totalLength < originalLength) {
 
         compressedLengths[i++] = in.readVInt();
@@ -99,7 +99,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
 
       final int numBlocks = readCompressedLengths(in, originalLength, dictLength, blockLength);
 
-      buffer = ArrayUtil.growSizeOnly(buffer, dictLength + blockLength);
+      buffer = ArrayUtil.growNoCopy(buffer, dictLength + blockLength);
       bytes.length = 0;
       // Read the dictionary
       if (LZ4.decompress(in, dictLength, buffer, 0) != dictLength) {
@@ -122,7 +122,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
         in.skipBytes(numBytesToSkip);
       } else {
         // The dictionary contains some bytes we need, copy its content to the BytesRef
-        bytes.bytes = ArrayUtil.growSizeOnly(bytes.bytes, dictLength);
+        bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, dictLength);
         System.arraycopy(buffer, 0, bytes.bytes, 0, dictLength);
         bytes.length = dictLength;
       }
@@ -171,7 +171,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
     public void compress(byte[] bytes, int off, int len, DataOutput out) throws IOException {
       final int dictLength = len / (NUM_SUB_BLOCKS * DICT_SIZE_FACTOR);
       final int blockLength = (len - dictLength + NUM_SUB_BLOCKS - 1) / NUM_SUB_BLOCKS;
-      buffer = ArrayUtil.growSizeOnly(buffer, dictLength + blockLength);
+      buffer = ArrayUtil.growNoCopy(buffer, dictLength + blockLength);
       out.writeVInt(dictLength);
       out.writeVInt(blockLength);
       final int end = off + len;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -75,7 +75,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
       int totalLength = dictLength;
       int i = 0;
       compressedLengths =
-          ArrayUtil.grow(compressedLengths, originalLength / blockLength + 1, false);
+          ArrayUtil.growSizeOnly(compressedLengths, originalLength / blockLength + 1);
       while (totalLength < originalLength) {
 
         compressedLengths[i++] = in.readVInt();
@@ -99,7 +99,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
 
       final int numBlocks = readCompressedLengths(in, originalLength, dictLength, blockLength);
 
-      buffer = ArrayUtil.grow(buffer, dictLength + blockLength, false);
+      buffer = ArrayUtil.growSizeOnly(buffer, dictLength + blockLength);
       bytes.length = 0;
       // Read the dictionary
       if (LZ4.decompress(in, dictLength, buffer, 0) != dictLength) {
@@ -122,7 +122,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
         in.skipBytes(numBytesToSkip);
       } else {
         // The dictionary contains some bytes we need, copy its content to the BytesRef
-        bytes.bytes = ArrayUtil.grow(bytes.bytes, dictLength, false);
+        bytes.bytes = ArrayUtil.growSizeOnly(bytes.bytes, dictLength);
         System.arraycopy(buffer, 0, bytes.bytes, 0, dictLength);
         bytes.length = dictLength;
       }
@@ -171,7 +171,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
     public void compress(byte[] bytes, int off, int len, DataOutput out) throws IOException {
       final int dictLength = len / (NUM_SUB_BLOCKS * DICT_SIZE_FACTOR);
       final int blockLength = (len - dictLength + NUM_SUB_BLOCKS - 1) / NUM_SUB_BLOCKS;
-      buffer = ArrayUtil.grow(buffer, dictLength + blockLength, false);
+      buffer = ArrayUtil.growSizeOnly(buffer, dictLength + blockLength);
       out.writeVInt(dictLength);
       out.writeVInt(blockLength);
       final int end = off + len;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -74,8 +74,10 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
       in.readVInt(); // compressed length of the dictionary, unused
       int totalLength = dictLength;
       int i = 0;
+      compressedLengths =
+          ArrayUtil.grow(compressedLengths, originalLength / blockLength + 1, false);
       while (totalLength < originalLength) {
-        compressedLengths = ArrayUtil.grow(compressedLengths, i + 1);
+
         compressedLengths[i++] = in.readVInt();
         totalLength += blockLength;
       }
@@ -97,7 +99,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
 
       final int numBlocks = readCompressedLengths(in, originalLength, dictLength, blockLength);
 
-      buffer = ArrayUtil.grow(buffer, dictLength + blockLength);
+      buffer = ArrayUtil.grow(buffer, dictLength + blockLength, false);
       bytes.length = 0;
       // Read the dictionary
       if (LZ4.decompress(in, dictLength, buffer, 0) != dictLength) {
@@ -120,7 +122,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
         in.skipBytes(numBytesToSkip);
       } else {
         // The dictionary contains some bytes we need, copy its content to the BytesRef
-        bytes.bytes = ArrayUtil.grow(bytes.bytes, dictLength);
+        bytes.bytes = ArrayUtil.grow(bytes.bytes, dictLength, false);
         System.arraycopy(buffer, 0, bytes.bytes, 0, dictLength);
         bytes.length = dictLength;
       }
@@ -169,7 +171,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
     public void compress(byte[] bytes, int off, int len, DataOutput out) throws IOException {
       final int dictLength = len / (NUM_SUB_BLOCKS * DICT_SIZE_FACTOR);
       final int blockLength = (len - dictLength + NUM_SUB_BLOCKS - 1) / NUM_SUB_BLOCKS;
-      buffer = ArrayUtil.grow(buffer, dictLength + blockLength);
+      buffer = ArrayUtil.grow(buffer, dictLength + blockLength, false);
       out.writeVInt(dictLength);
       out.writeVInt(blockLength);
       final int end = off + len;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -74,8 +74,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
       in.readVInt(); // compressed length of the dictionary, unused
       int totalLength = dictLength;
       int i = 0;
-      compressedLengths =
-          ArrayUtil.growNoCopy(compressedLengths, originalLength / blockLength + 1);
+      compressedLengths = ArrayUtil.growNoCopy(compressedLengths, originalLength / blockLength + 1);
       while (totalLength < originalLength) {
 
         compressedLengths[i++] = in.readVInt();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
@@ -814,7 +814,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
             int numBytes = payIn.readVInt();
 
             if (numBytes > payloadBytes.length) {
-              payloadBytes = ArrayUtil.grow(payloadBytes, numBytes);
+              payloadBytes = ArrayUtil.grow(payloadBytes, numBytes, false);
             }
             payIn.readBytes(payloadBytes, 0, numBytes);
           } else {
@@ -1799,7 +1799,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
             int numBytes = payIn.readVInt();
 
             if (numBytes > payloadBytes.length) {
-              payloadBytes = ArrayUtil.grow(payloadBytes, numBytes);
+              payloadBytes = ArrayUtil.grow(payloadBytes, numBytes, false);
             }
             payIn.readBytes(payloadBytes, 0, numBytes);
           } else {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
@@ -814,7 +814,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
             int numBytes = payIn.readVInt();
 
             if (numBytes > payloadBytes.length) {
-              payloadBytes = ArrayUtil.growSizeOnly(payloadBytes, numBytes);
+              payloadBytes = ArrayUtil.growNoCopy(payloadBytes, numBytes);
             }
             payIn.readBytes(payloadBytes, 0, numBytes);
           } else {
@@ -1799,7 +1799,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
             int numBytes = payIn.readVInt();
 
             if (numBytes > payloadBytes.length) {
-              payloadBytes = ArrayUtil.growSizeOnly(payloadBytes, numBytes);
+              payloadBytes = ArrayUtil.growNoCopy(payloadBytes, numBytes);
             }
             payIn.readBytes(payloadBytes, 0, numBytes);
           } else {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
@@ -814,7 +814,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
             int numBytes = payIn.readVInt();
 
             if (numBytes > payloadBytes.length) {
-              payloadBytes = ArrayUtil.grow(payloadBytes, numBytes, false);
+              payloadBytes = ArrayUtil.growSizeOnly(payloadBytes, numBytes);
             }
             payIn.readBytes(payloadBytes, 0, numBytes);
           } else {
@@ -1799,7 +1799,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
             int numBytes = payIn.readVInt();
 
             if (numBytes > payloadBytes.length) {
-              payloadBytes = ArrayUtil.grow(payloadBytes, numBytes, false);
+              payloadBytes = ArrayUtil.growSizeOnly(payloadBytes, numBytes);
             }
             payIn.readBytes(payloadBytes, 0, numBytes);
           } else {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
@@ -969,7 +969,7 @@ public final class Lucene90BlockTreeTermsWriter extends FieldsConsumer {
 
       // Write suffix lengths
       final int numSuffixBytes = Math.toIntExact(suffixLengthsWriter.size());
-      spareBytes = ArrayUtil.grow(spareBytes, numSuffixBytes);
+      spareBytes = ArrayUtil.grow(spareBytes, numSuffixBytes, false);
       suffixLengthsWriter.copyTo(new ByteArrayDataOutput(spareBytes));
       suffixLengthsWriter.reset();
       if (allEqual(spareBytes, 1, numSuffixBytes, spareBytes[0])) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
@@ -969,7 +969,7 @@ public final class Lucene90BlockTreeTermsWriter extends FieldsConsumer {
 
       // Write suffix lengths
       final int numSuffixBytes = Math.toIntExact(suffixLengthsWriter.size());
-      spareBytes = ArrayUtil.growSizeOnly(spareBytes, numSuffixBytes);
+      spareBytes = ArrayUtil.growNoCopy(spareBytes, numSuffixBytes);
       suffixLengthsWriter.copyTo(new ByteArrayDataOutput(spareBytes));
       suffixLengthsWriter.reset();
       if (allEqual(spareBytes, 1, numSuffixBytes, spareBytes[0])) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
@@ -969,7 +969,7 @@ public final class Lucene90BlockTreeTermsWriter extends FieldsConsumer {
 
       // Write suffix lengths
       final int numSuffixBytes = Math.toIntExact(suffixLengthsWriter.size());
-      spareBytes = ArrayUtil.grow(spareBytes, numSuffixBytes, false);
+      spareBytes = ArrayUtil.growSizeOnly(spareBytes, numSuffixBytes);
       suffixLengthsWriter.copyTo(new ByteArrayDataOutput(spareBytes));
       suffixLengthsWriter.reset();
       if (allEqual(spareBytes, 1, numSuffixBytes, spareBytes[0])) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
@@ -454,8 +454,8 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
 
       sliced = (token & 1) != 0;
 
-      offsets = ArrayUtil.growSizeOnly(offsets, chunkDocs + 1);
-      numStoredFields = ArrayUtil.growSizeOnly(numStoredFields, chunkDocs);
+      offsets = ArrayUtil.growNoCopy(offsets, chunkDocs + 1);
+      numStoredFields = ArrayUtil.growNoCopy(numStoredFields, chunkDocs);
 
       if (chunkDocs == 1) {
         numStoredFields[0] = fieldsStream.readVInt();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
@@ -454,8 +454,8 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
 
       sliced = (token & 1) != 0;
 
-      offsets = ArrayUtil.grow(offsets, chunkDocs + 1);
-      numStoredFields = ArrayUtil.grow(numStoredFields, chunkDocs);
+      offsets = ArrayUtil.grow(offsets, chunkDocs + 1, false);
+      numStoredFields = ArrayUtil.grow(numStoredFields, chunkDocs, false);
 
       if (chunkDocs == 1) {
         numStoredFields[0] = fieldsStream.readVInt();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
@@ -454,8 +454,8 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
 
       sliced = (token & 1) != 0;
 
-      offsets = ArrayUtil.grow(offsets, chunkDocs + 1, false);
-      numStoredFields = ArrayUtil.grow(numStoredFields, chunkDocs, false);
+      offsets = ArrayUtil.growSizeOnly(offsets, chunkDocs + 1);
+      numStoredFields = ArrayUtil.growSizeOnly(numStoredFields, chunkDocs);
 
       if (chunkDocs == 1) {
         numStoredFields[0] = fieldsStream.readVInt();

--- a/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
@@ -321,19 +321,8 @@ public final class ArrayUtil {
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
    */
   public static int[] growExact(int[] array, int newLength) {
-    return growExact(array, newLength, true);
-  }
-
-  /**
-   * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
-   *
-   * @param copyData if need to copy origin array data to the new array
-   */
-  public static int[] growExact(int[] array, int newLength, boolean copyData) {
     int[] copy = new int[newLength];
-    if (copyData) {
-      System.arraycopy(array, 0, copy, 0, array.length);
-    }
+    System.arraycopy(array, 0, copy, 0, array.length);
     return copy;
   }
 
@@ -342,14 +331,20 @@ public final class ArrayUtil {
    * exponentially
    */
   public static int[] grow(int[] array, int minSize) {
-    return grow(array, minSize, true);
-  }
-
-  /** @param copyData if need to copy origin array data to the new array */
-  public static int[] grow(int[] array, int minSize, boolean copyData) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
     if (array.length < minSize) {
-      return growExact(array, oversize(minSize, Integer.BYTES), copyData);
+      return growExact(array, oversize(minSize, Integer.BYTES));
+    } else return array;
+  }
+
+  /**
+   * Returns an array whose size is at least {@code minSize}, generally over-allocating
+   * exponentially, and it will not copy the origin data to the new array
+   */
+  public static int[] growSizeOnly(int[] array, int minSize) {
+    assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
+    if (array.length < minSize) {
+      return new int[oversize(minSize, Integer.BYTES)];
     } else return array;
   }
 
@@ -362,15 +357,8 @@ public final class ArrayUtil {
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
    */
   public static long[] growExact(long[] array, int newLength) {
-    return growExact(array, newLength, true);
-  }
-
-  /** @param copyData if need to copy origin array data to the new array */
-  public static long[] growExact(long[] array, int newLength, boolean copyData) {
     long[] copy = new long[newLength];
-    if (copyData) {
-      System.arraycopy(array, 0, copy, 0, array.length);
-    }
+    System.arraycopy(array, 0, copy, 0, array.length);
     return copy;
   }
 
@@ -379,14 +367,20 @@ public final class ArrayUtil {
    * exponentially
    */
   public static long[] grow(long[] array, int minSize) {
-    return grow(array, minSize, true);
-  }
-
-  /** @param copyData if need to copy origin array data to the new array */
-  public static long[] grow(long[] array, int minSize, boolean copyData) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
     if (array.length < minSize) {
-      return growExact(array, oversize(minSize, Long.BYTES), copyData);
+      return growExact(array, oversize(minSize, Long.BYTES));
+    } else return array;
+  }
+
+  /**
+   * Returns an array whose size is at least {@code minSize}, generally over-allocating
+   * exponentially, and it will not copy the origin data to the new array
+   */
+  public static long[] growSizeOnly(long[] array, int minSize) {
+    assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
+    if (array.length < minSize) {
+      return new long[oversize(minSize, Long.BYTES)];
     } else return array;
   }
 
@@ -399,17 +393,8 @@ public final class ArrayUtil {
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
    */
   public static byte[] growExact(byte[] array, int newLength) {
-    return growExact(array, newLength, true);
-  }
-
-  /**
-   * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
-   */
-  public static byte[] growExact(byte[] array, int newLength, boolean copyData) {
     byte[] copy = new byte[newLength];
-    if (copyData) {
-      System.arraycopy(array, 0, copy, 0, array.length);
-    }
+    System.arraycopy(array, 0, copy, 0, array.length);
     return copy;
   }
 
@@ -418,14 +403,20 @@ public final class ArrayUtil {
    * exponentially
    */
   public static byte[] grow(byte[] array, int minSize) {
-    return grow(array, minSize, true);
-  }
-
-  /** @param copyData if need to copy origin array data to the new array */
-  public static byte[] grow(byte[] array, int minSize, boolean copyData) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
     if (array.length < minSize) {
-      return growExact(array, oversize(minSize, Byte.BYTES), copyData);
+      return growExact(array, oversize(minSize, Byte.BYTES));
+    } else return array;
+  }
+
+  /**
+   * Returns an array whose size is at least {@code minSize}, generally over-allocating
+   * exponentially, and it will not copy the origin data to the new array
+   */
+  public static byte[] growSizeOnly(byte[] array, int minSize) {
+    assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
+    if (array.length < minSize) {
+      return new byte[oversize(minSize, Byte.BYTES)];
     } else return array;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
@@ -321,8 +321,19 @@ public final class ArrayUtil {
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
    */
   public static int[] growExact(int[] array, int newLength) {
+    return growExact(array, newLength, true);
+  }
+
+  /**
+   * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
+   *
+   * @param copyData if need to copy origin array data to the new array
+   */
+  public static int[] growExact(int[] array, int newLength, boolean copyData) {
     int[] copy = new int[newLength];
-    System.arraycopy(array, 0, copy, 0, array.length);
+    if (copyData) {
+      System.arraycopy(array, 0, copy, 0, array.length);
+    }
     return copy;
   }
 
@@ -331,9 +342,14 @@ public final class ArrayUtil {
    * exponentially
    */
   public static int[] grow(int[] array, int minSize) {
+    return grow(array, minSize, true);
+  }
+
+  /** @param copyData if need to copy origin array data to the new array */
+  public static int[] grow(int[] array, int minSize, boolean copyData) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
     if (array.length < minSize) {
-      return growExact(array, oversize(minSize, Integer.BYTES));
+      return growExact(array, oversize(minSize, Integer.BYTES), copyData);
     } else return array;
   }
 
@@ -346,8 +362,15 @@ public final class ArrayUtil {
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
    */
   public static long[] growExact(long[] array, int newLength) {
+    return growExact(array, newLength, true);
+  }
+
+  /** @param copyData if need to copy origin array data to the new array */
+  public static long[] growExact(long[] array, int newLength, boolean copyData) {
     long[] copy = new long[newLength];
-    System.arraycopy(array, 0, copy, 0, array.length);
+    if (copyData) {
+      System.arraycopy(array, 0, copy, 0, array.length);
+    }
     return copy;
   }
 
@@ -356,9 +379,14 @@ public final class ArrayUtil {
    * exponentially
    */
   public static long[] grow(long[] array, int minSize) {
+    return grow(array, minSize, true);
+  }
+
+  /** @param copyData if need to copy origin array data to the new array */
+  public static long[] grow(long[] array, int minSize, boolean copyData) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
     if (array.length < minSize) {
-      return growExact(array, oversize(minSize, Long.BYTES));
+      return growExact(array, oversize(minSize, Long.BYTES), copyData);
     } else return array;
   }
 
@@ -371,8 +399,17 @@ public final class ArrayUtil {
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
    */
   public static byte[] growExact(byte[] array, int newLength) {
+    return growExact(array, newLength, true);
+  }
+
+  /**
+   * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
+   */
+  public static byte[] growExact(byte[] array, int newLength, boolean copyData) {
     byte[] copy = new byte[newLength];
-    System.arraycopy(array, 0, copy, 0, array.length);
+    if (copyData) {
+      System.arraycopy(array, 0, copy, 0, array.length);
+    }
     return copy;
   }
 
@@ -381,9 +418,14 @@ public final class ArrayUtil {
    * exponentially
    */
   public static byte[] grow(byte[] array, int minSize) {
+    return grow(array, minSize, true);
+  }
+
+  /** @param copyData if need to copy origin array data to the new array */
+  public static byte[] grow(byte[] array, int minSize, boolean copyData) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
     if (array.length < minSize) {
-      return growExact(array, oversize(minSize, Byte.BYTES));
+      return growExact(array, oversize(minSize, Byte.BYTES), copyData);
     } else return array;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
@@ -341,7 +341,7 @@ public final class ArrayUtil {
    * Returns an array whose size is at least {@code minSize}, generally over-allocating
    * exponentially, and it will not copy the origin data to the new array
    */
-  public static int[] growSizeOnly(int[] array, int minSize) {
+  public static int[] growNoCopy(int[] array, int minSize) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
     if (array.length < minSize) {
       return new int[oversize(minSize, Integer.BYTES)];
@@ -377,7 +377,7 @@ public final class ArrayUtil {
    * Returns an array whose size is at least {@code minSize}, generally over-allocating
    * exponentially, and it will not copy the origin data to the new array
    */
-  public static long[] growSizeOnly(long[] array, int minSize) {
+  public static long[] growNoCopy(long[] array, int minSize) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
     if (array.length < minSize) {
       return new long[oversize(minSize, Long.BYTES)];
@@ -413,7 +413,7 @@ public final class ArrayUtil {
    * Returns an array whose size is at least {@code minSize}, generally over-allocating
    * exponentially, and it will not copy the origin data to the new array
    */
-  public static byte[] growSizeOnly(byte[] array, int minSize) {
+  public static byte[] growNoCopy(byte[] array, int minSize) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
     if (array.length < minSize) {
       return new byte[oversize(minSize, Byte.BYTES)];


### PR DESCRIPTION
`ArrayUtil#grow` will copy origin array data to the new array after growing size in default, but in many places, the new array needn't the origin data. This PR reduces the extra copy data overhead.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
