### PR TITLE
LUCENE-10578: Fail build if java minor/patch version is not met the minimum requirement

### DIFF
--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -39,7 +39,7 @@ import static java.nio.file.StandardOpenOption.APPEND;
  * Has no dependencies outside of standard java libraries
  */
 public class WrapperDownloader {
-  private static final String REQUIRED_JAVA_VERSION_STRING = "17.0.3";
+  private static final Runtime.Version REQUIRED_VERSION = Runtime.Version.parse("17.0.3");
 
   public static void main(String[] args) {
     if (args.length != 1) {
@@ -57,13 +57,12 @@ public class WrapperDownloader {
   }
 
   public static void checkVersion() {
-    final Runtime.Version requiredVersion = Runtime.Version.parse(REQUIRED_JAVA_VERSION_STRING);
     final Runtime.Version version = Runtime.version();
-    if (version.feature() != requiredVersion.feature()) {
-      throw new IllegalStateException("java version be exactly " + requiredVersion.feature() + " (>=" + requiredVersion + "), your version: " + version);
+    if (version.feature() != REQUIRED_VERSION.feature()) {
+      throw new IllegalStateException("java version be exactly " + REQUIRED_VERSION.feature() + " (>=" + REQUIRED_VERSION + "), your version: " + version);
     }
-    if (version.interim() < requiredVersion.interim() || (version.interim() == requiredVersion.interim() && version.update() < requiredVersion.update())) {
-      throw new IllegalStateException("you are using too old java minor version. use newer than " + requiredVersion + ", your version: " + version);
+    if (version.interim() < REQUIRED_VERSION.interim() || (version.interim() == REQUIRED_VERSION.interim() && version.update() < REQUIRED_VERSION.update())) {
+      throw new IllegalStateException("you are using too old java minor version. use newer than " + REQUIRED_VERSION + ", your version: " + version);
     }
   }
 

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -59,10 +59,10 @@ public class WrapperDownloader {
   public static void checkVersion() {
     final Runtime.Version version = Runtime.version();
     if (version.feature() != REQUIRED_VERSION.feature()) {
-      throw new IllegalStateException("java version must be exactly " + REQUIRED_VERSION.feature() + " (>=" + REQUIRED_VERSION + "), your version: " + version);
+      throw new IllegalStateException("Java version must be exactly " + REQUIRED_VERSION.feature() + " (>=" + REQUIRED_VERSION + "), your version: " + version);
     }
     if (version.interim() < REQUIRED_VERSION.interim() || (version.interim() == REQUIRED_VERSION.interim() && version.update() < REQUIRED_VERSION.update())) {
-      throw new IllegalStateException("you are using too old java minor version. use newer than " + REQUIRED_VERSION + ", your version: " + version);
+      throw new IllegalStateException("You are using too old Java minor version. Use newer than " + REQUIRED_VERSION + ", your version: " + version);
     }
   }
 

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -40,6 +40,7 @@ import static java.nio.file.StandardOpenOption.APPEND;
  */
 public class WrapperDownloader {
   private static final Runtime.Version REQUIRED_VERSION = Runtime.Version.parse("17.0.3");
+  private static final int MAXIMUM_FEATURE_VERSION = 17;
 
   public static void main(String[] args) {
     if (args.length != 1) {
@@ -58,8 +59,12 @@ public class WrapperDownloader {
 
   public static void checkVersion() {
     final Runtime.Version version = Runtime.version();
-    if (version.feature() != REQUIRED_VERSION.feature()) {
-      throw new IllegalStateException("Java version must be exactly " + REQUIRED_VERSION.feature() + " (>=" + REQUIRED_VERSION + "), your version: " + version);
+    if (version.feature() < REQUIRED_VERSION.feature() || version.feature() > MAXIMUM_FEATURE_VERSION) {
+      if (REQUIRED_VERSION.feature() == MAXIMUM_FEATURE_VERSION) {
+        throw new IllegalStateException("Java version must be exactly " + REQUIRED_VERSION.feature() + " (>=" + REQUIRED_VERSION + "), your version: " + version);
+      } else {
+        throw new IllegalStateException("Java version must be between " + REQUIRED_VERSION.feature() + " and " + MAXIMUM_FEATURE_VERSION + " (>=" + REQUIRED_VERSION + "), your version: " + version);
+      }
     }
     if (version.interim() < REQUIRED_VERSION.interim() || (version.interim() == REQUIRED_VERSION.interim() && version.update() < REQUIRED_VERSION.update())) {
       throw new IllegalStateException("You are using too old Java minor version. Use newer than " + REQUIRED_VERSION + ", your version: " + version);

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -59,6 +59,7 @@ public class WrapperDownloader {
 
   public static void checkVersion() {
     final Runtime.Version version = Runtime.version();
+    // check major version
     if (version.feature() < REQUIRED_VERSION.feature() || version.feature() > MAXIMUM_FEATURE_VERSION) {
       if (REQUIRED_VERSION.feature() == MAXIMUM_FEATURE_VERSION) {
         throw new IllegalStateException("Java version must be exactly " + REQUIRED_VERSION.feature() + " (>=" + REQUIRED_VERSION + "), your version: " + version);
@@ -66,7 +67,9 @@ public class WrapperDownloader {
         throw new IllegalStateException("Java version must be between " + REQUIRED_VERSION.feature() + " and " + MAXIMUM_FEATURE_VERSION + " (>=" + REQUIRED_VERSION + "), your version: " + version);
       }
     }
-    if (version.interim() < REQUIRED_VERSION.interim() || (version.interim() == REQUIRED_VERSION.interim() && version.update() < REQUIRED_VERSION.update())) {
+    // check minor versions
+    if ((version.feature() == REQUIRED_VERSION.feature() && version.interim() < REQUIRED_VERSION.interim()) ||
+      (version.feature() == REQUIRED_VERSION.feature() && version.interim() == REQUIRED_VERSION.interim() && version.update() < REQUIRED_VERSION.update())) {
       throw new IllegalStateException("You are using too old Java minor version. Use newer than " + REQUIRED_VERSION + ", your version: " + version);
     }
   }

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -59,7 +59,7 @@ public class WrapperDownloader {
   public static void checkVersion() {
     final Runtime.Version version = Runtime.version();
     if (version.feature() != REQUIRED_VERSION.feature()) {
-      throw new IllegalStateException("java version be exactly " + REQUIRED_VERSION.feature() + " (>=" + REQUIRED_VERSION + "), your version: " + version);
+      throw new IllegalStateException("java version must be exactly " + REQUIRED_VERSION.feature() + " (>=" + REQUIRED_VERSION + "), your version: " + version);
     }
     if (version.interim() < REQUIRED_VERSION.interim() || (version.interim() == REQUIRED_VERSION.interim() && version.update() < REQUIRED_VERSION.update())) {
       throw new IllegalStateException("you are using too old java minor version. use newer than " + REQUIRED_VERSION + ", your version: " + version);

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -68,14 +68,11 @@ public class WrapperDownloader {
     int feature = version.feature();
     int interim = version.interim();
     int update = version.update();
-    // Version.toString() can return arbitrary version string depending on vendors.
-    // Reformat as "$FEATURE.$INTERIM.$UPDATE"
-    final String runtimeVersionString = String.format("%d.%d.%d", feature, interim, update);
     if (feature != REQUIRED_JAVA_VERSION_FEATURE) {
-      throw new IllegalStateException("java version be exactly " + REQUIRED_JAVA_VERSION_FEATURE + " (>=" + REQUIRED_JAVA_VERSION_STRING + "), your version: " + runtimeVersionString);
+      throw new IllegalStateException("java version be exactly " + REQUIRED_JAVA_VERSION_FEATURE + " (>=" + REQUIRED_JAVA_VERSION_STRING + "), your version: " + version);
     }
     if (interim < REQUIERD_JAVA_VERSION_INTERIM || (interim == REQUIERD_JAVA_VERSION_INTERIM && update < REQUIRED_JAVA_VERSION_UPDATE)) {
-      throw new IllegalStateException("you are using too old java minor version. use newer than " + REQUIRED_JAVA_VERSION_STRING + ", your version: " + runtimeVersionString);
+      throw new IllegalStateException("you are using too old java minor version. use newer than " + REQUIRED_JAVA_VERSION_STRING + ", your version: " + version);
     }
   }
 

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -72,7 +72,7 @@ public class WrapperDownloader {
     // Reformat as "$FEATURE.$INTERIM.$UPDATE"
     final String runtimeVersionString = String.format("%d.%d.%d", feature, interim, update);
     if (feature != REQUIRED_JAVA_VERSION_FEATURE) {
-      throw new IllegalStateException("java version be exactly 17 (>=" + REQUIRED_JAVA_VERSION_STRING + "), your version: " + runtimeVersionString);
+      throw new IllegalStateException("java version be exactly " + REQUIRED_JAVA_VERSION_FEATURE + " (>=" + REQUIRED_JAVA_VERSION_STRING + "), your version: " + runtimeVersionString);
     }
     if (interim < REQUIERD_JAVA_VERSION_INTERIM || (interim == REQUIERD_JAVA_VERSION_INTERIM && update < REQUIRED_JAVA_VERSION_UPDATE)) {
       throw new IllegalStateException("you are using too old java minor version. use newer than " + REQUIRED_JAVA_VERSION_STRING + ", your version: " + runtimeVersionString);

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -39,14 +39,7 @@ import static java.nio.file.StandardOpenOption.APPEND;
  * Has no dependencies outside of standard java libraries
  */
 public class WrapperDownloader {
-  private static final int REQUIRED_JAVA_VERSION_FEATURE = 17;
-  private static final int REQUIERD_JAVA_VERSION_INTERIM = 0;
-  private static final int REQUIRED_JAVA_VERSION_UPDATE = 3;
-  private static final String REQUIRED_JAVA_VERSION_STRING = String.format(
-    "%d.%d.%d",
-    REQUIRED_JAVA_VERSION_FEATURE,
-    REQUIERD_JAVA_VERSION_INTERIM,
-    REQUIRED_JAVA_VERSION_UPDATE);
+  private static final String REQUIRED_JAVA_VERSION_STRING = "17.0.3";
 
   public static void main(String[] args) {
     if (args.length != 1) {
@@ -64,15 +57,13 @@ public class WrapperDownloader {
   }
 
   public static void checkVersion() {
-    Runtime.Version version = Runtime.version();
-    int feature = version.feature();
-    int interim = version.interim();
-    int update = version.update();
-    if (feature != REQUIRED_JAVA_VERSION_FEATURE) {
-      throw new IllegalStateException("java version be exactly " + REQUIRED_JAVA_VERSION_FEATURE + " (>=" + REQUIRED_JAVA_VERSION_STRING + "), your version: " + version);
+    final Runtime.Version requiredVersion = Runtime.Version.parse(REQUIRED_JAVA_VERSION_STRING);
+    final Runtime.Version version = Runtime.version();
+    if (version.feature() != requiredVersion.feature()) {
+      throw new IllegalStateException("java version be exactly " + requiredVersion.feature() + " (>=" + requiredVersion + "), your version: " + version);
     }
-    if (interim < REQUIERD_JAVA_VERSION_INTERIM || (interim == REQUIERD_JAVA_VERSION_INTERIM && update < REQUIRED_JAVA_VERSION_UPDATE)) {
-      throw new IllegalStateException("you are using too old java minor version. use newer than " + REQUIRED_JAVA_VERSION_STRING + ", your version: " + version);
+    if (version.interim() < requiredVersion.interim() || (version.interim() == requiredVersion.interim() && version.update() < requiredVersion.update())) {
+      throw new IllegalStateException("you are using too old java minor version. use newer than " + requiredVersion + ", your version: " + version);
     }
   }
 

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -39,6 +39,15 @@ import static java.nio.file.StandardOpenOption.APPEND;
  * Has no dependencies outside of standard java libraries
  */
 public class WrapperDownloader {
+  private static final int REQUIRED_JAVA_VERSION_FEATURE = 17;
+  private static final int REQUIERD_JAVA_VERSION_INTERIM = 0;
+  private static final int REQUIRED_JAVA_VERSION_UPDATE = 3;
+  private static final String REQUIRED_JAVA_VERSION_STRING = String.format(
+    "%d.%d.%d",
+    REQUIRED_JAVA_VERSION_FEATURE,
+    REQUIERD_JAVA_VERSION_INTERIM,
+    REQUIRED_JAVA_VERSION_UPDATE);
+
   public static void main(String[] args) {
     if (args.length != 1) {
       System.err.println("Usage: java WrapperDownloader.java <destination>");
@@ -55,9 +64,18 @@ public class WrapperDownloader {
   }
 
   public static void checkVersion() {
-    int major = Runtime.getRuntime().version().feature();
-    if (major != 17) {
-      throw new IllegalStateException("java version be exactly 17, your version: " + major);
+    Runtime.Version version = Runtime.version();
+    int feature = version.feature();
+    int interim = version.interim();
+    int update = version.update();
+    // Version.toString() can return arbitrary version string depending on vendors.
+    // Reformat as "$FEATURE.$INTERIM.$UPDATE"
+    final String runtimeVersionString = String.format("%d.%d.%d", feature, interim, update);
+    if (feature != REQUIRED_JAVA_VERSION_FEATURE) {
+      throw new IllegalStateException("java version be exactly 17 (>=" + REQUIRED_JAVA_VERSION_STRING + "), your version: " + runtimeVersionString);
+    }
+    if (interim < REQUIERD_JAVA_VERSION_INTERIM || (interim == REQUIERD_JAVA_VERSION_INTERIM && update < REQUIRED_JAVA_VERSION_UPDATE)) {
+      throw new IllegalStateException("you are using too old java minor version. use newer than " + REQUIRED_JAVA_VERSION_STRING + ", your version: " + runtimeVersionString);
     }
   }
 


### PR DESCRIPTION
### Description (or a Jira issue link if you have one)
https://issues.apache.org/jira/browse/LUCENE-10578

This pretty straight check works for me (also should work on branch_9x/Java11). 

Older major Java than 17.
```
ERROR: java version be exactly 17 (>=17.0.3), your version: 11.0.15
```

Newer major Java than 17.
```
ERROR: java version be exactly 17 (>=17.0.3), your version: 18.0.1
```

Old minor Java than 17.0.3.
```
ERROR: you are using too old java minor version. use newer than 17.0.3, your version: 17.0.0
```