### PR TITLE
LUCENE-10558: Implement URL ctor to support classpath/module usage in Kuromoji and Nori dictionaries

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -14,6 +14,11 @@ API Changes
   taxoEpoch decide. Add a test case that demonstrates the inconsistencies caused when you reuse taxoArrays on older
   checkpoints. (Gautam Worah)
 
+* LUCENE-10558: Add new constructors to Kuromoji and Nori dictionary classes to support classpath /
+  module system usage. It is now possible to use JDK's Class/ClassLoader/Module#getResource(...) apis
+  and pass their returned URL to dictionary constructors to load resources from Classpath or Module
+  resources. (Uwe Schindler, Tomoko Uchida, Mike Sokolov)
+
 New Features
 ---------------------
 
@@ -109,6 +114,10 @@ Bug Fixes
   (Greg Miller)
 
 * LUCENE-10518: Relax field consistency check for old indices (Nhat Nguyen)
+
+* LUCENE-10558: Restore behaviour of deprecated Kuromoji and Nori dictionary constructors for
+  custom dictionary support. Please also use new URL-based constructors for classpath/module
+  system ressources.  (Uwe Schindler, Tomoko Uchida, Mike Sokolov)
 
 Build
 ---------------------

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -51,6 +51,19 @@ the [Log4j JDK Logging Adapter](https://logging.apache.org/log4j/2.x/log4j-jul/i
 in combination with the corresponding system property:
 `java.util.logging.manager=org.apache.logging.log4j.jul.LogManager`.
 
+### Kuromoji and Nori analysis component constructors for custom dictionaries
+
+The Kuromoji and Nori analysis modules had some way to customize the backing dictionaries
+by passing a path to file or classpath resources using some inconsistently implemented
+APIs. This was buggy from the beginning, but some users made use of it. Due to move to Java
+module system, especially the resource lookup on classpath stopped to work correctly.
+The Lucene team therefore implemented new APIs to create dictionary implementations
+with custom data files. Unfortunately there were some shortcomings in the 9.1 version,
+also when using the now deprecated ctors, so users are advised to upgrade to
+Lucene 9.2 or stay with 9.0.
+
+See LUCENE-10558 for more details and workarounds.
+
 ## Migration from Lucene 8.x to Lucene 9.0
 
 ### Rename of binary artifacts from '**-analyzers-**' to '**-analysis-**' (LUCENE-9562)

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
@@ -150,7 +150,11 @@ public abstract class BinaryDictionary implements Dictionary {
 
   @Deprecated(forRemoval = true, since = "9.1")
   private static InputStream getClassResource(String path) throws IOException {
-    return IOUtils.requireResourceNonNull(BinaryDictionary.class.getResourceAsStream(path), path);
+    // we prefix the path with a "/" to ensure we have the same pre-9.1 behaviour (where we used
+    // ClassLoader#getResourceAsStream):
+    var prefixedPath = path.startsWith("/") ? path : "/".concat(path);
+    return IOUtils.requireResourceNonNull(
+        BinaryDictionary.class.getResourceAsStream(prefixedPath), path);
   }
 
   public void lookupWordIds(int sourceId, IntsRef ref) {

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
@@ -140,18 +140,13 @@ public abstract class BinaryDictionary implements Dictionary {
       throws IOException {
     switch (scheme) {
       case CLASSPATH:
-        return getClassResource(path);
+        return IOUtils.requireResourceNonNull(
+            BinaryDictionary.class.getClassLoader().getResourceAsStream(path), path);
       case FILE:
         return Files.newInputStream(Paths.get(path));
       default:
         throw new IllegalStateException("unknown resource scheme " + scheme);
     }
-  }
-
-  @Deprecated(forRemoval = true, since = "9.1")
-  private static InputStream getClassResource(String path) throws IOException {
-    return IOUtils.requireResourceNonNull(
-        BinaryDictionary.class.getClassLoader().getResourceAsStream(path), path);
   }
 
   public void lookupWordIds(int sourceId, IntsRef ref) {

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
@@ -25,6 +25,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Objects;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.InputStreamDataInput;
@@ -140,6 +141,9 @@ public abstract class BinaryDictionary implements Dictionary {
       throws IOException {
     switch (scheme) {
       case CLASSPATH:
+        Objects.requireNonNull(
+            path,
+            "Deprecated API no longer works with null paths, to load default resources use specialized APIs.");
         return IOUtils.requireResourceNonNull(
             BinaryDictionary.class.getClassLoader().getResourceAsStream(path), path);
       case FILE:

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
@@ -150,11 +150,8 @@ public abstract class BinaryDictionary implements Dictionary {
 
   @Deprecated(forRemoval = true, since = "9.1")
   private static InputStream getClassResource(String path) throws IOException {
-    // we prefix the path with a "/" to ensure we have the same pre-9.1 behaviour (where we used
-    // ClassLoader#getResourceAsStream):
-    var prefixedPath = path.startsWith("/") ? path : "/".concat(path);
     return IOUtils.requireResourceNonNull(
-        BinaryDictionary.class.getResourceAsStream(prefixedPath), path);
+        BinaryDictionary.class.getClassLoader().getResourceAsStream(path), path);
   }
 
   public void lookupWordIds(int sourceId, IntsRef ref) {

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/BinaryDictionary.java
@@ -143,7 +143,7 @@ public abstract class BinaryDictionary implements Dictionary {
       case CLASSPATH:
         Objects.requireNonNull(
             path,
-            "Deprecated API no longer works with null paths, to load default resources use specialized APIs.");
+            "Deprecated API no longer works with null paths, to load default resources use default ctors.");
         return IOUtils.requireResourceNonNull(
             BinaryDictionary.class.getClassLoader().getResourceAsStream(path), path);
       case FILE:

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/ConnectionCosts.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/ConnectionCosts.java
@@ -48,7 +48,7 @@ public final class ConnectionCosts {
   @Deprecated(forRemoval = true, since = "9.1")
   @SuppressWarnings("removal")
   public ConnectionCosts(BinaryDictionary.ResourceScheme scheme, String path) throws IOException {
-    this(() -> BinaryDictionary.getResource(scheme, path + FILENAME_SUFFIX));
+    this(() -> BinaryDictionary.getResource(scheme, path.replace('.', '/') + FILENAME_SUFFIX));
   }
 
   /**

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/ConnectionCosts.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/ConnectionCosts.java
@@ -23,7 +23,6 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.InputStreamDataInput;
@@ -49,10 +48,7 @@ public final class ConnectionCosts {
   @Deprecated(forRemoval = true, since = "9.1")
   @SuppressWarnings("removal")
   public ConnectionCosts(BinaryDictionary.ResourceScheme scheme, String path) throws IOException {
-    this(
-        scheme == BinaryDictionary.ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(path + FILENAME_SUFFIX))
-            : ConnectionCosts::getClassResource);
+    this(() -> BinaryDictionary.getResource(scheme, path + FILENAME_SUFFIX));
   }
 
   /**

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/ConnectionCosts.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/ConnectionCosts.java
@@ -19,6 +19,7 @@ package org.apache.lucene.analysis.ja.dict;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,7 +43,8 @@ public final class ConnectionCosts {
   /**
    * @param scheme - scheme for loading resources (FILE or CLASSPATH).
    * @param path - where to load resources from, without the ".dat" suffix
-   * @deprecated replaced by {@link #ConnectionCosts(Path)}
+   * @deprecated replaced by {@link #ConnectionCosts(Path)} for files and {@link
+   *     #ConnectionCosts(URL)} for classpath/module resources.
    */
   @Deprecated(forRemoval = true, since = "9.1")
   @SuppressWarnings("removal")
@@ -61,6 +63,17 @@ public final class ConnectionCosts {
    */
   public ConnectionCosts(Path connectionCostsFile) throws IOException {
     this(() -> Files.newInputStream(connectionCostsFile));
+  }
+
+  /**
+   * Create a {@link ConnectionCosts} from an external resource URL (e.g. from Classpath with {@link
+   * ClassLoader#getResource(String)}).
+   *
+   * @param connectionCostsUrl where to load connection costs resource
+   * @throws IOException if resource was not found or broken
+   */
+  public ConnectionCosts(URL connectionCostsUrl) throws IOException {
+    this(() -> connectionCostsUrl.openStream());
   }
 
   private ConnectionCosts() throws IOException {

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.InputStreamDataInput;
 import org.apache.lucene.util.IOSupplier;
@@ -52,18 +51,11 @@ public final class TokenInfoDictionary extends BinaryDictionary {
   public TokenInfoDictionary(ResourceScheme resourceScheme, String resourcePath)
       throws IOException {
     this(
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + TARGETMAP_FILENAME_SUFFIX))
-            : () -> getClassResource(TARGETMAP_FILENAME_SUFFIX),
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + POSDICT_FILENAME_SUFFIX))
-            : () -> getClassResource(POSDICT_FILENAME_SUFFIX),
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + DICT_FILENAME_SUFFIX))
-            : () -> getClassResource(DICT_FILENAME_SUFFIX),
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + FST_FILENAME_SUFFIX))
-            : () -> getClassResource(FST_FILENAME_SUFFIX));
+        () ->
+            BinaryDictionary.getResource(resourceScheme, resourcePath + TARGETMAP_FILENAME_SUFFIX),
+        () -> BinaryDictionary.getResource(resourceScheme, resourcePath + POSDICT_FILENAME_SUFFIX),
+        () -> BinaryDictionary.getResource(resourceScheme, resourcePath + DICT_FILENAME_SUFFIX),
+        () -> BinaryDictionary.getResource(resourceScheme, resourcePath + FST_FILENAME_SUFFIX));
   }
 
   /**

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
@@ -19,6 +19,7 @@ package org.apache.lucene.analysis.ja.dict;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -43,7 +44,8 @@ public final class TokenInfoDictionary extends BinaryDictionary {
    * @param resourceScheme - scheme for loading resources (FILE or CLASSPATH).
    * @param resourcePath - where to load resources (dictionaries) from. If null, with CLASSPATH
    *     scheme only, use this class's name as the path.
-   * @deprecated replaced by {@link #TokenInfoDictionary(Path, Path, Path, Path)}
+   * @deprecated replaced by {@link #TokenInfoDictionary(Path, Path, Path, Path)} for files and
+   *     {@link #TokenInfoDictionary(URL, URL, URL, URL)} for classpath/module resources
    */
   @Deprecated(forRemoval = true, since = "9.1")
   @SuppressWarnings("removal")
@@ -80,6 +82,25 @@ public final class TokenInfoDictionary extends BinaryDictionary {
         () -> Files.newInputStream(posDictFile),
         () -> Files.newInputStream(dictFile),
         () -> Files.newInputStream(fstFile));
+  }
+
+  /**
+   * Create a {@link TokenInfoDictionary} from an external resource URL (e.g. from Classpath with
+   * {@link ClassLoader#getResource(String)}).
+   *
+   * @param targetMapUrl where to load target map resource
+   * @param posDictUrl where to load POS dictionary resource
+   * @param dictUrl where to load dictionary entries resource
+   * @param fstUrl where to load encoded FST data resource
+   * @throws IOException if resource was not found or broken
+   */
+  public TokenInfoDictionary(URL targetMapUrl, URL posDictUrl, URL dictUrl, URL fstUrl)
+      throws IOException {
+    this(
+        () -> targetMapUrl.openStream(),
+        () -> posDictUrl.openStream(),
+        () -> dictUrl.openStream(),
+        () -> fstUrl.openStream());
   }
 
   private TokenInfoDictionary() throws IOException {

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
@@ -41,8 +41,7 @@ public final class TokenInfoDictionary extends BinaryDictionary {
 
   /**
    * @param resourceScheme - scheme for loading resources (FILE or CLASSPATH).
-   * @param resourcePath - where to load resources (dictionaries) from. If null, with CLASSPATH
-   *     scheme only, use this class's name as the path.
+   * @param resourcePath - where to load resources (dictionaries) from.
    * @deprecated replaced by {@link #TokenInfoDictionary(Path, Path, Path, Path)} for files and
    *     {@link #TokenInfoDictionary(URL, URL, URL, URL)} for classpath/module resources
    */

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionary.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.lucene.util.IOUtils;
 
 /** Dictionary for unknown-word handling. */
@@ -40,15 +39,9 @@ public final class UnknownDictionary extends BinaryDictionary {
   @SuppressWarnings("removal")
   public UnknownDictionary(ResourceScheme scheme, String path) throws IOException {
     super(
-        scheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(path + TARGETMAP_FILENAME_SUFFIX))
-            : () -> getClassResource(TARGETMAP_FILENAME_SUFFIX),
-        scheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(path + POSDICT_FILENAME_SUFFIX))
-            : () -> getClassResource(POSDICT_FILENAME_SUFFIX),
-        scheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(path + DICT_FILENAME_SUFFIX))
-            : () -> getClassResource(DICT_FILENAME_SUFFIX));
+        () -> BinaryDictionary.getResource(scheme, path + TARGETMAP_FILENAME_SUFFIX),
+        () -> BinaryDictionary.getResource(scheme, path + POSDICT_FILENAME_SUFFIX),
+        () -> BinaryDictionary.getResource(scheme, path + DICT_FILENAME_SUFFIX));
   }
 
   /**

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionary.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.ja.dict;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -32,7 +33,8 @@ public final class UnknownDictionary extends BinaryDictionary {
    * @param scheme scheme for loading resources (FILE or CLASSPATH).
    * @param path where to load resources from; a path, including the file base name without
    *     extension; this is used to match multiple files with the same base name.
-   * @deprecated replaced by {@link #UnknownDictionary(Path, Path, Path)}
+   * @deprecated replaced by {@link #UnknownDictionary(Path, Path, Path)} for files and {@link
+   *     #UnknownDictionary(URL, URL, URL)} for classpath/module resources
    */
   @Deprecated(forRemoval = true, since = "9.1")
   @SuppressWarnings("removal")
@@ -62,6 +64,20 @@ public final class UnknownDictionary extends BinaryDictionary {
         () -> Files.newInputStream(targetMapFile),
         () -> Files.newInputStream(posDictFile),
         () -> Files.newInputStream(dictFile));
+  }
+
+  /**
+   * Create a {@link UnknownDictionary} from an external resource URL (e.g. from Classpath with
+   * {@link ClassLoader#getResource(String)}).
+   *
+   * @param targetMapUrl where to load target map resource
+   * @param posDictUrl where to load POS dictionary resource
+   * @param dictUrl where to load dictionary entries resource
+   * @throws IOException if resource was not found or broken
+   */
+  public UnknownDictionary(URL targetMapUrl, URL posDictUrl, URL dictUrl) throws IOException {
+    super(
+        () -> targetMapUrl.openStream(), () -> posDictUrl.openStream(), () -> dictUrl.openStream());
   }
 
   private UnknownDictionary() throws IOException {

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestExternalDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestExternalDictionary.java
@@ -127,4 +127,12 @@ public class TestExternalDictionary extends LuceneTestCase {
         new ConnectionCosts(loader.getResource(dictionaryPath + ConnectionCosts.FILENAME_SUFFIX));
     assertEquals(1, cc.get(0, 1));
   }
+
+  @Deprecated(forRemoval = true, since = "9.1")
+  public void testDeprecatedLoadExternalTokenInfoDictionary() throws Exception {
+    String dictionaryPath = TokenInfoDictionary.class.getName().replace('.', '/');
+    TokenInfoDictionary dict =
+        new TokenInfoDictionary(BinaryDictionary.ResourceScheme.CLASSPATH, dictionaryPath);
+    assertNotNull(dict.getFST());
+  }
 }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestExternalDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestExternalDictionary.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 public class TestExternalDictionary extends LuceneTestCase {
 
   private Path dir;
+  private ClassLoader loader = getClass().getClassLoader();
 
   @Override
   @Before
@@ -96,6 +97,34 @@ public class TestExternalDictionary extends LuceneTestCase {
     String dictionaryPath = ConnectionCosts.class.getName().replace('.', '/');
     ConnectionCosts cc =
         new ConnectionCosts(dir.resolve(dictionaryPath + ConnectionCosts.FILENAME_SUFFIX));
+    assertEquals(1, cc.get(0, 1));
+  }
+
+  public void testLoadExternalUrlTokenInfoDictionary() throws Exception {
+    String dictionaryPath = TokenInfoDictionary.class.getName().replace('.', '/');
+    TokenInfoDictionary dict =
+        new TokenInfoDictionary(
+            loader.getResource(dictionaryPath + TARGETMAP_FILENAME_SUFFIX),
+            loader.getResource(dictionaryPath + POSDICT_FILENAME_SUFFIX),
+            loader.getResource(dictionaryPath + DICT_FILENAME_SUFFIX),
+            loader.getResource(dictionaryPath + FST_FILENAME_SUFFIX));
+    assertNotNull(dict.getFST());
+  }
+
+  public void testLoadExternalUrlUnknownDictionary() throws Exception {
+    String dictionaryPath = UnknownDictionary.class.getName().replace('.', '/');
+    UnknownDictionary dict =
+        new UnknownDictionary(
+            loader.getResource(dictionaryPath + TARGETMAP_FILENAME_SUFFIX),
+            loader.getResource(dictionaryPath + POSDICT_FILENAME_SUFFIX),
+            loader.getResource(dictionaryPath + DICT_FILENAME_SUFFIX));
+    assertNotNull(dict.getCharacterDefinition());
+  }
+
+  public void testLoadExternalUrlConnectionCosts() throws Exception {
+    String dictionaryPath = ConnectionCosts.class.getName().replace('.', '/');
+    ConnectionCosts cc =
+        new ConnectionCosts(loader.getResource(dictionaryPath + ConnectionCosts.FILENAME_SUFFIX));
     assertEquals(1, cc.get(0, 1));
   }
 }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestExternalDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestExternalDictionary.java
@@ -129,10 +129,29 @@ public class TestExternalDictionary extends LuceneTestCase {
   }
 
   @Deprecated(forRemoval = true, since = "9.1")
+  @SuppressWarnings("removal")
   public void testDeprecatedLoadExternalTokenInfoDictionary() throws Exception {
     String dictionaryPath = TokenInfoDictionary.class.getName().replace('.', '/');
     TokenInfoDictionary dict =
         new TokenInfoDictionary(BinaryDictionary.ResourceScheme.CLASSPATH, dictionaryPath);
     assertNotNull(dict.getFST());
+  }
+
+  @Deprecated(forRemoval = true, since = "9.1")
+  @SuppressWarnings("removal")
+  public void testDeprecatedLoadExternalUnknownDictionary() throws Exception {
+    String dictionaryPath = UnknownDictionary.class.getName().replace('.', '/');
+    UnknownDictionary dict =
+        new UnknownDictionary(BinaryDictionary.ResourceScheme.CLASSPATH, dictionaryPath);
+    assertNotNull(dict.getCharacterDefinition());
+  }
+
+  @Deprecated(forRemoval = true, since = "9.1")
+  @SuppressWarnings("removal")
+  public void testDeprecatedLoadExternalConnectionCosts() throws Exception {
+    String dictionaryPath = ConnectionCosts.class.getName().replace('.', '/');
+    ConnectionCosts cc =
+        new ConnectionCosts(BinaryDictionary.ResourceScheme.CLASSPATH, dictionaryPath);
+    assertEquals(1, cc.get(0, 1));
   }
 }

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/BinaryDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/BinaryDictionary.java
@@ -125,7 +125,7 @@ public abstract class BinaryDictionary implements Dictionary {
       case CLASSPATH:
         Objects.requireNonNull(
             path,
-            "Deprecated API no longer works with null paths, to load default resources use specialized APIs.");
+            "Deprecated API no longer works with null paths, to load default resources use default ctors.");
         return IOUtils.requireResourceNonNull(
             BinaryDictionary.class.getClassLoader().getResourceAsStream(path), path);
       case FILE:

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/BinaryDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/BinaryDictionary.java
@@ -118,21 +118,17 @@ public abstract class BinaryDictionary implements Dictionary {
   }
 
   @Deprecated(forRemoval = true, since = "9.1")
