### PR TITLE
LUCENE-10578: Fail build if java minor/patch version is not met the minimum requirement (for 9x)

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 17
+        java-version: '11.0.15'
         java-package: jdk
     - name: Prepare caches
       uses: ./.github/actions/gradle-caches

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -21,7 +21,7 @@ jobs:
         # Operating systems to run on.
         os: [ubuntu-latest]
         # Test JVMs.
-        java: [ '11' ]
+        java: [ '11.0.15' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -56,7 +56,7 @@ jobs:
         # macos-latest: a tad slower than ubuntu and pretty much the same (?) so leaving out.
         os: [ubuntu-latest]
         # Test JVMs.
-        java: [ '11' ]
+        java: [ '11.0.15' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/hunspell.yml
+++ b/.github/workflows/hunspell.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 17
+        java-version: '11.0.15'
         java-package: jdk
 
     - name: Prepare caches

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -39,6 +39,8 @@ import static java.nio.file.StandardOpenOption.APPEND;
  * Has no dependencies outside of standard java libraries
  */
 public class WrapperDownloader {
+  private static final Runtime.Version REQUIRED_VERSION = Runtime.Version.parse("11.0.15");
+
   public static void main(String[] args) {
     if (args.length != 1) {
       System.err.println("Usage: java WrapperDownloader.java <destination>");
@@ -46,10 +48,21 @@ public class WrapperDownloader {
     }
 
     try {
+      checkVersion();
       new WrapperDownloader().run(Paths.get(args[0]));
     } catch (Exception e) {
       System.err.println("ERROR: " + e.getMessage());
       System.exit(1);
+    }
+  }
+
+  public static void checkVersion() {
+    final Runtime.Version version = Runtime.version();
+    if (version.feature() != REQUIRED_VERSION.feature()) {
+      throw new IllegalStateException("Java version must be exactly " + REQUIRED_VERSION.feature() + " (>=" + REQUIRED_VERSION + "), your version: " + version);
+    }
+    if (version.interim() < REQUIRED_VERSION.interim() || (version.interim() == REQUIRED_VERSION.interim() && version.update() < REQUIRED_VERSION.update())) {
+      throw new IllegalStateException("You are using too old Java minor version. Use newer than " + REQUIRED_VERSION + ", your version: " + version);
     }
   }
 

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -40,6 +40,7 @@ import static java.nio.file.StandardOpenOption.APPEND;
  */
 public class WrapperDownloader {
   private static final Runtime.Version REQUIRED_VERSION = Runtime.Version.parse("11.0.15");
+  private static final int MAXIMUM_FEATURE_VERSION = 17;
 
   public static void main(String[] args) {
     if (args.length != 1) {
@@ -58,10 +59,17 @@ public class WrapperDownloader {
 
   public static void checkVersion() {
     final Runtime.Version version = Runtime.version();
-    if (version.feature() != REQUIRED_VERSION.feature()) {
-      throw new IllegalStateException("Java version must be exactly " + REQUIRED_VERSION.feature() + " (>=" + REQUIRED_VERSION + "), your version: " + version);
+    // check major version
+    if (version.feature() < REQUIRED_VERSION.feature() || version.feature() > MAXIMUM_FEATURE_VERSION) {
+      if (REQUIRED_VERSION.feature() == MAXIMUM_FEATURE_VERSION) {
+        throw new IllegalStateException("Java version must be exactly " + REQUIRED_VERSION.feature() + " (>=" + REQUIRED_VERSION + "), your version: " + version);
+      } else {
+        throw new IllegalStateException("Java version must be between " + REQUIRED_VERSION.feature() + " and " + MAXIMUM_FEATURE_VERSION + " (>=" + REQUIRED_VERSION + "), your version: " + version);
+      }
     }
-    if (version.interim() < REQUIRED_VERSION.interim() || (version.interim() == REQUIRED_VERSION.interim() && version.update() < REQUIRED_VERSION.update())) {
+    // check minor versions
+    if ((version.feature() == REQUIRED_VERSION.feature() && version.interim() < REQUIRED_VERSION.interim()) ||
+      (version.feature() == REQUIRED_VERSION.feature() && version.interim() == REQUIRED_VERSION.interim() && version.update() < REQUIRED_VERSION.update())) {
       throw new IllegalStateException("You are using too old Java minor version. Use newer than " + REQUIRED_VERSION + ", your version: " + version);
     }
   }


### PR DESCRIPTION
### Description (or a Jira issue link if you have one)

This applies the same change in #941 to branch_9x. Cherry-picking from main may not work (we don't have `checkVersion()` in 9x).