### PR TITLE
Cache decoded length bytes for TFIDFSimilarity scorer.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -271,7 +271,7 @@ public class TermInSetQuery extends Query implements Accountable {
         TermIterator iterator = termData.iterator();
 
         // We will first try to collect up to 'threshold' terms into 'matchingTerms'
-        // if there are two many terms, we will fall back to building the 'builder'
+        // if there are too many terms, we will fall back to building the 'builder'
         final int threshold =
             Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
         assert termData.size() > threshold : "Query should have been rewritten";

--- a/lucene/core/src/java/org/apache/lucene/search/similarities/TFIDFSimilarity.java
+++ b/lucene/core/src/java/org/apache/lucene/search/similarities/TFIDFSimilarity.java
@@ -444,6 +444,15 @@ public abstract class TFIDFSimilarity extends Similarity {
    */
   public abstract float lengthNorm(int length);
 
+  /** Cache of decoded bytes. */
+  private static final int[] LENGTH_TABLE = new int[256];
+
+  static {
+    for (int i = 0; i < 256; i++) {
+      LENGTH_TABLE[i] = SmallFloat.byte4ToInt((byte) i);
+    }
+  }
+
   @Override
   public final long computeNorm(FieldInvertState state) {
     final int numTerms;
@@ -466,8 +475,7 @@ public abstract class TFIDFSimilarity extends Similarity {
             : idfExplain(collectionStats, termStats);
     float[] normTable = new float[256];
     for (int i = 1; i < 256; ++i) {
-      int length = SmallFloat.byte4ToInt((byte) i);
-      float norm = lengthNorm(length);
+      float norm = lengthNorm(LENGTH_TABLE[i]);
       normTable[i] = norm;
     }
     normTable[0] = 1f / normTable[255];


### PR DESCRIPTION
### Description

When doing A/B testing between TF-IDF and BM25 similarity, we found scorer() method in TFIDFSimilarity is somewhat slower than that in BM25Similarity. After reading the code and profiling, we found [BM25Similarity caches decoded length bytes](https://github.com/apache/lucene/blob/8ac26737913d0c1555019e93bc6bf7db1ab9047e/lucene/core/src/java/org/apache/lucene/search/similarities/BM25Similarity.java#L122-L129) while [TFIDFSimilarity doesn't](https://github.com/apache/lucene/blob/8ac26737913d0c1555019e93bc6bf7db1ab9047e/lucene/core/src/java/org/apache/lucene/search/similarities/TFIDFSimilarity.java#L468-L472). By applying caching in BM25 to TFIDF, there is almost no speed difference for scorer method.

Btw, I corrected one comment typo in TermInSetQuery.

### Tests
```
./gradlew check

```


