### PR TITLE
LUCENE-10525 Improve WindowsFS emulation to catch invalid file names

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -150,6 +150,8 @@ Other
 * LUCENE-10526: Test-framework: Add FilterFileSystemProvider.wrapPath(Path) method for mock filesystems
   to override if they need to extend the Path implementation. (Gautam Worah, Robert Muir)
 
+* LUCENE-10525: Test-framework: Add detection of illegal windows filenames to WindowsFS. (Gautam Worah)
+
 ======================= Lucene 9.1.0 =======================
 
 API Changes

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterPath.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterPath.java
@@ -127,8 +127,8 @@ public class FilterPath implements Path, Unwrappable<Path> {
   }
 
   @Override
-  public boolean startsWith(String other) {
-    return delegate.startsWith(other);
+  public final boolean startsWith(String other) {
+    return Path.super.startsWith(other);
   }
 
   @Override
@@ -137,8 +137,8 @@ public class FilterPath implements Path, Unwrappable<Path> {
   }
 
   @Override
-  public boolean endsWith(String other) {
-    return delegate.startsWith(other);
+  public final boolean endsWith(String other) {
+    return Path.super.endsWith(other);
   }
 
   @Override
@@ -152,8 +152,8 @@ public class FilterPath implements Path, Unwrappable<Path> {
   }
 
   @Override
-  public Path resolve(String other) {
-    return wrap(delegate.resolve(other));
+  public final Path resolve(String other) {
+    return Path.super.resolve(other);
   }
 
   @Override
@@ -162,8 +162,8 @@ public class FilterPath implements Path, Unwrappable<Path> {
   }
 
   @Override
-  public Path resolveSibling(String other) {
-    return wrap(delegate.resolveSibling(other));
+  public final Path resolveSibling(String other) {
+    return Path.super.resolveSibling(other);
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterPath.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterPath.java
@@ -270,7 +270,7 @@ public class FilterPath implements Path, Unwrappable<Path> {
     return Unwrappable.unwrapAll(path);
   }
 
-  final Path wrap(Path other) {
+  protected final Path wrap(Path other) {
     return fileSystem.parent.wrapPath(other);
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterPath.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/FilterPath.java
@@ -270,7 +270,7 @@ public class FilterPath implements Path, Unwrappable<Path> {
     return Unwrappable.unwrapAll(path);
   }
 
-  private final Path wrap(Path other) {
+  final Path wrap(Path other) {
     return fileSystem.parent.wrapPath(other);
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsFS.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsFS.java
@@ -166,4 +166,9 @@ public class WindowsFS extends HandleTrackingFS {
       return super.deleteIfExists(path);
     }
   }
+
+  @Override
+  public FilterPath wrapPath(Path path) {
+    return new WindowsPath(path, fileSystem);
+  }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsPath.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsPath.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.tests.mockfile;
 
-import java.io.File;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -46,23 +45,6 @@ class WindowsPath extends FilterPath {
 
   private void checkInvalidPath(Path other) {
     String fileName = other.toString();
-
-    // windows is case-insensitive by default
-    File folder = delegate.toFile(); // folder is always not null
-    String[] siblingFiles = folder.list();
-    if (siblingFiles != null) {
-      for (String siblingFile : siblingFiles) {
-        // this can be slow if there are a lot of files in the parent dir
-        if (siblingFile.equalsIgnoreCase(fileName)) {
-          throw new InvalidPathException(
-              other.toString(),
-              "Case insensitive file name: "
-                  + siblingFile
-                  + " already exists in the parent directory: "
-                  + delegate);
-        }
-      }
-    }
 
     if (RESERVED_NAMES.contains(fileName)) {
       throw new InvalidPathException(

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsPath.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsPath.java
@@ -43,24 +43,6 @@ class WindowsPath extends FilterPath {
     return wrap(delegate.resolve(toDelegate(other)));
   }
 
-  @Override
-  public Path resolve(String other) {
-    checkInvalidPath(other);
-    return wrap(delegate.resolve(other));
-  }
-
-  @Override
-  public Path resolveSibling(Path other) {
-    checkInvalidPath(other.getFileName().toString());
-    return wrap(delegate.resolveSibling(toDelegate(other)));
-  }
-
-  @Override
-  public Path resolveSibling(String other) {
-    checkInvalidPath(other);
-    return wrap(delegate.resolveSibling(other));
-  }
-
   private void checkInvalidPath(String fileName) {
     // TODO 1: how "complete" do we want to make these tests? Spec:
     // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsPath.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsPath.java
@@ -24,7 +24,7 @@ import java.util.HashSet;
 class WindowsPath extends FilterPath {
 
   static HashSet<Character> RESERVED_CHARACTERS =
-      new HashSet<>(Arrays.asList('<', '>', ':', '\"', '/', '\\', '|', '?', '*'));
+      new HashSet<>(Arrays.asList('<', '>', ':', '\"', '\\', '|', '?', '*'));
 
   static HashSet<String> RESERVED_NAMES =
       new HashSet<>(
@@ -44,7 +44,7 @@ class WindowsPath extends FilterPath {
   }
 
   private void checkInvalidPath(Path other) {
-    String fileName = other.toString();
+    String fileName = other.getFileName().toString();
 
     if (RESERVED_NAMES.contains(fileName)) {
       throw new InvalidPathException(

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsPath.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsPath.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.tests.mockfile;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+
+class WindowsPath extends FilterPath {
+
+  static HashSet<Character> RESERVED_CHARACTERS =
+      new HashSet<>(Arrays.asList('<', '>', ':', '\"', '/', '\\', '|', '?', '*'));
+
+  static HashSet<String> RESERVED_NAMES =
+      new HashSet<>(
+          Arrays.asList(
+              "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
+              "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8",
+              "LPT9"));
+
+  WindowsPath(Path path, FilterFileSystem fileSystem) {
+    super(path, fileSystem);
+  }
+
+  @Override
+  public Path resolve(Path other) throws InvalidPathException {
+    checkInvalidPath(other.getFileName().toString());
+    return wrap(delegate.resolve(toDelegate(other)));
+  }
+
+  @Override
+  public Path resolve(String other) {
+    checkInvalidPath(other);
+    return wrap(delegate.resolve(other));
+  }
+
+  @Override
+  public Path resolveSibling(Path other) {
+    checkInvalidPath(other.getFileName().toString());
+    return wrap(delegate.resolveSibling(toDelegate(other)));
+  }
+
+  @Override
+  public Path resolveSibling(String other) {
+    checkInvalidPath(other);
+    return wrap(delegate.resolveSibling(other));
+  }
+
+  private void checkInvalidPath(String fileName) {
+    // TODO 1: how "complete" do we want to make these tests? Spec:
+    // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+    // or do we make our best attempt at doing this and keep adding checks as we go?
+
+    // TODO 2: Add a check for case insensitivity in the same directory
+    if (RESERVED_NAMES.contains(fileName)) {
+      throw new InvalidPathException(
+          fileName, "File name: " + fileName + " is one of the reserved file names");
+    }
+
+    for (int i = 0; i < fileName.length(); i++) {
+      if (RESERVED_CHARACTERS.contains(fileName.charAt(i))) {
+        throw new InvalidPathException(
+            fileName,
+            "File name: " + fileName + " contains a reserved character: " + fileName.charAt(i));
+      }
+    }
+  }
+}

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleTemporaryFilesCleanup.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleTemporaryFilesCleanup.java
@@ -157,7 +157,8 @@ final class TestRuleTemporaryFilesCleanup extends TestRuleAdapter {
         fs = new HandleLimitFS(fs, limit).getFileSystem(null);
       }
       // windows is currently slow
-      if (random.nextInt(10) == 0) {
+      // TEMPORARY HACK: will revert :)
+      if (random.nextInt(10) >= 0) {
         // don't try to emulate windows on windows: they don't get along
         if (!Constants.WINDOWS && allowed(avoid, WindowsFS.class)) {
           fs = new WindowsFS(fs).getFileSystem(null);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleTemporaryFilesCleanup.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleTemporaryFilesCleanup.java
@@ -157,8 +157,7 @@ final class TestRuleTemporaryFilesCleanup extends TestRuleAdapter {
         fs = new HandleLimitFS(fs, limit).getFileSystem(null);
       }
       // windows is currently slow
-      // TEMPORARY HACK: will revert :)
-      if (random.nextInt(10) >= 0) {
+      if (random.nextInt(10) == 0) {
         // don't try to emulate windows on windows: they don't get along
         if (!Constants.WINDOWS && allowed(avoid, WindowsFS.class)) {
           fs = new WindowsFS(fs).getFileSystem(null);

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
@@ -187,7 +187,7 @@ public class TestWindowsFS extends MockFileSystemTestCase {
     }
   }
 
-  public void testFileName() {
+  public void testFileName() throws IOException {
     Character[] reservedCharacters = WindowsPath.RESERVED_CHARACTERS.toArray(new Character[0]);
     String[] reservedNames = WindowsPath.RESERVED_NAMES.toArray(new String[0]);
     String fileName;
@@ -195,13 +195,46 @@ public class TestWindowsFS extends MockFileSystemTestCase {
     Path dir = wrap(createTempDir());
 
     if (r.nextBoolean()) {
+      // We need at least one char after the special char
+      // For example, in case of '/' we interpret `foo/` to just be a file `foo` which is valid
       fileName =
           RandomStrings.randomAsciiLettersOfLength(r, r.nextInt(10))
               + reservedCharacters[r.nextInt(reservedCharacters.length)]
-              + RandomStrings.randomAsciiLettersOfLength(r, r.nextInt(10));
+              + RandomStrings.randomAsciiLettersOfLength(r, r.nextInt(1, 10));
     } else {
       fileName = reservedNames[r.nextInt(reservedNames.length)];
     }
     expectThrows(InvalidPathException.class, () -> dir.resolve(fileName));
+
+    // some other basic tests
+    expectThrows(InvalidPathException.class, () -> dir.resolve("foo:bar"));
+    expectThrows(InvalidPathException.class, () -> dir.resolve("foo:bar:tar"));
+    expectThrows(InvalidPathException.class, () -> dir.resolve("foo?bar"));
+    expectThrows(InvalidPathException.class, () -> dir.resolve("foo\\bar"));
+    expectThrows(InvalidPathException.class, () -> dir.resolve("foo*bar"));
+    expectThrows(InvalidPathException.class, () -> dir.resolve("foo|bar"));
+
+    // test on edge cases with explicit "/" in them
+    expectThrows(InvalidPathException.class, () -> dir.resolve("foo/bar"));
+    expectThrows(InvalidPathException.class, () -> dir.resolve("foo/bar/tar"));
+
+    // test for case insensitivity
+    Files.createFile(dir.resolve("file")); // a simple file should pass successfully
+
+    expectThrows(
+        InvalidPathException.class,
+        () -> Files.createFile(dir.resolve("File"))); // duplicates should fail
+    expectThrows(InvalidPathException.class, () -> Files.createFile(dir.resolve("fIle")));
+
+    Path childDir1 =
+        Files.createDirectory(dir.resolve("childDir1")); // a child dir should pass successfully
+    // duplicate child directories should fail
+    expectThrows(InvalidPathException.class, () -> Files.createDirectory(dir.resolve("ChildDir1")));
+    expectThrows(InvalidPathException.class, () -> Files.createDirectory(dir.resolve("cHildDir1")));
+
+    Files.createFile(childDir1.resolve("file")); // file within a child dir should pass
+    // duplicate file within a child dir should fail
+    expectThrows(InvalidPathException.class, () -> Files.createFile(childDir1.resolve("fIle")));
+    Files.createFile(childDir1.resolve("completelyDifferentFoobarName")); // again this should pass
   }
 }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
@@ -210,12 +210,9 @@ public class TestWindowsFS extends MockFileSystemTestCase {
     expectThrows(InvalidPathException.class, () -> dir.resolve("foo:bar"));
     expectThrows(InvalidPathException.class, () -> dir.resolve("foo:bar:tar"));
     expectThrows(InvalidPathException.class, () -> dir.resolve("foo?bar"));
+    expectThrows(InvalidPathException.class, () -> dir.resolve("foo<bar"));
     expectThrows(InvalidPathException.class, () -> dir.resolve("foo\\bar"));
-    expectThrows(InvalidPathException.class, () -> dir.resolve("foo*bar"));
-    expectThrows(InvalidPathException.class, () -> dir.resolve("foo|bar"));
-
-    // test on edge cases with explicit "/" in them
-    expectThrows(InvalidPathException.class, () -> dir.resolve("foo/bar"));
-    expectThrows(InvalidPathException.class, () -> dir.resolve("foo/bar/tar"));
+    expectThrows(InvalidPathException.class, () -> dir.resolve("foo*bar|tar"));
+    expectThrows(InvalidPathException.class, () -> dir.resolve("foo|bar?tar"));
   }
 }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
@@ -187,7 +187,7 @@ public class TestWindowsFS extends MockFileSystemTestCase {
     }
   }
 
-  public void testFileName() throws IOException {
+  public void testFileName() {
     Character[] reservedCharacters = WindowsPath.RESERVED_CHARACTERS.toArray(new Character[0]);
     String[] reservedNames = WindowsPath.RESERVED_NAMES.toArray(new String[0]);
     String fileName;
@@ -217,24 +217,5 @@ public class TestWindowsFS extends MockFileSystemTestCase {
     // test on edge cases with explicit "/" in them
     expectThrows(InvalidPathException.class, () -> dir.resolve("foo/bar"));
     expectThrows(InvalidPathException.class, () -> dir.resolve("foo/bar/tar"));
-
-    // test for case insensitivity
-    Files.createFile(dir.resolve("file")); // a simple file should pass successfully
-
-    expectThrows(
-        InvalidPathException.class,
-        () -> Files.createFile(dir.resolve("File"))); // duplicates should fail
-    expectThrows(InvalidPathException.class, () -> Files.createFile(dir.resolve("fIle")));
-
-    Path childDir1 =
-        Files.createDirectory(dir.resolve("childDir1")); // a child dir should pass successfully
-    // duplicate child directories should fail
-    expectThrows(InvalidPathException.class, () -> Files.createDirectory(dir.resolve("ChildDir1")));
-    expectThrows(InvalidPathException.class, () -> Files.createDirectory(dir.resolve("cHildDir1")));
-
-    Files.createFile(childDir1.resolve("file")); // file within a child dir should pass
-    // duplicate file within a child dir should fail
-    expectThrows(InvalidPathException.class, () -> Files.createFile(childDir1.resolve("fIle")));
-    Files.createFile(childDir1.resolve("completelyDifferentFoobarName")); // again this should pass
   }
 }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
@@ -16,14 +16,17 @@
  */
 package org.apache.lucene.tests.mockfile;
 
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Random;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.lucene.util.Constants;
@@ -35,6 +38,9 @@ public class TestWindowsFS extends MockFileSystemTestCase {
   public void setUp() throws Exception {
     super.setUp();
     // irony: currently we don't emulate windows well enough to work on windows!
+    // TODO: Can we fork this class and create a new class with only those tests that can run on
+    // Windows and then check if
+    // the Lucene WindowsFS error is same as the one OG Windows throws
     assumeFalse("windows is not supported", Constants.WINDOWS);
   }
 
@@ -179,5 +185,23 @@ public class TestWindowsFS extends MockFileSystemTestCase {
     try (InputStream stream = Files.newInputStream(dir.resolve("target"))) {
       assertEquals(2, stream.read());
     }
+  }
+
+  public void testFileName() {
+    Character[] reservedCharacters = WindowsPath.RESERVED_CHARACTERS.toArray(new Character[0]);
+    String[] reservedNames = WindowsPath.RESERVED_NAMES.toArray(new String[0]);
+    String fileName;
+    Random r = random();
+    Path dir = wrap(createTempDir());
+
+    if (r.nextBoolean()) {
+      fileName =
+          RandomStrings.randomAsciiLettersOfLength(r, r.nextInt(10))
+              + reservedCharacters[r.nextInt(reservedCharacters.length)]
+              + RandomStrings.randomAsciiLettersOfLength(r, r.nextInt(10));
+    } else {
+      fileName = reservedNames[r.nextInt(reservedNames.length)];
+    }
+    expectThrows(InvalidPathException.class, () -> dir.resolve(fileName));
   }
 }


### PR DESCRIPTION
In PR (https://github.com/apache/lucene/pull/762) we missed the case where a tempDir name was using `:` in the dir name. This test was passing in Linux, MacOS environments but ended up failing in Windows build systems.

By adding these additional checks we will reduce cases of these bugs slipping through to our CI systems. 
The https://github.com/apache/lucene/pull/822 PR introduced a clean way for overriding the wrapPath(path) function and adding custom checks to different `<> extends FilterPath` classes.

JIRA: https://issues.apache.org/jira/browse/LUCENE-10525

# Solution

Add a new WindowsPath class that "checks" Paths before resolving them.

# Tests

Added a basic test to check the added logic. It is not randomized at the moment because WindowsFS does not have support for case-sensitive checks (and a random test can create duplicate file entries). There are some other questions as well that need some thought (about completeness of emulation etc, how to go about it, should we enable the tests in WindowsOS etc)

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
