### PR TITLE
LUCENE-10583: Add docstring warning to not lock on Lucene objects

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/Directory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/Directory.java
@@ -41,8 +41,8 @@ import org.apache.lucene.util.IOUtils;
  * </ul>
  *
  * <p><b>NOTE:</b> If your application requires external synchronization, you should <b>not</b>
- * synchronize on the <code>Directory</code> implementation instance as this may cause deadlock;
- * use your own (non-Lucene) objects instead.
+ * synchronize on the <code>Directory</code> implementation instance as this may cause deadlock; use
+ * your own (non-Lucene) objects instead.
  *
  * @see FSDirectory
  * @see ByteBuffersDirectory

--- a/lucene/core/src/java/org/apache/lucene/store/Directory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/Directory.java
@@ -40,6 +40,10 @@ import org.apache.lucene.util.IOUtils;
  *       java.nio.file.FileAlreadyExistsException}.
  * </ul>
  *
+ * <p><b>NOTE:</b> If your application requires external synchronization, you should <b>not</b>
+ * synchronize on the <code>Directory</code> implementation instance as this may cause deadlock;
+ * use your own (non-Lucene) objects instead.
+ *
  * @see FSDirectory
  * @see ByteBuffersDirectory
  * @see FilterDirectory

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -78,8 +78,8 @@ import org.apache.lucene.util.SuppressForbidden;
  * RAFDirectory} from the Lucene {@code misc} module in favor of {@link MMapDirectory}.
  *
  * <p><b>NOTE:</b> If your application requires external synchronization, you should <b>not</b>
- * synchronize on the <code>MMapDirectory</code> instance as this may cause deadlock;
- * use your own (non-Lucene) objects instead.
+ * synchronize on the <code>MMapDirectory</code> instance as this may cause deadlock; use your own
+ * (non-Lucene) objects instead.
  *
  * @see <a href="http://blog.thetaphi.de/2012/07/use-lucenes-mmapdirectory-on-64bit.html">Blog post
  *     about MMapDirectory</a>

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -77,6 +77,10 @@ import org.apache.lucene.util.SuppressForbidden;
  * Thread#interrupt()} or {@link Future#cancel(boolean)} you should use the legacy {@code
  * RAFDirectory} from the Lucene {@code misc} module in favor of {@link MMapDirectory}.
  *
+ * <p><b>NOTE:</b> If your application requires external synchronization, you should <b>not</b>
+ * synchronize on the <code>MMapDirectory</code> instance as this may cause deadlock;
+ * use your own (non-Lucene) objects instead.
+ *
  * @see <a href="http://blog.thetaphi.de/2012/07/use-lucenes-mmapdirectory-on-64bit.html">Blog post
  *     about MMapDirectory</a>
  */


### PR DESCRIPTION
In [LUCENE-10583](https://issues.apache.org/jira/browse/LUCENE-10583), our users ran into a deadlock for IndexWriter threads. This was because the application had acquired a lock on the MMapDirectory, which was preventing merge threads from cleaning up files and completing.

The IndexWriter docstring does present a "Note", to use non-Lucene objects for locking, but no such warning was evident for the MMapDirectory. This PR is a small change to add a similar warning to MMapDirectory and Directory docstrings.
