### PR TITLE
LUCENE-10647: Fix TestMergeSchedulerExternal failures

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
+++ b/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
@@ -135,7 +135,7 @@ public class TestMergeSchedulerExternal extends LuceneTestCase {
         writer.addDocument(doc);
       }
     } catch (
-      @SuppressWarnings("unused")
+        @SuppressWarnings("unused")
         IllegalStateException ise) {
       // OK
     }

--- a/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
+++ b/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
@@ -134,7 +134,13 @@ public class TestMergeSchedulerExternal extends LuceneTestCase {
       for (int i = 0; i < 20; i++) {
         writer.addDocument(doc);
       }
+    } catch (
+      @SuppressWarnings("unused")
+        IllegalStateException ise) {
+      // OK
+    }
 
+    try {
       ((MyMergeScheduler) writer.getConfig().getMergeScheduler()).sync();
     } catch (
         @SuppressWarnings("unused")


### PR DESCRIPTION
`TestMergeSchedulerExternal.testSubclassConcurrentMergeScheduler` fails with the following exception ([build job](https://jenkins.thetaphi.de/job/Lucene-main-Linux/35576/testReport/junit/org.apache.lucene/TestMergeSchedulerExternal/testSubclassConcurrentMergeScheduler/)):

```java
java.lang.AssertionError
	at __randomizedtesting.SeedInfo.seed([DDD39440C0DA45D4:5A5229EDC4FA3FD0]:0)
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at org.apache.lucene.TestMergeSchedulerExternal.testSubclassConcurrentMergeScheduler(TestMergeSchedulerExternal.java:149)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	...
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.lambda$forkTimeoutingTask$0(ThreadLeakControl.java:850)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

I tried beasting this test but was unable to repro the error. Going by code, we may be hitting `writer.rollback()` too soon.

An exception in `addDocument()`, would cause us to skip `getMergeScheduler().sync()` and directly invoke `writer.rollback()`. This *could* cause merge threads to start aborting before they hit the merge exception expected by this test. Since `MergeAbortedException` is not rethrown, it would not hit `mergeScheduler.handleMergeExceptions()`, and the `excCalled` flag would stay unset.
