### PR TITLE
LUCENE-10644: Facets#getAllChildren testing should ignore child order

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -119,6 +119,8 @@ Bug Fixes
 * LUCENE-10678: Fix potential overflow when building a BKD tree with more than 4 billion points. The overflow
   occurs when computing the partition point. (Ignacio Vera)
 
+* LUCENE-10644: Facets#getAllChildren testing should ignore child order. (Yuting Gan)
+
 Build
 ---------------------
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
@@ -254,14 +254,38 @@ public abstract class FacetTestCase extends LuceneTestCase {
     assertEquals(a.dim, b.dim);
     assertTrue(Arrays.equals(a.path, b.path));
     assertEquals(a.childCount, b.childCount);
-    assertEquals(a.value.floatValue(), b.value.floatValue(), a.value.floatValue() / 1e5);
+    assertNumericValuesEquals(a.value, b.value);
     assertEquals(a.labelValues.length, b.labelValues.length);
     for (int i = 0; i < a.labelValues.length; i++) {
       assertEquals(a.labelValues[i].label, b.labelValues[i].label);
-      assertEquals(
-          a.labelValues[i].value.floatValue(),
-          b.labelValues[i].value.floatValue(),
-          a.labelValues[i].value.floatValue() / 1e5);
+      assertNumericValuesEquals(a.labelValues[i].value, b.labelValues[i].value);
     }
+  }
+
+  protected void assertNumericValuesEquals(Number a, Number b) {
+    assertTrue(a.getClass().isInstance(b));
+    if (a instanceof Float) {
+      assertEquals(a.floatValue(), b.floatValue(), a.floatValue() / 1e5);
+    } else if (a instanceof Double) {
+      assertEquals(a.doubleValue(), b.doubleValue(), a.doubleValue() / 1e5);
+    } else {
+      assertEquals(a, b);
+    }
+  }
+
+  protected void assertFacetResult(
+      FacetResult result,
+      String expectedDim,
+      String[] expectedPath,
+      int expectedChildCount,
+      Number expectedValue,
+      LabelAndValue... expectedChildren) {
+    assertEquals(expectedDim, result.dim);
+    assertArrayEquals(expectedPath, result.path);
+    assertEquals(expectedChildCount, result.childCount);
+    assertNumericValuesEquals(expectedValue, result.value);
+    assertEquals(expectedChildren.length, result.labelValues.length);
+    // assert children equal with no assumption of the children ordering
+    assertTrue(Arrays.asList(result.labelValues).containsAll(Arrays.asList(expectedChildren)));
   }
 }

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -36,11 +36,10 @@ import org.apache.lucene.search.LongValuesSource;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 
 /** Tests long value facets. */
