### PR TITLE
LUCENE-10673: Improve check of equality for latitudes for spatial3d GeoBoundingBox

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -112,6 +112,8 @@ Bug Fixes
 ---------------------
 * LUCENE-10663: Fix KnnVectorQuery explain with multiple segments. (Shiming Li)
 
+* LUCENE-10673: Improve check of equality for latitudes for spatial3d GeoBoundingBox (ignacio Vera)
+
 Build
 ---------------------
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoBBoxFactory.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoBBoxFactory.java
@@ -146,7 +146,7 @@ public class GeoBBoxFactory {
     // it is not enough with using the MINIMUM_ANGULAR_RESOLUTION, check as well the sin values
     // just in case they describe the same plane
     return Math.abs(lat1 - lat2) < Vector.MINIMUM_ANGULAR_RESOLUTION
-        || Math.sin(lat1) == Math.sin(lat2);
+        || Math.abs(Math.sin(lat1) - Math.sin(lat2)) < Vector.MINIMUM_RESOLUTION;
   }
 
   private static boolean longitudesEquals(double lon1, double lon2) {

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoBBox.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoBBox.java
@@ -503,6 +503,15 @@ public class TestGeoBBox extends LuceneTestCase {
   }
 
   @Test
+  public void testBBoxLatDegenerate() {
+    double minX = Geo3DUtil.fromDegrees(-180.0);
+    double maxX = Geo3DUtil.fromDegrees(-174.37500008381903);
+    double minY = Geo3DUtil.fromDegrees(89.99999765306711);
+    double maxY = Geo3DUtil.fromDegrees(89.99999794643372);
+    assertNotNull(GeoAreaFactory.makeGeoArea(PlanetModel.SPHERE, maxY, minY, minX, maxX));
+  }
+
+  @Test
   public void testBBoxRandomLatDegenerate() {
     for (int i = 0; i < 100; i++) {
       double minX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());


### PR DESCRIPTION
The PR makes two latitudes to be equal if the value of the sine is lower than the vector resolution.