### PR TITLE
LUCENE-10488: Optimize Facets#getTopDims in FloatTaxonomyFacets

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
@@ -119,7 +119,7 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
       return null;
     }
 
-    LabelAndValue[] labelValues = getLabelValues(childOrdsResult.q, cp.length);
+    LabelAndValue[] labelValues = getLabelValues(childOrdsResult.q, cp);
     return new FacetResult(
         dim, path, childOrdsResult.aggregatedValue, labelValues, childOrdsResult.childCount);
   }
@@ -174,11 +174,8 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
     return new ChildOrdsResult(aggregatedValue, childCount, q);
   }
 
-  /**
-   * Returns label values for dims This portion of code is moved from getTopChildren because
-   * getTopDims needs to reuse it
-   */
-  private LabelAndValue[] getLabelValues(TopOrdAndFloatQueue q, int facetLabelLength)
+  /** Returns label values for dims */
+  private LabelAndValue[] getLabelValues(TopOrdAndFloatQueue q, FacetLabel facetLabel)
       throws IOException {
     LabelAndValue[] labelValues = new LabelAndValue[q.size()];
     int[] ordinals = new int[labelValues.length];
@@ -192,7 +189,7 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
 
     FacetLabel[] bulkPath = taxoReader.getBulkPath(ordinals);
     for (int i = 0; i < labelValues.length; i++) {
-      labelValues[i] = new LabelAndValue(bulkPath[i].components[facetLabelLength], values[i]);
+      labelValues[i] = new LabelAndValue(bulkPath[i].components[facetLabel.length], values[i]);
     }
     return labelValues;
   }
@@ -227,8 +224,8 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
     validateTopN(topNChildren);
 
     // get existing children and siblings ordinal array from TaxonomyFacets
-    int[] children = getExistingChildren();
-    int[] siblings = getExistingSiblings();
+    int[] children = getChildren();
+    int[] siblings = getSiblings();
 
     // Create priority queue to store top dimensions and sort by their aggregated values/hits and
     // string values.
@@ -302,7 +299,7 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
               dimValueResult.dim,
               emptyPath,
               dimValueResult.value,
-              getLabelValues(childOrdsResult.q, 1),
+              getLabelValues(childOrdsResult.q, new FacetLabel(dim, emptyPath)),
               childOrdsResult.childCount);
       results[pq.size()] = facetResult;
     }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
@@ -17,12 +17,16 @@
 package org.apache.lucene.facet.taxonomy;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.FacetsConfig.DimConfig;
 import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.facet.TopOrdAndFloatQueue;
+import org.apache.lucene.util.PriorityQueue;
 
 /** Base class for all taxonomy-based facets that aggregate to a per-ords float[]. */
 abstract class FloatTaxonomyFacets extends TaxonomyFacets {
@@ -34,6 +38,9 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
 
   /** Per-ordinal value. */
   final float[] values;
+
+  /** Pass in emptyPath for getTopDims and getAllDims. */
+  private static final String[] emptyPath = new String[0];
 
   /** Sole constructor. */
   FloatTaxonomyFacets(
@@ -107,6 +114,24 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
       return null;
     }
 
+    ChildOrdsResult childOrdsResult = getChildOrdsResult(dimConfig, dimOrd, topN);
+    if (childOrdsResult.aggregatedValue == 0) {
+      return null;
+    }
+
+    LabelAndValue[] labelValues = getLabelValues(childOrdsResult.q, cp.length);
+    return new FacetResult(
+        dim, path, childOrdsResult.aggregatedValue, labelValues, childOrdsResult.childCount);
+  }
+
+  /**
+   * Return ChildOrdsResult that contains results of aggregatedValue, childCount, and the queue for
+   * the dimension's top children to populate FacetResult in getPathResult. This portion of code is
+   * moved from getTopChildren because getTopDims needs to reuse it
+   */
+  private ChildOrdsResult getChildOrdsResult(DimConfig dimConfig, int dimOrd, int topN)
+      throws IOException {
+
     TopOrdAndFloatQueue q = new TopOrdAndFloatQueue(Math.min(taxoReader.getSize(), topN));
     float bottomValue = 0;
 
@@ -138,10 +163,6 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
       ord = siblings[ord];
     }
 