-public class TestLongValueFacetCounts extends LuceneTestCase {
+public class TestLongValueFacetCounts extends FacetTestCase {
 
   public void testBasic() throws Exception {
     Directory d = newDirectory();
@@ -75,11 +74,20 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
         "dim=field path=[] value=101 childCount=6\n  0 (20)\n  1 (20)\n",
         topChildrenResult.toString());
 
-    FacetResult allChildrenResult = facets.getAllChildren("field");
-    assertEquals(
-        "dim=field path=[] value=101 childCount=6\n  0 (20)\n  1 (20)\n  2 (20)\n  3 (20)\n  "
-            + "4 (20)\n  9223372036854775807 (1)\n",
-        allChildrenResult.toString());
+    assertFacetResult(
+        facets.getAllChildren("field"),
+        "field",
+        new String[0],
+        6,
+        101,
+        new LabelAndValue[] {
+          new LabelAndValue("0", 20),
+          new LabelAndValue("1", 20),
+          new LabelAndValue("2", 20),
+          new LabelAndValue("3", 20),
+          new LabelAndValue("4", 20),
+          new LabelAndValue("9223372036854775807", 1)
+        });
 
     r.close();
     d.close();
@@ -108,8 +116,16 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     assertEquals("dim=field path=[] value=9 childCount=2\n  0 (4)\n  1 (5)\n", result.toString());
     result = facets.getTopChildren(10, "field");
     assertEquals("dim=field path=[] value=9 childCount=2\n  1 (5)\n  0 (4)\n", result.toString());
-    result = facets.getAllChildren("field");
-    assertEquals("dim=field path=[] value=9 childCount=2\n  0 (4)\n  1 (5)\n", result.toString());
+
+    assertFacetResult(
+        facets.getAllChildren("field"),
+        "field",
+        new String[0],
+        2,
+        9,
+        new LabelAndValue[] {
+          new LabelAndValue("0", 4), new LabelAndValue("1", 5),
+        });
 
     r.close();
     d.close();
@@ -133,13 +149,18 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     LongValueFacetCounts facets = new LongValueFacetCounts("field", fc);
 
     FacetResult result = facets.getAllChildrenSortByValue();
-    assertEquals(
-        "dim=field path=[] value=3 childCount=3\n  9223372036854775805 (1)\n  "
-            + "9223372036854775806 (1)\n  9223372036854775807 (1)\n",
-        result.toString());
 
-    // test getAllChildren
-    result = facets.getAllChildren("field");
+    assertFacetResult(
+        facets.getAllChildren("field"),
+        "field",
+        new String[0],
+        3,
+        3,
+        new LabelAndValue[] {
+          new LabelAndValue("9223372036854775805", 1),
+          new LabelAndValue("9223372036854775806", 1),
+          new LabelAndValue("9223372036854775807", 1)
+        });
 
     // since we have no insight into the value order in the hashMap, we sort labels by value and
     // count in
@@ -805,8 +826,16 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     for (LabelAndValue labelAndValue : fr.labelValues) {
       assert labelAndValue.value.equals(1);
     }
-    FacetResult result = facetCounts.getAllChildren("field");
-    assertEquals("dim=field path=[] value=2 childCount=2\n  42 (1)\n  43 (1)\n", result.toString());
+
+    assertFacetResult(
+        facetCounts.getAllChildren("field"),
+        "field",
+        new String[0],
+        2,
+        2,
+        new LabelAndValue[] {
+          new LabelAndValue("42", 1), new LabelAndValue("43", 1),
+        });
 
     r.close();
     dir.close();

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestMultipleIndexFields.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestMultipleIndexFields.java
@@ -17,8 +17,6 @@
 package org.apache.lucene.facet;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.lucene.document.Document;
@@ -296,21 +294,45 @@ public class TestMultipleIndexFields extends FacetTestCase {
     assertEquals(
         "dim=Band path=[] value=5 childCount=2\n  Rock & Pop (4)\n  Punk (1)\n",
         facets.getTopChildren(10, "Band").toString());
-    assertEquals(
-        "dim=Band path=[] value=5 childCount=2\n  Punk (1)\n  Rock & Pop (4)\n",
-        sortAllChildren(facets.getAllChildren("Band")).toString());
+    assertFacetResult(
+        facets.getAllChildren("Band"),
+        "Band",
+        new String[0],
+        2,
+        5,
+        new LabelAndValue[] {
+          new LabelAndValue("Punk", 1), new LabelAndValue("Rock & Pop", 4),
+        });
     assertEquals(
         "dim=Band path=[Rock & Pop] value=4 childCount=4\n  The Beatles (1)\n  U2 (1)\n  REM (1)\n  Dave Matthews Band (1)\n",
         facets.getTopChildren(10, "Band", "Rock & Pop").toString());
-    assertEquals(
-        "dim=Band path=[Rock & Pop] value=4 childCount=4\n  Dave Matthews Band (1)\n  REM (1)\n  The Beatles (1)\n  U2 (1)\n",
-        sortAllChildren(facets.getAllChildren("Band", "Rock & Pop")).toString());
+    assertFacetResult(
+        facets.getAllChildren("Band", "Rock & Pop"),
+        "Band",
+        new String[] {"Rock & Pop"},
+        4,
+        4,
+        new LabelAndValue[] {
+          new LabelAndValue("Dave Matthews Band", 1),
+          new LabelAndValue("REM", 1),
+          new LabelAndValue("The Beatles", 1),
+          new LabelAndValue("U2", 1),
+        });
+
     assertEquals(
         "dim=Author path=[] value=3 childCount=3\n  Mark Twain (1)\n  Stephen King (1)\n  Kurt Vonnegut (1)\n",
         facets.getTopChildren(10, "Author").toString());
-    assertEquals(
-        "dim=Author path=[] value=3 childCount=3\n  Kurt Vonnegut (1)\n  Mark Twain (1)\n  Stephen King (1)\n",
-        sortAllChildren(facets.getAllChildren("Author")).toString());
+    assertFacetResult(
+        facets.getAllChildren("Author"),
+        "Author",
+        new String[0],
+        3,
+        3,
+        new LabelAndValue[] {
+          new LabelAndValue("Kurt Vonnegut", 1),
+          new LabelAndValue("Mark Twain", 1),
+          new LabelAndValue("Stephen King", 1),
+        });
   }
 
   private FacetsCollector performSearch(TaxonomyReader tr, IndexReader ir, IndexSearcher searcher)
@@ -328,16 +350,5 @@ public class TestMultipleIndexFields extends FacetTestCase {
       doc.add(new TextField("content", "alpha", Field.Store.YES));
       iw.addDocument(config.build(tw, doc));
     }
-  }
-
-  // since we have no insight into the ordinals assigned to the values, we sort labels by value and
-  // count in
-  // ascending order in order to compare with expected results
-  private static FacetResult sortAllChildren(FacetResult allChildrenResult) {
-    Arrays.sort(
-        allChildrenResult.labelValues,
-        Comparator.comparing((LabelAndValue a) -> a.label)
-            .thenComparingLong(a -> a.value.longValue()));
-    return allChildrenResult;
   }
 }

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
@@ -118,9 +118,15 @@ public class TestStringValueFacetCounts extends FacetTestCase {
         "dim=field path=[] value=2 childCount=2\n  bar (1)\n  foo (1)",
         facets.getTopChildren(10, "field").toString().trim());
 
