### PR TITLE
LUCENE-10657: CopyBytes now saves one memory copy on ByteBuffersDataOutput

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -42,7 +42,8 @@ Improvements
 
 Optimizations
 ---------------------
-(No changes)
+
+* LUCENE-10657: CopyBytes now saves one memory copy on ByteBuffersDataOutput. (luyuncheng)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
@@ -317,13 +317,12 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
       if (!currentBlock.hasRemaining()) {
         appendBlock();
       }
-      if (currentBlock.isDirect()) {
+      if (!currentBlock.hasArray()) {
         break;
       }
       int chunk = Math.min(currentBlock.remaining(), length);
       final int pos = currentBlock.position();
-      byte[] blockArray = currentBlock.array();
-      input.readBytes(blockArray, pos, chunk);
+      input.readBytes(currentBlock.array(), Math.addExact(currentBlock.arrayOffset(), pos), chunk);
       length -= chunk;
       currentBlock.position(pos + chunk);
     }

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
@@ -317,13 +317,19 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
       if (!currentBlock.hasRemaining()) {
         appendBlock();
       }
-
+      if (currentBlock.isDirect()) {
+        break;
+      }
       int chunk = Math.min(currentBlock.remaining(), length);
       final int pos = currentBlock.position();
       byte[] blockArray = currentBlock.array();
       input.readBytes(blockArray, pos, chunk);
       length -= chunk;
       currentBlock.position(pos + chunk);
+    }
+    // if current block is Direct, we fall back to super.copyBytes for remaining bytes
+    if (length > 0) {
+      super.copyBytes(input, length);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
@@ -309,6 +309,24 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
     return arr;
   }
 
+  @Override
+  public void copyBytes(DataInput input, long numBytes) throws IOException {
+    assert numBytes >= 0 : "numBytes=" + numBytes;
+    int length = (int) numBytes;
+    while (length > 0) {
+      if (!currentBlock.hasRemaining()) {
+        appendBlock();
+      }
+
+      int chunk = Math.min(currentBlock.remaining(), length);
+      final int pos = currentBlock.position();
+      byte[] blockArray = currentBlock.array();
+      input.readBytes(blockArray, pos, chunk);
+      length -= chunk;
+      currentBlock.position(pos + chunk);
+    }
+  }
+
   /** Copy the current content of this object into another {@link DataOutput}. */
   public void copyTo(DataOutput output) throws IOException {
     for (ByteBuffer bb : blocks) {

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataOutput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataOutput.java
@@ -205,6 +205,42 @@ public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<Byte
   }
 
   @Test
+  public void testCopyBytesOnHeap() throws IOException {
+    byte[] bytes = new byte[1024 * 8 + 10];
+    random().nextBytes(bytes);
+    int offset = TestUtil.nextInt(random(), 0, 100);
+    int len = bytes.length - offset;
+    ByteArrayDataInput in = new ByteArrayDataInput(bytes, offset, len);
+    ByteBuffersDataOutput o =
+        new ByteBuffersDataOutput(
+            ByteBuffersDataOutput.DEFAULT_MIN_BITS_PER_BLOCK,
+            ByteBuffersDataOutput.DEFAULT_MAX_BITS_PER_BLOCK,
+            ByteBuffersDataOutput.ALLOCATE_BB_ON_HEAP,
+            ByteBuffersDataOutput.NO_REUSE);
+    o.copyBytes(in, len);
+    Assert.assertArrayEquals(
+        o.toArrayCopy(), ArrayUtil.copyOfSubArray(bytes, offset, offset + len));
+  }
+
+  @Test
+  public void testCopyBytesOnDirectByteBuffer() throws IOException {
+    byte[] bytes = new byte[1024 * 8 + 10];
+    random().nextBytes(bytes);
+    int offset = TestUtil.nextInt(random(), 0, 100);
+    int len = bytes.length - offset;
+    ByteArrayDataInput in = new ByteArrayDataInput(bytes, offset, len);
+    ByteBuffersDataOutput o =
+        new ByteBuffersDataOutput(
+            ByteBuffersDataOutput.DEFAULT_MIN_BITS_PER_BLOCK,
+            ByteBuffersDataOutput.DEFAULT_MAX_BITS_PER_BLOCK,
+            ByteBuffer::allocateDirect,
+            ByteBuffersDataOutput.NO_REUSE);
+    o.copyBytes(in, len);
+    Assert.assertArrayEquals(
+        o.toArrayCopy(), ArrayUtil.copyOfSubArray(bytes, offset, offset + len));
+  }
+
+  @Test
   public void testToBufferListReturnsReadOnlyBuffers() throws Exception {
     ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
     dst.writeBytes(new byte[100]);


### PR DESCRIPTION
This is derived from [LUCENE-10627](https://issues.apache.org/jira/browse/LUCENE-10627) at #987 
Jira: https://issues.apache.org/jira/browse/LUCENE-10657

The abstract method `copyBytes` in DataOutput have to copy from input to a copyBuffer and then write into ByteBuffersDataOutput.blocks, i think there is unnecessary, we can override it, copy directly from input into output.

with override this method, we can:

1. Reduce memory copy in `Lucene90CompressingStoredFieldsWriter#copyOneDoc` -> `bufferdDocs.copyBytes(DataInput input)`
2. Reduce memory copy in `Lucene90CompoundFormat.writeCompoundFile` -> `data.copyBytes` when input is `BufferedChecksumIndexinput` and output is `ByteBuffersDataOutput`
3. Reduce memory `IndexWriter#copySegmentAsIs` ->CopyFrom -> copyBytes
