### PR TITLE
LUCENE-10480: Use BulkScorer to limit BMMScorer to only top-level disjunctions

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/Boolean2ScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Boolean2ScorerSupplier.java
@@ -118,21 +118,6 @@ final class Boolean2ScorerSupplier extends ScorerSupplier {
           leadCost);
     }
 
-    // pure two terms disjunction
-    if (scoreMode == ScoreMode.TOP_SCORES
-        && minShouldMatch <= 1
-        && subs.get(Occur.FILTER).isEmpty()
-        && subs.get(Occur.MUST).isEmpty()
-        && subs.get(Occur.MUST_NOT).isEmpty()
-        && subs.get(Occur.SHOULD).size() == 2) {
-
-      final List<Scorer> optionalScorers = new ArrayList<>();
-      for (ScorerSupplier scorer : subs.get(Occur.SHOULD)) {
-        optionalScorers.add(scorer.get(leadCost));
-      }
-      return new BlockMaxMaxscoreScorer(weight, optionalScorers);
-    }
-
     // pure disjunction
     if (subs.get(Occur.FILTER).isEmpty() && subs.get(Occur.MUST).isEmpty()) {
       return excl(

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
@@ -192,7 +192,7 @@ final class BooleanWeight extends Weight {
   // pkg-private for forcing use of BooleanScorer in tests
   BulkScorer optionalBulkScorer(LeafReaderContext context) throws IOException {
     if (scoreMode == ScoreMode.TOP_SCORES) {
-      if (query.getMinimumNumberShouldMatch() > 1 || weightedClauses.size() > 2) {
+      if (!query.isPureDisjunction() || weightedClauses.size() > 2) {
         return null;
       }
 

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
@@ -34,7 +34,7 @@ final class BooleanWeight extends Weight {
 
   final BooleanQuery query;
 
-  private static class WeightedBooleanClause {
+  protected static class WeightedBooleanClause {
     final BooleanClause clause;
     final Weight weight;
 

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
@@ -226,25 +226,22 @@ final class BooleanWeight extends Weight {
         @Override
         public int score(LeafCollector collector, Bits acceptDocs, int min, int max)
             throws IOException {
-          max = Math.min(max, maxDoc);
           collector.setScorer(bmmScorer);
 
-          for (int doc = min; doc < max; ) {
-            int advancedDoc = iterator.advance(doc);
-            if (advancedDoc == DocIdSetIterator.NO_MORE_DOCS) {
-              return DocIdSetIterator.NO_MORE_DOCS;
-            } else if (advancedDoc >= max) {
-              return max;
+          int doc = min;
+          while (true) {
+            doc = iterator.advance(doc);
+
+            if (doc >= max) {
+              return doc;
             }
 
-            if (acceptDocs == null || acceptDocs.get(advancedDoc)) {
-              collector.collect(advancedDoc);
+            if (acceptDocs == null || acceptDocs.get(doc)) {
+              collector.collect(doc);
             }
 
-            doc = advancedDoc + 1;
+            doc++;
           }
-
-          return max == maxDoc ? DocIdSetIterator.NO_MORE_DOCS : max;
         }
 
         @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestBlockMaxMaxscoreScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBlockMaxMaxscoreScorer.java
@@ -18,15 +18,16 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.tests.search.AssertingScorer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 // These basic tests are similar to some of the tests in TestWANDScorer, and may not need to be kept
@@ -62,14 +63,16 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
         IndexSearcher searcher = newSearcher(reader);
 
         Query query =
-            new BooleanQuery.Builder()
-                .add(
-                    new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
-                    BooleanClause.Occur.SHOULD)
-                .add(
-                    new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
-                    BooleanClause.Occur.SHOULD)
-                .build();
+            new BlockMaxMaxscoreQuery(
+                new BooleanQuery.Builder()
+                    .add(
+                        new BoostQuery(
+                            new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
+                        BooleanClause.Occur.SHOULD)
+                    .add(
+                        new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
+                        BooleanClause.Occur.SHOULD)
+                    .build());
 
         Scorer scorer =
             searcher
@@ -96,7 +99,7 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
     }
   }
 
-  public void testBasicsWithThreeDisjunctionClausesNotUseBMMScorer() throws Exception {
+  public void testBasicsWithThreeDisjunctionClauses() throws Exception {
     try (Directory dir = newDirectory()) {
       writeDocuments(dir);
 
@@ -104,28 +107,25 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
         IndexSearcher searcher = newSearcher(reader);
 
         Query query =
-            new BooleanQuery.Builder()
-                .add(
-                    new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
-                    BooleanClause.Occur.SHOULD)
-                .add(
-                    new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
-                    BooleanClause.Occur.SHOULD)
-                .add(
-                    new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "C"))), 3),
-                    BooleanClause.Occur.SHOULD)
-                .build();
+            new BlockMaxMaxscoreQuery(
+                new BooleanQuery.Builder()
+                    .add(
+                        new BoostQuery(
+                            new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
+                        BooleanClause.Occur.SHOULD)
+                    .add(
+                        new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
+                        BooleanClause.Occur.SHOULD)
+                    .add(
+                        new BoostQuery(
+                            new ConstantScoreQuery(new TermQuery(new Term("foo", "C"))), 3),
+                        BooleanClause.Occur.SHOULD)
+                    .build());
 
         Scorer scorer =
             searcher
                 .createWeight(searcher.rewrite(query), ScoreMode.TOP_SCORES, 1)
                 .scorer(searcher.getIndexReader().leaves().get(0));
-
-        if (scorer instanceof AssertingScorer) {
-          assertTrue(((AssertingScorer) scorer).getIn() instanceof WANDScorer);
-        } else {
-          assertTrue(scorer instanceof WANDScorer);
-        }
 
         assertEquals(0, scorer.iterator().nextDoc());
         assertEquals(2 + 1, scorer.score(), 0);
@@ -157,15 +157,16 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
         Query query =
             new BooleanQuery.Builder()
                 .add(
-                    new BooleanQuery.Builder()
-                        .add(
-                            new BoostQuery(
-                                new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
-                            BooleanClause.Occur.SHOULD)
-                        .add(
-                            new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
-                            BooleanClause.Occur.SHOULD)
-                        .build(),
+                    new BlockMaxMaxscoreQuery(
+                        new BooleanQuery.Builder()
+                            .add(
+                                new BoostQuery(
+                                    new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
+                                BooleanClause.Occur.SHOULD)
+                            .add(
+                                new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
+                                BooleanClause.Occur.SHOULD)
+                            .build()),
                     BooleanClause.Occur.MUST)
                 .add(new TermQuery(new Term("foo", "C")), BooleanClause.Occur.FILTER)
                 .build();
@@ -208,11 +209,17 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
         Query query =
             new BooleanQuery.Builder()
                 .add(
-                    new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
-                    BooleanClause.Occur.SHOULD)
-                .add(
-                    new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
-                    BooleanClause.Occur.SHOULD)
+                    new BlockMaxMaxscoreQuery(
+                        new BooleanQuery.Builder()
+                            .add(
+                                new BoostQuery(
+                                    new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
+                                BooleanClause.Occur.SHOULD)
+                            .add(
+                                new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
+                                BooleanClause.Occur.SHOULD)
+                            .build()),
+                    BooleanClause.Occur.MUST)
                 .add(new TermQuery(new Term("foo", "C")), BooleanClause.Occur.MUST_NOT)
                 .build();
 
@@ -244,6 +251,83 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
 
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().nextDoc());
       }
+    }
+  }
+
+  private static class BlockMaxMaxscoreQuery extends Query {
+    private final BooleanQuery query;
+
+    private BlockMaxMaxscoreQuery(BooleanQuery query) {
+      assert query.isPureDisjunction()
+          : "This test utility query is only used to create BlockMaxMaxscoreScorer for disjunctions.";
+      assert query.clauses().size() >= 2
+          : "There must be at least two optional clauses to use this test utility query.";
+      this.query = query;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
+        throws IOException {
+      return new Weight(query) {
+
+        @Override
+        public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+          // no-ops
+          return null;
+        }
+
+        @Override
+        public Scorer scorer(LeafReaderContext context) throws IOException {
+          BooleanWeight weight = (BooleanWeight) query.createWeight(searcher, scoreMode, boost);
+          List<Scorer> optionalScorers =
+              weight.weightedClauses.stream()
+                  .map(wc -> wc.weight)
+                  .map(
+                      w -> {
+                        try {
+                          return w.scorerSupplier(context);
+                        } catch (IOException e) {
+                          throw new AssertionError(e);
+                        }
+                      })
+                  .map(
+                      ss -> {
+                        try {
+                          return ss.get(Long.MAX_VALUE);
+                        } catch (IOException e) {
+                          throw new AssertionError(e);
+                        }
+                      })
+                  .toList();
+
+          return new BlockMaxMaxscoreScorer(weight, optionalScorers);
+        }
+
+        @Override
+        public boolean isCacheable(LeafReaderContext ctx) {
+          return false;
+        }
+      };
+    }
+
+    @Override
+    public String toString(String field) {
+      return "BlockMaxMaxscoreQuery";
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+      // no-ops
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return sameClassAs(other) && query.equals(((BlockMaxMaxscoreQuery) other).query);
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * classHash() + query.hashCode();
     }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBlockMaxMaxscoreScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBlockMaxMaxscoreScorer.java
@@ -76,12 +76,6 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
                 .createWeight(searcher.rewrite(query), ScoreMode.TOP_SCORES, 1)
                 .scorer(searcher.getIndexReader().leaves().get(0));
 
-        if (scorer instanceof AssertingScorer) {
-          assertTrue(((AssertingScorer) scorer).getIn() instanceof BlockMaxMaxscoreScorer);
-        } else {
-          assertTrue(scorer instanceof BlockMaxMaxscoreScorer);
-        }
-
         assertEquals(0, scorer.iterator().nextDoc());
         assertEquals(2 + 1, scorer.score(), 0);
 


### PR DESCRIPTION
### Description (or a Jira issue link if you have one)

Use BulkScorer to limit BMMScorer to only top-level disjunctions

~Note: Tests update pending~ Test updated