### PR TITLE
LUCENE-10588: log elapsed time for initializing gui

### DIFF
--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/LukeMain.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/LukeMain.java
@@ -92,6 +92,7 @@ public class LukeMain {
     javax.swing.SwingUtilities.invokeLater(
         () -> {
           try {
+            long _start = System.nanoTime() / 1_000_000;
             guiThreadResult.put(createGUI());
 
             // Show the initial dialog.
@@ -102,6 +103,9 @@ public class LukeMain {
                     600,
                     420,
                     (factory) -> {});
+
+            long _end = System.nanoTime() / 1_000_000;
+            log.info("Elapsed time for initializing GUI: " + (_end - _start) + "msec");
           } catch (Exception e) {
             throw new RuntimeException(e);
           }


### PR DESCRIPTION
### Description (or a Jira issue link if you have one)

Just emit the elapsed time for initializing gui components for LUCENE-10588.

It takes 2000 to 3000 msec on my Linux box. On windows, it takes more I think (it's slower on Windows than on Linux or Mac from my experience).