### PR TITLE
Detect CI builds and enable errorprone by default for those CI builds

### DIFF
--- a/gradle/globals.gradle
+++ b/gradle/globals.gradle
@@ -151,6 +151,6 @@ allprojects {
     // detect if we run in CI environment by looking at existence of env vars:
     // "CI": Github (https://docs.github.com/en/actions/learn-github-actions/environment-variables)
     // anything starting with "JENKINS_" or "HUDSON_": Jenkins/Hudson (https://jenkins.thetaphi.de/env-vars.html/)
-    isCIBuild = System.getenv().keySet().find { it ==~ /(?i)(JENKINS_?.*|HUDSON_?.*|CI)/ } != null
+    isCIBuild = System.getenv().keySet().find { it ==~ /(?i)((JENKINS|HUDSON)(_\w+)?|CI)/ } != null
   }
 }

--- a/gradle/globals.gradle
+++ b/gradle/globals.gradle
@@ -147,5 +147,10 @@ allprojects {
       }
       return taskList
     }
+
+    // detect if we run in CI environment by looking at existence of env vars:
+    // "CI": Github (https://docs.github.com/en/actions/learn-github-actions/environment-variables)
+    // anything starting with "JENKINS_" or "HUDSON_": Jenkins/Hudson (https://jenkins.thetaphi.de/env-vars.html/)
+    isCIBuild = System.getenv().keySet().find { it ==~ /(?i)(JENKINS_?.*|HUDSON_?.*|CI)/ } != null
   }
 }

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -21,8 +21,8 @@ if (rootProject.usesAltJvm && rootProject.runtimeJavaVersion > JavaVersion.VERSI
   skipReason = "won't work with JDK ${rootProject.runtimeJavaVersion} if used as alternative java toolchain"
 }
 
-if (!Boolean.parseBoolean(propertyOrDefault("errorprone.enabled", isCIBuild as String))) {
-  skipReason = "skipped on non-CI (Jenkins/Github) runs, pass -Perrorprone.enabled=true to run"
+if (!propertyOrDefault("validation.errorprone", isCIBuild).asBoolean()) {
+  skipReason = "skipped on builds not running inside CI environments, pass -Pvalidation.errorprone=true to enable"
 }
 
 if (skipReason) {

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -21,8 +21,8 @@ if (rootProject.usesAltJvm && rootProject.runtimeJavaVersion > JavaVersion.VERSI
   skipReason = "won't work with JDK ${rootProject.runtimeJavaVersion} if used as alternative java toolchain"
 }
 
-if (!Boolean.parseBoolean(propertyOrDefault("tests.nightly", "false"))) {
-  skipReason = "skipped on non-nightly runs, pass -Ptests.nightly=true to run"
+if (!Boolean.parseBoolean(propertyOrDefault("errorprone.enabled", isCIBuild as String))) {
+  skipReason = "skipped on non-CI (Jenkins/Github) runs, pass -Perrorprone.enabled=true to run"
 }
 
 if (skipReason) {

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -211,7 +211,9 @@ Build
 
 * Upgrade forbiddenapis to version 3.3.  (Uwe Schindler)
 
-* LUCENE-10532: Remove LuceneTestCase.Slow annotation. ALl tests can be fast. (Robert Muir)
+* Detect CI builds on Github or Jenkins and enable errorprone.  (Uwe Schindler, Dawid Weiss)
+
+* LUCENE-10532: Remove LuceneTestCase.Slow annotation. All tests can be fast. (Robert Muir)
 
 Other
 ---------------------


### PR DESCRIPTION
This detects CI builds (Github and Jenkins) using existence of some environment variables. There is a new ext property `project.ext.isCIBuild`.

The ext property is used to enable errorprone on thse builds. You can still enable just errorprone on local builds with: `-Perrorprone.enabled=true`

We can use the new project property to enable other expensive checks by default for CI builds.
