### PR TITLE
[LUCENE-2587] Highlighter fragment bug

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -62,6 +62,10 @@ Bug Fixes
 * LUCENE-10599: LogMergePolicy is more likely to keep merging segments until
   they reach the maximum merge size. (Adrien Grand)
 
+* LUCENE-2587: Computing the right offset in the case of trailing whitespaces.
+  and added a test case testForIssue2587 demonstrating the issue. Before the fix
+  this test case would fail, returning ". F <B>g</B> h i j" as hitline. (Roberto Minelli)
+
 Other
 ---------------------
 * LUCENE-10283: The minimum required Java version was bumped from 11 to 17.

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -64,7 +64,7 @@ Bug Fixes
 
 * LUCENE-2587: Computing the right offset in the case of trailing whitespaces.
   and added a test case testForIssue2587 demonstrating the issue. Before the fix
-  this test case would fail, returning ". F <B>g</B> h i j" as hitline. (Roberto Minelli)
+  this test case would fail, returning ". F <B>g</B> h i j" as hitline. (Roberto Minelli, Elliot Lin)
 
 Other
 ---------------------

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/Highlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/Highlighter.java
@@ -164,8 +164,7 @@ public class Highlighter {
 
     CharTermAttribute termAtt = tokenStream.addAttribute(CharTermAttribute.class);
     OffsetAttribute offsetAtt = tokenStream.addAttribute(OffsetAttribute.class);
-    TextFragment currentFrag =
-        new TextFragment(newText, newText.length(), -1, docFrags.size());
+    TextFragment currentFrag = new TextFragment(newText, newText.length(), -1, docFrags.size());
 
     if (fragmentScorer instanceof QueryScorer) {
       ((QueryScorer) fragmentScorer).setMaxDocCharsToAnalyze(maxDocCharsToAnalyze);

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/Highlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/Highlighter.java
@@ -164,7 +164,8 @@ public class Highlighter {
 
     CharTermAttribute termAtt = tokenStream.addAttribute(CharTermAttribute.class);
     OffsetAttribute offsetAtt = tokenStream.addAttribute(OffsetAttribute.class);
-    TextFragment currentFrag = new TextFragment(newText, newText.length(), docFrags.size());
+    TextFragment currentFrag =
+        new TextFragment(newText, newText.length(), -1, docFrags.size());
 
     if (fragmentScorer instanceof QueryScorer) {
       ((QueryScorer) fragmentScorer).setMaxDocCharsToAnalyze(maxDocCharsToAnalyze);
@@ -219,9 +220,12 @@ public class Highlighter {
             currentFrag.setScore(fragmentScorer.getFragmentScore());
             // record stats for a new fragment
             currentFrag.textEndPos = newText.length();
-            currentFrag = new TextFragment(newText, newText.length(), docFrags.size());
-            // XXX FIX FOR LUCENE-2587
-            //currentFrag = new TextFragment(newText, newText.length() + offsetAtt.startOffset() - endOffset, docFrags.size());
+            currentFrag =
+                new TextFragment(
+                    newText,
+                    newText.length() + offsetAtt.startOffset() - endOffset,
+                    newText.length(),
+                    docFrags.size());
             fragmentScorer.startFragment(currentFrag);
             docFrags.add(currentFrag);
           }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/Highlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/Highlighter.java
@@ -220,6 +220,8 @@ public class Highlighter {
             // record stats for a new fragment
             currentFrag.textEndPos = newText.length();
             currentFrag = new TextFragment(newText, newText.length(), docFrags.size());
+            // XXX FIX FOR LUCENE-2587
+            //currentFrag = new TextFragment(newText, newText.length() + offsetAtt.startOffset() - endOffset, docFrags.size());
             fragmentScorer.startFragment(currentFrag);
             docFrags.add(currentFrag);
           }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TextFragment.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TextFragment.java
@@ -19,13 +19,16 @@ package org.apache.lucene.search.highlight;
 public class TextFragment {
   CharSequence markedUpText;
   int fragNum;
+  int prevFragEndPos;
   int textStartPos;
   int textEndPos;
   float score;
 
-  public TextFragment(CharSequence markedUpText, int textStartPos, int fragNum) {
+  public TextFragment(
+      CharSequence markedUpText, int textStartPos, int prevFragEndPos, int fragNum) {
     this.markedUpText = markedUpText;
     this.textStartPos = textStartPos;
+    this.prevFragEndPos = prevFragEndPos;
     this.fragNum = fragNum;
   }
 
@@ -43,7 +46,7 @@ public class TextFragment {
   }
   /** @return true if this fragment follows the one passed */
   public boolean follows(TextFragment fragment) {
-    return textStartPos == fragment.textEndPos;
+    return prevFragEndPos == fragment.textEndPos;
   }
 
   /** @return the fragment sequence number */

--- a/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
@@ -2196,33 +2196,71 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
     }
   }
 
-public void testForIssue2587() throws Exception {
-    TestHighlightRunner helper = new TestHighlightRunner() {
-      @Override
-      void run() throws Exception {
-        TermQuery query = new TermQuery(new Term("data", "g"));
-        Highlighter hg = new Highlighter(new SimpleHTMLFormatter(), new QueryTermScorer(query));
-
-        hg.setTextFragmenter(new Fragmenter() {
-          private CharTermAttribute termAtt;
-
-          public void start(String originalText, TokenStream tokenStream) {
-            termAtt = tokenStream.addAttribute(CharTermAttribute.class);
-          }
-
+  /** Tests Highlighter fragments don't start with un-analyzed chars (e.g. punctuation here) */
+  public void testForIssue2587() throws Exception {
+    TestHighlightRunner helper =
+        new TestHighlightRunner() {
           @Override
-          public boolean isNewFragment() {
-            return (termAtt.toString().equals("f") || termAtt.toString().equals("k"));
+          void run() throws Exception {
+            TermQuery query = new TermQuery(new Term("data", "g"));
+            Highlighter hg = new Highlighter(new SimpleHTMLFormatter(), new QueryTermScorer(query));
+
+            hg.setTextFragmenter(
+                new Fragmenter() {
+                  private CharTermAttribute termAtt;
+
+                  @Override
+                  public void start(String originalText, TokenStream tokenStream) {
+                    termAtt = tokenStream.addAttribute(CharTermAttribute.class);
+                  }
+
+                  @Override
+                  public boolean isNewFragment() {
+                    return (termAtt.toString().equals("f") || termAtt.toString().equals("k"));
+                  }
+                });
+
+            String match =
+                hg.getBestFragment(analyzer, "data", "A b c d e... F g h i j! K l m n o. ");
+
+            assertEquals("F <B>g</B> h i j", match);
           }
-        });
-
-        String match = hg.getBestFragment(analyzer, "data", "A b c d e... F g h i j! K l m n o. ");
-
-        assertEquals("F <B>g</B> h i j", match);
-      }
-    };
+        };
     helper.start();
-}
+  }
+
+  /** Tests that Highlighter merges adjacent fragments, including chars not analyzed. */
+  public void testForIssue2587AdjacentFragments() throws Exception {
+    TestHighlightRunner helper =
+        new TestHighlightRunner() {
+          @Override
+          void run() throws Exception {
+            TermQuery query = new TermQuery(new Term("data", "g"));
+            Highlighter hg = new Highlighter(new SimpleHTMLFormatter(), new QueryTermScorer(query));
+
+            hg.setTextFragmenter(
+                new Fragmenter() {
+                  private CharTermAttribute termAtt;
+
+                  @Override
+                  public void start(String originalText, TokenStream tokenStream) {
+                    termAtt = tokenStream.addAttribute(CharTermAttribute.class);
+                  }
+
+                  @Override
+                  public boolean isNewFragment() {
+                    return (termAtt.toString().equals("f") || termAtt.toString().equals("k"));
+                  }
+                });
+
+            String[] matches =
+                hg.getBestFragments(analyzer, "data", "A b c d e... F g h i j! K l m n o. ", 2);
+
+            assertArrayEquals(new String[] {"A b c d e... F <B>g</B> h i j"}, matches);
+          }
+        };
+    helper.start();
+  }
 
   @Override
   public String highlightTerm(String originalText, TokenGroup group) {


### PR DESCRIPTION
### Description (or a Jira issue link if you have one)
#3661
[LUCENE-2587](https://issues.apache.org/jira/browse/LUCENE-2587) 

The issue has a good write up of the bug.

To summarize, we start new fragments at the end offset of the previous fragment instead of the start offset of the first token of the fragment, which potentially introduces spurious un-analyzed chars in the fragment. To take the test case as an example, we analyze out punctuation when tokenizing the string. However when highlighting the fragment containing the hit we get a fragment that starts with a period `.`.

The fix here starts new fragments at the start offset of the token that leads the new fragment. We also store the end offset of the antecedent fragment so we can use that to determine whether we can merge contiguous fragments.
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
