### PR TITLE
LUCENE-10493: Unify token Type enum in kuromoji and nori

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/morph/Token.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/morph/Token.java
@@ -27,12 +27,16 @@ public abstract class Token {
   protected int posIncr = 1;
   protected int posLen = 1;
 
-  protected Token(char[] surfaceForm, int offset, int length, int startOffset, int endOffset) {
+  protected final TokenType type;
+
+  protected Token(
+      char[] surfaceForm, int offset, int length, int startOffset, int endOffset, TokenType type) {
     this.surfaceForm = surfaceForm;
     this.offset = offset;
     this.length = length;
     this.startOffset = startOffset;
     this.endOffset = endOffset;
+    this.type = type;
   }
 
   /** @return surfaceForm */
@@ -87,5 +91,10 @@ public abstract class Token {
    */
   public int getPositionLength() {
     return posLen;
+  }
+
+  /** Returns the type of this token */
+  public TokenType getType() {
+    return type;
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/morph/TokenType.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/morph/TokenType.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.analysis.morph;
+
+/** Token type reflecting the original source of this token */
+public enum TokenType {
+  /** Known words from the system dictionary. */
+  KNOWN,
+  /** Unknown words (heuristically segmented). */
+  UNKNOWN,
+  /** Known words from the user dictionary. */
+  USER
+}

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/Token.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/Token.java
@@ -16,16 +16,14 @@
  */
 package org.apache.lucene.analysis.ja;
 
-import org.apache.lucene.analysis.ja.JapaneseTokenizer.Type;
 import org.apache.lucene.analysis.ja.dict.JaMorphData;
+import org.apache.lucene.analysis.morph.TokenType;
 
 /** Analyzed token with morphological data from its dictionary. */
 public class Token extends org.apache.lucene.analysis.morph.Token {
   private final JaMorphData morphData;
 
   private final int morphId;
-
-  private final Type type;
 
   public Token(
       char[] surfaceForm,
@@ -34,11 +32,10 @@ public class Token extends org.apache.lucene.analysis.morph.Token {
       int startOffset,
       int endOffset,
       int morphId,
-      Type type,
+      TokenType type,
       JaMorphData morphData) {
-    super(surfaceForm, offset, length, startOffset, endOffset);
+    super(surfaceForm, offset, length, startOffset, endOffset, type);
     this.morphId = morphId;
-    this.type = type;
     this.morphData = morphData;
   }
 
@@ -92,21 +89,12 @@ public class Token extends org.apache.lucene.analysis.morph.Token {
   }
 
   /**
-   * Returns the type of this token
-   *
-   * @return token type, not null
-   */
-  public Type getType() {
-    return type;
-  }
-
-  /**
    * Returns true if this token is known word
    *
    * @return true if this token is in standard dictionary. false if not.
    */
   public boolean isKnown() {
-    return type == Type.KNOWN;
+    return type == TokenType.KNOWN;
   }
 
   /**
@@ -115,7 +103,7 @@ public class Token extends org.apache.lucene.analysis.morph.Token {
    * @return true if this token is unknown word. false if not.
    */
   public boolean isUnknown() {
-    return type == Type.UNKNOWN;
+    return type == TokenType.UNKNOWN;
   }
 
   /**
@@ -124,6 +112,6 @@ public class Token extends org.apache.lucene.analysis.morph.Token {
    * @return true if this token is in user dictionary. false if not.
    */
   public boolean isUser() {
-    return type == Type.USER;
+    return type == TokenType.USER;
   }
 }

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/DecompoundToken.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/DecompoundToken.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.analysis.ko;
 
 import org.apache.lucene.analysis.ko.dict.KoMorphData;
+import org.apache.lucene.analysis.morph.TokenType;
 
 /** A token that was generated from a compound. */
 public class DecompoundToken extends Token {
@@ -29,9 +30,11 @@ public class DecompoundToken extends Token {
    * @param surfaceForm The surface form of the token.
    * @param startOffset The start offset of the token in the analyzed text.
    * @param endOffset The end offset of the token in the analyzed text.
+   * @param type The type of this token.
    */
-  public DecompoundToken(POS.Tag posTag, String surfaceForm, int startOffset, int endOffset) {
-    super(surfaceForm.toCharArray(), 0, surfaceForm.length(), startOffset, endOffset);
+  public DecompoundToken(
+      POS.Tag posTag, String surfaceForm, int startOffset, int endOffset, TokenType type) {
+    super(surfaceForm.toCharArray(), 0, surfaceForm.length(), startOffset, endOffset, type);
     this.posTag = posTag;
   }
 

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/DictionaryToken.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/DictionaryToken.java
@@ -17,15 +17,15 @@
 package org.apache.lucene.analysis.ko;
 
 import org.apache.lucene.analysis.ko.dict.KoMorphData;
+import org.apache.lucene.analysis.morph.TokenType;
 
 /** A token stored in a {@link KoMorphData}. */
 public class DictionaryToken extends Token {
   private final int wordId;
-  private final KoreanTokenizer.Type type;
   private final KoMorphData morphAtts;
 
   public DictionaryToken(
-      KoreanTokenizer.Type type,
+      TokenType type,
       KoMorphData morphAtts,
       int wordId,
       char[] surfaceForm,
@@ -33,8 +33,7 @@ public class DictionaryToken extends Token {
       int length,
       int startOffset,
       int endOffset) {
-    super(surfaceForm, offset, length, startOffset, endOffset);
-    this.type = type;
+    super(surfaceForm, offset, length, startOffset, endOffset, type);
     this.morphAtts = morphAtts;
     this.wordId = wordId;
   }
@@ -59,21 +58,12 @@ public class DictionaryToken extends Token {
   }
 
   /**
-   * Returns the type of this token
-   *
-   * @return token type, not null
-   */
-  public KoreanTokenizer.Type getType() {
-    return type;
-  }
-
-  /**
    * Returns true if this token is known word
    *
    * @return true if this token is in standard dictionary. false if not.
    */
   public boolean isKnown() {
-    return type == KoreanTokenizer.Type.KNOWN;
+    return type == TokenType.KNOWN;
   }
 
   /**
@@ -82,7 +72,7 @@ public class DictionaryToken extends Token {
    * @return true if this token is unknown word. false if not.
    */
   public boolean isUnknown() {
-    return type == KoreanTokenizer.Type.UNKNOWN;
+    return type == TokenType.UNKNOWN;
   }
 
   /**
@@ -91,7 +81,7 @@ public class DictionaryToken extends Token {
    * @return true if this token is in user dictionary. false if not.
    */
   public boolean isUser() {
-    return type == KoreanTokenizer.Type.USER;
+    return type == TokenType.USER;
   }
 
   @Override

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/Token.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/Token.java
@@ -17,12 +17,14 @@
 package org.apache.lucene.analysis.ko;
 
 import org.apache.lucene.analysis.ko.dict.KoMorphData;
+import org.apache.lucene.analysis.morph.TokenType;
 
 /** Analyzed token with morphological data. */
 public abstract class Token extends org.apache.lucene.analysis.morph.Token {
 
-  protected Token(char[] surfaceForm, int offset, int length, int startOffset, int endOffset) {
-    super(surfaceForm, offset, length, startOffset, endOffset);
+  protected Token(
+      char[] surfaceForm, int offset, int length, int startOffset, int endOffset, TokenType type) {
+    super(surfaceForm, offset, length, startOffset, endOffset, type);
   }
 
   /** Get the {@link POS.Type} of the token. */


### PR DESCRIPTION
Both `JapaneseTokenizer.Type` and `KoreanTokenizer.Type` enums are identical and they should be placed in the `o.a.l.a.morph` package in analysis-common (so that `o.a.l.a.morph.Token` can have the type of this token as its property).