### PR TITLE
LUCENE-10663: KnnVectorQuery explain incorrect when multiple segments

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -101,7 +101,7 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+* LUCENE-10663: Fix KnnVectorQuery explain incorrect when multiple segments. (Shiming Li)
 
 Other
 ---------------------
@@ -204,8 +204,6 @@ Bug Fixes
 * LUCENE-10623: Error implementation of docValueCount for SortingSortedSetDocValues (Lu Xugang)
 
 * GITHUB#1028: Fix error in TieredMergePolicy (Lin Jian)
-
-* LUCENE-10663: Fix KnnVectorQuery explain incorrect when multiple segments. (Shiming Li)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -101,7 +101,7 @@ Optimizations
 
 Bug Fixes
 ---------------------
-* LUCENE-10663: Fix KnnVectorQuery explain incorrect when multiple segments. (Shiming Li)
+* LUCENE-10663: Fix KnnVectorQuery explain with multiple segments. (Shiming Li)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -205,6 +205,8 @@ Bug Fixes
 
 * GITHUB#1028: Fix error in TieredMergePolicy (Lin Jian)
 
+* LUCENE-10663: Fix KnnVectorQuery explain incorrect when multiple segments. (Shiming Li)
+
 Other
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java
@@ -318,7 +318,7 @@ public class KnnVectorQuery extends Query {
       return new Weight(this) {
         @Override
         public Explanation explain(LeafReaderContext context, int doc) {
-          int found = Arrays.binarySearch(docs, doc);
+          int found = Arrays.binarySearch(docs, doc + context.docBase);
           if (found < 0) {
             return Explanation.noMatch("not in top " + k);
           }

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnVectorQuery.java
@@ -446,6 +446,34 @@ public class TestKnnVectorQuery extends LuceneTestCase {
     }
   }
 
+  public void testExplainMultipleSegments() throws IOException {
+    try (Directory d = newDirectory()) {
+      try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
+        for (int j = 0; j < 5; j++) {
+          Document doc = new Document();
+          doc.add(new KnnVectorField("field", new float[] {j, j}));
+          w.addDocument(doc);
+          w.commit();
+        }
+      }
+      try (IndexReader reader = DirectoryReader.open(d)) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+        KnnVectorQuery query = new KnnVectorQuery("field", new float[] {2, 3}, 3);
+        Explanation matched = searcher.explain(query, 2);
+        assertTrue(matched.isMatch());
+        assertEquals(1 / 2f, matched.getValue());
+        assertEquals(0, matched.getDetails().length);
+        assertEquals("within top 3", matched.getDescription());
+
+        Explanation nomatch = searcher.explain(query, 4);
+        assertFalse(nomatch.isMatch());
+        assertEquals(0f, nomatch.getValue());
+        assertEquals(0, matched.getDetails().length);
+        assertEquals("not in top 3", nomatch.getDescription());
+      }
+    }
+  }
+
   /** Test that when vectors are abnormally distributed among segments, we still find the top K */
   public void testSkewedIndex() throws IOException {
     /* We have to choose the numbers carefully here so that some segment has more than the expected


### PR DESCRIPTION
### Description (or a Jira issue link if you have one)

[LUCENE-10663](https://issues.apache.org/jira/browse/LUCENE-10663)

If there are multiple segments. KnnVectorQuery explain has a bug in locating docid. 

This is because the docid in explain, which is the docBase without the segment. 

In KnnVectorQuery.DocAndScoreQuery docs docid is increased in each segment of the docBase. 

The two docid are not in the same dimension.

So, in the 'DocAndScoreQuery.explain', needs to be added with the segment's docBase. 