### PR TITLE
LUCENE-10482 Bug Fix: Don't use Instant.now() as prefix for the temp dir name

### DIFF
--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestAlwaysRefreshDirectoryTaxonomyReader.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestAlwaysRefreshDirectoryTaxonomyReader.java
@@ -21,7 +21,6 @@ import static org.apache.lucene.tests.mockfile.ExtrasFS.isExtra;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.List;
 import java.util.function.Function;
 import org.apache.lucene.facet.FacetTestCase;

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestAlwaysRefreshDirectoryTaxonomyReader.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestAlwaysRefreshDirectoryTaxonomyReader.java
@@ -53,7 +53,7 @@ public class TestAlwaysRefreshDirectoryTaxonomyReader extends FacetTestCase {
   private <T extends Throwable> void testAlwaysRefreshDirectoryTaxonomyReader(
       Function<Directory, DirectoryTaxonomyReader> dtrProducer, Class<T> exceptionType)
       throws IOException {
-    final Path taxoPath1 = createTempDir(String.valueOf(Instant.now()));
+    final Path taxoPath1 = createTempDir();
     final Directory dir1 = newFSDirectory(taxoPath1);
 
     final DirectoryTaxonomyWriter tw1 =
@@ -61,7 +61,7 @@ public class TestAlwaysRefreshDirectoryTaxonomyReader extends FacetTestCase {
     tw1.addCategory(new FacetLabel("a"));
     tw1.commit(); // commit1
 
-    final Path taxoPath2 = createTempDir(String.valueOf(Instant.now()));
+    final Path taxoPath2 = createTempDir();
     final Directory commit1 = newFSDirectory(taxoPath2);
     // copy all index files from dir1
     for (String file : dir1.listAll()) {


### PR DESCRIPTION
Tests in Windows are failing because of an invalid `:` character in the directory name. 

Full stack trace and the comment which detected the issue: https://github.com/apache/lucene/pull/762#issuecomment-1100941707
Previous PR: https://github.com/apache/lucene/pull/762

# Solution

Rely on the default implementation of `createTempDir`

# Tests

Multiple runs of the `testAlwaysRefreshDirectoryTaxonomyReader` test through the IDE on a Mac.

---

I'll also submit a fix for the backported commit once this one gets merged.
Apologies again.

cc: @uschindler @mikemccand 
