### PR TITLE
LUCENE-10649: Fix failures in TestDemoParallelLeafReader

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
@@ -735,7 +735,9 @@ public class TestDemoParallelLeafReader extends LuceneTestCase {
       }
 
       @Override
-      public MergeSpecification findFullFlushMerges(MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
+      public MergeSpecification findFullFlushMerges(
+          MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext)
+          throws IOException {
         return wrap(in.findFullFlushMerges(mergeTrigger, segmentInfos, mergeContext));
       }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
@@ -735,6 +735,11 @@ public class TestDemoParallelLeafReader extends LuceneTestCase {
       }
 
       @Override
+      public MergeSpecification findFullFlushMerges(MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
+        return wrap(in.findFullFlushMerges(mergeTrigger, segmentInfos, mergeContext));
+      }
+
+      @Override
       public boolean useCompoundFile(
           SegmentInfos segments, SegmentCommitInfo newSegment, MergeContext mergeContext)
           throws IOException {


### PR DESCRIPTION
With merge-on-refresh enabled, the `ReindexingMergePolicy` in this test, needs to overide `findFullFlushMerges()`, to wrap the input reader, so that merged segment gets fields from the parallel readers.

##### Testing:
Ran the test on repeat on my dev box. Without the fix, it fails in a couple of runs.

```java
% ./gradlew test --tests TestDemoParallelLeafReader.testRandomMultipleSchemaGensSameField -Dtests.seed=A7496D7D3957981A -Dtests.multiplier=3 -Dtests.locale=sr-Latn-BA -Dtests.timezone=Etc/GMT-7 -Dtests.asserts=true -Dtests.file.encoding=UTF-8 -Dtests.iters=500 -Dtests.failfast=true
...
:lucene:core:test (SUCCESS): 500 test(s)
...
```