### PR TITLE
LUCENE-10557: temprarily enable github issue

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,6 +17,11 @@ github:
     merge:  false
     rebase: false
 
+  features:
+    wiki: false
+    issues: true  # temporarily enabled for testing
+    projects: false
+
 notifications:
   commits:      commits@lucene.apache.org
   issues:       issues@lucene.apache.org


### PR DESCRIPTION
This temporarily enables github issue for testing (LUCENE-10557).
https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Repositoryfeatures

After checking it works (it has to be merged into main), I'll re-disable the feature until actual migration.


