### PR TITLE
Add release wizard step around build failures

### DIFF
--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -345,6 +345,13 @@ groups:
     title: Select JIRA issues to be included
     description: Set the appropriate "Fix Version" in JIRA for the issues that should be included in the release.
   - !Todo
+    id: fix_build_failures
+    title: Look into common build failures
+    description: |
+      Look over recent build results sent to the builds@lucene.apache.org list and try to address any recurring
+      failures. It's best to fix common failures now, so they don't pop up later and interfere with release smoke
+      testing. Build email archives are available at https://lists.apache.org/list.html?builds@lucene.apache.org.
+  - !Todo
     id: decide_branch_date
     title: Decide the date for branching
     types:
@@ -355,7 +362,7 @@ groups:
       name: branch_date
   - !Todo
     id: decide_freeze_length
-    title: Decide the lenght of feature freeze
+    title: Decide the length of feature freeze
     types:
     - major
     - minor


### PR DESCRIPTION
This PR proposes adding a preparation step to look at
builds@lucene.apache.org and address recurring failures. This helps make sure we
catch and fix known bugs before spinning the release candidate. It also prevents
flaky tests from failing during the release vote (which adds confusion).