### PR TITLE
LUCENE-10605: fix error in 32bit jvm object alignment gap calculation

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -97,6 +97,8 @@ Bug Fixes
 
 * LUCENE-10563: Fix failure to tessellate complex polygon (Craig Taverner)
 
+* LUCENE-10605: Fix error in 32bit jvm object alignment gap calculation (Sun Wuqiang)
+
 Other
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
@@ -191,17 +191,21 @@ public final class ArrayUtil {
           return newSize;
       }
     } else {
-      // round up to 4 byte alignment in 64bit env
+      // In 32bit jvm, it's still 8-byte aligned,
+      // but the array header is 12 bytes, not a multiple of 8.
+      // So saving 4,12,20,28... bytes of data is the most cost-effective.
       switch (bytesPerElement) {
-        case 2:
-          // round up to multiple of 2
-          return (newSize + 1) & 0x7ffffffe;
         case 1:
-          // round up to multiple of 4
-          return (newSize + 3) & 0x7ffffffc;
+          // align with size of 4,12,20,28...
+          return ((newSize + 3) & 0x7ffffff8) + 4;
+        case 2:
+          // align with size of 6,10,14,18...
+          return ((newSize + 1) & 0x7ffffffc) + 2;
         case 4:
+          // align with size of 5,7,9,11...
+          return (newSize & 0x7ffffffe) + 1;
         case 8:
-          // no rounding
+          // no processing required
         default:
           // odd (invalid?) size
           return newSize;


### PR DESCRIPTION
### Description
https://issues.apache.org/jira/browse/LUCENE-10605
ArrayUtil.oversize()
The generated array length cannot eliminate the Object alignment gap, wasting some space