### PR TITLE
LUCENE-10654: Fix ShapeDocValue Bounding Box failure (#1066)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
@@ -194,7 +194,7 @@ public final class Tessellator {
         sortByMorton(outerNode);
       }
     }
-    if (checkSelfIntersections) {
+    if (checkSelfIntersections == true) {
       checkIntersection(outerNode, mortonOptimized);
     }
     // Calculate the tessellation using the doubly LinkedList.
@@ -1060,6 +1060,7 @@ public final class Tessellator {
     return isPointInLine(a, b, point.getX(), point.getY());
   }
 
+  /** returns true if the lon, lat point is colinear w/ the provided a and b point */
   private static boolean isPointInLine(
       final Node a, final Node b, final double lon, final double lat) {
     final double dxc = lon - a.getX();


### PR DESCRIPTION
Backport of #1066 to 9x

The base spatial test case may create invalid self crossing polygons. These
polygons are cleaned by the tessellator which may result in an inconsistent
bounding box between the tessellated shape and the original, invalid, geometry.
This commit fixes the shape doc value test case to compute the bounding box from
the cleaned geometry instead of relying on the, potentially invalid, original
geometry.