### PR TITLE
LUCENE-10495: Fix return statement of siblingsLoaded() in TaxonomyFacets

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -80,7 +80,9 @@ Bug Fixes
 * LUCENE-10508: Fixes some edge cases where GeoArea were built in a way that vertical planes
   could not evaluate their sign, either because the planes where the same or the center between those
   planes was lying in one of the planes. (Ignacio Vera)
-  
+
+* LUCENE-10495: Fix return statement of siblingsLoaded() in TaxonomyFacets. (Yuting Gan)
+
 Build
 ---------------------
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -118,7 +118,7 @@ public abstract class TaxonomyFacets extends Facets {
    * @lucene.experimental
    */
   public boolean siblingsLoaded() {
-    return children != null;
+    return siblings != null;
   }
 
   /**

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
@@ -549,6 +549,56 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
     IOUtils.close(taxoWriter, taxoReader, taxoDir, r, indexDir);
   }
 
+  // LUCENE-10495
+  public void testSiblingsLoaded() throws Exception {
+    Directory indexDir = newDirectory();
+    Directory taxoDir = newDirectory();
+
+    DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir);
+    IndexWriter iw = new IndexWriter(indexDir, newIndexWriterConfig(new MockAnalyzer(random())));
+    FacetsConfig config = new FacetsConfig();
+
+    config.setHierarchical("a", true);
+    config.setMultiValued("a", true);
+    config.setRequireDimCount("a", true);
+
+    Document doc = new Document();
+    doc.add(new FacetField("a", Integer.toString(2), "1"));
+    iw.addDocument(config.build(taxoWriter, doc));
+
+    DirectoryReader r = DirectoryReader.open(iw);
+    DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
+
+    FacetsCollector sfc =
+        newSearcher(r).search(new MatchAllDocsQuery(), new FacetsCollectorManager());
+
+    // Test MAX:
+    Facets facets =
+        new TaxonomyFacetFloatAssociations(
+            taxoReader,
+            config,
+            sfc,
+            AssociationAggregationFunction.MAX,
+            DoubleValuesSource.fromLongField("price"));
+
+    assertTrue(((TaxonomyFacets) facets).childrenLoaded());
+    assertFalse(((TaxonomyFacets) facets).siblingsLoaded());
+
+    // Test SUM:
+    facets =
+        new TaxonomyFacetFloatAssociations(
+            taxoReader,
+            config,
+            sfc,
+            AssociationAggregationFunction.SUM,
+            DoubleValuesSource.fromLongField("price"));
+    assertTrue(((TaxonomyFacets) facets).childrenLoaded());
+    assertFalse(((TaxonomyFacets) facets).siblingsLoaded());
+
+    iw.close();
+    IOUtils.close(taxoWriter, taxoReader, taxoDir, r, indexDir);
+  }
+
   public void testCountAndSumScore() throws Exception {
     Directory indexDir = newDirectory();
     Directory taxoDir = newDirectory();


### PR DESCRIPTION
Backport of #778