### PR TITLE
LUCENE-10558: expose stream-based Kuromoji resource constructors

### DIFF
--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/ConnectionCosts.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/ConnectionCosts.java
@@ -40,7 +40,13 @@ public final class ConnectionCosts extends org.apache.lucene.analysis.morph.Conn
     this(ConnectionCosts::getClassResource);
   }
 
-  private ConnectionCosts(IOSupplier<InputStream> connectionCostResource) throws IOException {
+  /**
+   * Create a {@link ConnectionCosts} from an input stream supplier.
+   *
+   * @param connectionCostResource supplies a stream where connection costs resource can be read
+   * @throws IOException if the supplied stream could not be read
+   */
+  public ConnectionCosts(IOSupplier<InputStream> connectionCostResource) throws IOException {
     super(
         connectionCostResource, DictionaryConstants.CONN_COSTS_HEADER, DictionaryConstants.VERSION);
   }

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
@@ -66,7 +66,16 @@ public final class TokenInfoDictionary extends BinaryDictionary<TokenInfoMorphDa
         () -> getClassResource(FST_FILENAME_SUFFIX));
   }
 
-  private TokenInfoDictionary(
+  /**
+   * Create a {@link ConnectionCosts} from an input stream supplier.
+   *
+   * @param targetMapResource supplies a stream where the target map can be read
+   * @param posResource supplies a stream where the pos resource can be read
+   * @param dictResource supplies a stream where the dictionary can be read
+   * @param fstResource supplies a stream where the FST can be read
+   * @throws IOException if the supplied stream could not be read
+   */
+  public TokenInfoDictionary(
       IOSupplier<InputStream> targetMapResource,
       IOSupplier<InputStream> posResource,
       IOSupplier<InputStream> dictResource,

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionary.java
@@ -52,18 +52,26 @@ public final class UnknownDictionary extends BinaryDictionary<UnknownMorphData> 
         () -> getClassResource(DICT_FILENAME_SUFFIX));
   }
 
-  private UnknownDictionary(
-      IOSupplier<InputStream> targetMapResource,
-      IOSupplier<InputStream> posResource,
-      IOSupplier<InputStream> dictResource)
+  /**
+   * Create a {@link UnknownDictionary} from an external resource path.
+   *
+   * @param targetMap supplier for stream containing target map
+   * @param posDict supplier for stream containing POS dictionary
+   * @param dict supplier for stream containing dictionary entries
+   * @throws IOException if a stream could not be read
+   */
+  public UnknownDictionary(
+      IOSupplier<InputStream> targetMap,
+      IOSupplier<InputStream> posDict,
+      IOSupplier<InputStream> dict)
       throws IOException {
     super(
-        targetMapResource,
-        dictResource,
+        targetMap,
+        dict,
         DictionaryConstants.TARGETMAP_HEADER,
         DictionaryConstants.DICT_HEADER,
         DictionaryConstants.VERSION);
-    this.morphAtts = new UnknownMorphData(buffer, posResource);
+    this.morphAtts = new UnknownMorphData(buffer, posDict);
   }
 
   private static InputStream getClassResource(String suffix) throws IOException {


### PR DESCRIPTION
Just makes some existing constructors public, and adds javadocs