### PR TITLE
LUCENE-10568: fix javadocs errors in IndexWriter.DocStats

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -6198,14 +6198,15 @@ public class IndexWriter
   /** DocStats for this index */
   public static final class DocStats {
     /**
-     * The total number of docs in this index, including docs not yet flushed (still in the RAM
-     * buffer), not counting deletions.
+     * The total number of docs in this index, counting docs not yet flushed (still in the RAM
+     * buffer), and also counting deleted docs. <b>NOTE:</b> buffered deletions are not counted. If
+     * you really need these to be counted you should call {@link IndexWriter#commit()} first.
      */
     public final int maxDoc;
+
     /**
-     * The total number of docs in this index, including docs not yet flushed (still in the RAM
-     * buffer), and including deletions. <b>NOTE:</b> buffered deletions are not counted. If you
-     * really need these to be counted you should call {@link IndexWriter#commit()} first.
+     * The total number of docs in this index, counting docs not yet flushed (still in the RAM
+     * buffer), but not counting deleted docs.
      */
     public final int numDocs;
 


### PR DESCRIPTION
# Description
org.apache.lucene.index.IndexWriter.DocStats
This class has two fields.
The field maxDoc should contain numDeletedDocs, and numDocs does not contain numDeletedDocs
However, the javadocs are just the opposite.

# Solution

adjusted javadocs for two fields

# Tests

The related logic is not modified，No new unit tests were added

# Checklist

Please review the following and check all that apply:

- [√ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [√ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [√ ] I have developed this patch against the `main` branch.
- [√ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
