### PR TITLE
LUCENE-10506: change visibility of ProfilerCollector#deriveCollectorName to protected

### DIFF
--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/ProfilerCollector.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/ProfilerCollector.java
@@ -68,12 +68,12 @@ public class ProfilerCollector implements Collector {
   }
 
   /**
-   * Creates a human-friendly representation of the Collector name.
+   * Creates a human-friendly representation of the Collector name. Override to customize how the name is derived.
    *
    * @param c The Collector to derive a name from
    * @return A (hopefully) prettier name
    */
-  private String deriveCollectorName(Collector c) {
+  protected String deriveCollectorName(Collector c) {
     return c.getClass().getSimpleName();
   }
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/ProfilerCollector.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/ProfilerCollector.java
@@ -68,7 +68,8 @@ public class ProfilerCollector implements Collector {
   }
 
   /**
-   * Creates a human-friendly representation of the Collector name. Override to customize how the name is derived.
+   * Creates a human-friendly representation of the Collector name. Override to customize how the
+   * name is derived.
    *
    * @param c The Collector to derive a name from
    * @return A (hopefully) prettier name

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestProfilerCollector.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestProfilerCollector.java
@@ -27,6 +27,8 @@ import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.FilterCollector;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -57,11 +59,38 @@ public class TestProfilerCollector extends LuceneTestCase {
     Query query = new TermQuery(new Term("foo", "bar"));
     searcher.search(query, collector);
 
+    MatcherAssert.assertThat(collector.getReason(), equalTo("total_hits"));
+    MatcherAssert.assertThat(collector.getName(), equalTo("TotalHitCountCollector"));
     ProfilerCollectorResult profileResult = collector.getProfileResult();
     MatcherAssert.assertThat(profileResult.getReason(), equalTo("total_hits"));
+    MatcherAssert.assertThat(profileResult.getName(), equalTo("TotalHitCountCollector"));
     MatcherAssert.assertThat(profileResult.getTime(), greaterThan(0L));
+    MatcherAssert.assertThat(profileResult.getTime(), equalTo(collector.getTime()));
 
     reader.close();
     dir.close();
+  }
+
+  public void testProfilerCollectorCustomName() {
+    ProfilerCollector collector =
+            new ProfilerCollector(new TestCollector(new TotalHitCountCollector()), "filter", List.of()) {
+              @Override
+              protected String deriveCollectorName(Collector c) {
+                return c.toString();
+              }
+            };
+
+    assertEquals("TestCollector(TotalHitCountCollector)", collector.getName());
+  }
+
+  private static final class TestCollector extends FilterCollector {
+    TestCollector(Collector in) {
+      super(in);
+    }
+
+    @Override
+    public String toString() {
+      return getClass().getSimpleName() + "(" + in.getClass().getSimpleName() + ")";
+    }
   }
 }

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestProfilerCollector.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestProfilerCollector.java
@@ -73,12 +73,13 @@ public class TestProfilerCollector extends LuceneTestCase {
 
   public void testProfilerCollectorCustomName() {
     ProfilerCollector collector =
-            new ProfilerCollector(new TestCollector(new TotalHitCountCollector()), "filter", List.of()) {
-              @Override
-              protected String deriveCollectorName(Collector c) {
-                return c.toString();
-              }
-            };
+        new ProfilerCollector(
+            new TestCollector(new TotalHitCountCollector()), "filter", List.of()) {
+          @Override
+          protected String deriveCollectorName(Collector c) {
+            return c.toString();
+          }
+        };
 
     assertEquals("TestCollector(TotalHitCountCollector)", collector.getName());
   }


### PR DESCRIPTION
This allows subclasses to extend how the inner collector name is derived.

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