-    if (aggregatedValue == 0) {
-      return null;
-    }
-
     if (dimConfig.multiValued) {
       if (dimConfig.requireDimCount) {
         aggregatedValue = values[dimOrd];
@@ -149,10 +170,16 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
         // Our sum'd count is not correct, in general:
         aggregatedValue = -1;
       }
-    } else {
-      // Our sum'd dim count is accurate, so we keep it
     }
+    return new ChildOrdsResult(aggregatedValue, childCount, q);
+  }
 
+  /**
+   * Returns label values for dims This portion of code is moved from getTopChildren because
+   * getTopDims needs to reuse it
+   */
+  private LabelAndValue[] getLabelValues(TopOrdAndFloatQueue q, int facetLabelLength)
+      throws IOException {
     LabelAndValue[] labelValues = new LabelAndValue[q.size()];
     int[] ordinals = new int[labelValues.length];
     float[] values = new float[labelValues.length];
@@ -165,9 +192,151 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
 
     FacetLabel[] bulkPath = taxoReader.getBulkPath(ordinals);
     for (int i = 0; i < labelValues.length; i++) {
-      labelValues[i] = new LabelAndValue(bulkPath[i].components[cp.length], values[i]);
+      labelValues[i] = new LabelAndValue(bulkPath[i].components[facetLabelLength], values[i]);
+    }
+    return labelValues;
+  }
+
+  /** Returns value of a dimension. */
+  private float getDimValue(
+      FacetsConfig.DimConfig dimConfig,
+      String dim,
+      int dimOrd,
+      int topN,
+      HashMap<String, ChildOrdsResult> dimToChildOrdsResult)
+      throws IOException {
+
+    // if dimConfig.hierarchical == true || dim is multiValued and dim count has been aggregated at
+    // indexing time, return dimCount directly
+    if (dimConfig.hierarchical == true || (dimConfig.multiValued && dimConfig.requireDimCount)) {
+      return values[dimOrd];
     }
 
-    return new FacetResult(dim, path, aggregatedValue, labelValues, childCount);
+    // if dimCount was not aggregated at indexing time, iterate over childOrds to get dimCount
+    ChildOrdsResult childOrdsResult = getChildOrdsResult(dimConfig, dimOrd, topN);
+
+    // if no early termination, store dim and childOrdsResult into a hashmap to avoid calling
+    // getChildOrdsResult again in getTopDims
+    dimToChildOrdsResult.put(dim, childOrdsResult);
+    return childOrdsResult.aggregatedValue;
+  }
+
+  @Override
+  public List<FacetResult> getTopDims(int topNDims, int topNChildren) throws IOException {
+    validateTopN(topNDims);
+    validateTopN(topNChildren);
+
+    // get existing children and siblings ordinal array from TaxonomyFacets
+    int[] children = getExistingChildren();
+    int[] siblings = getExistingSiblings();
+
+    // Create priority queue to store top dimensions and sort by their aggregated values/hits and
+    // string values.
+    PriorityQueue<DimValueResult> pq =
+        new PriorityQueue<>(topNDims) {
+          @Override
+          protected boolean lessThan(DimValueResult a, DimValueResult b) {
+            if (a.value > b.value) {
+              return false;
+            } else if (a.value < b.value) {
+              return true;
+            } else {
+              return a.dim.compareTo(b.dim) > 0;
+            }
+          }
+        };
+
+    // create hashMap to store the ChildOrdsResult to avoid calling getChildOrdsResult for all dims
+    HashMap<String, ChildOrdsResult> dimToChildOrdsResult = new HashMap<>();
+
+    // iterate over children and siblings ordinals for all dims
+    int ord = children[TaxonomyReader.ROOT_ORDINAL];
+    while (ord != TaxonomyReader.INVALID_ORDINAL) {
+      String dim = taxoReader.getPath(ord).components[0];
+      FacetsConfig.DimConfig dimConfig = config.getDimConfig(dim);
+      if (dimConfig.indexFieldName.equals(indexFieldName)) {
+        FacetLabel cp = new FacetLabel(dim, emptyPath);
+        int dimOrd = taxoReader.getOrdinal(cp);
+        float dimCount = 0;
+        // if dimOrd = -1, we skip this dim, else call getDimValue
+        if (dimOrd != -1) {
+          dimCount = getDimValue(dimConfig, dim, dimOrd, topNChildren, dimToChildOrdsResult);
+          if (dimCount != 0) {
+            // use priority queue to store DimValueResult for topNDims
+            if (pq.size() < topNDims) {
+              pq.add(new DimValueResult(dim, dimOrd, dimCount));
+            } else {
+              if (dimCount > pq.top().value
+                  || (dimCount == pq.top().value && dim.compareTo(pq.top().dim) < 0)) {
+                DimValueResult bottomDim = pq.top();
+                bottomDim.dim = dim;
+                bottomDim.value = dimCount;
+                pq.updateTop();
+              }
+            }
+          }
+        }
+      }
+      ord = siblings[ord];
+    }
+
+    // use fixed-size array to reduce space usage
+    FacetResult[] results = new FacetResult[pq.size()];
+
+    while (pq.size() > 0) {
+      DimValueResult dimValueResult = pq.pop();
+      String dim = dimValueResult.dim;
+      ChildOrdsResult childOrdsResult;
+      // if the childOrdsResult was stored in the map, avoid calling getChildOrdsResult again
+      if (dimToChildOrdsResult.containsKey(dim)) {
+        childOrdsResult = dimToChildOrdsResult.get(dim);
+      } else {
+        FacetsConfig.DimConfig dimConfig = config.getDimConfig(dim);
+        childOrdsResult = getChildOrdsResult(dimConfig, dimValueResult.dimOrd, topNChildren);
+      }
+      // FacetResult requires String[] path, and path is always empty for getTopDims.
+      // FacetLabelLength is always equal to 1 when FacetLabel is constructed with
+      // FacetLabel(dim, emptyPath), and therefore, 1 is passed in when calling getLabelValues
+      FacetResult facetResult =
+          new FacetResult(
+              dimValueResult.dim,
+              emptyPath,
+              dimValueResult.value,
+              getLabelValues(childOrdsResult.q, 1),
+              childOrdsResult.childCount);
+      results[pq.size()] = facetResult;
+    }
+    return Arrays.asList(results);
+  }
+
+  /**
+   * Create DimValueResult to store the label, dim ordinal and dim count of a dim in priority queue
+   */
+  private static class DimValueResult {
+    String dim;
+    int dimOrd;
+    float value;
+
+    DimValueResult(String dim, int dimOrd, float value) {
+      this.dim = dim;
+      this.dimOrd = dimOrd;
+      this.value = value;
+    }
+  }
+
+  /**
+   * Create ChildOrdsResult to store dimCount, childCount, and the queue for the dimension's top
+   * children
+   */
+  private static class ChildOrdsResult {
+    final float aggregatedValue;
+    final int childCount;
+    final TopOrdAndFloatQueue q;
+
+    ChildOrdsResult(float aggregatedValue, int childCount, TopOrdAndFloatQueue q) {
+      this.aggregatedValue = aggregatedValue;
+      this.childCount = childCount;
+      this.q = q;
+    }
   }
 }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
