### PR TITLE
Fix FieldExistsQuery rewrite when all docs have vectors

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -131,6 +131,8 @@ Bug Fixes
 
 * LUCENE-10607: Fix potential integer overflow in maxArcs computions (Tang Donghai)
 
+* GITHUB#986: Fix FieldExistsQuery rewrite when all docs have vectors. (Julie Tibshirani)
+
 Other
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -126,7 +126,7 @@ public class FieldExistsQuery extends Query {
           break;
         }
       } else if (fieldInfo.getVectorDimension() != 0) { // the field indexes vectors
-        if (leaf.getVectorValues(field).size() != reader.maxDoc()) {
+        if (leaf.getVectorValues(field).size() != leaf.maxDoc()) {
           allReadersRewritable = false;
           break;
         }

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
@@ -626,13 +626,18 @@ public class TestFieldExistsQuery extends LuceneTestCase {
   public void testKnnVectorAllDocsHaveField() throws IOException {
     try (Directory dir = newDirectory();
         RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
-      Document doc = new Document();
-      doc.add(new KnnVectorField("vector", randomVector(3)));
-      iw.addDocument(doc);
+      for (int i = 0; i < 100; ++i) {
+        Document doc = new Document();
+        doc.add(new KnnVectorField("vector", randomVector(5)));
+        iw.addDocument(doc);
+      }
       iw.commit();
+
       try (IndexReader reader = iw.getReader()) {
         IndexSearcher searcher = newSearcher(reader);
-        assertEquals(1, searcher.count(new FieldExistsQuery("vector")));
+        Query query = new FieldExistsQuery("vector");
+        assertTrue(searcher.rewrite(query) instanceof MatchAllDocsQuery);
+        assertEquals(100, searcher.count(query));
       }
     }
   }


### PR DESCRIPTION
Before we were checking the number of vectors in the segment against the total
number of documents in IndexReader. This meant FieldExistsQuery would not
rewrite to MatchAllDocsQuery when there were multiple segments.