### PR TITLE
Fix error in TieredMergePolicy

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -170,6 +170,8 @@ Bug Fixes
 
 * LUCENE-10623: Error implementation of docValueCount for SortingSortedSetDocValues (Lu Xugang)
 
+* GITHUB#1028: Fix error in TieredMergePolicy (Lin Jian)
+
 Other
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -878,7 +878,7 @@ public class TieredMergePolicy extends MergePolicy {
       // segments or that create a segment close to the
       // maximum allowed segment sized are permitted
       if (candidateSize > 1
-          && (forceMergeRunning == false || candidateSize > 0.7 * maxMergeBytes)) {
+          && (forceMergeRunning == false || currentCandidateBytes > 0.7 * maxMergeBytes)) {
         final OneMerge merge = new OneMerge(candidate);
         if (verbose(mergeContext)) {
           message("add merge=" + segString(mergeContext, merge.segments), mergeContext);


### PR DESCRIPTION
Fix error in comparing between bytes of candidates and bytes of max merge.
It's wrong to use `candidateSize` rather than `currentCandidateBytes` comparing with `maxMergeBytes`. Minor change to fix it.
