### PR TITLE
LUCENE-10200: Correct outdated instruction in the demo tutorial

### DIFF
--- a/lucene/demo/src/java/overview.html
+++ b/lucene/demo/src/java/overview.html
@@ -69,7 +69,7 @@ files called <span class="codefrag">lucene-queryparser-{version}.jar</span>,
 <h2 class="boxed">Indexing Files</h2>
 <div class="section">
 <p>Once you've gotten this far you're probably itching to go. Let's <b>build an
-index!</b>Just type either command:</p>
+index!</b> Just type either command:</p>
 <p>With module path</p>
 <pre>
     java --module-path modules:modules-thirdparty --module org.apache.lucene.demo/org.apache.lucene.demo.IndexFiles -docs {path-to-lucene}

--- a/lucene/demo/src/java/overview.html
+++ b/lucene/demo/src/java/overview.html
@@ -80,8 +80,8 @@ which will contain an index of all of the Lucene source code.
     java --module-path modules:modules-thirdparty --add-modules jdk.unsupported --module org.apache.lucene.demo/org.apache.lucene.demo.SearchFiles
 </pre>
 You'll be prompted for a query. Type in a gibberish or made up word (for example: 
-"superca<!-- need to break up word in a way that is not visibile so it doesn't cause this ile to match a search on this word -->lifragilisticexpialidocious").
-You'll see that there are no maching results in the lucene source code. 
+"superca<!-- need to break up word in a way that is not visible so it doesn't cause this file to match a search on this word -->lifragilisticexpialidocious").
+You'll see that there are no matching results in the lucene source code.
 Now try entering the word "string". That should return a whole bunch
 of documents. The results will page at every tenth result and ask you whether
 you want more results.</div>

--- a/lucene/demo/src/java/overview.html
+++ b/lucene/demo/src/java/overview.html
@@ -26,7 +26,7 @@
 <ul class="minitoc">
 <li><a href="#About_this_Document">About this Document</a></li>
 <li><a href="#About_the_Demo">About the Demo</a></li>
-<li><a href="#Setting_your_module_path">Setting your module path</a></li>
+<li><a href="#Setting_your_module_path">Setting your module path (or classpath)</a></li>
 <li><a href="#Indexing_Files">Indexing Files</a></li>
 <li><a href="#About_the_code">About the code</a></li>
 <li><a href="#Location_of_the_source">Location of the source</a></li>
@@ -50,7 +50,7 @@ demonstrates various functionalities of Lucene and how you can add Lucene to
 your applications.</p>
 </div>
 <a id="Setting_your_module_path"></a>
-<h2 class="boxed">Setting your module path</h2>
+<h2 class="boxed">Setting your module path (or classpath)</h2>
 <div class="section">
 <p>First, you should <a href=
 "http://www.apache.org/dyn/closer.cgi/lucene/java/">download</a> the latest
@@ -63,21 +63,31 @@ files called <span class="codefrag">lucene-queryparser-{version}.jar</span>,
 <span class=
 "codefrag">lucene-analysis-common-{version}.jar</span> and <span class=
 "codefrag">lucene-demo-{version}.jar</span> under modules directory.</p>
-<p>Put all of these files in your Java module path.</p>
+<p>There are two ways to run Java program: with module path or with classpath. Either way is fine. Put all of these files in your Java modulepath or class path.</p>
 </div>
 <a id="Indexing_Files"></a>
 <h2 class="boxed">Indexing Files</h2>
 <div class="section">
 <p>Once you've gotten this far you're probably itching to go. Let's <b>build an
-index!</b> Just type:</p>
+index!</b>Just type either command:</p>
+<p>With module path</p>
 <pre>
     java --module-path modules:modules-thirdparty --module org.apache.lucene.demo/org.apache.lucene.demo.IndexFiles -docs {path-to-lucene}
 </pre>
+<p>With classpath</p>
+<pre>
+    java -cp "modules/*:modules-thirdparty/*" org.apache.lucene.demo.IndexFiles -docs {path-to-lucene}
+</pre>
 This will produce a subdirectory called <span class="codefrag">index</span>
 which will contain an index of all of the Lucene source code.
