### PR TITLE
improve spotless error to suggest running 'gradlew tidy'

### DIFF
--- a/gradle/validation/spotless.gradle
+++ b/gradle/validation/spotless.gradle
@@ -114,6 +114,6 @@ configure(project(":lucene").subprojects) { prj ->
 
 gradle.taskGraph.afterTask { Task task, TaskState state ->
   if (task.name == 'spotlessJavaCheck' && state.failure) {
-    throw new GradleException("\n***************************\n*PLEASE RUN ./gradle tidy!*\n***************************");
+    throw new GradleException("\n****************************\n*PLEASE RUN ./gradlew tidy!*\n****************************");
   }
 }

--- a/gradle/validation/spotless.gradle
+++ b/gradle/validation/spotless.gradle
@@ -111,3 +111,9 @@ configure(project(":lucene").subprojects) { prj ->
     v.dependsOn ":checkJdkInternalsExportedToGradle"
   }
 }
+
+gradle.taskGraph.afterTask { Task task, TaskState state ->
+  if (task.name == 'spotlessJavaCheck' && state.failure) {
+    throw new GradleException("\n***************************\n*PLEASE RUN ./gradle tidy!*\n***************************");
+  }
+}


### PR DESCRIPTION
The current error isn't helpful as it suggests a per-module command. If the user has modified multiple modules, they will be running gradle
commands to try to fix each one of them, when it would be easier to just run 'gradlew tidy' a single time and fix everything.

![Screen_Shot_2022-04-18_at_11 15 06](https://user-images.githubusercontent.com/504194/163830917-e9b326db-ef27-4c5c-941c-7fa61139c090.png)
