### PR TITLE
LUCENE-10524 Add benchmark suite details to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,16 @@ In case your contribution fixes a bug, please create a new test case that fails 
 - *Eclipse*  - Basic support ([help/IDEs.txt](https://github.com/apache/lucene/blob/main/help/IDEs.txt#L7)).
 - *Netbeans* - Not tested.
 
+## Benchmarking 
+
+Use the tool suite at [luceneutil](https://github.com/mikemccand/luceneutil) to benchmark your code changes
+if you think that your change may have measurably changed the performance of a task.
+
+The instructions for running the benchmarks can be found in the luceneutil [README](https://github.com/mikemccand/luceneutil/blob/master/README.md).
+
+The Lucene community is also interested in other implementations of these benchmark tasks.
+Feel free to share your findings (especially if your implementation performs better!) through the [Lucene mailing lists](https://lucene.apache.org/core/discussion.html).
+
 ## Contributing your work
 
 You have two options to contribute your work: you can either create a patch and attach it to an issue on [Jira](https://issues.apache.org/jira/browse/LUCENE), or open a pull request at https://github.com/apache/lucene - whichever works best for you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,12 +69,14 @@ In case your contribution fixes a bug, please create a new test case that fails 
 ## Benchmarking 
 
 Use the tool suite at [luceneutil](https://github.com/mikemccand/luceneutil) to benchmark your code changes
-if you think that your change may have measurably changed the performance of a task.
+if you think that your change may have measurably changed the performance of a task. Apache Lucene also contains an off the shelf benchmark [module](https://github.com/apache/lucene/tree/main/lucene/benchmark).
+
+This is the same suite that is run in the [nightly benchmarks](https://home.apache.org/~mikemccand/lucenebench/).
 
 The instructions for running the benchmarks can be found in the luceneutil [README](https://github.com/mikemccand/luceneutil/blob/master/README.md).
 
 The Lucene community is also interested in other implementations of these benchmark tasks.
-Feel free to share your findings (especially if your implementation performs better!) through the [Lucene mailing lists](https://lucene.apache.org/core/discussion.html).
+Feel free to share your findings (especially if your implementation performs better!) through the [Lucene mailing lists](https://lucene.apache.org/core/discussion.html) or open [PRs](https://github.com/mikemccand/luceneutil/pulls), [issues](https://github.com/mikemccand/luceneutil/issues) on the luceneutil project directly.
 
 ## Contributing your work
 


### PR DESCRIPTION
Today, new contributors are usually unaware of where luceneutil benchmarks are and when/how to run them. Committers usually end up pointing contributors to the benchmarks package when they make perf impacting changes and then they run the benchmarks.

Adding benchmark details to the Lucene repo will also make them more accessible to other researchers who want to experiment/benchmark their own custom task implementation with Java Lucene.

JIRA: https://issues.apache.org/jira/browse/LUCENE-10524

cc: @mocobeta 

