### PR TITLE
LUCENE-10603: Mark SortedSetDocValues#NO_MORE_ORDS deprecated

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -71,7 +71,9 @@ Other
 
 API Changes
 ---------------------
-(No changes)
+
+* LUCENE-10603: SortedSetDocValues#NO_MORE_ORDS marked @deprecated in favor of iterating with
+  SortedSetDocValues#docValueCount().
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -73,7 +73,7 @@ API Changes
 ---------------------
 
 * LUCENE-10603: SortedSetDocValues#NO_MORE_ORDS marked @deprecated in favor of iterating with
-  SortedSetDocValues#docValueCount().
+  SortedSetDocValues#docValueCount(). (Greg Miller)
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValues.java
@@ -32,12 +32,21 @@ public abstract class SortedSetDocValues extends DocValuesIterator {
   /** Sole constructor. (For invocation by subclass constructors, typically implicit.) */
   protected SortedSetDocValues() {}
 
-  /** When returned by {@link #nextOrd()} it means there are no more ordinals for the document. */
-  public static final long NO_MORE_ORDS = -1;
+  /**
+   * When returned by {@link #nextOrd()} it means there are no more ordinals for the document.
+   *
+   * @deprecated Will be removed in a future version. Please use {@link #docValueCount()} to know
+   *     the number of doc values for the current document up-front.
+   */
+  @Deprecated public static final long NO_MORE_ORDS = -1;
 
   /**
    * Returns the next ordinal for the current document. It is illegal to call this method after
    * {@link #advanceExact(int)} returned {@code false}.
+   *
+   * <p>Note: Returns {@link #NO_MORE_ORDS} when the current document has no more ordinals. This
+   * behavior will be removed in a future version. Callers should use {@link #docValueCount()} to
+   * determine the number of values for the current document up-front.
    *
    * @return next ordinal for the document, or {@link #NO_MORE_ORDS}. ordinals are dense, start at
    *     0, then increment by 1 for the next value in sorted order.


### PR DESCRIPTION
Let's get this marked as deprecated ASAP if we want to actually remove it in a 10.0 release. Unless we remove it, we won't see any performance benefits of LUCENE-10603 since we'll still need to do the internal book-keeping in `Lucene90DocValuesProducer` to surface `NO_MORE_ORDS` as long as it exists as part of the API.