### PR TITLE
LUCENE-10519: Improvement for CloseableThreadLocal

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/CloseableThreadLocal.java
+++ b/lucene/core/src/java/org/apache/lucene/util/CloseableThreadLocal.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.util;
 
 import java.io.Closeable;
-import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;

--- a/lucene/core/src/java/org/apache/lucene/util/CloseableThreadLocal.java
+++ b/lucene/core/src/java/org/apache/lucene/util/CloseableThreadLocal.java
@@ -86,7 +86,6 @@ public class CloseableThreadLocal<T> implements Closeable {
       perThreadValues.put(Thread.currentThread(), object);
       maybePurge();
     }
-
   }
 
   private void maybePurge() {
@@ -132,13 +131,12 @@ public class CloseableThreadLocal<T> implements Closeable {
     }
   }
 
-
   /**
    * Visible to test.
    *
    * @return per-thread values map.
    */
-  Map<String,T> getValuesAfterPurge() {
+  Map<String, T> getValuesAfterPurge() {
     Map<String, T> values = new HashMap<>();
     synchronized (lock) {
       purge();

--- a/lucene/core/src/java/org/apache/lucene/util/CloseableThreadLocal.java
+++ b/lucene/core/src/java/org/apache/lucene/util/CloseableThreadLocal.java
@@ -18,6 +18,7 @@ package org.apache.lucene.util;
 
 import java.io.Closeable;
 import java.lang.ref.WeakReference;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;

--- a/lucene/core/src/test/org/apache/lucene/util/TestCloseableThreadLocal.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestCloseableThreadLocal.java
@@ -55,8 +55,8 @@ public class TestCloseableThreadLocal extends LuceneTestCase {
   public void testSetGetValueWithMultiThreads() {
     final int CONCURRENT_THREADS = 5;
     final int LOOPS = 10000;
-    final CloseableThreadLocal<String> ctl1 = new CloseableThreadLocal();
-    final CloseableThreadLocal<Integer> ctl2 = new CloseableThreadLocal();
+    final CloseableThreadLocal<String> ctl1 = new CloseableThreadLocal<>();
+    final CloseableThreadLocal<Integer> ctl2 = new CloseableThreadLocal<>();
 
     final Thread[] threads = new Thread[CONCURRENT_THREADS];
     final AtomicBoolean[] results = new AtomicBoolean[CONCURRENT_THREADS];

--- a/lucene/core/src/test/org/apache/lucene/util/TestCloseableThreadLocal.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestCloseableThreadLocal.java
@@ -18,6 +18,8 @@ package org.apache.lucene.util;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class TestCloseableThreadLocal extends LuceneTestCase {
   public static final String TEST_VALUE = "initvaluetest";
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestCloseableThreadLocal.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestCloseableThreadLocal.java
@@ -94,6 +94,7 @@ public class TestCloseableThreadLocal extends LuceneTestCase {
       try {
         t.join();
       } catch (InterruptedException e) {
+        fail("Got interrupted due to " + e.getMessage());
       }
     }
     for (AtomicBoolean r : results) {

--- a/lucene/core/src/test/org/apache/lucene/util/TestCloseableThreadLocal.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestCloseableThreadLocal.java
@@ -48,4 +48,65 @@ public class TestCloseableThreadLocal extends LuceneTestCase {
       return TEST_VALUE;
     }
   }
+
+
+  public void testSetGetValueWithMultiThreads() {
+    final int CONCURRENT_THREADS = 5;
+    final int LOOPS = 10000;
+    final CloseableThreadLocal<String> ctl1 = new CloseableThreadLocal();
+    final CloseableThreadLocal<Integer> ctl2 = new CloseableThreadLocal();
+
+    final Thread[] threads = new Thread[CONCURRENT_THREADS];
+    final AtomicBoolean[] results = new AtomicBoolean[CONCURRENT_THREADS];
+    for (int i = 0; i < CONCURRENT_THREADS; i++) {
+      final String TNAME = "T-" + i;
+      final int BASE = (i + 1) * 100000;
+      AtomicBoolean result = new AtomicBoolean(true);
+      results[i] = result;
+
+      threads[i] = new Thread(() -> {
+        String lastValue1 = null;
+        int lastValue2 = -1;
+        for (int j = 0; j < LOOPS; j++) {
+          if (j > 0) {
+            if (!lastValue1.equals(ctl1.get()) || ctl2.get() != lastValue2) {
+              result.set(false);
+              break;
+            }
+          }
+
+          String value1 = TNAME + "-" + j;
+          int value2 = BASE + j;
+          ctl1.set(value1);
+          ctl2.set(value2);
+
+          lastValue1 = value1;
+          lastValue2 = value2;
+        }
+
+      });
+      threads[i].setName(TNAME);
+      threads[i].start();
+    }
+    for (Thread t : threads) {
+      try {
+        t.join();
+      } catch (InterruptedException e) {
+      }
+    }
+    for (AtomicBoolean r : results) {
+      assertTrue(r.get());
+    }
+
+    // Set Value from current thread.
+    ctl1.set("Value-FromCurrentThread");
+    ctl2.set(123456789);
+
+    // Check values after force purge. Expecting all the dead threads values get cleared except current thread.
+    assertEquals(1, ctl1.getValuesAfterPurge().size());
+    assertEquals(1, ctl2.getValuesAfterPurge().size());
+
+    ctl1.close();
+    ctl2.close();
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestCloseableThreadLocal.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestCloseableThreadLocal.java
@@ -16,9 +16,8 @@
  */
 package org.apache.lucene.util;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
-
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestCloseableThreadLocal extends LuceneTestCase {
   public static final String TEST_VALUE = "initvaluetest";
@@ -51,7 +50,6 @@ public class TestCloseableThreadLocal extends LuceneTestCase {
     }
   }
 
-
   public void testSetGetValueWithMultiThreads() {
     final int CONCURRENT_THREADS = 5;
     final int LOOPS = 10000;
@@ -66,27 +64,28 @@ public class TestCloseableThreadLocal extends LuceneTestCase {
       AtomicBoolean result = new AtomicBoolean(true);
       results[i] = result;
 
-      threads[i] = new Thread(() -> {
-        String lastValue1 = null;
-        int lastValue2 = -1;
-        for (int j = 0; j < LOOPS; j++) {
-          if (j > 0) {
-            if (!lastValue1.equals(ctl1.get()) || ctl2.get() != lastValue2) {
-              result.set(false);
-              break;
-            }
-          }
+      threads[i] =
+          new Thread(
+              () -> {
+                String lastValue1 = null;
+                int lastValue2 = -1;
+                for (int j = 0; j < LOOPS; j++) {
+                  if (j > 0) {
+                    if (!lastValue1.equals(ctl1.get()) || ctl2.get() != lastValue2) {
+                      result.set(false);
+                      break;
+                    }
+                  }
 
-          String value1 = TNAME + "-" + j;
-          int value2 = BASE + j;
-          ctl1.set(value1);
-          ctl2.set(value2);
+                  String value1 = TNAME + "-" + j;
+                  int value2 = BASE + j;
+                  ctl1.set(value1);
+                  ctl2.set(value2);
 
-          lastValue1 = value1;
-          lastValue2 = value2;
-        }
-
-      });
+                  lastValue1 = value1;
+                  lastValue2 = value2;
+                }
+              });
       threads[i].setName(TNAME);
       threads[i].start();
     }
@@ -105,7 +104,8 @@ public class TestCloseableThreadLocal extends LuceneTestCase {
     ctl1.set("Value-FromCurrentThread");
     ctl2.set(123456789);
 
-    // Check values after force purge. Expecting all the dead threads values get cleared except current thread.
+    // Check values after force purge. Expecting all the dead threads values get cleared except
+    // current thread.
     assertEquals(1, ctl1.getValuesAfterPurge().size());
     assertEquals(1, ctl2.getValuesAfterPurge().size());
 


### PR DESCRIPTION
See also: https://issues.apache.org/jira/browse/LUCENE-10519

#11555

Solution
---
We don't need to store entry twice in the hardRefs And ThreadLocals. Remove ThreadLocal from CloseableThreadLocal so that we would not be affected by the serious flaw of Java's built-in ThreadLocal.