### PR TITLE
LUCENE-10436: Reinstate public getdocValuesdocIdSetIterator method on DocValues

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -56,6 +56,7 @@ import org.apache.lucene.index.CheckIndex.Status.DocValuesStatus;
 import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.LeafFieldComparator;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
@@ -4145,7 +4146,7 @@ public final class CheckIndex implements Closeable {
     try {
       int softDeletes =
           PendingSoftDeletes.countSoftDeletes(
-              DocValues.getDocValuesDocIdSetIterator(softDeletesField, reader),
+              FieldExistsQuery.getDocValuesDocIdSetIterator(softDeletesField, reader),
               reader.getLiveDocs());
       if (softDeletes != info.getSoftDelCount()) {
         throw new CheckIndexException(

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -4145,7 +4145,7 @@ public final class CheckIndex implements Closeable {
     try {
       int softDeletes =
           PendingSoftDeletes.countSoftDeletes(
-              DocValuesIterator.getDocValuesDocIdSetIterator(softDeletesField, reader),
+              DocValues.getDocValuesDocIdSetIterator(softDeletesField, reader),
               reader.getLiveDocs());
       if (softDeletes != info.getSoftDelCount()) {
         throw new CheckIndexException(

--- a/lucene/core/src/java/org/apache/lucene/index/DocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValues.java
@@ -19,7 +19,6 @@ package org.apache.lucene.index;
 import java.io.IOException;
 import java.util.Arrays;
 
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 
 /** This class contains utility methods and constants for DocValues */
@@ -339,39 +338,4 @@ public final class DocValues {
     return true;
   }
 
-  /**
-   * Returns a {@link DocIdSetIterator} from the given field or null if the field doesn't exist in
-   * the reader or if the reader has no doc values for the field.
-   */
-  public static DocIdSetIterator getDocValuesDocIdSetIterator(String field, LeafReader reader)
-      throws IOException {
-    FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
-    final DocIdSetIterator iterator;
-    if (fieldInfo != null) {
-      switch (fieldInfo.getDocValuesType()) {
-        case NONE:
-          iterator = null;
-          break;
-        case NUMERIC:
-          iterator = reader.getNumericDocValues(field);
-          break;
-        case BINARY:
-          iterator = reader.getBinaryDocValues(field);
-          break;
-        case SORTED:
-          iterator = reader.getSortedDocValues(field);
-          break;
-        case SORTED_NUMERIC:
-          iterator = reader.getSortedNumericDocValues(field);
-          break;
-        case SORTED_SET:
-          iterator = reader.getSortedSetDocValues(field);
-          break;
-        default:
-          throw new AssertionError();
-      }
-      return iterator;
-    }
-    return null;
-  }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValues.java
@@ -18,6 +18,8 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Arrays;
+
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 
 /** This class contains utility methods and constants for DocValues */
@@ -335,5 +337,41 @@ public final class DocValues {
       if (fi != null && fi.getDocValuesGen() > -1) return false;
     }
     return true;
+  }
+
+  /**
+   * Returns a {@link DocIdSetIterator} from the given field or null if the field doesn't exist in
+   * the reader or if the reader has no doc values for the field.
+   */
+  public static DocIdSetIterator getDocValuesDocIdSetIterator(String field, LeafReader reader)
+      throws IOException {
+    FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
+    final DocIdSetIterator iterator;
+    if (fieldInfo != null) {
+      switch (fieldInfo.getDocValuesType()) {
+        case NONE:
+          iterator = null;
+          break;
+        case NUMERIC:
+          iterator = reader.getNumericDocValues(field);
+          break;
+        case BINARY:
+          iterator = reader.getBinaryDocValues(field);
+          break;
+        case SORTED:
+          iterator = reader.getSortedDocValues(field);
+          break;
+        case SORTED_NUMERIC:
+          iterator = reader.getSortedNumericDocValues(field);
+          break;
+        case SORTED_SET:
+          iterator = reader.getSortedSetDocValues(field);
+          break;
+        default:
+          throw new AssertionError();
+      }
+      return iterator;
+    }
+    return null;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValues.java
@@ -18,7 +18,6 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Arrays;
-
 import org.apache.lucene.util.BytesRef;
 
 /** This class contains utility methods and constants for DocValues */
@@ -337,5 +336,4 @@ public final class DocValues {
     }
     return true;
   }
-
 }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
@@ -28,5 +28,4 @@ abstract class DocValuesIterator extends DocIdSetIterator {
    * returns {@code target}.
    */
   public abstract boolean advanceExact(int target) throws IOException;
-
 }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
@@ -29,39 +29,4 @@ abstract class DocValuesIterator extends DocIdSetIterator {
    */
   public abstract boolean advanceExact(int target) throws IOException;
 
-  /**
-   * Returns a {@link DocIdSetIterator} from the given field or null if the field doesn't exist in
-   * the reader or if the reader has no doc values for the field.
-   */
-  public static DocIdSetIterator getDocValuesDocIdSetIterator(String field, LeafReader reader)
-      throws IOException {
-    FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
-    final DocIdSetIterator iterator;
-    if (fieldInfo != null) {
-      switch (fieldInfo.getDocValuesType()) {
-        case NONE:
-          iterator = null;
-          break;
-        case NUMERIC:
-          iterator = reader.getNumericDocValues(field);
-          break;
-        case BINARY:
-          iterator = reader.getBinaryDocValues(field);
-          break;
-        case SORTED:
-          iterator = reader.getSortedDocValues(field);
-          break;
-        case SORTED_NUMERIC:
-          iterator = reader.getSortedNumericDocValues(field);
-          break;
-        case SORTED_SET:
-          iterator = reader.getSortedSetDocValues(field);
-          break;
-        default:
-          throw new AssertionError();
-      }
-      return iterator;
-    }
-    return null;
-  }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -59,6 +59,7 @@ import org.apache.lucene.internal.tests.IndexPackageAccess;
 import org.apache.lucene.internal.tests.IndexWriterAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
@@ -3141,7 +3142,7 @@ public class IndexWriter
           Bits liveDocs = leaf.getLiveDocs();
           numSoftDeleted +=
               PendingSoftDeletes.countSoftDeletes(
-                  DocValues.getDocValuesDocIdSetIterator(
+                  FieldExistsQuery.getDocValuesDocIdSetIterator(
                       config.getSoftDeletesField(), leaf),
                   liveDocs);
         }
@@ -4847,7 +4848,7 @@ public class IndexWriter
     int hardDeleteCount = 0;
     int softDeletesCount = 0;
     DocIdSetIterator softDeletedDocs =
-        DocValues.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), reader);
+        FieldExistsQuery.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), reader);
     if (softDeletedDocs != null) {
       int docId;
       while ((docId = softDeletedDocs.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3141,7 +3141,7 @@ public class IndexWriter
           Bits liveDocs = leaf.getLiveDocs();
           numSoftDeleted +=
               PendingSoftDeletes.countSoftDeletes(
-                  DocValuesIterator.getDocValuesDocIdSetIterator(
+                  DocValues.getDocValuesDocIdSetIterator(
                       config.getSoftDeletesField(), leaf),
                   liveDocs);
         }
@@ -4847,7 +4847,7 @@ public class IndexWriter
     int hardDeleteCount = 0;
     int softDeletesCount = 0;
     DocIdSetIterator softDeletedDocs =
-        DocValuesIterator.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), reader);
+        DocValues.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), reader);
     if (softDeletedDocs != null) {
       int docId;
       while ((docId = softDeletedDocs.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3142,8 +3142,7 @@ public class IndexWriter
           Bits liveDocs = leaf.getLiveDocs();
           numSoftDeleted +=
               PendingSoftDeletes.countSoftDeletes(
-                  FieldExistsQuery.getDocValuesDocIdSetIterator(
-                      config.getSoftDeletesField(), leaf),
+                  FieldExistsQuery.getDocValuesDocIdSetIterator(config.getSoftDeletesField(), leaf),
                   liveDocs);
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/index/PendingSoftDeletes.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PendingSoftDeletes.java
@@ -77,7 +77,7 @@ final class PendingSoftDeletes extends PendingDeletes {
     // only re-calculate this if we haven't seen this generation
     if (dvGeneration < info.getDocValuesGen()) {
       final DocIdSetIterator iterator =
-          DocValuesIterator.getDocValuesDocIdSetIterator(field, reader);
+          DocValues.getDocValuesDocIdSetIterator(field, reader);
       int newDelCount;
       if (iterator
           != null) { // nothing is deleted we don't have a soft deletes field in this segment

--- a/lucene/core/src/java/org/apache/lucene/index/PendingSoftDeletes.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PendingSoftDeletes.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import org.apache.lucene.codecs.FieldInfosFormat;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Bits;
@@ -77,7 +78,7 @@ final class PendingSoftDeletes extends PendingDeletes {
     // only re-calculate this if we haven't seen this generation
     if (dvGeneration < info.getDocValuesGen()) {
       final DocIdSetIterator iterator =
-          DocValues.getDocValuesDocIdSetIterator(field, reader);
+          FieldExistsQuery.getDocValuesDocIdSetIterator(field, reader);
       int newDelCount;
       if (iterator
           != null) { // nothing is deleted we don't have a soft deletes field in this segment

--- a/lucene/core/src/java/org/apache/lucene/index/SoftDeletesDirectoryReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SoftDeletesDirectoryReaderWrapper.java
@@ -126,7 +126,7 @@ public final class SoftDeletesDirectoryReaderWrapper extends FilterDirectoryRead
   }
 
   static LeafReader wrap(LeafReader reader, String field) throws IOException {
-    DocIdSetIterator iterator = DocValuesIterator.getDocValuesDocIdSetIterator(field, reader);
+    DocIdSetIterator iterator = DocValues.getDocValuesDocIdSetIterator(field, reader);
     if (iterator == null) {
       return reader;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/SoftDeletesDirectoryReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SoftDeletesDirectoryReaderWrapper.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 
@@ -126,7 +127,7 @@ public final class SoftDeletesDirectoryReaderWrapper extends FilterDirectoryRead
   }
 
   static LeafReader wrap(LeafReader reader, String field) throws IOException {
-    DocIdSetIterator iterator = DocValues.getDocValuesDocIdSetIterator(field, reader);
+    DocIdSetIterator iterator = FieldExistsQuery.getDocValuesDocIdSetIterator(field, reader);
     if (iterator == null) {
       return reader;
     }

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -41,43 +41,43 @@ public class FieldExistsQuery extends Query {
     this.field = Objects.requireNonNull(field);
   }
 
-    /**
-     * Returns a {@link DocIdSetIterator} from the given field or null if the field doesn't exist in
-     * the reader or if the reader has no doc values for the field.
-     */
-    public static DocIdSetIterator getDocValuesDocIdSetIterator(String field, LeafReader reader)
-        throws IOException {
-      FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
-      final DocIdSetIterator iterator;
-      if (fieldInfo != null) {
-        switch (fieldInfo.getDocValuesType()) {
-          case NONE:
-            iterator = null;
-            break;
-          case NUMERIC:
-            iterator = reader.getNumericDocValues(field);
-            break;
-          case BINARY:
-            iterator = reader.getBinaryDocValues(field);
-            break;
-          case SORTED:
-            iterator = reader.getSortedDocValues(field);
-            break;
-          case SORTED_NUMERIC:
-            iterator = reader.getSortedNumericDocValues(field);
-            break;
-          case SORTED_SET:
-            iterator = reader.getSortedSetDocValues(field);
-            break;
-          default:
-            throw new AssertionError();
-        }
-        return iterator;
+  /**
+   * Returns a {@link DocIdSetIterator} from the given field or null if the field doesn't exist in
+   * the reader or if the reader has no doc values for the field.
+   */
+  public static DocIdSetIterator getDocValuesDocIdSetIterator(String field, LeafReader reader)
+      throws IOException {
+    FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
+    final DocIdSetIterator iterator;
+    if (fieldInfo != null) {
+      switch (fieldInfo.getDocValuesType()) {
+        case NONE:
+          iterator = null;
+          break;
+        case NUMERIC:
+          iterator = reader.getNumericDocValues(field);
+          break;
+        case BINARY:
+          iterator = reader.getBinaryDocValues(field);
+          break;
+        case SORTED:
+          iterator = reader.getSortedDocValues(field);
+          break;
+        case SORTED_NUMERIC:
+          iterator = reader.getSortedNumericDocValues(field);
+          break;
+        case SORTED_SET:
+          iterator = reader.getSortedSetDocValues(field);
+          break;
+        default:
+          throw new AssertionError();
       }
-      return null;
+      return iterator;
     }
+    return null;
+  }
 
-    public String getField() {
+  public String getField() {
     return field;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -41,7 +41,43 @@ public class FieldExistsQuery extends Query {
     this.field = Objects.requireNonNull(field);
   }
 
-  public String getField() {
+    /**
+     * Returns a {@link DocIdSetIterator} from the given field or null if the field doesn't exist in
+     * the reader or if the reader has no doc values for the field.
+     */
+    public static DocIdSetIterator getDocValuesDocIdSetIterator(String field, LeafReader reader)
+        throws IOException {
+      FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
+      final DocIdSetIterator iterator;
+      if (fieldInfo != null) {
+        switch (fieldInfo.getDocValuesType()) {
+          case NONE:
+            iterator = null;
+            break;
+          case NUMERIC:
+            iterator = reader.getNumericDocValues(field);
+            break;
+          case BINARY:
+            iterator = reader.getBinaryDocValues(field);
+            break;
+          case SORTED:
+            iterator = reader.getSortedDocValues(field);
+            break;
+          case SORTED_NUMERIC:
+            iterator = reader.getSortedNumericDocValues(field);
+            break;
+          case SORTED_SET:
+            iterator = reader.getSortedSetDocValues(field);
+            break;
+          default:
+            throw new AssertionError();
+        }
+        return iterator;
+      }
+      return null;
+    }
+
+    public String getField() {
     return field;
   }
 


### PR DESCRIPTION
When this was refactored previously, we moved a public static method from
DocValuesFieldExistsQuery to the package-private DocValuesIterator class.  This
makes the method available again by moving it instead to the public DocValues 
utility class.