### PR TITLE
LUCENE-10603: Stop using SortedSetDocValues.NO_MORE_ORDS in tests

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -98,8 +98,8 @@ Improvements
 * LUCENE-10585: Facet module code cleanup (copy/paste scrubbing, simplification and some very minor
   optimization tweaks). (Greg Miller)
 
-* LUCENE-10603: Update SortedSetDocValues iteration within production code to use
-  SortedSetDocValues#docValueCount(). (Greg Miller)
+* LUCENE-10603: Update SortedSetDocValues iteration to use SortedSetDocValues#docValueCount().
+  (Greg Miller, Stefan Vodita)
 
 * GITHUB#983: AbstractSortedSetDocValueFacetCounts internal code cleanup/refactoring. (Greg Miller)
 

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/BaseLucene80DocValuesFormatTestCase.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/BaseLucene80DocValuesFormatTestCase.java
@@ -257,16 +257,12 @@ public abstract class BaseLucene80DocValuesFormatTestCase
             assertTrue(valueSet.contains(sortedNumeric.nextValue()));
           }
           assertEquals(i, sortedSet.nextDoc());
-          int sortedSetCount = 0;
-          while (true) {
+
+          assertEquals(valueSet.size(), sortedSet.docValueCount());
+          for (int j = 0; j < sortedSet.docValueCount(); ++j) {
             long ord = sortedSet.nextOrd();
-            if (ord == SortedSetDocValues.NO_MORE_ORDS) {
-              break;
-            }
             assertTrue(valueSet.contains(Long.parseLong(sortedSet.lookupOrd(ord).utf8ToString())));
-            sortedSetCount++;
           }
-          assertEquals(valueSet.size(), sortedSetCount);
         }
       }
     }
