### PR TITLE
Add Integer awareness to RamUsageEstimator.sizeOf

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -97,6 +97,8 @@ Improvements
 ---------------------
 * LUCENE-10592: Build HNSW Graph on indexing. (Mayya Sharipova, Adrien Grand, Julie Tibshirani)
 
+* GITHUB#11715: Add Integer awareness to RamUsageEstimator.sizeOf (Mike Drob)
+
 Optimizations
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
@@ -209,9 +209,10 @@ public final class RamUsageEstimator {
   }
 
   /**
-   * Return the size of the provided {@link Integer} object, returning 0 if it is cached by the JVM and
-   * its shallow size otherwise.
+   * Return the size of the provided {@link Integer} object, returning 0 if it is cached by the JVM
+   * and its shallow size otherwise.
    */
+  @SuppressWarnings("BoxedPrimitiveEquality")
   public static long sizeOf(Integer value) {
     // Explicitly need to use reference equality and unboxing to check for the cache
     return value == Integer.valueOf(value.intValue()) ? 0 : INTEGER_SIZE;
@@ -221,6 +222,7 @@ public final class RamUsageEstimator {
    * Return the size of the provided {@link Long} object, returning 0 if it is cached by the JVM and
    * its shallow size otherwise.
    */
+  @SuppressWarnings("BoxedPrimitiveEquality")
   public static long sizeOf(Long value) {
     // Explicitly need to use reference equality and unboxing to check for the cache
     return value == Long.valueOf(value.longValue()) ? 0 : LONG_SIZE;

--- a/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
@@ -107,7 +107,6 @@ public final class RamUsageEstimator {
     primitiveSizes = Collections.unmodifiableMap(primitiveSizesMap);
   }
 
-  /** JVMs typically cache small longs. This tries to find out what the range is. */
   static final int INTEGER_SIZE, LONG_SIZE, STRING_SIZE;
 
   /** For testing only */
@@ -209,23 +208,19 @@ public final class RamUsageEstimator {
   }
 
   /**
-   * Return the size of the provided {@link Integer} object, returning 0 if it is cached by the JVM
-   * and its shallow size otherwise.
+   * Return the shallow size of the provided {@link Integer} object. Ignores the possibility that
+   * this object is part of the VM IntegerCache
    */
-  @SuppressWarnings("BoxedPrimitiveEquality")
-  public static long sizeOf(Integer value) {
-    // Explicitly need to use reference equality and unboxing to check for the cache
-    return value == Integer.valueOf(value.intValue()) ? 0 : INTEGER_SIZE;
+  public static long sizeOf(Integer ignored) {
+    return INTEGER_SIZE;
   }
 
   /**
-   * Return the size of the provided {@link Long} object, returning 0 if it is cached by the JVM and
-   * its shallow size otherwise.
+   * Return the shallow size of the provided {@link Long} object. Ignores the possibility that this
+   * object is part of the VM LongCache
    */
-  @SuppressWarnings("BoxedPrimitiveEquality")
-  public static long sizeOf(Long value) {
-    // Explicitly need to use reference equality and unboxing to check for the cache
-    return value == Long.valueOf(value.longValue()) ? 0 : LONG_SIZE;
+  public static long sizeOf(Long ignored) {
+    return LONG_SIZE;
   }
 
   /** Returns the size in bytes of the byte[] object. */

--- a/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
@@ -108,7 +108,7 @@ public final class RamUsageEstimator {
   }
 
   /** JVMs typically cache small longs. This tries to find out what the range is. */
-  static final int LONG_SIZE, STRING_SIZE;
+  static final int INTEGER_SIZE, LONG_SIZE, STRING_SIZE;
 
   /** For testing only */
   static final boolean JVM_IS_HOTSPOT_64BIT;
@@ -187,6 +187,7 @@ public final class RamUsageEstimator {
       NUM_BYTES_ARRAY_HEADER = NUM_BYTES_OBJECT_HEADER + Integer.BYTES;
     }
 
+    INTEGER_SIZE = (int) shallowSizeOfInstance(Integer.class);
     LONG_SIZE = (int) shallowSizeOfInstance(Long.class);
     STRING_SIZE = (int) shallowSizeOfInstance(String.class);
   }
@@ -208,11 +209,21 @@ public final class RamUsageEstimator {
   }
 
   /**
+   * Return the size of the provided {@link Integer} object, returning 0 if it is cached by the JVM and
+   * its shallow size otherwise.
+   */
+  public static long sizeOf(Integer value) {
+    // Explicitly need to use reference equality and unboxing to check for the cache
+    return value == Integer.valueOf(value.intValue()) ? 0 : INTEGER_SIZE;
+  }
+
+  /**
    * Return the size of the provided {@link Long} object, returning 0 if it is cached by the JVM and
    * its shallow size otherwise.
    */
   public static long sizeOf(Long value) {
-    return LONG_SIZE;
+    // Explicitly need to use reference equality and unboxing to check for the cache
+    return value == Long.valueOf(value.longValue()) ? 0 : LONG_SIZE;
   }
 
   /** Returns the size in bytes of the byte[] object. */
@@ -456,6 +467,8 @@ public final class RamUsageEstimator {
       size = sizeOf((float[]) o);
     } else if (o instanceof int[]) {
       size = sizeOf((int[]) o);
+    } else if (o instanceof Integer) {
+      size = sizeOf((Integer) o);
     } else if (o instanceof Long) {
       size = sizeOf((Long) o);
     } else if (o instanceof long[]) {


### PR DESCRIPTION
Add RamUsageEstimator.sizeOf(Integer)
Improve estimation for both Long and Integer to not count VM Cache values.