### PR TITLE
LUCENE-10538: TopN is not being used in getTopChildren in RangeFacetCounts

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
@@ -226,8 +226,9 @@ abstract class RangeFacetCounts extends Facets {
     if (path.length != 0) {
       throw new IllegalArgumentException("path.length should be 0");
     }
-    LabelAndValue[] labelValues = new LabelAndValue[counts.length];
-    for (int i = 0; i < counts.length; i++) {
+    int resultSize = Math.min(topN, counts.length);
+    LabelAndValue[] labelValues = new LabelAndValue[resultSize];
+    for (int i = 0; i < resultSize; i++) {
       labelValues[i] = new LabelAndValue(ranges[i].label, counts[i]);
     }
     return new FacetResult(dim, path, totCount, labelValues, labelValues.length);

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -159,8 +159,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     // test fewer topChildren
     FacetResult result2 = facets.getTopChildren(2, "field");
     assertEquals(
-            "dim=field path=[] value=22 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
-            result2.toString());
+        "dim=field path=[] value=22 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+        result2.toString());
 
     r.close();
     d.close();
@@ -215,8 +215,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     // test fewer topChildren
     FacetResult result2 = facets.getTopChildren(2, "field");
     assertEquals(
-            "dim=field path=[] value=21 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
-            result2.toString());
+        "dim=field path=[] value=21 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+        result2.toString());
 
     r.close();
     d.close();
@@ -270,8 +270,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     List<FacetResult> test2Child = facets.getAllDims(2);
     assertEquals(1, test2Child.size());
     assertEquals(
-            "dim=field path=[] value=22 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
-            test2Child.get(0).toString());
+        "dim=field path=[] value=22 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+        test2Child.get(0).toString());
 
     // test default implementation of getTopDims
     List<FacetResult> topNDimsResult = facets.getTopDims(1, 1);
@@ -354,8 +354,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
     // test fewer topChildren
     FacetResult result2 = facets.getTopChildren(2, "field");
     assertEquals(
-            "dim=field path=[] value=3 childCount=2\n  min (1)\n  max (1)\n",
-            result2.toString());
+        "dim=field path=[] value=3 childCount=2\n  min (1)\n  max (1)\n", result2.toString());
 
     r.close();
     d.close();
@@ -397,8 +396,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
     // test fewer topChildren
     FacetResult result2 = facets.getTopChildren(2, "field");
     assertEquals(
-            "dim=field path=[] value=41 childCount=2\n  0-10 (11)\n  10-20 (11)\n",
-            result.toString());
+        "dim=field path=[] value=41 childCount=2\n  0-10 (11)\n  10-20 (11)\n", result2.toString());
 
     r.close();
     d.close();
@@ -610,8 +608,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
 
     // test fewer topChildren
     assertEquals(
-            "dim=field path=[] value=21 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
-            facets.getTopChildren(2, "field").toString());
+        "dim=field path=[] value=21 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+        facets.getTopChildren(2, "field").toString());
 
     w.close();
     IOUtils.close(r, d);
@@ -652,8 +650,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
 
     // test fewer topChildren
     assertEquals(
-            "dim=field path=[] value=21 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
-            facets.getTopChildren(2, "field").toString());
+        "dim=field path=[] value=21 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+        facets.getTopChildren(2, "field").toString());
 
     w.close();
     IOUtils.close(r, d);
@@ -708,8 +706,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     // test fewer topChildren
     FacetResult result2 = facets.getTopChildren(2, "field");
     assertEquals(
-            "dim=field path=[] value=21 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
-            result2.toString());
+        "dim=field path=[] value=21 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+        result2.toString());
 
     r.close();
     d.close();

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -156,6 +156,12 @@ public class TestRangeFacetCounts extends FacetTestCase {
         "dim=field path=[] value=22 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (1)\n",
         result.toString());
 
+    // test fewer topChildren
+    FacetResult result2 = facets.getTopChildren(2, "field");
+    assertEquals(
+            "dim=field path=[] value=22 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+            result2.toString());
+
     r.close();
     d.close();
   }
@@ -206,6 +212,12 @@ public class TestRangeFacetCounts extends FacetTestCase {
         "dim=field path=[] value=21 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (0)\n",
         result.toString());
 
+    // test fewer topChildren
+    FacetResult result2 = facets.getTopChildren(2, "field");
+    assertEquals(
+            "dim=field path=[] value=21 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+            result2.toString());
+
     r.close();
     d.close();
   }
