### PR TITLE
LUCENE-10670: Add a codec class to track merge time of each index part

### DIFF
--- a/lucene/core/src/java/module-info.java
+++ b/lucene/core/src/java/module-info.java
@@ -60,6 +60,8 @@ module org.apache.lucene.core {
   opens org.apache.lucene.document to
       org.apache.lucene.test_framework;
 
+  exports org.apache.lucene.codecs.monitoring;
+
   provides org.apache.lucene.analysis.TokenizerFactory with
       org.apache.lucene.analysis.standard.StandardTokenizerFactory;
   provides org.apache.lucene.codecs.Codec with

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -61,7 +61,7 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
    * #mergeOneField}, passing a {@link KnnVectorsReader} that combines the vector values and ignores
    * deleted documents.
    */
-  public final void merge(MergeState mergeState) throws IOException {
+  public void merge(MergeState mergeState) throws IOException {
     for (int i = 0; i < mergeState.fieldInfos.length; i++) {
       KnnVectorsReader reader = mergeState.knnVectorsReaders[i];
       assert reader != null || mergeState.fieldInfos[i].hasVectorValues() == false;

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterDocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterDocValuesConsumer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.FieldInfo;
+
+/** DocValuesConsumer implementation that delegates calls to another DocValuesConsumer. */
+public abstract class FilterDocValuesConsumer extends DocValuesConsumer {
+  protected final DocValuesConsumer in;
+
+  public FilterDocValuesConsumer(DocValuesConsumer in) {
+    this.in = in;
+  }
+
+  @Override
+  public void addNumericField(FieldInfo fieldInfo, DocValuesProducer docValuesProducer)
+      throws IOException {
+    in.addNumericField(fieldInfo, docValuesProducer);
+  }
+
+  @Override
+  public void addBinaryField(FieldInfo fieldInfo, DocValuesProducer docValuesProducer)
+      throws IOException {
+    in.addBinaryField(fieldInfo, docValuesProducer);
+  }
+
+  @Override
+  public void addSortedField(FieldInfo fieldInfo, DocValuesProducer docValuesProducer)
+      throws IOException {
+    in.addSortedField(fieldInfo, docValuesProducer);
+  }
+
+  @Override
+  public void addSortedNumericField(FieldInfo fieldInfo, DocValuesProducer docValuesProducer)
+      throws IOException {
+    in.addSortedNumericField(fieldInfo, docValuesProducer);
+  }
+
+  @Override
+  public void addSortedSetField(FieldInfo fieldInfo, DocValuesProducer docValuesProducer)
+      throws IOException {
+    in.addSortedSetField(fieldInfo, docValuesProducer);
+  }
+
+  @Override
+  public void close() throws IOException {
+    in.close();
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterDocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterDocValuesFormat.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+/** DocValuesFormat implementation that delegates calls to another DocValuesFormat. */
+public abstract class FilterDocValuesFormat extends DocValuesFormat {
+  protected final DocValuesFormat in;
+
+  public FilterDocValuesFormat(DocValuesFormat in) {
+    super(in.getName());
+    this.in = in;
+  }
+
+  @Override
+  public DocValuesConsumer fieldsConsumer(SegmentWriteState var1) throws IOException {
+    return in.fieldsConsumer(var1);
+  }
+
+  @Override
+  public DocValuesProducer fieldsProducer(SegmentReadState var1) throws IOException {
+    return in.fieldsProducer(var1);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterFieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterFieldsConsumer.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.index.Fields;
+
+/** FieldsConsumer implementation that delegates calls to another FieldsConsumer. */
+public abstract class FilterFieldsConsumer extends FieldsConsumer {
+  FieldsConsumer in;
+
+  public FilterFieldsConsumer(FieldsConsumer in) {
+    this.in = in;
+  }
+
+  @Override
+  public void write(Fields fields, NormsProducer normsProducer) throws IOException {
+    in.write(fields, normsProducer);
+  }
+
+  @Override
+  public void close() throws IOException {
+    in.close();
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterKnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterKnnVectorsFormat.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+/** KnnVectorsFormat implementation that delegates calls to another KnnVectorsFormat. */
+public abstract class FilterKnnVectorsFormat extends KnnVectorsFormat {
+  protected final KnnVectorsFormat in;
+
+  public FilterKnnVectorsFormat(KnnVectorsFormat in) {
+    super(in.getName());
+    this.in = in;
+  }
+
+  @Override
+  public KnnVectorsWriter fieldsWriter(SegmentWriteState var1) throws IOException {
+    return in.fieldsWriter(var1);
+  }
+
+  @Override
+  public KnnVectorsReader fieldsReader(SegmentReadState var1) throws IOException {
+    return in.fieldsReader(var1);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterKnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterKnnVectorsWriter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.KnnFieldVectorsWriter;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Sorter;
+
+/** KnnVectorsWriter implementation that delegates calls to another KnnVectorsWriter. */
+public abstract class FilterKnnVectorsWriter extends KnnVectorsWriter {
+  protected final KnnVectorsWriter in;
+
+  public FilterKnnVectorsWriter(KnnVectorsWriter in) {
+    this.in = in;
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return in.ramBytesUsed();
+  }
+
+  @Override
+  public KnnFieldVectorsWriter addField(FieldInfo fieldInfo) throws IOException {
+    return in.addField(fieldInfo);
+  }
+
+  @Override
+  public void flush(int maxDoc, Sorter.DocMap sortMap) throws IOException {
+    in.flush(maxDoc, sortMap);
+  }
+
+  @Override
+  public void finish() throws IOException {
+    in.finish();
+  }
+
+  @Override
+  public void close() throws IOException {
+    in.close();
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterNormsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterNormsConsumer.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.NormsConsumer;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.index.FieldInfo;
+
+/** NormsConsumer implementation that delegates calls to another NormsConsumer. */
+public abstract class FilterNormsConsumer extends NormsConsumer {
+  protected final NormsConsumer in;
+
+  public FilterNormsConsumer(NormsConsumer in) {
+    this.in = in;
+  }
+
+  @Override
+  public void addNormsField(FieldInfo fieldInfo, NormsProducer normsProducer) throws IOException {
+    in.addNormsField(fieldInfo, normsProducer);
+  }
+
+  @Override
+  public void close() throws IOException {
+    in.close();
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterNormsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterNormsFormat.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.NormsConsumer;
+import org.apache.lucene.codecs.NormsFormat;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+/** NormsFormat implementation that delegates calls to another NormsFormat. */
+public abstract class FilterNormsFormat extends NormsFormat {
+  protected final NormsFormat in;
+
+  public FilterNormsFormat(NormsFormat in) {
+    this.in = in;
+  }
+
+  @Override
+  public NormsConsumer normsConsumer(SegmentWriteState var1) throws IOException {
+    return in.normsConsumer(var1);
+  }
+
+  @Override
+  public NormsProducer normsProducer(SegmentReadState var1) throws IOException {
+    return in.normsProducer(var1);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterPointsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterPointsFormat.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.PointsFormat;
+import org.apache.lucene.codecs.PointsReader;
+import org.apache.lucene.codecs.PointsWriter;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+/** PointsFormat implementation that delegates calls to another PointsFormat. */
+public abstract class FilterPointsFormat extends PointsFormat {
+  protected final PointsFormat in;
+
+  public FilterPointsFormat(PointsFormat in) {
+    this.in = in;
+  }
+
+  @Override
+  public PointsWriter fieldsWriter(SegmentWriteState var1) throws IOException {
+    return in.fieldsWriter(var1);
+  }
+
+  @Override
+  public PointsReader fieldsReader(SegmentReadState var1) throws IOException {
+    return in.fieldsReader(var1);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterPointsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterPointsWriter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.PointsReader;
+import org.apache.lucene.codecs.PointsWriter;
+import org.apache.lucene.index.FieldInfo;
+
+/** PointsWriter implementation that delegates calls to another PointsWriter. */
+public abstract class FilterPointsWriter extends PointsWriter {
+  protected final PointsWriter in;
+
+  public FilterPointsWriter(PointsWriter in) {
+    this.in = in;
+  }
+
+  @Override
+  public void writeField(FieldInfo fieldInfo, PointsReader pointsReader) throws IOException {
+    in.writeField(fieldInfo, pointsReader);
+  }
+
+  @Override
+  public void finish() throws IOException {
+    in.finish();
+  }
+
+  @Override
+  public void close() throws IOException {
+    in.close();
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterPostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterPostingsFormat.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+/** PostingsFormat implementation that delegates calls to another PostingsFormat. */
+public abstract class FilterPostingsFormat extends PostingsFormat {
+  PostingsFormat in;
+
+  public FilterPostingsFormat(PostingsFormat in) {
+    super(in.getName());
+    this.in = in;
+  }
+
+  @Override
+  public FieldsConsumer fieldsConsumer(SegmentWriteState var1) throws IOException {
+    return in.fieldsConsumer(var1);
+  }
+
+  @Override
+  public FieldsProducer fieldsProducer(SegmentReadState var1) throws IOException {
+    return in.fieldsProducer(var1);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterStoredFieldsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterStoredFieldsFormat.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.StoredFieldsFormat;
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.codecs.StoredFieldsWriter;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+
+/** StoredFieldsFormat implementation that delegates calls to another StoredFieldsFormat. */
+public abstract class FilterStoredFieldsFormat extends StoredFieldsFormat {
+  protected final StoredFieldsFormat in;
+
+  public FilterStoredFieldsFormat(StoredFieldsFormat in) {
+    this.in = in;
+  }
+
+  @Override
+  public StoredFieldsReader fieldsReader(
+      Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext ioContext)
+      throws IOException {
+    return in.fieldsReader(directory, segmentInfo, fieldInfos, ioContext);
+  }
+
+  @Override
+  public StoredFieldsWriter fieldsWriter(
+      Directory directory, SegmentInfo segmentInfo, IOContext ioContext) throws IOException {
+    return in.fieldsWriter(directory, segmentInfo, ioContext);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterStoredFieldsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterStoredFieldsWriter.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.StoredFieldsWriter;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexableField;
+
+/** StoredFieldsWriter implementation that delegates calls to another StoredFieldsWriter. */
+public abstract class FilterStoredFieldsWriter extends StoredFieldsWriter {
+  protected final StoredFieldsWriter in;
+
+  public FilterStoredFieldsWriter(StoredFieldsWriter in) {
+    this.in = in;
+  }
+
+  @Override
+  public void startDocument() throws IOException {
+    in.startDocument();
+  }
+
+  @Override
+  public void writeField(FieldInfo fieldInfo, IndexableField indexableField) throws IOException {
+    in.writeField(fieldInfo, indexableField);
+  }
+
+  @Override
+  public void finish(int i) throws IOException {
+    in.finish(i);
+  }
+
+  @Override
+  public void close() throws IOException {
+    in.close();
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return 0;
+  }
+
+  @Override
+  public void finishDocument() throws IOException {
+    in.finishDocument();
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterTermVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterTermVectorsFormat.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.TermVectorsFormat;
+import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsWriter;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+
+/** TermVectorsFormat implementation that delegates calls to another TermVectorsFormat. */
+public abstract class FilterTermVectorsFormat extends TermVectorsFormat {
+  protected final TermVectorsFormat in;
+
+  public FilterTermVectorsFormat(TermVectorsFormat in) {
+    this.in = in;
+  }
+
+  @Override
+  public TermVectorsReader vectorsReader(
+      Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext ioContext)
+      throws IOException {
+    return in.vectorsReader(directory, segmentInfo, fieldInfos, ioContext);
+  }
+
+  @Override
+  public TermVectorsWriter vectorsWriter(
+      Directory directory, SegmentInfo segmentInfo, IOContext ioContext) throws IOException {
+    return in.vectorsWriter(directory, segmentInfo, ioContext);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterTermVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/FilterTermVectorsWriter.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.TermVectorsWriter;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.util.BytesRef;
+
+/** TermVectorsWriter implementation that delegates calls to another TermVectorsWriter. */
+public abstract class FilterTermVectorsWriter extends TermVectorsWriter {
+  protected final TermVectorsWriter in;
+
+  public FilterTermVectorsWriter(TermVectorsWriter in) {
+    this.in = in;
+  }
+
+  @Override
+  public void startDocument(int i) throws IOException {
+    in.startDocument(i);
+  }
+
+  @Override
+  public void startField(FieldInfo fieldInfo, int i, boolean b, boolean b1, boolean b2)
+      throws IOException {
+    in.startField(fieldInfo, i, b, b1, b2);
+  }
+
+  @Override
+  public void startTerm(BytesRef bytesRef, int i) throws IOException {
+    in.startTerm(bytesRef, i);
+  }
+
+  @Override
+  public void addPosition(int i, int i1, int i2, BytesRef bytesRef) throws IOException {
+    in.addPosition(i, i1, i2, bytesRef);
+  }
+
+  @Override
+  public void finish(int i) throws IOException {
+    in.finish(i);
+  }
+
+  @Override
+  public void close() throws IOException {
+    in.close();
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return in.ramBytesUsed();
+  }
+
+  @Override
+  public void finishDocument() throws IOException {
+    in.finishDocument();
+  }
+
+  @Override
+  public void finishField() throws IOException {
+    in.finishField();
+  }
+
+  @Override
+  public void finishTerm() throws IOException {
+    in.finishTerm();
+  }
+
+  @Override
+  public void addProx(int numProx, DataInput positions, DataInput offsets) throws IOException {
+    in.addProx(numProx, positions, offsets);
+  }
+
+  @Override
+  public int merge(MergeState mergeState) throws IOException {
+    return in.merge(mergeState);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/MergeTimeTrackingCodec.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/MergeTimeTrackingCodec.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.*;
+import org.apache.lucene.index.*;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+
+/**
+ * A codec track the merge time of each part of index and vent it to {@link TimeMetric} It forwards
+ * all its method calls to another codec.
+ */
+public class MergeTimeTrackingCodec extends FilterCodec {
+  private final TimeMetric metric;
+
+  public MergeTimeTrackingCodec(Codec codec, TimeMetric metric) {
+    super(codec.getName(), codec);
+    this.metric = metric;
+  }
+
+  @Override
+  public DocValuesFormat docValuesFormat() {
+    DocValuesFormat docValuesFormat = delegate.docValuesFormat();
+    return new FilterDocValuesFormat(docValuesFormat) {
+      @Override
+      public DocValuesConsumer fieldsConsumer(SegmentWriteState var1) throws IOException {
+        return new FilterDocValuesConsumer(in.fieldsConsumer(var1)) {
+          @Override
+          public void merge(MergeState mergeState) throws IOException {
+            long t0 = System.nanoTime();
+            in.merge(mergeState);
+            metric.addNano("DocValuesMergeTime", System.nanoTime() - t0);
+          }
+        };
+      }
+    };
+  }
+
+  @Override
+  public PointsFormat pointsFormat() {
+    PointsFormat pointsFormat = delegate.pointsFormat();
+    return new FilterPointsFormat(pointsFormat) {
+      @Override
+      public PointsWriter fieldsWriter(SegmentWriteState var1) throws IOException {
+        return new FilterPointsWriter(in.fieldsWriter(var1)) {
+          @Override
+          public void merge(MergeState mergeState) throws IOException {
+            long t0 = System.nanoTime();
+            in.merge(mergeState);
+            metric.addNano("PointsMergeTime", System.nanoTime() - t0);
+          }
+        };
+      }
+    };
+  }
+
+  @Override
+  public NormsFormat normsFormat() {
+    NormsFormat normsFormat = delegate.normsFormat();
+    return new FilterNormsFormat(normsFormat) {
+      @Override
+      public NormsConsumer normsConsumer(SegmentWriteState var1) throws IOException {
+        return new FilterNormsConsumer(in.normsConsumer(var1)) {
+          @Override
+          public void merge(MergeState mergeState) throws IOException {
+            long t0 = System.nanoTime();
+            in.merge(mergeState);
+            metric.addNano("NormsMergeTime", System.nanoTime() - t0);
+          }
+        };
+      }
+    };
+  }
+
+  @Override
+  public PostingsFormat postingsFormat() {
+    PostingsFormat postingsFormat = delegate.postingsFormat();
+
+    return new FilterPostingsFormat(postingsFormat) {
+      @Override
+      public FieldsConsumer fieldsConsumer(SegmentWriteState var1) throws IOException {
+        return new FilterFieldsConsumer(in.fieldsConsumer(var1)) {
+          @Override
+          public void merge(MergeState mergeState, NormsProducer norms) throws IOException {
+            long t0 = System.nanoTime();
+            in.merge(mergeState, norms);
+            metric.addNano("PostingsMergeTime", System.nanoTime() - t0);
+          }
+        };
+      }
+    };
+  }
+
+  @Override
+  public StoredFieldsFormat storedFieldsFormat() {
+    StoredFieldsFormat storedFieldsFormat = delegate.storedFieldsFormat();
+    return new FilterStoredFieldsFormat(storedFieldsFormat) {
+      @Override
+      public StoredFieldsWriter fieldsWriter(
+          Directory directory, SegmentInfo segmentInfo, IOContext ioContext) throws IOException {
+        return new FilterStoredFieldsWriter(in.fieldsWriter(directory, segmentInfo, ioContext)) {
+          @Override
+          public int merge(MergeState mergeState) throws IOException {
+            long t0 = System.nanoTime();
+            int docCount = in.merge(mergeState);
+            metric.addNano("StoredFieldsMergeTime", System.nanoTime() - t0);
+            return docCount;
+          }
+        };
+      }
+    };
+  }
+
+  @Override
+  public final TermVectorsFormat termVectorsFormat() {
+    TermVectorsFormat termVectorsFormat = delegate.termVectorsFormat();
+    return new FilterTermVectorsFormat(termVectorsFormat) {
+      @Override
+      public TermVectorsWriter vectorsWriter(
+          Directory directory, SegmentInfo segmentInfo, IOContext ioContext) throws IOException {
+        TermVectorsWriter termVectorsWriter = in.vectorsWriter(directory, segmentInfo, ioContext);
+        return new FilterTermVectorsWriter(termVectorsWriter) {
+          @Override
+          public int merge(MergeState mergeState) throws IOException {
+            long t0 = System.nanoTime();
+            int docCount = in.merge(mergeState);
+            metric.addNano("TermVectorsMergeTime", System.nanoTime() - t0);
+            return docCount;
+          }
+        };
+      }
+    };
+  }
+
+  @Override
+  public final KnnVectorsFormat knnVectorsFormat() {
+    KnnVectorsFormat knnVectorsFormat = delegate.knnVectorsFormat();
+    return new FilterKnnVectorsFormat(knnVectorsFormat) {
+      @Override
+      public KnnVectorsWriter fieldsWriter(SegmentWriteState var1) throws IOException {
+        return new FilterKnnVectorsWriter(in.fieldsWriter(var1)) {
+          @Override
+          public void merge(final MergeState mergeState) throws IOException {
+            long t0 = System.nanoTime();
+            in.merge(mergeState);
+            metric.addNano("KnnVectorsMergeTime", System.nanoTime() - t0);
+          }
+        };
+      }
+    };
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/TimeMetric.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/TimeMetric.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.monitoring;
+
+/** An interface to be implemented by application's monitoring system */
+public interface TimeMetric {
+  void addNano(String var1, long var2);
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/monitoring/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/monitoring/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Monitoring Helper Classes */
+package org.apache.lucene.codecs.monitoring;


### PR DESCRIPTION
This PR add filter class for each index format classes and their writer/producer/reader/consumer and add a tracking codec class to track merge time of each index part.
#11706
[Jira Issue Link](https://issues.apache.org/jira/projects/LUCENE/issues/LUCENE-10670) 


