### PR TITLE
LUCENE-10526: add single method to mockfile to wrap a Path

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -142,7 +142,8 @@ Build
 
 Other
 ---------------------
-(No changes)
+* LUCENE-10526: Test-framework: Add FilterFileSystemProvider.wrapPath(Path) method for mock filesystems
+  to override if they need to extend the Path implementation. (Gautam Worah, Robert Muir)
 
 ======================= Lucene 9.1.0 =======================
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -27,8 +27,6 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.net.URI;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -1272,8 +1270,7 @@ public class TestIndexWriter extends LuceneTestCase {
       // relies on windows semantics
       Path path = createTempDir();
       WindowsFS provider = new WindowsFS(path.getFileSystem());
-      FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-      Path indexPath = provider.wrapPath(path, fs);
+      Path indexPath = provider.wrapPath(path);
 
       // NOTE: on Unix, we cannot use MMapDir, because WindowsFS doesn't see/think it keeps file
       // handles open.  Yet, on Windows, we MUST use
@@ -2808,8 +2805,7 @@ public class TestIndexWriter extends LuceneTestCase {
 
     // Use WindowsFS to prevent open files from being deleted:
     WindowsFS provider = new WindowsFS(path.getFileSystem());
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    Path root = provider.wrapPath(path, fs);
+    Path root = provider.wrapPath(path);
 
     // MMapDirectory doesn't work because it closes its file handles after mapping!
     List<Closeable> toClose = new ArrayList<>();
@@ -2881,8 +2877,7 @@ public class TestIndexWriter extends LuceneTestCase {
 
     // Use WindowsFS to prevent open files from being deleted:
     WindowsFS provider = new WindowsFS(path.getFileSystem());
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    Path root = provider.wrapPath(path, fs);
+    Path root = provider.wrapPath(path);
     try (FSDirectory _dir = new NIOFSDirectory(root)) {
       Directory dir = new FilterDirectory(_dir) {};
 
@@ -2921,8 +2916,7 @@ public class TestIndexWriter extends LuceneTestCase {
 
     // Use WindowsFS to prevent open files from being deleted:
     WindowsFS provider = new WindowsFS(path.getFileSystem());
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    Path root = provider.wrapPath(path, fs);
+    Path root = provider.wrapPath(path);
     IndexCommit indexCommit;
     DirectoryReader reader;
     // MMapDirectory doesn't work because it closes its file handles after mapping!
@@ -2977,8 +2971,7 @@ public class TestIndexWriter extends LuceneTestCase {
 
     // Use WindowsFS to prevent open files from being deleted:
     WindowsFS provider = new WindowsFS(path.getFileSystem());
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    Path root = provider.wrapPath(path, fs);
+    Path root = provider.wrapPath(path);
     // MMapDirectory doesn't work because it closes its file handles after mapping!
     try (FSDirectory dir = new NIOFSDirectory(root)) {
       IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -100,7 +100,6 @@ import org.apache.lucene.tests.analysis.Token;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.index.SuppressingConcurrentMergeScheduler;
 import org.apache.lucene.tests.mockfile.ExtrasFS;
-import org.apache.lucene.tests.mockfile.FilterPath;
 import org.apache.lucene.tests.mockfile.WindowsFS;
 import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.tests.store.MockDirectoryWrapper;
@@ -1272,8 +1271,9 @@ public class TestIndexWriter extends LuceneTestCase {
     for (int iter = 0; iter < 2; iter++) {
       // relies on windows semantics
       Path path = createTempDir();
-      FileSystem fs = new WindowsFS(path.getFileSystem()).getFileSystem(URI.create("file:///"));
-      Path indexPath = new FilterPath(path, fs);
+      WindowsFS provider = new WindowsFS(path.getFileSystem());
+      FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+      Path indexPath = provider.wrapPath(path, fs);
 
       // NOTE: on Unix, we cannot use MMapDir, because WindowsFS doesn't see/think it keeps file
       // handles open.  Yet, on Windows, we MUST use
@@ -2807,8 +2807,9 @@ public class TestIndexWriter extends LuceneTestCase {
     Path path = createTempDir();
 
     // Use WindowsFS to prevent open files from being deleted:
-    FileSystem fs = new WindowsFS(path.getFileSystem()).getFileSystem(URI.create("file:///"));
-    Path root = new FilterPath(path, fs);
+    WindowsFS provider = new WindowsFS(path.getFileSystem());
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    Path root = provider.wrapPath(path, fs);
 
     // MMapDirectory doesn't work because it closes its file handles after mapping!
     List<Closeable> toClose = new ArrayList<>();
@@ -2879,8 +2880,9 @@ public class TestIndexWriter extends LuceneTestCase {
     Path path = createTempDir();
 
     // Use WindowsFS to prevent open files from being deleted:
-    FileSystem fs = new WindowsFS(path.getFileSystem()).getFileSystem(URI.create("file:///"));
-    Path root = new FilterPath(path, fs);
+    WindowsFS provider = new WindowsFS(path.getFileSystem());
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    Path root = provider.wrapPath(path, fs);
     try (FSDirectory _dir = new NIOFSDirectory(root)) {
       Directory dir = new FilterDirectory(_dir) {};
 
@@ -2918,8 +2920,9 @@ public class TestIndexWriter extends LuceneTestCase {
     Path path = createTempDir();
 
     // Use WindowsFS to prevent open files from being deleted:
-    FileSystem fs = new WindowsFS(path.getFileSystem()).getFileSystem(URI.create("file:///"));
-    Path root = new FilterPath(path, fs);
+    WindowsFS provider = new WindowsFS(path.getFileSystem());
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    Path root = provider.wrapPath(path, fs);
     IndexCommit indexCommit;
     DirectoryReader reader;
     // MMapDirectory doesn't work because it closes its file handles after mapping!
@@ -2973,8 +2976,9 @@ public class TestIndexWriter extends LuceneTestCase {
     assumeFalse("windows is not supported", Constants.WINDOWS);
 
     // Use WindowsFS to prevent open files from being deleted:
-    FileSystem fs = new WindowsFS(path.getFileSystem()).getFileSystem(URI.create("file:///"));
-    Path root = new FilterPath(path, fs);
+    WindowsFS provider = new WindowsFS(path.getFileSystem());
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    Path root = provider.wrapPath(path, fs);
     // MMapDirectory doesn't work because it closes its file handles after mapping!
     try (FSDirectory dir = new NIOFSDirectory(root)) {
       IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));

--- a/lucene/core/src/test/org/apache/lucene/store/TestFileSwitchDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestFileSwitchDirectory.java
@@ -34,7 +34,6 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.TestIndexWriterReader;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
-import org.apache.lucene.tests.mockfile.FilterPath;
 import org.apache.lucene.tests.mockfile.WindowsFS;
 import org.apache.lucene.tests.store.BaseDirectoryTestCase;
 import org.apache.lucene.tests.store.MockDirectoryWrapper;
@@ -180,8 +179,9 @@ public class TestFileSwitchDirectory extends BaseDirectoryTestCase {
     // relies on windows semantics
     Path path = createTempDir();
     assumeFalse("Irony we seem to not emulate windows well enough", Constants.WINDOWS);
-    FileSystem fs = new WindowsFS(path.getFileSystem()).getFileSystem(URI.create("file:///"));
-    Path indexPath = new FilterPath(path, fs);
+    WindowsFS provider = new WindowsFS(path.getFileSystem());
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    Path indexPath = provider.wrapPath(path, fs);
     try (final FileSwitchDirectory dir =
         new FileSwitchDirectory(
             Collections.singleton("tim"),

--- a/lucene/core/src/test/org/apache/lucene/store/TestFileSwitchDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestFileSwitchDirectory.java
@@ -17,9 +17,7 @@
 package org.apache.lucene.store;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.AtomicMoveNotSupportedException;
-import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -180,8 +178,7 @@ public class TestFileSwitchDirectory extends BaseDirectoryTestCase {
     Path path = createTempDir();
     assumeFalse("Irony we seem to not emulate windows well enough", Constants.WINDOWS);
     WindowsFS provider = new WindowsFS(path.getFileSystem());
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    Path indexPath = provider.wrapPath(path, fs);
+    Path indexPath = provider.wrapPath(path);
     try (final FileSwitchDirectory dir =
         new FileSwitchDirectory(
             Collections.singleton("tim"),

--- a/lucene/core/src/test/org/apache/lucene/store/TestNIOFSDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestNIOFSDirectory.java
@@ -25,7 +25,6 @@ import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
 import java.util.Set;
 import org.apache.lucene.tests.mockfile.FilterFileChannel;
-import org.apache.lucene.tests.mockfile.FilterPath;
 import org.apache.lucene.tests.mockfile.LeakFS;
 import org.apache.lucene.tests.store.BaseDirectoryTestCase;
 
@@ -54,7 +53,7 @@ public class TestNIOFSDirectory extends BaseDirectoryTestCase {
           }
         };
     FileSystem fs = leakFS.getFileSystem(URI.create("file:///"));
-    Path wrapped = new FilterPath(path, fs);
+    Path wrapped = leakFS.wrapPath(path, fs);
     try (Directory dir = new NIOFSDirectory(wrapped)) {
       try (IndexOutput out = dir.createOutput("test.bin", IOContext.DEFAULT)) {
         out.writeString("hello");

--- a/lucene/core/src/test/org/apache/lucene/store/TestNIOFSDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestNIOFSDirectory.java
@@ -17,9 +17,7 @@
 package org.apache.lucene.store;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.channels.FileChannel;
-import java.nio.file.FileSystem;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
@@ -52,8 +50,7 @@ public class TestNIOFSDirectory extends BaseDirectoryTestCase {
             };
           }
         };
-    FileSystem fs = leakFS.getFileSystem(URI.create("file:///"));
-    Path wrapped = leakFS.wrapPath(path, fs);
+    Path wrapped = leakFS.wrapPath(path);
     try (Directory dir = new NIOFSDirectory(wrapped)) {
       try (IndexOutput out = dir.createOutput("test.bin", IOContext.DEFAULT)) {
         out.writeString("hello");

--- a/lucene/core/src/test/org/apache/lucene/util/TestIOUtils.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestIOUtils.java
@@ -125,10 +125,10 @@ public class TestIOUtils extends LuceneTestCase {
 
   public void testFsyncAccessDeniedOpeningDirectory() throws Exception {
     final Path path = createTempDir().toRealPath();
-    final FileSystem fs =
-        new AccessDeniedWhileOpeningDirectoryFileSystem(path.getFileSystem())
-            .getFileSystem(URI.create("file:///"));
-    final Path wrapped = new FilterPath(path, fs);
+    final FilterFileSystemProvider provider =
+        new AccessDeniedWhileOpeningDirectoryFileSystem(path.getFileSystem());
+    final FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    final Path wrapped = provider.wrapPath(path, fs);
     if (Constants.WINDOWS) {
       // no exception, we early return and do not even try to open the directory
       IOUtils.fsync(wrapped, true);

--- a/lucene/core/src/test/org/apache/lucene/util/TestIOUtils.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestIOUtils.java
@@ -18,7 +18,6 @@ package org.apache.lucene.util;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URI;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
@@ -127,8 +126,7 @@ public class TestIOUtils extends LuceneTestCase {
     final Path path = createTempDir().toRealPath();
     final FilterFileSystemProvider provider =
         new AccessDeniedWhileOpeningDirectoryFileSystem(path.getFileSystem());
-    final FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    final Path wrapped = provider.wrapPath(path, fs);
+    final Path wrapped = provider.wrapPath(path);
     if (Constants.WINDOWS) {
       // no exception, we early return and do not even try to open the directory
       IOUtils.fsync(wrapped, true);

--- a/lucene/misc/src/test/org/apache/lucene/misc/store/TestHardLinkCopyDirectoryWrapper.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/store/TestHardLinkCopyDirectoryWrapper.java
@@ -18,8 +18,6 @@
 package org.apache.lucene.misc.store;
 
 import java.io.IOException;
-import java.net.URI;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -111,9 +109,8 @@ public class TestHardLinkCopyDirectoryWrapper extends BaseDirectoryTestCase {
     assumeFalse("windows is not supported", Constants.WINDOWS);
     Path path = createTempDir();
     WindowsFS provider = new WindowsFS(path.getFileSystem());
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    Directory dir1 = new NIOFSDirectory(provider.wrapPath(path, fs));
-    Directory dir2 = new NIOFSDirectory(provider.wrapPath(path.resolve("link"), fs));
+    Directory dir1 = new NIOFSDirectory(provider.wrapPath(path));
+    Directory dir2 = new NIOFSDirectory(provider.wrapPath(path.resolve("link")));
 
     IndexOutput target = dir1.createOutput("target.txt", IOContext.DEFAULT);
     target.writeInt(1);

--- a/lucene/misc/src/test/org/apache/lucene/misc/store/TestHardLinkCopyDirectoryWrapper.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/store/TestHardLinkCopyDirectoryWrapper.java
@@ -33,7 +33,6 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.NIOFSDirectory;
-import org.apache.lucene.tests.mockfile.FilterPath;
 import org.apache.lucene.tests.mockfile.WindowsFS;
 import org.apache.lucene.tests.store.BaseDirectoryTestCase;
 import org.apache.lucene.util.Constants;
@@ -111,9 +110,10 @@ public class TestHardLinkCopyDirectoryWrapper extends BaseDirectoryTestCase {
     // irony: currently we don't emulate windows well enough to work on windows!
     assumeFalse("windows is not supported", Constants.WINDOWS);
     Path path = createTempDir();
-    FileSystem fs = new WindowsFS(path.getFileSystem()).getFileSystem(URI.create("file:///"));
-    Directory dir1 = new NIOFSDirectory(new FilterPath(path, fs));
-    Directory dir2 = new NIOFSDirectory(new FilterPath(path.resolve("link"), fs));
+    WindowsFS provider = new WindowsFS(path.getFileSystem());
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    Directory dir1 = new NIOFSDirectory(provider.wrapPath(path, fs));
+    Directory dir2 = new NIOFSDirectory(provider.wrapPath(path.resolve("link"), fs));
 
     IndexOutput target = dir1.createOutput("target.txt", IOContext.DEFAULT);
     target.writeInt(1);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterDirectoryStream.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterDirectoryStream.java
@@ -18,7 +18,6 @@ package org.apache.lucene.tests.mockfile;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
-import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Objects;
@@ -34,7 +33,7 @@ public class FilterDirectoryStream implements DirectoryStream<Path> {
   protected final DirectoryStream<Path> delegate;
 
   /** The underlying {@code FileSystem} instance. */
-  protected final FileSystem fileSystem;
+  protected final FilterFileSystem fileSystem;
 
   /**
    * Construct a {@code FilterDirectoryStream} based on the specified base stream.
@@ -43,7 +42,7 @@ public class FilterDirectoryStream implements DirectoryStream<Path> {
    *
    * @param delegate specified base stream.
    */
-  public FilterDirectoryStream(DirectoryStream<Path> delegate, FileSystem fileSystem) {
+  public FilterDirectoryStream(DirectoryStream<Path> delegate, FilterFileSystem fileSystem) {
     this.delegate = Objects.requireNonNull(delegate);
     this.fileSystem = Objects.requireNonNull(fileSystem);
   }
@@ -64,7 +63,7 @@ public class FilterDirectoryStream implements DirectoryStream<Path> {
 
       @Override
       public Path next() {
-        return new FilterPath(delegateIterator.next(), fileSystem);
+        return fileSystem.parent.wrapPath(delegateIterator.next(), fileSystem);
       }
 
       @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterDirectoryStream.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterDirectoryStream.java
@@ -63,7 +63,7 @@ public class FilterDirectoryStream implements DirectoryStream<Path> {
 
       @Override
       public Path next() {
-        return fileSystem.parent.wrapPath(delegateIterator.next(), fileSystem);
+        return fileSystem.parent.wrapPath(delegateIterator.next());
       }
 
       @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterFileSystem.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterFileSystem.java
@@ -36,7 +36,7 @@ import java.util.Set;
 public class FilterFileSystem extends FileSystem {
 
   /** FileSystemProvider that created this FilterFileSystem */
-  protected final FilterFileSystemProvider parent;
+  public final FilterFileSystemProvider parent;
 
   /** The underlying {@code FileSystem} instance. */
   protected final FileSystem delegate;
@@ -100,7 +100,7 @@ public class FilterFileSystem extends FileSystem {
 
         @Override
         public Path next() {
-          return new FilterPath(iterator.next(), FilterFileSystem.this);
+          return parent.wrapPath(iterator.next(), FilterFileSystem.this);
         }
 
         @Override
@@ -142,7 +142,7 @@ public class FilterFileSystem extends FileSystem {
 
   @Override
   public Path getPath(String first, String... more) {
-    return new FilterPath(delegate.getPath(first, more), this);
+    return parent.wrapPath(delegate.getPath(first, more), this);
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterFileSystem.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterFileSystem.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.WatchService;
 import java.nio.file.attribute.UserPrincipalLookupService;
-import java.nio.file.spi.FileSystemProvider;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
@@ -36,7 +35,7 @@ import java.util.Set;
 public class FilterFileSystem extends FileSystem {
 
   /** FileSystemProvider that created this FilterFileSystem */
-  public final FilterFileSystemProvider parent;
+  protected final FilterFileSystemProvider parent;
 
   /** The underlying {@code FileSystem} instance. */
   protected final FileSystem delegate;
@@ -55,7 +54,7 @@ public class FilterFileSystem extends FileSystem {
   }
 
   @Override
-  public FileSystemProvider provider() {
+  public FilterFileSystemProvider provider() {
     return parent;
   }
 
@@ -100,7 +99,7 @@ public class FilterFileSystem extends FileSystem {
 
         @Override
         public Path next() {
-          return parent.wrapPath(iterator.next(), FilterFileSystem.this);
+          return parent.wrapPath(iterator.next());
         }
 
         @Override
@@ -142,7 +141,7 @@ public class FilterFileSystem extends FileSystem {
 
   @Override
   public Path getPath(String first, String... more) {
-    return parent.wrapPath(delegate.getPath(first, more), this);
+    return parent.wrapPath(delegate.getPath(first, more));
   }
 
   @Override
@@ -169,10 +168,5 @@ public class FilterFileSystem extends FileSystem {
   /** Returns the {@code FileSystem} we wrap. */
   public FileSystem getDelegate() {
     return delegate;
-  }
-
-  /** Returns the {@code FilterFileSystemProvider} sent to this on init. */
-  public FileSystemProvider getParent() {
-    return parent;
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterFileSystemProvider.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterFileSystemProvider.java
@@ -116,11 +116,11 @@ public abstract class FilterFileSystemProvider extends FileSystemProvider {
     if (fileSystem == null) {
       throw new IllegalStateException("subclass did not initialize singleton filesystem");
     }
-    return wrapPath(delegate.getPath(uri), fileSystem);
+    return wrapPath(delegate.getPath(uri));
   }
 
   /** wraps a Path with provider-specific behavior */
-  public FilterPath wrapPath(Path path, FileSystem filesystem) {
+  public FilterPath wrapPath(Path path) {
     return new FilterPath(path, fileSystem);
   }
 
@@ -227,7 +227,7 @@ public abstract class FilterFileSystemProvider extends FileSystemProvider {
         new Filter<Path>() {
           @Override
           public boolean accept(Path entry) throws IOException {
-            return filter.accept(wrapPath(entry, fileSystem));
+            return filter.accept(wrapPath(entry));
           }
         };
     return new FilterDirectoryStream(

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterFileSystemProvider.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterFileSystemProvider.java
@@ -52,7 +52,7 @@ public abstract class FilterFileSystemProvider extends FileSystemProvider {
   /** The underlying {@code FileSystemProvider}. */
   protected final FileSystemProvider delegate;
   /** The underlying {@code FileSystem} instance. */
-  protected FileSystem fileSystem;
+  protected FilterFileSystem fileSystem;
   /** The URI scheme for this provider. */
   protected final String scheme;
 
@@ -116,7 +116,11 @@ public abstract class FilterFileSystemProvider extends FileSystemProvider {
     if (fileSystem == null) {
       throw new IllegalStateException("subclass did not initialize singleton filesystem");
     }
-    Path path = delegate.getPath(uri);
+    return wrapPath(delegate.getPath(uri), fileSystem);
+  }
+
+  /** wraps a Path with provider-specific behavior */
+  public FilterPath wrapPath(Path path, FileSystem filesystem) {
     return new FilterPath(path, fileSystem);
   }
 
@@ -223,7 +227,7 @@ public abstract class FilterFileSystemProvider extends FileSystemProvider {
         new Filter<Path>() {
           @Override
           public boolean accept(Path entry) throws IOException {
-            return filter.accept(new FilterPath(entry, fileSystem));
+            return filter.accept(wrapPath(entry, fileSystem));
           }
         };
     return new FilterDirectoryStream(

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterPath.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterPath.java
@@ -271,7 +271,7 @@ public class FilterPath implements Path, Unwrappable<Path> {
   }
 
   private final Path wrap(Path other) {
-    return fileSystem.parent.wrapPath(other, fileSystem);
+    return fileSystem.parent.wrapPath(other);
   }
 
   /** Override this to customize the unboxing of Path from various operations */

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterPath.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterPath.java
@@ -41,7 +41,7 @@ public class FilterPath implements Path, Unwrappable<Path> {
   protected final Path delegate;
 
   /** The parent {@code FileSystem} for this path. */
-  protected final FileSystem fileSystem;
+  protected final FilterFileSystem fileSystem;
 
   /**
    * Construct a {@code FilterPath} with parent {@code fileSystem}, based on the specified base
@@ -50,7 +50,7 @@ public class FilterPath implements Path, Unwrappable<Path> {
    * @param delegate specified base path.
    * @param fileSystem parent fileSystem.
    */
-  public FilterPath(Path delegate, FileSystem fileSystem) {
+  public FilterPath(Path delegate, FilterFileSystem fileSystem) {
     this.delegate = delegate;
     this.fileSystem = fileSystem;
   }
@@ -270,9 +270,8 @@ public class FilterPath implements Path, Unwrappable<Path> {
     return Unwrappable.unwrapAll(path);
   }
 
-  /** Override this to customize the return wrapped path from various operations */
-  protected Path wrap(Path other) {
-    return new FilterPath(other, fileSystem);
+  private final Path wrap(Path other) {
+    return fileSystem.parent.wrapPath(other, fileSystem);
   }
 
   /** Override this to customize the unboxing of Path from various operations */

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/HandleTrackingFS.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/HandleTrackingFS.java
@@ -293,7 +293,7 @@ public abstract class HandleTrackingFS extends FilterFileSystemProvider {
         new Filter<Path>() {
           @Override
           public boolean accept(Path entry) throws IOException {
-            return filter.accept(new FilterPath(entry, fileSystem));
+            return filter.accept(wrapPath(entry, fileSystem));
           }
         };
     DirectoryStream<Path> stream = delegate.newDirectoryStream(toDelegate(dir), wrappedFilter);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/HandleTrackingFS.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/HandleTrackingFS.java
@@ -293,7 +293,7 @@ public abstract class HandleTrackingFS extends FilterFileSystemProvider {
         new Filter<Path>() {
           @Override
           public boolean accept(Path entry) throws IOException {
-            return filter.accept(wrapPath(entry, fileSystem));
+            return filter.accept(wrapPath(entry));
           }
         };
     DirectoryStream<Path> stream = delegate.newDirectoryStream(toDelegate(dir), wrappedFilter);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -140,7 +140,6 @@ import org.apache.lucene.tests.index.MismatchedDirectoryReader;
 import org.apache.lucene.tests.index.MismatchedLeafReader;
 import org.apache.lucene.tests.index.MockIndexWriterEventListener;
 import org.apache.lucene.tests.index.MockRandomMergePolicy;
-import org.apache.lucene.tests.mockfile.FilterPath;
 import org.apache.lucene.tests.mockfile.VirusCheckingFS;
 import org.apache.lucene.tests.search.AssertingIndexSearcher;
 import org.apache.lucene.tests.store.BaseDirectoryWrapper;
@@ -1399,7 +1398,7 @@ public abstract class LuceneTestCase extends Assert {
     if (TestUtil.hasVirusChecker(path) == false) {
       VirusCheckingFS fs = new VirusCheckingFS(path.getFileSystem(), random().nextLong());
       FileSystem filesystem = fs.getFileSystem(URI.create("file:///"));
-      path = new FilterPath(path, filesystem);
+      path = fs.wrapPath(path, filesystem);
     }
     return path;
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -61,10 +61,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystem;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -1397,8 +1395,7 @@ public abstract class LuceneTestCase extends Assert {
   public static Path addVirusChecker(Path path) {
     if (TestUtil.hasVirusChecker(path) == false) {
       VirusCheckingFS fs = new VirusCheckingFS(path.getFileSystem(), random().nextLong());
-      FileSystem filesystem = fs.getFileSystem(URI.create("file:///"));
-      path = fs.wrapPath(path, filesystem);
+      path = fs.wrapPath(path);
     }
     return path;
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestUtil.java
@@ -1682,7 +1682,7 @@ public final class TestUtil {
       FileSystem fs = path.getFileSystem();
       while (fs instanceof FilterFileSystem) {
         FilterFileSystem ffs = (FilterFileSystem) fs;
-        if (ffs.getParent() instanceof WindowsFS) {
+        if (ffs.provider() instanceof WindowsFS) {
           return true;
         }
         fs = ffs.getDelegate();
@@ -1696,7 +1696,7 @@ public final class TestUtil {
     FileSystem fs = path.getFileSystem();
     while (fs instanceof FilterFileSystem) {
       FilterFileSystem ffs = (FilterFileSystem) fs;
-      if (ffs.getParent() instanceof WindowsFS) {
+      if (ffs.provider() instanceof WindowsFS) {
         return true;
       }
       fs = ffs.getDelegate();
@@ -1718,7 +1718,7 @@ public final class TestUtil {
     FileSystem fs = path.getFileSystem();
     while (fs instanceof FilterFileSystem) {
       FilterFileSystem ffs = (FilterFileSystem) fs;
-      if (ffs.getParent() instanceof VirusCheckingFS) {
+      if (ffs.provider() instanceof VirusCheckingFS) {
         return true;
       }
       fs = ffs.getDelegate();
@@ -1735,8 +1735,8 @@ public final class TestUtil {
       FileSystem fs = ((FSDirectory) dir).getDirectory().getFileSystem();
       while (fs instanceof FilterFileSystem) {
         FilterFileSystem ffs = (FilterFileSystem) fs;
-        if (ffs.getParent() instanceof VirusCheckingFS) {
-          VirusCheckingFS vfs = (VirusCheckingFS) ffs.getParent();
+        if (ffs.provider() instanceof VirusCheckingFS) {
+          VirusCheckingFS vfs = (VirusCheckingFS) ffs.provider();
           boolean isEnabled = vfs.isEnabled();
           vfs.disable();
           return isEnabled;
@@ -1755,8 +1755,8 @@ public final class TestUtil {
       FileSystem fs = ((FSDirectory) dir).getDirectory().getFileSystem();
       while (fs instanceof FilterFileSystem) {
         FilterFileSystem ffs = (FilterFileSystem) fs;
-        if (ffs.getParent() instanceof VirusCheckingFS) {
-          VirusCheckingFS vfs = (VirusCheckingFS) ffs.getParent();
+        if (ffs.provider() instanceof VirusCheckingFS) {
+          VirusCheckingFS vfs = (VirusCheckingFS) ffs.provider();
           vfs.enable();
           return;
         }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestDisableFsyncFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestDisableFsyncFS.java
@@ -28,8 +28,9 @@ public class TestDisableFsyncFS extends MockFileSystemTestCase {
 
   @Override
   protected Path wrap(Path path) {
-    FileSystem fs = new DisableFsyncFS(path.getFileSystem()).getFileSystem(URI.create("file:///"));
-    return new FilterPath(path, fs);
+    DisableFsyncFS provider = new DisableFsyncFS(path.getFileSystem());
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    return provider.wrapPath(path, fs);
   }
 
   /** Test that we don't corrumpt fsync: it just doesnt happen */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestDisableFsyncFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestDisableFsyncFS.java
@@ -16,10 +16,8 @@
  */
 package org.apache.lucene.tests.mockfile;
 
-import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
@@ -29,8 +27,7 @@ public class TestDisableFsyncFS extends MockFileSystemTestCase {
   @Override
   protected Path wrap(Path path) {
     DisableFsyncFS provider = new DisableFsyncFS(path.getFileSystem());
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    return provider.wrapPath(path, fs);
+    return provider.wrapPath(path);
   }
 
   /** Test that we don't corrumpt fsync: it just doesnt happen */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestExtrasFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestExtrasFS.java
@@ -34,10 +34,9 @@ public class TestExtrasFS extends MockFileSystemTestCase {
   }
 
   Path wrap(Path path, boolean active, boolean createDirectory) {
-    FileSystem fs =
-        new ExtrasFS(path.getFileSystem(), active, createDirectory)
-            .getFileSystem(URI.create("file:///"));
-    return new FilterPath(path, fs);
+    ExtrasFS provider = new ExtrasFS(path.getFileSystem(), active, createDirectory);
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    return provider.wrapPath(path, fs);
   }
 
   /** test where extra file is created */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestExtrasFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestExtrasFS.java
@@ -16,9 +16,7 @@
  */
 package org.apache.lucene.tests.mockfile;
 
-import java.net.URI;
 import java.nio.file.DirectoryStream;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -35,8 +33,7 @@ public class TestExtrasFS extends MockFileSystemTestCase {
 
   Path wrap(Path path, boolean active, boolean createDirectory) {
     ExtrasFS provider = new ExtrasFS(path.getFileSystem(), active, createDirectory);
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    return provider.wrapPath(path, fs);
+    return provider.wrapPath(path);
   }
 
   /** test where extra file is created */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestHandleLimitFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestHandleLimitFS.java
@@ -35,9 +35,9 @@ public class TestHandleLimitFS extends MockFileSystemTestCase {
   }
 
   Path wrap(Path path, int limit) {
-    FileSystem fs =
-        new HandleLimitFS(path.getFileSystem(), limit).getFileSystem(URI.create("file:///"));
-    return new FilterPath(path, fs);
+    HandleLimitFS provider = new HandleLimitFS(path.getFileSystem(), limit);
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    return provider.wrapPath(path, fs);
   }
 
   /** set a limit at n files, then open more than that and ensure we hit exception */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestHandleLimitFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestHandleLimitFS.java
@@ -18,8 +18,6 @@ package org.apache.lucene.tests.mockfile;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.net.URI;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -36,8 +34,7 @@ public class TestHandleLimitFS extends MockFileSystemTestCase {
 
   Path wrap(Path path, int limit) {
     HandleLimitFS provider = new HandleLimitFS(path.getFileSystem(), limit);
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    return provider.wrapPath(path, fs);
+    return provider.wrapPath(path);
   }
 
   /** set a limit at n files, then open more than that and ensure we hit exception */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestHandleTrackingFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestHandleTrackingFS.java
@@ -19,10 +19,8 @@ package org.apache.lucene.tests.mockfile;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.DirectoryStream;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -32,8 +30,7 @@ public class TestHandleTrackingFS extends MockFileSystemTestCase {
   @Override
   protected Path wrap(Path path) {
     LeakFS provider = new LeakFS(path.getFileSystem());
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    return provider.wrapPath(path, fs);
+    return provider.wrapPath(path);
   }
 
   /** Test that the delegate gets closed on exception in HandleTrackingFS#onClose */
@@ -53,8 +50,7 @@ public class TestHandleTrackingFS extends MockFileSystemTestCase {
             //
           }
         };
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    Path dir = provider.wrapPath(path, fs);
+    Path dir = provider.wrapPath(path);
 
     OutputStream file = Files.newOutputStream(dir.resolve("somefile"));
     file.write(5);
@@ -65,7 +61,6 @@ public class TestHandleTrackingFS extends MockFileSystemTestCase {
 
     InputStream stream = Files.newInputStream(dir.resolve("somefile"));
     expectThrows(IOException.class, stream::close);
-    fs.close();
 
     DirectoryStream<Path> dirStream = Files.newDirectoryStream(dir);
     expectThrows(IOException.class, dirStream::close);
@@ -86,17 +81,14 @@ public class TestHandleTrackingFS extends MockFileSystemTestCase {
             throw new IOException("boom");
           }
         };
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    Path dir = provider.wrapPath(path, fs);
+    Path dir = provider.wrapPath(path);
 
     expectThrows(IOException.class, () -> Files.newOutputStream(dir.resolve("somefile")));
 
     expectThrows(IOException.class, () -> Files.newByteChannel(dir.resolve("somefile")));
 
     expectThrows(IOException.class, () -> Files.newInputStream(dir.resolve("somefile")));
-    fs.close();
 
     expectThrows(IOException.class, () -> Files.newDirectoryStream(dir));
-    fs.close();
   }
 }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestLeakFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestLeakFS.java
@@ -19,11 +19,9 @@ package org.apache.lucene.tests.mockfile;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
 import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -38,8 +36,7 @@ public class TestLeakFS extends MockFileSystemTestCase {
   @Override
   protected Path wrap(Path path) {
     LeakFS provider = new LeakFS(path.getFileSystem());
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    return provider.wrapPath(path, fs);
+    return provider.wrapPath(path);
   }
 
   /** Test leaks via Files.newInputStream */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestLeakFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestLeakFS.java
@@ -37,8 +37,9 @@ public class TestLeakFS extends MockFileSystemTestCase {
 
   @Override
   protected Path wrap(Path path) {
-    FileSystem fs = new LeakFS(path.getFileSystem()).getFileSystem(URI.create("file:///"));
-    return new FilterPath(path, fs);
+    LeakFS provider = new LeakFS(path.getFileSystem());
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    return provider.wrapPath(path, fs);
   }
 
   /** Test leaks via Files.newInputStream */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestShuffleFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestShuffleFS.java
@@ -35,8 +35,9 @@ public class TestShuffleFS extends MockFileSystemTestCase {
   }
 
   Path wrap(Path path, long seed) {
-    FileSystem fs = new ShuffleFS(path.getFileSystem(), seed).getFileSystem(URI.create("file:///"));
-    return new FilterPath(path, fs);
+    ShuffleFS provider = new ShuffleFS(path.getFileSystem(), seed);
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    return provider.wrapPath(path, fs);
   }
 
   /** test that we return directory listings correctly */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestShuffleFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestShuffleFS.java
@@ -17,9 +17,7 @@
 package org.apache.lucene.tests.mockfile;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.DirectoryStream;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -36,8 +34,7 @@ public class TestShuffleFS extends MockFileSystemTestCase {
 
   Path wrap(Path path, long seed) {
     ShuffleFS provider = new ShuffleFS(path.getFileSystem(), seed);
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    return provider.wrapPath(path, fs);
+    return provider.wrapPath(path);
   }
 
   /** test that we return directory listings correctly */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestVerboseFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestVerboseFS.java
@@ -44,9 +44,9 @@ public class TestVerboseFS extends MockFileSystemTestCase {
   }
 
   Path wrap(Path path, InfoStream stream) {
-    FileSystem fs =
-        new VerboseFS(path.getFileSystem(), stream).getFileSystem(URI.create("file:///"));
-    return new FilterPath(path, fs);
+    VerboseFS provider = new VerboseFS(path.getFileSystem(), stream);
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    return provider.wrapPath(path, fs);
   }
 
   /** InfoStream that looks for a substring and indicates if it saw it */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestVerboseFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestVerboseFS.java
@@ -18,11 +18,9 @@ package org.apache.lucene.tests.mockfile;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URI;
 import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -45,8 +43,7 @@ public class TestVerboseFS extends MockFileSystemTestCase {
 
   Path wrap(Path path, InfoStream stream) {
     VerboseFS provider = new VerboseFS(path.getFileSystem(), stream);
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    return provider.wrapPath(path, fs);
+    return provider.wrapPath(path);
   }
 
   /** InfoStream that looks for a substring and indicates if it saw it */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestVirusCheckingFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestVirusCheckingFS.java
@@ -30,10 +30,9 @@ public class TestVirusCheckingFS extends MockFileSystemTestCase {
 
   @Override
   protected Path wrap(Path path) {
-    FileSystem fs =
-        new VirusCheckingFS(path.getFileSystem(), random().nextLong())
-            .getFileSystem(URI.create("file:///"));
-    return new FilterPath(path, fs);
+    VirusCheckingFS provider = new VirusCheckingFS(path.getFileSystem(), random().nextLong());
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    return provider.wrapPath(path, fs);
   }
 
   /** Test Files.delete fails if a file has an open inputstream against it */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestVirusCheckingFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestVirusCheckingFS.java
@@ -19,9 +19,7 @@ package org.apache.lucene.tests.mockfile;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URI;
 import java.nio.file.AccessDeniedException;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -31,8 +29,7 @@ public class TestVirusCheckingFS extends MockFileSystemTestCase {
   @Override
   protected Path wrap(Path path) {
     VirusCheckingFS provider = new VirusCheckingFS(path.getFileSystem(), random().nextLong());
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    return provider.wrapPath(path, fs);
+    return provider.wrapPath(path);
   }
 
   /** Test Files.delete fails if a file has an open inputstream against it */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
@@ -20,8 +20,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -43,8 +41,7 @@ public class TestWindowsFS extends MockFileSystemTestCase {
   @Override
   protected Path wrap(Path path) {
     WindowsFS provider = new WindowsFS(path.getFileSystem());
-    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
-    return provider.wrapPath(path, fs);
+    return provider.wrapPath(path);
   }
 
   /** Test Files.delete fails if a file has an open inputstream against it */

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
@@ -42,8 +42,9 @@ public class TestWindowsFS extends MockFileSystemTestCase {
 
   @Override
   protected Path wrap(Path path) {
-    FileSystem fs = new WindowsFS(path.getFileSystem()).getFileSystem(URI.create("file:///"));
-    return new FilterPath(path, fs);
+    WindowsFS provider = new WindowsFS(path.getFileSystem());
+    FileSystem fs = provider.getFileSystem(URI.create("file:///"));
+    return provider.wrapPath(path, fs);
   }
 
   /** Test Files.delete fails if a file has an open inputstream against it */


### PR DESCRIPTION
Currently "new FilterPath" is called from everywhere, making it impossible for a mockfilesystem to use a custom subclass.

See JIRA for full description.

The use case here is to e.g. allow WindowsFS to wrap with a custom subclass that checks for special characters that windows doesn't allow. But today it can't do that since there is code everywhere doing the wrapping.

This PR adds a single method `wrapPath()` to FilterFileSystemProvider to do this wrapping, and refactors everything to use it.