@@ -251,8 +263,15 @@ public class TestRangeFacetCounts extends FacetTestCase {
     List<FacetResult> test1Child = facets.getAllDims(1);
     assertEquals(1, test1Child.size());
     assertEquals(
-        "dim=field path=[] value=22 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (1)\n",
+        "dim=field path=[] value=22 childCount=1\n  less than 10 (10)\n",
         test1Child.get(0).toString());
+
+    // test getAllDims(2)
+    List<FacetResult> test2Child = facets.getAllDims(2);
+    assertEquals(1, test2Child.size());
+    assertEquals(
+            "dim=field path=[] value=22 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+            test2Child.get(0).toString());
 
     // test default implementation of getTopDims
     List<FacetResult> topNDimsResult = facets.getTopDims(1, 1);
@@ -332,6 +351,12 @@ public class TestRangeFacetCounts extends FacetTestCase {
         "dim=field path=[] value=3 childCount=6\n  min (1)\n  max (1)\n  all0 (3)\n  all1 (2)\n  all2 (2)\n  all3 (1)\n",
         result.toString());
 
+    // test fewer topChildren
+    FacetResult result2 = facets.getTopChildren(2, "field");
+    assertEquals(
+            "dim=field path=[] value=3 childCount=2\n  min (1)\n  max (1)\n",
+            result2.toString());
+
     r.close();
     d.close();
   }
@@ -368,6 +393,13 @@ public class TestRangeFacetCounts extends FacetTestCase {
     assertEquals(
         "dim=field path=[] value=41 childCount=4\n  0-10 (11)\n  10-20 (11)\n  20-30 (11)\n  30-40 (11)\n",
         result.toString());
+
+    // test fewer topChildren
+    FacetResult result2 = facets.getTopChildren(2, "field");
+    assertEquals(
+            "dim=field path=[] value=41 childCount=2\n  0-10 (11)\n  10-20 (11)\n",
+            result.toString());
+
     r.close();
     d.close();
   }
@@ -575,6 +607,12 @@ public class TestRangeFacetCounts extends FacetTestCase {
     assertEquals(
         "dim=field path=[] value=21 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (0)\n",
         facets.getTopChildren(10, "field").toString());
+
+    // test fewer topChildren
+    assertEquals(
+            "dim=field path=[] value=21 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+            facets.getTopChildren(2, "field").toString());
+
     w.close();
     IOUtils.close(r, d);
   }
@@ -611,6 +649,12 @@ public class TestRangeFacetCounts extends FacetTestCase {
     assertEquals(
         "dim=field path=[] value=21 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (0)\n",
         facets.getTopChildren(10, "field").toString());
+
+    // test fewer topChildren
+    assertEquals(
+            "dim=field path=[] value=21 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+            facets.getTopChildren(2, "field").toString());
+
     w.close();
     IOUtils.close(r, d);
   }
@@ -660,6 +704,12 @@ public class TestRangeFacetCounts extends FacetTestCase {
     assertEquals(
         "dim=field path=[] value=21 childCount=5\n  less than 10 (10)\n  less than or equal to 10 (11)\n  over 90 (9)\n  90 or above (10)\n  over 1000 (0)\n",
         result.toString());
+
+    // test fewer topChildren
+    FacetResult result2 = facets.getTopChildren(2, "field");
+    assertEquals(
+            "dim=field path=[] value=21 childCount=2\n  less than 10 (10)\n  less than or equal to 10 (11)\n",
+            result2.toString());
 
     r.close();
     d.close();
@@ -798,8 +848,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
                   "field", MultiLongValuesSource.fromSingleValued(vs), sfc, fastMatchQuery, ranges);
         }
         FacetResult result = facets.getTopChildren(10, "field");
-        assertEquals(numRange, result.labelValues.length);
-        for (int rangeID = 0; rangeID < numRange; rangeID++) {
+        for (int rangeID = 0; rangeID < result.labelValues.length; rangeID++) {
           if (VERBOSE) {
             System.out.println("  range " + rangeID + " expectedCount=" + expectedCounts[rangeID]);
           }
@@ -823,9 +872,9 @@ public class TestRangeFacetCounts extends FacetTestCase {
       } else {
         MultiLongValuesSource vs = MultiLongValuesSource.fromLongField("field");
         Facets facets = new LongRangeFacetCounts("field", vs, sfc, fastMatchQuery, ranges);
-        FacetResult result = facets.getTopChildren(10, "field");
-        assertEquals(numRange, result.labelValues.length);
-        for (int rangeID = 0; rangeID < numRange; rangeID++) {
+
+        FacetResult result = facets.getTopChildren(3, "field");
+        for (int rangeID = 0; rangeID < result.labelValues.length; rangeID++) {
           if (VERBOSE) {
             System.out.println("  range " + rangeID + " expectedCount=" + expectedCounts[rangeID]);
           }
@@ -990,8 +1039,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
                 "field", (MultiLongValuesSource) null, sfc, fastMatchQuery, ranges);
       }
       FacetResult result = facets.getTopChildren(10, "field");
-      assertEquals(numRange, result.labelValues.length);
-      for (int rangeID = 0; rangeID < numRange; rangeID++) {
+      for (int rangeID = 0; rangeID < result.labelValues.length; rangeID++) {
         if (VERBOSE) {
           System.out.println("  range " + rangeID + " expectedCount=" + expectedCounts[rangeID]);
         }


### PR DESCRIPTION
# Description

This change fixed the issue that top-n parameter is not being used in the getTopChildren function in RangeFacetCounts. 

# Solution

Evaluate if top-n value is less than the children size, if it does, set the result size to topN.

# Tests

Fixed existing tests that failed to test getTopChildren and added new tests in TestRangeFacetCounts

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `main` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
