### PR TITLE
LUCENE-9356: Change test to detect mismatched checksums instead of byte flips.

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -149,6 +149,7 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
             in);
       }
       checksumRef[0] = CodecUtil.retrieveChecksum(in);
+      success = true;
       return in;
     } finally {
       if (success == false) {

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -128,26 +128,33 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
     String fileName =
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
     IndexInput in = state.directory.openInput(fileName, state.context);
-    int versionVectorData =
-        CodecUtil.checkIndexHeader(
-            in,
-            codecName,
-            Lucene90HnswVectorsFormat.VERSION_START,
-            Lucene90HnswVectorsFormat.VERSION_CURRENT,
-            state.segmentInfo.getId(),
-            state.segmentSuffix);
-    if (versionMeta != versionVectorData) {
-      throw new CorruptIndexException(
-          "Format versions mismatch: meta="
-              + versionMeta
-              + ", "
-              + codecName
-              + "="
-              + versionVectorData,
-          in);
+    boolean success = false;
+    try {
+      int versionVectorData =
+          CodecUtil.checkIndexHeader(
+              in,
+              codecName,
+              Lucene90HnswVectorsFormat.VERSION_START,
+              Lucene90HnswVectorsFormat.VERSION_CURRENT,
+              state.segmentInfo.getId(),
+              state.segmentSuffix);
+      if (versionMeta != versionVectorData) {
+        throw new CorruptIndexException(
+            "Format versions mismatch: meta="
+                + versionMeta
+                + ", "
+                + codecName
+                + "="
+                + versionVectorData,
+            in);
+      }
+      checksumRef[0] = CodecUtil.retrieveChecksum(in);
+      return in;
+    } finally {
+      if (success == false) {
+        IOUtils.closeWhileHandlingException(in);
+      }
     }
-    checksumRef[0] = CodecUtil.retrieveChecksum(in);
-    return in;
   }
 
   private void readFields(ChecksumIndexInput meta, FieldInfos infos) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene92/Lucene92HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene92/Lucene92HnswVectorsReader.java
@@ -136,6 +136,7 @@ public final class Lucene92HnswVectorsReader extends KnnVectorsReader {
             in);
       }
       CodecUtil.retrieveChecksum(in);
+      success = true;
       return in;
     } finally {
       if (success == false) {


### PR DESCRIPTION
This makes the test more robust and gives a good sense of whether file formats
are implementing `checkIntegrity` correctly.