### PR TITLE
LUCENE-10480: (Backporting) Use BulkScorer to limit BMMScorer to only top-level disjunctions

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/Boolean2ScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Boolean2ScorerSupplier.java
@@ -118,21 +118,6 @@ final class Boolean2ScorerSupplier extends ScorerSupplier {
           leadCost);
     }
 
-    // pure two terms disjunction
-    if (scoreMode == ScoreMode.TOP_SCORES
-        && minShouldMatch <= 1
-        && subs.get(Occur.FILTER).isEmpty()
-        && subs.get(Occur.MUST).isEmpty()
-        && subs.get(Occur.MUST_NOT).isEmpty()
-        && subs.get(Occur.SHOULD).size() == 2) {
-
-      final List<Scorer> optionalScorers = new ArrayList<>();
-      for (ScorerSupplier scorer : subs.get(Occur.SHOULD)) {
-        optionalScorers.add(scorer.get(leadCost));
-      }
-      return new BlockMaxMaxscoreScorer(weight, optionalScorers);
-    }
-
     // pure disjunction
     if (subs.get(Occur.FILTER).isEmpty() && subs.get(Occur.MUST).isEmpty()) {
       return excl(

--- a/lucene/core/src/test/org/apache/lucene/search/TestBlockMaxMaxscoreScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBlockMaxMaxscoreScorer.java
@@ -18,15 +18,16 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.tests.search.AssertingScorer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 // These basic tests are similar to some of the tests in TestWANDScorer, and may not need to be kept
@@ -62,25 +63,21 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
         IndexSearcher searcher = newSearcher(reader);
 
         Query query =
-            new BooleanQuery.Builder()
-                .add(
-                    new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
-                    BooleanClause.Occur.SHOULD)
-                .add(
-                    new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
-                    BooleanClause.Occur.SHOULD)
-                .build();
+            new BlockMaxMaxscoreQuery(
+                new BooleanQuery.Builder()
+                    .add(
+                        new BoostQuery(
+                            new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
+                        BooleanClause.Occur.SHOULD)
+                    .add(
+                        new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
+                        BooleanClause.Occur.SHOULD)
+                    .build());
 
         Scorer scorer =
             searcher
                 .createWeight(searcher.rewrite(query), ScoreMode.TOP_SCORES, 1)
                 .scorer(searcher.getIndexReader().leaves().get(0));
-
-        if (scorer instanceof AssertingScorer) {
-          assertTrue(((AssertingScorer) scorer).getIn() instanceof BlockMaxMaxscoreScorer);
-        } else {
-          assertTrue(scorer instanceof BlockMaxMaxscoreScorer);
-        }
 
         assertEquals(0, scorer.iterator().nextDoc());
         assertEquals(2 + 1, scorer.score(), 0);
@@ -102,7 +99,7 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
     }
   }
 
-  public void testBasicsWithThreeDisjunctionClausesNotUseBMMScorer() throws Exception {
+  public void testBasicsWithThreeDisjunctionClauses() throws Exception {
     try (Directory dir = newDirectory()) {
       writeDocuments(dir);
 
@@ -110,28 +107,25 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
         IndexSearcher searcher = newSearcher(reader);
 
         Query query =
-            new BooleanQuery.Builder()
-                .add(
-                    new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
-                    BooleanClause.Occur.SHOULD)
-                .add(
-                    new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
-                    BooleanClause.Occur.SHOULD)
-                .add(
-                    new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "C"))), 3),
-                    BooleanClause.Occur.SHOULD)
-                .build();
+            new BlockMaxMaxscoreQuery(
+                new BooleanQuery.Builder()
+                    .add(
+                        new BoostQuery(
+                            new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
+                        BooleanClause.Occur.SHOULD)
+                    .add(
+                        new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
+                        BooleanClause.Occur.SHOULD)
+                    .add(
+                        new BoostQuery(
+                            new ConstantScoreQuery(new TermQuery(new Term("foo", "C"))), 3),
+                        BooleanClause.Occur.SHOULD)
+                    .build());
 
         Scorer scorer =
             searcher
                 .createWeight(searcher.rewrite(query), ScoreMode.TOP_SCORES, 1)
                 .scorer(searcher.getIndexReader().leaves().get(0));
-
-        if (scorer instanceof AssertingScorer) {
-          assertTrue(((AssertingScorer) scorer).getIn() instanceof WANDScorer);
-        } else {
-          assertTrue(scorer instanceof WANDScorer);
-        }
 
         assertEquals(0, scorer.iterator().nextDoc());
         assertEquals(2 + 1, scorer.score(), 0);
@@ -163,15 +157,16 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
         Query query =
             new BooleanQuery.Builder()
                 .add(
-                    new BooleanQuery.Builder()
-                        .add(
-                            new BoostQuery(
-                                new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
-                            BooleanClause.Occur.SHOULD)
-                        .add(
-                            new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
-                            BooleanClause.Occur.SHOULD)
-                        .build(),
+                    new BlockMaxMaxscoreQuery(
+                        new BooleanQuery.Builder()
+                            .add(
+                                new BoostQuery(
+                                    new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
+                                BooleanClause.Occur.SHOULD)
+                            .add(
+                                new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
+                                BooleanClause.Occur.SHOULD)
+                            .build()),
                     BooleanClause.Occur.MUST)
                 .add(new TermQuery(new Term("foo", "C")), BooleanClause.Occur.FILTER)
                 .build();
@@ -214,11 +209,17 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
         Query query =
             new BooleanQuery.Builder()
                 .add(
-                    new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
-                    BooleanClause.Occur.SHOULD)
-                .add(
-                    new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
-                    BooleanClause.Occur.SHOULD)
+                    new BlockMaxMaxscoreQuery(
+                        new BooleanQuery.Builder()
+                            .add(
+                                new BoostQuery(
+                                    new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2),
+                                BooleanClause.Occur.SHOULD)
+                            .add(
+                                new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
+                                BooleanClause.Occur.SHOULD)
+                            .build()),
+                    BooleanClause.Occur.MUST)
                 .add(new TermQuery(new Term("foo", "C")), BooleanClause.Occur.MUST_NOT)
                 .build();
 
@@ -250,6 +251,83 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
 
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().nextDoc());
       }
