### PR TITLE
LUCENE-10629: Add fastMatchQuery to MatchingFacetSetCounts

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -42,6 +42,8 @@ Improvements
 * LUCENE-10416: Update Korean Dictionary to mecab-ko-dic-2.1.1-20180720 for Nori.
   (Uihyun Kim)
 
+* LUCENE-10629: Support match set filtering with a query in MatchingFacetSetCounts. (Stefan Vodita)
+
 Optimizations
 ---------------------
 (No changes)

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetCountsWithFilterQuery.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetCountsWithFilterQuery.java
@@ -1,5 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.facet;
 
+import java.io.IOException;
+import java.util.Arrays;
 import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.search.ConjunctionUtils;
@@ -10,13 +28,7 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 
-import java.io.IOException;
-import java.util.Arrays;
-
-/**
- * Base class for facet counts.
- * It allows for a query to be passed in to filter the match set.
- */
+/** Base class for facet counts. It allows for a query to be passed in to filter the match set. */
 public abstract class FacetCountsWithFilterQuery extends Facets {
   /**
    * Optional: if specified, we first test this Query to see whether the document should be checked

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetCountsWithFilterQuery.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetCountsWithFilterQuery.java
@@ -1,0 +1,55 @@
+package org.apache.lucene.facet;
+
+import org.apache.lucene.index.IndexReaderContext;
+import org.apache.lucene.index.ReaderUtil;
+import org.apache.lucene.search.ConjunctionUtils;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Base class for facet counts.
+ * It allows for a query to be passed in to filter the match set.
+ */
+public abstract class FacetCountsWithFilterQuery extends Facets {
+  /**
+   * Optional: if specified, we first test this Query to see whether the document should be checked
+   * for matching ranges. If this is null, all documents are checked.
+   */
+  protected final Query fastMatchQuery;
+
+  /** Create {@code FacetCounts} */
+  protected FacetCountsWithFilterQuery(Query fastMatchQuery) {
+    this.fastMatchQuery = fastMatchQuery;
+  }
+
+  /**
+   * Create a {@link org.apache.lucene.search.DocIdSetIterator} from the provided {@code hits} that
+   * relies on {@code fastMatchQuery} if available for first-pass filtering. A null response
+   * indicates no documents will match.
+   */
+  protected DocIdSetIterator createIterator(FacetsCollector.MatchingDocs hits) throws IOException {
+    if (fastMatchQuery == null) {
+      return hits.bits.iterator();
+    }
+
+    final IndexReaderContext topLevelContext = ReaderUtil.getTopLevelContext(hits.context);
+    final IndexSearcher searcher = new IndexSearcher(topLevelContext);
+    searcher.setQueryCache(null);
+    final Weight fastMatchWeight =
+        searcher.createWeight(searcher.rewrite(fastMatchQuery), ScoreMode.COMPLETE_NO_SCORES, 1);
+    final Scorer s = fastMatchWeight.scorer(hits.context);
+    if (s == null) {
+      return null; // no hits from the fastMatchQuery; return null
+    }
+
+    DocIdSetIterator fastMatchDocs = s.iterator();
+    return ConjunctionUtils.intersectIterators(Arrays.asList(hits.bits.iterator(), fastMatchDocs));
+  }
+}

--- a/lucene/facet/src/java/org/apache/lucene/facet/facetset/MatchingFacetSetsCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/facetset/MatchingFacetSetsCounts.java
@@ -46,8 +46,8 @@ public class MatchingFacetSetsCounts extends FacetCountsWithFilterQuery {
   private final int totCount;
 
   /**
-   * Constructs a new instance of {@code MatchingFacetSetsCounts} which calculates the counts for each
-   * given facet set matcher.
+   * Constructs a new instance of {@code MatchingFacetSetsCounts} which calculates the counts for
+   * each given facet set matcher.
    */
   public MatchingFacetSetsCounts(
       String field,
@@ -71,8 +71,8 @@ public class MatchingFacetSetsCounts extends FacetCountsWithFilterQuery {
   }
 
   /**
-   * Constructs a new instance of {@code MatchingFacetSetsCounts} which calculates the counts for each
-   * given facet set matcher.
+   * Constructs a new instance of {@code MatchingFacetSetsCounts} which calculates the counts for
+   * each given facet set matcher.
    */
   public MatchingFacetSetsCounts(
       String field,

--- a/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
@@ -17,43 +17,30 @@
 package org.apache.lucene.facet.range;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.apache.lucene.facet.FacetCountsWithFilterQuery;
 import org.apache.lucene.facet.FacetResult;
-import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.search.ConjunctionUtils;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.Weight;
 
 /**
  * Base class for range faceting.
  *
  * @lucene.experimental
  */
-abstract class RangeFacetCounts extends Facets {
+abstract class RangeFacetCounts extends FacetCountsWithFilterQuery {
   /** Ranges passed to constructor. */
   protected final Range[] ranges;
 
   /** Counts, initialized in by subclass. */
   protected final int[] counts;
-
-  /**
-   * Optional: if specified, we first test this Query to see whether the document should be checked
-   * for matching ranges. If this is null, all documents are checked.
-   */
-  protected final Query fastMatchQuery;
 
   /** Our field name. */
   protected final String field;
@@ -62,40 +49,11 @@ abstract class RangeFacetCounts extends Facets {
   protected int totCount;
 
   /** Create {@code RangeFacetCounts} */
-  protected RangeFacetCounts(String field, Range[] ranges, Query fastMatchQuery)
-      throws IOException {
+  protected RangeFacetCounts(String field, Range[] ranges, Query fastMatchQuery) {
+    super(fastMatchQuery);
     this.field = field;
     this.ranges = ranges;
-    this.fastMatchQuery = fastMatchQuery;
     counts = new int[ranges.length];
-  }
-
-  /**
-   * Create a {@link org.apache.lucene.search.DocIdSetIterator} from the provided {@code hits} that
-   * relies on {@code fastMatchQuery} if available for first-pass filtering. A null response
-   * indicates no documents will match.
-   */
-  protected DocIdSetIterator createIterator(FacetsCollector.MatchingDocs hits) throws IOException {
-
-    if (fastMatchQuery != null) {
-
-      final IndexReaderContext topLevelContext = ReaderUtil.getTopLevelContext(hits.context);
-      final IndexSearcher searcher = new IndexSearcher(topLevelContext);
-      searcher.setQueryCache(null);
-      final Weight fastMatchWeight =
-          searcher.createWeight(searcher.rewrite(fastMatchQuery), ScoreMode.COMPLETE_NO_SCORES, 1);
-      final Scorer s = fastMatchWeight.scorer(hits.context);
-      if (s == null) {
-        return null; // no hits from the fastMatchQuery; return null
-      } else {
-        DocIdSetIterator fastMatchDocs = s.iterator();
-        return ConjunctionUtils.intersectIterators(
-            Arrays.asList(hits.bits.iterator(), fastMatchDocs));
-      }
-
-    } else {
-      return hits.bits.iterator();
-    }
   }
 
   protected abstract LongRange[] getLongRanges();

--- a/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/RangeFacetCounts.java
@@ -19,7 +19,6 @@ package org.apache.lucene.facet.range;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.lucene.facet.FacetCountsWithFilterQuery;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.FacetsCollector;

--- a/lucene/facet/src/test/org/apache/lucene/facet/facetset/TestMatchingFacetSetsCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/facetset/TestMatchingFacetSetsCounts.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.facet.facetset;
 
 import java.io.IOException;
-
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.facet.FacetResult;
@@ -120,22 +119,24 @@ public class TestMatchingFacetSetsCounts extends FacetTestCase {
     FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
 
     // Test without fastMatchQuery. First 2 docs will match, the 3rd will not.
-    Facets facets = new MatchingFacetSetsCounts(
-        "field",
-        fc,
-        FacetSetDecoder::decodeLongs,
-        new ExactFacetSetMatcher("Test", new LongFacetSet(123, 456)));
+    Facets facets =
+        new MatchingFacetSetsCounts(
+            "field",
+            fc,
+            FacetSetDecoder::decodeLongs,
+            new ExactFacetSetMatcher("Test", new LongFacetSet(123, 456)));
 
     FacetResult facetResult = facets.getAllChildren("field");
     assertEquals(2, facetResult.value);
 
     // Test with fastMatchQuery. First 2 docs will match. 2nd doc will be filtered out.
-    facets = new MatchingFacetSetsCounts(
-        "field",
-        new FieldExistsQuery("pass-filter"),
-        fc,
-        FacetSetDecoder::decodeLongs,
-        new ExactFacetSetMatcher("Test", new LongFacetSet(123, 456)));
+    facets =
+        new MatchingFacetSetsCounts(
+            "field",
+            new FieldExistsQuery("pass-filter"),
+            fc,
+            FacetSetDecoder::decodeLongs,
+            new ExactFacetSetMatcher("Test", new LongFacetSet(123, 456)));
 
     facetResult = facets.getAllChildren("field");
     assertEquals(1, facetResult.value);

--- a/lucene/facet/src/test/org/apache/lucene/facet/facetset/TestMatchingFacetSetsCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/facetset/TestMatchingFacetSetsCounts.java
@@ -17,16 +17,21 @@
 package org.apache.lucene.facet.facetset;
 
 import java.io.IOException;
+
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
 
 public class TestMatchingFacetSetsCounts extends FacetTestCase {
 
@@ -83,6 +88,57 @@ public class TestMatchingFacetSetsCounts extends FacetTestCase {
                 fc,
                 FacetSetDecoder::decodeLongs,
                 new ExactFacetSetMatcher("Test", new LongFacetSet(1))));
+
+    r.close();
+    d.close();
+  }
+
+  public void testFastMatchQuery() throws IOException {
+    Directory d = newDirectory();
+    RandomIndexWriter w = new RandomIndexWriter(random(), d);
+
+    // This doc will match and go through the filter.
+    Document doc = new Document();
+    doc.add(FacetSetsField.create("field", new LongFacetSet(123, 456)));
+    doc.add(new BinaryDocValuesField("pass-filter", new BytesRef("yes")));
+    w.addDocument(doc);
+
+    // This doc will match and get caught by the filter.
+    doc = new Document();
+    doc.add(FacetSetsField.create("field", new LongFacetSet(123, 456)));
+    w.addDocument(doc);
+
+    // This doc will not match.
+    doc = new Document();
+    doc.add(FacetSetsField.create("field", new LongFacetSet(123, 789)));
+    w.addDocument(doc);
+
+    IndexReader r = w.getReader();
+    w.close();
+
+    IndexSearcher s = newSearcher(r);
+    FacetsCollector fc = s.search(new MatchAllDocsQuery(), new FacetsCollectorManager());
+
+    // Test without fastMatchQuery. First 2 docs will match, the 3rd will not.
+    Facets facets = new MatchingFacetSetsCounts(
+        "field",
+        fc,
+        FacetSetDecoder::decodeLongs,
+        new ExactFacetSetMatcher("Test", new LongFacetSet(123, 456)));
+
+    FacetResult facetResult = facets.getAllChildren("field");
+    assertEquals(2, facetResult.value);
+
+    // Test with fastMatchQuery. First 2 docs will match. 2nd doc will be filtered out.
+    facets = new MatchingFacetSetsCounts(
+        "field",
+        new FieldExistsQuery("pass-filter"),
+        fc,
+        FacetSetDecoder::decodeLongs,
+        new ExactFacetSetMatcher("Test", new LongFacetSet(123, 456)));
+
+    facetResult = facets.getAllChildren("field");
+    assertEquals(1, facetResult.value);
 
     r.close();
     d.close();


### PR DESCRIPTION
Support filtering the match set in MatchingFacetSetCounts (and more generally) by adding a new facets count abstract class that creates an iterator from the match set and a query.

Jira: https://issues.apache.org/jira/browse/LUCENE-10629
