### PR TITLE
LUCENE-10500: StringValueFacetCounts to not rely on sequential collection

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/StringValueFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/StringValueFacetCounts.java
@@ -280,10 +280,7 @@ public class StringValueFacetCounts extends Facets {
       // should all ladder up to the same top-level reader:
       validateState(matchingDocs.get(0).context);
 
-      for (int i = 0; i < matchingDocs.size(); i++) {
-
-        FacetsCollector.MatchingDocs hits = matchingDocs.get(i);
-
+      for (FacetsCollector.MatchingDocs hits : matchingDocs) {
         // Assuming the state is valid, ordinalMap should be non-null and docValues should be
         // a MultiSortedSetDocValues since we have more than one segment:
         assert ordinalMap != null;
@@ -292,7 +289,7 @@ public class StringValueFacetCounts extends Facets {
         MultiDocValues.MultiSortedSetDocValues multiValues =
             (MultiDocValues.MultiSortedSetDocValues) docValues;
 
-        countOneSegment(multiValues.values[i], hits.context.ord, hits, null);
+        countOneSegment(multiValues.values[hits.context.ord], hits.context.ord, hits, null);
       }
     }
   }


### PR DESCRIPTION
StringValueFacetCounts should use the segment ordinal instead of the current index when looping through the matching hits, as when search is multi-threaded the order of the matching hits (one per segment) is not deterministic.


- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
