### PR TITLE
LUCENE-10612: Introduced Lucene93CodecParameters for Lucene93Codec

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene93/Lucene93Codec.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene93/Lucene93Codec.java
@@ -54,20 +54,6 @@ import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
  */
 public class Lucene93Codec extends Codec {
 
-  /** Configuration option for the codec. */
-  public enum Mode {
-    /** Trade compression ratio for retrieval speed. */
-    BEST_SPEED(Lucene90StoredFieldsFormat.Mode.BEST_SPEED),
-    /** Trade retrieval speed for compression ratio. */
-    BEST_COMPRESSION(Lucene90StoredFieldsFormat.Mode.BEST_COMPRESSION);
-
-    private final Lucene90StoredFieldsFormat.Mode storedMode;
-
-    private Mode(Lucene90StoredFieldsFormat.Mode storedMode) {
-      this.storedMode = Objects.requireNonNull(storedMode);
-    }
-  }
-
   private final TermVectorsFormat vectorsFormat = new Lucene90TermVectorsFormat();
   private final FieldInfosFormat fieldInfosFormat = new Lucene90FieldInfosFormat();
   private final SegmentInfoFormat segmentInfosFormat = new Lucene90SegmentInfoFormat();
@@ -106,21 +92,21 @@ public class Lucene93Codec extends Codec {
 
   /** Instantiates a new codec. */
   public Lucene93Codec() {
-    this(Mode.BEST_SPEED);
+    this(Lucene93CodecParameters.builder().build());
   }
-
-  /**
-   * Instantiates a new codec, specifying the stored fields compression mode to use.
-   *
-   * @param mode stored fields compression mode to use for newly flushed/merged segments.
-   */
-  public Lucene93Codec(Mode mode) {
+  /** Instantiates a new codec, specifying the stored fields compression mode to use. */
+  public Lucene93Codec(Lucene93CodecParameters codecParameters) {
     super("Lucene93");
     this.storedFieldsFormat =
-        new Lucene90StoredFieldsFormat(Objects.requireNonNull(mode).storedMode);
+        new Lucene90StoredFieldsFormat(
+            Objects.requireNonNull(codecParameters)
+                .getStoredFieldsCompressionMode()
+                .getStoredMode());
     this.defaultPostingsFormat = new Lucene90PostingsFormat();
     this.defaultDVFormat = new Lucene90DocValuesFormat();
-    this.defaultKnnVectorsFormat = new Lucene93HnswVectorsFormat();
+    this.defaultKnnVectorsFormat =
+        new Lucene93HnswVectorsFormat(
+            codecParameters.getHnswMaxConn(), codecParameters.getHnswBeamWidth());
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene93/Lucene93CodecParameters.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene93/Lucene93CodecParameters.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene93;
+
+import java.util.Objects;
+import org.apache.lucene.codecs.lucene90.Lucene90StoredFieldsFormat;
+
+/** Parameters for Lucene codecs * */
+public class Lucene93CodecParameters {
+
+  private StoredFieldsCompressionMode storedFieldsCompressionMode;
+  private int hnswMaxConn;
+  private int hnswBeamWidth;
+
+  /** Configuration option for the codec. */
+  public enum StoredFieldsCompressionMode {
+    /** Trade compression ratio for retrieval speed. */
+    BEST_SPEED(Lucene90StoredFieldsFormat.Mode.BEST_SPEED),
+    /** Trade retrieval speed for compression ratio. */
+    BEST_COMPRESSION(Lucene90StoredFieldsFormat.Mode.BEST_COMPRESSION);
+
+    private final Lucene90StoredFieldsFormat.Mode storedMode;
+
+    StoredFieldsCompressionMode(Lucene90StoredFieldsFormat.Mode storedMode) {
+      this.storedMode = Objects.requireNonNull(storedMode);
+    }
+
+    public Lucene90StoredFieldsFormat.Mode getStoredMode() {
+      return storedMode;
+    }
+  }
+
+  public Lucene93CodecParameters(
+      StoredFieldsCompressionMode storedFieldsCompressionMode, int hnswMaxConn, int hnswBeamWidth) {
+    this.storedFieldsCompressionMode = storedFieldsCompressionMode;
+    this.hnswMaxConn = hnswMaxConn;
+    this.hnswBeamWidth = hnswBeamWidth;
+  }
+
+  public int getHnswMaxConn() {
+    return hnswMaxConn;
+  }
+
+  public int getHnswBeamWidth() {
+    return hnswBeamWidth;
+  }
+
+  public StoredFieldsCompressionMode getStoredFieldsCompressionMode() {
+    return storedFieldsCompressionMode;
+  }
+
+  public static Lucene93CodecParametersBuilder builder() {
+    return new Lucene93CodecParametersBuilder();
+  }
+
+  /** Builder for Lucene93CodecParameters */
+  public static class Lucene93CodecParametersBuilder {
+    private StoredFieldsCompressionMode storedFieldsCompressionMode =
+        StoredFieldsCompressionMode.BEST_SPEED;
+    private int hnswMaxConn = Lucene93HnswVectorsFormat.DEFAULT_MAX_CONN;
+    private int hnswBeamWidth = Lucene93HnswVectorsFormat.DEFAULT_BEAM_WIDTH;
+
+    public Lucene93CodecParametersBuilder withStoredFieldsCompressionMode(
+        StoredFieldsCompressionMode storedFieldsCompressionMode) {
+      this.storedFieldsCompressionMode = storedFieldsCompressionMode;
+      return this;
+    }
+
+    public Lucene93CodecParametersBuilder withHnswBeamWidth(int hnswBeamWidth) {
+      this.hnswBeamWidth = hnswBeamWidth;
+      return this;
+    }
+
+    public Lucene93CodecParametersBuilder withHnswMaxConn(int hnswMaxConn) {
+      this.hnswMaxConn = hnswMaxConn;
+      return this;
+    }
+
+    public Lucene93CodecParameters build() {
+      return new Lucene93CodecParameters(
+          this.storedFieldsCompressionMode, this.hnswMaxConn, this.hnswBeamWidth);
+    }
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90StoredFieldsFormatHighCompression.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90StoredFieldsFormatHighCompression.java
@@ -19,7 +19,8 @@ package org.apache.lucene.codecs.lucene90;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.lucene93.Lucene93Codec;
-import org.apache.lucene.codecs.lucene93.Lucene93Codec.Mode;
+import org.apache.lucene.codecs.lucene93.Lucene93CodecParameters;
+import org.apache.lucene.codecs.lucene93.Lucene93CodecParameters.StoredFieldsCompressionMode;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DirectoryReader;
@@ -31,7 +32,10 @@ import org.apache.lucene.tests.index.BaseStoredFieldsFormatTestCase;
 public class TestLucene90StoredFieldsFormatHighCompression extends BaseStoredFieldsFormatTestCase {
   @Override
   protected Codec getCodec() {
-    return new Lucene93Codec(Mode.BEST_COMPRESSION);
+    return new Lucene93Codec(
+        Lucene93CodecParameters.builder()
+            .withStoredFieldsCompressionMode(StoredFieldsCompressionMode.BEST_COMPRESSION)
+            .build());
   }
 
   /**
@@ -41,7 +45,15 @@ public class TestLucene90StoredFieldsFormatHighCompression extends BaseStoredFie
     Directory dir = newDirectory();
     for (int i = 0; i < 10; i++) {
       IndexWriterConfig iwc = newIndexWriterConfig();
-      iwc.setCodec(new Lucene93Codec(RandomPicks.randomFrom(random(), Mode.values())));
+
+      StoredFieldsCompressionMode storedFieldsCompressionMode =
+          RandomPicks.randomFrom(random(), StoredFieldsCompressionMode.values());
+
+      iwc.setCodec(
+          new Lucene93Codec(
+              Lucene93CodecParameters.builder()
+                  .withStoredFieldsCompressionMode(storedFieldsCompressionMode)
+                  .build()));
       IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig());
       Document doc = new Document();
       doc.add(new StoredField("field1", "value1"));

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
@@ -39,6 +39,7 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.lucene93.Lucene93Codec;
+import org.apache.lucene.codecs.lucene93.Lucene93CodecParameters;
 import org.apache.lucene.codecs.simpletext.SimpleTextCodec;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
@@ -195,7 +196,16 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
       codec = CompressingCodec.randomInstance(random);
     } else if ("Lucene93".equals(TEST_CODEC)
         || ("random".equals(TEST_CODEC) && randomVal == 5 && !shouldAvoidCodec("Lucene93"))) {
-      codec = new Lucene93Codec(RandomPicks.randomFrom(random, Lucene93Codec.Mode.values()));
+
+      Lucene93CodecParameters.StoredFieldsCompressionMode storedFieldsCompressionMode =
+          RandomPicks.randomFrom(
+              random, Lucene93CodecParameters.StoredFieldsCompressionMode.values());
+
+      codec =
+          new Lucene93Codec(
+              Lucene93CodecParameters.builder()
+                  .withStoredFieldsCompressionMode(storedFieldsCompressionMode)
+                  .build());
     } else if (!"random".equals(TEST_CODEC)) {
       codec = Codec.forName(TEST_CODEC);
     } else if ("random".equals(TEST_POSTINGSFORMAT)) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-10612

# Description
Lucene93Codec should provide a way for providing custom parameters to HnswVectorsFormat

# Solution
For providing the various parameters to Lucene93Codec, I wrap them up in a Lucene93CodecParameters class. This should provide a cleaner and easier way to pass custom parameters.

#11648