### PR TITLE
LUCENE-10518: Relax field consistency check for old indices (#842)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,7 +7,7 @@ http://s.apache.org/luceneversions
 
 Bug Fixes
 ---------------------
-(No changes)
+* LUCENE-10518: Relax field consistency check for old indices (Nhat Nguyen)
 
 ======================= Lucene 9.1.0 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
@@ -210,14 +210,15 @@ public final class FieldInfo {
    * @param o – other FieldInfo whose schema is verified against this FieldInfo's schema
    * @throws IllegalArgumentException if the field schemas are not the same
    */
-  void verifySameSchema(FieldInfo o) {
+  void verifySameSchema(FieldInfo o, boolean strictlyConsistent) {
     String fieldName = this.name;
-    verifySameIndexOptions(fieldName, this.indexOptions, o.getIndexOptions());
+    verifySameIndexOptions(fieldName, this.indexOptions, o.getIndexOptions(), strictlyConsistent);
     if (this.indexOptions != IndexOptions.NONE) {
-      verifySameOmitNorms(fieldName, this.omitNorms, o.omitNorms);
-      verifySameStoreTermVectors(fieldName, this.storeTermVector, o.storeTermVector);
+      verifySameOmitNorms(fieldName, this.omitNorms, o.omitNorms, strictlyConsistent);
+      verifySameStoreTermVectors(
+          fieldName, this.storeTermVector, o.storeTermVector, strictlyConsistent);
     }
-    verifySameDocValuesType(fieldName, this.docValuesType, o.docValuesType);
+    verifySameDocValuesType(fieldName, this.docValuesType, o.docValuesType, strictlyConsistent);
     verifySamePointsOptions(
         fieldName,
         this.pointDimensionCount,
@@ -225,7 +226,8 @@ public final class FieldInfo {
         this.pointNumBytes,
         o.pointDimensionCount,
         o.pointIndexDimensionCount,
-        o.pointNumBytes);
+        o.pointNumBytes,
+        strictlyConsistent);
     verifySameVectorOptions(
         fieldName,
         this.vectorDimension,
@@ -240,7 +242,14 @@ public final class FieldInfo {
    * @throws IllegalArgumentException if they are not the same
    */
   static void verifySameIndexOptions(
-      String fieldName, IndexOptions indexOptions1, IndexOptions indexOptions2) {
+      String fieldName,
+      IndexOptions indexOptions1,
+      IndexOptions indexOptions2,
+      boolean strictlyConsistent) {
+    if (strictlyConsistent == false
+        && (indexOptions1 == IndexOptions.NONE || indexOptions2 == IndexOptions.NONE)) {
+      return;
+    }
     if (indexOptions1 != indexOptions2) {
       throw new IllegalArgumentException(
           "cannot change field \""
@@ -258,7 +267,14 @@ public final class FieldInfo {
    * @throws IllegalArgumentException if they are not the same
    */
   static void verifySameDocValuesType(
-      String fieldName, DocValuesType docValuesType1, DocValuesType docValuesType2) {
+      String fieldName,
+      DocValuesType docValuesType1,
+      DocValuesType docValuesType2,
+      boolean strictlyConsistent) {
+    if (strictlyConsistent == false
+        && (docValuesType1 == DocValuesType.NONE || docValuesType2 == DocValuesType.NONE)) {
+      return;
+    }
     if (docValuesType1 != docValuesType2) {
       throw new IllegalArgumentException(
           "cannot change field \""
@@ -276,8 +292,11 @@ public final class FieldInfo {
    * @throws IllegalArgumentException if they are not the same
    */
   static void verifySameStoreTermVectors(
-      String fieldName, boolean storeTermVector1, boolean storeTermVector2) {
-    if (storeTermVector1 != storeTermVector2) {
+      String fieldName,
+      boolean storeTermVector1,
+      boolean storeTermVector2,
+      boolean strictlyConsistent) {
+    if (strictlyConsistent && storeTermVector1 != storeTermVector2) {
       throw new IllegalArgumentException(
           "cannot change field \""
               + fieldName
@@ -293,8 +312,9 @@ public final class FieldInfo {
    *
    * @throws IllegalArgumentException if they are not the same
    */
-  static void verifySameOmitNorms(String fieldName, boolean omitNorms1, boolean omitNorms2) {
-    if (omitNorms1 != omitNorms2) {
+  static void verifySameOmitNorms(
+      String fieldName, boolean omitNorms1, boolean omitNorms2, boolean strictlyConsistent) {
+    if (strictlyConsistent && omitNorms1 != omitNorms2) {
       throw new IllegalArgumentException(
           "cannot change field \""
               + fieldName
@@ -317,7 +337,11 @@ public final class FieldInfo {
       int numBytes1,
       int pointDimensionCount2,
       int indexDimensionCount2,
-      int numBytes2) {
+      int numBytes2,
+      boolean strictlyConsistent) {
+    if (strictlyConsistent == false && (pointDimensionCount1 == 0 || pointDimensionCount2 == 0)) {
+      return;
+    }
     if (pointDimensionCount1 != pointDimensionCount2
         || indexDimensionCount1 != indexDimensionCount2
         || numBytes1 != numBytes2) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1255,7 +1255,8 @@ public class IndexWriter
    * If this {@link SegmentInfos} has no global field number map the returned instance is empty
    */
   private FieldNumbers getFieldNumberMap() throws IOException {
-    final FieldNumbers map = new FieldNumbers(config.softDeletesField);
+    final FieldNumbers map =
+        new FieldNumbers(config.softDeletesField, segmentInfos.getIndexCreatedVersionMajor());
 
     for (SegmentCommitInfo info : segmentInfos) {
       FieldInfos fis = readFieldInfos(info);
@@ -6336,7 +6337,8 @@ public class IndexWriter
           public FieldInfosBuilder newFieldInfosBuilder(String softDeletesFieldName) {
             return new FieldInfosBuilder() {
               private FieldInfos.Builder builder =
-                  new FieldInfos.Builder(new FieldInfos.FieldNumbers(softDeletesFieldName));
+                  new FieldInfos.Builder(
+                      new FieldInfos.FieldNumbers(softDeletesFieldName, Version.LATEST.major));
 
               @Override
               public FieldInfosBuilder add(FieldInfo fi) {

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -112,8 +112,16 @@ public class ParallelLeafReader extends LeafReader {
             .findAny()
             .orElse(null);
     // TODO: make this read-only in a cleaner way?
+    final int indexCreatedVersionMajor =
+        completeReaderSet.stream()
+            .map(LeafReader::getMetaData)
+            .filter(Objects::nonNull)
+            .mapToInt(LeafMetaData::getCreatedVersionMajor)
+            .min()
+            .orElse(Version.LATEST.major);
     FieldInfos.Builder builder =
-        new FieldInfos.Builder(new FieldInfos.FieldNumbers(softDeletesField));
+        new FieldInfos.Builder(
+            new FieldInfos.FieldNumbers(softDeletesField, indexCreatedVersionMajor));
 
     Sort indexSort = null;
     int createdVersionMajor = -1;

--- a/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
@@ -228,7 +228,8 @@ public class TestCodecs extends LuceneTestCase {
       terms[i] = new TermData(text, docs, null);
     }
 
-    final FieldInfos.Builder builder = new FieldInfos.Builder(new FieldInfos.FieldNumbers(null));
+    final FieldInfos.Builder builder =
+        new FieldInfos.Builder(new FieldInfos.FieldNumbers(null, Version.LATEST.major));
 
     final FieldData field = new FieldData("field", builder, terms, true, false);
     final FieldData[] fields = new FieldData[] {field};
@@ -290,7 +291,8 @@ public class TestCodecs extends LuceneTestCase {
   }
 
   public void testRandomPostings() throws Throwable {
-    final FieldInfos.Builder builder = new FieldInfos.Builder(new FieldInfos.FieldNumbers(null));
+    final FieldInfos.Builder builder =
+        new FieldInfos.Builder(new FieldInfos.FieldNumbers(null, Version.LATEST.major));
 
     final FieldData[] fields = new FieldData[NUM_FIELDS];
     for (int i = 0; i < NUM_FIELDS; i++) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestDoc.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDoc.java
@@ -235,7 +235,7 @@ public class TestDoc extends LuceneTestCase {
             si,
             InfoStream.getDefault(),
             trackingDir,
-            new FieldInfos.FieldNumbers(null),
+            new FieldInfos.FieldNumbers(null, Version.LATEST.major),
             context);
 
     merger.merge();

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
@@ -22,13 +22,18 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.Version;
 
 public class TestFieldInfos extends LuceneTestCase {
 
@@ -243,7 +248,8 @@ public class TestFieldInfos extends LuceneTestCase {
   }
 
   public void testFieldNumbersAutoIncrement() {
-    FieldInfos.FieldNumbers fieldNumbers = new FieldInfos.FieldNumbers("softDeletes");
+    FieldInfos.FieldNumbers fieldNumbers =
+        new FieldInfos.FieldNumbers("softDeletes", Version.LATEST.major);
     for (int i = 0; i < 10; i++) {
       fieldNumbers.addOrGet(
           new FieldInfo(
@@ -303,5 +309,53 @@ public class TestFieldInfos extends LuceneTestCase {
                 VectorSimilarityFunction.EUCLIDEAN,
                 false));
     assertEquals("Field numbers should reset after clear()", 0, idx);
+  }
+
+  public void testRelaxConsistencyCheckForOldIndices() throws IOException {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig config =
+          new IndexWriterConfig()
+              .setIndexCreatedVersionMajor(8)
+              .setOpenMode(IndexWriterConfig.OpenMode.CREATE);
+      try (IndexWriter writer = new IndexWriter(dir, config)) {
+        // first segment with DV
+        Document d1 = new Document();
+        d1.add(new StringField("my_field", "first", Field.Store.NO));
+        d1.add(new BinaryDocValuesField("my_field", new BytesRef("first")));
+        writer.addDocument(d1);
+        writer.flush();
+        // second segment without DV
+        Document d2 = new Document();
+        d2.add(new StringField("my_field", "second", Field.Store.NO));
+        writer.addDocument(d2);
+        writer.flush();
+        writer.commit();
+      }
+      config = new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.APPEND);
+      try (IndexWriter writer = new IndexWriter(dir, config)) {
+        // third segment with DV only
+        Document d3 = new Document();
+        d3.add(new BinaryDocValuesField("my_field", new BytesRef("third")));
+        writer.addDocument(d3);
+        writer.flush();
+        writer.commit();
+        // fails due to inconsistent DV type
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              Document d = new Document();
+              d.add(new NumericDocValuesField("my_field", 3));
+              writer.addDocument(d);
+            });
+        // fails due to inconsistent index options
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              Document d = new Document();
+              d.add(new TextField("my_field", "more", Field.Store.NO));
+              writer.addDocument(d);
+            });
+      }
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldsReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldsReader.java
@@ -33,6 +33,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.DocHelper;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.Version;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -45,7 +46,9 @@ public class TestFieldsReader extends LuceneTestCase {
   public static void beforeClass() throws Exception {
     testDoc = new Document();
     final String softDeletesFieldName = null;
-    fieldInfos = new FieldInfos.Builder(new FieldInfos.FieldNumbers(softDeletesFieldName));
+    fieldInfos =
+        new FieldInfos.Builder(
+            new FieldInfos.FieldNumbers(softDeletesFieldName, Version.LATEST.major));
     DocHelper.setupDoc(testDoc);
     for (IndexableField field : testDoc.getFields()) {
       IndexableFieldType ift = field.fieldType();

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentMerger.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentMerger.java
@@ -103,7 +103,7 @@ public class TestSegmentMerger extends LuceneTestCase {
             si,
             InfoStream.getDefault(),
             mergedDir,
-            new FieldInfos.FieldNumbers(null),
+            new FieldInfos.FieldNumbers(null, Version.LATEST.major),
             newIOContext(random(), new IOContext(new MergeInfo(-1, -1, false, -1))));
     MergeState mergeState = merger.merge();
     int docsMerged = mergeState.segmentInfo.maxDoc();


### PR DESCRIPTION
This change relaxes the field consistency check for old indices as we
didn't enforce that in the previous versions. This commit also disables
the optimization that relies on the field consistency for old indices.

Backport of #842 to 9.1