### PR TITLE
LUCENE-10534: FieldSource exists improvements

### DIFF
--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/DoubleFieldSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/DoubleFieldSource.java
@@ -25,8 +25,6 @@ import org.apache.lucene.queries.function.FunctionValues;
 import org.apache.lucene.queries.function.docvalues.DoubleDocValues;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortField.Type;
-import org.apache.lucene.util.mutable.MutableValue;
-import org.apache.lucene.util.mutable.MutableValueDouble;
 
 /**
  * Obtains double field values from {@link org.apache.lucene.index.LeafReader#getNumericDocValues}
@@ -52,55 +50,32 @@ public class DoubleFieldSource extends FieldCacheSource {
   public FunctionValues getValues(Map<Object, Object> context, LeafReaderContext readerContext)
       throws IOException {
 
-    final NumericDocValues values = getNumericDocValues(context, readerContext);
+    final NumericDocValues arr = getNumericDocValues(context, readerContext);
 
     return new DoubleDocValues(this) {
       int lastDocID;
 
-      private double getValueForDoc(int doc) throws IOException {
-        if (doc < lastDocID) {
-          throw new IllegalArgumentException(
-              "docs were sent out-of-order: lastDocID=" + lastDocID + " vs docID=" + doc);
-        }
-        lastDocID = doc;
-        int curDocID = values.docID();
-        if (doc > curDocID) {
-          curDocID = values.advance(doc);
-        }
-        if (doc == curDocID) {
-          return Double.longBitsToDouble(values.longValue());
+      @Override
+      public double doubleVal(int doc) throws IOException {
+        if (exists(doc)) {
+          return Double.longBitsToDouble(arr.longValue());
         } else {
           return 0.0;
         }
       }
 
       @Override
-      public double doubleVal(int doc) throws IOException {
-        return getValueForDoc(doc);
-      }
-
-      @Override
       public boolean exists(int doc) throws IOException {
-        getValueForDoc(doc);
-        return doc == values.docID();
-      }
-
-      @Override
-      public ValueFiller getValueFiller() {
-        return new ValueFiller() {
-          private final MutableValueDouble mval = new MutableValueDouble();
-
-          @Override
-          public MutableValue getValue() {
-            return mval;
-          }
-
-          @Override
-          public void fillValue(int doc) throws IOException {
-            mval.value = getValueForDoc(doc);
-            mval.exists = exists(doc);
-          }
-        };
+        if (doc < lastDocID) {
+          throw new IllegalArgumentException(
+              "docs were sent out-of-order: lastDocID=" + lastDocID + " vs docID=" + doc);
+        }
+        lastDocID = doc;
+        int curDocID = arr.docID();
+        if (doc > curDocID) {
+          curDocID = arr.advance(doc);
+        }
+        return doc == curDocID;
       }
     };
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/IntFieldSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/IntFieldSource.java
@@ -25,8 +25,6 @@ import org.apache.lucene.queries.function.FunctionValues;
 import org.apache.lucene.queries.function.docvalues.IntDocValues;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortField.Type;
-import org.apache.lucene.util.mutable.MutableValue;
-import org.apache.lucene.util.mutable.MutableValueInt;
 
 /**
  * Obtains int field values from {@link org.apache.lucene.index.LeafReader#getNumericDocValues} and
@@ -57,26 +55,13 @@ public class IntFieldSource extends FieldCacheSource {
     return new IntDocValues(this) {
       int lastDocID;
 
-      private int getValueForDoc(int doc) throws IOException {
-        if (doc < lastDocID) {
-          throw new IllegalArgumentException(
-              "docs were sent out-of-order: lastDocID=" + lastDocID + " vs docID=" + doc);
-        }
-        lastDocID = doc;
-        int curDocID = arr.docID();
-        if (doc > curDocID) {
-          curDocID = arr.advance(doc);
-        }
-        if (doc == curDocID) {
+      @Override
+      public int intVal(int doc) throws IOException {
+        if (exists(doc)) {
           return (int) arr.longValue();
         } else {
           return 0;
         }
-      }
-
-      @Override
-      public int intVal(int doc) throws IOException {
-        return getValueForDoc(doc);
       }
 
       @Override
@@ -86,26 +71,16 @@ public class IntFieldSource extends FieldCacheSource {
 
       @Override
       public boolean exists(int doc) throws IOException {
-        getValueForDoc(doc);
-        return arr.docID() == doc;
-      }
-
-      @Override
-      public ValueFiller getValueFiller() {
-        return new ValueFiller() {
-          private final MutableValueInt mval = new MutableValueInt();
-
-          @Override
-          public MutableValue getValue() {
-            return mval;
-          }
-
-          @Override
-          public void fillValue(int doc) throws IOException {
-            mval.value = getValueForDoc(doc);
-            mval.exists = arr.docID() == doc;
-          }
-        };
+        if (doc < lastDocID) {
+          throw new IllegalArgumentException(
+              "docs were sent out-of-order: lastDocID=" + lastDocID + " vs docID=" + doc);
+        }
+        lastDocID = doc;
+        int curDocID = arr.docID();
+        if (doc > curDocID) {
+          curDocID = arr.advance(doc);
+        }
+        return doc == curDocID;
       }
     };
   }


### PR DESCRIPTION
# Description

`getValueForDoc` is doing too much at once - checking for both exists and getting the value. This change splits the logic into the existing functions and removes the duplicate unneeded code (`getValueFiller` is removed since it is now the same as the base class and doesn't need to be overridden.)

# Tests

Existing tests cover this logic.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
