### PR TITLE
LUCENE-10512: Grammar: Remove incidents of "the the" in comments.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene91/Lucene91HnswVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene91/Lucene91HnswVectorsFormat.java
@@ -76,7 +76,7 @@ import org.apache.lucene.util.hnsw.HnswGraph;
  *       <ul>
  *         <li><b>[int]</b> the number of nodes on this level
  *         <li><b>array[int]</b> for levels greater than 0 list of nodes on this level, stored as
- *             the the level 0th nodes ordinals.
+ *             the level 0th nodes ordinals.
  *       </ul>
  * </ul>
  *

--- a/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
@@ -61,7 +61,7 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
   }
 
   /**
-   * Returns a IndexReader for the the index in the given Directory
+   * Returns a IndexReader for the index in the given Directory
    *
    * @param directory the index directory
    * @param leafSorter a comparator for sorting leaf readers. Providing leafSorter is useful for

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterDeleteQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterDeleteQueue.java
@@ -579,12 +579,12 @@ final class DocumentsWriterDeleteQueue implements Accountable, Closeable {
   }
 
   /**
-   * Advances the queue to the next queue on flush. This carries over the the generation to the next
+   * Advances the queue to the next queue on flush. This carries over the generation to the next
    * queue and set the {@link #getMaxSeqNo()} based on the given maxNumPendingOps. This method can
    * only be called once, subsequently the returned queue should be used.
    *
    * @param maxNumPendingOps the max number of possible concurrent operations that will execute on
-   *     this queue after it was advanced. This corresponds the the number of DWPTs that own the
+   *     this queue after it was advanced. This corresponds to the number of DWPTs that own the
    *     current queue at the moment when this queue is advanced since each these DWPTs can
    *     increment the seqId after we advanced it.
    * @return a new queue as a successor of this queue.

--- a/lucene/core/src/java/org/apache/lucene/index/OrdinalMap.java
+++ b/lucene/core/src/java/org/apache/lucene/index/OrdinalMap.java
@@ -189,7 +189,7 @@ public class OrdinalMap implements Accountable {
   public final IndexReader.CacheKey owner;
   // number of global ordinals
   final long valueCount;
-  // globalOrd -> (globalOrd - segmentOrd) where segmentOrd is the the ordinal in the first segment
+  // globalOrd -> (globalOrd - segmentOrd) where segmentOrd is the ordinal in the first segment
   // that contains this term
   final LongValues globalOrdDeltas;
   // globalOrd -> first segment container

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentCommitInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentCommitInfo.java
@@ -408,7 +408,7 @@ public class SegmentCommitInfo {
 
   /**
    * Returns and Id that uniquely identifies this segment commit or <code>null</code> if there is no
-   * ID assigned. This ID changes each time the the segment changes due to a delete, doc-value or
+   * ID assigned. This ID changes each time the segment changes due to a delete, doc-value or
    * field update.
    */
   public byte[] getId() {

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentCommitInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentCommitInfo.java
@@ -408,8 +408,8 @@ public class SegmentCommitInfo {
 
   /**
    * Returns and Id that uniquely identifies this segment commit or <code>null</code> if there is no
-   * ID assigned. This ID changes each time the segment changes due to a delete, doc-value or
-   * field update.
+   * ID assigned. This ID changes each time the segment changes due to a delete, doc-value or field
+   * update.
    */
   public byte[] getId() {
     return id == null ? null : id.clone();

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -396,8 +396,8 @@ public class BKDWriter implements Closeable {
     int numLeaves();
     /**
      * pointer to the leaf node previously written. Leaves are order from left to right, so leaf at
-     * {@code index} 0 is the leftmost leaf and the leaf at {@code numleaves()} -1 is the
-     * rightmost leaf
+     * {@code index} 0 is the leftmost leaf and the leaf at {@code numleaves()} -1 is the rightmost
+     * leaf
      */
     long getLeafLP(int index);
     /**

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -396,7 +396,7 @@ public class BKDWriter implements Closeable {
     int numLeaves();
     /**
      * pointer to the leaf node previously written. Leaves are order from left to right, so leaf at
-     * {@code index} 0 is the leftmost leaf and the the leaf at {@code numleaves()} -1 is the
+     * {@code index} 0 is the leftmost leaf and the leaf at {@code numleaves()} -1 is the
      * rightmost leaf
      */
     long getLeafLP(int index);

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/MultiTermHighlighting.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/MultiTermHighlighting.java
@@ -48,7 +48,7 @@ final class MultiTermHighlighting {
   }
 
   /**
-   * Indicates if the the leaf query (from {@link QueryVisitor#visitLeaf(Query)}) is a type of query
+   * Indicates if the leaf query (from {@link QueryVisitor#visitLeaf(Query)}) is a type of query
    * that we can extract automata from.
    */
   public static boolean canExtractAutomataFromLeafQuery(Query query) {

--- a/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
@@ -66,7 +66,7 @@ public final class JoinUtil {
    *
    * <p>In the case a single document relates to more than one document the <code>
    * multipleValuesPerDocument</code> option should be set to true. When the <code>
-   * multipleValuesPerDocument</code> is set to <code>true</code> only the the score from the first
+   * multipleValuesPerDocument</code> is set to <code>true</code> only the score from the first
    * encountered join value originating from the 'from' side is mapped into the 'to' side. Even in
    * the case when a second join value related to a specific document yields a higher score.
    * Obviously this doesn't apply in the case that {@link ScoreMode#None} is used, since no scores

--- a/lucene/join/src/java/org/apache/lucene/search/join/SeekingTermSetTermsEnum.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/SeekingTermSetTermsEnum.java
@@ -74,7 +74,7 @@ public class SeekingTermSetTermsEnum extends FilteredTermsEnum {
     } else {
       if (upto == lastElement) {
         return AcceptStatus.NO;
-      } else { // Our current term doesn't match the the given term.
+      } else { // Our current term doesn't match the given term.
         int cmp;
         do { // We maybe are behind the given term by more than one step. Keep incrementing till
           // we're the same or higher.

--- a/lucene/join/src/java/org/apache/lucene/search/join/package-info.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/package-info.java
@@ -40,7 +40,7 @@
  * <p>If you care about what child documents matched for each parent document, then use the {@link
  * org.apache.lucene.search.join.ParentChildrenBlockJoinQuery} query to per matched parent document
  * retrieve the child documents that caused to match the parent document in first place. This query
- * should be used after your main query has been executed. For each hit execute the the {@link
+ * should be used after your main query has been executed. For each hit execute the {@link
  * org.apache.lucene.search.join.ParentChildrenBlockJoinQuery} query
  *
  * <pre class="prettyprint">

--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -74,7 +74,7 @@ public class DirectIODirectory extends FilterDirectory {
    * <ol>
    *   <li>ExtendedOpenOption.DIRECT is OpenJDK's internal proprietary API. This API causes
    *       un-suppressible(?) warning to be emitted when compiling with --release flag and value N,
-   *       where N is smaller than the the version of javac used for compilation. For details,
+   *       where N is smaller than the version of javac used for compilation. For details,
    *       please refer to https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8259039.
    *   <li>It is possible that Lucene is run using JDK that does not support
    *       ExtendedOpenOption.DIRECT. In such a case, dynamic lookup allows us to bail out with

--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -74,8 +74,8 @@ public class DirectIODirectory extends FilterDirectory {
    * <ol>
    *   <li>ExtendedOpenOption.DIRECT is OpenJDK's internal proprietary API. This API causes
    *       un-suppressible(?) warning to be emitted when compiling with --release flag and value N,
-   *       where N is smaller than the version of javac used for compilation. For details,
-   *       please refer to https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8259039.
+   *       where N is smaller than the version of javac used for compilation. For details, please
+   *       refer to https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8259039.
    *   <li>It is possible that Lucene is run using JDK that does not support
    *       ExtendedOpenOption.DIRECT. In such a case, dynamic lookup allows us to bail out with
    *       UnsupportedOperationException with meaningful error message.

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoComplexPolygon.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoComplexPolygon.java
@@ -769,7 +769,7 @@ class GeoComplexPolygon extends GeoBasePolygon {
       final Plane p, final GeoPoint[] notablePoints, final Membership... bounds) {
     // Create the intersector
     final EdgeIterator intersector = new IntersectorEdgeIterator(p, notablePoints, bounds);
-    // First, compute the bounds for the the plane
+    // First, compute the bounds for the plane
     final XYZBounds xyzBounds = new XYZBounds();
     p.recordBounds(planetModel, xyzBounds, bounds);
     for (final GeoPoint point : notablePoints) {
@@ -806,7 +806,7 @@ class GeoComplexPolygon extends GeoBasePolygon {
   public boolean intersects(GeoShape geoShape) {
     // Create the intersector
     final EdgeIterator intersector = new IntersectorShapeIterator(geoShape);
-    // First, compute the bounds for the the plane
+    // First, compute the bounds for the plane
     final XYZBounds xyzBounds = new XYZBounds();
     geoShape.getBounds(xyzBounds);
 

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/DocumentDictionary.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/DocumentDictionary.java
@@ -64,7 +64,7 @@ public class DocumentDictionary implements Dictionary {
 
   /**
    * Creates a new dictionary with the contents of the fields named <code>field</code> for the
-   * terms, <code>weightField</code> for the weights that will be used for the the corresponding
+   * terms, <code>weightField</code> for the weights that will be used for the corresponding
    * terms and <code>payloadField</code> for the corresponding payloads for the entry.
    */
   public DocumentDictionary(
@@ -74,7 +74,7 @@ public class DocumentDictionary implements Dictionary {
 
   /**
    * Creates a new dictionary with the contents of the fields named <code>field</code> for the
-   * terms, <code>weightField</code> for the weights that will be used for the the corresponding
+   * terms, <code>weightField</code> for the weights that will be used for the corresponding
    * terms, <code>payloadField</code> for the corresponding payloads for the entry and <code>
    * contextsField</code> for associated contexts.
    */

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/DocumentDictionary.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/DocumentDictionary.java
@@ -64,8 +64,8 @@ public class DocumentDictionary implements Dictionary {
 
   /**
    * Creates a new dictionary with the contents of the fields named <code>field</code> for the
-   * terms, <code>weightField</code> for the weights that will be used for the corresponding
-   * terms and <code>payloadField</code> for the corresponding payloads for the entry.
+   * terms, <code>weightField</code> for the weights that will be used for the corresponding terms
+   * and <code>payloadField</code> for the corresponding payloads for the entry.
    */
   public DocumentDictionary(
       IndexReader reader, String field, String weightField, String payloadField) {
@@ -74,8 +74,8 @@ public class DocumentDictionary implements Dictionary {
 
   /**
    * Creates a new dictionary with the contents of the fields named <code>field</code> for the
-   * terms, <code>weightField</code> for the weights that will be used for the corresponding
-   * terms, <code>payloadField</code> for the corresponding payloads for the entry and <code>
+   * terms, <code>weightField</code> for the weights that will be used for the corresponding terms,
+   * <code>payloadField</code> for the corresponding payloads for the entry and <code>
    * contextsField</code> for associated contexts.
    */
   public DocumentDictionary(

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -3134,7 +3134,7 @@ public abstract class LuceneTestCase extends Assert {
   }
 
   /**
-   * Compares two strings with a collator, also looking to see if the the strings are impacted by
+   * Compares two strings with a collator, also looking to see if the strings are impacted by
    * jdk bugs. may not avoid all jdk bugs in tests. see
    * https://bugs.openjdk.java.net/browse/JDK-8071862
    */

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -3134,9 +3134,8 @@ public abstract class LuceneTestCase extends Assert {
   }
 
   /**
-   * Compares two strings with a collator, also looking to see if the strings are impacted by
-   * jdk bugs. may not avoid all jdk bugs in tests. see
-   * https://bugs.openjdk.java.net/browse/JDK-8071862
+   * Compares two strings with a collator, also looking to see if the strings are impacted by jdk
+   * bugs. may not avoid all jdk bugs in tests. see https://bugs.openjdk.java.net/browse/JDK-8071862
    */
   @SuppressForbidden(reason = "dodges JDK-8071862")
   public static int collate(Collator collator, String s1, String s2) {


### PR DESCRIPTION
# Description

Identify and fix "the the" repeated words in comments/docs.

# Solution

Purely cosmetic/grammar: Remove/replace "the the" in comments, documentation.

# Tests

No tests, because no functional change.

# Checklist

Please review the following and check all that apply:

- [ x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x ] I have created a Jira issue and added the issue ID to my pull request title.
- [x ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ x] I have developed this patch against the `main` branch.
- [ x] I have run `./gradlew check`.
- [ ] I have added tests for my changes. (No: This makes no functional change)
