### PR TITLE
(trivial) revice contributing.md?

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ For more information, consult with the help task: this will show the main tasks 
 
 ### Code formatting and checks
 
-Please make sure that all unit tests and validations succeed before constructing your patch. There are various commands to format/check the code; type this to show typical workflow tasks.
+Please make sure that all unit tests and validations succeed before constructing your patch. There are various commands to format/check the code; type this to show typical workflow tasks ([help/workflow.txt](./help/workflow.txt)).
 
 ```
 ./gradlew helpWorkflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,6 @@ Be sure that you are using an appropriate version of the JDK. Please check [READ
 
 Lucene uses [Gradle](https://gradle.org/) for build control. Gradle is itself Java-based and may be incompatible with newer Java versions; you can still build and test Lucene with these Java releases, see [jvms.txt](./help/jvms.txt) for more information.
 
-Run "./gradlew help", this will show the main tasks that can be executed to show help sub-topics.
-
 If you want to build Lucene, type:
 
 ```
@@ -45,23 +43,25 @@ NOTE: DO NOT use the `gradle` command that is perhaps installed on your machine.
 
 The first time you run gradlew, it will create a file "gradle.properties" that contains machine-specific settings. Normally you can use this file as-is, but it can be modified if necessary.
 
-`./gradlew check` will assemble Lucene and run all validation
-  tasks (including tests).
-
-`./gradlew help` will print a list of help guides that introduce and explain
-  various parts of the build system, including typical workflow tasks.
-
 If you want to just build the documentation, type:
 
 ```
 ./gradlew documentation
 ```
 
-### Checks
+For more information, consult with the help task: this will show the main tasks that can be executed to show help sub-topics.
 
-Please make sure that all unit tests and validations succeed before constructing your patch: `./gradlew check`. If you've modified any sources, run `./gradlew tidy` to apply code formatting conventions automatically (see [help/formatting.txt](https://github.com/apache/lucene/blob/main/help/formatting.txt)).
+```
+./gradlew help
+```
 
-To run a single test case from the lucene/core directory in your working copy:  `./gradlew -p lucene/core test --tests NameOfYourUnitTest`. Run `./gradlew helpTests` to get more information about running tests.
+### Code formatting and checks
+
+Please make sure that all unit tests and validations succeed before constructing your patch. There are various commands to format/check the code; type this to show typical workflow tasks.
+
+```
+./gradlew helpWorkflow
+```
 
 In case your contribution fixes a bug, please create a new test case that fails before your fix, to show the presence of the bug and ensure it never re-occurs. A test case showing the presence of a bug is also a good contribution by itself.
 


### PR DESCRIPTION
This kind of documentation tends to become bloated.
I think it might be good if we maintain only files in [lucene/help](https://github.com/apache/lucene/tree/main/help) and make the guide include just links to proper help docs, instead of adding specific commands to it as needed? It can't cover various use-cases anyway...

You can check this for a preview:
https://github.com/mocobeta/lucene/blob/slimdown-contributing-guide/CONTRIBUTING.md

