### PR TITLE
LUCENE-10575: Fix some visibility issues

### DIFF
--- a/lucene/codecs/src/java/org/apache/lucene/codecs/uniformsplit/sharedterms/STMergingTermsEnum.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/uniformsplit/sharedterms/STMergingTermsEnum.java
@@ -34,7 +34,7 @@ import org.apache.lucene.util.BytesRef;
  *
  * @lucene.experimental
  */
-public class STMergingTermsEnum extends TermsEnum {
+class STMergingTermsEnum extends TermsEnum {
 
   protected final String fieldName;
   protected final MultiSegmentsPostingsEnum multiPostingsEnum;

--- a/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchRegionRetriever.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchRegionRetriever.java
@@ -70,8 +70,8 @@ public class MatchRegionRetriever {
   }
 
   /**
-   * An abstraction that provides document values for a given field. Default implementation in
-   * {@link DocumentFieldValueProvider} just reaches to a preloaded {@link Document}. It is possible
+   * An abstraction that provides document values for a given field.
+   * The default implementation just reaches to a preloaded {@link Document}. It is possible
    * to write a more efficient implementation on top of a reusable character buffer (that reuses the
    * buffer while retrieving hit regions for documents).
    */

--- a/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchRegionRetriever.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchRegionRetriever.java
@@ -70,10 +70,10 @@ public class MatchRegionRetriever {
   }
 
   /**
-   * An abstraction that provides document values for a given field.
-   * The default implementation just reaches to a preloaded {@link Document}. It is possible
-   * to write a more efficient implementation on top of a reusable character buffer (that reuses the
-   * buffer while retrieving hit regions for documents).
+   * An abstraction that provides document values for a given field. The default implementation just
+   * reaches to a preloaded {@link Document}. It is possible to write a more efficient
+   * implementation on top of a reusable character buffer (that reuses the buffer while retrieving
+   * hit regions for documents).
    */
   @FunctionalInterface
   public interface FieldValueProvider {

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/ExternalRefSorter.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/ExternalRefSorter.java
@@ -118,11 +118,10 @@ public class ExternalRefSorter implements BytesRefSorter, Closeable {
   /**
    * Iterates over {@link BytesRef}s in a file, closes the reader when the iterator is exhausted.
    */
-  static class ByteSequenceIterator implements BytesRefIterator, Closeable {
+  public static class ByteSequenceIterator implements BytesRefIterator, Closeable {
     private final OfflineSorter.ByteSequencesReader reader;
-    private BytesRef scratch;
 
-    public ByteSequenceIterator(OfflineSorter.ByteSequencesReader reader) {
+    private ByteSequenceIterator(OfflineSorter.ByteSequencesReader reader) {
       this.reader = reader;
     }
 
@@ -130,7 +129,7 @@ public class ExternalRefSorter implements BytesRefSorter, Closeable {
     public BytesRef next() throws IOException {
       boolean success = false;
       try {
-        scratch = reader.next();
+        BytesRef scratch = reader.next();
         if (scratch == null) {
           close();
         }


### PR DESCRIPTION
* ExternalRefSorter.ByteSequenceIterator should be public, as it's designed for external use
* MatchRegionRetriever refers to a private class in its public javadoc.  I've just removed the link for now, but we could think about making the private implementation public as it looks as though it may be useful for other implementations of the highlighter?
* STMergingTermsEnum is now package-private.  It uses private classes in some protected methods, and just making the whole thing package-private seemed to be the simplest solution to me.  If we want to keep it public, then we should probably go through this more carefully and work out what needs to be available for extension and what doesn't.