### PR TITLE
LUCENE-10513: Run `gradlew tidy` first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ If you want to just build the documentation, type:
 
 ### Checks
 
-Please make sure that all unit tests and validations succeed before constructing your patch: `./gradlew check`.
+Please make sure that all unit tests and validations succeed before constructing your patch: `./gradlew check`. If you've modified any sources, run `./gradlew tidy` to apply code formatting conventions automatically (see [help/formatting.txt](https://github.com/apache/lucene/blob/main/help/formatting.txt)).
 
 To run a single test case from the lucene/core directory in your working copy:  `./gradlew -p lucene/core test --tests NameOfYourUnitTest`. Run `./gradlew helpTests` to get more information about running tests.
 

--- a/help/workflow.txt
+++ b/help/workflow.txt
@@ -3,6 +3,9 @@ Typical workflow and tasks
 
 This shows some typical workflow gradle commands.
 
+Ensure your changes are correctly formatted
+gradlew tidy
+
 Run tests on a module:
 gradlew -p lucene/core test
 

--- a/help/workflow.txt
+++ b/help/workflow.txt
@@ -3,7 +3,7 @@ Typical workflow and tasks
 
 This shows some typical workflow gradle commands.
 
-Ensure your changes are correctly formatted
+Ensure your changes are correctly formatted (run "gradlew :helpFormatting" for more):
 gradlew tidy
 
 Run tests on a module:


### PR DESCRIPTION
Encourage running `gradlew tidy` first, which, in turn, prevents failures in later steps.

# Description

In contributing my first change, I encountered formatting advice that would have been rendered unnecessary if I had first run `gradlew tidy`

# Solution

Recommend `gradlew tidy` as first step of workflow.

# Tests

Docs-only change - no tests.

# Checklist

Please review the following and check all that apply:

- [x ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x ] I have developed this patch against the `main` branch.
- [x ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
