### PR TITLE
LUCENE-10634: Speed up WANDScorer.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreSumPropagator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreSumPropagator.java
@@ -167,6 +167,10 @@ final class MaxScoreSumPropagator {
   }
 
   float scoreSumUpperBound(double sum) {
+    return scoreSumUpperBound(sum, numClauses);
+  }
+
+  static float scoreSumUpperBound(double sum, int numClauses) {
     if (numClauses <= 2) {
       // When there are only two clauses, the sum is always the same regardless
       // of the order.

--- a/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
@@ -406,6 +406,10 @@ final class WANDScorer extends Scorer {
     }
   }
 
+  /**
+   * Advance the given {@link DisiWrapper} and return it if, and only if, it matches the current
+   * candidate document. Otherwise return {@code null}.
+   */
   private DisiWrapper advanceTail(DisiWrapper disi) throws IOException {
     disi.doc = disi.iterator.advance(doc);
     if (disi.doc == doc) {

--- a/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
@@ -102,8 +102,8 @@ final class WANDScorer extends Scorer {
     return (long) Math.ceil(scaled); // round up, cast is accurate since value is < 2^24
   }
 
-  static float unscaleScore(long scaledMaxScore, int scalingFactor) {
-    return Math.scalb(scaledMaxScore, -scalingFactor);
+  static double unscaleScore(long scaledMaxScore, int scalingFactor) {
+    return Math.scalb((double) scaledMaxScore, -scalingFactor);
   }
 
   /**


### PR DESCRIPTION
This speeds up WANDScorer by computing scores of docs that are positioned on
the next candidate competitive document in order to potentially detect that no
further match is possible, before advancing scorers that are still located in
the tail.

#11670