### PR TITLE
LUCENE-10603: Change iteration methodology for SSDV ordinals in the f…

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -84,6 +84,9 @@ Improvements
 * LUCENE-10585: Facet module code cleanup (copy/paste scrubbing, simplification and some very minor
   optimization tweaks). (Greg Miller)
 
+* LUCENE-10603: Update SortedSetDocValues iteration within faceting implementations to use
+  SortedSetDocValues#docValueCount(). (Greg Miller)
+
 Optimizations
 ---------------------
 * LUCENE-8519: MultiDocValues.getNormValues should not call getMergedFieldInfos (Rushabh Shah)

--- a/lucene/facet/src/java/org/apache/lucene/facet/StringValueFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/StringValueFacetCounts.java
@@ -374,15 +374,14 @@ public class StringValueFacetCounts extends Facets {
         }
       } else {
         for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
-          int term = (int) multiValues.nextOrd();
           boolean countedDocInTotal = false;
-          while (term != SortedSetDocValues.NO_MORE_ORDS) {
+          for (int i = 0; i < multiValues.docValueCount(); i++) {
+            int term = (int) multiValues.nextOrd();
             increment(term);
             if (countedDocInTotal == false) {
               totalDocCount++;
               countedDocInTotal = true;
             }
-            term = (int) multiValues.nextOrd();
           }
         }
       }
@@ -402,15 +401,14 @@ public class StringValueFacetCounts extends Facets {
           }
         } else {
           for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
-            int term = (int) multiValues.nextOrd();
             boolean countedDocInTotal = false;
-            while (term != SortedSetDocValues.NO_MORE_ORDS) {
+            for (int i = 0; i < multiValues.docValueCount(); i++) {
+              int term = (int) multiValues.nextOrd();
               increment((int) ordMap.get(term));
               if (countedDocInTotal == false) {
                 totalDocCount++;
                 countedDocInTotal = true;
               }
-              term = (int) multiValues.nextOrd();
             }
           }
         }
@@ -427,15 +425,14 @@ public class StringValueFacetCounts extends Facets {
           }
         } else {
           for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
-            int term = (int) multiValues.nextOrd();
             boolean countedDocInTotal = false;
-            while (term != SortedSetDocValues.NO_MORE_ORDS) {
+            for (int i = 0; i < multiValues.docValueCount(); i++) {
+              int term = (int) multiValues.nextOrd();
               segCounts[term]++;
               if (countedDocInTotal == false) {
                 totalDocCount++;
                 countedDocInTotal = true;
               }
-              term = (int) multiValues.nextOrd();
             }
           }
         }
