### PR TITLE
LUCENE-10656: It is unnecessary that using `limit` to check boundary

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/SortedNumericDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortedNumericDocValuesWriter.java
@@ -253,9 +253,6 @@ class SortedNumericDocValuesWriter extends DocValuesWriter<SortedNumericDocValue
 
     @Override
     public long nextValue() {
-      if (valueUpto == valueCount) {
-        throw new IllegalStateException();
-      }
       valueUpto++;
       return valuesIter.next();
     }
@@ -272,7 +269,6 @@ class SortedNumericDocValuesWriter extends DocValuesWriter<SortedNumericDocValue
     private int docID = -1;
     private long upto;
     private int numValues = -1;
-    private long limit;
 
     SortingSortedNumericDocValues(SortedNumericDocValues in, LongValues values) {
       this.in = in;
@@ -294,7 +290,6 @@ class SortedNumericDocValuesWriter extends DocValuesWriter<SortedNumericDocValue
       } while (values.offsets[docID] <= 0);
       upto = values.offsets[docID];
       numValues = Math.toIntExact(values.values.get(upto - 1));
-      limit = upto + numValues;
       return docID;
     }
 
@@ -309,21 +304,14 @@ class SortedNumericDocValuesWriter extends DocValuesWriter<SortedNumericDocValue
       upto = values.offsets[docID];
       if (values.offsets[docID] > 0) {
         numValues = Math.toIntExact(values.values.get(upto - 1));
-        limit = upto + numValues;
         return true;
-      } else {
-        limit = upto;
       }
       return false;
     }
 
     @Override
     public long nextValue() {
-      if (upto == limit) {
-        throw new AssertionError();
-      } else {
-        return values.values.get(upto++);
-      }
+      return values.values.get(upto++);
     }
 
     @Override


### PR DESCRIPTION
Follow-up discussion in https://github.com/apache/lucene/pull/1021