### PR TITLE
LUCENE-10559: Add Prefilter Option to KnnGraphTester

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -108,7 +108,7 @@ Bug Fixes
 
 Other
 ---------------------
-(No changes)
+* LUCENE-10559: Add Prefilter Option to KnnGraphTester (Kaival Parikh)
 
 ======================== Lucene 9.3.0 =======================
 


### PR DESCRIPTION
### Description
Link to [Jira](https://issues.apache.org/jira/browse/LUCENE-10559)

### Solution

Added a `prefilter` and `filterSelectivity` argument to KnnGraphTester to be able to compare pre and post-filtering benchmarks

`filterSelectivity` expresses the selectivity of a filter as proportion of passing docs that are randomly selected. We store these in a FixedBitSet and use this to calculate true KNN as well as in HNSW search

In case of post-filter, we over-select results as `topK / filterSelectivity` to get final hits close to actual requested `topK`
For pre-filter, we wrap the FixedBitSet in a query and pass it as prefilter argument to KnnVectorQuery

**Edit 1**: I should also add that a custom BulkScorer is provided to the wrapped query that directly updates the reference of the BitSetCollector (to prevent arbitrary hit collection time of pre-filter query, so we can focus on HNSW search time)

**Edit 2**: We have decided to split the possible collection optimization to a new [issue](https://issues.apache.org/jira/browse/LUCENE-10606). This PR only adds prefilter testing functionality to KnnGraphTester, and depends on KnnVectorQuery for internal implementations