### PR TITLE
Rework TestElevationComparator

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestElevationComparator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestElevationComparator.java
@@ -37,12 +37,15 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
 
 public class TestElevationComparator extends LuceneTestCase {
-
+  private Directory directory;
+  private IndexReader reader;
+  private IndexSearcher searcher;
   private final Map<BytesRef, Integer> priority = new HashMap<>();
 
-  // @Test
-  public void testSorting() throws Throwable {
-    Directory directory = newDirectory();
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    directory = newDirectory();
     IndexWriter writer =
         new IndexWriter(
             directory,
@@ -58,20 +61,29 @@ public class TestElevationComparator extends LuceneTestCase {
     writer.addDocument(
         adoc(new String[] {"id", "z", "title", "boosted boosted boosted", "str_s", "z"}));
 
-    IndexReader r = DirectoryReader.open(writer);
+    reader = DirectoryReader.open(writer);
     writer.close();
 
-    IndexSearcher searcher = newSearcher(r);
+    searcher = newSearcher(reader);
     searcher.setSimilarity(new BM25Similarity());
+  }
 
-    runTest(searcher, true);
-    runTest(searcher, false);
-
-    r.close();
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+    reader.close();
     directory.close();
   }
 
-  private void runTest(IndexSearcher searcher, boolean reversed) throws Throwable {
+  public void testSorting() throws Throwable {
+    runTest(false);
+  }
+
+  public void testSortingReversed() throws Throwable {
+    runTest(true);
+  }
+
+  private void runTest(boolean reversed) throws Throwable {
 
     BooleanQuery.Builder newq = new BooleanQuery.Builder();
     TermQuery query = new TermQuery(new Term("title", "ipod"));


### PR DESCRIPTION
I was digging on a failure triggered by concurrent search, made more likely by LUCENE-10507, and I noticed some additional issues (beside the failure itself which was quickly fixed by Adrien) with the test so I went and reworked it.

The test used to leave hanging threads behind following a failure. Also one method was executing two different tests. I split the existing method into two and I am now leveraging setup and teardown to properly close all the resources both when the tests succeed as well as whey they fail.

