### PR TITLE
LUCENE-10554: fix bkd test case logic error and java doc error

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
@@ -56,7 +56,7 @@ public abstract class RadixSelector extends Selector {
 
   /**
    * Return the k-th byte of the entry at index {@code i}, or {@code -1} if its length is less than
-   * or equal to {@code k}. This may only be called with a value of {@code i} between {@code 0}
+   * or equal to {@code k}. This may only be called with a value of {@code k} between {@code 0}
    * included and {@code maxLength} excluded.
    */
   protected abstract int byteAt(int i, int k);

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
@@ -1674,6 +1674,7 @@ public class TestBKD extends LuceneTestCase {
     final int numValues = 10;
     final int numBytesPerDim = TestUtil.nextInt(random(), 1, 4);
     final byte[][] pointValue = new byte[11][numBytesPerDim];
+    final int[] docId = new int[11];
     BKDWriter w =
         new BKDWriter(
             numValues + 1,
@@ -1684,6 +1685,7 @@ public class TestBKD extends LuceneTestCase {
             numValues);
     for (int i = 0; i < numValues + 1; i++) {
       random().nextBytes(pointValue[i]);
+      docId[i] = i;
     }
     MutablePointTree val =
         new MutablePointTree() {
@@ -1701,7 +1703,7 @@ public class TestBKD extends LuceneTestCase {
 
           @Override
           public int getDocID(int i) {
-            return i;
+            return docId[i];
           }
 
           @Override
@@ -1709,6 +1711,9 @@ public class TestBKD extends LuceneTestCase {
             byte[] temp = pointValue[i];
             pointValue[i] = pointValue[j];
             pointValue[j] = temp;
+            int tempDocId = docId[i];
+            docId[i] = docId[j];
+            docId[j] = tempDocId;
           }
 
           @Override
@@ -1729,7 +1734,7 @@ public class TestBKD extends LuceneTestCase {
           @Override
           public void visitDocValues(IntersectVisitor visitor) throws IOException {
             for (int i = 0; i < size(); i++) {
-              visitor.visit(i, pointValue[i]);
+              visitor.visit(docId[i], pointValue[i]);
             }
           }
         };


### PR DESCRIPTION
fix `TestBKD` case `testTooManyPoints1D`  sort logic error and java doc error

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
