### PR TITLE
LUCENE-10471 Increse max dims for vectors to 2048

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
@@ -30,7 +30,7 @@ import org.apache.lucene.util.BytesRef;
 public abstract class VectorValues extends DocIdSetIterator {
 
   /** The maximum length of a vector */
-  public static final int MAX_DIMENSIONS = 1024;
+  public static final int MAX_DIMENSIONS = 2048;
 
   /** Sole constructor */
   protected VectorValues() {}


### PR DESCRIPTION
Increase the maximum number of dims for KNN vectors to 2048.

The current maximum allowed number of dimensions is equal to 1024.
But we see in practice a number of models that produce vectors with > 1024
dimensions, especially for image encoding (e.g mobilenet_v2 uses
 1280d vectors, OpenAI / GPT-3 Babbage uses 2048d vectors).
Increasing max dims to `2048` will satisfy these use cases.

We will not recommend further increase of vector dims.

#11507