-  static final InputStream getResource(ResourceScheme scheme, String path) throws IOException {
+  public static final InputStream getResource(ResourceScheme scheme, String path)
+      throws IOException {
     switch (scheme) {
       case CLASSPATH:
-        return getClassResource(path);
+        return IOUtils.requireResourceNonNull(
+            BinaryDictionary.class.getClassLoader().getResourceAsStream(path), path);
       case FILE:
         return Files.newInputStream(Paths.get(path));
       default:
         throw new IllegalStateException("unknown resource scheme " + scheme);
     }
-  }
-
-  @Deprecated(forRemoval = true, since = "9.1")
-  private static InputStream getClassResource(String path) throws IOException {
-    return IOUtils.requireResourceNonNull(
-        BinaryDictionary.class.getClassLoader().getResourceAsStream(path), path);
   }
 
   public void lookupWordIds(int sourceId, IntsRef ref) {

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/BinaryDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/BinaryDictionary.java
@@ -25,6 +25,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Objects;
 import org.apache.lucene.analysis.ko.POS;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.DataInput;
@@ -122,6 +123,9 @@ public abstract class BinaryDictionary implements Dictionary {
       throws IOException {
     switch (scheme) {
       case CLASSPATH:
+        Objects.requireNonNull(
+            path,
+            "Deprecated API no longer works with null paths, to load default resources use specialized APIs.");
         return IOUtils.requireResourceNonNull(
             BinaryDictionary.class.getClassLoader().getResourceAsStream(path), path);
       case FILE:

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/BinaryDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/BinaryDictionary.java
@@ -23,11 +23,14 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.apache.lucene.analysis.ko.POS;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.InputStreamDataInput;
 import org.apache.lucene.util.IOSupplier;
+import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.IntsRef;
 
 /** Base class for a binary-encoded in-memory dictionary. */
@@ -112,6 +115,24 @@ public abstract class BinaryDictionary implements Dictionary {
               + ", sourceId="
               + sourceId);
     targetMapOffsets[sourceId] = targetMap.length;
+  }
+
+  @Deprecated(forRemoval = true, since = "9.1")
+  static final InputStream getResource(ResourceScheme scheme, String path) throws IOException {
+    switch (scheme) {
+      case CLASSPATH:
+        return getClassResource(path);
+      case FILE:
+        return Files.newInputStream(Paths.get(path));
+      default:
+        throw new IllegalStateException("unknown resource scheme " + scheme);
+    }
+  }
+
+  @Deprecated(forRemoval = true, since = "9.1")
+  private static InputStream getClassResource(String path) throws IOException {
+    return IOUtils.requireResourceNonNull(
+        BinaryDictionary.class.getClassLoader().getResourceAsStream(path), path);
   }
 
   public void lookupWordIds(int sourceId, IntsRef ref) {

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/ConnectionCosts.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/ConnectionCosts.java
@@ -23,7 +23,6 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.InputStreamDataInput;
@@ -50,10 +49,7 @@ public final class ConnectionCosts {
   @SuppressWarnings("removal")
   public ConnectionCosts(BinaryDictionary.ResourceScheme scheme, String resourcePath)
       throws IOException {
-    this(
-        scheme == BinaryDictionary.ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + FILENAME_SUFFIX))
-            : ConnectionCosts::getClassResource);
+    this(() -> BinaryDictionary.getResource(scheme, resourcePath + FILENAME_SUFFIX));
   }
 
   /**

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/ConnectionCosts.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/ConnectionCosts.java
@@ -19,6 +19,7 @@ package org.apache.lucene.analysis.ko.dict;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -41,7 +42,9 @@ public final class ConnectionCosts {
 
   /**
    * @param scheme - scheme for loading resources (FILE or CLASSPATH).
-   * @param resourcePath - where to load resources from, without the ".dat" suffix
+   * @param path - where to load resources from, without the ".dat" suffix
+   * @deprecated replaced by {@link #ConnectionCosts(Path)} for files and {@link
+   *     #ConnectionCosts(URL)} for classpath/module resources.
    */
   @Deprecated(forRemoval = true, since = "9.1")
   @SuppressWarnings("removal")
@@ -61,6 +64,17 @@ public final class ConnectionCosts {
    */
   public ConnectionCosts(Path connectionCostsFile) throws IOException {
     this(() -> Files.newInputStream(connectionCostsFile));
+  }
+
+  /**
+   * Create a {@link ConnectionCosts} from an external resource URL (e.g. from Classpath with {@link
+   * ClassLoader#getResource(String)}).
+   *
+   * @param connectionCostsUrl where to load connection costs resource
+   * @throws IOException if resource was not found or broken
+   */
+  public ConnectionCosts(URL connectionCostsUrl) throws IOException {
+    this(() -> connectionCostsUrl.openStream());
   }
 
   private ConnectionCosts() throws IOException {

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/ConnectionCosts.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/ConnectionCosts.java
@@ -41,15 +41,14 @@ public final class ConnectionCosts {
 
   /**
    * @param scheme - scheme for loading resources (FILE or CLASSPATH).
-   * @param resourcePath - where to load resources from, without the ".dat" suffix
+   * @param path - where to load resources from, without the ".dat" suffix
    * @deprecated replaced by {@link #ConnectionCosts(Path)} for files and {@link
    *     #ConnectionCosts(URL)} for classpath/module resources.
    */
   @Deprecated(forRemoval = true, since = "9.1")
   @SuppressWarnings("removal")
-  public ConnectionCosts(BinaryDictionary.ResourceScheme scheme, String resourcePath)
-      throws IOException {
-    this(() -> BinaryDictionary.getResource(scheme, resourcePath + FILENAME_SUFFIX));
+  public ConnectionCosts(BinaryDictionary.ResourceScheme scheme, String path) throws IOException {
+    this(() -> BinaryDictionary.getResource(scheme, path.replace('.', '/') + FILENAME_SUFFIX));
   }
 
   /**

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/ConnectionCosts.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/ConnectionCosts.java
@@ -42,7 +42,7 @@ public final class ConnectionCosts {
 
   /**
    * @param scheme - scheme for loading resources (FILE or CLASSPATH).
-   * @param path - where to load resources from, without the ".dat" suffix
+   * @param resourcePath - where to load resources from, without the ".dat" suffix
    * @deprecated replaced by {@link #ConnectionCosts(Path)} for files and {@link
    *     #ConnectionCosts(URL)} for classpath/module resources.
    */

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/TokenInfoDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/TokenInfoDictionary.java
@@ -19,6 +19,7 @@ package org.apache.lucene.analysis.ko.dict;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -51,6 +52,8 @@ public final class TokenInfoDictionary extends BinaryDictionary {
    * @param resourceScheme - scheme for loading resources (FILE or CLASSPATH).
    * @param resourcePath - where to load resources (dictionaries) from. If null, with CLASSPATH
    *     scheme only, use this class's name as the path.
+   * @deprecated replaced by {@link #TokenInfoDictionary(Path, Path, Path, Path)} for files and
+   *     {@link #TokenInfoDictionary(URL, URL, URL, URL)} for classpath/module resources
    */
   @Deprecated(forRemoval = true, since = "9.1")
   @SuppressWarnings("removal")
@@ -87,6 +90,25 @@ public final class TokenInfoDictionary extends BinaryDictionary {
         () -> Files.newInputStream(posDictFile),
         () -> Files.newInputStream(dictFile),
         () -> Files.newInputStream(fstFile));
+  }
+
+  /**
+   * Create a {@link TokenInfoDictionary} from an external resource URL (e.g. from Classpath with
+   * {@link ClassLoader#getResource(String)}).
+   *
+   * @param targetMapUrl where to load target map resource
+   * @param posDictUrl where to load POS dictionary resource
+   * @param dictUrl where to load dictionary entries resource
+   * @param fstUrl where to load encoded FST data resource
+   * @throws IOException if resource was not found or broken
+   */
+  public TokenInfoDictionary(URL targetMapUrl, URL posDictUrl, URL dictUrl, URL fstUrl)
+      throws IOException {
+    this(
+        () -> targetMapUrl.openStream(),
+        () -> posDictUrl.openStream(),
+        () -> dictUrl.openStream(),
+        () -> fstUrl.openStream());
   }
 
   private TokenInfoDictionary(

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/TokenInfoDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/TokenInfoDictionary.java
@@ -49,8 +49,7 @@ public final class TokenInfoDictionary extends BinaryDictionary {
 
   /**
    * @param resourceScheme - scheme for loading resources (FILE or CLASSPATH).
-   * @param resourcePath - where to load resources (dictionaries) from. If null, with CLASSPATH
-   *     scheme only, use this class's name as the path.
+   * @param resourcePath - where to load resources (dictionaries) from.
    * @deprecated replaced by {@link #TokenInfoDictionary(Path, Path, Path, Path)} for files and
    *     {@link #TokenInfoDictionary(URL, URL, URL, URL)} for classpath/module resources
    */

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/TokenInfoDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/TokenInfoDictionary.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.InputStreamDataInput;
 import org.apache.lucene.util.IOSupplier;
@@ -60,18 +59,11 @@ public final class TokenInfoDictionary extends BinaryDictionary {
   public TokenInfoDictionary(ResourceScheme resourceScheme, String resourcePath)
       throws IOException {
     this(
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + TARGETMAP_FILENAME_SUFFIX))
-            : () -> getClassResource(TARGETMAP_FILENAME_SUFFIX),
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + POSDICT_FILENAME_SUFFIX))
-            : () -> getClassResource(POSDICT_FILENAME_SUFFIX),
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + DICT_FILENAME_SUFFIX))
-            : () -> getClassResource(DICT_FILENAME_SUFFIX),
-        resourceScheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + FST_FILENAME_SUFFIX))
-            : () -> getClassResource(FST_FILENAME_SUFFIX));
+        () ->
+            BinaryDictionary.getResource(resourceScheme, resourcePath + TARGETMAP_FILENAME_SUFFIX),
+        () -> BinaryDictionary.getResource(resourceScheme, resourcePath + POSDICT_FILENAME_SUFFIX),
+        () -> BinaryDictionary.getResource(resourceScheme, resourcePath + DICT_FILENAME_SUFFIX),
+        () -> BinaryDictionary.getResource(resourceScheme, resourcePath + FST_FILENAME_SUFFIX));
   }
 
   /**

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UnknownDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UnknownDictionary.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.ko.dict;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -31,6 +32,8 @@ public final class UnknownDictionary extends BinaryDictionary {
    * @param scheme scheme for loading resources (FILE or CLASSPATH).
    * @param resourcePath where to load resources from; a path, including the file base name without
    *     extension; this is used to match multiple files with the same base name.
+   * @deprecated replaced by {@link #UnknownDictionary(Path, Path, Path)} for files and {@link
+   *     #UnknownDictionary(URL, URL, URL)} for classpath/module resources
    */
   @Deprecated(forRemoval = true, since = "9.1")
   @SuppressWarnings("removal")
@@ -60,6 +63,20 @@ public final class UnknownDictionary extends BinaryDictionary {
         () -> Files.newInputStream(targetMapFile),
         () -> Files.newInputStream(posDictFile),
         () -> Files.newInputStream(dictFile));
+  }
+
+  /**
+   * Create a {@link UnknownDictionary} from an external resource URL (e.g. from Classpath with
+   * {@link ClassLoader#getResource(String)}).
+   *
+   * @param targetMapUrl where to load target map resource
+   * @param posDictUrl where to load POS dictionary resource
+   * @param dictUrl where to load dictionary entries resource
+   * @throws IOException if resource was not found or broken
+   */
+  public UnknownDictionary(URL targetMapUrl, URL posDictUrl, URL dictUrl) throws IOException {
+    super(
+        () -> targetMapUrl.openStream(), () -> posDictUrl.openStream(), () -> dictUrl.openStream());
   }
 
   private UnknownDictionary() throws IOException {

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UnknownDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UnknownDictionary.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.lucene.util.IOUtils;
 
 /** Dictionary for unknown-word handling. */
@@ -39,15 +38,9 @@ public final class UnknownDictionary extends BinaryDictionary {
   @SuppressWarnings("removal")
   public UnknownDictionary(ResourceScheme scheme, String resourcePath) throws IOException {
     super(
-        scheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + TARGETMAP_FILENAME_SUFFIX))
-            : () -> getClassResource(TARGETMAP_FILENAME_SUFFIX),
-        scheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + POSDICT_FILENAME_SUFFIX))
-            : () -> getClassResource(POSDICT_FILENAME_SUFFIX),
-        scheme == ResourceScheme.FILE
-            ? () -> Files.newInputStream(Paths.get(resourcePath + DICT_FILENAME_SUFFIX))
-            : () -> getClassResource(DICT_FILENAME_SUFFIX));
+        () -> BinaryDictionary.getResource(scheme, resourcePath + TARGETMAP_FILENAME_SUFFIX),
+        () -> BinaryDictionary.getResource(scheme, resourcePath + POSDICT_FILENAME_SUFFIX),
+        () -> BinaryDictionary.getResource(scheme, resourcePath + DICT_FILENAME_SUFFIX));
   }
 
   /**

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestExternalDictionary.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestExternalDictionary.java
@@ -127,4 +127,31 @@ public class TestExternalDictionary extends LuceneTestCase {
         new ConnectionCosts(loader.getResource(dictionaryPath + ConnectionCosts.FILENAME_SUFFIX));
     assertEquals(0, cc.get(1, 1));
   }
+
+  @Deprecated(forRemoval = true, since = "9.1")
+  @SuppressWarnings("removal")
+  public void testDeprecatedLoadExternalTokenInfoDictionary() throws Exception {
+    String dictionaryPath = TokenInfoDictionary.class.getName().replace('.', '/');
+    TokenInfoDictionary dict =
+        new TokenInfoDictionary(BinaryDictionary.ResourceScheme.CLASSPATH, dictionaryPath);
+    assertNotNull(dict.getFST());
+  }
+
+  @Deprecated(forRemoval = true, since = "9.1")
+  @SuppressWarnings("removal")
+  public void testDeprecatedLoadExternalUnknownDictionary() throws Exception {
+    String dictionaryPath = UnknownDictionary.class.getName().replace('.', '/');
+    UnknownDictionary dict =
+        new UnknownDictionary(BinaryDictionary.ResourceScheme.CLASSPATH, dictionaryPath);
+    assertNotNull(dict.getCharacterDefinition());
+  }
+
+  @Deprecated(forRemoval = true, since = "9.1")
+  @SuppressWarnings("removal")
+  public void testDeprecatedLoadExternalConnectionCosts() throws Exception {
+    String dictionaryPath = ConnectionCosts.class.getName().replace('.', '/');
+    ConnectionCosts cc =
+        new ConnectionCosts(BinaryDictionary.ResourceScheme.CLASSPATH, dictionaryPath);
+    assertEquals(0, cc.get(1, 1));
+  }
 }

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestExternalDictionary.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestExternalDictionary.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 public class TestExternalDictionary extends LuceneTestCase {
 
   private Path dir;
+  private ClassLoader loader = getClass().getClassLoader();
 
   @Override
   @Before
@@ -96,6 +97,34 @@ public class TestExternalDictionary extends LuceneTestCase {
     String dictionaryPath = ConnectionCosts.class.getName().replace('.', '/');
     ConnectionCosts cc =
         new ConnectionCosts(dir.resolve(dictionaryPath + ConnectionCosts.FILENAME_SUFFIX));
+    assertEquals(0, cc.get(1, 1));
+  }
+
+  public void testLoadExternalUrlTokenInfoDictionary() throws Exception {
+    String dictionaryPath = TokenInfoDictionary.class.getName().replace('.', '/');
+    TokenInfoDictionary dict =
+        new TokenInfoDictionary(
+            loader.getResource(dictionaryPath + TARGETMAP_FILENAME_SUFFIX),
+            loader.getResource(dictionaryPath + POSDICT_FILENAME_SUFFIX),
+            loader.getResource(dictionaryPath + DICT_FILENAME_SUFFIX),
+            loader.getResource(dictionaryPath + FST_FILENAME_SUFFIX));
+    assertNotNull(dict.getFST());
+  }
+
+  public void testLoadExternalUrlUnknownDictionary() throws Exception {
+    String dictionaryPath = UnknownDictionary.class.getName().replace('.', '/');
+    UnknownDictionary dict =
+        new UnknownDictionary(
+            loader.getResource(dictionaryPath + TARGETMAP_FILENAME_SUFFIX),
+            loader.getResource(dictionaryPath + POSDICT_FILENAME_SUFFIX),
+            loader.getResource(dictionaryPath + DICT_FILENAME_SUFFIX));
+    assertNotNull(dict.getCharacterDefinition());
+  }
+
+  public void testLoadExternalUrlConnectionCosts() throws Exception {
+    String dictionaryPath = ConnectionCosts.class.getName().replace('.', '/');
+    ConnectionCosts cc =
+        new ConnectionCosts(loader.getResource(dictionaryPath + ConnectionCosts.FILENAME_SUFFIX));
     assertEquals(0, cc.get(1, 1));
   }
 }


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/LUCENE-10558

This is against 9.x branch, but can be forward ported to main.