### PR TITLE
Add some basic tasks to help/workflow

### DIFF
--- a/help/workflow.txt
+++ b/help/workflow.txt
@@ -33,6 +33,9 @@ local maven repository for inspection:
 gradlew mavenLocal
 ls -R build/maven-local/
 
+Assemble Javdocs on a module:
+gradlew -p lucene/core javadoc
+ls lucene/core/build/docs
 
 Assemble entire documentation (including javadocs):
 gradlew documentation

--- a/help/workflow.txt
+++ b/help/workflow.txt
@@ -25,10 +25,18 @@ Assemble a single module's JAR (here for lucene-core):
 gradlew -p lucene/core assemble
 ls lucene/core/build/libs
 
+Assemble all JARs:
+gradlew assemble
+
 Create all distributable packages, POMs, etc. and create a
 local maven repository for inspection:
 gradlew mavenLocal
 ls -R build/maven-local/
+
+
+Assemble entire documentation (including javadocs):
+gradlew documentation
+ls lucene/documentation/build/site
 
 
 Other validation and checks

--- a/help/workflow.txt
+++ b/help/workflow.txt
@@ -25,7 +25,7 @@ Assemble a single module's JAR (here for lucene-core):
 gradlew -p lucene/core assemble
 ls lucene/core/build/libs
 
-Assemble all JARs:
+Assemble all Lucene artifacts (JARs, and so on):
 gradlew assemble
 
 Create all distributable packages, POMs, etc. and create a


### PR DESCRIPTION
They might be worth adding to `help/workflow.txt`, and to me, it'd be great if we make this file a single entry point for every developer. e.g., we can just add a link to it from https://github.com/apache/lucene/blob/main/CONTRIBUTING.md instead of explaining each grade command to readers.