### PR TITLE
LUCENE-10577: Remove KnnVectorsFormat#currentVersion

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/TestLucene90HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/TestLucene90HnswVectorsFormat.java
@@ -22,12 +22,19 @@ import static org.apache.lucene.backward_codecs.lucene90.Lucene90HnswVectorsForm
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 
 public class TestLucene90HnswVectorsFormat extends BaseKnnVectorsFormatTestCase {
   @Override
   protected Codec getCodec() {
     return new Lucene90RWCodec();
+  }
+
+  @Override
+  protected VectorEncoding randomVectorEncoding() {
+    // Older formats only support float vectors
+    return VectorEncoding.FLOAT32;
   }
 
   public void testToString() {

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/TestLucene91HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/TestLucene91HnswVectorsFormat.java
@@ -22,12 +22,19 @@ import static org.apache.lucene.backward_codecs.lucene91.Lucene91HnswVectorsForm
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 
 public class TestLucene91HnswVectorsFormat extends BaseKnnVectorsFormatTestCase {
   @Override
   protected Codec getCodec() {
     return new Lucene91RWCodec();
+  }
+
+  @Override
+  protected VectorEncoding randomVectorEncoding() {
+    // Older formats only support float vectors
+    return VectorEncoding.FLOAT32;
   }
 
   public void testToString() {

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/TestLucene92HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/TestLucene92HnswVectorsFormat.java
@@ -18,12 +18,19 @@ package org.apache.lucene.backward_codecs.lucene92;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 
 public class TestLucene92HnswVectorsFormat extends BaseKnnVectorsFormatTestCase {
   @Override
   protected Codec getCodec() {
     return new Lucene92RWCodec();
+  }
+
+  @Override
+  protected VectorEncoding randomVectorEncoding() {
+    // Older formats only support float vectors
+    return VectorEncoding.FLOAT32;
   }
 
   public void testToString() {

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -18,7 +18,6 @@
 package org.apache.lucene.codecs;
 
 import java.io.IOException;
-import org.apache.lucene.codecs.lucene94.Lucene94HnswVectorsFormat;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.VectorValues;
@@ -77,15 +76,6 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
 
   /** Returns a {@link KnnVectorsReader} to read the vectors from the index. */
   public abstract KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException;
-
-  /**
-   * Returns the current KnnVectorsFormat version number. Indexes written using the format will be
-   * "stamped" with this version.
-   */
-  public int currentVersion() {
-    // return the version supported by older codecs that did not override this method
-    return Lucene94HnswVectorsFormat.VERSION_START;
-  }
 
   /**
    * EMPTY throws an exception when written. It acts as a sentinel indicating a Codec that does not

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene94/Lucene94Codec.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene94/Lucene94Codec.java
@@ -99,11 +99,6 @@ public class Lucene94Codec extends Codec {
         public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
           return Lucene94Codec.this.getKnnVectorsFormatForField(field);
         }
-
-        @Override
-        public int currentVersion() {
-          return Lucene94HnswVectorsFormat.VERSION_CURRENT;
-        }
       };
 
   private final StoredFieldsFormat storedFieldsFormat;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene94/Lucene94HnswVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene94/Lucene94HnswVectorsFormat.java
@@ -158,11 +158,6 @@ public final class Lucene94HnswVectorsFormat extends KnnVectorsFormat {
   }
 
   @Override
-  public int currentVersion() {
-    return VERSION_CURRENT;
-  }
-
-  @Override
   public String toString() {
     return "Lucene94HnswVectorsFormat(name=Lucene94HnswVectorsFormat, maxConn="
         + maxConn

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -670,14 +670,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         random().nextInt(VectorSimilarityFunction.values().length)];
   }
 
-  private VectorEncoding randomVectorEncoding() {
-    Codec codec = getCodec();
-    if (codec.knnVectorsFormat().currentVersion()
-        >= Codec.forName("Lucene94").knnVectorsFormat().currentVersion()) {
-      return VectorEncoding.values()[random().nextInt(VectorEncoding.values().length)];
-    } else {
-      return VectorEncoding.FLOAT32;
-    }
+  /**
+   * This method is overrideable since old codec versions only support {@link
+   * VectorEncoding#FLOAT32}.
+   */
+  protected VectorEncoding randomVectorEncoding() {
+    return VectorEncoding.values()[random().nextInt(VectorEncoding.values().length)];
   }
 
   public void testIndexedValueNotAliased() throws Exception {


### PR DESCRIPTION
These internal versions only make sense within a codec definition, and aren't
meant to be exposed and compared across codecs. Since this method is only used
in tests, we can move the check to the test classes instead.

Follow-up to #1054.