### PR TITLE
LUCENE-10678: Fix potential overflow when computing the partition point on the BKD tree

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -116,6 +116,9 @@ Bug Fixes
 
 * LUCENE-10673: Improve check of equality for latitudes for spatial3d GeoBoundingBox (ignacio Vera)
 
+* LUCENE-10678: Fix potential overflow when building a BKD tree with more than 4 billion points. The overflow
+  occurs when computing the partition point. (Ignacio Vera)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -2018,7 +2018,7 @@ public class BKDWriter implements Closeable {
       // How many leaves will be in the left tree:
       final int numLeftLeafNodes = getNumLeftLeafNodes(numLeaves);
       // How many points will be in the left tree:
-      final long leftCount = numLeftLeafNodes * config.maxPointsInLeafNode;
+      final long leftCount = numLeftLeafNodes * (long) config.maxPointsInLeafNode;
 
       BKDRadixSelector.PathSlice[] slices = new BKDRadixSelector.PathSlice[2];
 

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/Test4BBKDPoints.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/Test4BBKDPoints.java
@@ -28,19 +28,19 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.Monster;
 import org.apache.lucene.util.NumericUtils;
 
-// e.g. run like this: ant test -Dtestcase=Test2BBKDPoints -Dtests.nightly=true -Dtests.verbose=true
+// e.g. run like this: ant test -Dtestcase=Test4BBKDPoints -Dtests.nightly=true -Dtests.verbose=true
 // -Dtests.monster=true
 //
 //   or: python -u /l/util/src/python/repeatLuceneTest.py -heap 4g -once -nolog -tmpDir /b/tmp
-// -logDir /l/logs Test2BBKDPoints.test2D -verbose
+// -logDir /l/logs Test4BBKDPoints.test2D -verbose
 
 @TimeoutSuite(millis = Integer.MAX_VALUE) // hopefully ~24 days is long enough ;)
 @Monster("takes at least 4 hours and consumes many GB of temp disk space")
-public class Test2BBKDPoints extends LuceneTestCase {
+public class Test4BBKDPoints extends LuceneTestCase {
   public void test1D() throws Exception {
-    Directory dir = FSDirectory.open(createTempDir("2BBKDPoints1D"));
+    Directory dir = FSDirectory.open(createTempDir("4BBKDPoints1D"));
 
-    final int numDocs = (Integer.MAX_VALUE / 26) + 100;
+    final int numDocs = (Integer.MAX_VALUE / 13) + 100;
 
     BKDWriter w =
         new BKDWriter(
@@ -83,9 +83,9 @@ public class Test2BBKDPoints extends LuceneTestCase {
   }
 
   public void test2D() throws Exception {
-    Directory dir = FSDirectory.open(createTempDir("2BBKDPoints2D"));
+    Directory dir = FSDirectory.open(createTempDir("4BBKDPoints2D"));
 
-    final int numDocs = (Integer.MAX_VALUE / 26) + 100;
+    final int numDocs = (Integer.MAX_VALUE / 13) + 100;
 
     BKDWriter w =
         new BKDWriter(


### PR DESCRIPTION
We currently compute the partition point for a set of points by multiplying the number of nodes that needs to be on the left of the BKD tree by the maxPointsInLeafNode. This multiplication is done on the integer space so if the partition point is bigger than Integer.MAX_VALUE it will overflow. 

This may happen for high dimension cases (numDims > 1) and when documents are multivalued. 

This PR moves the multiplication to the long space so it doesn't overflow.

In order to test it I modify the test `Test2BBKDPoints` to index 4Billion points instead and test is renamed accordingly. That should be fine, this test was developed before we improve the efficiency of the tree so CI should be ok running it in Monster runs.
