### PR TITLE
LUCENE-10598: Use count to record docValueCount similar to SortedNumericDocValues did

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80DocValuesProducer.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80DocValuesProducer.java
@@ -1560,8 +1560,8 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
       return new BaseSortedSetDocValues(entry, data) {
 
         int doc = -1;
-        long start;
-        long end;
+        long start, end;
+        long count;
 
         @Override
         public int nextDoc() throws IOException {
@@ -1585,6 +1585,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
           }
           start = addresses.get(target);
           end = addresses.get(target + 1L);
+          count = (end - start);
           return doc = target;
         }
 
@@ -1592,6 +1593,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
         public boolean advanceExact(int target) throws IOException {
           start = addresses.get(target);
           end = addresses.get(target + 1L);
+          count = (end - start);
           doc = target;
           return true;
         }
@@ -1606,7 +1608,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
 
         @Override
         public long docValueCount() {
-          return end - start;
+          return count;
         }
       };
     } else {
@@ -1624,6 +1626,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
         boolean set;
         long start;
         long end = 0;
+        long count;
 
         @Override
         public int nextDoc() throws IOException {
@@ -1658,6 +1661,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
             final int index = disi.index();
             start = addresses.get(index);
             end = addresses.get(index + 1L);
+            count = end - start;
             set = true;
             return true;
           }
@@ -1678,7 +1682,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
         @Override
         public long docValueCount() {
           set();
-          return end - start;
+          return count;
         }
       };
     }

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -3357,6 +3357,14 @@ public final class CheckIndex implements Closeable {
       long ord;
       int ordCount = 0;
       while ((ord = dv.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
+        if (count != dv.docValueCount()) {
+          throw new CheckIndexException(
+              "value count changed from "
+                  + count
+                  + " to "
+                  + dv.docValueCount()
+                  + " during iterating over all values");
+        }
         long ord2 = dv2.nextOrd();
         if (ord != ord2) {
           throw new CheckIndexException(
@@ -3373,6 +3381,13 @@ public final class CheckIndex implements Closeable {
         maxOrd2 = Math.max(maxOrd2, ord);
         seenOrds.set(ord);
         ordCount++;
+      }
+      if (dv.docValueCount() != dv2.docValueCount()) {
+        throw new CheckIndexException(
+            "dv and dv2 report different values count after iterating over all values: "
+                + dv.docValueCount()
+                + " != "
+                + dv2.docValueCount());
       }
       if (ordCount == 0) {
         throw new CheckIndexException(


### PR DESCRIPTION
Add a count used to record docValueCount in Lucene80DocValuesProducer#getSortedSet, similar to what SortedNumericDocValues did.