-    assertEquals(
-        "dim=field path=[] value=2 childCount=2\n  bar (1)\n  foo (1)",
-        facets.getAllChildren("field").toString().trim());
+    assertFacetResult(
+        facets.getAllChildren("field"),
+        "field",
+        new String[0],
+        2,
+        2,
+        new LabelAndValue[] {
+          new LabelAndValue("bar", 1), new LabelAndValue("foo", 1),
+        });
 
     IOUtils.close(searcher.getIndexReader(), dir);
   }
@@ -502,8 +508,7 @@ public class TestStringValueFacetCounts extends FacetTestCase {
     assertEquals(expectedTotalDocsWithValue, facetResult.value);
 
     // since we have no insight into the ordinals assigned to the values, we sort labels by value
-    // and count in
-    // ascending order in order to compare with expected results
+    // and count in ascending order in order to compare with expected results
     Arrays.sort(
         facetResult.labelValues,
         Comparator.comparing((LabelAndValue a) -> a.label)

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -106,10 +106,17 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               facets.getTopChildren(10, "b").toString());
 
           // test getAllChildren
-          // value for dim a should be -1 since it's multivalued but doesn't require dim counts:
-          assertEquals(
-              "dim=a path=[] value=-1 childCount=3\n  bar (1)\n  foo (2)\n  zoo (1)\n",
-              facets.getAllChildren("a").toString());
+          assertFacetResult(
+              facets.getAllChildren("a"),
+              "a",
+              new String[0],
+              3,
+              -1,
+              new LabelAndValue[] {
+                new LabelAndValue("bar", 1),
+                new LabelAndValue("foo", 2),
+                new LabelAndValue("zoo", 1)
+              });
 
           // test getAllDims
           List<FacetResult> results = facets.getAllDims(10);
@@ -361,20 +368,46 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               "dim=a path=[] value=2 childCount=3\n  foo (2)\n  bar (1)\n  zoo (1)\n",
               facets.getTopChildren(10, "a").toString());
           assertEquals(
-              "dim=a path=[] value=2 childCount=3\n  bar (1)\n  foo (2)\n  zoo (1)\n",
-              facets.getAllChildren("a").toString());
-          assertEquals(
               "dim=b path=[] value=1 childCount=1\n  baz (1)\n",
               facets.getTopChildren(10, "b").toString());
           assertEquals(
               "dim=c path=[buzz] value=2 childCount=3\n  bif (2)\n  bee (1)\n  biz (1)\n",
               facets.getTopChildren(10, "c", "buzz").toString());
           assertEquals(
-              "dim=c path=[buzz] value=2 childCount=3\n  bee (1)\n  bif (2)\n  biz (1)\n",
-              facets.getAllChildren("c", "buzz").toString());
-          assertEquals(
               "dim=c path=[buzz, bif] value=2 childCount=1\n  baf (2)\n",
               facets.getTopChildren(10, "c", "buzz", "bif").toString());
