### PR TITLE
LUCENE-10508: Use MIN_WIDE_EXTENT for GeoWideDegenerateHorizontalLine

### DIFF
--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideDegenerateHorizontalLine.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideDegenerateHorizontalLine.java
@@ -83,7 +83,7 @@ class GeoWideDegenerateHorizontalLine extends GeoBaseBBox {
     if (extent < 0.0) {
       extent += 2.0 * Math.PI;
     }
-    if (extent < Math.PI) {
+    if (extent < GeoWideRectangle.MIN_WIDE_EXTENT) {
       throw new IllegalArgumentException("Width of rectangle too small");
     }
 


### PR DESCRIPTION
Follow up of https://github.com/apache/lucene/pull/845 where I miss GeoWideDegenerateHorizontalLine.