@@ -119,15 +119,14 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
       return null;
     }
 
-    LabelAndValue[] labelValues = getLabelValues(childOrdsResult.q, cp);
+    LabelAndValue[] labelValues = getLabelValues(childOrdsResult.q, cp.length);
     return new FacetResult(
         dim, path, childOrdsResult.aggregatedValue, labelValues, childOrdsResult.childCount);
   }
 
   /**
    * Return ChildOrdsResult that contains results of aggregatedValue, childCount, and the queue for
-   * the dimension's top children to populate FacetResult in getPathResult. This portion of code is
-   * moved from getTopChildren because getTopDims needs to reuse it
+   * the dimension's top children to populate FacetResult in getPathResult.
    */
   private ChildOrdsResult getChildOrdsResult(DimConfig dimConfig, int dimOrd, int topN)
       throws IOException {
@@ -174,9 +173,13 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
     return new ChildOrdsResult(aggregatedValue, childCount, q);
   }
 
-  /** Returns label values for dims */
-  private LabelAndValue[] getLabelValues(TopOrdAndFloatQueue q, FacetLabel facetLabel)
-      throws IOException {
+  /**
+   * Return label and values for top dimensions and children
+   *
+   * @param q the queue for the dimension's top children
+   * @param pathLength the length of a dimension's children paths
+   */
+  private LabelAndValue[] getLabelValues(TopOrdAndFloatQueue q, int pathLength) throws IOException {
     LabelAndValue[] labelValues = new LabelAndValue[q.size()];
     int[] ordinals = new int[labelValues.length];
     float[] values = new float[labelValues.length];
@@ -189,12 +192,12 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
 
     FacetLabel[] bulkPath = taxoReader.getBulkPath(ordinals);
     for (int i = 0; i < labelValues.length; i++) {
-      labelValues[i] = new LabelAndValue(bulkPath[i].components[facetLabel.length], values[i]);
+      labelValues[i] = new LabelAndValue(bulkPath[i].components[pathLength], values[i]);
     }
     return labelValues;
   }
 
-  /** Returns value of a dimension. */
+  /** Return value of a dimension. */
   private float getDimValue(
       FacetsConfig.DimConfig dimConfig,
       String dim,
@@ -292,14 +295,14 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
         childOrdsResult = getChildOrdsResult(dimConfig, dimValueResult.dimOrd, topNChildren);
       }
       // FacetResult requires String[] path, and path is always empty for getTopDims.
-      // FacetLabelLength is always equal to 1 when FacetLabel is constructed with
+      // pathLength is always equal to 1 when FacetLabel is constructed with
       // FacetLabel(dim, emptyPath), and therefore, 1 is passed in when calling getLabelValues
       FacetResult facetResult =
           new FacetResult(
               dimValueResult.dim,
               emptyPath,
               dimValueResult.value,
-              getLabelValues(childOrdsResult.q, new FacetLabel(dim, emptyPath)),
+              getLabelValues(childOrdsResult.q, 1),
               childOrdsResult.childCount);
       results[pq.size()] = facetResult;
     }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -113,6 +113,22 @@ abstract class TaxonomyFacets extends Facets {
   }
 
   /**
+   * Returns existing int[] mapping each ordinal to its next sibling to avoid re-creating int[] for
+   * siblings in subclass
+   */
+  public int[] getExistingSiblings() throws IOException {
+    return childrenLoaded() ? this.siblings : getSiblings();
+  }
+
+  /**
+   * Returns existing int[] mapping each ordinal to its first child to avoid re-creating int[] for
+   * children in subclass
+   */
+  public int[] getExistingChildren() throws IOException {
+    return childrenLoaded() ? this.children : getChildren();
+  }
+
+  /**
    * Verifies and returns {@link DimConfig} for the given dimension name.
    *
    * @return {@link DimConfig} for the given dim, or {@link FacetsConfig#DEFAULT_DIM_CONFIG} if it

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -113,22 +113,6 @@ abstract class TaxonomyFacets extends Facets {
   }
 
   /**
-   * Returns existing int[] mapping each ordinal to its next sibling to avoid re-creating int[] for
-   * siblings in subclass
-   */
-  public int[] getExistingSiblings() throws IOException {
-    return childrenLoaded() ? this.siblings : getSiblings();
-  }
-
-  /**
-   * Returns existing int[] mapping each ordinal to its first child to avoid re-creating int[] for
-   * children in subclass
-   */
-  public int[] getExistingChildren() throws IOException {
-    return childrenLoaded() ? this.children : getChildren();
-  }
-
-  /**
    * Verifies and returns {@link DimConfig} for the given dimension name.
    *
    * @return {@link DimConfig} for the given dim, or {@link FacetsConfig#DEFAULT_DIM_CONFIG} if it

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
@@ -202,6 +202,11 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
         "Wrong count for category 'a'!", 200, facets.getSpecificValue("int", "a").intValue());
     assertEquals(
         "Wrong count for category 'b'!", 150, facets.getSpecificValue("int", "b").intValue());
+
+    // test getAllDims and getTopDims
+    List<FacetResult> topDims = facets.getTopDims(10, 10);
+    List<FacetResult> allDims = facets.getAllDims(10);
+    assertEquals(topDims, allDims);
   }
 
   public void testIntAssociationRandom() throws Exception {
@@ -229,6 +234,11 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
     }
     validateInts("int_single_valued", expected, AssociationAggregationFunction.SUM, false, facets);
 
+    // test getAllDims and getTopDims
+    List<FacetResult> allDims = facets.getAllDims(10);
+    List<FacetResult> topDims = facets.getTopDims(10, 10);
+    assertEquals(topDims, allDims);
+
     // MAX:
     facets =
         new TaxonomyFacetIntAssociations(
@@ -243,6 +253,11 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
       expected.put(e.getKey(), e.getValue().stream().max(Integer::compareTo).orElse(0));
     }
     validateInts("int_single_valued", expected, AssociationAggregationFunction.MAX, false, facets);
+
+    // test getAllDims and getTopDims
+    topDims = facets.getTopDims(10, 10);
+    allDims = facets.getAllDims(10);
+    assertEquals(topDims, allDims);
   }
 
   public void testFloatSumAssociation() throws Exception {
@@ -265,6 +280,11 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
         10f,
         facets.getSpecificValue("float", "b").floatValue(),
         0.00001);
+
+    // test getAllDims and getTopDims
+    List<FacetResult> topDims = facets.getTopDims(10, 10);
+    List<FacetResult> allDims = facets.getAllDims(10);
+    assertEquals(topDims, allDims);
   }
 
   public void testFloatAssociationRandom() throws Exception {
@@ -293,6 +313,11 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
     validateFloats(
         "float_single_valued", expected, AssociationAggregationFunction.SUM, false, facets);
 
+    // test getAllDims and getTopDims
+    List<FacetResult> topDims = facets.getTopDims(10, 10);
+    List<FacetResult> allDims = facets.getAllDims(10);
+    assertEquals(topDims, allDims);
+
     // MAX:
     facets =
         new TaxonomyFacetFloatAssociations(
@@ -308,6 +333,11 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
     }
     validateFloats(
         "float_single_valued", expected, AssociationAggregationFunction.MAX, false, facets);
+
+    // test getAllDims and getTopDims
+    topDims = facets.getTopDims(10, 10);
+    allDims = facets.getAllDims(10);
+    assertEquals(topDims, allDims);
   }
 
   /**

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
@@ -236,8 +236,11 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
     assertEquals(results, allDimsResults);
 
     // test getTopDims(0, 1)
-    List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
-    assertEquals(0, topDimsResults2.size());
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          facets.getTopDims(0, 1);
+        });
 
     // test getTopDims(1, 0) with topNChildren = 0
     expectThrows(


### PR DESCRIPTION
# Description

This change overrides and optimizes the default implementation of getTopDims in FloatTaxonomyFacets which is extended by TaxonomyFacetFloatAssociations

# Solution
Override getTopDims and refactor the getTopChildren function in FloatTaxonomyFacets to get dimCount (aggregated dim values) more efficiently by checking if dimCount has been populated in indexing time for a dim that is hierarchical or multiValued && requireDimCount before aggregating dimCount by iterating its child ordinal.

# Tests

Added new testing for getAllDims and getTopDims in TestTaxonomyFacetAssociations

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