+
+          assertFacetResult(
+              facets.getAllChildren("a"),
+              "a",
+              new String[0],
+              3,
+              2,
+              new LabelAndValue[] {
+                new LabelAndValue("bar", 1),
+                new LabelAndValue("foo", 2),
+                new LabelAndValue("zoo", 1)
+              });
+
+          assertFacetResult(
+              facets.getAllChildren("c", "buzz"),
+              "c",
+              new String[] {"buzz"},
+              3,
+              2,
+              new LabelAndValue[] {
+                new LabelAndValue("bee", 1),
+                new LabelAndValue("bif", 2),
+                new LabelAndValue("biz", 1)
+              });
+
+          assertFacetResult(
+              facets.getAllChildren("c", "buzz", "bif"),
+              "c",
+              new String[] {"buzz", "bif"},
+              1,
+              2,
+              new LabelAndValue[] {new LabelAndValue("baf", 2)});
 
           // test getSpecificValue (and make sure hierarchical dims are supported: LUCENE-10584):
           assertEquals(2, facets.getSpecificValue("c", "buzz"));
@@ -383,9 +416,6 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
           // ... but not on non-hierarchical dims:
           expectThrows(
               IllegalArgumentException.class, () -> facets.getSpecificValue("a", "foo", "bar)"));
-          assertEquals(
-              "dim=c path=[buzz, bif] value=2 childCount=1\n  baf (2)\n",
-              facets.getAllChildren("c", "buzz", "bif").toString());
           // DrillDown:
           DrillDownQuery q = new DrillDownQuery(config);
           q.add("a", "foo");
@@ -441,9 +471,16 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
             "dim=a path=[] value=1 childCount=1\n  bar (1)\n",
             facets.getTopChildren(10, "a").toString());
 
-        assertEquals(
-            "dim=a path=[] value=1 childCount=1\n  bar (1)\n",
-            facets.getAllChildren("a").toString());
+        // test getAllChildren
+        assertFacetResult(
+            facets.getAllChildren("a"),
+            "a",
+            new String[0],
+            1,
+            1,
+            new LabelAndValue[] {
+              new LabelAndValue("bar", 1),
+            });
 
         // test topNChildren = 0
         Facets finalFacets = facets;
@@ -535,12 +572,26 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
         assertEquals(
             "dim=b path=[buzz] value=1 childCount=1\n  baz (1)\n",
             facets.getTopChildren(10, "b", "buzz").toString());
