### PR TITLE
LUCENE-10600: (backport)SortedSetDocValues#docValueCount should be an int, not long (#960)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -106,6 +106,8 @@ Bug Fixes
 
 * LUCENE-10598: SortedSetDocValues#docValueCount() should be always greater than zero. (Lu Xugang)
 
+* LUCENE-10600: SortedSetDocValues#docValueCount should be an int, not long (Lu Xugang)
+
 Other
 ---------------------
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene70/Lucene70DocValuesProducer.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene70/Lucene70DocValuesProducer.java
@@ -1368,7 +1368,7 @@ final class Lucene70DocValuesProducer extends DocValuesProducer {
 
         int doc = -1;
         long start, end;
-        long count;
+        int count;
 
         @Override
         public int nextDoc() throws IOException {
@@ -1392,7 +1392,7 @@ final class Lucene70DocValuesProducer extends DocValuesProducer {
           }
           start = addresses.get(target);
           end = addresses.get(target + 1L);
-          count = (end - start);
+          count = (int) (end - start);
           return doc = target;
         }
 
@@ -1400,7 +1400,7 @@ final class Lucene70DocValuesProducer extends DocValuesProducer {
         public boolean advanceExact(int target) throws IOException {
           start = addresses.get(target);
           end = addresses.get(target + 1L);
-          count = (end - start);
+          count = (int) (end - start);
           doc = target;
           return true;
         }
@@ -1414,7 +1414,7 @@ final class Lucene70DocValuesProducer extends DocValuesProducer {
         }
 
         @Override
-        public long docValueCount() {
+        public int docValueCount() {
           return count;
         }
       };
@@ -1428,7 +1428,7 @@ final class Lucene70DocValuesProducer extends DocValuesProducer {
         boolean set;
         long start;
         long end = 0;
-        long count;
+        int count;
 
         @Override
         public int nextDoc() throws IOException {
@@ -1463,7 +1463,7 @@ final class Lucene70DocValuesProducer extends DocValuesProducer {
             final int index = disi.index();
             start = addresses.get(index);
             end = addresses.get(index + 1L);
-            count = end - start;
+            count = (int) (end - start);
             set = true;
             return true;
           }
@@ -1482,7 +1482,7 @@ final class Lucene70DocValuesProducer extends DocValuesProducer {
         }
 
         @Override
-        public long docValueCount() {
+        public int docValueCount() {
           set();
           return count;
         }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80DocValuesProducer.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80DocValuesProducer.java
@@ -1561,7 +1561,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
 
         int doc = -1;
         long start, end;
-        long count;
+        int count;
 
         @Override
         public int nextDoc() throws IOException {
@@ -1585,7 +1585,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
           }
           start = addresses.get(target);
           end = addresses.get(target + 1L);
-          count = (end - start);
+          count = (int) (end - start);
           return doc = target;
         }
 
@@ -1593,7 +1593,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
         public boolean advanceExact(int target) throws IOException {
           start = addresses.get(target);
           end = addresses.get(target + 1L);
-          count = (end - start);
+          count = (int) (end - start);
           doc = target;
           return true;
         }
@@ -1607,7 +1607,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
         }
 
         @Override
-        public long docValueCount() {
+        public int docValueCount() {
           return count;
         }
       };
@@ -1626,7 +1626,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
         boolean set;
         long start;
         long end = 0;
-        long count;
+        int count;
 
         @Override
         public int nextDoc() throws IOException {
@@ -1661,7 +1661,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
             final int index = disi.index();
             start = addresses.get(index);
             end = addresses.get(index + 1L);
-            count = end - start;
+            count = (int) (end - start);
             set = true;
             return true;
           }
@@ -1680,7 +1680,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer {
         }
 
         @Override
-        public long docValueCount() {
+        public int docValueCount() {
           set();
           return count;
         }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextDocValuesReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextDocValuesReader.java
@@ -728,7 +728,7 @@ class SimpleTextDocValuesReader extends DocValuesProducer {
       }
 
       @Override
-      public long docValueCount() {
+      public int docValueCount() {
         return currentOrds.length;
       }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/DocValuesConsumer.java
@@ -948,7 +948,7 @@ public abstract class DocValuesConsumer implements Closeable {
               }
 
               @Override
-              public long docValueCount() {
+              public int docValueCount() {
                 return currentSub.values.docValueCount();
               }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -1453,7 +1453,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
       }
 
       @Override
-      public long docValueCount() {
+      public int docValueCount() {
         return ords.docValueCount();
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -3337,7 +3337,7 @@ public final class CheckIndex implements Closeable {
     LongBitSet seenOrds = new LongBitSet(dv.getValueCount());
     long maxOrd2 = -1;
     for (int docID = dv.nextDoc(); docID != NO_MORE_DOCS; docID = dv.nextDoc()) {
-      long count = dv.docValueCount();
+      int count = dv.docValueCount();
       if (count == 0) {
         throw new CheckIndexException(
             "sortedset dv for field: "
@@ -3348,7 +3348,7 @@ public final class CheckIndex implements Closeable {
       if (dv2.advanceExact(docID) == false) {
         throw new CheckIndexException("advanceExact did not find matching doc ID: " + docID);
       }
-      long count2 = dv2.docValueCount();
+      int count2 = dv2.docValueCount();
       if (count != count2) {
         throw new CheckIndexException(
             "advanceExact reports different value count: " + count + " != " + count2);

--- a/lucene/core/src/java/org/apache/lucene/index/FilterSortedSetDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterSortedSetDocValues.java
@@ -44,7 +44,7 @@ public class FilterSortedSetDocValues extends SortedSetDocValues {
   }
 
   @Override
-  public long docValueCount() {
+  public int docValueCount() {
     return in.docValueCount();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/MultiDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiDocValues.java
@@ -938,7 +938,7 @@ public class MultiDocValues {
     }
 
     @Override
-    public long docValueCount() {
+    public int docValueCount() {
       return currentValues.docValueCount();
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SingletonSortedSetDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SingletonSortedSetDocValues.java
@@ -58,7 +58,7 @@ final class SingletonSortedSetDocValues extends SortedSetDocValues {
   }
 
   @Override
-  public long docValueCount() {
+  public int docValueCount() {
     return 1;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValues.java
@@ -49,7 +49,7 @@ public abstract class SortedSetDocValues extends DocValuesIterator {
    * zero. It is illegal to call this method after {@link #advanceExact(int)} returned {@code
    * false}.
    */
-  public abstract long docValueCount();
+  public abstract int docValueCount();
 
   /**
    * Retrieves the value for the specified ordinal. The returned {@link BytesRef} may be re-used

--- a/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValuesWriter.java
@@ -311,7 +311,7 @@ class SortedSetDocValuesWriter extends DocValuesWriter<SortedSetDocValues> {
     }
 
     @Override
-    public long docValueCount() {
+    public int docValueCount() {
       return ordCount;
     }
 
@@ -397,8 +397,8 @@ class SortedSetDocValuesWriter extends DocValuesWriter<SortedSetDocValues> {
     }
 
     @Override
-    public long docValueCount() {
-      return ords.ords.size();
+    public int docValueCount() {
+      return (int) ords.ords.size();
     }
 
     @Override

--- a/lucene/join/src/java/org/apache/lucene/search/join/GenericTermsCollector.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/GenericTermsCollector.java
@@ -94,7 +94,7 @@ interface GenericTermsCollector extends Collector {
         }
 
         @Override
-        public long docValueCount() {
+        public int docValueCount() {
           return target.docValueCount();
         }
 

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -1155,7 +1155,7 @@ public class MemoryIndex {
       }
 
       @Override
-      public long docValueCount() {
+      public int docValueCount() {
         return values.size();
       }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -1065,7 +1065,7 @@ public class AssertingLeafReader extends FilterLeafReader {
     }
 
     @Override
-    public long docValueCount() {
+    public int docValueCount() {
       return in.docValueCount();
     }
 


### PR DESCRIPTION
Backport for https://github.com/apache/lucene/pull/960 and make same change for Lucene70DocValues