### PR TITLE
LUCENE-10560: Reduce the number of bytes compared while constructing an OrdinalMap.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -1265,6 +1265,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     }
 
     @Override
+    public long size() {
+      return entry.termsDictSize;
+    }
+
+    @Override
     public long totalTermFreq() throws IOException {
       return -1L;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/TermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermsEnum.java
@@ -105,6 +105,9 @@ public abstract class TermsEnum implements BytesRefIterator {
    */
   public abstract long ord() throws IOException;
 
+  // TODO: clean this up
+  public long size() { return Long.MAX_VALUE; }
+
   /**
    * Returns the number of documents containing the current term. Do not call this when the enum is
    * unpositioned. {@link SeekStatus#END}.


### PR DESCRIPTION
This changes OrdinalMap construction to work on windows of 4096 terms at a time
and identify shared prefixes within the window, so that the PriorityQueue can
ignore these shared prefixes when comparing its entries.

On the OrdinalMapBenchmark, this made things slightly slower because shared
prefixes within a window are only in the order of 2 bytes, so there are not
enough savings to amortize the additional overhead introduced by the seeks that
try to estimate shared prefixed within the next window.
