### PR TITLE
Make constructor for QueryOffsetRange public

### DIFF
--- a/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchHighlighter.java
@@ -156,7 +156,7 @@ public class MatchHighlighter {
   public static class QueryOffsetRange extends OffsetRange {
     public final Query query;
 
-    QueryOffsetRange(Query query, int from, int to) {
+    public QueryOffsetRange(Query query, int from, int to) {
       super(from, to);
       this.query = query;
     }


### PR DESCRIPTION
QueryOffsetRange is a public class and is used in other classes
(e.g. FieldValueHighlighters needs it).
Make it constructor public as well to be used in other packages