### PR TITLE
LUCENE-10560: Speed up OrdinalMap construction a bit.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/OrdinalMap.java
+++ b/lucene/core/src/java/org/apache/lucene/index/OrdinalMap.java
@@ -78,6 +78,7 @@ public class OrdinalMap implements Accountable {
     }
   }
 
+  // TODO: Can we take advantage of shared prefixes? E.g. in a dataset of IPv4-mapped IPv6 addresses, all values would share the same 12-bytes prefix. Likewise, in a dataset of URL, most values might share the `https://www.` prefix.
   private static int compare(BytesRef termA, long prefix8A, BytesRef termB, long prefix8B) {
     assert prefix8A == prefix8ToComparableUnsignedLong(termA);
     assert prefix8B == prefix8ToComparableUnsignedLong(termB);

--- a/lucene/core/src/java/org/apache/lucene/index/OrdinalMap.java
+++ b/lucene/core/src/java/org/apache/lucene/index/OrdinalMap.java
@@ -78,7 +78,9 @@ public class OrdinalMap implements Accountable {
     }
   }
 
-  // TODO: Can we take advantage of shared prefixes? E.g. in a dataset of IPv4-mapped IPv6 addresses, all values would share the same 12-bytes prefix. Likewise, in a dataset of URL, most values might share the `https://www.` prefix.
+  // TODO: Can we take advantage of shared prefixes? E.g. in a dataset of IPv4-mapped IPv6
+  // addresses, all values would share the same 12-bytes prefix. Likewise, in a dataset of URL, most
+  // values might share the `https://www.` prefix.
   private static int compare(BytesRef termA, long prefix8A, BytesRef termB, long prefix8B) {
     assert prefix8A == prefix8ToComparableUnsignedLong(termA);
     assert prefix8B == prefix8ToComparableUnsignedLong(termB);

--- a/lucene/core/src/java/org/apache/lucene/index/OrdinalMap.java
+++ b/lucene/core/src/java/org/apache/lucene/index/OrdinalMap.java
@@ -370,7 +370,8 @@ public class OrdinalMap implements Accountable {
         } else {
           top = queue.updateTop();
         }
-        if (equals(top.currentTerm, top.currentTermPrefix8, scratch.get(), scratchPrefix8) == false) {
+        if (equals(top.currentTerm, top.currentTermPrefix8, scratch.get(), scratchPrefix8)
+            == false) {
           break;
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/index/OrdinalMap.java
+++ b/lucene/core/src/java/org/apache/lucene/index/OrdinalMap.java
@@ -107,6 +107,23 @@ public class OrdinalMap implements Accountable {
     }
   }
 
+  private static boolean equals(BytesRef termA, long prefix8A, BytesRef termB, long prefix8B) {
+    assert prefix8A == prefix8ToComparableUnsignedLong(termA);
+    assert prefix8B == prefix8ToComparableUnsignedLong(termB);
+    if (prefix8A != prefix8B) {
+      return false;
+    } else {
+      // Compare terms
+      return Arrays.equals(
+          termA.bytes,
+          termA.offset,
+          termA.offset + termA.length,
+          termB.bytes,
+          termB.offset,
+          termB.offset + termB.length);
+    }
+  }
+
   private static class TermsEnumIndex {
     final int subIndex;
     final TermsEnum termsEnum;
@@ -353,7 +370,7 @@ public class OrdinalMap implements Accountable {
         } else {
           top = queue.updateTop();
         }
-        if (compare(top.currentTerm, top.currentTermPrefix8, scratch.get(), scratchPrefix8) != 0) {
+        if (equals(top.currentTerm, top.currentTermPrefix8, scratch.get(), scratchPrefix8) == false) {
           break;
         }
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestOrdinalMap.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestOrdinalMap.java
@@ -156,4 +156,95 @@ public class TestOrdinalMap extends LuceneTestCase {
     r.close();
     dir.close();
   }
+
+  public void testPrefix8ToComparableUnsignedLong() {
+    assertTrue(
+        Long.compareUnsigned(
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("")),
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("a")))
+            < 0);
+    assertTrue(
+        Long.compareUnsigned(
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("abc")),
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("abd")))
+            < 0);
+    assertTrue(
+        Long.compareUnsigned(
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("abc")),
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("abca")))
+            < 0);
+    assertTrue(
+        Long.compareUnsigned(
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("abcdef")),
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("abcdefgh")))
+            < 0);
+    assertTrue(
+        Long.compareUnsigned(
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("abcdef")),
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("abcdeg")))
+            < 0);
+    assertTrue(
+        Long.compareUnsigned(
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("abcdefgh")),
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef("abcdefgi")))
+            < 0);
+    assertTrue(
+        Long.compareUnsigned(
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(new byte[] {(byte) 0x0f})),
+                OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(new byte[] {(byte) 0xf0})))
+            < 0);
+  }
+
+  public void testPrefix8ToComparableLongAssumesZeroForMissingBytes() {
+    byte[] b1 = new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    byte[] b2 = b1.clone();
+    b2[9] = 0;
+    assertEquals(
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b2, 1, 8)),
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b1, 1, 9)));
+
+    assertEquals(
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b2, 1, 8)),
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b1, 1, 8)));
+
+    b2[8] = 0;
+    assertEquals(
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b2, 1, 8)),
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b1, 1, 7)));
+
+    b2[7] = 0;
+    assertEquals(
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b2, 1, 8)),
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b1, 1, 6)));
+
+    b2[6] = 0;
+    assertEquals(
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b2, 1, 8)),
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b1, 1, 5)));
+
+    b2[5] = 0;
+    assertEquals(
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b2, 1, 8)),
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b1, 1, 4)));
+
+    b2[4] = 0;
+    assertEquals(
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b2, 1, 8)),
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b1, 1, 3)));
+
+    b2[3] = 0;
+    assertEquals(
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b2, 1, 8)),
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b1, 1, 2)));
+
+    b2[2] = 0;
+    assertEquals(
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b2, 1, 8)),
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b1, 1, 1)));
+
+    b2[1] = 0;
+    assertEquals(
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b2, 1, 8)),
+        OrdinalMap.prefix8ToComparableUnsignedLong(new BytesRef(b1, 1, 0)));
+  }
 }


### PR DESCRIPTION
I benchmarked OrdinalMap construction over high-cardinality fields, and lots of
time gets spent into `PriorityQueue#downHeap` due to entry comparisons. I added
a small hack that speeds up these comparisons a bit by extracting the first 8
bytes of the terms as a comparable unsigned long, and using this long whenever
possible for comparisons.

On a dataset that consists of 100M documents and 10M unique values that consist
of 16-bytes random bytes, OrdinalMap construction went from 9.4s to 6.0s. On
the same number of docs/values where values consist of the same 8-bytes prefix
and then 8 random bytes to simulate a worst-case scenario for this change,
OrdinalMap construction went from 9.6s to 10.1s. So this looks like it can
yield a significant speedup in some scenarios, while the slowdown is contained
in the worst-case scenario?

Unfortunately, this worst-case scenario is not exactly unlikely, e.g. this is
what you would get with a dataset of IPv4-mapped IPv6 addresses, where all
values share the same 12-bytes prefix.