### PR TITLE
LUCENE-10508: Fixes some failures where a GeoArea is built with degenerated latitudes

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -119,6 +119,10 @@ Bug Fixes
 * LUCENE-10466: Ensure IndexSortSortedNumericDocValuesRangeQuery handles sort field
   types besides LONG (Andriy Redko)
 
+* LUCENE-10508: Fixes some edge cases where GeoArea were built in a way that vertical planes
+  could not evaluate their sign, either because the planes where the same or the center between those
+  planes was lying in one of the planes. (Ignacio Vera)
+
 Build
 ---------------------
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoBBoxFactory.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoBBoxFactory.java
@@ -55,24 +55,22 @@ public class GeoBBoxFactory {
     if (rightLon > Math.PI) {
       rightLon = Math.PI;
     }
-    if ((Math.abs(leftLon + Math.PI) < Vector.MINIMUM_ANGULAR_RESOLUTION
-            && Math.abs(rightLon - Math.PI) < Vector.MINIMUM_ANGULAR_RESOLUTION)
-        || (Math.abs(rightLon + Math.PI) < Vector.MINIMUM_ANGULAR_RESOLUTION
-            && Math.abs(leftLon - Math.PI) < Vector.MINIMUM_ANGULAR_RESOLUTION)) {
-      if (Math.abs(topLat - Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION
-          && Math.abs(bottomLat + Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+    if ((longitudesEquals(leftLon, -Math.PI) && longitudesEquals(rightLon, Math.PI))
+        || (longitudesEquals(rightLon, -Math.PI) && longitudesEquals(leftLon, Math.PI))) {
+      if (isNorthPole(topLat) && isSouthPole(bottomLat)) {
         return new GeoWorld(planetModel);
       }
-      if (Math.abs(topLat - bottomLat) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
-        if (Math.abs(topLat - Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION
-            || Math.abs(topLat + Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+      if (latitudesEquals(topLat, bottomLat)) {
+        if (isNorthPole(topLat)) {
           return new GeoDegeneratePoint(planetModel, topLat, 0.0);
+        } else if (isSouthPole(bottomLat)) {
+          return new GeoDegeneratePoint(planetModel, bottomLat, 0.0);
         }
         return new GeoDegenerateLatitudeZone(planetModel, topLat);
       }
-      if (Math.abs(topLat - Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+      if (isNorthPole(topLat)) {
         return new GeoNorthLatitudeZone(planetModel, bottomLat);
-      } else if (Math.abs(bottomLat + Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+      } else if (isSouthPole(bottomLat)) {
         return new GeoSouthLatitudeZone(planetModel, topLat);
       }
       return new GeoLatitudeZone(planetModel, topLat, bottomLat);
@@ -82,10 +80,10 @@ public class GeoBBoxFactory {
     if (extent < 0.0) {
       extent += Math.PI * 2.0;
     }
-    if (topLat == Math.PI * 0.5 && bottomLat == -Math.PI * 0.5) {
-      if (Math.abs(leftLon - rightLon) < Vector.MINIMUM_ANGULAR_RESOLUTION)
+    if (isNorthPole(topLat) && isSouthPole(bottomLat)) {
+      if (longitudesEquals(leftLon, rightLon)) {
         return new GeoDegenerateLongitudeSlice(planetModel, leftLon);
-
+      }
       if (extent >= Math.PI) {
         return new GeoWideLongitudeSlice(planetModel, leftLon, rightLon);
       }
@@ -93,47 +91,66 @@ public class GeoBBoxFactory {
       return new GeoLongitudeSlice(planetModel, leftLon, rightLon);
     }
     // System.err.println(" not longitude slice");
-    if (Math.abs(leftLon - rightLon) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
-      if (Math.abs(topLat - bottomLat) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+    if (longitudesEquals(leftLon, rightLon)) {
+      if (latitudesEquals(topLat, bottomLat)) {
         return new GeoDegeneratePoint(planetModel, topLat, leftLon);
       }
       return new GeoDegenerateVerticalLine(planetModel, topLat, bottomLat, leftLon);
     }
     // System.err.println(" not vertical line");
     if (extent >= Math.PI) {
-      if (Math.abs(topLat - bottomLat) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
-        if (Math.abs(topLat - Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+      if (latitudesEquals(topLat, bottomLat)) {
+        if (isNorthPole(topLat)) {
           return new GeoDegeneratePoint(planetModel, topLat, 0.0);
-        } else if (Math.abs(bottomLat + Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+        } else if (isSouthPole(bottomLat)) {
           return new GeoDegeneratePoint(planetModel, bottomLat, 0.0);
         }
         // System.err.println(" wide degenerate line");
         return new GeoWideDegenerateHorizontalLine(planetModel, topLat, leftLon, rightLon);
       }
-      if (Math.abs(topLat - Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+      if (isNorthPole(topLat)) {
         return new GeoWideNorthRectangle(planetModel, bottomLat, leftLon, rightLon);
-      } else if (Math.abs(bottomLat + Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+      } else if (isSouthPole(bottomLat)) {
         return new GeoWideSouthRectangle(planetModel, topLat, leftLon, rightLon);
       }
       // System.err.println(" wide rect");
       return new GeoWideRectangle(planetModel, topLat, bottomLat, leftLon, rightLon);
     }
-    if (Math.abs(topLat - bottomLat) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
-      if (Math.abs(topLat - Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+    if (latitudesEquals(topLat, bottomLat)) {
+      if (isNorthPole(topLat)) {
         return new GeoDegeneratePoint(planetModel, topLat, 0.0);
-      } else if (Math.abs(bottomLat + Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+      } else if (isSouthPole(bottomLat)) {
         return new GeoDegeneratePoint(planetModel, bottomLat, 0.0);
       }
       // System.err.println(" horizontal line");
       return new GeoDegenerateHorizontalLine(planetModel, topLat, leftLon, rightLon);
     }
-    if (Math.abs(topLat - Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+    if (isNorthPole(topLat)) {
       return new GeoNorthRectangle(planetModel, bottomLat, leftLon, rightLon);
-    } else if (Math.abs(bottomLat + Math.PI * 0.5) < Vector.MINIMUM_ANGULAR_RESOLUTION) {
+    } else if (isSouthPole(bottomLat)) {
       return new GeoSouthRectangle(planetModel, topLat, leftLon, rightLon);
     }
     // System.err.println(" rectangle");
     return new GeoRectangle(planetModel, topLat, bottomLat, leftLon, rightLon);
+  }
+
+  private static boolean isNorthPole(double lat) {
+    return latitudesEquals(lat, Math.PI * 0.5);
+  }
+
+  private static boolean isSouthPole(double lat) {
+    return latitudesEquals(lat, -Math.PI * 0.5);
+  }
+
+  private static boolean latitudesEquals(double lat1, double lat2) {
+    // it is not enough with using the MINIMUM_ANGULAR_RESOLUTION, check as well the sin values
+    // just in case they describe the same plane
+    return Math.abs(lat1 - lat2) < Vector.MINIMUM_ANGULAR_RESOLUTION
+        || Math.sin(lat1) == Math.sin(lat2);
+  }
+
+  private static boolean longitudesEquals(double lon1, double lon2) {
+    return Math.abs(lon1 - lon2) < Vector.MINIMUM_ANGULAR_RESOLUTION;
   }
 
   /**

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateHorizontalLine.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateHorizontalLine.java
@@ -111,8 +111,11 @@ class GeoDegenerateHorizontalLine extends GeoBaseBBox {
 
     this.centerPoint =
         new GeoPoint(planetModel, sinLatitude, sinMiddleLon, cosLatitude, cosMiddleLon);
-    this.leftPlane = new SidedPlane(centerPoint, cosLeftLon, sinLeftLon);
-    this.rightPlane = new SidedPlane(centerPoint, cosRightLon, sinRightLon);
+    this.leftPlane = new SidedPlane(RHC, cosLeftLon, sinLeftLon);
+    this.rightPlane = new SidedPlane(LHC, cosRightLon, sinRightLon);
+
+    assert (leftPlane.isWithin(centerPoint));
+    assert (rightPlane.isWithin(centerPoint));
 
     this.planePoints = new GeoPoint[] {LHC, RHC};
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateVerticalLine.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateVerticalLine.java
@@ -107,8 +107,11 @@ public class GeoDegenerateVerticalLine extends GeoBaseBBox {
     this.centerPoint =
         new GeoPoint(planetModel, sinMiddleLat, sinLongitude, cosMiddleLat, cosLongitude);
 
-    this.topPlane = new SidedPlane(centerPoint, planetModel, sinTopLat);
-    this.bottomPlane = new SidedPlane(centerPoint, planetModel, sinBottomLat);
+    this.topPlane = new SidedPlane(LHC, planetModel, sinTopLat);
+    this.bottomPlane = new SidedPlane(UHC, planetModel, sinBottomLat);
+
+    assert (topPlane.isWithin(centerPoint));
+    assert (bottomPlane.isWithin(centerPoint));
 
     this.boundingPlane = new SidedPlane(centerPoint, -sinLongitude, cosLongitude);
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoNorthRectangle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoNorthRectangle.java
@@ -124,9 +124,9 @@ class GeoNorthRectangle extends GeoBaseBBox {
     this.centerPoint =
         new GeoPoint(planetModel, sinMiddleLat, sinMiddleLon, cosMiddleLat, cosMiddleLon);
 
-    this.bottomPlane = new SidedPlane(centerPoint, planetModel, sinBottomLat);
-    this.leftPlane = new SidedPlane(centerPoint, cosLeftLon, sinLeftLon);
-    this.rightPlane = new SidedPlane(centerPoint, cosRightLon, sinRightLon);
+    this.bottomPlane = new SidedPlane(planetModel.NORTH_POLE, planetModel, sinBottomLat);
+    this.leftPlane = new SidedPlane(LRHC, cosLeftLon, sinLeftLon);
+    this.rightPlane = new SidedPlane(LLHC, cosRightLon, sinRightLon);
 
     assert (bottomPlane.isWithin(centerPoint));
     assert (leftPlane.isWithin(centerPoint));

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoRectangle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoRectangle.java
@@ -146,10 +146,15 @@ class GeoRectangle extends GeoBaseBBox {
     this.centerPoint =
         new GeoPoint(planetModel, sinMiddleLat, sinMiddleLon, cosMiddleLat, cosMiddleLon);
 
-    this.topPlane = new SidedPlane(centerPoint, planetModel, sinTopLat);
-    this.bottomPlane = new SidedPlane(centerPoint, planetModel, sinBottomLat);
-    this.leftPlane = new SidedPlane(centerPoint, cosLeftLon, sinLeftLon);
-    this.rightPlane = new SidedPlane(centerPoint, cosRightLon, sinRightLon);
+    this.topPlane = new SidedPlane(LLHC, planetModel, sinTopLat);
+    this.bottomPlane = new SidedPlane(URHC, planetModel, sinBottomLat);
+    this.leftPlane = new SidedPlane(URHC, cosLeftLon, sinLeftLon);
+    this.rightPlane = new SidedPlane(LLHC, cosRightLon, sinRightLon);
+
+    assert (topPlane.isWithin(centerPoint));
+    assert (bottomPlane.isWithin(centerPoint));
+    assert (leftPlane.isWithin(centerPoint));
+    assert (rightPlane.isWithin(centerPoint));
 
     // Compute the backing plane
     // The normal for this plane is a unit vector through the origin that goes through the middle

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoSouthRectangle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoSouthRectangle.java
@@ -120,9 +120,9 @@ class GeoSouthRectangle extends GeoBaseBBox {
     this.centerPoint =
         new GeoPoint(planetModel, sinMiddleLat, sinMiddleLon, cosMiddleLat, cosMiddleLon);
 
-    this.topPlane = new SidedPlane(centerPoint, planetModel, sinTopLat);
-    this.leftPlane = new SidedPlane(centerPoint, cosLeftLon, sinLeftLon);
-    this.rightPlane = new SidedPlane(centerPoint, cosRightLon, sinRightLon);
+    this.topPlane = new SidedPlane(planetModel.SOUTH_POLE, planetModel, sinTopLat);
+    this.leftPlane = new SidedPlane(URHC, cosLeftLon, sinLeftLon);
+    this.rightPlane = new SidedPlane(ULHC, cosRightLon, sinRightLon);
 
     assert (topPlane.isWithin(centerPoint));
     assert (leftPlane.isWithin(centerPoint));

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoBBox.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoBBox.java
@@ -18,6 +18,7 @@ package org.apache.lucene.spatial3d.geom;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
@@ -479,5 +480,52 @@ public class TestGeoBBox extends LuceneTestCase {
     // System.out.println("XYZBounds = "+bounds+" is within? "+solid.isWithin(point)+"
     // solid="+solid);
     assertTrue(box.isWithin(point) == solid.isWithin(point));
+  }
+
+  @Test
+  public void testLUCENE10508() {
+    double minX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());
+    double maxX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());
+    double minY = -Math.PI * 0.5;
+    double maxY = -Math.PI * 0.5 + 1e-8;
+    assertNotNull(GeoAreaFactory.makeGeoArea(PlanetModel.SPHERE, maxY, minY, minX, maxX));
+  }
+
+  @Test
+  public void testBBoxRandomDegenerate() {
+    for (int i = 0; i < 100; i++) {
+      double minX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());
+      double maxX = Math.nextUp(minX + i * Vector.MINIMUM_ANGULAR_RESOLUTION);
+      double minY = Geo3DUtil.fromDegrees(GeoTestUtil.nextLatitude());
+      double maxY = Math.nextUp(minY + i * Vector.MINIMUM_ANGULAR_RESOLUTION);
+      assertNotNull(GeoAreaFactory.makeGeoArea(PlanetModel.SPHERE, maxY, minY, minX, maxX));
+    }
+  }
+
+  @Test
+  public void testBBoxRandomLatDegenerate() {
+    for (int i = 0; i < 100; i++) {
+      double minX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());
+      double maxX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());
+      double minY = Geo3DUtil.fromDegrees(GeoTestUtil.nextLatitude());
+      double maxY = Math.nextUp(minY + i * Vector.MINIMUM_ANGULAR_RESOLUTION);
+      assertNotNull(GeoAreaFactory.makeGeoArea(PlanetModel.SPHERE, maxY, minY, minX, maxX));
+    }
+  }
+
+  @Test
+  public void testBBoxRandomLonDegenerate() {
+    for (int i = 0; i < 100; i++) {
+      double minX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());
+      double maxX = Math.nextUp(minX + i * Vector.MINIMUM_ANGULAR_RESOLUTION);
+      double minY = Geo3DUtil.fromDegrees(GeoTestUtil.nextLatitude());
+      double maxY = Geo3DUtil.fromDegrees(GeoTestUtil.nextLatitude());
+      if (minY > maxY) {
+        double temp = minY;
+        minY = maxY;
+        maxY = temp;
+      }
+      assertNotNull(GeoAreaFactory.makeGeoArea(PlanetModel.SPHERE, maxY, minY, minX, maxX));
+    }
   }
 }


### PR DESCRIPTION
In spatial3d in order to built a bounding box we need to check the provided values and decide which kind of structure we need to build depending on the characteristics of the bounding box. One of this characteristics is when the min latitude and max latitude are the same. In that case we might build a `GeoDegenerateVerticalLine` or a `GeoDegeneratePoint` if the min and max longitudes are the same. Trying to build a `GeoRectangle` with the same min and max latitude results in an error as we cannot compute the sidedness for the vertical planes.

In order to decide if the min and max latitude are equal we need to account for numerical errors when building the planes. We currently consider that two angular magnitudes are equivalent if the distance between them is lower than the `MINIMUM_ANGULAR_RESOLUTION`. Unfortunately this is not enough as it might happen that two latitudes at bigger distance produce the same planes and therefore it makes the logic fail. This PR adds an extra check to make sure that if we have min max latitudes that resolve in the same planes, we build one of our specialised structures.


The new test showed as well, that sometimes even when we re able to build our planes we fail because we use the center of those planes to check for sidedness. When they are too close, it might happen that the center of those planes is on top of one of the planes due to numerical errors, resulting in an error. This PR uses points from the bounding box instead of the center to check for sidedness.
