### PR TITLE
LUCENE-10577: Add vectors format unit test and fix toString

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene93/Lucene93HnswVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene93/Lucene93HnswVectorsFormat.java
@@ -141,7 +141,7 @@ public final class Lucene93HnswVectorsFormat extends KnnVectorsFormat {
    * @param beamWidth the size of the queue maintained during graph construction.
    */
   public Lucene93HnswVectorsFormat(int maxConn, int beamWidth) {
-    super("lucene93HnswVectorsFormat");
+    super("Lucene93HnswVectorsFormat");
     this.maxConn = maxConn;
     this.beamWidth = beamWidth;
   }
@@ -158,7 +158,7 @@ public final class Lucene93HnswVectorsFormat extends KnnVectorsFormat {
 
   @Override
   public String toString() {
-    return "lucene93HnswVectorsFormat(name = lucene93HnswVectorsFormat, maxConn = "
+    return "Lucene93HnswVectorsFormat(name=Lucene93HnswVectorsFormat, maxConn="
         + maxConn
         + ", beamWidth="
         + beamWidth

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene93/TestLucene93HnswVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene93/TestLucene93HnswVectorsFormat.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene93;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+
+public class TestLucene93HnswVectorsFormat extends BaseKnnVectorsFormatTestCase {
+  @Override
+  protected Codec getCodec() {
+    return TestUtil.getDefaultCodec();
+  }
+
+  public void testToString() {
+    Lucene93Codec customCodec =
+        new Lucene93Codec() {
+          @Override
+          public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+            return new Lucene93HnswVectorsFormat(10, 20);
+          }
+        };
+    String expectedString =
+        "Lucene93HnswVectorsFormat(name=Lucene93HnswVectorsFormat, maxConn=10, beamWidth=20)";
+    assertEquals(expectedString, customCodec.getKnnVectorsFormatForField("bogus_field").toString());
+  }
+}


### PR DESCRIPTION
We forgot to add this unit test when introducing the new 9.3 vectors format.
This commit adds the test and fixes issues it uncovered in toString.