### PR TITLE
LUCENE-10576: ConcurrentMergeScheduler maxThreadCount calculation is artificially low

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -206,6 +206,8 @@ Bug Fixes
 
 * LUCENE-10564: Make sure SparseFixedBitSet#or updates ramBytesUsed. (Julie Tibshirani)
 
+* LUCENE-10576: ConcurrentMergeScheduler maxThreadCount calculation is artificially low (Kevin Risden)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -174,7 +174,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
           Throwable ignored) {
       }
 
-      maxThreadCount = Math.max(1, Math.min(4, coreCount / 2));
+      maxThreadCount = Math.max(4, coreCount / 2);
       maxMergeCount = maxThreadCount + 5;
     }
   }


### PR DESCRIPTION
# Description

ConcurrentMergeScheduler tries to calculate number of max threads. This is artificially low and capped at 4 due to the logic in the calculation.

# Solution

This updates the logic to `Math.max(4, coreCount / 2)` which sets a minimum to 4 threads (the previous lower limit) and max of `coreCount / 2`.

# Tests

No new tests were added.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
