### PR TITLE
LUCENE-10598: (backport) SortedSetDocValues#docValueCount() should be always greater than zero

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -99,6 +99,8 @@ Bug Fixes
 
 * LUCENE-10605: Fix error in 32bit jvm object alignment gap calculation (Sun Wuqiang)
 
+* LUCENE-10598: SortedSetDocValues#docValueCount() should be always greater than zero. (Lu Xugang)
+
 Other
 ---------------------
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80DocValuesProducer.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80DocValuesProducer.java
@@ -1560,8 +1560,8 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
       return new BaseSortedSetDocValues(entry, data) {
 
         int doc = -1;
-        long start;
-        long end;
+        long start, end;
+        long count;
 
         @Override
         public int nextDoc() throws IOException {
@@ -1585,6 +1585,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
           }
           start = addresses.get(target);
           end = addresses.get(target + 1L);
+          count = (end - start);
           return doc = target;
         }
 
@@ -1592,6 +1593,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
         public boolean advanceExact(int target) throws IOException {
           start = addresses.get(target);
           end = addresses.get(target + 1L);
+          count = (end - start);
           doc = target;
           return true;
         }
@@ -1606,7 +1608,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
 
         @Override
         public long docValueCount() {
-          return end - start;
+          return count;
         }
       };
     } else {
@@ -1624,6 +1626,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
         boolean set;
         long start;
         long end = 0;
+        long count;
 
         @Override
         public int nextDoc() throws IOException {
@@ -1658,6 +1661,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
             final int index = disi.index();
             start = addresses.get(index);
             end = addresses.get(index + 1L);
+            count = end - start;
             set = true;
             return true;
           }
@@ -1678,7 +1682,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
         @Override
         public long docValueCount() {
           set();
-          return end - start;
+          return count;
         }
       };
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -1454,7 +1454,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
 
       @Override
       public long docValueCount() {
-        return count;
+        return ords.docValueCount();
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -3357,6 +3357,14 @@ public final class CheckIndex implements Closeable {
       long ord;
       int ordCount = 0;
       while ((ord = dv.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
+        if (count != dv.docValueCount()) {
+          throw new CheckIndexException(
+              "value count changed from "
+                  + count
+                  + " to "
+                  + dv.docValueCount()
+                  + " during iterating over all values");
+        }
         long ord2 = dv2.nextOrd();
         if (ord != ord2) {
           throw new CheckIndexException(
@@ -3373,6 +3381,13 @@ public final class CheckIndex implements Closeable {
         maxOrd2 = Math.max(maxOrd2, ord);
         seenOrds.set(ord);
         ordCount++;
+      }
+      if (dv.docValueCount() != dv2.docValueCount()) {
+        throw new CheckIndexException(
+            "dv and dv2 report different values count after iterating over all values: "
+                + dv.docValueCount()
+                + " != "
+                + dv2.docValueCount());
       }
       if (ordCount == 0) {
         throw new CheckIndexException(

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -3337,8 +3337,21 @@ public final class CheckIndex implements Closeable {
     LongBitSet seenOrds = new LongBitSet(dv.getValueCount());
     long maxOrd2 = -1;
     for (int docID = dv.nextDoc(); docID != NO_MORE_DOCS; docID = dv.nextDoc()) {
+      long count = dv.docValueCount();
+      if (count == 0) {
+        throw new CheckIndexException(
+            "sortedset dv for field: "
+                + fieldName
+                + " returned docValueCount=0 for docID="
+                + docID);
+      }
       if (dv2.advanceExact(docID) == false) {
         throw new CheckIndexException("advanceExact did not find matching doc ID: " + docID);
+      }
+      long count2 = dv2.docValueCount();
+      if (count != count2) {
+        throw new CheckIndexException(
+            "advanceExact reports different value count: " + count + " != " + count2);
       }
       long lastOrd = -1;
       long ord;

--- a/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValues.java
@@ -45,8 +45,9 @@ public abstract class SortedSetDocValues extends DocValuesIterator {
   public abstract long nextOrd() throws IOException;
 
   /**
-   * Retrieves the number of values for the current document. This must always be greater than zero.
-   * It is illegal to call this method after {@link #advanceExact(int)} returned {@code false}.
+   * Retrieves the number of unique ords for the current document. This must always be greater than
+   * zero. It is illegal to call this method after {@link #advanceExact(int)} returned {@code
+   * false}.
    */
   public abstract long docValueCount();
 

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormat.java
@@ -265,6 +265,7 @@ public class TestLucene90DocValuesFormat extends BaseCompressingDocValuesFormatT
             assertTrue(valueSet.contains(sortedNumeric.nextValue()));
           }
           assertEquals(i, sortedSet.nextDoc());
+          assertEquals(valueSet.size(), sortedSet.docValueCount());
           int sortedSetCount = 0;
           while (true) {
             long ord = sortedSet.nextOrd();
@@ -488,6 +489,7 @@ public class TestLucene90DocValuesFormat extends BaseCompressingDocValuesFormatT
       for (int i = 0; i < maxDoc; ++i) {
         assertEquals(i, values.nextDoc());
         final int numValues = in.readVInt();
+        assertEquals(numValues, values.docValueCount());
 
         for (int j = 0; j < numValues; ++j) {
           b.setLength(in.readVInt());

--- a/lucene/core/src/test/org/apache/lucene/index/TestMultiDocValues.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMultiDocValues.java
@@ -279,6 +279,7 @@ public class TestMultiDocValues extends LuceneTestCase {
         if (docID == NO_MORE_DOCS) {
           break;
         }
+        assertEquals(single.docValueCount(), multi.docValueCount());
 
         ArrayList<Long> expectedList = new ArrayList<>();
         long ord;

--- a/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
@@ -230,6 +230,7 @@ public class TestSortingCodecReader extends LuceneTestCase {
               assertEquals(
                   new BytesRef(ids.longValue() + ""),
                   sorted_set_dv.lookupOrd(sorted_set_dv.nextOrd()));
+              assertEquals(1, sorted_set_dv.docValueCount());
               assertEquals(1, sorted_numeric_dv.docValueCount());
               assertEquals(ids.longValue(), sorted_numeric_dv.nextValue());
 

--- a/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
+++ b/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
@@ -297,6 +297,7 @@ public class TestMemoryIndex extends LuceneTestCase {
     SortedSetDocValues sortedSetDocValues = leafReader.getSortedSetDocValues("sorted_set");
     assertEquals(3, sortedSetDocValues.getValueCount());
     assertEquals(0, sortedSetDocValues.nextDoc());
+    assertEquals(3, sortedSetDocValues.docValueCount());
     assertEquals(0L, sortedSetDocValues.nextOrd());
     assertEquals(1L, sortedSetDocValues.nextOrd());
     assertEquals(2L, sortedSetDocValues.nextOrd());


### PR DESCRIPTION
Backport for https://github.com/apache/lucene/pull/942 and https://github.com/apache/lucene/pull/934 

And make the same change to Lucene70DocValuesProducer.