### PR TITLE
Optimize TermInSetQuery for terms that match all docs in a segment

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -108,6 +108,9 @@ Optimizations
 
 * LUCENE-10627: Using ByteBuffersDataInput reduce memory copy on compressing data. (luyuncheng)
 
+* GITHUB#1062: Optimize TermInSetQuery when a term is present that matches all docs in a segment.
+  (Greg Miller)
+
 Bug Fixes
 ---------------------
 * LUCENE-10663: Fix KnnVectorQuery explain with multiple segments. (Shiming Li)

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
@@ -48,7 +48,7 @@ public abstract class DocIdSet implements Accountable {
         }
       };
 
-  /** A {@code DocIdSet} that matches all doc ids up to a specified value. */
+  /** A {@code DocIdSet} that matches all doc ids up to a specified doc (exclusive). */
   public static DocIdSet all(int maxDoc) {
     return new DocIdSet() {
       @Override

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
@@ -48,6 +48,26 @@ public abstract class DocIdSet implements Accountable {
         }
       };
 
+  /** A {@code DocIdSet} that matches all doc ids up to a specified value. */
+  public static DocIdSet all(int maxDoc) {
+    return new DocIdSet() {
+      @Override
+      public DocIdSetIterator iterator() throws IOException {
+        return DocIdSetIterator.all(maxDoc);
+      }
+
+      @Override
+      public Bits bits() throws IOException {
+        return new Bits.MatchAllBits(maxDoc);
+      }
+
+      @Override
+      public long ramBytesUsed() {
+        return Integer.BYTES;
+      }
+    };
+  }
+
   /**
    * Provides a {@link DocIdSetIterator} to access the set. This implementation can return <code>
    * null</code> if there are no docs that match.

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -38,7 +38,6 @@ import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.DocIdSetBuilder;
@@ -284,7 +283,7 @@ public class TermInSetQuery extends Query implements Accountable {
           if (termsEnum.seekExact(term)) {
             if (matchingTerms == null) {
               if (reader.maxDoc() == termsEnum.docFreq()) {
-                return new WeightOrDocIdSet(new MatchAllDocIdSet(reader.maxDoc()));
+                return new WeightOrDocIdSet(DocIdSet.all(reader.maxDoc()));
               }
               docs = termsEnum.postings(docs, PostingsEnum.NONE);
               builder.add(docs);
@@ -298,7 +297,7 @@ public class TermInSetQuery extends Query implements Accountable {
               for (TermAndState t : matchingTerms) {
                 t.termsEnum.seekExact(t.term, t.state);
                 if (reader.maxDoc() == t.docFreq) {
-                  return new WeightOrDocIdSet(new MatchAllDocIdSet(reader.maxDoc()));
+                  return new WeightOrDocIdSet(DocIdSet.all(reader.maxDoc()));
                 }
                 docs = t.termsEnum.postings(docs, PostingsEnum.NONE);
                 builder.add(docs);
@@ -369,29 +368,6 @@ public class TermInSetQuery extends Query implements Accountable {
         // with the query cache if most memory ends up being spent on queries rather than doc id
         // sets.
         return ramBytesUsed() <= RamUsageEstimator.QUERY_DEFAULT_RAM_BYTES_USED;
-      }
-
-      static final class MatchAllDocIdSet extends DocIdSet {
-        private final int size;
-
-        MatchAllDocIdSet(int size) {
-          this.size = size;
-        }
-
-        @Override
-        public DocIdSetIterator iterator() throws IOException {
-          return DocIdSetIterator.all(size);
-        }
-
-        @Override
-        public Bits bits() throws IOException {
-          return new Bits.MatchAllBits(size);
-        }
-
-        @Override
-        public long ramBytesUsed() {
-          return Integer.BYTES;
-        }
       }
     };
   }

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -292,6 +292,9 @@ public class TermInSetQuery extends Query implements Accountable {
             } else {
               assert matchingTerms.size() == threshold;
               builder = new DocIdSetBuilder(reader.maxDoc(), terms);
+              if (reader.maxDoc() == termsEnum.docFreq()) {
+                return new WeightOrDocIdSet(DocIdSet.all(reader.maxDoc()));
+              }
               docs = termsEnum.postings(docs, PostingsEnum.NONE);
               builder.add(docs);
               for (TermAndState t : matchingTerms) {

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -38,6 +38,7 @@ import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.DocIdSetBuilder;
@@ -283,7 +284,7 @@ public class TermInSetQuery extends Query implements Accountable {
           if (termsEnum.seekExact(term)) {
             if (matchingTerms == null) {
               if (reader.maxDoc() == termsEnum.docFreq()) {
-                builder.add(DocIdSetIterator.all(reader.maxDoc()));
+                return new WeightOrDocIdSet(new MatchAllDocIdSet(reader.maxDoc()));
               } else {
                 docs = termsEnum.postings(docs, PostingsEnum.NONE);
                 builder.add(docs);
@@ -298,7 +299,7 @@ public class TermInSetQuery extends Query implements Accountable {
               for (TermAndState t : matchingTerms) {
                 t.termsEnum.seekExact(t.term, t.state);
                 if (reader.maxDoc() == t.docFreq) {
-                  builder.add(DocIdSetIterator.all(reader.maxDoc()));
+                  return new WeightOrDocIdSet(new MatchAllDocIdSet(reader.maxDoc()));
                 } else {
                   docs = t.termsEnum.postings(docs, PostingsEnum.NONE);
                   builder.add(docs);
@@ -370,6 +371,29 @@ public class TermInSetQuery extends Query implements Accountable {
         // with the query cache if most memory ends up being spent on queries rather than doc id
         // sets.
         return ramBytesUsed() <= RamUsageEstimator.QUERY_DEFAULT_RAM_BYTES_USED;
+      }
+
+      static final class MatchAllDocIdSet extends DocIdSet {
+        private final int size;
+
+        MatchAllDocIdSet(int size) {
+          this.size = size;
+        }
+
+        @Override
+        public DocIdSetIterator iterator() throws IOException {
+          return DocIdSetIterator.all(size);
+        }
+
+        @Override
+        public Bits bits() throws IOException {
+          return new Bits.MatchAllBits(size);
+        }
+
+        @Override
+        public long ramBytesUsed() {
+          return Integer.BYTES;
+        }
       }
     };
   }

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -285,10 +285,9 @@ public class TermInSetQuery extends Query implements Accountable {
             if (matchingTerms == null) {
               if (reader.maxDoc() == termsEnum.docFreq()) {
                 return new WeightOrDocIdSet(new MatchAllDocIdSet(reader.maxDoc()));
-              } else {
-                docs = termsEnum.postings(docs, PostingsEnum.NONE);
-                builder.add(docs);
               }
+              docs = termsEnum.postings(docs, PostingsEnum.NONE);
+              builder.add(docs);
             } else if (matchingTerms.size() < threshold) {
               matchingTerms.add(new TermAndState(field, termsEnum));
             } else {
@@ -300,10 +299,9 @@ public class TermInSetQuery extends Query implements Accountable {
                 t.termsEnum.seekExact(t.term, t.state);
                 if (reader.maxDoc() == t.docFreq) {
                   return new WeightOrDocIdSet(new MatchAllDocIdSet(reader.maxDoc()));
-                } else {
-                  docs = t.termsEnum.postings(docs, PostingsEnum.NONE);
-                  builder.add(docs);
                 }
+                docs = t.termsEnum.postings(docs, PostingsEnum.NONE);
+                builder.add(docs);
               }
               matchingTerms = null;
             }

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -282,8 +282,12 @@ public class TermInSetQuery extends Query implements Accountable {
           assert field.equals(iterator.field());
           if (termsEnum.seekExact(term)) {
             if (matchingTerms == null) {
-              docs = termsEnum.postings(docs, PostingsEnum.NONE);
-              builder.add(docs);
+              if (reader.maxDoc() == termsEnum.docFreq()) {
+                builder.add(DocIdSetIterator.all(reader.maxDoc()));
+              } else {
+                docs = termsEnum.postings(docs, PostingsEnum.NONE);
+                builder.add(docs);
+              }
             } else if (matchingTerms.size() < threshold) {
               matchingTerms.add(new TermAndState(field, termsEnum));
             } else {
@@ -293,8 +297,12 @@ public class TermInSetQuery extends Query implements Accountable {
               builder.add(docs);
               for (TermAndState t : matchingTerms) {
                 t.termsEnum.seekExact(t.term, t.state);
-                docs = t.termsEnum.postings(docs, PostingsEnum.NONE);
-                builder.add(docs);
+                if (reader.maxDoc() == t.docFreq) {
+                  builder.add(DocIdSetIterator.all(reader.maxDoc()));
+                } else {
+                  docs = t.termsEnum.postings(docs, PostingsEnum.NONE);
+                  builder.add(docs);
+                }
               }
               matchingTerms = null;
             }

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
@@ -22,13 +22,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.StringField;

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
@@ -19,12 +19,16 @@ package org.apache.lucene.search;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.StringField;
@@ -48,6 +52,48 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 
 public class TestTermInSetQuery extends LuceneTestCase {
+
+  public void testAllDocsTerm() throws IOException {
+    Directory dir = newDirectory();
+    RandomIndexWriter iw = new RandomIndexWriter(random(), dir);
+    String field = "f";
+
+    BytesRef denseTerm = new BytesRef(TestUtil.randomAnalysisString(random(), 10, true));
+
+    Set<BytesRef> randomTerms = new HashSet<>();
+    while (randomTerms.size() < TermInSetQuery.BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD) {
+      randomTerms.add(new BytesRef(TestUtil.randomAnalysisString(random(), 10, true)));
+    }
+    assert randomTerms.size() == TermInSetQuery.BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD;
+    BytesRef[] otherTerms = new BytesRef[randomTerms.size()];
+    int idx = 0;
+    for (BytesRef term : randomTerms) {
+      otherTerms[idx++] = term;
+    }
+
+    int numDocs = 10 * otherTerms.length;
+    for (int i = 0; i < numDocs; i++) {
+      Document doc = new Document();
+      doc.add(new StringField(field, denseTerm, Store.NO));
+      BytesRef sparseTerm = otherTerms[i % otherTerms.length];
+      doc.add(new StringField(field, sparseTerm, Store.NO));
+      iw.addDocument(doc);
+    }
+
+    IndexReader reader = iw.getReader();
+    IndexSearcher searcher = newSearcher(reader);
+    iw.close();
+
+    List<BytesRef> queryTerms = Arrays.stream(otherTerms).collect(Collectors.toList());
+    queryTerms.add(denseTerm);
+
+    TermInSetQuery query = new TermInSetQuery(field, queryTerms);
+    TopDocs topDocs = searcher.search(query, numDocs);
+    assertEquals(numDocs, topDocs.totalHits.value);
+
+    reader.close();
+    dir.close();
+  }
 
   public void testDuel() throws IOException {
     final int iters = atLeast(2);


### PR DESCRIPTION
### Description (or a Jira issue link if you have one)

This change introduces an optimization to `TermInSetQuery` when a term is present that matches all docs in a segment.