### PR TITLE
LUCENE-10594: Duplicated value should be involve in SortedSetDocValues#docValueCount() in MemoryIndex

### DIFF
--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -596,6 +596,7 @@ public class MemoryIndex {
           info.bytesRefHashProducer.dvBytesRefHashValuesSet = new BytesRefHash(byteBlockPool);
         }
         info.bytesRefHashProducer.dvBytesRefHashValuesSet.add((BytesRef) docValuesValue);
+        info.bytesRefHashProducer.count++;
         break;
       case NONE:
       default:
@@ -1142,7 +1143,8 @@ public class MemoryIndex {
     };
   }
 
-  private static SortedSetDocValues sortedSetDocValues(BytesRefHash values, int[] bytesIds) {
+  private static SortedSetDocValues sortedSetDocValues(
+      BytesRefHash values, int[] bytesIds, int count) {
     MemoryDocValuesIterator it = new MemoryDocValuesIterator();
     BytesRef scratch = new BytesRef();
     return new SortedSetDocValues() {
@@ -1156,7 +1158,7 @@ public class MemoryIndex {
 
       @Override
       public long docValueCount() {
-        return values.size();
+        return count;
       }
 
       @Override
@@ -1205,6 +1207,7 @@ public class MemoryIndex {
 
     BytesRefHash dvBytesRefHashValuesSet;
     int[] bytesIds;
+    int count;
 
     private void prepareForUsage() {
       bytesIds = dvBytesRefHashValuesSet.sort();
@@ -1346,7 +1349,9 @@ public class MemoryIndex {
       Info info = getInfoForExpectedDocValuesType(field, DocValuesType.SORTED_SET);
       if (info != null) {
         return sortedSetDocValues(
-            info.bytesRefHashProducer.dvBytesRefHashValuesSet, info.bytesRefHashProducer.bytesIds);
+            info.bytesRefHashProducer.dvBytesRefHashValuesSet,
+            info.bytesRefHashProducer.bytesIds,
+            info.bytesRefHashProducer.count);
       } else {
         return null;
       }

--- a/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
+++ b/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
@@ -296,6 +296,7 @@ public class TestMemoryIndex extends LuceneTestCase {
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, sortedDocValues.nextDoc());
     SortedSetDocValues sortedSetDocValues = leafReader.getSortedSetDocValues("sorted_set");
     assertEquals(3, sortedSetDocValues.getValueCount());
+    assertEquals(4, sortedSetDocValues.docValueCount());
     assertEquals(0, sortedSetDocValues.nextDoc());
     assertEquals(0L, sortedSetDocValues.nextOrd());
     assertEquals(1L, sortedSetDocValues.nextOrd());


### PR DESCRIPTION
Base on [LUCENE-10188](https://issues.apache.org/jira/browse/LUCENE-10188) , SortedSetDocValues#docValueCount() in MemoryIndex should keep the same semantic that duplicated values should also be involve in calculating count.
Due to `dvBytesRefHashValuesSet` only record number of unique values, so a additional `count` is needed.