### PR TITLE
LUCENE-10552: KnnVectorQuery has incorrect equals/ hashCode

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -162,6 +162,8 @@ Bug Fixes
 * LUCENE-10530: Avoid floating point precision test case bug in TestTaxonomyFacetAssociations.
   (Greg Miller)
 
+* LUCENE-10552: KnnVectorQuery has incorrect equals/ hashCode. (Lu Xugang)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -292,11 +292,9 @@ public class KnnVectorQuery extends Query {
       return false;
     }
     return ((KnnVectorQuery) obj).k == k
-            && ((KnnVectorQuery) obj).field.equals(field)
-            && Arrays.equals(((KnnVectorQuery) obj).target, target)
-            && ((KnnVectorQuery) obj).filter == null
-        ? filter == null
-        : filter != null && ((KnnVectorQuery) obj).filter.equals(filter);
+        && ((KnnVectorQuery) obj).field.equals(field)
+        && Arrays.equals(((KnnVectorQuery) obj).target, target)
+        && Objects.equals(filter, ((KnnVectorQuery) obj).filter);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -288,15 +288,20 @@ public class KnnVectorQuery extends Query {
 
   @Override
   public boolean equals(Object obj) {
-    return sameClassAs(obj)
-        && ((KnnVectorQuery) obj).k == k
-        && ((KnnVectorQuery) obj).field.equals(field)
-        && Arrays.equals(((KnnVectorQuery) obj).target, target);
+    if (sameClassAs(obj) == false) {
+      return false;
+    }
+    return ((KnnVectorQuery) obj).k == k
+            && ((KnnVectorQuery) obj).field.equals(field)
+            && Arrays.equals(((KnnVectorQuery) obj).target, target)
+            && ((KnnVectorQuery) obj).filter == null
+        ? filter == null
+        : filter != null && ((KnnVectorQuery) obj).filter.equals(filter);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(classHash(), field, k, Arrays.hashCode(target));
+    return Objects.hash(classHash(), field, k, Arrays.hashCode(target), filter);
   }
 
   /** Caches the results of a KnnVector search: a list of docs and their scores */

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -56,6 +56,7 @@ public class TestKnnVectorQuery extends LuceneTestCase {
     Query filter1 = new TermQuery(new Term("id", "id1"));
     KnnVectorQuery q2 = new KnnVectorQuery("f1", new float[] {0, 1}, 10, filter1);
 
+    assertNotEquals(q2, q1);
     assertNotEquals(q1, q2);
     assertEquals(q2, new KnnVectorQuery("f1", new float[] {0, 1}, 10, filter1));
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -53,6 +53,15 @@ public class TestKnnVectorQuery extends LuceneTestCase {
 
   public void testEquals() {
     KnnVectorQuery q1 = new KnnVectorQuery("f1", new float[] {0, 1}, 10);
+    Query filter1 = new TermQuery(new Term("id", "id1"));
+    KnnVectorQuery q2 = new KnnVectorQuery("f1", new float[] {0, 1}, 10, filter1);
+
+    assertNotEquals(q2, q1);
+    assertNotEquals(q1, q2);
+    assertEquals(q2, new KnnVectorQuery("f1", new float[] {0, 1}, 10, filter1));
+
+    Query filter2 = new TermQuery(new Term("id", "id2"));
+    assertNotEquals(q2, new KnnVectorQuery("f1", new float[] {0, 1}, 10, filter2));
 
     assertEquals(q1, new KnnVectorQuery("f1", new float[] {0, 1}, 10));
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -56,7 +56,6 @@ public class TestKnnVectorQuery extends LuceneTestCase {
     Query filter1 = new TermQuery(new Term("id", "id1"));
     KnnVectorQuery q2 = new KnnVectorQuery("f1", new float[] {0, 1}, 10, filter1);
 
-    assertNotEquals(q2, q1);
     assertNotEquals(q1, q2);
     assertEquals(q2, new KnnVectorQuery("f1", new float[] {0, 1}, 10, filter1));
 


### PR DESCRIPTION
filter query could impact document-filtering properties, so maybe it should be a condition in Query#equals and Query#hashCode ?