@@ -480,6 +476,7 @@ public abstract class BaseLucene80DocValuesFormatTestCase
       for (int i = 0; i < maxDoc; ++i) {
         assertEquals(i, values.nextDoc());
         final int numValues = in.readVInt();
+        assertEquals(numValues, values.docValueCount());
 
         for (int j = 0; j < numValues; ++j) {
           b.setLength(in.readVInt());

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
@@ -1205,6 +1205,7 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
       assertEquals(id, dvShort.longValue());
 
       assertEquals(i, dvSortedSet.nextDoc());
+      assertEquals(1, dvSortedSet.docValueCount());
       long ord = dvSortedSet.nextOrd();
       assertEquals(SortedSetDocValues.NO_MORE_ORDS, dvSortedSet.nextOrd());
       term = dvSortedSet.lookupOrd(ord);

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormat.java
@@ -265,17 +265,12 @@ public class TestLucene90DocValuesFormat extends BaseCompressingDocValuesFormatT
             assertTrue(valueSet.contains(sortedNumeric.nextValue()));
           }
           assertEquals(i, sortedSet.nextDoc());
+
           assertEquals(valueSet.size(), sortedSet.docValueCount());
-          int sortedSetCount = 0;
-          while (true) {
+          for (int j = 0; j < sortedSet.docValueCount(); ++j) {
             long ord = sortedSet.nextOrd();
-            if (ord == SortedSetDocValues.NO_MORE_ORDS) {
-              break;
-            }
             assertTrue(valueSet.contains(Long.parseLong(sortedSet.lookupOrd(ord).utf8ToString())));
-            sortedSetCount++;
           }
-          assertEquals(valueSet.size(), sortedSetCount);
         }
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestBinaryDocValuesUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestBinaryDocValuesUpdates.java
@@ -369,12 +369,14 @@ public class TestBinaryDocValuesUpdates extends LuceneTestCase {
       assertEquals(i, Integer.parseInt(term.utf8ToString()));
       // For the i=0 case, we added the same value twice, which was dedup'd by IndexWriter so it has
       // only one value:
-      if (i != 0) {
+      if (i == 0) {
+        assertEquals(1, ssdv.docValueCount());
+      } else {
+        assertEquals(2, ssdv.docValueCount());
         ord = ssdv.nextOrd();
         term = ssdv.lookupOrd(ord);
         assertEquals(i * 2, Integer.parseInt(term.utf8ToString()));
       }
-      assertEquals(SortedSetDocValues.NO_MORE_ORDS, ssdv.nextOrd());
     }
 
     reader.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestMultiDocValues.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMultiDocValues.java
@@ -19,7 +19,6 @@ package org.apache.lucene.index;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -279,20 +278,11 @@ public class TestMultiDocValues extends LuceneTestCase {
         if (docID == NO_MORE_DOCS) {
           break;
         }
+
         assertEquals(single.docValueCount(), multi.docValueCount());
-
-        ArrayList<Long> expectedList = new ArrayList<>();
-        long ord;
-        while ((ord = single.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
-          expectedList.add(ord);
+        for (int i = 0; i < single.docValueCount(); i++) {
+          assertEquals(single.nextOrd(), multi.nextOrd());
         }
-
-        int upto = 0;
-        while ((ord = multi.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
-          assertEquals(expectedList.get(upto).longValue(), ord);
-          upto++;
-        }
-        assertEquals(expectedList.size(), upto);
       }
     }
     testRandomAdvance(
@@ -354,18 +344,11 @@ public class TestMultiDocValues extends LuceneTestCase {
         if (docID == NO_MORE_DOCS) {
           break;
         }
-        ArrayList<Long> expectedList = new ArrayList<>();
-        long ord;
-        while ((ord = single.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
-          expectedList.add(ord);
-        }
 
-        int upto = 0;
-        while ((ord = multi.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
-          assertEquals(expectedList.get(upto).longValue(), ord);
-          upto++;
+        assertEquals(single.docValueCount(), multi.docValueCount());
+        for (int i = 0; i < single.docValueCount(); i++) {
+          assertEquals(single.nextOrd(), multi.nextOrd());
         }
-        assertEquals(expectedList.size(), upto);
       }
     }
     testRandomAdvance(

--- a/lucene/core/src/test/org/apache/lucene/index/TestNumericDocValuesUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestNumericDocValuesUpdates.java
@@ -459,12 +459,14 @@ public class TestNumericDocValuesUpdates extends LuceneTestCase {
       long ord = ssdv.nextOrd();
       term = ssdv.lookupOrd(ord);
       assertEquals(i, Integer.parseInt(term.utf8ToString()));
-      if (i != 0) {
+      if (i == 0) {
+        assertEquals(1, ssdv.docValueCount());
+      } else {
+        assertEquals(2, ssdv.docValueCount());
         ord = ssdv.nextOrd();
         term = ssdv.lookupOrd(ord);
         assertEquals(i * 2, Integer.parseInt(term.utf8ToString()));
       }
-      assertEquals(SortedSetDocValues.NO_MORE_ORDS, ssdv.nextOrd());
     }
 
     reader.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestMinShouldMatch2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMinShouldMatch2.java
@@ -409,7 +409,8 @@ public class TestMinShouldMatch2 extends LuceneTestCase {
               continue;
             }
             long ord;
-            while ((ord = dv.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
+            for (int i = 0; i < dv.docValueCount(); i++) {
+              ord = dv.nextOrd();
               if (ords.contains(ord)) {
                 currentMatched++;
                 score += sims[(int) ord].score(currentDoc, 1);

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
@@ -1760,7 +1760,8 @@ public class TestJoinUtil extends LuceneTestCase {
                 }
                 if (doc == docTermOrds.docID()) {
                   long ord;
-                  while ((ord = docTermOrds.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
+                  for (int j = 0; j < docTermOrds.docValueCount(); j++) {
+                    ord = docTermOrds.nextOrd();
                     final BytesRef joinValue = docTermOrds.lookupOrd(ord);
                     JoinScore joinScore = joinValueToJoinScores.get(joinValue);
                     if (joinScore == null) {

--- a/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
+++ b/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
@@ -329,6 +329,7 @@ public class TestMemoryIndex extends LuceneTestCase {
     assertEquals(3, sortedSetDocValues.getValueCount());
     for (int times = 0; times < 3; times++) {
       assertTrue(sortedSetDocValues.advanceExact(0));
+      assertEquals(3, sortedSetDocValues.docValueCount());
       assertEquals(0L, sortedSetDocValues.nextOrd());
       assertEquals(1L, sortedSetDocValues.nextOrd());
       assertEquals(2L, sortedSetDocValues.nextOrd());

--- a/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndexAgainstDirectory.java
+++ b/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndexAgainstDirectory.java
@@ -533,14 +533,14 @@ public class TestMemoryIndexAgainstDirectory extends BaseTokenStreamTestCase {
         controlLeafReader.getSortedSetDocValues("sorted_set");
     assertEquals(0, controlSortedSetDocValues.nextDoc());
     assertEquals(controlSortedSetDocValues.getValueCount(), sortedSetDocValues.getValueCount());
-    for (long controlOrd = controlSortedSetDocValues.nextOrd();
-        controlOrd != SortedSetDocValues.NO_MORE_ORDS;
-        controlOrd = controlSortedSetDocValues.nextOrd()) {
+    for (int i = 0; i < controlSortedSetDocValues.docValueCount(); i++) {
+      long controlOrd = controlSortedSetDocValues.nextOrd();
       assertEquals(controlOrd, sortedSetDocValues.nextOrd());
       assertEquals(
           controlSortedSetDocValues.lookupOrd(controlOrd),
           sortedSetDocValues.lookupOrd(controlOrd));
     }
+    assertEquals(SortedSetDocValues.NO_MORE_ORDS, controlSortedSetDocValues.nextOrd());
     assertEquals(SortedSetDocValues.NO_MORE_ORDS, sortedSetDocValues.nextOrd());
 
     indexReader.close();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.tests.index;
 
-import static org.apache.lucene.index.SortedSetDocValues.NO_MORE_ORDS;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
@@ -1809,8 +1808,9 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     SortedSetDocValues dv = getOnlyLeafReader(ireader).getSortedSetDocValues("field");
     assertEquals(0, dv.nextDoc());
+
+    assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -1834,17 +1834,17 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     SortedSetDocValues dv = getOnlyLeafReader(ireader).getSortedSetDocValues("field");
     assertEquals(0, dv.nextDoc());
 
+    assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
 
     dv = getOnlyLeafReader(ireader).getSortedSetDocValues("field2");
-
     assertEquals(0, dv.nextDoc());
+
+    assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("world"), bytes);
@@ -1877,15 +1877,15 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     assertEquals(2, dv.getValueCount());
 
     assertEquals(0, dv.nextDoc());
+    assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
 
     assertEquals(1, dv.nextDoc());
+    assertEquals(1, dv.docValueCount());
     assertEquals(1, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     bytes = dv.lookupOrd(1);
     assertEquals(newBytesRef("world"), bytes);
@@ -1909,9 +1909,9 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     SortedSetDocValues dv = getOnlyLeafReader(ireader).getSortedSetDocValues("field");
     assertEquals(0, dv.nextDoc());
 
+    assertEquals(2, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
     assertEquals(1, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -1938,9 +1938,9 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     SortedSetDocValues dv = getOnlyLeafReader(ireader).getSortedSetDocValues("field");
     assertEquals(0, dv.nextDoc());
 
+    assertEquals(2, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
     assertEquals(1, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -1978,14 +1978,14 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     assertEquals(3, dv.getValueCount());
 
     assertEquals(0, dv.nextDoc());
+    assertEquals(2, dv.docValueCount());
     assertEquals(1, dv.nextOrd());
     assertEquals(2, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     assertEquals(1, dv.nextDoc());
+    assertEquals(2, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
     assertEquals(1, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("beer"), bytes);
@@ -2019,10 +2019,10 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     SortedSetDocValues dv = getOnlyLeafReader(ireader).getSortedSetDocValues("field");
     assertEquals(1, dv.getValueCount());
-
     assertEquals(0, dv.nextDoc());
+
+    assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -2052,10 +2052,10 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     SortedSetDocValues dv = getOnlyLeafReader(ireader).getSortedSetDocValues("field");
     assertEquals(1, dv.getValueCount());
-
     assertEquals(0, dv.nextDoc());
+
+    assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -2084,10 +2084,10 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     SortedSetDocValues dv = getOnlyLeafReader(ireader).getSortedSetDocValues("field");
     assertEquals(1, dv.getValueCount());
-
     assertEquals(1, dv.nextDoc());
+
+    assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -2117,10 +2117,10 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     SortedSetDocValues dv = getOnlyLeafReader(ireader).getSortedSetDocValues("field");
     assertEquals(1, dv.getValueCount());
-
     assertEquals(1, dv.nextDoc());
+
+    assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
-    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -2320,14 +2320,13 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
         }
         if (docValues != null && stringValues.length > 0) {
           assertEquals(i, docValues.docID());
-          for (int j = 0; j < stringValues.length; j++) {
+          assertEquals(stringValues.length, docValues.docValueCount());
+          for (String stringValue : stringValues) {
             assert docValues != null;
             long ord = docValues.nextOrd();
-            assert ord != NO_MORE_ORDS;
             BytesRef scratch = docValues.lookupOrd(ord);
-            assertEquals(stringValues[j], scratch.utf8ToString());
+            assertEquals(stringValue, scratch.utf8ToString());
           }
-          assertEquals(NO_MORE_ORDS, docValues.nextOrd());
         }
       }
     }
@@ -2353,14 +2352,13 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
         }
         if (stringValues.length > 0) {
           assertEquals(i, docValues.docID());
-          for (int j = 0; j < stringValues.length; j++) {
+          assertEquals(stringValues.length, docValues.docValueCount());
+          for (String stringValue : stringValues) {
             assert docValues != null;
             long ord = docValues.nextOrd();
-            assert ord != NO_MORE_ORDS;
             BytesRef scratch = docValues.lookupOrd(ord);
-            assertEquals(stringValues[j], scratch.utf8ToString());
+            assertEquals(stringValue, scratch.utf8ToString());
           }
-          assertEquals(NO_MORE_ORDS, docValues.nextOrd());
         }
       }
     }
@@ -2891,13 +2889,12 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
                     if (values.length > 0) {
                       assertNotNull(sortedSet);
                       assertEquals(j, sortedSet.nextDoc());
-                      for (int k = 0; k < values.length; k++) {
+                      assertEquals(values.length, sortedSet.docValueCount());
+                      for (String s : values) {
                         long ord = sortedSet.nextOrd();
-                        assertTrue(ord != SortedSetDocValues.NO_MORE_ORDS);
                         BytesRef value = sortedSet.lookupOrd(ord);
-                        assertEquals(values[k], value.utf8ToString());
+                        assertEquals(s, value.utf8ToString());
                       }
-                      assertEquals(SortedSetDocValues.NO_MORE_ORDS, sortedSet.nextOrd());
                     }
 
                     String[] numValues = r.document(j).getValues("storedSortedNumeric");

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.tests.index;
 
+import static org.apache.lucene.index.SortedSetDocValues.NO_MORE_ORDS;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
@@ -1811,6 +1812,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -1836,6 +1838,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -1845,6 +1848,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("world"), bytes);
@@ -1879,6 +1883,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     assertEquals(0, dv.nextDoc());
     assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -1886,6 +1891,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     assertEquals(1, dv.nextDoc());
     assertEquals(1, dv.docValueCount());
     assertEquals(1, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     bytes = dv.lookupOrd(1);
     assertEquals(newBytesRef("world"), bytes);
@@ -1912,6 +1918,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     assertEquals(2, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
     assertEquals(1, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -1941,6 +1948,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     assertEquals(2, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
     assertEquals(1, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -1981,11 +1989,13 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     assertEquals(2, dv.docValueCount());
     assertEquals(1, dv.nextOrd());
     assertEquals(2, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     assertEquals(1, dv.nextDoc());
     assertEquals(2, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
     assertEquals(1, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("beer"), bytes);
@@ -2023,6 +2033,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -2056,6 +2067,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -2088,6 +2100,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -2121,6 +2134,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
 
     assertEquals(1, dv.docValueCount());
     assertEquals(0, dv.nextOrd());
+    assertEquals(NO_MORE_ORDS, dv.nextOrd());
 
     BytesRef bytes = dv.lookupOrd(0);
     assertEquals(newBytesRef("hello"), bytes);
@@ -2327,6 +2341,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
             BytesRef scratch = docValues.lookupOrd(ord);
             assertEquals(stringValue, scratch.utf8ToString());
           }
+          assertEquals(NO_MORE_ORDS, docValues.nextOrd());
         }
       }
     }
@@ -2359,6 +2374,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
             BytesRef scratch = docValues.lookupOrd(ord);
             assertEquals(stringValue, scratch.utf8ToString());
           }
+          assertEquals(NO_MORE_ORDS, docValues.nextOrd());
         }
       }
     }
@@ -2895,6 +2911,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
                         BytesRef value = sortedSet.lookupOrd(ord);
                         assertEquals(s, value.utf8ToString());
                       }
+                      assertEquals(NO_MORE_ORDS, sortedSet.nextOrd());
                     }
 
                     String[] numValues = r.document(j).getValues("storedSortedNumeric");

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -2576,11 +2576,10 @@ public abstract class LuceneTestCase extends Assert {
             if (docID == NO_MORE_DOCS) {
               break;
             }
-            long ord;
-            while ((ord = leftValues.nextOrd()) != SortedSetDocValues.NO_MORE_ORDS) {
-              assertEquals(info, ord, rightValues.nextOrd());
+            assertEquals(info, leftValues.docValueCount(), rightValues.docValueCount());
+            for (int i = 0; i < leftValues.docValueCount(); i++) {
+              assertEquals(info, leftValues.nextOrd(), rightValues.nextOrd());
             }
-            assertEquals(info, SortedSetDocValues.NO_MORE_ORDS, rightValues.nextOrd());
           }
         } else {
           assertNull(info, leftValues);


### PR DESCRIPTION
Replace all usages of `SortedSetDocValues.NO_MORE_ORDS` in tests and start using `SortedSetDocValues.docValueCount()`.

Jira: https://issues.apache.org/jira/browse/LUCENE-10603
