### PR TITLE
Add comment for no pauses in RateLimitedIndexOutput.writeBytes

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/RateLimitedIndexOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RateLimitedIndexOutput.java
@@ -70,6 +70,10 @@ public final class RateLimitedIndexOutput extends IndexOutput {
   public void writeBytes(byte[] b, int offset, int length) throws IOException {
     bytesSinceLastPause += length;
     checkRate();
+    // The bytes array slice is written without pauses.
+    // This can cause instant write rate to breach rate limit if there have
+    // been no writes for enough time to keep the average write rate within limit.
+    // See https://issues.apache.org/jira/browse/LUCENE-10448
     delegate.writeBytes(b, offset, length);
   }
 


### PR DESCRIPTION
This PR is based on the discussion in #738 ([comment](https://github.com/apache/lucene/pull/738#issuecomment-1156523966)].. 

`RateLimitedIndexOutput.writeBytes()` does not pause while writing the provided array slice. A big array write after a long pause can cause instant write rate to breach the configured limit. This is different from the other APIs, which only write a single byte/int/short/long, and hence won't spike the instant rate. 

This has been a cause of confusion for some users. The PR adds a comment to call it out. More details in jira [LUCENE-10448](https://issues.apache.org/jira/browse/LUCENE-10448).
