### PR TITLE
LUCENE-10436: (Backport) Remove usage of DocValuesFieldExistsQuery, NormsFieldExistsQuery and KnnVectorFieldExistsQuery

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
@@ -97,12 +97,11 @@ import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnVectorQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.NormsFieldExistsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
@@ -2150,10 +2149,10 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
   private void searchExampleIndex(DirectoryReader reader) throws IOException {
     IndexSearcher searcher = newSearcher(reader);
 
-    TopDocs topDocs = searcher.search(new NormsFieldExistsQuery("titleTokenized"), 10);
+    TopDocs topDocs = searcher.search(new FieldExistsQuery("titleTokenized"), 10);
     assertEquals(50, topDocs.totalHits.value);
 
-    topDocs = searcher.search(new DocValuesFieldExistsQuery("titleDV"), 10);
+    topDocs = searcher.search(new FieldExistsQuery("titleDV"), 10);
     assertEquals(50, topDocs.totalHits.value);
 
     topDocs = searcher.search(new TermQuery(new Term("body", "ja")), 10);

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -26,7 +26,7 @@ import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
@@ -91,7 +91,7 @@ abstract class SortedNumericDocValuesRangeQuery extends Query {
   @Override
   public Query rewrite(IndexReader reader) throws IOException {
     if (lowerValue == Long.MIN_VALUE && upperValue == Long.MAX_VALUE) {
-      return new DocValuesFieldExistsQuery(field);
+      return new FieldExistsQuery(field);
     }
     return super.rewrite(reader);
   }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -26,7 +26,7 @@ import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
@@ -105,7 +105,7 @@ abstract class SortedSetDocValuesRangeQuery extends Query {
   @Override
   public Query rewrite(IndexReader reader) throws IOException {
     if (lowerValue == null && upperValue == null) {
-      return new DocValuesFieldExistsQuery(field);
+      return new FieldExistsQuery(field);
     }
     return super.rewrite(reader);
   }

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -56,7 +56,6 @@ import org.apache.lucene.index.CheckIndex.Status.DocValuesStatus;
 import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.LeafFieldComparator;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
@@ -4146,7 +4145,7 @@ public final class CheckIndex implements Closeable {
     try {
       int softDeletes =
           PendingSoftDeletes.countSoftDeletes(
-              DocValuesFieldExistsQuery.getDocValuesDocIdSetIterator(softDeletesField, reader),
+              DocValuesIterator.getDocValuesDocIdSetIterator(softDeletesField, reader),
               reader.getLiveDocs());
       if (softDeletes != info.getSoftDelCount()) {
         throw new CheckIndexException(

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
@@ -28,4 +28,40 @@ abstract class DocValuesIterator extends DocIdSetIterator {
    * returns {@code target}.
    */
   public abstract boolean advanceExact(int target) throws IOException;
+
+  /**
+   * Returns a {@link DocIdSetIterator} from the given field or null if the field doesn't exist in
+   * the reader or if the reader has no doc values for the field.
+   */
+  public static DocIdSetIterator getDocValuesDocIdSetIterator(String field, LeafReader reader)
+      throws IOException {
+    FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
+    final DocIdSetIterator iterator;
+    if (fieldInfo != null) {
+      switch (fieldInfo.getDocValuesType()) {
+        case NONE:
+          iterator = null;
+          break;
+        case NUMERIC:
+          iterator = reader.getNumericDocValues(field);
+          break;
+        case BINARY:
+          iterator = reader.getBinaryDocValues(field);
+          break;
+        case SORTED:
+          iterator = reader.getSortedDocValues(field);
+          break;
+        case SORTED_NUMERIC:
+          iterator = reader.getSortedNumericDocValues(field);
+          break;
+        case SORTED_SET:
+          iterator = reader.getSortedSetDocValues(field);
+          break;
+        default:
+          throw new AssertionError();
+      }
+      return iterator;
+    }
+    return null;
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -59,7 +59,6 @@ import org.apache.lucene.internal.tests.IndexPackageAccess;
 import org.apache.lucene.internal.tests.IndexWriterAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
@@ -3142,7 +3141,7 @@ public class IndexWriter
           Bits liveDocs = leaf.getLiveDocs();
           numSoftDeleted +=
               PendingSoftDeletes.countSoftDeletes(
-                  DocValuesFieldExistsQuery.getDocValuesDocIdSetIterator(
+                  DocValuesIterator.getDocValuesDocIdSetIterator(
                       config.getSoftDeletesField(), leaf),
                   liveDocs);
         }
@@ -4848,8 +4847,7 @@ public class IndexWriter
     int hardDeleteCount = 0;
     int softDeletesCount = 0;
     DocIdSetIterator softDeletedDocs =
-        DocValuesFieldExistsQuery.getDocValuesDocIdSetIterator(
-            config.getSoftDeletesField(), reader);
+        DocValuesIterator.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), reader);
     if (softDeletedDocs != null) {
       int docId;
       while ((docId = softDeletedDocs.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {

--- a/lucene/core/src/java/org/apache/lucene/index/PendingSoftDeletes.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PendingSoftDeletes.java
@@ -21,7 +21,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import org.apache.lucene.codecs.FieldInfosFormat;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Bits;
@@ -78,7 +77,7 @@ final class PendingSoftDeletes extends PendingDeletes {
     // only re-calculate this if we haven't seen this generation
     if (dvGeneration < info.getDocValuesGen()) {
       final DocIdSetIterator iterator =
-          DocValuesFieldExistsQuery.getDocValuesDocIdSetIterator(field, reader);
+          DocValuesIterator.getDocValuesDocIdSetIterator(field, reader);
       int newDelCount;
       if (iterator
           != null) { // nothing is deleted we don't have a soft deletes field in this segment

--- a/lucene/core/src/java/org/apache/lucene/index/SoftDeletesDirectoryReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SoftDeletesDirectoryReaderWrapper.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 
@@ -127,8 +126,7 @@ public final class SoftDeletesDirectoryReaderWrapper extends FilterDirectoryRead
   }
 
   static LeafReader wrap(LeafReader reader, String field) throws IOException {
-    DocIdSetIterator iterator =
-        DocValuesFieldExistsQuery.getDocValuesDocIdSetIterator(field, reader);
+    DocIdSetIterator iterator = DocValuesIterator.getDocValuesDocIdSetIterator(field, reader);
     if (iterator == null) {
       return reader;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/SoftDeletesRetentionMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SoftDeletesRetentionMergePolicy.java
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
@@ -115,7 +115,7 @@ public final class SoftDeletesRetentionMergePolicy extends OneMergeWrappingMerge
             },
             reader.maxDoc() - reader.numDocs());
     BooleanQuery.Builder builder = new BooleanQuery.Builder();
-    builder.add(new DocValuesFieldExistsQuery(softDeleteField), BooleanClause.Occur.FILTER);
+    builder.add(new FieldExistsQuery(softDeleteField), BooleanClause.Occur.FILTER);
     builder.add(retentionQuery, BooleanClause.Occur.FILTER);
     Scorer scorer = getScorer(builder.build(), wrappedReader);
     if (scorer != null) {
@@ -158,7 +158,7 @@ public final class SoftDeletesRetentionMergePolicy extends OneMergeWrappingMerge
       final CodecReader reader = readerSupplier.get();
       if (reader.getLiveDocs() != null) {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
-        builder.add(new DocValuesFieldExistsQuery(field), BooleanClause.Occur.FILTER);
+        builder.add(new FieldExistsQuery(field), BooleanClause.Occur.FILTER);
         builder.add(retentionQuerySupplier.get(), BooleanClause.Occur.FILTER);
         Scorer scorer =
             getScorer(

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesFieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesFieldExistsQuery.java
@@ -16,10 +16,6 @@
  */
 package org.apache.lucene.search;
 
-import java.io.IOException;
-import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.LeafReader;
-
 /**
  * A {@link Query} that matches documents that have a value for a given field as reported by doc
  * values iterators.
@@ -32,41 +28,5 @@ public final class DocValuesFieldExistsQuery extends FieldExistsQuery {
   /** Create a query that will match documents which have a value for the given {@code field}. */
   public DocValuesFieldExistsQuery(String field) {
     super(field);
-  }
-
-  /**
-   * Returns a {@link DocIdSetIterator} from the given field or null if the field doesn't exist in
-   * the reader or if the reader has no doc values for the field.
-   */
-  public static DocIdSetIterator getDocValuesDocIdSetIterator(String field, LeafReader reader)
-      throws IOException {
-    FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
-    final DocIdSetIterator iterator;
-    if (fieldInfo != null) {
-      switch (fieldInfo.getDocValuesType()) {
-        case NONE:
-          iterator = null;
-          break;
-        case NUMERIC:
-          iterator = reader.getNumericDocValues(field);
-          break;
-        case BINARY:
-          iterator = reader.getBinaryDocValues(field);
-          break;
-        case SORTED:
-          iterator = reader.getSortedDocValues(field);
-          break;
-        case SORTED_NUMERIC:
-          iterator = reader.getSortedNumericDocValues(field);
-          break;
-        case SORTED_SET:
-          iterator = reader.getSortedSetDocValues(field);
-          break;
-        default:
-          throw new AssertionError();
-      }
-      return iterator;
-    }
-    return null;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -99,7 +99,7 @@ public class KnnVectorQuery extends Query {
       BooleanQuery booleanQuery =
           new BooleanQuery.Builder()
               .add(filter, BooleanClause.Occur.FILTER)
-              .add(new KnnVectorFieldExistsQuery(field), BooleanClause.Occur.FILTER)
+              .add(new FieldExistsQuery(field), BooleanClause.Occur.FILTER)
               .build();
       indexSearcher.search(booleanQuery, filterCollector);
     }

--- a/lucene/core/src/java/org/apache/lucene/search/UsageTrackingQueryCachingPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/search/UsageTrackingQueryCachingPolicy.java
@@ -58,12 +58,6 @@ public class UsageTrackingQueryCachingPolicy implements QueryCachingPolicy {
       return true;
     }
 
-    if (query instanceof DocValuesFieldExistsQuery) {
-      // We do not bother caching DocValuesFieldExistsQuery queries since they are already plenty
-      // fast.
-      return true;
-    }
-
     if (query instanceof MatchAllDocsQuery) {
       // MatchAllDocsQuery has an iterator that is faster than what a bit set could do.
       return true;

--- a/lucene/core/src/java/org/apache/lucene/search/UsageTrackingQueryCachingPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/search/UsageTrackingQueryCachingPolicy.java
@@ -58,6 +58,11 @@ public class UsageTrackingQueryCachingPolicy implements QueryCachingPolicy {
       return true;
     }
 
+    if (query instanceof FieldExistsQuery) {
+      // We do not bother caching FieldExistsQuery queries since they are already plenty fast.
+      return true;
+    }
+
     if (query instanceof MatchAllDocsQuery) {
       // MatchAllDocsQuery has an iterator that is faster than what a bit set could do.
       return true;

--- a/lucene/core/src/test/org/apache/lucene/index/TestMixedDocValuesUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMixedDocValuesUpdates.java
@@ -34,7 +34,7 @@ import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
@@ -674,7 +674,7 @@ public class TestMixedDocValuesUpdates extends LuceneTestCase {
     try (DirectoryReader reader = DirectoryReader.open(writer)) {
       IndexSearcher searcher = new IndexSearcher(reader);
 
-      TopDocs is_live = searcher.search(new DocValuesFieldExistsQuery("is_live"), 5);
+      TopDocs is_live = searcher.search(new FieldExistsQuery("is_live"), 5);
       assertEquals(numHits, is_live.totalHits.value);
       for (ScoreDoc doc : is_live.scoreDocs) {
         int id = Integer.parseInt(reader.document(doc.doc).get("id"));

--- a/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesRetentionMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesRetentionMergePolicy.java
@@ -35,7 +35,7 @@ import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StringField;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
@@ -126,9 +126,7 @@ public class TestSoftDeletesRetentionMergePolicy extends LuceneTestCase {
     assertEquals(1, reader.leaves().size());
     MergePolicy policy =
         new SoftDeletesRetentionMergePolicy(
-            "soft_delete",
-            () -> new DocValuesFieldExistsQuery("keep_around"),
-            NoMergePolicy.INSTANCE);
+            "soft_delete", () -> new FieldExistsQuery("keep_around"), NoMergePolicy.INSTANCE);
     assertFalse(
         policy.keepFullyDeletedSegment(() -> (SegmentReader) reader.leaves().get(0).reader()));
     reader.close();
@@ -496,7 +494,7 @@ public class TestSoftDeletesRetentionMergePolicy extends LuceneTestCase {
     config.setReaderPooling(true);
     config.setMergePolicy(
         new SoftDeletesRetentionMergePolicy(
-            "soft_delete", () -> new DocValuesFieldExistsQuery("keep"), new LogDocMergePolicy()));
+            "soft_delete", () -> new FieldExistsQuery("keep"), new LogDocMergePolicy()));
     IndexWriter writer = new IndexWriter(dir, config);
     writer
         .getConfig()

--- a/lucene/core/src/test/org/apache/lucene/search/TestUsageTrackingFilterCachingPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestUsageTrackingFilterCachingPolicy.java
@@ -56,15 +56,6 @@ public class TestUsageTrackingFilterCachingPolicy extends LuceneTestCase {
     assertFalse(policy.shouldCache(q));
   }
 
-  public void testNeverCacheDocValuesFieldExistsFilter() throws IOException {
-    Query q = new DocValuesFieldExistsQuery("foo");
-    UsageTrackingQueryCachingPolicy policy = new UsageTrackingQueryCachingPolicy();
-    for (int i = 0; i < 1000; ++i) {
-      policy.onUse(q);
-    }
-    assertFalse(policy.shouldCache(q));
-  }
-
   public void testBooleanQueries() throws IOException {
     Directory dir = newDirectory();
     RandomIndexWriter w = new RandomIndexWriter(random(), dir);

--- a/lucene/core/src/test/org/apache/lucene/search/TestUsageTrackingFilterCachingPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestUsageTrackingFilterCachingPolicy.java
@@ -56,6 +56,15 @@ public class TestUsageTrackingFilterCachingPolicy extends LuceneTestCase {
     assertFalse(policy.shouldCache(q));
   }
 
+  public void testNeverCacheDocValuesFieldExistsFilter() throws IOException {
+    Query q = new FieldExistsQuery("foo");
+    UsageTrackingQueryCachingPolicy policy = new UsageTrackingQueryCachingPolicy();
+    for (int i = 0; i < 1000; ++i) {
+      policy.onUse(q);
+    }
+    assertFalse(policy.shouldCache(q));
+  }
+
   public void testBooleanQueries() throws IOException {
     Directory dir = newDirectory();
     RandomIndexWriter w = new RandomIndexWriter(random(), dir);

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestDoubleRangeGroupSelector.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestDoubleRangeGroupSelector.java
@@ -22,8 +22,8 @@ import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.DoubleValuesSource;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 
@@ -51,7 +51,7 @@ public class TestDoubleRangeGroupSelector extends BaseGroupSelectorTestCase<Doub
     if (groupValue == null) {
       return new BooleanQuery.Builder()
           .add(new MatchAllDocsQuery(), BooleanClause.Occur.FILTER)
-          .add(new DocValuesFieldExistsQuery("double"), BooleanClause.Occur.MUST_NOT)
+          .add(new FieldExistsQuery("double"), BooleanClause.Occur.MUST_NOT)
           .build();
     }
     return DoublePoint.newRangeQuery("double", groupValue.min, Math.nextDown(groupValue.max));

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestLongRangeGroupSelector.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestLongRangeGroupSelector.java
@@ -22,7 +22,7 @@ import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.LongValuesSource;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
@@ -51,7 +51,7 @@ public class TestLongRangeGroupSelector extends BaseGroupSelectorTestCase<LongRa
     if (groupValue == null) {
       return new BooleanQuery.Builder()
           .add(new MatchAllDocsQuery(), BooleanClause.Occur.FILTER)
-          .add(new DocValuesFieldExistsQuery("long"), BooleanClause.Occur.MUST_NOT)
+          .add(new FieldExistsQuery("long"), BooleanClause.Occur.MUST_NOT)
           .build();
     }
     return LongPoint.newRangeQuery("long", groupValue.min, groupValue.max - 1);

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestTermGroupSelector.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestTermGroupSelector.java
@@ -24,7 +24,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -52,7 +52,7 @@ public class TestTermGroupSelector extends BaseGroupSelectorTestCase<BytesRef> {
     if (groupValue == null) {
       return new BooleanQuery.Builder()
           .add(new MatchAllDocsQuery(), BooleanClause.Occur.FILTER)
-          .add(new DocValuesFieldExistsQuery("groupField"), BooleanClause.Occur.MUST_NOT)
+          .add(new FieldExistsQuery("groupField"), BooleanClause.Occur.MUST_NOT)
           .build();
     }
     return new TermQuery(new Term("groupField", groupValue));

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
@@ -559,7 +559,7 @@ public class TestJoinUtil extends LuceneTestCase {
   static Query numericDocValuesScoreQuery(final String field) {
     return new Query() {
 
-      private final Query fieldQuery = new DocValuesFieldExistsQuery(field);
+      private final Query fieldQuery = new FieldExistsQuery(field);
 
       @Override
       public Weight createWeight(

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -28,8 +28,8 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LeafFieldComparator;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -143,7 +143,7 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
   @Override
   public Query rewrite(IndexReader reader) throws IOException {
     if (lowerValue == Long.MIN_VALUE && upperValue == Long.MAX_VALUE) {
-      return new DocValuesFieldExistsQuery(field);
+      return new FieldExistsQuery(field);
     }
 
     Query rewrittenFallback = fallbackQuery.rewrite(reader);

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestIndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestIndexSortSortedNumericDocValuesRangeQuery.java
@@ -30,7 +30,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -371,7 +371,7 @@ public class TestIndexSortSortedNumericDocValuesRangeQuery extends LuceneTestCas
 
     Query query = createQuery("field", Long.MIN_VALUE, Long.MAX_VALUE);
     Query rewrittenQuery = query.rewrite(reader);
-    assertEquals(new DocValuesFieldExistsQuery("field"), rewrittenQuery);
+    assertEquals(new FieldExistsQuery("field"), rewrittenQuery);
 
     writer.close();
     reader.close();


### PR DESCRIPTION
Backporting PR https://github.com/apache/lucene/pull/790 without removal of the deprecated queries.