### PR TITLE
LUCENE-10531: Disable distribution test (gui test) on windows.

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # we want to run the distribution tests on all major OSs, but it's occasionally too slow (or hangs or the forked process is started at all..., not sure the cause) on windows.
+        # we want to run the distribution tests on all major OSs, but it's occasionally too slow (or hangs or the forked process is not started at all..., not sure the cause) on windows.
         #os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest, macos-latest]
 

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # we want to run the distribution tests on all major OSs, but it's occasionally too slow on windows.
+        # we want to run the distribution tests on all major OSs, but it's occasionally too slow (or hangs or the forked process is started at all..., not sure the cause) on windows.
         #os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest, macos-latest]
 

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -19,8 +19,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # we run the distribution tests on all major OSs.
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # we want to run the distribution tests on all major OSs, but it's occasionally too slow on windows.
+        #os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Occasionally the test is too slow (or hangs?) and fails on Windows VM. 
We can't increase the timeout infinitely, I would disable it on GitHub Actions for now (we still run it on Jenkins Servers).