-        assertEquals(
-            "dim=a path=[] value=3 childCount=3\n  bar (1)\n  baz (1)\n  buz (1)\n",
-            facets.getAllChildren("a").toString());
-        assertEquals(
-            "dim=b path=[] value=3 childCount=2\n  bar (2)\n  buzz (1)\n",
-            facets.getAllChildren("b").toString());
+
+        assertFacetResult(
+            facets.getAllChildren("a"),
+            "a",
+            new String[0],
+            3,
+            3,
+            new LabelAndValue[] {
+              new LabelAndValue("bar", 1), new LabelAndValue("baz", 1), new LabelAndValue("buz", 1),
+            });
+
+        assertFacetResult(
+            facets.getAllChildren("b"),
+            "b",
+            new String[0],
+            2,
+            3,
+            new LabelAndValue[] {
+              new LabelAndValue("bar", 2), new LabelAndValue("buzz", 1),
+            });
 
         ExecutorService exec =
             new ThreadPoolExecutor(
@@ -614,11 +665,17 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               "dim=a path=[] value=3 childCount=2\n  foo (2)\n  baz (1)\n",
               facets.getTopChildren(10, "a").toString());
           assertEquals(
-              "dim=a path=[] value=3 childCount=2\n  baz (1)\n  foo (2)\n",
-              facets.getAllChildren("a").toString());
-          assertEquals(
               "dim=b path=[] value=1 childCount=1\n  bar (1)\n",
               facets.getTopChildren(10, "b").toString());
+          assertFacetResult(
+              facets.getAllChildren("a"),
+              "a",
+              new String[0],
+              2,
+              3,
+              new LabelAndValue[] {
+                new LabelAndValue("baz", 1), new LabelAndValue("foo", 2),
+              });
 
           // DrillDown:
           DrillDownQuery q = new DrillDownQuery(config);
@@ -1045,19 +1102,43 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               "dim=d path=[] value=2 childCount=2\n  biz1 (1)\n  biz2 (1)\n",
               topDimsResults2.get(2).toString());
 
-          // test getAllChildren
-          assertEquals(
-              "dim=a path=[] value=3 childCount=3\n  foo1 (1)\n  foo2 (1)\n  foo3 (1)\n",
-              facets.getAllChildren("a").toString());
-          assertEquals(
-              "dim=b path=[] value=2 childCount=2\n  bar1 (1)\n  bar2 (1)\n",
-              facets.getAllChildren("b").toString());
-          assertEquals(
-              "dim=c path=[] value=1 childCount=1\n  baz1 (1)\n",
-              facets.getAllChildren("c").toString());
-          assertEquals(
-              "dim=d path=[] value=2 childCount=2\n  biz1 (1)\n  biz2 (1)\n",
-              facets.getAllChildren("d").toString());
+          assertFacetResult(
+              facets.getAllChildren("a"),
+              "a",
+              new String[0],
+              3,
+              3,
+              new LabelAndValue[] {
+                new LabelAndValue("foo1", 1),
+                new LabelAndValue("foo2", 1),
+                new LabelAndValue("foo3", 1),
+              });
+
+          assertFacetResult(
+              facets.getAllChildren("b"),
+              "b",
+              new String[0],
+              2,
+              2,
+              new LabelAndValue[] {
+                new LabelAndValue("bar1", 1), new LabelAndValue("bar2", 1),
+              });
+
+          assertFacetResult(
+              facets.getAllChildren("c"),
+              "c",
+              new String[0],
+              1,
+              1,
+              new LabelAndValue[] {new LabelAndValue("baz1", 1)});
+
+          assertFacetResult(
+              facets.getAllChildren("d"),
+              "d",
+              new String[0],
+              2,
+              2,
+              new LabelAndValue[] {new LabelAndValue("biz1", 1), new LabelAndValue("biz2", 1)});
 
           Collection<Accountable> resources = state.getChildResources();
           assertTrue(state.toString().contains(FacetsConfig.DEFAULT_INDEX_FIELD_NAME));