-<p>To <b>search the index</b> type:</p>
+<p>To <b>search the index</b> type either command:</p>
+<p>With module path</p>
 <pre>
     java --module-path modules:modules-thirdparty --add-modules jdk.unsupported --module org.apache.lucene.demo/org.apache.lucene.demo.SearchFiles
+</pre>
+<p>With classpath</p>
+<pre>
+    java -cp "modules/*:modules-thirdparty/*" org.apache.lucene.demo.SearchFiles
 </pre>
 You'll be prompted for a query. Type in a gibberish or made up word (for example: 
 "superca<!-- need to break up word in a way that is not visible so it doesn't cause this file to match a search on this word -->lifragilisticexpialidocious").

--- a/lucene/demo/src/java/overview.html
+++ b/lucene/demo/src/java/overview.html
@@ -26,7 +26,7 @@
 <ul class="minitoc">
 <li><a href="#About_this_Document">About this Document</a></li>
 <li><a href="#About_the_Demo">About the Demo</a></li>
-<li><a href="#Setting_your_CLASSPATH">Setting your CLASSPATH</a></li>
+<li><a href="#Setting_your_MODULEPATH">Setting your MODULEPATH</a></li>
 <li><a href="#Indexing_Files">Indexing Files</a></li>
 <li><a href="#About_the_code">About the code</a></li>
 <li><a href="#Location_of_the_source">Location of the source</a></li>
@@ -49,36 +49,35 @@ configuration.</p>
 demonstrates various functionalities of Lucene and how you can add Lucene to
 your applications.</p>
 </div>
-<a id="Setting_your_CLASSPATH"></a>
-<h2 class="boxed">Setting your CLASSPATH</h2>
+<a id="Setting_your_MODULEPATH"></a>
+<h2 class="boxed">Setting your MODULEPATH</h2>
 <div class="section">
 <p>First, you should <a href=
 "http://www.apache.org/dyn/closer.cgi/lucene/java/">download</a> the latest
 Lucene distribution and then extract it to a working directory.</p>
-<p>You need four JARs: the Lucene JAR, the queryparser JAR, the common analysis JAR, and the Lucene
-demo JAR. You should see the Lucene JAR file in the modules/ directory you created
+<p>You need Lucene demo and a few dependent modules.
+You should see the Lucene module (JAR) files in the modules/ and modules-thirdparty/ directory you created
 when you extracted the archive -- it should be named something like
 <span class="codefrag">lucene-core-{version}.jar</span>. You should also see
 files called <span class="codefrag">lucene-queryparser-{version}.jar</span>,
 <span class=
 "codefrag">lucene-analysis-common-{version}.jar</span> and <span class=
-"codefrag">lucene-demo-{version}.jar</span> under queryparser, analysis/common/ and demo/,
-respectively.</p>
-<p>Put all four of these files in your Java CLASSPATH.</p>
+"codefrag">lucene-demo-{version}.jar</span> under modules directory.</p>
+<p>Put all of these files in your Java MODULEPATH.</p>
 </div>
 <a id="Indexing_Files"></a>
 <h2 class="boxed">Indexing Files</h2>
 <div class="section">
 <p>Once you've gotten this far you're probably itching to go. Let's <b>build an
-index!</b> Assuming you've set your CLASSPATH correctly, just type:</p>
+index!</b> Just type:</p>
 <pre>
-    java org.apache.lucene.demo.IndexFiles -docs {path-to-lucene}
+    java --module-path modules:modules-thirdparty --module org.apache.lucene.demo/org.apache.lucene.demo.IndexFiles -docs {path-to-lucene}
 </pre>
 This will produce a subdirectory called <span class="codefrag">index</span>
 which will contain an index of all of the Lucene source code.
 <p>To <b>search the index</b> type:</p>
 <pre>
-    java org.apache.lucene.demo.SearchFiles
+    java --module-path modules:modules-thirdparty --add-modules jdk.unsupported --module org.apache.lucene.demo/org.apache.lucene.demo.SearchFiles
 </pre>
 You'll be prompted for a query. Type in a gibberish or made up word (for example: 
 "superca<!-- need to break up word in a way that is not visibile so it doesn't cause this ile to match a search on this word -->lifragilisticexpialidocious").

