### PR TITLE
LUCENE-10530: Avoid floating point precision bug in TestTaxonomyFacetAssociations

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -94,8 +94,11 @@ Bug Fixes
   no documents instead of throwing an NPE. (Greg Miller)
 
 * LUCENE-10470: Check if polygon has been successfully tessellated before we fail (we are failing some valid
-  tessellations) and allow filtering edges that fold on top of the previous one. (Ignacio Vera)  
-  
+  tessellations) and allow filtering edges that fold on top of the previous one. (Ignacio Vera)
+
+* LUCENE-10530: Avoid floating point precision test case bug in TestTaxonomyFacetAssociations.
+  (Greg Miller)
+
 Build
 ---------------------
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
@@ -524,10 +524,7 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
       assertNull(facetResult);
     } else {
       assertEquals(dim, facetResult.dim);
-      // We can expect the floats to be exactly equal here since we're ensuring that we sum them
-      // in the same order when determining expected values and when computing facets. See
-      // LUCENE-10530:
-      assertEquals(aggregatedValue, facetResult.value.floatValue(), 0f);
+      assertEquals(aggregatedValue, facetResult.value.floatValue(), 1f);
       assertEquals(expected.size(), facetResult.childCount);
     }
   }


### PR DESCRIPTION
backport only