### PR TITLE
LUCENE-10396: Add capability to jump to the next document with different ord in SortedDocValues

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80DocValuesConsumer.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80DocValuesConsumer.java
@@ -683,7 +683,8 @@ final class Lucene80DocValuesConsumer extends DocValuesConsumer {
   }
 
   @Override
-  public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+  public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer, boolean primarySort)
+      throws IOException {
     meta.writeInt(field.number);
     meta.writeByte(Lucene80DocValuesFormat.SORTED);
     doAddSortedField(field, valuesProducer);

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextDocValuesWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextDocValuesWriter.java
@@ -228,7 +228,8 @@ class SimpleTextDocValuesWriter extends DocValuesConsumer {
   }
 
   @Override
-  public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+  public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer, boolean primarySort)
+      throws IOException {
     assert fieldSeen(field.name);
     assert field.getDocValuesType() == DocValuesType.SORTED;
     writeFieldEntry(field, DocValuesType.SORTED);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -488,57 +488,94 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
   }
 
   @Override
-  public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+  public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer, boolean primarySort)
+      throws IOException {
     meta.writeInt(field.number);
     meta.writeByte(Lucene90DocValuesFormat.SORTED);
-    doAddSortedField(field, valuesProducer);
+    doAddSortedField(field, valuesProducer, primarySort);
   }
 
-  private void doAddSortedField(FieldInfo field, DocValuesProducer valuesProducer)
-      throws IOException {
-    writeValues(
-        field,
-        new EmptyDocValuesProducer() {
-          @Override
-          public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
-            SortedDocValues sorted = valuesProducer.getSorted(field);
-            NumericDocValues sortedOrds =
-                new NumericDocValues() {
-                  @Override
-                  public long longValue() throws IOException {
-                    return sorted.ordValue();
-                  }
+  private void doAddSortedField(
+      FieldInfo field, DocValuesProducer valuesProducer, boolean primarySort) throws IOException {
+    long[] valuesStats =
+        writeValues(
+            field,
+            new EmptyDocValuesProducer() {
+              @Override
+              public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+                SortedDocValues sorted = valuesProducer.getSorted(field);
+                NumericDocValues sortedOrds =
+                    new NumericDocValues() {
+                      @Override
+                      public long longValue() throws IOException {
+                        return sorted.ordValue();
+                      }
 
-                  @Override
-                  public boolean advanceExact(int target) throws IOException {
-                    return sorted.advanceExact(target);
-                  }
+                      @Override
+                      public boolean advanceExact(int target) throws IOException {
+                        return sorted.advanceExact(target);
+                      }
 
-                  @Override
-                  public int docID() {
-                    return sorted.docID();
-                  }
+                      @Override
+                      public int docID() {
+                        return sorted.docID();
+                      }
 
-                  @Override
-                  public int nextDoc() throws IOException {
-                    return sorted.nextDoc();
-                  }
+                      @Override
+                      public int nextDoc() throws IOException {
+                        return sorted.nextDoc();
+                      }
 
-                  @Override
-                  public int advance(int target) throws IOException {
-                    return sorted.advance(target);
-                  }
+                      @Override
+                      public int advance(int target) throws IOException {
+                        return sorted.advance(target);
+                      }
 
-                  @Override
-                  public long cost() {
-                    return sorted.cost();
-                  }
-                };
-            return DocValues.singleton(sortedOrds);
-          }
-        },
-        true);
+                      @Override
+                      public long cost() {
+                        return sorted.cost();
+                      }
+                    };
+                return DocValues.singleton(sortedOrds);
+              }
+            },
+            true);
     addTermsDict(DocValues.singleton(valuesProducer.getSorted(field)));
+    // Add jump table if the field is the primary sort, and there is more than 64 documents per term
+    if (primarySort) {
+      final SortedDocValues values = valuesProducer.getSorted(field);
+      final long threshold = valuesStats[0] >>> 6;
+      final boolean addOrdJumpTable = values.getValueCount() <= threshold;
+      meta.writeByte((byte) (addOrdJumpTable ? 1 : 0));
+      if (addOrdJumpTable) {
+        addOrdsJumpTable(values);
+      }
+    } else {
+      meta.writeByte((byte) 0);
+    }
+  }
+
+  private void addOrdsJumpTable(SortedDocValues values) throws IOException {
+    meta.writeInt(DIRECT_MONOTONIC_BLOCK_SHIFT);
+    final long start = data.getFilePointer();
+    final ByteBuffersDataOutput addressBuffer = new ByteBuffersDataOutput();
+    final ByteBuffersIndexOutput addressOutput =
+        new ByteBuffersIndexOutput(addressBuffer, "temp", "temp");
+
+    final DirectMonotonicWriter writer =
+        DirectMonotonicWriter.getInstance(
+            meta, addressOutput, values.getValueCount(), DIRECT_MONOTONIC_BLOCK_SHIFT);
+    values.nextDoc();
+    int doc = values.advanceOrd();
+    while (doc != DocIdSetIterator.NO_MORE_DOCS) {
+      writer.add(doc);
+      doc = values.advanceOrd();
+    }
+    writer.add(DocIdSetIterator.NO_MORE_DOCS);
+    writer.finish();
+    addressBuffer.copyTo(data);
+    meta.writeLong(start);
+    meta.writeLong(data.getFilePointer() - start);
   }
 
   private void addTermsDict(SortedSetDocValues values) throws IOException {
@@ -566,7 +603,6 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
     LZ4.FastCompressionHashTable ht = new LZ4.FastCompressionHashTable();
     ByteArrayDataOutput bufferedOutput = new ByteArrayDataOutput(termsDictBuffer);
     int dictLength = 0;
-
     for (BytesRef term = iterator.next(); term != null; term = iterator.next()) {
       if ((ord & blockMask) == 0) {
         if (ord != 0) {
@@ -764,7 +800,8 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
               return SortedSetSelector.wrap(
                   valuesProducer.getSortedSet(field), SortedSetSelector.Type.MIN);
             }
-          });
+          },
+          false);
       return;
     }
     meta.writeByte((byte) 1); // multiValued (1 = multiValued)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
