### PR TITLE
LUCENE-10618: Implement BooleanQuery rewrite rules based for minimumShouldMatch

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -86,11 +86,11 @@ Improvements
 * LUCENE-10585: Facet module code cleanup (copy/paste scrubbing, simplification and some very minor
   optimization tweaks). (Greg Miller)
 
-* LUCENE-10618: Implement BooleanQuery rewrite rules based for minimumShouldMatch. (Fang Hou)
-
 Optimizations
 ---------------------
 * LUCENE-8519: MultiDocValues.getNormValues should not call getMergedFieldInfos (Rushabh Shah)
+
+* LUCENE-10618: Implement BooleanQuery rewrite rules based for minimumShouldMatch. (Fang Hou)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -86,6 +86,8 @@ Improvements
 * LUCENE-10585: Facet module code cleanup (copy/paste scrubbing, simplification and some very minor
   optimization tweaks). (Greg Miller)
 
+* LUCENE-10618: Implement BooleanQuery rewrite rules based for minimumShouldMatch. (Fang Hou)
+
 Optimizations
 ---------------------
 * LUCENE-8519: MultiDocValues.getNormValues should not call getMergedFieldInfos (Rushabh Shah)

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanMinShouldMatch.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanMinShouldMatch.java
@@ -436,6 +436,31 @@ public class TestBooleanMinShouldMatch extends LuceneTestCase {
     assertSubsetOfSameScores(q2.build(), top1, top2);
   }
 
+  public void testFlattenInnerDisjunctions() throws Exception {
+    Query q =
+        new BooleanQuery.Builder()
+            .setMinimumNumberShouldMatch(2)
+            .add(new TermQuery(new Term("all", "all")), BooleanClause.Occur.SHOULD)
+            .add(new TermQuery(new Term("data", "1")), BooleanClause.Occur.SHOULD)
+            .add(new TermQuery(new Term("data", "2")), BooleanClause.Occur.MUST)
+            .build();
+    verifyNrHits(q, 1);
+
+    Query inner =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("all", "all")), BooleanClause.Occur.SHOULD)
+            .add(new TermQuery(new Term("data", "1")), BooleanClause.Occur.SHOULD)
+            .build();
+    q =
+        new BooleanQuery.Builder()
+            .setMinimumNumberShouldMatch(2)
+            .add(inner, BooleanClause.Occur.SHOULD)
+            .add(new TermQuery(new Term("data", "2")), BooleanClause.Occur.MUST)
+            .build();
+
+    verifyNrHits(q, 0);
+  }
+
   protected void printHits(String test, ScoreDoc[] h, IndexSearcher searcher) throws Exception {
 
     System.err.println("------- " + test + " -------");

--- a/lucene/core/src/test/org/apache/lucene/search/TestMinShouldMatch2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMinShouldMatch2.java
@@ -253,7 +253,7 @@ public class TestMinShouldMatch2 extends LuceneTestCase {
     termsList.addAll(Arrays.asList(rareTerms));
     String[] terms = termsList.toArray(new String[0]);
 
-    for (int minNrShouldMatch = 1; minNrShouldMatch <= terms.length; minNrShouldMatch++) {
+    for (int minNrShouldMatch = 1; minNrShouldMatch < terms.length; minNrShouldMatch++) {
       Scorer expected = scorer(terms, minNrShouldMatch, Mode.DOC_VALUES);
       Scorer actual = scorer(terms, minNrShouldMatch, Mode.SCORER);
       assertNext(expected, actual);
@@ -273,7 +273,7 @@ public class TestMinShouldMatch2 extends LuceneTestCase {
     String[] terms = termsList.toArray(new String[0]);
 
     for (int amount = 25; amount < 200; amount += 25) {
-      for (int minNrShouldMatch = 1; minNrShouldMatch <= terms.length; minNrShouldMatch++) {
+      for (int minNrShouldMatch = 1; minNrShouldMatch < terms.length; minNrShouldMatch++) {
         Scorer expected = scorer(terms, minNrShouldMatch, Mode.DOC_VALUES);
         Scorer actual = scorer(terms, minNrShouldMatch, Mode.SCORER);
         assertAdvance(expected, actual, amount);
@@ -294,7 +294,7 @@ public class TestMinShouldMatch2 extends LuceneTestCase {
     Collections.shuffle(termsList, random());
     for (int numTerms = 2; numTerms <= termsList.size(); numTerms++) {
       String[] terms = termsList.subList(0, numTerms).toArray(new String[0]);
-      for (int minNrShouldMatch = 1; minNrShouldMatch <= terms.length; minNrShouldMatch++) {
+      for (int minNrShouldMatch = 1; minNrShouldMatch < terms.length; minNrShouldMatch++) {
         Scorer expected = scorer(terms, minNrShouldMatch, Mode.DOC_VALUES);
         Scorer actual = scorer(terms, minNrShouldMatch, Mode.SCORER);
         assertNext(expected, actual);
@@ -318,7 +318,7 @@ public class TestMinShouldMatch2 extends LuceneTestCase {
     for (int amount = 25; amount < 200; amount += 25) {
       for (int numTerms = 2; numTerms <= termsList.size(); numTerms++) {
         String[] terms = termsList.subList(0, numTerms).toArray(new String[0]);
-        for (int minNrShouldMatch = 1; minNrShouldMatch <= terms.length; minNrShouldMatch++) {
+        for (int minNrShouldMatch = 1; minNrShouldMatch < terms.length; minNrShouldMatch++) {
           Scorer expected = scorer(terms, minNrShouldMatch, Mode.DOC_VALUES);
           Scorer actual = scorer(terms, minNrShouldMatch, Mode.SCORER);
           assertAdvance(expected, actual, amount);


### PR DESCRIPTION
### Description (or a Jira issue link if you have one)
1. rewrite to `MatchNoDocsQuery` when there are not enough meaningful `SHOULD` clauses (less than `minimumNumberShouldMatch`)
2. change to `MUSH` clause when meaningful `SHOULD` clauses equal to `minimumNumberShouldMatch`

Detailed discussion see: https://issues.apache.org/jira/browse/LUCENE-10618

### How To Test
1. test boolean query rewrite
2. test boolean min should match
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