+    }
+  }
+
+  private static class BlockMaxMaxscoreQuery extends Query {
+    private final BooleanQuery query;
+
+    private BlockMaxMaxscoreQuery(BooleanQuery query) {
+      assert query.isPureDisjunction()
+          : "This test utility query is only used to create BlockMaxMaxscoreScorer for disjunctions.";
+      assert query.clauses().size() >= 2
+          : "There must be at least two optional clauses to use this test utility query.";
+      this.query = query;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
+        throws IOException {
+      return new Weight(query) {
+
+        @Override
+        public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+          // no-ops
+          return null;
+        }
+
+        @Override
+        public Scorer scorer(LeafReaderContext context) throws IOException {
+          BooleanWeight weight = (BooleanWeight) query.createWeight(searcher, scoreMode, boost);
+          List<Scorer> optionalScorers =
+              weight.weightedClauses.stream()
+                  .map(wc -> wc.weight)
+                  .map(
+                      w -> {
+                        try {
+                          return w.scorerSupplier(context);
+                        } catch (IOException e) {
+                          throw new AssertionError(e);
+                        }
+                      })
+                  .map(
+                      ss -> {
+                        try {
+                          return ss.get(Long.MAX_VALUE);
+                        } catch (IOException e) {
+                          throw new AssertionError(e);
+                        }
+                      })
+                  .toList();
+
+          return new BlockMaxMaxscoreScorer(weight, optionalScorers);
+        }
+
+        @Override
+        public boolean isCacheable(LeafReaderContext ctx) {
+          return false;
+        }
+      };
+    }
+
+    @Override
+    public String toString(String field) {
+      return "BlockMaxMaxscoreQuery";
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+      // no-ops
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return sameClassAs(other) && query.equals(((BlockMaxMaxscoreQuery) other).query);
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * classHash() + query.hashCode();
     }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBlockMaxMaxscoreScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBlockMaxMaxscoreScorer.java
@@ -19,6 +19,7 @@ package org.apache.lucene.search;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
@@ -298,7 +299,7 @@ public class TestBlockMaxMaxscoreScorer extends LuceneTestCase {
                           throw new AssertionError(e);
                         }
                       })
-                  .toList();
+                  .collect(Collectors.toList());
 
           return new BlockMaxMaxscoreScorer(weight, optionalScorers);
         }


### PR DESCRIPTION
### Description (or a Jira issue link if you have one)

This PR backports https://github.com/apache/lucene/pull/1018 to `branch_9x`