### PR TITLE
LUCENE-10533: SpellChecker.formGrams is missing bounds check

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -147,6 +147,8 @@ Bug Fixes
 
 * LUCENE-10495: Fix return statement of siblingsLoaded() in TaxonomyFacets. (Yuting Gan)
 
+* LUCENE-10533: SpellChecker.formGrams is missing bounds check (Kevin Risden)
+
 Build
 ---------------------
 

--- a/lucene/suggest/src/java/org/apache/lucene/search/spell/SpellChecker.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/spell/SpellChecker.java
@@ -426,6 +426,9 @@ public class SpellChecker implements java.io.Closeable {
    */
   private static String[] formGrams(String text, int ng) {
     int len = text.length();
+    if (len < ng) {
+      return new String[] {};
+    }
     String[] res = new String[len - ng + 1];
     for (int i = 0; i < len - ng + 1; i++) {
       res[i] = text.substring(i, i + ng);
@@ -559,7 +562,7 @@ public class SpellChecker implements java.io.Closeable {
     if (l == 5) {
       return 3;
     }
-    return 2;
+    return Math.min(l, 2);
   }
 
   private static Document createDocument(String text, int ng1, int ng2) {

--- a/lucene/suggest/src/test/org/apache/lucene/search/spell/TestLuceneDictionary.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/spell/TestLuceneDictionary.java
@@ -187,7 +187,9 @@ public class TestLuceneDictionary extends LuceneTestCase {
     indexReader = DirectoryReader.open(store);
     sc.indexDictionary(
         new LuceneDictionary(indexReader, "contents"), newIndexWriterConfig(null), false);
-    String[] suggestions = sc.suggestSimilar("Tam", 1);
+    String[] suggestions = sc.suggestSimilar("", 1);
+    assertEquals(0, suggestions.length);
+    suggestions = sc.suggestSimilar("Tam", 1);
     assertEquals(1, suggestions.length);
     assertEquals("Tom", suggestions[0]);
     suggestions = sc.suggestSimilar("Jarry", 1);

--- a/lucene/suggest/src/test/org/apache/lucene/search/spell/TestPlainTextDictionary.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/spell/TestPlainTextDictionary.java
@@ -31,7 +31,9 @@ public class TestPlainTextDictionary extends LuceneTestCase {
     Directory ramDir = newDirectory();
     SpellChecker spellChecker = new SpellChecker(ramDir);
     spellChecker.indexDictionary(ptd, newIndexWriterConfig(null), false);
-    String[] similar = spellChecker.suggestSimilar("treeword", 2);
+    String[] similar = spellChecker.suggestSimilar("", 2);
+    assertEquals(0, similar.length);
+    similar = spellChecker.suggestSimilar("treeword", 2);
     assertEquals(2, similar.length);
     assertEquals(similar[0], "threeword");
     assertEquals(similar[1], "oneword");

--- a/lucene/suggest/src/test/org/apache/lucene/search/spell/TestSpellChecker.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/spell/TestSpellChecker.java
@@ -196,6 +196,12 @@ public class TestSpellChecker extends LuceneTestCase {
 
     {
       String[] similar =
+          spellChecker.suggestSimilar("", 2, r, "field1", SuggestMode.SUGGEST_WHEN_NOT_IN_INDEX);
+      assertEquals(0, similar.length);
+    }
+
+    {
+      String[] similar =
           spellChecker.suggestSimilar(
               "eighty", 2, r, "field1", SuggestMode.SUGGEST_WHEN_NOT_IN_INDEX);
       assertEquals(1, similar.length);
@@ -208,6 +214,12 @@ public class TestSpellChecker extends LuceneTestCase {
               "eight", 2, r, "field1", SuggestMode.SUGGEST_WHEN_NOT_IN_INDEX);
       assertEquals(1, similar.length);
       assertEquals("eight", similar[0]);
+    }
+
+    {
+      String[] similar =
+          spellChecker.suggestSimilar("", 5, r, "field1", SuggestMode.SUGGEST_MORE_POPULAR);
+      assertEquals(0, similar.length);
     }
 
     {
@@ -227,6 +239,12 @@ public class TestSpellChecker extends LuceneTestCase {
     {
       String[] similar =
           spellChecker.suggestSimilar("eight", 5, r, "field1", SuggestMode.SUGGEST_MORE_POPULAR);
+      assertEquals(0, similar.length);
+    }
+
+    {
+      String[] similar =
+          spellChecker.suggestSimilar("", 5, r, "field1", SuggestMode.SUGGEST_ALWAYS);
       assertEquals(0, similar.length);
     }
 


### PR DESCRIPTION
# Description

SpellChecker.formGrams is missing a bounds check that results in NegativeArraySizeException in some cases.

# Solution

This adds a bounds check to SpellChecker.formGrams and ensures that SpellChecker has a proper upper bound on the size of the word being matched against. Also adds tests to check for this case.

# Tests

`./gradlew check`

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