@@ -160,7 +160,9 @@ public final class Lucene90DocValuesFormat extends DocValuesFormat {
   static final String META_CODEC = "Lucene90DocValuesMetadata";
   static final String META_EXTENSION = "dvm";
   static final int VERSION_START = 0;
-  static final int VERSION_CURRENT = VERSION_START;
+
+  static final int VERSION_ORDS_JUMP_TABLE = 1;
+  static final int VERSION_CURRENT = VERSION_ORDS_JUMP_TABLE;
 
   // indicates docvalues type
   static final byte NUMERIC = 0;

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
@@ -111,9 +111,9 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
     }
 
     @Override
-    public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer)
-        throws IOException {
-      getInstance(field).addSortedField(field, valuesProducer);
+    public void addSortedField(
+        FieldInfo field, DocValuesProducer valuesProducer, boolean primarySort) throws IOException {
+      getInstance(field).addSortedField(field, valuesProducer, primarySort);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/index/SortedDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortedDocValuesWriter.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.apache.lucene.codecs.DocValuesConsumer;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.ByteBlockPool;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefHash;
@@ -148,10 +149,17 @@ class SortedDocValuesWriter extends DocValuesWriter<SortedDocValues> {
       throws IOException {
     finish();
 
+    boolean primarySort = false;
+    final Sort sort = state.segmentInfo.getIndexSort();
+    if (sort != null && sort.getSort().length > 0) {
+      primarySort = fieldInfo.getName().equals(sort.getSort()[0].getField());
+    }
+
     dvConsumer.addSortedField(
         fieldInfo,
         getDocValuesProducer(
-            fieldInfo, hash, finalOrds, finalSortedValues, finalOrdMap, docsWithField, sortMap));
+            fieldInfo, hash, finalOrds, finalSortedValues, finalOrdMap, docsWithField, sortMap),
+        primarySort);
   }
 
   static DocValuesProducer getDocValuesProducer(

--- a/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldDocValuesFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldDocValuesFormat.java
@@ -258,8 +258,9 @@ public class TestPerFieldDocValuesFormat extends BaseDocValuesFormatTestCase {
         }
 
         @Override
-        public void addSortedField(FieldInfo field, DocValuesProducer values) throws IOException {
-          consumer.addSortedField(field, values);
+        public void addSortedField(FieldInfo field, DocValuesProducer values, boolean primarySort)
+            throws IOException {
+          consumer.addSortedField(field, values, primarySort);
         }
 
         @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingDocValuesFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingDocValuesFormat.java
@@ -105,8 +105,8 @@ public class AssertingDocValuesFormat extends DocValuesFormat {
     }
 
     @Override
-    public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer)
-        throws IOException {
+    public void addSortedField(
+        FieldInfo field, DocValuesProducer valuesProducer, boolean primarySort) throws IOException {
       SortedDocValues values = valuesProducer.getSorted(field);
 
       int valueCount = values.getValueCount();
@@ -136,7 +136,7 @@ public class AssertingDocValuesFormat extends DocValuesFormat {
       }
 
       assert seenOrds.cardinality() == valueCount;
-      in.addSortedField(field, valuesProducer);
+      in.addSortedField(field, valuesProducer, primarySort);
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/cranky/CrankyDocValuesFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/cranky/CrankyDocValuesFormat.java
@@ -86,12 +86,12 @@ class CrankyDocValuesFormat extends DocValuesFormat {
     }
 
     @Override
-    public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer)
-        throws IOException {
+    public void addSortedField(
+        FieldInfo field, DocValuesProducer valuesProducer, boolean primarySort) throws IOException {
       if (random.nextInt(100) == 0) {
         throw new IOException("Fake IOException from DocValuesConsumer.addSortedField()");
       }
-      delegate.addSortedField(field, valuesProducer);
+      delegate.addSortedField(field, valuesProducer, primarySort);
     }
 
     @Override


### PR DESCRIPTION
This PR proposes to add a new method to SortedDocValues that helps users to advance an iterator to the next document that contains a different term that the current document, which can be specially useful when the index is sorted by this field. 

The method contains a default implementation but this PR produces as well a fast implementation when the index is sorted by this field and it has low cardinality. In this case we write to disk a jump table that allows to quickly skip documents instead of manually iterating through the docs. 

In https://issues.apache.org/jira/browse/LUCENE-10396 it is discussed some of the use cases where this method can be used, for example computing the number of unique values for documents that match a query. On the other hand, it diverges from the sparse index approach but as this ids less intrusive, it seems appealing.

Note that in order to handle backwards compatibility, I have increase the version of the codec instead of creating a new one.

#11432