@@ -1130,14 +1211,20 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
           assertEquals(1, topDimsResults1.size());
           assertEquals(
               "dim=d path=[] value=2 childCount=1\n  foo (2)\n", results.get(0).toString());
-
-          // test getAllChildren
-          assertEquals(
-              "dim=d path=[foo] value=2 childCount=2\n  bar (1)\n  baz (1)\n",
-              facets.getAllChildren("d", "foo").toString());
-          assertEquals(
-              "dim=d path=[] value=2 childCount=1\n  foo (2)\n",
-              facets.getAllChildren("d").toString());
+          assertFacetResult(
+              facets.getAllChildren("d", "foo"),
+              "d",
+              new String[] {"foo"},
+              2,
+              2,
+              new LabelAndValue[] {new LabelAndValue("bar", 1), new LabelAndValue("baz", 1)});
+          assertFacetResult(
+              facets.getAllChildren("d"),
+              "d",
+              new String[0],
+              1,
+              2,
+              new LabelAndValue[] {new LabelAndValue("foo", 2)});
 
           Collection<Accountable> resources = state.getChildResources();
           assertTrue(state.toString().contains(FacetsConfig.DEFAULT_INDEX_FIELD_NAME));
@@ -1192,9 +1279,13 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
           assertEquals(
               "dim=a path=[] value=2 childCount=2\n  foo1 (1)\n  foo2 (1)\n",
               facets.getTopChildren(10, "a").toString());
-          assertEquals(
-              "dim=a path=[] value=2 childCount=2\n  foo1 (1)\n  foo2 (1)\n",
-              facets.getAllChildren("a").toString());
+          assertFacetResult(
+              facets.getAllChildren("a"),
+              "a",
+              new String[0],
+              2,
+              2,
+              new LabelAndValue[] {new LabelAndValue("foo1", 1), new LabelAndValue("foo2", 1)});
         } finally {
           if (exec != null) exec.shutdownNow();
         }
@@ -1247,11 +1338,15 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               "dim=b path=[] value=2 childCount=2\n  foo (2)\n  boo (1)\n",
               facets.getTopChildren(10, "b").toString());
           assertEquals(
-              "dim=b path=[] value=2 childCount=2\n  boo (1)\n  foo (2)\n",
-              facets.getAllChildren("b").toString());
-          assertEquals(
               "dim=b path=[foo] value=2 childCount=2\n  bar (1)\n  buzz (1)\n",
               facets.getTopChildren(10, "b", "foo").toString());
+          assertFacetResult(
+              facets.getAllChildren("b"),
+              "b",
+              new String[0],
+              2,
+              2,
+              new LabelAndValue[] {new LabelAndValue("boo", 1), new LabelAndValue("foo", 2)});
         } finally {
           if (exec != null) exec.shutdownNow();
         }

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
@@ -201,9 +201,15 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
     assertEquals(
         "dim=int path=[] value=-1 childCount=2\n  a (200)\n  b (150)\n",
         facets.getTopChildren(10, "int").toString());
