### PR TITLE
Fix incorrect docs in README.md: it must be java 17 exactly, java 18 does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ comprehensive documentation, visit:
 
 ### Basic steps:
   
-1. Install OpenJDK 17 (or greater).
+1. Install OpenJDK 17 (exactly this version).
 2. Clone Lucene's git repository (or download the source distribution).
 3. Run gradle launcher script (`gradlew`).
 


### PR DESCRIPTION
These instructions tell the user to install 17 (or greater), then run `./gradlew`. This will not actually work if they install something greater than java 17.