### PR TITLE
LUCENE-10604: Add Tessellation monitor for easier debugging of triangulation algorithm

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -102,6 +102,8 @@ Other
 
 * LUCENE-10370: pass proper classpath/module arguments for forking jvms from within tests. (Dawid Weiss)
 
+* LUCENE-10604: Improve ability to test and debug triangulation algorithm in Tessellator.
+  (Craig Taverner)
 
 ======================= Lucene 9.2.0 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
@@ -86,6 +86,11 @@ public final class Tessellator {
   private Tessellator() {}
 
   public static List<Triangle> tessellate(final Polygon polygon, boolean checkSelfIntersections) {
+    return tessellate(polygon, checkSelfIntersections, null);
+  }
+
+  public static List<Triangle> tessellate(
+      final Polygon polygon, boolean checkSelfIntersections, Monitor monitor) {
     // Attempt to establish a doubly-linked list of the provided shell points (should be CCW, but
     // this will correct);
     // then filter instances of intersections.
@@ -131,16 +136,24 @@ public final class Tessellator {
     }
     // Calculate the tessellation using the doubly LinkedList.
     List<Triangle> result =
-        earcutLinkedList(polygon, outerNode, new ArrayList<>(), State.INIT, mortonOptimized);
+        earcutLinkedList(
+            polygon, outerNode, new ArrayList<>(), State.INIT, mortonOptimized, monitor, 0);
     if (result.size() == 0) {
+      notifyMonitor("FAILED", monitor, null, result);
       throw new IllegalArgumentException(
           "Unable to Tessellate shape. Possible malformed shape detected.");
     }
+    notifyMonitor("COMPLETED", monitor, null, result);
 
     return result;
   }
 
   public static List<Triangle> tessellate(final XYPolygon polygon, boolean checkSelfIntersections) {
+    return tessellate(polygon, checkSelfIntersections, null);
+  }
+
+  public static List<Triangle> tessellate(
+      final XYPolygon polygon, boolean checkSelfIntersections, Monitor monitor) {
     // Attempt to establish a doubly-linked list of the provided shell points (should be CCW, but
     // this will correct);
     // then filter instances of intersections.0
@@ -186,11 +199,14 @@ public final class Tessellator {
     }
     // Calculate the tessellation using the doubly LinkedList.
     List<Triangle> result =
-        earcutLinkedList(polygon, outerNode, new ArrayList<>(), State.INIT, mortonOptimized);
+        earcutLinkedList(
+            polygon, outerNode, new ArrayList<>(), State.INIT, mortonOptimized, monitor, 0);
     if (result.size() == 0) {
+      notifyMonitor("FAILED", monitor, null, result);
       throw new IllegalArgumentException(
           "Unable to Tessellate shape. Possible malformed shape detected.");
     }
+    notifyMonitor("COMPLETED", monitor, null, result);
 
     return result;
   }
@@ -512,7 +528,9 @@ public final class Tessellator {
       Node currEar,
       final List<Triangle> tessellation,
       State state,
-      final boolean mortonOptimized) {
+      final boolean mortonOptimized,
+      final Monitor monitor,
+      int depth) {
     earcut:
     do {
       if (currEar == null || currEar.previous == currEar.next) {
@@ -525,6 +543,8 @@ public final class Tessellator {
 
       // Iteratively slice ears
       do {
+        notifyMonitor(
+            state.name() + (depth == 0 ? "" : "[" + depth + "]"), monitor, currEar, tessellation);
         prevNode = currEar.previous;
         nextNode = currEar.next;
         // Determine whether the current triangle must be cut off.
@@ -570,8 +590,10 @@ public final class Tessellator {
               continue earcut;
             case SPLIT:
               // as a last resort, try splitting the remaining polygon into two
-              if (splitEarcut(polygon, currEar, tessellation, mortonOptimized) == false) {
+              if (splitEarcut(polygon, currEar, tessellation, mortonOptimized, monitor, depth + 1)
+                  == false) {
                 // we could not process all points. Tessellation failed
+                notifyMonitor(state.name() + "[FAILED]", monitor, currEar, tessellation);
                 throw new IllegalArgumentException(
                     "Unable to Tessellate shape. Possible malformed shape detected.");
               }
@@ -797,7 +819,9 @@ public final class Tessellator {
       final Object polygon,
       final Node start,
       final List<Triangle> tessellation,
-      final boolean mortonOptimized) {
+      final boolean mortonOptimized,
+      final Monitor monitor,
+      int depth) {
     // Search for a valid diagonal that divides the polygon into two.
     Node searchNode = start;
     do {
@@ -817,8 +841,12 @@ public final class Tessellator {
             sortByMortonWithReset(searchNode);
             sortByMortonWithReset(splitNode);
           }
-          earcutLinkedList(polygon, searchNode, tessellation, State.INIT, mortonOptimized);
-          earcutLinkedList(polygon, splitNode, tessellation, State.INIT, mortonOptimized);
+          notifyMonitorSplit("SPLIT[" + depth + "]", monitor, searchNode, splitNode);
+          earcutLinkedList(
+              polygon, searchNode, tessellation, State.INIT, mortonOptimized, monitor, depth);
+          earcutLinkedList(
+              polygon, splitNode, tessellation, State.INIT, mortonOptimized, monitor, depth);
+          notifyMonitorSplitEnd("SPLIT[" + depth + "]", monitor);
           // Finish the iterative search
           return true;
         }
@@ -1442,6 +1470,60 @@ public final class Tessellator {
       }
     }
     return false;
+  }
+
+  /**
+   * Implementation of this interface will receive calls with internal data at each step of the
+   * triangulation algoirithm. This is of use for debugging complex cases, as well as gaining
+   * insight into the way the algorithm works. Data provided includes a status string containing the
+   * current mode, list of points representing the current linked-list of internal nodes used for
+   * triangulation, and a list of triangles so far created by the algorithm.
+   */
+  public interface Monitor {
+    /** Each loop of the main earclip algorithm will call this with the current state */
+    void currentState(String status, List<Point> points, List<Triangle> tessellation);
+
+    /** When a new polygon split is entered for mode=SPLIT, this is called. */
+    void startSplit(String status, List<Point> leftPolygon, List<Point> rightPolygon);
+
+    /** When a polygon split is completed, this is called. */
+    void endSplit(String status);
+  }
+
+  private static List<Point> getPoints(Node start) {
+    Node node = start;
+    ArrayList<Point> points = new ArrayList<>();
+    do {
+      points.add(new Point(node.getY(), node.getX()));
+      node = node.next;
+    } while (node != start);
+    return points;
+  }
+
+  private static void notifyMonitorSplit(
+      String status, Monitor monitor, Node searchNode, Node diagonalNode) {
+    if (monitor != null) {
+      if (searchNode == null || diagonalNode == null)
+        throw new IllegalStateException("Invalid split provided to monitor");
+      monitor.startSplit(status, getPoints(searchNode), getPoints(diagonalNode));
+    }
+  }
+
+  private static void notifyMonitorSplitEnd(String status, Monitor monitor) {
+    if (monitor != null) {
+      monitor.endSplit(status);
+    }
+  }
+
+  private static void notifyMonitor(
+      String status, Monitor monitor, Node start, List<Triangle> tessellation) {
+    if (monitor != null) {
+      if (start == null) {
+        monitor.currentState(status, null, tessellation);
+      } else {
+        monitor.currentState(status, getPoints(start), tessellation);
+      }
+    }
   }
 
   /** Circular Doubly-linked list used for polygon coordinates */


### PR DESCRIPTION
### Add Tessellation monitor for easier debugging of triangulation algorithm LUCENE-10604

While working on https://github.com/apache/lucene/pull/933, it was found to be very, very helpful to visualize the state of the triangulation at each step. For this purpose an external tool, called `polygon-triangulator-debug` was created and published at https://github.com/craigtaverner/polygon-triangulator-debug. This tool requires a small amount of instrumentation of the class `Tessellator`. That is provided by this PR, and adds an interface called `Monitor` which receives events for each step of the triangulation. We test this here using a simple counting implementation, and leave the complex image and video generation code to the external tool.
