### PR TITLE
Use similarity.tf() in MoreLikeThis

### DIFF
--- a/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
@@ -637,8 +637,8 @@ public final class MoreLikeThis {
 
       for (Map.Entry<String, Int> tfEntry : perWordTermFrequencies.entrySet()) { // for every word
         String word = tfEntry.getKey();
-        int tf = tfEntry.getValue().x; // term freq in the source doc
-        if (minTermFreq > 0 && tf < minTermFreq) {
+        int termFreq = tfEntry.getValue().x; // term freq in the source doc
+        if (minTermFreq > 0 && termFreq < minTermFreq) {
           continue; // filter out words that don't occur enough times in the source
         }
 
@@ -656,6 +656,7 @@ public final class MoreLikeThis {
           continue; // index update problem?
         }
 
+        float tf = similarity.tf(termFreq);
         float idf = similarity.idf(docFreq, numDocs);
         float score = tf * idf;
 


### PR DESCRIPTION
### Description

MoreLikeThis picks terms by their TF-IDF score. The TF part of the score was used by taking the term frequency directly, without applying a square root through `ClassicSimilarity.tf()`. The result is that how common a term is in an input can have too much weight on whether it's selected as a search term. An example of a negative effect is that this can make more stop words make their way into the final query.

### Tests

Ran MoreLikeThis tests with:
```commandline
./gradlew -p lucene/queries test --tests TestMoreLikeThis
```


