### PR TITLE
LUCENE-10574: Avoid O(n^2) merging with LogMergePolicy

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/LogByteSizeMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LogByteSizeMergePolicy.java
@@ -96,11 +96,9 @@ public class LogByteSizeMergePolicy extends LogMergePolicy {
   }
 
   /**
-   * Sets the minimum size for the lowest level segments. Any segments below this size are
-   * considered to be on the same level (even if they vary drastically in size) and will be merged
-   * whenever there are mergeFactor of them. This effectively truncates the "long tail" of small
-   * segments that would otherwise be created into a single level. If you set this too large, it
-   * could greatly increase the merging cost during indexing (if you flush many small segments).
+   * Sets the minimum size for the lowest level segments. Any segments below this size will be
+   * merged more aggressively in order to avoid having a long tail of small segments. Large values
+   * of this parameter increase the merging cost during indexing if you flush small segments.
    */
   public void setMinMergeMB(double mb) {
     minMergeSize = (long) (mb * 1024 * 1024);

--- a/lucene/core/src/java/org/apache/lucene/index/LogDocMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LogDocMergePolicy.java
@@ -43,11 +43,9 @@ public class LogDocMergePolicy extends LogMergePolicy {
   }
 
   /**
-   * Sets the minimum size for the lowest level segments. Any segments below this size are
-   * considered to be on the same level (even if they vary drastically in size) and will be merged
-   * whenever there are mergeFactor of them. This effectively truncates the "long tail" of small
-   * segments that would otherwise be created into a single level. If you set this too large, it
-   * could greatly increase the merging cost during indexing (if you flush many small segments).
+   * Sets the minimum size for the lowest level segments. Any segments below this size will be
+   * merged more aggressively in order to avoid having a long tail of small segments. Large values
+   * of this parameter increase the merging cost during indexing if you flush small segments.
    */
   public void setMinMergeDocs(int minMergeDocs) {
     minMergeSize = minMergeDocs;

--- a/lucene/core/src/java/org/apache/lucene/index/LogMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LogMergePolicy.java
@@ -570,7 +570,7 @@ public abstract class LogMergePolicy extends MergePolicy {
           final SegmentCommitInfo info = segLevel.info;
           anyTooLarge |=
               (size(info, mergeContext) >= maxMergeSize
-              || sizeDocs(info, mergeContext) >= maxMergeDocs);
+                  || sizeDocs(info, mergeContext) >= maxMergeDocs);
           if (mergingSegments.contains(info)) {
             anyMerging = true;
             break;
@@ -596,7 +596,7 @@ public abstract class LogMergePolicy extends MergePolicy {
                     + start
                     + " end="
                     + end,
-                    mergeContext);
+                mergeContext);
           }
           spec.add(new OneMerge(mergeInfos));
         } else if (verbose(mergeContext)) {
@@ -606,7 +606,7 @@ public abstract class LogMergePolicy extends MergePolicy {
                   + " to "
                   + end
                   + ": contains segment over maxMergeSize or maxMergeDocs; skipping",
-                  mergeContext);
+              mergeContext);
         }
 
         start = end;

