### PR TITLE
LUCENE-10555: avoid NumericLeafComparator#iteratorCost repeated initialization   when NumericLeafComparator#setScorer is called

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -118,6 +118,9 @@ Improvements
 Optimizations
 ---------------------
 
+* LUCENE-10555: avoid NumericLeafComparator#iteratorCost repeated initialization
+  when NumericLeafComparator#setScorer is called. (Jianping Weng)
+
 * LUCENE-10452: Hunspell: call checkCanceled less frequently to reduce the overhead (Peter Gromov)
 
 * LUCENE-10451: Hunspell: don't perform potentially expensive spellchecking after timeout (Peter Gromov)

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -165,7 +165,7 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
 
     @Override
     public void setScorer(Scorable scorer) throws IOException {
-      if (iteratorCost != -1 && scorer instanceof Scorer) {
+      if (iteratorCost == -1 && scorer instanceof Scorer) {
         iteratorCost =
             ((Scorer) scorer).iterator().cost(); // starting iterator cost is the scorer's cost
         updateCompetitiveIterator(); // update an iterator when we have a new segment

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -91,10 +91,9 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     private final byte[] maxValueAsBytes;
 
     private DocIdSetIterator competitiveIterator;
-    private long iteratorCost;
+    private long iteratorCost = -1;
     private int maxDocVisited = -1;
     private int updateCounter = 0;
-    private boolean hasSetScorer = false;
 
     public NumericLeafComparator(LeafReaderContext context) throws IOException {
       this.docValues = getNumericDocValues(context, field);
@@ -166,11 +165,10 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
 
     @Override
     public void setScorer(Scorable scorer) throws IOException {
-      if (hasSetScorer == false && scorer instanceof Scorer) {
+      if (iteratorCost != -1 && scorer instanceof Scorer) {
         iteratorCost =
             ((Scorer) scorer).iterator().cost(); // starting iterator cost is the scorer's cost
         updateCompetitiveIterator(); // update an iterator when we have a new segment
-        hasSetScorer = true;
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -94,6 +94,7 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     private long iteratorCost;
     private int maxDocVisited = -1;
     private int updateCounter = 0;
+    private boolean hasSetScorer = false;
 
     public NumericLeafComparator(LeafReaderContext context) throws IOException {
       this.docValues = getNumericDocValues(context, field);
@@ -165,10 +166,11 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
 
     @Override
     public void setScorer(Scorable scorer) throws IOException {
-      if (scorer instanceof Scorer) {
+      if (hasSetScorer == false && scorer instanceof Scorer) {
         iteratorCost =
             ((Scorer) scorer).iterator().cost(); // starting iterator cost is the scorer's cost
         updateCompetitiveIterator(); // update an iterator when we have a new segment
+        hasSetScorer = true;
       }
     }
 


### PR DESCRIPTION
Elasticsearch use `CancellableBulkScorer` to fast cancel long time query execution by splitting one segment docs to many doc sets. When users search a topN query, for every split doc sets, `TopFieldLeafCollector#setScorer` is called, then  `NumericLeafComparator#setScorer` is called successively. As a result, for one segment, `NumericLeafComparator#setScorer` is called many times. 

Every time `NumericLeafComparator#setScorer` is called, the `NumericLeafComparator#iteratorCost` is reset to the Scorer.cost and will increase many unnecessary  `pointValues#intersect` calls to get  competitive docIds. This result in performance degradation

This pr checks `NumericLeafComparator#setScorer` to be called only once for one segment
# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
