### PR TITLE
Fix typo in PostingsReaderBase docstring

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/PostingsReaderBase.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/PostingsReaderBase.java
@@ -27,10 +27,9 @@ import org.apache.lucene.store.IndexInput;
 
 /**
  * The core terms dictionaries (BlockTermsReader, BlockTreeTermsReader) interact with a single
- * instance of this class to manage creation of {@link org.apache.lucene.index.PostingsEnum} and
- * {@link org.apache.lucene.index.PostingsEnum} instances. It provides an IndexInput (termsIn) where
- * this class may read any previously stored data that it had written in its corresponding {@link
- * PostingsWriterBase} at indexing time.
+ * instance of this class to manage creation of {@link org.apache.lucene.index.PostingsEnum}
+ * instances. It provides an IndexInput (termsIn) where this class may read any previously stored
+ * data that it had written in its corresponding {@link PostingsWriterBase} at indexing time.
  *
  * @lucene.experimental
  */

--- a/lucene/core/src/java/org/apache/lucene/codecs/PostingsReaderBase.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/PostingsReaderBase.java
@@ -27,9 +27,10 @@ import org.apache.lucene.store.IndexInput;
 
 /**
  * The core terms dictionaries (BlockTermsReader, BlockTreeTermsReader) interact with a single
- * instance of this class to manage creation of {@link org.apache.lucene.index.PostingsEnum}
- * instances. It provides an IndexInput (termsIn) where this class may read any previously stored
- * data that it had written in its corresponding {@link PostingsWriterBase} at indexing time.
+ * instance of this class to manage creation of {@link org.apache.lucene.index.PostingsEnum} and
+ * {@link org.apache.lucene.index.ImpactsEnum} instances. It provides an IndexInput (termsIn) where
+ * this class may read any previously stored data that it had written in its corresponding {@link
+ * PostingsWriterBase} at indexing time.
  *
  * @lucene.experimental
  */


### PR DESCRIPTION
The docstring for `PostingsReaderBase` seems to have an extra `{@link PostingsEnum}`. Minor change to fix it.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
