### PR TITLE
LUCENE-10508: Fix error for rectangles with an extent close to 180 degrees

### DIFF
--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoBBoxFactory.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoBBoxFactory.java
@@ -98,7 +98,7 @@ public class GeoBBoxFactory {
       return new GeoDegenerateVerticalLine(planetModel, topLat, bottomLat, leftLon);
     }
     // System.err.println(" not vertical line");
-    if (extent >= Math.PI) {
+    if (extent >= GeoWideRectangle.MIN_WIDE_EXTENT) {
       if (latitudesEquals(topLat, bottomLat)) {
         if (isNorthPole(topLat)) {
           return new GeoDegeneratePoint(planetModel, topLat, 0.0);

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideRectangle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideRectangle.java
@@ -26,10 +26,10 @@ import java.io.OutputStream;
  * @lucene.internal
  */
 class GeoWideRectangle extends GeoBaseBBox {
-  
+
   /** Minimum extent for a rectangle of this type */
   public static final double MIN_WIDE_EXTENT = Math.PI - Vector.MINIMUM_ANGULAR_RESOLUTION;
-  
+
   /** The top latitude */
   protected final double topLat;
   /** The bottom latitude */

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideRectangle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideRectangle.java
@@ -26,6 +26,10 @@ import java.io.OutputStream;
  * @lucene.internal
  */
 class GeoWideRectangle extends GeoBaseBBox {
+  
+  /** Minimum extent for a rectangle of this type */
+  public static final double MIN_WIDE_EXTENT = Math.PI - Vector.MINIMUM_ANGULAR_RESOLUTION;
+  
   /** The top latitude */
   protected final double topLat;
   /** The bottom latitude */
@@ -111,7 +115,7 @@ class GeoWideRectangle extends GeoBaseBBox {
     if (extent < 0.0) {
       extent += 2.0 * Math.PI;
     }
-    if (extent < Math.PI) {
+    if (extent < MIN_WIDE_EXTENT) {
       throw new IllegalArgumentException("Width of rectangle too small");
     }
 


### PR DESCRIPTION
In https://github.com/apache/lucene/pull/804 we fixes some edge cases when building rectangles where min longitude and max longitude were very close together. This introduced now problems when the min/max longitudes are almost 180 degrees apart.

This PR introduces a `GeoWideRectangle.MIN_WIDE_EXTENT` that takes into account the angular resolution in order to build a `GeoWideRectangle`.