--- a/lucene/demo/src/java/overview.html
+++ b/lucene/demo/src/java/overview.html
@@ -63,7 +63,7 @@ files called <span class="codefrag">lucene-queryparser-{version}.jar</span>,
 <span class=
 "codefrag">lucene-analysis-common-{version}.jar</span> and <span class=
 "codefrag">lucene-demo-{version}.jar</span> under modules directory.</p>
-<p>There are two ways to run Java program: with module path or with classpath. Either way is fine. Put all of these files in your Java modulepath or class path.</p>
+<p>There are two ways to run Java program: with module path or with classpath. Either way is fine. Put all of these files in your Java module path or classpath.</p>
 </div>
 <a id="Indexing_Files"></a>
 <h2 class="boxed">Indexing Files</h2>

--- a/lucene/demo/src/java/overview.html
+++ b/lucene/demo/src/java/overview.html
@@ -56,8 +56,8 @@ your applications.</p>
 "http://www.apache.org/dyn/closer.cgi/lucene/java/">download</a> the latest
 Lucene distribution and then extract it to a working directory.</p>
 <p>You need Lucene demo and a few dependent modules.
-You should see the Lucene module (JAR) files in the modules/ and modules-thirdparty/ directory you created
-when you extracted the archive -- it should be named something like
+You should see the Lucene modules (JARs) in the modules/ and third party modules in the modules-thirdparty/ directory
+you created when you extracted the archive -- it should be named something like
 <span class="codefrag">lucene-core-{version}.jar</span>. You should also see
 files called <span class="codefrag">lucene-queryparser-{version}.jar</span>,
 <span class=

--- a/lucene/demo/src/java/overview.html
+++ b/lucene/demo/src/java/overview.html
@@ -26,7 +26,7 @@
 <ul class="minitoc">
 <li><a href="#About_this_Document">About this Document</a></li>
 <li><a href="#About_the_Demo">About the Demo</a></li>
-<li><a href="#Setting_your_MODULEPATH">Setting your MODULEPATH</a></li>
+<li><a href="#Setting_your_module_path">Setting your module path</a></li>
 <li><a href="#Indexing_Files">Indexing Files</a></li>
 <li><a href="#About_the_code">About the code</a></li>
 <li><a href="#Location_of_the_source">Location of the source</a></li>
@@ -49,8 +49,8 @@ configuration.</p>
 demonstrates various functionalities of Lucene and how you can add Lucene to
 your applications.</p>
 </div>
-<a id="Setting_your_MODULEPATH"></a>
-<h2 class="boxed">Setting your MODULEPATH</h2>
+<a id="Setting_your_module_path"></a>
+<h2 class="boxed">Setting your module path</h2>
 <div class="section">
 <p>First, you should <a href=
 "http://www.apache.org/dyn/closer.cgi/lucene/java/">download</a> the latest
@@ -63,7 +63,7 @@ files called <span class="codefrag">lucene-queryparser-{version}.jar</span>,
 <span class=
 "codefrag">lucene-analysis-common-{version}.jar</span> and <span class=
 "codefrag">lucene-demo-{version}.jar</span> under modules directory.</p>
-<p>Put all of these files in your Java MODULEPATH.</p>
+<p>Put all of these files in your Java module path.</p>
 </div>
 <a id="Indexing_Files"></a>
 <h2 class="boxed">Indexing Files</h2>


### PR DESCRIPTION
### Description (or a Jira issue link if you have one)

This is a minor update for `demo` module documentation.
I had a chance to run the demo app and noticed that commands in the tutorial use `CLASSPATH` (and some description has been outdated); maybe it'd be worth updating to use modulepath instead of classpath?

The latest tutorial:
![Screenshot from 2022-05-24 19-28-13](https://user-images.githubusercontent.com/1825333/170011199-2d13f34c-ef36-46c5-b5fb-e297c7d0510e.png)

Updated tutorial in this patch:
![Screenshot from 2022-05-25 22-43-32](https://user-images.githubusercontent.com/1825333/170276904-20db449e-8a9f-4f3d-8959-081f6b7d1e6f.png)