@@ -474,9 +471,8 @@ public class StringValueFacetCounts extends Facets {
             doc != DocIdSetIterator.NO_MORE_DOCS;
             doc = multiValues.nextDoc()) {
           boolean countedDocInTotal = false;
-          for (int term = (int) multiValues.nextOrd();
-              term != SortedSetDocValues.NO_MORE_ORDS;
-              term = (int) multiValues.nextOrd()) {
+          for (int i = 0; i < multiValues.docValueCount(); i++) {
+            int term = (int) multiValues.nextOrd();
             increment(term);
             if (countedDocInTotal == false) {
               totalDocCount++;
@@ -509,9 +505,8 @@ public class StringValueFacetCounts extends Facets {
             doc != DocIdSetIterator.NO_MORE_DOCS;
             doc = multiValues.nextDoc()) {
           boolean countedDocInTotal = false;
-          for (int term = (int) multiValues.nextOrd();
-              term != SortedSetDocValues.NO_MORE_ORDS;
-              term = (int) multiValues.nextOrd()) {
+          for (int i = 0; i < multiValues.docValueCount(); i++) {
+            int term = (int) multiValues.nextOrd();
             segCounts[term]++;
             if (countedDocInTotal == false) {
               totalDocCount++;

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/ConcurrentSortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/ConcurrentSortedSetDocValuesFacetCounts.java
@@ -157,9 +157,8 @@ public class ConcurrentSortedSetDocValuesFacetCounts extends AbstractSortedSetDo
               for (int doc = multiValues.nextDoc();
                   doc != DocIdSetIterator.NO_MORE_DOCS;
                   doc = multiValues.nextDoc()) {
-                for (int term = (int) multiValues.nextOrd();
-                    term != SortedSetDocValues.NO_MORE_ORDS;
-                    term = (int) multiValues.nextOrd()) {
+                for (int i = 0; i < multiValues.docValueCount(); i++) {
+                  int term = (int) multiValues.nextOrd();
                   counts.incrementAndGet((int) ordMap.get(term));
                 }
               }
@@ -167,9 +166,8 @@ public class ConcurrentSortedSetDocValuesFacetCounts extends AbstractSortedSetDo
               for (int doc = it.nextDoc();
                   doc != DocIdSetIterator.NO_MORE_DOCS;
                   doc = it.nextDoc()) {
-                for (int term = (int) multiValues.nextOrd();
-                    term != SortedSetDocValues.NO_MORE_ORDS;
-                    term = (int) multiValues.nextOrd()) {
+                for (int i = 0; i < multiValues.docValueCount(); i++) {
+                  int term = (int) multiValues.nextOrd();
                   counts.incrementAndGet((int) ordMap.get(term));
                 }
               }
@@ -198,9 +196,8 @@ public class ConcurrentSortedSetDocValuesFacetCounts extends AbstractSortedSetDo
               for (int doc = multiValues.nextDoc();
                   doc != DocIdSetIterator.NO_MORE_DOCS;
                   doc = multiValues.nextDoc()) {
-                for (int term = (int) multiValues.nextOrd();
-                    term != SortedSetDocValues.NO_MORE_ORDS;
-                    term = (int) multiValues.nextOrd()) {
+                for (int i = 0; i < multiValues.docValueCount(); i++) {
+                  int term = (int) multiValues.nextOrd();
                   segCounts[term]++;
                 }
               }
@@ -208,9 +205,8 @@ public class ConcurrentSortedSetDocValuesFacetCounts extends AbstractSortedSetDo
               for (int doc = it.nextDoc();
                   doc != DocIdSetIterator.NO_MORE_DOCS;
                   doc = it.nextDoc()) {
-                for (int term = (int) multiValues.nextOrd();
-                    term != SortedSetDocValues.NO_MORE_ORDS;
-                    term = (int) multiValues.nextOrd()) {
+                for (int i = 0; i < multiValues.docValueCount(); i++) {
+                  int term = (int) multiValues.nextOrd();
                   segCounts[term]++;
                 }
               }
@@ -245,17 +241,15 @@ public class ConcurrentSortedSetDocValuesFacetCounts extends AbstractSortedSetDo
             for (int doc = multiValues.nextDoc();
                 doc != DocIdSetIterator.NO_MORE_DOCS;
                 doc = multiValues.nextDoc()) {
-              for (int term = (int) multiValues.nextOrd();
-                  term != SortedSetDocValues.NO_MORE_ORDS;
-                  term = (int) multiValues.nextOrd()) {
+              for (int i = 0; i < multiValues.docValueCount(); i++) {
+                int term = (int) multiValues.nextOrd();
                 counts.incrementAndGet(term);
               }
             }
           } else {
             for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
-              for (int term = (int) multiValues.nextOrd();
-                  term != SortedSetDocValues.NO_MORE_ORDS;
-                  term = (int) multiValues.nextOrd()) {
+              for (int i = 0; i < multiValues.docValueCount(); i++) {
+                int term = (int) multiValues.nextOrd();
                 counts.incrementAndGet(term);
               }
             }

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -121,10 +121,9 @@ public class SortedSetDocValuesFacetCounts extends AbstractSortedSetDocValueFace
         for (int doc = multiValues.nextDoc();
             doc != DocIdSetIterator.NO_MORE_DOCS;
             doc = multiValues.nextDoc()) {
-          int term = (int) multiValues.nextOrd();
-          while (term != SortedSetDocValues.NO_MORE_ORDS) {
+          for (int i = 0; i < multiValues.docValueCount(); i++) {
+            int term = (int) multiValues.nextOrd();
             segCounts[term]++;
-            term = (int) multiValues.nextOrd();
           }
         }
       }
@@ -150,10 +149,9 @@ public class SortedSetDocValuesFacetCounts extends AbstractSortedSetDocValueFace
         for (int doc = multiValues.nextDoc();
             doc != DocIdSetIterator.NO_MORE_DOCS;
             doc = multiValues.nextDoc()) {
-          int term = (int) multiValues.nextOrd();
-          while (term != SortedSetDocValues.NO_MORE_ORDS) {
+          for (int i = 0; i < multiValues.docValueCount(); i++) {
+            int term = (int) multiValues.nextOrd();
             counts[term]++;
-            term = (int) multiValues.nextOrd();
           }
         }
       }
@@ -204,10 +202,9 @@ public class SortedSetDocValuesFacetCounts extends AbstractSortedSetDocValueFace
           }
         } else {
           for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
-            int term = (int) multiValues.nextOrd();
-            while (term != SortedSetDocValues.NO_MORE_ORDS) {
+            for (int i = 0; i < multiValues.docValueCount(); i++) {
+              int term = (int) multiValues.nextOrd();
               counts[(int) ordMap.get(term)]++;
-              term = (int) multiValues.nextOrd();
             }
           }
         }
@@ -220,10 +217,9 @@ public class SortedSetDocValuesFacetCounts extends AbstractSortedSetDocValueFace
           }
         } else {
           for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
-            int term = (int) multiValues.nextOrd();
-            while (term != SortedSetDocValues.NO_MORE_ORDS) {
+            for (int i = 0; i < multiValues.docValueCount(); i++) {
+              int term = (int) multiValues.nextOrd();
               segCounts[term]++;
-              term = (int) multiValues.nextOrd();
             }
           }
         }
@@ -246,10 +242,9 @@ public class SortedSetDocValuesFacetCounts extends AbstractSortedSetDocValueFace
         }
       } else {
         for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
-          int term = (int) multiValues.nextOrd();
-          while (term != SortedSetDocValues.NO_MORE_ORDS) {
+          for (int i = 0; i < multiValues.docValueCount(); i++) {
+            int term = (int) multiValues.nextOrd();
             counts[term]++;
-            term = (int) multiValues.nextOrd();
           }
         }
       }


### PR DESCRIPTION
This PR is to migrate the facets module to using the newly-added `SortedSetDocValues#docValueCount()` for iteration, as described in LUCENE-10603. It doesn't attempt to move all `SSDV` iteration, just the facets module.

Benchmark results look good to my eye:

```
                            TaskQPS baseline      StdDevQPS candidate      StdDev                Pct diff p-value
                      TermDTSort       99.36     (13.9%)       93.27     (12.9%)   -6.1% ( -28% -   24%) 0.149
           HighTermDayOfYearSort       99.67     (13.9%)       96.80     (12.2%)   -2.9% ( -25% -   27%) 0.487
       BrowseDayOfYearSSDVFacets       14.07     (18.4%)       13.82     (13.8%)   -1.8% ( -28% -   37%) 0.729
            HighTermTitleBDVSort      126.78     (21.9%)      124.79     (25.4%)   -1.6% ( -40% -   58%) 0.835
                          IntNRQ       73.42      (4.7%)       72.57      (5.1%)   -1.2% ( -10% -    9%) 0.454
                       OrHighMed       99.39      (3.5%)       98.39      (3.2%)   -1.0% (  -7% -    5%) 0.345
                    OrHighNotMed     1295.86      (3.2%)     1285.26      (5.0%)   -0.8% (  -8% -    7%) 0.535
                      OrHighHigh       46.15      (3.1%)       45.78      (3.0%)   -0.8% (  -6% -    5%) 0.400
           BrowseMonthSSDVFacets       16.26     (15.1%)       16.13      (9.7%)   -0.8% ( -22% -   28%) 0.848
                       OrHighLow      970.97      (2.8%)      964.35      (1.9%)   -0.7% (  -5% -    4%) 0.375
                    OrNotHighMed      945.22      (3.4%)      939.06      (4.1%)   -0.7% (  -7% -    7%) 0.582
                         MedTerm     2116.21      (5.1%)     2103.04      (4.5%)   -0.6% (  -9% -    9%) 0.684
                        PKLookup      169.76      (3.4%)      168.71      (3.8%)   -0.6% (  -7% -    6%) 0.588
                     AndHighHigh       44.04      (3.0%)       43.78      (5.5%)   -0.6% (  -8% -    8%) 0.677
             MedIntervalsOrdered       10.35      (5.8%)       10.31      (5.2%)   -0.4% ( -10% -   11%) 0.820
                   OrNotHighHigh     1077.87      (4.1%)     1074.45      (5.0%)   -0.3% (  -9% -    9%) 0.827
                        HighTerm     2923.10      (4.7%)     2914.62      (4.3%)   -0.3% (  -8% -    9%) 0.838
                         LowTerm     1969.85      (4.9%)     1964.63      (5.6%)   -0.3% ( -10% -   10%) 0.873
                     MedSpanNear       59.53      (2.6%)       59.38      (3.1%)   -0.2% (  -5% -    5%) 0.784
            HighIntervalsOrdered       12.23      (8.2%)       12.20      (7.6%)   -0.2% ( -14% -   16%) 0.920
                    HighSpanNear        5.30      (2.7%)        5.29      (3.2%)   -0.1% (  -5% -    5%) 0.902
                    OrNotHighLow     1213.60      (2.8%)     1212.64      (2.8%)   -0.1% (  -5% -    5%) 0.928
                 LowSloppyPhrase       24.51      (3.3%)       24.49      (3.3%)   -0.1% (  -6% -    6%) 0.953
          OrHighMedDayTaxoFacets       12.99      (4.9%)       12.98      (6.2%)   -0.1% ( -10% -   11%) 0.974
            MedTermDayTaxoFacets       23.69      (4.8%)       23.68      (4.1%)   -0.1% (  -8% -    9%) 0.971
             LowIntervalsOrdered      107.55      (5.3%)      107.51      (3.8%)   -0.0% (  -8% -    9%) 0.980
                    OrHighNotLow     1064.18      (4.6%)     1064.82      (5.6%)    0.1% (  -9% -   10%) 0.970
                     LowSpanNear      190.49      (3.1%)      190.62      (3.9%)    0.1% (  -6% -    7%) 0.951
         AndHighMedDayTaxoFacets       39.56      (2.1%)       39.60      (1.6%)    0.1% (  -3% -    3%) 0.868
                       MedPhrase      379.28      (2.1%)      379.69      (2.5%)    0.1% (  -4% -    4%) 0.883
                      HighPhrase      223.12      (2.5%)      223.61      (2.8%)    0.2% (  -4% -    5%) 0.795
               HighTermMonthSort      121.98     (16.5%)      122.28     (13.8%)    0.2% ( -25% -   36%) 0.959
                       LowPhrase       66.70      (2.8%)       66.89      (3.9%)    0.3% (  -6% -    7%) 0.792
                          Fuzzy1       93.42      (1.8%)       93.69      (1.2%)    0.3% (  -2% -    3%) 0.556
                         Respell       53.91      (1.8%)       54.07      (1.4%)    0.3% (  -2% -    3%) 0.552
                 MedSloppyPhrase       16.33      (3.2%)       16.38      (3.3%)    0.3% (  -6% -    7%) 0.763
                      AndHighMed       90.72      (3.2%)       91.05      (4.0%)    0.4% (  -6% -    7%) 0.753
                HighSloppyPhrase       32.08      (4.7%)       32.21      (4.4%)    0.4% (  -8% -    9%) 0.774
                   OrHighNotHigh      895.72      (4.9%)      899.79      (5.1%)    0.5% (  -9% -   10%) 0.773
                      AndHighLow      588.99      (2.5%)      591.85      (2.0%)    0.5% (  -3% -    5%) 0.497
                          Fuzzy2       19.51      (1.8%)       19.61      (1.1%)    0.5% (  -2% -    3%) 0.285
        AndHighHighDayTaxoFacets       13.45      (2.7%)       13.53      (2.3%)    0.5% (  -4% -    5%) 0.508
     BrowseRandomLabelSSDVFacets       10.00      (5.2%)       10.08      (4.9%)    0.8% (  -8% -   11%) 0.608
     BrowseRandomLabelTaxoFacets       17.77     (16.3%)       18.16     (13.7%)    2.2% ( -23% -   38%) 0.638
           BrowseMonthTaxoFacets       27.62     (23.3%)       28.42     (18.9%)    2.9% ( -31% -   58%) 0.665
            BrowseDateTaxoFacets       20.98     (18.5%)       21.63     (17.7%)    3.1% ( -27% -   48%) 0.590
       BrowseDayOfYearTaxoFacets       20.96     (18.7%)       21.63     (18.1%)    3.2% ( -28% -   49%) 0.584
                        Wildcard       56.56      (8.9%)       58.60      (6.0%)    3.6% ( -10% -   20%) 0.133
                         Prefix3      521.60     (12.1%)      548.29     (11.9%)    5.1% ( -16% -   33%) 0.178
            BrowseDateSSDVFacets        2.63     (11.6%)        2.82     (12.1%)    7.2% ( -14% -   35%) 0.054
```