### PR TITLE
Refine contribution guide and pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,39 +1,8 @@
+### Description (or a Jira issue link if you have one)
+
 <!--
-_(If you are a project committer then you may remove some/all of the following template.)_
+If this is your first contribution to Lucene, please make sure you have read the contribution guide.
 
-Before creating a pull request, please file an issue in the ASF Jira system for Lucene:
+https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
 
-* https://issues.apache.org/jira/projects/LUCENE
-
-You will need to create an account in Jira in order to create an issue.
-
-The title of the PR should reference the Jira issue number in the form:
-
-* LUCENE-####: <short description of problem or changes>
-
-LUCENE must be fully capitalized. A short description helps people scanning pull requests for items they can work on.
-
-Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->
-
-
-# Description
-
-Please provide a short description of the changes you're making with this pull request.
-
-# Solution
-
-Please provide a short description of the approach taken to implement your solution.
-
-# Tests
-
-Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.
-
-# Checklist
-
-Please review the following and check all that apply:
-
-- [ ] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
-- [ ] I have given Lucene maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
-- [ ] I have developed this patch against the `main` branch.
-- [ ] I have run `./gradlew check`.
-- [ ] I have added tests for my changes.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,5 @@
 
 <!--
 If this is your first contribution to Lucene, please make sure you have read the contribution guide.
-
 https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Description (or a Jira issue link if you have one)
 
 <!--
-If this is your first contribution to Lucene, please make sure you have read the contribution guide.
+If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
 https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Please be patient. Committers are busy people too. If no one responds to your pa
 
 Please refer to [GitHub's documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests) for an explanation of how to create a pull request.
 
-You should open a pull request against the `main` branch. It is also recommended to give Lucene maintainers [access](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch.
+You should open a pull request against the `main` branch. It is also recommended to give Lucene maintainers [access](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to your PR branch.
 
 You can open a pull request with or without Jira issue. If there is an associated Jira issue, the pull request title should start with the Jira issue number that your work is related to, this way your pull request will get automatically linked from the Jira issue.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,10 @@ Please be patient. Committers are busy people too. If no one responds to your pa
 
 Please refer to [GitHub's documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests) for an explanation of how to create a pull request.
 
+You should open a pull request against the `main` branch. It is also recommended to give Lucene maintainers [access](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch.
+
 You can open a pull request with or without Jira issue. If there is an associated Jira issue, the pull request title should start with the Jira issue number that your work is related to, this way your pull request will get automatically linked from the Jira issue.
+
 
 ### Creating a patch
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Please be patient. Committers are busy people too. If no one responds to your pa
 
 Please refer to [GitHub's documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests) for an explanation of how to create a pull request.
 
-You should open a pull request against the `main` branch. It is also recommended to give Lucene maintainers [access](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to your PR branch.
+You should open a pull request against the `main` branch. 
 
 You can open a pull request with or without Jira issue. If there is an associated Jira issue, the pull request title should start with the Jira issue number that your work is related to, this way your pull request will get automatically linked from the Jira issue.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Please be patient. Committers are busy people too. If no one responds to your pa
 
 Please refer to [GitHub's documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests) for an explanation of how to create a pull request.
 
-You should open a pull request against the `main` branch. 
+You should open a pull request against the `main` branch. Committers will backport it to the maintenance branches once the change is merged into `main` (as far as it is possible).
 
 You can open a pull request with or without Jira issue. If there is an associated Jira issue, the pull request title should start with the Jira issue number that your work is related to, this way your pull request will get automatically linked from the Jira issue.
 


### PR DESCRIPTION
Some part of the pull request template has been a bit obsoleted, and there are overlaps between the contribution guide and the template.

I noticed the majority of developers (including me...) delete all texts in the template and start with a blank sheet (90% of PRs, I roughly estimate) - then how about just encouraging people to refer to the contribution guide in the template?

To avoid information loss, I moved checklist items that did not appear in the contribution guide to it.