### PR TITLE
LUCENE-10551: switch to PUAFIF

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/compress/LowercaseAsciiCompression.java
+++ b/lucene/core/src/java/org/apache/lucene/util/compress/LowercaseAsciiCompression.java
@@ -112,12 +112,13 @@ public final class LowercaseAsciiCompression {
         }
       }
 
-      // TODO: shouldn't this really be an assert instead?  but then this real "if" triggered
-      // LUCENE-10551 so maybe it should remain a real "if":
-
       if (numExceptions != numExceptions2) {
-        throw new IllegalStateException(
-            "" + numExceptions + " <> " + numExceptions2 + " " + new BytesRef(in, 0, len));
+        // This is a PUAFIF (paranoid upgraded assert flavored if): it means there is a bug
+        // somewhere (our code here, the JVM, etc.).  This
+        // could in theory be an assert instead, but because of high risk of possible bugs, we
+        // upgrae to PUAFIF:
+        throw new AssertionError(
+            numExceptions + " <> " + numExceptions2 + " " + new BytesRef(in, 0, len));
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/util/compress/LowercaseAsciiCompression.java
+++ b/lucene/core/src/java/org/apache/lucene/util/compress/LowercaseAsciiCompression.java
@@ -116,7 +116,7 @@ public final class LowercaseAsciiCompression {
         // This is a PUAFIF (paranoid upgraded assert flavored if): it means there is a bug
         // somewhere (our code here, the JVM, etc.).  This
         // could in theory be an assert instead, but because of high risk of possible bugs, we
-        // upgrae to PUAFIF:
+        // upgrade to PUAFIF:
         throw new AssertionError(
             numExceptions + " <> " + numExceptions2 + " " + new BytesRef(in, 0, len));
       }


### PR DESCRIPTION
Just a fast follow from https://github.com/apache/lucene/pull/858, switching from `if` to `PUAFIF`.