### PR TITLE
Make CONTRIBUTING.md a bit more succinct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,30 +33,20 @@ Be sure that you are using an appropriate version of the JDK. Please check [READ
 
 Lucene uses [Gradle](https://gradle.org/) for build control. Gradle is itself Java-based and may be incompatible with newer Java versions; you can still build and test Lucene with these Java releases, see [jvms.txt](./help/jvms.txt) for more information.
 
-Run `./gradlew help`, this will print a list of help guides that introduce and explain
-  various parts of the build system, including typical workflow tasks.
-
-If you want to build Lucene, type:
-
-```
-./gradlew assemble
-```
-
 NOTE: DO NOT use the `gradle` command that is perhaps installed on your machine. This may result in using a different gradle version than the project requires and this is known to lead to very cryptic errors. The "gradle wrapper" (gradlew script) does everything required to build the project from scratch: it downloads the correct version of gradle, sets up sane local configurations and is tested on multiple environments.
 
 The first time you run gradlew, it will create a file "gradle.properties" that contains machine-specific settings. Normally you can use this file as-is, but it can be modified if necessary.
 
-If you want to just build the documentation, type:
+Type `./gradlew helpWorkflow` to show typical workflow tasks ([help/workflow.txt](./help/workflow.txt)).
 
-```
-./gradlew documentation
-```
+Also run `./gradlew help`, this will print a list of help guides that introduce and explain
+various parts of the build system, including typical workflow tasks.
 
 ### Code formatting and checks
 
 If you've modified any sources, run `./gradlew tidy` to apply code formatting conventions automatically (see [help/formatting.txt](https://github.com/apache/lucene/blob/main/help/formatting.txt)).
 
-Please make sure that all unit tests and validations succeed before constructing your patch: `./gradlew check`. This will assemble Lucene and run all validation tasks (including tests). There are various commands to check the code; type `./gradlew helpWorkflow` to show typical workflow tasks ([help/workflow.txt](./help/workflow.txt)).
+Please make sure that all unit tests and validations succeed before constructing your patch: `./gradlew check`. This will assemble Lucene and run all validation tasks (including tests). There are various commands to check the code; type `./gradlew helpTest` for more information ([help/tests.txt](./help/tests.txt)).
 
 In case your contribution fixes a bug, please create a new test case that fails before your fix, to show the presence of the bug and ensure it never re-occurs. A test case showing the presence of a bug is also a good contribution by itself.
 
@@ -94,21 +84,9 @@ You can open a pull request with or without Jira issue. If there is an associate
 
 Note that you do not need to create a patch if you already opened a pull request on GitHub.
 
+Patches should be attached to an issue in [Apache Jira](https://issues.apache.org/jira/projects/LUCENE/issues/), so first you'll need to create an account for it (if you don't have one).
+
 Before creating your patch, you may want to get 'main' up to date with the latest from upstream. This will help avoid the possibility of others finding merge conflicts when applying your patch. This can be done with git pull if main is the current branch.
-
-If your changes are in your git working tree (i.e. not committed to a branch), then do this:
-
-1. Check to see what files you have modified with: `git status`
-2. Add any new files with: `git add src/.../MyNewClass.java`
-3. In order to create a patch, just type `git diff HEAD > LUCENE-NNNN.patch`
-
-If your changes are all committed to the current (feature) branch: `git diff main... > LUCENE-NNNN.patch`
-
-If some of your changes are committed to the current (feature) branch but you have working-copy changes too: `git diff {{git merge-base main head > LUCENE-NNNN.patch}}`. This will save a diff into the LUCENE-NNNN.patch file. Read the patch file. Make sure it includes ONLY the modifications required to fix a single issue.
-
-Patches should be attached to an issue in Jira.
-
-To enable automatic validation of Jira patches, switch the issue's status to "Patch Available" by clicking on the "Enable Patch Review" button near the top of the page. This will enqueue an ASF Jenkins job PreCommit-LUCENE-Build to run various quality checks on the patch and post a validation report as a comment (by "Lucene/Solr QA") on the issue. Expect a delay of 12 hours or so before the patch validation job actually runs. Note that in order for a patch file to trigger validation, its name must conform to the naming rules outlined here: https://yetus.apache.org/documentation/in-progress/precommit-patchnames/
 
 ### Add a CHANGES entry
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,8 @@ Note that you do not need to create a patch if you already opened a pull request
 
 Patches should be attached to an issue in [Apache Jira](https://issues.apache.org/jira/projects/LUCENE/issues/), so first you'll need to create an account for it (if you don't have one).
 
+Please refer to [git diff documentation](https://git-scm.com/docs/git-diff) for information of how to create a patch.
+
 Before creating your patch, you may want to get 'main' up to date with the latest from upstream. This will help avoid the possibility of others finding merge conflicts when applying your patch. This can be done with git pull if main is the current branch.
 
 ### Add a CHANGES entry


### PR DESCRIPTION
I think it'd be good to try to keep the contributing guide succinct as far as possible so that it is helpful for experienced developers (the main target readers of the document, I think).

- remove specific Gradle commands - Instead, we can link to the corresponding help documents.
- remove the instruction for making a patch - I assume contributors who prefer patches to pull requests are already familiar with it. Instead of a detailed explanation of how to make a patch, we can add a link to the reference of `git diff`.
- remove the explanation about Yetus - I don't think it is still working on the Jira Lucene project.