### PR TITLE
LUCENE-10397: KnnVectorQuery doesn't tie break by doc ID

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/LongHeap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/LongHeap.java
@@ -76,7 +76,7 @@ public final class LongHeap {
    */
   public final boolean insertWithOverflow(long value) {
     if (size >= maxSize) {
-      if ((value < heap[1])) {
+      if (value < heap[1]) {
         return false;
       }
       updateTop(value);

--- a/lucene/core/src/java/org/apache/lucene/util/LongHeap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/LongHeap.java
@@ -26,7 +26,7 @@ package org.apache.lucene.util;
  *
  * @lucene.internal
  */
-public final class LongHeap {
+public class LongHeap {
 
   private final int maxSize;
 
@@ -68,15 +68,22 @@ public final class LongHeap {
   }
 
   /**
+   * @return <code>true</code> iff parameter <code>a</code> is less than parameter <code>b</code>.
+   */
+  protected boolean lessThan(long a, long b) {
+    return a < b;
+  }
+
+  /**
    * Adds a value to an LongHeap in log(size) time. If the number of values would exceed the heap's
    * maxSize, the least value is discarded.
    *
    * @return whether the value was added (unless the heap is full, or the new value is less than the
    *     top value)
    */
-  public boolean insertWithOverflow(long value) {
+  public final boolean insertWithOverflow(long value) {
     if (size >= maxSize) {
-      if (value < heap[1]) {
+      if (lessThan(value, heap[1])) {
         return false;
       }
       updateTop(value);
@@ -152,7 +159,7 @@ public final class LongHeap {
     int i = origPos;
     long value = heap[i]; // save bottom value
     int j = i >>> 1;
-    while (j > 0 && value < heap[j]) {
+    while (j > 0 && lessThan(value, heap[j])) {
       heap[i] = heap[j]; // shift parents down
       i = j;
       j = j >>> 1;
@@ -164,22 +171,22 @@ public final class LongHeap {
     long value = heap[i]; // save top value
     int j = i << 1; // find smaller child
     int k = j + 1;
-    if (k <= size && heap[k] < heap[j]) {
+    if (k <= size && lessThan(heap[k], heap[j])) {
       j = k;
     }
-    while (j <= size && heap[j] < value) {
+    while (j <= size && lessThan(heap[j], value)) {
       heap[i] = heap[j]; // shift up child
       i = j;
       j = i << 1;
       k = j + 1;
-      if (k <= size && heap[k] < heap[j]) {
+      if (k <= size && lessThan(heap[k], heap[j])) {
         j = k;
       }
     }
     heap[i] = value; // install saved value
   }
 
-  public void pushAll(LongHeap other) {
+  public final void pushAll(LongHeap other) {
     for (int i = 1; i <= other.size; i++) {
       push(other.heap[i]);
     }
@@ -189,7 +196,7 @@ public final class LongHeap {
    * Return the element at the ith location in the heap array. Use for iterating over elements when
    * the order doesn't matter. Note that the valid arguments range from [1, size].
    */
-  public long get(int i) {
+  public final long get(int i) {
     return heap[i];
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/LongHeap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/LongHeap.java
@@ -26,7 +26,7 @@ package org.apache.lucene.util;
  *
  * @lucene.internal
  */
-public class LongHeap {
+public final class LongHeap {
 
   private final int maxSize;
 
@@ -68,13 +68,6 @@ public class LongHeap {
   }
 
   /**
-   * @return <code>true</code> iff parameter <code>a</code> is less than parameter <code>b</code>.
-   */
-  protected boolean lessThan(long a, long b) {
-    return a < b;
-  }
-
-  /**
    * Adds a value to an LongHeap in log(size) time. If the number of values would exceed the heap's
    * maxSize, the least value is discarded.
    *
@@ -83,7 +76,7 @@ public class LongHeap {
    */
   public final boolean insertWithOverflow(long value) {
     if (size >= maxSize) {
-      if (lessThan(value, heap[1])) {
+      if ((value < heap[1])) {
         return false;
       }
       updateTop(value);
@@ -159,7 +152,7 @@ public class LongHeap {
     int i = origPos;
     long value = heap[i]; // save bottom value
     int j = i >>> 1;
-    while (j > 0 && lessThan(value, heap[j])) {
+    while (j > 0 && value < heap[j]) {
       heap[i] = heap[j]; // shift parents down
       i = j;
       j = j >>> 1;
@@ -171,15 +164,15 @@ public class LongHeap {
     long value = heap[i]; // save top value
     int j = i << 1; // find smaller child
     int k = j + 1;
-    if (k <= size && lessThan(heap[k], heap[j])) {
+    if (k <= size && heap[k] < heap[j]) {
       j = k;
     }
-    while (j <= size && lessThan(heap[j], value)) {
+    while (j <= size && heap[j] < value) {
       heap[i] = heap[j]; // shift up child
       i = j;
       j = i << 1;
       k = j + 1;
-      if (k <= size && lessThan(heap[k], heap[j])) {
+      if (k <= size && heap[k] < heap[j]) {
         j = k;
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -57,8 +57,19 @@ public class NeighborQueue {
   private boolean incomplete;
 
   public NeighborQueue(int initialSize, boolean reversed) {
-    this.heap = new LongHeap(initialSize);
     this.order = reversed ? Order.REVERSED : Order.NATURAL;
+    this.heap =
+        new LongHeap(initialSize) {
+          @Override
+          protected boolean lessThan(long a, long b) {
+            final float aScore = NumericUtils.sortableIntToFloat((int) (order.apply(a) >> 32));
+            final float bScore = NumericUtils.sortableIntToFloat((int) (order.apply(b) >> 32));
+            if (aScore == bScore) {
+              return (int) order.apply(a) > (int) order.apply(b);
+            }
+            return reversed == false ? aScore < bScore : bScore < aScore;
+          }
+        };
   }
 
   /** @return the number of elements in the heap */

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -92,15 +92,15 @@ public class NeighborQueue {
   }
 
   private long encode(int node, float score) {
-    long nodeReverse = reversed ? node : (-1 - node);
-    // make sure all high 32 bits were 0 by unsigned right shift
-    nodeReverse = nodeReverse << 32 >>> 32;
+    int nodeReverse = reversed ? node : Integer.MAX_VALUE - node;
     return order.apply((((long) NumericUtils.floatToSortableInt(score)) << 32) | nodeReverse);
   }
 
   /** Removes the top element and returns its node id. */
   public int pop() {
-    return reversed ? (int) order.apply(heap.pop()) : -1 - (int) order.apply(heap.pop());
+    return reversed
+        ? (int) order.apply(heap.pop())
+        : Integer.MAX_VALUE - (int) order.apply(heap.pop());
   }
 
   int[] nodes() {
@@ -108,14 +108,18 @@ public class NeighborQueue {
     int[] nodes = new int[size];
     for (int i = 0; i < size; i++) {
       nodes[i] =
-          reversed ? (int) order.apply(heap.get(i + 1)) : -1 - (int) order.apply(heap.get(i + 1));
+          reversed
+              ? (int) order.apply(heap.get(i + 1))
+              : Integer.MAX_VALUE - (int) order.apply(heap.get(i + 1));
     }
     return nodes;
   }
 
   /** Returns the top element's node id. */
   public int topNode() {
-    return reversed ? (int) (order.apply(heap.top())) : -1 - (int) (order.apply(heap.top()));
+    return reversed
+        ? (int) (order.apply(heap.top()))
+        : Integer.MAX_VALUE - (int) (order.apply(heap.top()));
   }
 
   /** Returns the top element's node score. */

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -35,6 +35,11 @@ public class NeighborQueue {
       long apply(long v) {
         return v;
       }
+
+      @Override
+      int getNode(long v) {
+        return Integer.MAX_VALUE - (int) v;
+      }
     },
     REVERSED {
       @Override
@@ -43,9 +48,16 @@ public class NeighborQueue {
         // needs a function that returns MAX_VALUE for MIN_VALUE and vice-versa.
         return -1 - v;
       }
+
+      @Override
+      int getNode(long v) {
+        return (int) (-1 - v);
+      }
     };
 
     abstract long apply(long v);
+
+    abstract int getNode(long v);
   }
 
   private final LongHeap heap;
@@ -98,28 +110,21 @@ public class NeighborQueue {
 
   /** Removes the top element and returns its node id. */
   public int pop() {
-    return reversed
-        ? (int) order.apply(heap.pop())
-        : Integer.MAX_VALUE - (int) order.apply(heap.pop());
+    return order.getNode(heap.pop());
   }
 
   int[] nodes() {
     int size = size();
     int[] nodes = new int[size];
     for (int i = 0; i < size; i++) {
-      nodes[i] =
-          reversed
-              ? (int) order.apply(heap.get(i + 1))
-              : Integer.MAX_VALUE - (int) order.apply(heap.get(i + 1));
+      nodes[i] = order.getNode(heap.get(i + 1));
     }
     return nodes;
   }
 
   /** Returns the top element's node id. */
   public int topNode() {
-    return reversed
-        ? (int) (order.apply(heap.top()))
-        : Integer.MAX_VALUE - (int) (order.apply(heap.top()));
+    return order.getNode(heap.top());
   }
 
   /** Returns the top element's node score. */

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborQueue.java
@@ -21,6 +21,42 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestNeighborQueue extends LuceneTestCase {
 
+  public void testSameScoreNATURAL() {
+    NeighborQueue nn = new NeighborQueue(2, false);
+    nn.add(1, 0.1f);
+    nn.add(2, 0.5f);
+    nn.add(3, 0.5f);
+    nn.add(4, 0.1f);
+    // higher scores are better; lowest score on top
+    // same score then lower node means lower doc no matter REVERSED OR NATURAL
+    assertEquals(4, nn.topNode());
+    nn.pop();
+    assertEquals(1, nn.topNode());
+    nn.pop();
+    assertEquals(3, nn.topNode());
+    nn.pop();
+    assertEquals(2, nn.topNode());
+    nn.pop();
+  }
+
+  public void testSameScoreREVERSED() {
+    NeighborQueue nn = new NeighborQueue(2, true);
+    nn.add(1, 0.1f);
+    nn.add(2, 0.5f);
+    nn.add(3, 0.5f);
+    nn.add(4, 0.1f);
+    // lower scores are better; highest score on top
+    // same score then lower node means lower doc no matter REVERSED OR NATURAL
+    assertEquals(3, nn.topNode());
+    nn.pop();
+    assertEquals(2, nn.topNode());
+    nn.pop();
+    assertEquals(4, nn.topNode());
+    nn.pop();
+    assertEquals(1, nn.topNode());
+    nn.pop();
+  }
+
   public void testNeighborsProduct() {
     // make sure we have the sign correct
     NeighborQueue nn = new NeighborQueue(2, false);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborQueue.java
@@ -22,16 +22,22 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 public class TestNeighborQueue extends LuceneTestCase {
 
   public void testSameScoreNATURAL() {
-    NeighborQueue nn = new NeighborQueue(2, false);
+    NeighborQueue nn = new NeighborQueue(5, false);
+    nn.add(0, 0.1f);
     nn.add(1, 0.1f);
     nn.add(2, 0.5f);
     nn.add(3, 0.5f);
     nn.add(4, 0.1f);
+    nn.add(Integer.MAX_VALUE, 0.1f);
     // higher scores are better; lowest score on top
     // same score then lower node means lower doc no matter REVERSED OR NATURAL
+    assertEquals(Integer.MAX_VALUE, nn.topNode());
+    nn.pop();
     assertEquals(4, nn.topNode());
     nn.pop();
     assertEquals(1, nn.topNode());
+    nn.pop();
+    assertEquals(0, nn.topNode());
     nn.pop();
     assertEquals(3, nn.topNode());
     nn.pop();
@@ -40,7 +46,8 @@ public class TestNeighborQueue extends LuceneTestCase {
   }
 
   public void testSameScoreREVERSED() {
-    NeighborQueue nn = new NeighborQueue(2, true);
+    NeighborQueue nn = new NeighborQueue(5, true);
+    nn.add(0, 0.1f);
     nn.add(1, 0.1f);
     nn.add(2, 0.5f);
     nn.add(3, 0.5f);
@@ -54,6 +61,8 @@ public class TestNeighborQueue extends LuceneTestCase {
     assertEquals(4, nn.topNode());
     nn.pop();
     assertEquals(1, nn.topNode());
+    nn.pop();
+    assertEquals(0, nn.topNode());
     nn.pop();
   }
 


### PR DESCRIPTION
Lower node means lower docId, so I think we could split this sortable `long` to fix this bug.

If so, should we still need to  do the packed together things?