### PR TITLE
LUCENE-10555: fix NumericComparator#iteratorCost initial logic error

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -126,7 +126,6 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
         this.minValueAsBytes =
             reverse ? new byte[bytesCount] : topValueSet ? new byte[bytesCount] : null;
         this.competitiveIterator = DocIdSetIterator.all(maxDoc);
-        this.iteratorCost = maxDoc;
       } else {
         this.enableSkipping = false;
         this.maxDoc = 0;
@@ -165,9 +164,13 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
 
     @Override
     public void setScorer(Scorable scorer) throws IOException {
-      if (iteratorCost == -1 && scorer instanceof Scorer) {
-        iteratorCost =
-            ((Scorer) scorer).iterator().cost(); // starting iterator cost is the scorer's cost
+      if (iteratorCost == -1) {
+        if (scorer instanceof Scorer) {
+          iteratorCost =
+              ((Scorer) scorer).iterator().cost(); // starting iterator cost is the scorer's cost
+        } else {
+          iteratorCost = maxDoc;
+        }
         updateCompetitiveIterator(); // update an iterator when we have a new segment
       }
     }


### PR DESCRIPTION
#864  judges if `NumericComparator#iteratorCost` is -1 or not to determine whether to set `NumericComparator#iteratorCost` in `NumericComparator#setScorer`, but `NumericComparator#iteratorCost` is set as `maxDoc` in `NumericComparator` construction method, So #864  does not work normally.
 
this pr fix this logic error

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
