### PR TITLE
LUCENE-10574: Keep allowing unbalanced merges if they would reclaim lots of deletes.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -538,7 +538,7 @@ public class TieredMergePolicy extends MergePolicy {
             && mergeType == MERGE_TYPE.NATURAL
             && bytesThisMerge < maxCandidateSegmentSize.sizeInBytes * 1.5
             && maxCandidateSegmentSize.delCount
-                > maxCandidateSegmentSize.maxDoc * deletesPctAllowed) {
+                < maxCandidateSegmentSize.maxDoc * deletesPctAllowed / 100) {
           // Ignore any merge where the resulting segment is not at least 50% larger than the
           // biggest input segment.
           // Otherwise we could run into pathological O(N^2) merging where merges keep rewriting

--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -545,7 +545,7 @@ public class TieredMergePolicy extends MergePolicy {
           // again and again the biggest input segment into a segment that is barely bigger.
           // The only exception we make is when the merge would reclaim lots of deletes in the
           // biggest segment. This is important for cases when lots of documents get deleted at once
-          // without introducing new segments for instance.
+          // without introducing new segments of a similar size for instance.
           continue;
         }
 


### PR DESCRIPTION
`TestTieredMergePolicy` caught this special case: if a segment has lots of
deletes, we should still allow unbalanced merges.