### PR TITLE
LUCENE-10589: increase upper bound of test range query to the maximum value + 1

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -551,7 +551,7 @@ public class TestKnnVectorQuery extends LuceneTestCase {
                       numDocs));
 
           // Test an unrestrictive filter and check we use approximate search
-          Query filter3 = IntPoint.newRangeQuery("tag", lower, lower + 150);
+          Query filter3 = IntPoint.newRangeQuery("tag", lower, 200);
           results =
               searcher.search(
                   new ThrowingKnnVectorQuery("field", randomVector(dimension), 5, filter3),
@@ -565,7 +565,7 @@ public class TestKnnVectorQuery extends LuceneTestCase {
             assertEquals(1, fieldDoc.fields.length);
 
             int tag = (int) fieldDoc.fields[0];
-            assertTrue(lower <= tag && tag <= lower + 150);
+            assertTrue(lower <= tag && tag <= 200);
           }
         }
       }


### PR DESCRIPTION
This is a small tweak for `TestKnnVectorQuery.testRandomWithFilter()`.

See https://issues.apache.org/jira/browse/LUCENE-10589.

On main:
```
./gradlew test --tests TestKnnVectorQuery.testRandomWithFilter -Dtests.seed=1DA39B92702DAC45 -Dtests.multiplier=3

org.apache.lucene.search.TestKnnVectorQuery > testRandomWithFilter FAILED
    java.lang.UnsupportedOperationException: exact search is not supported
        at __randomizedtesting.SeedInfo.seed([1DA39B92702DAC45:6BEAC2197AD96AE0]:0)
        at org.apache.lucene.search.TestKnnVectorQuery$ThrowingKnnVectorQuery.exactSearch(TestKnnVectorQuery.java:715)
```

With this patch:
```
./gradlew test --tests TestKnnVectorQuery.testRandomWithFilter -Dtests.seed=1DA39B92702DAC45 -Dtests.multiplier=3

:lucene:core:test (SUCCESS): 1 test(s)
```