### PR TITLE
LUCENE-10648: Fix failures in TestAssertingPointsFormat.testWithExceptions

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3427,7 +3427,8 @@ public class IndexWriter
       TrackingDirectoryWrapper trackingCFSDir = new TrackingDirectoryWrapper(mergeDirectory);
       // TODO: unlike merge, on exception we arent sniping any trash cfs files here?
       // createCompoundFile tries to cleanup, but it might not always be able to...
-      createCompoundFile(infoStream, trackingCFSDir, merge.getMergeInfo().info, context, this::deleteNewFiles);
+      createCompoundFile(
+          infoStream, trackingCFSDir, merge.getMergeInfo().info, context, this::deleteNewFiles);
 
       // creating cfs resets the files tracked in SegmentInfo. if it succeeds, we
       // delete the non cfs files directly as they are not tracked anymore.

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3423,22 +3423,15 @@ public class IndexWriter
 
     // Now create the compound file if needed
     if (useCompoundFile) {
-      boolean createCFSSuccess = false;
       Collection<String> filesToDelete = merge.getMergeInfo().files();
       TrackingDirectoryWrapper trackingCFSDir = new TrackingDirectoryWrapper(mergeDirectory);
       // TODO: unlike merge, on exception we arent sniping any trash cfs files here?
       // createCompoundFile tries to cleanup, but it might not always be able to...
-      try {
-        createCompoundFile(
-            infoStream, trackingCFSDir, merge.getMergeInfo().info, context, this::deleteNewFiles);
-        createCFSSuccess = true;
-      } finally {
-        if (createCFSSuccess) {
-          // creating cfs resets the files tracked in SegmentInfo. if it succeeds, we
-          // delete the non cfs files directly as they are not tracked anymore.
-          deleteNewFiles(filesToDelete);
-        }
-      }
+      createCompoundFile(infoStream, trackingCFSDir, merge.getMergeInfo().info, context, this::deleteNewFiles);
+
+      // creating cfs resets the files tracked in SegmentInfo. if it succeeds, we
+      // delete the non cfs files directly as they are not tracked anymore.
+      deleteNewFiles(filesToDelete);
       merge.getMergeInfo().info.setUseCompoundFile(true);
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3425,7 +3425,6 @@ public class IndexWriter
     if (useCompoundFile) {
       Collection<String> filesToDelete = merge.getMergeInfo().files();
       TrackingDirectoryWrapper trackingCFSDir = new TrackingDirectoryWrapper(mergeDirectory);
-      // TODO: unlike merge, on exception we arent sniping any trash cfs files here?
       // createCompoundFile tries to cleanup, but it might not always be able to...
       createCompoundFile(
           infoStream, trackingCFSDir, merge.getMergeInfo().info, context, this::deleteNewFiles);


### PR DESCRIPTION
When `createCompoundFile()` succeeds, it replaces all previously tracked files in segment info, with the new CFS/CFE files. 
If it passes, the files created prior to writing the CFS files need to be deleted directly. However, if it fails, the calling thread in `IW.addIndexes()` deletes any pending files.

The finally block in this code was leading us to double delete those files, causing the test to fail.