### PR TITLE
LUCENE-10514: Component2D#Within methods should return NOTWITHIN when the query geometry contains the triangle

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/LatLonShapeBoundingBoxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonShapeBoundingBoxQuery.java
@@ -485,8 +485,11 @@ final class LatLonShapeBoundingBoxQuery extends SpatialQuery {
     }
 
     /** Returns the Within relation to the provided triangle */
-    Component2D.WithinRelation withinLine(int ax, int ay, boolean ab, int bx, int by) {
-      if (ab == true && edgeIntersectsBox(ax, ay, bx, by, minX, maxX, minY, maxY) == true) {
+    Component2D.WithinRelation withinLine(int aX, int aY, boolean ab, int bX, int bY) {
+      if (contains(aX, aY) || contains(bX, bY)) {
+        return Component2D.WithinRelation.NOTWITHIN;
+      }
+      if (ab == true && edgeIntersectsBox(aX, aY, bX, bY, minX, maxX, minY, maxY) == true) {
         return Component2D.WithinRelation.NOTWITHIN;
       }
       return Component2D.WithinRelation.DISJOINT;

--- a/lucene/core/src/java/org/apache/lucene/geo/Circle2D.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Circle2D.java
@@ -159,6 +159,9 @@ class Circle2D implements Component2D {
     if (calculator.disjoint(minX, maxX, minY, maxY)) {
       return WithinRelation.DISJOINT;
     }
+    if (contains(aX, aY) || contains(bX, bY)) {
+      return WithinRelation.NOTWITHIN;
+    }
     if (ab == true && calculator.intersectsLine(aX, aY, bX, bY)) {
       return WithinRelation.NOTWITHIN;
     }

--- a/lucene/core/src/java/org/apache/lucene/geo/Polygon2D.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Polygon2D.java
@@ -257,10 +257,13 @@ final class Polygon2D implements Component2D {
       boolean ab,
       double bX,
       double bY) {
-    if (ab == true
-        && Component2D.disjoint(this.minX, this.maxX, this.minY, this.maxY, minX, maxX, minY, maxY)
-            == false
-        && tree.crossesLine(minX, maxX, minY, maxY, aX, aY, bX, bY, true)) {
+    if (Component2D.disjoint(this.minX, this.maxX, this.minY, this.maxY, minX, maxX, minY, maxY)) {
+      return WithinRelation.DISJOINT;
+    }
+    if (contains(aX, aY) || contains(bX, bY)) {
+      return WithinRelation.NOTWITHIN;
+    }
+    if (ab == true && tree.crossesLine(minX, maxX, minY, maxY, aX, aY, bX, bY, true)) {
       return WithinRelation.NOTWITHIN;
     }
     return WithinRelation.DISJOINT;

--- a/lucene/core/src/java/org/apache/lucene/geo/Rectangle2D.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Rectangle2D.java
@@ -164,10 +164,13 @@ final class Rectangle2D implements Component2D {
       boolean ab,
       double bX,
       double bY) {
-    if (ab == true
-        && Component2D.disjoint(this.minX, this.maxX, this.minY, this.maxY, minX, maxX, minY, maxY)
-            == false
-        && edgesIntersect(aX, aY, bX, bY)) {
+    if (Component2D.disjoint(this.minX, this.maxX, this.minY, this.maxY, minX, maxX, minY, maxY)) {
+      return WithinRelation.DISJOINT;
+    }
+    if (contains(aX, aY) || contains(bX, bY)) {
+      return WithinRelation.NOTWITHIN;
+    }
+    if (ab == true && edgesIntersect(aX, aY, bX, bY)) {
       return WithinRelation.NOTWITHIN;
     }
     return WithinRelation.DISJOINT;

--- a/lucene/core/src/test/org/apache/lucene/document/TestLatLonShape.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLatLonShape.java
@@ -22,6 +22,7 @@ import static org.apache.lucene.geo.GeoEncodingUtils.encodeLatitude;
 import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
 
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import java.io.IOException;
 import org.apache.lucene.document.ShapeField.QueryRelation;
 import org.apache.lucene.geo.Circle;
 import org.apache.lucene.geo.Component2D;
@@ -915,24 +916,52 @@ public class TestLatLonShape extends LuceneTestCase {
     IOUtils.close(r, dir);
   }
 
-  public void testContainsIndexedGeometryCollection() throws Exception {
-    Directory dir = newDirectory();
-    RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+  public void testContainsGeometryCollectionIntersectsPoint() throws Exception {
     Polygon polygon =
         new Polygon(
             new double[] {-64, -64, 64, 64, -64}, new double[] {-132, 132, 132, -132, -132});
-    Field[] polygonFields = LatLonShape.createIndexableFields(FIELDNAME, polygon);
-    // POINT(5, 5) inside the indexed polygon
-    Field[] pointFields = LatLonShape.createIndexableFields(FIELDNAME, 5, 5);
+    doTestContainsGeometryCollectionIntersects(
+        LatLonShape.createIndexableFields(FIELDNAME, polygon),
+        // point inside the indexed polygon
+        LatLonShape.createIndexableFields(FIELDNAME, 5, 5));
+  }
+
+  public void testContainsGeometryCollectionIntersectsLine() throws Exception {
+    Polygon polygon =
+        new Polygon(
+            new double[] {-64, -64, 64, 64, -64}, new double[] {-132, 132, 132, -132, -132});
+    Line line = new Line(new double[] {5, 5.1}, new double[] {5, 5.1});
+    doTestContainsGeometryCollectionIntersects(
+        LatLonShape.createIndexableFields(FIELDNAME, polygon),
+        // Line inside the polygon
+        LatLonShape.createIndexableFields(FIELDNAME, line));
+  }
+
+  public void testContainsGeometryCollectionIntersectsPolygon() throws Exception {
+    Polygon polygon =
+        new Polygon(
+            new double[] {-64, -64, 64, 64, -64}, new double[] {-132, 132, 132, -132, -132});
+    Polygon polygonInside =
+        new Polygon(new double[] {5, 5, 5.1, 5.1, 5}, new double[] {5, 5.1, 5.1, 5, 5});
+    doTestContainsGeometryCollectionIntersects(
+        LatLonShape.createIndexableFields(FIELDNAME, polygon),
+        // this polygon is inside the other polygon
+        LatLonShape.createIndexableFields(FIELDNAME, polygonInside));
+  }
+
+  private void doTestContainsGeometryCollectionIntersects(
+      Field[] containsFields, Field[] intersectsField) throws IOException {
+    Directory dir = newDirectory();
+    RandomIndexWriter w = new RandomIndexWriter(random(), dir);
     int numDocs = random().nextInt(1000);
     // index the same multi geometry many times
     for (int i = 0; i < numDocs; i++) {
       Document doc = new Document();
-      for (Field f : polygonFields) {
+      for (Field f : containsFields) {
         doc.add(f);
       }
       for (int j = 0; j < 10; j++) {
-        for (Field f : pointFields) {
+        for (Field f : intersectsField) {
           doc.add(f);
         }
       }
@@ -946,8 +975,8 @@ public class TestLatLonShape extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
     // Contains is only true if the query geometry is inside a geometry and does not intersect with
     // any other geometry
-    // belonging to the same document. In this case the query geometry contains the indexed polygon
-    // but the point is
+    // belonging to the same document. In this case the query geometry contains the indexed fields
+    // but the intersectsFields are
     // inside the query as well, hence the result is 0.
     Polygon polygonQuery = new Polygon(new double[] {4, 4, 6, 6, 4}, new double[] {4, 6, 6, 4, 4});
     Query query = LatLonShape.newGeometryQuery(FIELDNAME, QueryRelation.CONTAINS, polygonQuery);


### PR DESCRIPTION
We can return different Within relationships for a document depending if the relationship is computed in a inner node or by traversing the leaf node:

1) If the document lies in an inner node that is fully contained in the query shape, the relationship returned is NOTWITHIN. 
2) If the document is visited by traversing the leaf node and the triangle / line / point is fully inside the query shape, we might return DISJOINT. 

This discrepancy can cause issues on edge cases: for example if the indexed shapes is a multi-shape with two geometries where one geometry is inside the other geometry,  and the query shape is inside one of the geometries by the second geometry is inside the query, then a contains query might return the document or not depending on how our triangles are stored on the tree.

This PR brings these behaviour together by making sure we always return NOTWITHIN for fully contained triangles.

cc: @nknize could you have a look?