--- a/lucene/core/src/java/org/apache/lucene/index/LogMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LogMergePolicy.java
@@ -535,7 +535,7 @@ public abstract class LogMergePolicy extends MergePolicy {
       // Now search backwards for the rightmost segment that
       // falls into this level:
       float levelBottom;
-      if (maxLevel >= levelFloor) {
+      if (maxLevel > levelFloor) {
         // With a merge factor of 10, this means that the biggest segment and the smallest segment
         // that take part of a merge have a size difference of at most 5.6x.
         levelBottom = (float) (maxLevel - LEVEL_LOG_SPAN);

--- a/lucene/core/src/java/org/apache/lucene/index/LogMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LogMergePolicy.java
@@ -539,6 +539,11 @@ public abstract class LogMergePolicy extends MergePolicy {
         // With a merge factor of 10, this means that the biggest segment and the smallest segment
         // that take part of a merge have a size difference of at most 5.6x.
         levelBottom = (float) (maxLevel - LEVEL_LOG_SPAN);
+
+        // Force a boundary at the level floor
+        if (levelBottom < levelFloor && maxLevel >= levelFloor) {
+          levelBottom = levelFloor;
+        }
       } else {
         // For segments below the floor size, we allow more unbalanced merges, but still somewhat
         // balanced to avoid running into O(n^2) merging.

--- a/lucene/core/src/test/org/apache/lucene/index/TestLogMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestLogMergePolicy.java
@@ -17,9 +17,12 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.lucene.index.MergePolicy.MergeContext;
 import org.apache.lucene.index.MergePolicy.MergeSpecification;
 import org.apache.lucene.index.MergePolicy.OneMerge;
 import org.apache.lucene.tests.index.BaseMergePolicyTestCase;
+import org.apache.lucene.util.Version;
 
 public class TestLogMergePolicy extends BaseMergePolicyTestCase {
 
@@ -35,7 +38,12 @@ public class TestLogMergePolicy extends BaseMergePolicyTestCase {
 
   @Override
   protected void assertSegmentInfos(MergePolicy policy, SegmentInfos infos) throws IOException {
-    // TODO
+    LogMergePolicy mp = (LogMergePolicy) policy;
+
+    MergeContext mockMergeContext = new MockMergeContext(SegmentCommitInfo::getDelCount);
+    for (SegmentCommitInfo info : infos) {
+      assertTrue(mp.size(info, mockMergeContext) / mp.getMergeFactor() < mp.maxMergeSize);
+    }
   }
 
   @Override
@@ -44,5 +52,136 @@ public class TestLogMergePolicy extends BaseMergePolicyTestCase {
     for (OneMerge oneMerge : merge.merges) {
       assertEquals(lmp.getMergeFactor(), oneMerge.segments.size());
     }
+  }
+
+  public void testIgnoreLargeSegments() throws IOException {
+    LogDocMergePolicy mergePolicy = new LogDocMergePolicy();
+    IOStats stats = new IOStats();
+    mergePolicy.setMaxMergeDocs(10_000);
+    AtomicLong segNameGenerator = new AtomicLong();
+    MergeContext mergeContext = new MockMergeContext(SegmentCommitInfo::getDelCount);
+    SegmentInfos segmentInfos = new SegmentInfos(Version.LATEST.major);
+    // 1 segment that reached the maximum segment size
+    segmentInfos.add(
+        makeSegmentCommitInfo(
+            "_" + segNameGenerator.getAndIncrement(), 11_000, 0, 0, IndexWriter.SOURCE_MERGE));
+    // and 10 segments below the max segment size, but within the same level
+    for (int i = 0; i < 10; ++i) {
+      segmentInfos.add(
+          makeSegmentCommitInfo(
+              "_" + segNameGenerator.getAndIncrement(), 3_000, 0, 0, IndexWriter.SOURCE_MERGE));
+    }
+    // LogMergePolicy used to have a bug that would make it exclude the first mergeFactor segments
+    // from merging if any of them was above the maximum merged size
+    MergeSpecification spec =
+        mergePolicy.findMerges(MergeTrigger.EXPLICIT, segmentInfos, mergeContext);
+    assertNotNull(spec);
+    for (OneMerge oneMerge : spec.merges) {
+      segmentInfos =
+          applyMerge(segmentInfos, oneMerge, "_" + segNameGenerator.getAndIncrement(), stats);
+    }
+    assertEquals(2, segmentInfos.size());
+    assertEquals(11_000, segmentInfos.info(0).info.maxDoc());
+    assertEquals(30_000, segmentInfos.info(1).info.maxDoc());
+  }
+
+  public void testIncreasingSegmentSizes() throws IOException {
+    LogDocMergePolicy mergePolicy = new LogDocMergePolicy();
+    IOStats stats = new IOStats();
+    AtomicLong segNameGenerator = new AtomicLong();
+    MergeContext mergeContext = new MockMergeContext(SegmentCommitInfo::getDelCount);
+    SegmentInfos segmentInfos = new SegmentInfos(Version.LATEST.major);
+    // 11 segments of increasing sizes
+    for (int i = 0; i < 11; ++i) {
+      segmentInfos.add(
+          makeSegmentCommitInfo(
+              "_" + segNameGenerator.getAndIncrement(),
+              (i + 1) * 1000,
+              0,
+              0,
+              IndexWriter.SOURCE_MERGE));
+    }
+    MergeSpecification spec =
+        mergePolicy.findMerges(MergeTrigger.EXPLICIT, segmentInfos, mergeContext);
+    assertNotNull(spec);
+    for (OneMerge oneMerge : spec.merges) {
+      segmentInfos =
+          applyMerge(segmentInfos, oneMerge, "_" + segNameGenerator.getAndIncrement(), stats);
+    }
+    assertEquals(2, segmentInfos.size());
+    assertEquals(55_000, segmentInfos.info(0).info.maxDoc());
+    assertEquals(11_000, segmentInfos.info(1).info.maxDoc());
+  }
+
+  public void testSmallMiddleSegment() throws IOException {
+    LogDocMergePolicy mergePolicy = new LogDocMergePolicy();
+    IOStats stats = new IOStats();
+    AtomicLong segNameGenerator = new AtomicLong();
+    MergeContext mergeContext = new MockMergeContext(SegmentCommitInfo::getDelCount);
+    SegmentInfos segmentInfos = new SegmentInfos(Version.LATEST.major);
+    // 5 big segments
+    for (int i = 0; i < 5; ++i) {
+      segmentInfos.add(
+          makeSegmentCommitInfo(
+              "_" + segNameGenerator.getAndIncrement(), 10_000, 0, 0, IndexWriter.SOURCE_MERGE));
+    }
+    // 1 segment on a lower tier
+    segmentInfos.add(
+        makeSegmentCommitInfo(
+            "_" + segNameGenerator.getAndIncrement(), 1_000, 0, 0, IndexWriter.SOURCE_MERGE));
+    // 5 big segments again
+    for (int i = 0; i < 5; ++i) {
+      segmentInfos.add(
+          makeSegmentCommitInfo(
+              "_" + segNameGenerator.getAndIncrement(), 10_000, 0, 0, IndexWriter.SOURCE_MERGE));
+    }
+    // Ensure that having a small segment in the middle doesn't prevent merging
+    MergeSpecification spec =
+        mergePolicy.findMerges(MergeTrigger.EXPLICIT, segmentInfos, mergeContext);
+    assertNotNull(spec);
+    for (OneMerge oneMerge : spec.merges) {
+      segmentInfos =
+          applyMerge(segmentInfos, oneMerge, "_" + segNameGenerator.getAndIncrement(), stats);
+    }
+    assertEquals(2, segmentInfos.size());
+    assertEquals(91_000, segmentInfos.info(0).info.maxDoc());
+    assertEquals(10_000, segmentInfos.info(1).info.maxDoc());
+  }
+
+  public void testRejectUnbalancedMerges() throws IOException {
+    LogDocMergePolicy mergePolicy = new LogDocMergePolicy();
+    mergePolicy.setMinMergeDocs(10_000);
+    IOStats stats = new IOStats();
+    AtomicLong segNameGenerator = new AtomicLong();
+    MergeContext mergeContext = new MockMergeContext(SegmentCommitInfo::getDelCount);
+    SegmentInfos segmentInfos = new SegmentInfos(Version.LATEST.major);
+    // 1 100-docs segment
+    segmentInfos.add(
+        makeSegmentCommitInfo(
+            "_" + segNameGenerator.getAndIncrement(), 100, 0, 0, IndexWriter.SOURCE_MERGE));
+    // 9 1-doc segments again
+    for (int i = 0; i < 9; ++i) {
+      segmentInfos.add(
+          makeSegmentCommitInfo(
+              "_" + segNameGenerator.getAndIncrement(), 1, 0, 0, IndexWriter.SOURCE_FLUSH));
+    }
+    // Ensure though we're below the floor size, the merge would be too unbalanced
+    MergeSpecification spec =
+        mergePolicy.findMerges(MergeTrigger.EXPLICIT, segmentInfos, mergeContext);
+    assertNull(spec);
+
+    // another 1-doc segment, now we can merge 10 1-doc segments
+    segmentInfos.add(
+        makeSegmentCommitInfo(
+            "_" + segNameGenerator.getAndIncrement(), 1, 0, 0, IndexWriter.SOURCE_FLUSH));
+    spec = mergePolicy.findMerges(MergeTrigger.EXPLICIT, segmentInfos, mergeContext);
+    assertNotNull(spec);
+    for (OneMerge oneMerge : spec.merges) {
+      segmentInfos =
+          applyMerge(segmentInfos, oneMerge, "_" + segNameGenerator.getAndIncrement(), stats);
+    }
+    assertEquals(2, segmentInfos.size());
+    assertEquals(100, segmentInfos.info(0).info.maxDoc());
+    assertEquals(10, segmentInfos.info(1).info.maxDoc());
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestLogMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestLogMergePolicy.java
@@ -98,7 +98,7 @@ public class TestLogMergePolicy extends BaseMergePolicyTestCase {
     // 1 segment on a lower tier
     segmentInfos.add(
         makeSegmentCommitInfo(
-            "_" + segNameGenerator.getAndIncrement(), 1_000, 0, 0, IndexWriter.SOURCE_MERGE));
+            "_" + segNameGenerator.getAndIncrement(), 100, 0, 0, IndexWriter.SOURCE_MERGE));
     // 5 big segments again
     for (int i = 0; i < 5; ++i) {
       segmentInfos.add(
@@ -114,7 +114,7 @@ public class TestLogMergePolicy extends BaseMergePolicyTestCase {
           applyMerge(segmentInfos, oneMerge, "_" + segNameGenerator.getAndIncrement(), stats);
     }
     assertEquals(2, segmentInfos.size());
-    assertEquals(91_000, segmentInfos.info(0).info.maxDoc());
+    assertEquals(90_100, segmentInfos.info(0).info.maxDoc());
     assertEquals(10_000, segmentInfos.info(1).info.maxDoc());
   }
 
@@ -128,11 +128,11 @@ public class TestLogMergePolicy extends BaseMergePolicyTestCase {
     segmentInfos.add(
         makeSegmentCommitInfo(
             "_" + segNameGenerator.getAndIncrement(), 10_000, 0, 0, IndexWriter.SOURCE_MERGE));
-    // 8 segment on a lower tier
-    for (int i = 0; i < 8; ++i) {
+    // 9 segment on a lower tier
+    for (int i = 0; i < 9; ++i) {
       segmentInfos.add(
           makeSegmentCommitInfo(
-              "_" + segNameGenerator.getAndIncrement(), 1_000, 0, 0, IndexWriter.SOURCE_MERGE));
+              "_" + segNameGenerator.getAndIncrement(), 100, 0, 0, IndexWriter.SOURCE_MERGE));
     }
     // 1 big segment again
     segmentInfos.add(
@@ -147,7 +147,7 @@ public class TestLogMergePolicy extends BaseMergePolicyTestCase {
           applyMerge(segmentInfos, oneMerge, "_" + segNameGenerator.getAndIncrement(), stats);
     }
     assertEquals(2, segmentInfos.size());
-    assertEquals(91_000, segmentInfos.info(0).info.maxDoc());
+    assertEquals(10_900, segmentInfos.info(0).info.maxDoc());
     assertEquals(10_000, segmentInfos.info(1).info.maxDoc());
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseMergePolicyTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseMergePolicyTestCase.java
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -328,21 +328,31 @@ public abstract class BaseMergePolicyTestCase extends LuceneTestCase {
   protected static SegmentInfos applyMerge(
       SegmentInfos infos, OneMerge merge, String mergedSegmentName, IOStats stats)
       throws IOException {
-    LinkedHashSet<SegmentCommitInfo> scis = new LinkedHashSet<>(infos.asList());
+
     int newMaxDoc = 0;
     double newSize = 0;
     for (SegmentCommitInfo sci : merge.segments) {
       int numLiveDocs = sci.info.maxDoc() - sci.getDelCount();
       newSize += (double) sci.sizeInBytes() * numLiveDocs / sci.info.maxDoc() / 1024 / 1024;
       newMaxDoc += numLiveDocs;
-      boolean removed = scis.remove(sci);
-      assertTrue(removed);
     }
+    SegmentCommitInfo mergedInfo =
+        makeSegmentCommitInfo(mergedSegmentName, newMaxDoc, 0, newSize, IndexWriter.SOURCE_MERGE);
+
+    Set<SegmentCommitInfo> mergedAway = new HashSet<>(merge.segments);
+    boolean mergedSegmentAdded = false;
     SegmentInfos newInfos = new SegmentInfos(Version.LATEST.major);
-    newInfos.addAll(scis);
-    // Now add the merged segment
-    newInfos.add(
-        makeSegmentCommitInfo(mergedSegmentName, newMaxDoc, 0, newSize, IndexWriter.SOURCE_MERGE));
+    for (int i = 0; i < infos.size(); ++i) {
+      SegmentCommitInfo info = infos.info(i);
+      if (mergedAway.contains(info)) {
+        if (mergedSegmentAdded == false) {
+          newInfos.add(mergedInfo);
+          mergedSegmentAdded = true;
+        }
+      } else {
+        newInfos.add(info);
+      }
+    }
     stats.mergeBytesWritten += newSize * 1024 * 1024;
     return newInfos;
   }


### PR DESCRIPTION
Originally I had tried to remove O(n^2) merging from LogMergePolicy using the 
same approach as for TieredMergePolicy, but this did not work well as it fought
against invariants that LogMergePolicy is trying to maintain. So this switches
to a completely different approach that is more in line with the existing logir
of LogMergePolicy: instead of being rounded to the floor segment size, segments
below the floor segment size get applied a greater level span that allows more
unbalanced merges on smaller segments but still requires them to be somewhat
balanced.