-    assertEquals(
-        "dim=int path=[] value=-1 childCount=2\n  a (200)\n  b (150)\n",
-        sortAllChildren(facets.getAllChildren("int")).toString());
+    assertFacetResult(
+        facets.getAllChildren("int"),
+        "int",
+        new String[0],
+        2,
+        -1,
+        new LabelAndValue[] {
+          new LabelAndValue("a", 200), new LabelAndValue("b", 150),
+        });
     assertEquals(
         "Wrong count for category 'a'!", 200, facets.getSpecificValue("int", "a").intValue());
     assertEquals(
@@ -276,9 +282,17 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
     assertEquals(
         "dim=float path=[] value=-1.0 childCount=2\n  a (50.0)\n  b (9.999995)\n",
         facets.getTopChildren(10, "float").toString());
-    assertEquals(
-        "dim=float path=[] value=-1.0 childCount=2\n  a (50.0)\n  b (9.999995)\n",
-        sortAllChildren(facets.getAllChildren("float")).toString());
+
+    assertFacetResult(
+        facets.getAllChildren("float"),
+        "float",
+        new String[0],
+        2,
+        -1.0f,
+        new LabelAndValue[] {
+          new LabelAndValue("a", 50.0f), new LabelAndValue("b", 9.999995f),
+        });
+
     assertEquals(
         "Wrong count for category 'a'!",
         50f,
@@ -483,6 +497,16 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
     assertEquals(
         "dim=int path=[] value=-1 childCount=2\n  a (100)\n  b (150)\n",
         sortAllChildren(facets.getAllChildren("int")).toString());
+
+    assertFacetResult(
+        facets.getAllChildren("int"),
+        "int",
+        new String[0],
+        2,
+        -1,
+        new LabelAndValue[] {
+          new LabelAndValue("a", 100), new LabelAndValue("b", 150),
+        });
 
     assertEquals(
         "Wrong count for category 'a'!", 100, facets.getSpecificValue("int", "a").intValue());

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -20,9 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -114,7 +112,6 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     assertTrue(((TaxonomyFacets) facets).siblingsLoaded());
     assertTrue(((TaxonomyFacets) facets).childrenLoaded());
 
-    // test getTopChildren(0, dim)
     Facets finalFacets = facets;
     expectThrows(
         IllegalArgumentException.class,
@@ -130,13 +127,28 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
         "dim=Author path=[] value=5 childCount=4\n  Lisa (2)\n  Bob (1)\n  Susan (1)\n  Frank (1)\n",
         facets.getTopChildren(10, "Author").toString());
 
-    // test getAllChildren
-    assertEquals(
-        "dim=Publish Date path=[] value=5 childCount=3\n  1999 (1)\n  2010 (2)\n  2012 (2)\n",
-        sortAllChildren(facets.getAllChildren("Publish Date")).toString());
-    assertEquals(
-        "dim=Author path=[] value=5 childCount=4\n  Bob (1)\n  Frank (1)\n  Lisa (2)\n  Susan (1)\n",
-        sortAllChildren(facets.getAllChildren("Author")).toString());
+    assertFacetResult(
+        facets.getAllChildren("Publish Date"),
+        "Publish Date",
+        new String[0],
+        3,
+        5,
+        new LabelAndValue[] {
+          new LabelAndValue("1999", 1), new LabelAndValue("2010", 2), new LabelAndValue("2012", 2),
+        });
+
+    assertFacetResult(
+        facets.getAllChildren("Author"),
+        "Author",
+        new String[0],
+        4,
+        5,
+        new LabelAndValue[] {
+          new LabelAndValue("Bob", 1),
+          new LabelAndValue("Frank", 1),
+          new LabelAndValue("Lisa", 2),
+          new LabelAndValue("Susan", 1),
+        });
 
     // test getAllDims
     List<FacetResult> results = facets.getAllDims(10);
@@ -475,9 +487,16 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     assertEquals(
         "dim=dim path=[] value=-1 childCount=2\n  test\u001Fone (1)\n  test\u001Etwo (1)\n",
         result.toString());
-    assertEquals(
-        "dim=dim path=[] value=-1 childCount=2\n  test\u001Etwo (1)\n  test\u001Fone (1)\n",
-        sortAllChildren(facets.getAllChildren("dim")).toString());
+
+    assertFacetResult(
+        facets.getAllChildren("dim"),
+        "dim",
+        new String[0],
+        2,
+        -1,
+        new LabelAndValue[] {
+          new LabelAndValue("test\u001Etwo", 1), new LabelAndValue("test\u001Fone", 1),
+        });
     writer.close();
     IOUtils.close(taxoWriter, searcher.getIndexReader(), taxoReader, dir, taxoDir);
   }
@@ -826,9 +845,16 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     assertEquals(
         "dim=Author path=[] value=2 childCount=2\n  Bob (1)\n  Lisa (1)",
         facets.getTopChildren(10, "Author").toString().trim());
-    assertEquals(
-        "dim=Author path=[] value=2 childCount=2\n  Bob (1)\n  Lisa (1)",
-        sortAllChildren(facets.getAllChildren("Author")).toString().trim());
+
+    assertFacetResult(
+        facets.getAllChildren("Author"),
+        "Author",
+        new String[0],
+        2,
+        2,
+        new LabelAndValue[] {
+          new LabelAndValue("Bob", 1), new LabelAndValue("Lisa", 1),
+        });
 
     // -- delete to trigger liveDocs != null
     writer.deleteDocuments(new Term("id", "0"));
@@ -840,9 +866,16 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     assertEquals(
         "dim=Author path=[] value=1 childCount=1\n  Lisa (1)",
         facets.getTopChildren(10, "Author").toString().trim());
-    assertEquals(
-        "dim=Author path=[] value=1 childCount=1\n  Lisa (1)",
-        facets.getAllChildren("Author").toString().trim());
+
+    assertFacetResult(
+        facets.getAllChildren("Author"),
+        "Author",
+        new String[0],
+        1,
+        1,
+        new LabelAndValue[] {
+          new LabelAndValue("Lisa", 1),
+        });
 
     IOUtils.close(
         writer,
@@ -886,9 +919,16 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     assertEquals(
         "dim=Author path=[] value=2 childCount=2\n  Bob (1)\n  Lisa (1)",
         facets.getTopChildren(10, "Author").toString().trim());
-    assertEquals(
-        "dim=Author path=[] value=2 childCount=2\n  Bob (1)\n  Lisa (1)",
-        sortAllChildren(facets.getAllChildren("Author")).toString().trim());
+
+    assertFacetResult(
+        facets.getAllChildren("Author"),
+        "Author",
+        new String[0],
+        2,
+        2,
+        new LabelAndValue[] {
+          new LabelAndValue("Bob", 1), new LabelAndValue("Lisa", 1),
+        });
 
     // -- delete to trigger liveDocs != null
     writer.deleteDocuments(new Term("id", "0"));
@@ -900,9 +940,16 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     assertEquals(
         "dim=Author path=[] value=1 childCount=1\n  Lisa (1)",
         facets.getTopChildren(10, "Author").toString().trim());
-    assertEquals(
-        "dim=Author path=[] value=1 childCount=1\n  Lisa (1)",
-        facets.getAllChildren("Author").toString().trim());
+
+    assertFacetResult(
+        facets.getAllChildren("Author"),
+        "Author",
+        new String[0],
+        1,
+        1,
+        new LabelAndValue[] {
+          new LabelAndValue("Lisa", 1),
+        });
 
     IOUtils.close(
         writer,
@@ -1142,16 +1189,5 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
       return new FastTaxonomyFacetCounts(
           indexFieldName, searcher.getIndexReader(), taxoReader, config);
     }
-  }
-
-  // since we have no insight into the ordinals assigned to the values, we sort labels by value and
-  // count in
-  // ascending order in order to compare with expected results
-  private static FacetResult sortAllChildren(FacetResult allChildrenResult) {
-    Arrays.sort(
-        allChildrenResult.labelValues,
-        Comparator.comparing((LabelAndValue a) -> a.label)
-            .thenComparingLong(a -> a.value.longValue()));
-    return allChildrenResult;
   }
 }


### PR DESCRIPTION
Fixed `getAllChildren` unit tests to compare labels and values with no assumption about the child ordering. This pr only fixed some of the unit tests, and will continue to fix all of them after receiving feedback on this initial attempt. Thanks!

Jira: https://issues.apache.org/jira/browse/LUCENE-10644


