### PR TITLE
Fix repeating token sentence boundary bug

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -110,6 +110,12 @@ Bug Fixes
   trying to apply a dictionary whose size is greater than the maximum supported
   window size for LZ4. (Adrien Grand)
 
+* GITHUB#11735: KeywordRepeatFilter + OpenNLPLemmatizer always drops last token of a stream.
+  (Luke Kot-Zaniewski)
+
+* GITHUB#11771: KeywordRepeatFilter + OpenNLPLemmatizer sometimes arbitrarily exits token stream.
+  (Luke Kot-Zaniewski)
+
 Other
 ---------------------
 * LUCENE-10423: Remove usages of System.currentTimeMillis() from tests. (Marios Trivyzas)

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPChunkerFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPChunkerFilter.java
@@ -54,7 +54,7 @@ public final class OpenNLPChunkerFilter extends TokenFilter {
     List<AttributeSource> sentenceTokenAttrs = sentenceAttributeExtractor.getSentenceAttributes();
     boolean readNextSentence =
         tokenNum >= sentenceTokenAttrs.size()
-            && sentenceAttributeExtractor.areMoreTokensAvailable();
+            && sentenceAttributeExtractor.areMoreSentencesAvailable();
     if (readNextSentence) {
       nextSentence();
       assignTokenTypes(chunkerOp.getChunks(sentenceTerms, sentenceTermPOSTags, null));

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPChunkerFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPChunkerFilter.java
@@ -17,17 +17,18 @@
 
 package org.apache.lucene.analysis.opennlp;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.opennlp.tools.NLPChunkerOp;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.lucene.analysis.tokenattributes.FlagsAttribute;
+import org.apache.lucene.analysis.tokenattributes.SentenceAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.IgnoreRandomChains;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Run OpenNLP chunker. Prerequisite: the OpenNLPTokenizer and OpenNLPPOSFilter must precede this
@@ -36,74 +37,61 @@ import org.apache.lucene.util.IgnoreRandomChains;
  */
 @IgnoreRandomChains(reason = "other filters must precede this one (see docs)")
 public final class OpenNLPChunkerFilter extends TokenFilter {
-
-  private List<AttributeSource> sentenceTokenAttrs = new ArrayList<>();
   private int tokenNum = 0;
-  private boolean moreTokensAvailable = true;
   private String[] sentenceTerms = null;
   private String[] sentenceTermPOSTags = null;
-
   private final NLPChunkerOp chunkerOp;
-  private final TypeAttribute typeAtt = addAttribute(TypeAttribute.class);
-  private final FlagsAttribute flagsAtt = addAttribute(FlagsAttribute.class);
-  private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+  private final SentenceAttributeExtractor sentenceAttributeExtractor;
 
   public OpenNLPChunkerFilter(TokenStream input, NLPChunkerOp chunkerOp) {
     super(input);
     this.chunkerOp = chunkerOp;
+    sentenceAttributeExtractor = new SentenceAttributeExtractor(input, addAttribute(SentenceAttribute.class));
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
-    if (!moreTokensAvailable) {
-      clear();
-      return false;
-    }
-    if (tokenNum == sentenceTokenAttrs.size()) {
+  public boolean incrementToken() throws IOException {
+    List<AttributeSource> sentenceTokenAttrs = sentenceAttributeExtractor.getSentenceAttributes();
+    boolean readNextSentence = tokenNum >= sentenceTokenAttrs.size() && sentenceAttributeExtractor.areMoreTokensAvailable();
+    if (readNextSentence) {
       nextSentence();
-      if (sentenceTerms == null) {
-        clear();
-        return false;
-      }
       assignTokenTypes(chunkerOp.getChunks(sentenceTerms, sentenceTermPOSTags, null));
-      tokenNum = 0;
     }
-    clearAttributes();
-    sentenceTokenAttrs.get(tokenNum++).copyTo(this);
-    return true;
+    if (tokenNum < sentenceTokenAttrs.size()) {
+      clearAttributes();
+      sentenceTokenAttrs.get(tokenNum++).copyTo(this);
+      return true;
+    }
+    return false;
   }
 
   private void nextSentence() throws IOException {
+    tokenNum = 0;
     List<String> termList = new ArrayList<>();
     List<String> posTagList = new ArrayList<>();
-    sentenceTokenAttrs.clear();
-    boolean endOfSentence = false;
-    while (!endOfSentence && (moreTokensAvailable = input.incrementToken())) {
-      termList.add(termAtt.toString());
-      posTagList.add(typeAtt.type());
-      endOfSentence = 0 != (flagsAtt.getFlags() & OpenNLPTokenizer.EOS_FLAG_BIT);
-      sentenceTokenAttrs.add(input.cloneAttributes());
+    for (AttributeSource attributeSource : sentenceAttributeExtractor.extractSentenceAttributes()) {
+      termList.add(attributeSource.getAttribute(CharTermAttribute.class).toString());
+      posTagList.add(attributeSource.getAttribute(TypeAttribute.class).type());
     }
-    sentenceTerms = termList.size() > 0 ? termList.toArray(new String[termList.size()]) : null;
+    sentenceTerms = termList.size() > 0 ? termList.toArray(new String[0]) : null;
     sentenceTermPOSTags =
-        posTagList.size() > 0 ? posTagList.toArray(new String[posTagList.size()]) : null;
+        posTagList.size() > 0 ? posTagList.toArray(new String[0]) : null;
   }
 
   private void assignTokenTypes(String[] tags) {
     for (int i = 0; i < tags.length; ++i) {
-      sentenceTokenAttrs.get(i).getAttribute(TypeAttribute.class).setType(tags[i]);
+      sentenceAttributeExtractor.getSentenceAttributes().get(i).getAttribute(TypeAttribute.class).setType(tags[i]);
     }
   }
 
   @Override
   public void reset() throws IOException {
     super.reset();
-    moreTokensAvailable = true;
+    sentenceAttributeExtractor.reset();
     clear();
   }
 
   private void clear() {
-    sentenceTokenAttrs.clear();
     sentenceTerms = null;
     sentenceTermPOSTags = null;
     tokenNum = 0;

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPChunkerFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPChunkerFilter.java
@@ -17,6 +17,9 @@
 
 package org.apache.lucene.analysis.opennlp;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.opennlp.tools.NLPChunkerOp;
@@ -25,10 +28,6 @@ import org.apache.lucene.analysis.tokenattributes.SentenceAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.IgnoreRandomChains;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Run OpenNLP chunker. Prerequisite: the OpenNLPTokenizer and OpenNLPPOSFilter must precede this
@@ -46,13 +45,16 @@ public final class OpenNLPChunkerFilter extends TokenFilter {
   public OpenNLPChunkerFilter(TokenStream input, NLPChunkerOp chunkerOp) {
     super(input);
     this.chunkerOp = chunkerOp;
-    sentenceAttributeExtractor = new SentenceAttributeExtractor(input, addAttribute(SentenceAttribute.class));
+    sentenceAttributeExtractor =
+        new SentenceAttributeExtractor(input, addAttribute(SentenceAttribute.class));
   }
 
   @Override
   public boolean incrementToken() throws IOException {
     List<AttributeSource> sentenceTokenAttrs = sentenceAttributeExtractor.getSentenceAttributes();
-    boolean readNextSentence = tokenNum >= sentenceTokenAttrs.size() && sentenceAttributeExtractor.areMoreTokensAvailable();
+    boolean readNextSentence =
+        tokenNum >= sentenceTokenAttrs.size()
+            && sentenceAttributeExtractor.areMoreTokensAvailable();
     if (readNextSentence) {
       nextSentence();
       assignTokenTypes(chunkerOp.getChunks(sentenceTerms, sentenceTermPOSTags, null));
@@ -74,13 +76,16 @@ public final class OpenNLPChunkerFilter extends TokenFilter {
       posTagList.add(attributeSource.getAttribute(TypeAttribute.class).type());
     }
     sentenceTerms = termList.size() > 0 ? termList.toArray(new String[0]) : null;
-    sentenceTermPOSTags =
-        posTagList.size() > 0 ? posTagList.toArray(new String[0]) : null;
+    sentenceTermPOSTags = posTagList.size() > 0 ? posTagList.toArray(new String[0]) : null;
   }
 
   private void assignTokenTypes(String[] tags) {
     for (int i = 0; i < tags.length; ++i) {
-      sentenceAttributeExtractor.getSentenceAttributes().get(i).getAttribute(TypeAttribute.class).setType(tags[i]);
+      sentenceAttributeExtractor
+          .getSentenceAttributes()
+          .get(i)
+          .getAttribute(TypeAttribute.class)
+          .setType(tags[i]);
     }
   }
 

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
@@ -47,8 +47,6 @@ public class OpenNLPLemmatizerFilter extends TokenFilter {
   private final KeywordAttribute keywordAtt = addAttribute(KeywordAttribute.class);
   private Iterator<AttributeSource> sentenceTokenAttrsIter = null;
   private final SentenceAttributeExtractor sentenceAttributeExtractor;
-  private String[] sentenceTokens = null; // non-keyword tokens
-  private String[] sentenceTokenTypes = null; // types for non-keyword tokens
   private String[] lemmas = null; // lemmas for non-keyword tokens
   private int lemmaNum = 0; // lemma counter
 
@@ -86,8 +84,8 @@ public class OpenNLPLemmatizerFilter extends TokenFilter {
         typeList.add(attributeSource.getAttribute(TypeAttribute.class).type());
       }
     }
-    sentenceTokens = tokenList.size() > 0 ? tokenList.toArray(new String[0]) : null;
-    sentenceTokenTypes = typeList.size() > 0 ? typeList.toArray(new String[0]) : null;
+    String[] sentenceTokens = tokenList.size() > 0 ? tokenList.toArray(new String[0]) : null;
+    String[] sentenceTokenTypes = typeList.size() > 0 ? typeList.toArray(new String[0]) : null;
     lemmas = lemmatizerOp.lemmatize(sentenceTokens, sentenceTokenTypes);
     sentenceTokenAttrsIter = sentenceAttributes.iterator();
   }
@@ -101,8 +99,6 @@ public class OpenNLPLemmatizerFilter extends TokenFilter {
 
   private void clear() {
     sentenceTokenAttrsIter = null;
-    sentenceTokens = null;
-    sentenceTokenTypes = null;
     lemmas = null;
     lemmaNum = 0;
   }

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
@@ -58,20 +58,19 @@ public class OpenNLPLemmatizerFilter extends TokenFilter {
 
   @Override
   public final boolean incrementToken() throws IOException {
-    boolean readNextSentence =
-        lemmaNum >= lemmas.length && sentenceAttributeExtractor.areMoreSentencesAvailable();
-    if (readNextSentence) {
+    boolean isEndOfCurrentSentence = lemmaNum >= lemmas.length;
+    if (isEndOfCurrentSentence) {
+      if (!sentenceAttributeExtractor.areMoreSentencesAvailable()) {
+        return false;
+      }
       nextSentence();
     }
-    if (lemmaNum < lemmas.length) {
-      clearAttributes();
-      sentenceTokenAttrsIter.next().copyTo(this);
-      if (!keywordAtt.isKeyword()) {
-        termAtt.setEmpty().append(lemmas[lemmaNum++]);
-      }
-      return true;
+    clearAttributes();
+    sentenceTokenAttrsIter.next().copyTo(this);
+    if (!keywordAtt.isKeyword()) {
+      termAtt.setEmpty().append(lemmas[lemmaNum++]);
     }
-    return false;
+    return true;
   }
 
   private void nextSentence() throws IOException {

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
@@ -47,7 +47,7 @@ public class OpenNLPLemmatizerFilter extends TokenFilter {
   private final KeywordAttribute keywordAtt = addAttribute(KeywordAttribute.class);
   private Iterator<AttributeSource> sentenceTokenAttrsIter = null;
   private final SentenceAttributeExtractor sentenceAttributeExtractor;
-  private String[] lemmas = null; // lemmas for non-keyword tokens
+  private String[] lemmas = new String[0]; // lemmas for non-keyword tokens
   private int lemmaNum = 0; // lemma counter
 
   public OpenNLPLemmatizerFilter(TokenStream input, NLPLemmatizerOp lemmatizerOp) {
@@ -58,7 +58,7 @@ public class OpenNLPLemmatizerFilter extends TokenFilter {
 
   @Override
   public final boolean incrementToken() throws IOException {
-    boolean readNextSentence = (sentenceTokenAttrsIter == null || !sentenceTokenAttrsIter.hasNext()) && sentenceAttributeExtractor.areMoreTokensAvailable();
+    boolean readNextSentence = lemmaNum >= lemmas.length && sentenceAttributeExtractor.areMoreTokensAvailable();
     if (readNextSentence) {
       nextSentence();
     }
@@ -99,7 +99,7 @@ public class OpenNLPLemmatizerFilter extends TokenFilter {
 
   private void clear() {
     sentenceTokenAttrsIter = null;
-    lemmas = null;
+    lemmas = new String[0];
     lemmaNum = 0;
   }
 }

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
@@ -64,7 +64,7 @@ public class OpenNLPLemmatizerFilter extends TokenFilter {
     if (readNextSentence) {
       nextSentence();
     }
-    if (lemmaNum < lemmas.length || sentenceAttributeExtractor.areMoreTokensAvailable()) {
+    if (lemmaNum < lemmas.length) {
       clearAttributes();
       sentenceTokenAttrsIter.next().copyTo(this);
       if (!keywordAtt.isKeyword()) {

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
@@ -17,17 +17,16 @@
 
 package org.apache.lucene.analysis.opennlp;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.opennlp.tools.NLPLemmatizerOp;
 import org.apache.lucene.analysis.tokenattributes.*;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.IgnoreRandomChains;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
 
 /**
  * Runs OpenNLP dictionary-based and/or MaxEnt lemmatizers.
@@ -53,12 +52,14 @@ public class OpenNLPLemmatizerFilter extends TokenFilter {
   public OpenNLPLemmatizerFilter(TokenStream input, NLPLemmatizerOp lemmatizerOp) {
     super(input);
     this.lemmatizerOp = lemmatizerOp;
-    sentenceAttributeExtractor = new SentenceAttributeExtractor(input, addAttribute(SentenceAttribute.class));
+    sentenceAttributeExtractor =
+        new SentenceAttributeExtractor(input, addAttribute(SentenceAttribute.class));
   }
 
   @Override
   public final boolean incrementToken() throws IOException {
-    boolean readNextSentence = lemmaNum >= lemmas.length && sentenceAttributeExtractor.areMoreTokensAvailable();
+    boolean readNextSentence =
+        lemmaNum >= lemmas.length && sentenceAttributeExtractor.areMoreTokensAvailable();
     if (readNextSentence) {
       nextSentence();
     }
@@ -77,7 +78,8 @@ public class OpenNLPLemmatizerFilter extends TokenFilter {
     lemmaNum = 0;
     List<String> tokenList = new ArrayList<>();
     List<String> typeList = new ArrayList<>();
-    List<AttributeSource> sentenceAttributes = sentenceAttributeExtractor.extractSentenceAttributes();
+    List<AttributeSource> sentenceAttributes =
+        sentenceAttributeExtractor.extractSentenceAttributes();
     for (AttributeSource attributeSource : sentenceAttributes) {
       if (!attributeSource.getAttribute(KeywordAttribute.class).isKeyword()) {
         tokenList.add(attributeSource.getAttribute(CharTermAttribute.class).toString());

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilter.java
@@ -59,7 +59,7 @@ public class OpenNLPLemmatizerFilter extends TokenFilter {
   @Override
   public final boolean incrementToken() throws IOException {
     boolean readNextSentence =
-        lemmaNum >= lemmas.length && sentenceAttributeExtractor.areMoreTokensAvailable();
+        lemmaNum >= lemmas.length && sentenceAttributeExtractor.areMoreSentencesAvailable();
     if (readNextSentence) {
       nextSentence();
     }

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilter.java
@@ -17,6 +17,9 @@
 
 package org.apache.lucene.analysis.opennlp;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.opennlp.tools.NLPPOSTaggerOp;
@@ -25,10 +28,6 @@ import org.apache.lucene.analysis.tokenattributes.SentenceAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.IgnoreRandomChains;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /** Run OpenNLP POS tagger. Tags all terms in the TypeAttribute. */
 @IgnoreRandomChains(reason = "LUCENE-10352: add argument providers for this one")
@@ -41,13 +40,16 @@ public final class OpenNLPPOSFilter extends TokenFilter {
   public OpenNLPPOSFilter(TokenStream input, NLPPOSTaggerOp posTaggerOp) {
     super(input);
     this.posTaggerOp = posTaggerOp;
-    sentenceAttributeExtractor = new SentenceAttributeExtractor(input, addAttribute(SentenceAttribute.class));
+    sentenceAttributeExtractor =
+        new SentenceAttributeExtractor(input, addAttribute(SentenceAttribute.class));
   }
 
   @Override
   public boolean incrementToken() throws IOException {
     List<AttributeSource> sentenceTokenAttrs = sentenceAttributeExtractor.getSentenceAttributes();
-    boolean readNextSentence = tokenNum >= sentenceTokenAttrs.size() && sentenceAttributeExtractor.areMoreTokensAvailable();
+    boolean readNextSentence =
+        tokenNum >= sentenceTokenAttrs.size()
+            && sentenceAttributeExtractor.areMoreTokensAvailable();
     if (readNextSentence) {
       String[] sentenceTokens = nextSentence();
       assignTokenTypes(posTaggerOp.getPOSTags(sentenceTokens));
@@ -71,7 +73,11 @@ public final class OpenNLPPOSFilter extends TokenFilter {
 
   private void assignTokenTypes(String[] tags) {
     for (int i = 0; i < tags.length; ++i) {
-      sentenceAttributeExtractor.getSentenceAttributes().get(i).getAttribute(TypeAttribute.class).setType(tags[i]);
+      sentenceAttributeExtractor
+          .getSentenceAttributes()
+          .get(i)
+          .getAttribute(TypeAttribute.class)
+          .setType(tags[i]);
     }
   }
 

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilter.java
@@ -34,7 +34,6 @@ import java.util.List;
 @IgnoreRandomChains(reason = "LUCENE-10352: add argument providers for this one")
 public final class OpenNLPPOSFilter extends TokenFilter {
 
-  private List<AttributeSource> sentenceTokenAttrs = new ArrayList<>();
   String[] tags = null;
   private int tokenNum = 0;
 
@@ -50,6 +49,7 @@ public final class OpenNLPPOSFilter extends TokenFilter {
 
   @Override
   public boolean incrementToken() throws IOException {
+    List<AttributeSource> sentenceTokenAttrs = sentenceAttributeExtractor.getSentenceAttributes();
     boolean readNextSentence = tokenNum >= sentenceTokenAttrs.size() && sentenceAttributeExtractor.areMoreTokensAvailable();
     if (readNextSentence) {
       String[] sentenceTokens = nextSentence();
@@ -67,8 +67,7 @@ public final class OpenNLPPOSFilter extends TokenFilter {
   private String[] nextSentence() throws IOException {
     tokenNum = 0;
     List<String> termList = new ArrayList<>();
-    sentenceTokenAttrs = sentenceAttributeExtractor.extractSentenceAttributes();
-    for (AttributeSource attributeSource : sentenceTokenAttrs) {
+    for (AttributeSource attributeSource : sentenceAttributeExtractor.extractSentenceAttributes()) {
       termList.add(attributeSource.getAttribute(CharTermAttribute.class).toString());
     }
     return termList.size() > 0 ? termList.toArray(new String[0]) : null;

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilter.java
@@ -49,8 +49,8 @@ public final class OpenNLPPOSFilter extends TokenFilter {
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
-    boolean readNextSentence = tokenNum == sentenceTokenAttrs.size() && sentenceAttributeExtractor.areMoreTokensAvailable();
+  public boolean incrementToken() throws IOException {
+    boolean readNextSentence = tokenNum >= sentenceTokenAttrs.size() && sentenceAttributeExtractor.areMoreTokensAvailable();
     if (readNextSentence) {
       String[] sentenceTokens = nextSentence();
       tags = posTaggerOp.getPOSTags(sentenceTokens);

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilter.java
@@ -49,7 +49,7 @@ public final class OpenNLPPOSFilter extends TokenFilter {
     List<AttributeSource> sentenceTokenAttrs = sentenceAttributeExtractor.getSentenceAttributes();
     boolean readNextSentence =
         tokenNum >= sentenceTokenAttrs.size()
-            && sentenceAttributeExtractor.areMoreTokensAvailable();
+            && sentenceAttributeExtractor.areMoreSentencesAvailable();
     if (readNextSentence) {
       String[] sentenceTokens = nextSentence();
       assignTokenTypes(posTaggerOp.getPOSTags(sentenceTokens));

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilter.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilter.java
@@ -49,24 +49,26 @@ public final class OpenNLPPOSFilter extends TokenFilter {
     List<AttributeSource> sentenceTokenAttrs = sentenceAttributeExtractor.getSentenceAttributes();
     boolean isEndOfCurrentSentence = tokenNum >= sentenceTokenAttrs.size();
     if (isEndOfCurrentSentence) {
-      if (!sentenceAttributeExtractor.areMoreSentencesAvailable()) {
+      boolean noSentencesLeft =
+          sentenceAttributeExtractor.allSentencesProcessed() || nextSentence().isEmpty();
+      if (noSentencesLeft) {
         return false;
       }
-      nextSentence();
     }
     clearAttributes();
     sentenceTokenAttrs.get(tokenNum++).copyTo(this);
     return true;
   }
 
-  private void nextSentence() throws IOException {
+  private List<AttributeSource> nextSentence() throws IOException {
     tokenNum = 0;
     List<String> termList = new ArrayList<>();
     for (AttributeSource attributeSource : sentenceAttributeExtractor.extractSentenceAttributes()) {
       termList.add(attributeSource.getAttribute(CharTermAttribute.class).toString());
     }
-    String[] sentenceTerms = termList.size() > 0 ? termList.toArray(new String[0]) : null;
+    String[] sentenceTerms = termList.toArray(new String[0]);
     assignTokenTypes(posTaggerOp.getPOSTags(sentenceTerms));
+    return sentenceAttributeExtractor.getSentenceAttributes();
   }
 
   private void assignTokenTypes(String[] tags) {

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPTokenizer.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPTokenizer.java
@@ -88,7 +88,7 @@ public final class OpenNLPTokenizer extends SegmentingTokenizerBase {
     offsetAtt.setOffset(
         correctOffset(offset + sentenceStart + term.getStart()),
         correctOffset(offset + sentenceStart + term.getEnd()));
-    sentenceAtt.setSentence(sentenceIndex);
+    sentenceAtt.setSentenceIndex(sentenceIndex);
     if (termNum == termSpans.length - 1) {
       flagsAtt.setFlags(
               flagsAtt.getFlags()

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPTokenizer.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPTokenizer.java
@@ -17,31 +17,28 @@
 
 package org.apache.lucene.analysis.opennlp;
 
-import java.io.IOException;
 import opennlp.tools.util.Span;
 import org.apache.lucene.analysis.opennlp.tools.NLPSentenceDetectorOp;
 import org.apache.lucene.analysis.opennlp.tools.NLPTokenizerOp;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.lucene.analysis.tokenattributes.FlagsAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.analysis.tokenattributes.SentenceAttribute;
 import org.apache.lucene.analysis.util.SegmentingTokenizerBase;
 import org.apache.lucene.util.AttributeFactory;
 import org.apache.lucene.util.IgnoreRandomChains;
 
+import java.io.IOException;
+
 /**
- * Run OpenNLP SentenceDetector and Tokenizer. The last token in each sentence is marked by setting
- * the {@link #EOS_FLAG_BIT} in the FlagsAttribute; following filters can use this information to
- * apply operations to tokens one sentence at a time.
+ * Run OpenNLP SentenceDetector and Tokenizer.
+ * The index of each sentence is stored in SentenceAttribute.
  */
 @IgnoreRandomChains(reason = "LUCENE-10352: add argument providers for this one")
 public final class OpenNLPTokenizer extends SegmentingTokenizerBase {
-  public static int EOS_FLAG_BIT = 1;
 
   private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
   private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
   private final SentenceAttribute sentenceAtt = addAttribute(SentenceAttribute.class);
-  private final FlagsAttribute flagsAtt = addAttribute(FlagsAttribute.class);
 
   private Span[] termSpans = null;
   private int termNum = 0;
@@ -89,11 +86,6 @@ public final class OpenNLPTokenizer extends SegmentingTokenizerBase {
         correctOffset(offset + sentenceStart + term.getStart()),
         correctOffset(offset + sentenceStart + term.getEnd()));
     sentenceAtt.setSentenceIndex(sentenceIndex);
-    if (termNum == termSpans.length - 1) {
-      flagsAtt.setFlags(
-              flagsAtt.getFlags()
-                      | EOS_FLAG_BIT); // mark the last token in the sentence with EOS_FLAG_BIT
-    }
     ++termNum;
     return true;
   }

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPTokenizer.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPTokenizer.java
@@ -17,6 +17,7 @@
 
 package org.apache.lucene.analysis.opennlp;
 
+import java.io.IOException;
 import opennlp.tools.util.Span;
 import org.apache.lucene.analysis.opennlp.tools.NLPSentenceDetectorOp;
 import org.apache.lucene.analysis.opennlp.tools.NLPTokenizerOp;
@@ -27,11 +28,9 @@ import org.apache.lucene.analysis.util.SegmentingTokenizerBase;
 import org.apache.lucene.util.AttributeFactory;
 import org.apache.lucene.util.IgnoreRandomChains;
 
-import java.io.IOException;
-
 /**
- * Run OpenNLP SentenceDetector and Tokenizer.
- * The index of each sentence is stored in SentenceAttribute.
+ * Run OpenNLP SentenceDetector and Tokenizer. The index of each sentence is stored in
+ * SentenceAttribute.
  */
 @IgnoreRandomChains(reason = "LUCENE-10352: add argument providers for this one")
 public final class OpenNLPTokenizer extends SegmentingTokenizerBase {

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
@@ -48,7 +48,7 @@ public class SentenceAttributeExtractor {
     do {
       hasNextToken = input.incrementToken();
       int currSentenceTmp = sentenceAtt.getSentenceIndex();
-      hasNext = currSentence == currSentenceTmp && hasNextToken;
+      hasNext = (currSentence == currSentenceTmp && hasNextToken);
       currSentence = currSentenceTmp;
       if (prevAttributeSource != null) {
         sentenceTokenAttrs.add(prevAttributeSource);

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
@@ -24,6 +24,10 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.SentenceAttribute;
 import org.apache.lucene.util.AttributeSource;
 
+/**
+ * Iterate through sentence tokens and cache their attributes. Could consider moving this to a more
+ * central location to be used by other sentence-aware components.
+ */
 public class SentenceAttributeExtractor {
 
   private final TokenStream input;

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
@@ -14,7 +14,7 @@ public class SentenceAttributeExtractor {
   private final List<AttributeSource> sentenceTokenAttrs = new ArrayList<>();
   private AttributeSource prevAttributeSource;
   private int currSentence = 0;
-  private boolean moreTokensAvailable = true;
+  private boolean hasNextToken = true;
 
   public SentenceAttributeExtractor(TokenStream input, SentenceAttribute sentenceAtt) {
     this.input = input;
@@ -25,9 +25,9 @@ public class SentenceAttributeExtractor {
     sentenceTokenAttrs.clear();
     boolean hasNext;
     do {
-      moreTokensAvailable = input.incrementToken();
+      hasNextToken = input.incrementToken();
       int currSentenceTmp = sentenceAtt.getSentenceIndex();
-      hasNext = currSentence == currSentenceTmp && moreTokensAvailable;
+      hasNext = currSentence == currSentenceTmp && hasNextToken;
       currSentence = currSentenceTmp;
       if (prevAttributeSource != null) {
         sentenceTokenAttrs.add(prevAttributeSource);
@@ -41,12 +41,12 @@ public class SentenceAttributeExtractor {
     return sentenceTokenAttrs;
   }
 
-  public boolean areMoreTokensAvailable() {
-    return moreTokensAvailable;
+  public boolean areMoreSentencesAvailable() {
+    return hasNextToken;
   }
 
   public void reset() {
-    moreTokensAvailable = true;
+    hasNextToken = true;
     sentenceTokenAttrs.clear();
     currSentence = 0;
     prevAttributeSource = null;

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.lucene.analysis.opennlp;
 
 import java.io.IOException;

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
@@ -22,22 +22,23 @@ public class SentenceAttributeExtractor {
         this.sentenceAtt = sentenceAtt;
     }
 
-    public boolean hasNext() throws IOException {
-        moreTokensAvailable = input.incrementToken();
-        int currSentenceTmp = sentenceAtt.getSentence();
-        boolean hasNext = currSentence == currSentenceTmp && moreTokensAvailable;
-        currSentence = currSentenceTmp;
-        if (prevAttributeSource != null) {
-            sentenceTokenAttrs.add(prevAttributeSource);
-        }
-        prevAttributeSource = input.cloneAttributes();
-        return hasNext;
-    }
-
     public List<AttributeSource> extractSentenceAttributes() throws IOException {
         sentenceTokenAttrs.clear();
-        while (hasNext()) {
-        }
+        boolean hasNext;
+        do {
+            moreTokensAvailable = input.incrementToken();
+            int currSentenceTmp = sentenceAtt.getSentence();
+            hasNext = currSentence == currSentenceTmp && moreTokensAvailable;
+            currSentence = currSentenceTmp;
+            if (prevAttributeSource != null) {
+                sentenceTokenAttrs.add(prevAttributeSource);
+            }
+            prevAttributeSource = input.cloneAttributes();
+        } while(hasNext);
+        return sentenceTokenAttrs;
+    }
+
+    public List<AttributeSource> getSentenceAttributes() {
         return sentenceTokenAttrs;
     }
 

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
@@ -1,55 +1,54 @@
 package org.apache.lucene.analysis.opennlp;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.SentenceAttribute;
 import org.apache.lucene.util.AttributeSource;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 public class SentenceAttributeExtractor {
 
-    private final TokenStream input;
-    private final SentenceAttribute sentenceAtt;
-    private final List<AttributeSource> sentenceTokenAttrs = new ArrayList<>();
-    private AttributeSource prevAttributeSource;
-    private int currSentence = 0;
-    private boolean moreTokensAvailable = true;
+  private final TokenStream input;
+  private final SentenceAttribute sentenceAtt;
+  private final List<AttributeSource> sentenceTokenAttrs = new ArrayList<>();
+  private AttributeSource prevAttributeSource;
+  private int currSentence = 0;
+  private boolean moreTokensAvailable = true;
 
-    public SentenceAttributeExtractor(TokenStream input, SentenceAttribute sentenceAtt) {
-        this.input = input;
-        this.sentenceAtt = sentenceAtt;
-    }
+  public SentenceAttributeExtractor(TokenStream input, SentenceAttribute sentenceAtt) {
+    this.input = input;
+    this.sentenceAtt = sentenceAtt;
+  }
 
-    public List<AttributeSource> extractSentenceAttributes() throws IOException {
-        sentenceTokenAttrs.clear();
-        boolean hasNext;
-        do {
-            moreTokensAvailable = input.incrementToken();
-            int currSentenceTmp = sentenceAtt.getSentenceIndex();
-            hasNext = currSentence == currSentenceTmp && moreTokensAvailable;
-            currSentence = currSentenceTmp;
-            if (prevAttributeSource != null) {
-                sentenceTokenAttrs.add(prevAttributeSource);
-            }
-            prevAttributeSource = input.cloneAttributes();
-        } while(hasNext);
-        return sentenceTokenAttrs;
-    }
+  public List<AttributeSource> extractSentenceAttributes() throws IOException {
+    sentenceTokenAttrs.clear();
+    boolean hasNext;
+    do {
+      moreTokensAvailable = input.incrementToken();
+      int currSentenceTmp = sentenceAtt.getSentenceIndex();
+      hasNext = currSentence == currSentenceTmp && moreTokensAvailable;
+      currSentence = currSentenceTmp;
+      if (prevAttributeSource != null) {
+        sentenceTokenAttrs.add(prevAttributeSource);
+      }
+      prevAttributeSource = input.cloneAttributes();
+    } while (hasNext);
+    return sentenceTokenAttrs;
+  }
 
-    public List<AttributeSource> getSentenceAttributes() {
-        return sentenceTokenAttrs;
-    }
+  public List<AttributeSource> getSentenceAttributes() {
+    return sentenceTokenAttrs;
+  }
 
-    public boolean areMoreTokensAvailable() {
-        return moreTokensAvailable;
-    }
+  public boolean areMoreTokensAvailable() {
+    return moreTokensAvailable;
+  }
 
-    public void reset() {
-        moreTokensAvailable = true;
-        sentenceTokenAttrs.clear();
-        currSentence = 0;
-        prevAttributeSource = null;
-    }
+  public void reset() {
+    moreTokensAvailable = true;
+    sentenceTokenAttrs.clear();
+    currSentence = 0;
+    prevAttributeSource = null;
+  }
 }

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
@@ -62,8 +62,8 @@ public class SentenceAttributeExtractor {
     return sentenceTokenAttrs;
   }
 
-  public boolean areMoreSentencesAvailable() {
-    return hasNextToken;
+  public boolean allSentencesProcessed() {
+    return !hasNextToken;
   }
 
   public void reset() {

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
@@ -27,6 +27,9 @@ import org.apache.lucene.util.AttributeSource;
 /**
  * Iterate through sentence tokens and cache their attributes. Could consider moving this to a more
  * central location to be used by other sentence-aware components.
+ *
+ * <p>May want to consider making this its own Filter so that extracted sentence token attributes
+ * can be shared by downstream sentence-aware filters.
  */
 public class SentenceAttributeExtractor {
 
@@ -42,6 +45,9 @@ public class SentenceAttributeExtractor {
     this.sentenceAtt = sentenceAtt;
   }
 
+  // If this class were a stand-alone filter it could conceivably extract the attributes once
+  // and cache a reference to those attributes in SentenceAttribute. That way downstream filters
+  // could read the full sentence without having to independently extract it.
   public List<AttributeSource> extractSentenceAttributes() throws IOException {
     sentenceTokenAttrs.clear();
     boolean hasNext;

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
@@ -1,0 +1,54 @@
+package org.apache.lucene.analysis.opennlp;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.SentenceAttribute;
+import org.apache.lucene.util.AttributeSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SentenceAttributeExtractor {
+
+    private final TokenStream input;
+    private final SentenceAttribute sentenceAtt;
+    private final List<AttributeSource> sentenceTokenAttrs = new ArrayList<>();
+    private AttributeSource prevAttributeSource;
+    private int currSentence = 0;
+    private boolean moreTokensAvailable = true;
+
+    public SentenceAttributeExtractor(TokenStream input, SentenceAttribute sentenceAtt) {
+        this.input = input;
+        this.sentenceAtt = sentenceAtt;
+    }
+
+    public boolean hasNext() throws IOException {
+        moreTokensAvailable = input.incrementToken();
+        int currSentenceTmp = sentenceAtt.getSentence();
+        boolean hasNext = currSentence == currSentenceTmp && moreTokensAvailable;
+        currSentence = currSentenceTmp;
+        if (prevAttributeSource != null) {
+            sentenceTokenAttrs.add(prevAttributeSource);
+        }
+        prevAttributeSource = input.cloneAttributes();
+        return hasNext;
+    }
+
+    public List<AttributeSource> extractSentenceAttributes() throws IOException {
+        sentenceTokenAttrs.clear();
+        while (hasNext()) {
+        }
+        return sentenceTokenAttrs;
+    }
+
+    public boolean areMoreTokensAvailable() {
+        return moreTokensAvailable;
+    }
+
+    public void reset() {
+        moreTokensAvailable = true;
+        sentenceTokenAttrs.clear();
+        currSentence = 0;
+        prevAttributeSource = null;
+    }
+}

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/SentenceAttributeExtractor.java
@@ -27,7 +27,7 @@ public class SentenceAttributeExtractor {
         boolean hasNext;
         do {
             moreTokensAvailable = input.incrementToken();
-            int currSentenceTmp = sentenceAtt.getSentence();
+            int currSentenceTmp = sentenceAtt.getSentenceIndex();
             hasNext = currSentence == currSentenceTmp && moreTokensAvailable;
             currSentence = currSentenceTmp;
             if (prevAttributeSource != null) {

--- a/lucene/analysis/opennlp/src/test-files/org/apache/lucene/analysis/opennlp/data/early-exit-bug-input.txt
+++ b/lucene/analysis/opennlp/src/test-files/org/apache/lucene/analysis/opennlp/data/early-exit-bug-input.txt
@@ -18,6 +18,6 @@ Quick brown fox jumped over the lazy dog.
 x
 Quick brown fox jumped over the lazy dog.
 x
-This will not get indexed.
+This should hopefully get analyzed.
 x
-And neither will this.
+And so should this.

--- a/lucene/analysis/opennlp/src/test-files/org/apache/lucene/analysis/opennlp/data/early-exit-bug-input.txt
+++ b/lucene/analysis/opennlp/src/test-files/org/apache/lucene/analysis/opennlp/data/early-exit-bug-input.txt
@@ -1,0 +1,23 @@
+Quick brown fox jumped over the lazy dog. Quick brown fox jumped over the lazy dog.
+Quick brown fox jumped over the lazy dog. Quick brown fox jumped over the lazy dog.
+Quick brown fox jumped over the lazy dog. Quick brown fox jumped over the lazy dog.
+Quick brown fox jumped over the lazy dog. Quick brown fox jumped over the lazy dog.
+Quick brown fox jumped over the lazy dog. Quick brown fox jumped over the lazy dog.
+Quick brown fox jumped over the lazy dog. Quick brown fox jumped over the lazy dog.
+Quick brown fox jumped over the lazy dog. Quick brown fox jumped over the lazy dog.
+Quick brown fox jumped over the lazy dog. Quick brown fox jumped over the lazy dog.
+Quick brown fox jumped over the lazy dog. Quick brown fox jumped over the lazy dog.
+x
+Quick brown fox jumped over the lazy dog.
+x
+Quick brown fox jumped over the lazy dog.
+x
+Quick brown fox jumped over the lazy dog.
+x
+Quick brown fox jumped over the lazy dog.
+x
+Quick brown fox jumped over the lazy dog.
+x
+This will not get indexed.
+x
+And neither will this.

--- a/lucene/analysis/opennlp/src/test-files/org/apache/lucene/analysis/opennlp/data/early-exit-bug-output.txt
+++ b/lucene/analysis/opennlp/src/test-files/org/apache/lucene/analysis/opennlp/data/early-exit-bug-output.txt
@@ -27,6 +27,6 @@ Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog do
 x x
 Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
 x x
-This This will will not not get get indexed indexed . .
+This This should should hopefully hopefully get get analyzed analyzed . .
 x x
-And And neither neither will will this this . .
+And And so so should should this this . .

--- a/lucene/analysis/opennlp/src/test-files/org/apache/lucene/analysis/opennlp/data/early-exit-bug-output.txt
+++ b/lucene/analysis/opennlp/src/test-files/org/apache/lucene/analysis/opennlp/data/early-exit-bug-output.txt
@@ -1,0 +1,32 @@
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+x x
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+x x
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+x x
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+x x
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+x x
+Quick Quick brown brown fox fox jumped jumped over over the the lazy lazy dog dog . .
+x x
+This This will will not not get get indexed indexed . .
+x x
+And And neither neither will will this this . .

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPChunkerFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPChunkerFilterFactory.java
@@ -114,4 +114,16 @@ public class TestOpenNLPChunkerFilterFactory extends BaseTokenStreamTestCase {
         true,
         toPayloads(SENTENCES_chunks));
   }
+
+  public void testEmptyField() throws Exception {
+    CustomAnalyzer analyzer =
+        CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+            .withTokenizer(
+                "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
+            .addTokenFilter("opennlpPOS", "posTaggerModel", posTaggerModelFile)
+            .addTokenFilter("opennlpChunker", "chunkerModel", chunkerModelFile)
+            .addTokenFilter(TypeAsPayloadTokenFilterFactory.class)
+            .build();
+    assertAnalyzesTo(analyzer, "", new String[0], null, null, null, null, null, true);
+  }
 }

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
@@ -297,14 +297,22 @@ public class TestOpenNLPLemmatizerFilterFactory extends BaseTokenStreamTestCase 
 
   public void testNoBreakWithRepeatKeywordFilter() throws Exception {
     CustomAnalyzer analyzer =
-            CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
-                    .withTokenizer(
-                            "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
-                    .addTokenFilter("opennlpPOS", "posTaggerModel", "en-test-pos-maxent.bin")
-                    .addTokenFilter(KeywordRepeatFilterFactory.class)
-                    .addTokenFilter("opennlplemmatizer", "dictionary", "en-test-lemmas.dict")
-                    .build();
+        CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+            .withTokenizer(
+                "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
+            .addTokenFilter("opennlpPOS", "posTaggerModel", "en-test-pos-maxent.bin")
+            .addTokenFilter(KeywordRepeatFilterFactory.class)
+            .addTokenFilter("opennlplemmatizer", "dictionary", "en-test-lemmas.dict")
+            .build();
     assertAnalyzesTo(
-            analyzer, NO_BREAK_REPEAT_KEYWORD, NO_BREAK_REPEAT_KEYWORD_terms, null, null, null, null, null, true);
+        analyzer,
+        NO_BREAK_REPEAT_KEYWORD,
+        NO_BREAK_REPEAT_KEYWORD_terms,
+        null,
+        null,
+        null,
+        null,
+        null,
+        true);
   }
 }

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
@@ -108,6 +108,10 @@ public class TestOpenNLPLemmatizerFilterFactory extends BaseTokenStreamTestCase 
     "IN", "IN", "JJ", "JJ", "NN", "VBN", "VBN", ".", "NNP", "NNP", "VBN", "NN", ",", "NN", "."
   };
 
+  private static final String NO_BREAK_REPEAT_KEYWORD = "period";
+
+  private static final String[] NO_BREAK_REPEAT_KEYWORD_terms = {"period", "period"};
+
   private static final String tokenizerModelFile = "en-test-tokenizer.bin";
   private static final String sentenceModelFile = "en-test-sent.bin";
   private static final String posTaggerModelFile = "en-test-pos-maxent.bin";
@@ -289,5 +293,18 @@ public class TestOpenNLPLemmatizerFilterFactory extends BaseTokenStreamTestCase 
         null,
         null,
         true);
+  }
+
+  public void testNoBreakWithRepeatKeywordFilter() throws Exception {
+    CustomAnalyzer analyzer =
+            CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+                    .withTokenizer(
+                            "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
+                    .addTokenFilter("opennlpPOS", "posTaggerModel", "en-test-pos-maxent.bin")
+                    .addTokenFilter(KeywordRepeatFilterFactory.class)
+                    .addTokenFilter("opennlplemmatizer", "dictionary", "en-test-lemmas.dict")
+                    .build();
+    assertAnalyzesTo(
+            analyzer, NO_BREAK_REPEAT_KEYWORD, NO_BREAK_REPEAT_KEYWORD_terms, null, null, null, null, null, true);
   }
 }

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
@@ -108,9 +108,9 @@ public class TestOpenNLPLemmatizerFilterFactory extends BaseTokenStreamTestCase 
     "IN", "IN", "JJ", "JJ", "NN", "VBN", "VBN", ".", "NNP", "NNP", "VBN", "NN", ",", "NN", "."
   };
 
-  private static final String NO_BREAK_REPEAT_KEYWORD = "period";
+  private static final String NO_BREAK_SINGLE_TOKEN_REPEAT_KEYWORD = "period";
 
-  private static final String[] NO_BREAK_REPEAT_KEYWORD_terms = {"period", "period"};
+  private static final String[] NO_BREAK_SINGLE_TOKEN_REPEAT_KEYWORD_terms = {"period", "period"};
 
   private static final String tokenizerModelFile = "en-test-tokenizer.bin";
   private static final String sentenceModelFile = "en-test-sent.bin";
@@ -306,8 +306,8 @@ public class TestOpenNLPLemmatizerFilterFactory extends BaseTokenStreamTestCase 
             .build();
     assertAnalyzesTo(
         analyzer,
-        NO_BREAK_REPEAT_KEYWORD,
-        NO_BREAK_REPEAT_KEYWORD_terms,
+            NO_BREAK_SINGLE_TOKEN_REPEAT_KEYWORD,
+        NO_BREAK_SINGLE_TOKEN_REPEAT_KEYWORD_terms,
         null,
         null,
         null,

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
@@ -344,4 +344,16 @@ public class TestOpenNLPLemmatizerFilterFactory extends BaseTokenStreamTestCase 
     assertAnalyzesTo(
         analyzer, earlyExitInputText, earlyExitOutputTexts, null, null, null, null, null, true);
   }
+
+  public void testEmptyField() throws Exception {
+    CustomAnalyzer analyzer =
+        CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+            .withTokenizer(
+                "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
+            .addTokenFilter("opennlpPOS", "posTaggerModel", "en-test-pos-maxent.bin")
+            .addTokenFilter(KeywordRepeatFilterFactory.class)
+            .addTokenFilter("opennlplemmatizer", "dictionary", "en-test-lemmas.dict")
+            .build();
+    assertAnalyzesTo(analyzer, "", new String[0], null, null, null, null, null, true);
+  }
 }

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
@@ -323,16 +323,13 @@ public class TestOpenNLPLemmatizerFilterFactory extends BaseTokenStreamTestCase 
 
   // checks for bug described in https://github.com/apache/lucene/issues/11771
   public void testPreventEarlyExit() throws IOException {
-    ClasspathResourceLoader loader = new ClasspathResourceLoader(getClass());
-    try (InputStream earlyExitInput = loader.openResource("data/early-exit-bug-input.txt")) {
+    InputStream earlyExitInput = null;
+    InputStream earlyExitOutput = null;
+    try {
+      ClasspathResourceLoader loader = new ClasspathResourceLoader(getClass());
+      earlyExitInput = loader.openResource("data/early-exit-bug-input.txt");
       String earlyExitInputText = new String(earlyExitInput.readAllBytes(), StandardCharsets.UTF_8);
-      verifyNoEarlyExitWithInput(earlyExitInputText, loader);
-    }
-  }
-
-  private void verifyNoEarlyExitWithInput(String earlyExitInputText, ClasspathResourceLoader loader)
-      throws IOException {
-    try (InputStream earlyExitOutput = loader.openResource("data/early-exit-bug-output.txt")) {
+      earlyExitOutput = loader.openResource("data/early-exit-bug-output.txt");
       String earlyExitOutputText =
           new String(earlyExitOutput.readAllBytes(), StandardCharsets.UTF_8);
       String[] earlyExitOutputTexts =
@@ -354,6 +351,13 @@ public class TestOpenNLPLemmatizerFilterFactory extends BaseTokenStreamTestCase 
               .build();
       assertAnalyzesTo(
           analyzer, earlyExitInputText, earlyExitOutputTexts, null, null, null, null, null, true);
+    } finally {
+      if (earlyExitInput != null) {
+        earlyExitInput.close();
+      }
+      if (earlyExitOutput != null) {
+        earlyExitOutput.close();
+      }
     }
   }
 

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
@@ -306,7 +306,7 @@ public class TestOpenNLPLemmatizerFilterFactory extends BaseTokenStreamTestCase 
             .build();
     assertAnalyzesTo(
         analyzer,
-            NO_BREAK_SINGLE_TOKEN_REPEAT_KEYWORD,
+        NO_BREAK_SINGLE_TOKEN_REPEAT_KEYWORD,
         NO_BREAK_SINGLE_TOKEN_REPEAT_KEYWORD_terms,
         null,
         null,

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
+import org.apache.lucene.analysis.miscellaneous.KeywordRepeatFilterFactory;
 import org.apache.lucene.analysis.payloads.TypeAsPayloadTokenFilterFactory;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.util.ClasspathResourceLoader;
@@ -66,6 +67,7 @@ public class TestOpenNLPPOSFilterFactory extends BaseTokenStreamTestCase {
   private static final String[] NO_BREAK_terms = {"No", "period"};
   private static final int[] NO_BREAK_startOffsets = {0, 3};
   private static final int[] NO_BREAK_endOffsets = {2, 9};
+  private static final String[] NO_BREAK_KEYWORD_REPEAT_terms = {"No", "No", "period", "period"};
 
   private static final String sentenceModelFile = "en-test-sent.bin";
   private static final String tokenizerModelFile = "en-test-tokenizer.bin";
@@ -143,5 +145,25 @@ public class TestOpenNLPPOSFilterFactory extends BaseTokenStreamTestCase {
         null,
         null,
         true);
+  }
+
+  public void testNoBreakWithRepeatKeywordFilter() throws Exception {
+    CustomAnalyzer analyzer =
+            CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+                    .withTokenizer(
+                            "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
+                    .addTokenFilter(KeywordRepeatFilterFactory.class)
+                    .addTokenFilter("opennlpPOS", "posTaggerModel", posTaggerModelFile)
+                    .build();
+    assertAnalyzesTo(
+            analyzer,
+            NO_BREAK,
+            NO_BREAK_KEYWORD_REPEAT_terms,
+            null,
+            null,
+            null,
+            null,
+            null,
+            true);
   }
 }

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
@@ -149,21 +149,13 @@ public class TestOpenNLPPOSFilterFactory extends BaseTokenStreamTestCase {
 
   public void testNoBreakWithRepeatKeywordFilter() throws Exception {
     CustomAnalyzer analyzer =
-            CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
-                    .withTokenizer(
-                            "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
-                    .addTokenFilter(KeywordRepeatFilterFactory.class)
-                    .addTokenFilter("opennlpPOS", "posTaggerModel", posTaggerModelFile)
-                    .build();
+        CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+            .withTokenizer(
+                "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
+            .addTokenFilter(KeywordRepeatFilterFactory.class)
+            .addTokenFilter("opennlpPOS", "posTaggerModel", posTaggerModelFile)
+            .build();
     assertAnalyzesTo(
-            analyzer,
-            NO_BREAK,
-            NO_BREAK_KEYWORD_REPEAT_terms,
-            null,
-            null,
-            null,
-            null,
-            null,
-            true);
+        analyzer, NO_BREAK, NO_BREAK_KEYWORD_REPEAT_terms, null, null, null, null, null, true);
   }
 }

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
@@ -158,4 +158,14 @@ public class TestOpenNLPPOSFilterFactory extends BaseTokenStreamTestCase {
     assertAnalyzesTo(
         analyzer, NO_BREAK, NO_BREAK_KEYWORD_REPEAT_terms, null, null, null, null, null, true);
   }
+
+  public void testEmptyField() throws Exception {
+    CustomAnalyzer analyzer =
+        CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+            .withTokenizer(
+                "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
+            .addTokenFilter("opennlpPOS", "posTaggerModel", posTaggerModelFile)
+            .build();
+    assertAnalyzesTo(analyzer, "", new String[0], null, null, null, null, null, true);
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttribute.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttribute.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.lucene.analysis.tokenattributes;
 
 import org.apache.lucene.util.Attribute;

--- a/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttribute.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttribute.java
@@ -3,23 +3,23 @@ package org.apache.lucene.analysis.tokenattributes;
 import org.apache.lucene.util.Attribute;
 
 /**
- * This attribute tracks what sentence a given token belongs to
- * as well as potentially other sentence specific attributes.
+ * This attribute tracks what sentence a given token belongs to as well as potentially other
+ * sentence specific attributes.
  */
 public interface SentenceAttribute extends Attribute {
 
-    /**
-     * Get the sentence index for the current token
-     *
-     * @return The index of the sentence
-     * @see #getSentenceIndex()
-     */
-    int getSentenceIndex();
+  /**
+   * Get the sentence index for the current token
+   *
+   * @return The index of the sentence
+   * @see #getSentenceIndex()
+   */
+  int getSentenceIndex();
 
-    /**
-     * Set the sentence of the current token
-     *
-     * @see #setSentenceIndex(int sentenceIndex)
-     */
-    void setSentenceIndex(int sentenceIndex);
+  /**
+   * Set the sentence of the current token
+   *
+   * @see #setSentenceIndex(int sentenceIndex)
+   */
+  void setSentenceIndex(int sentenceIndex);
 }

--- a/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttribute.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttribute.java
@@ -4,6 +4,7 @@ import org.apache.lucene.util.Attribute;
 
 /**
  * This attribute tracks what sentence a given token belongs to
+ * as well as potentially other sentence specific attributes.
  */
 public interface SentenceAttribute extends Attribute {
 
@@ -11,14 +12,14 @@ public interface SentenceAttribute extends Attribute {
      * Get the sentence index for the current token
      *
      * @return The index of the sentence
-     * @see #getSentence()
+     * @see #getSentenceIndex()
      */
-    int getSentence();
+    int getSentenceIndex();
 
     /**
      * Set the sentence of the current token
      *
-     * @see #setSentence(int sentenceIndex)
+     * @see #setSentenceIndex(int sentenceIndex)
      */
-    void setSentence(int sentenceIndex);
+    void setSentenceIndex(int sentenceIndex);
 }

--- a/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttribute.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttribute.java
@@ -1,0 +1,24 @@
+package org.apache.lucene.analysis.tokenattributes;
+
+import org.apache.lucene.util.Attribute;
+
+/**
+ * This attribute tracks what sentence a given token belongs to
+ */
+public interface SentenceAttribute extends Attribute {
+
+    /**
+     * Get the sentence index for the current token
+     *
+     * @return The index of the sentence
+     * @see #getSentence()
+     */
+    int getSentence();
+
+    /**
+     * Set the sentence of the current token
+     *
+     * @see #setSentence(int sentenceIndex)
+     */
+    void setSentence(int sentenceIndex);
+}

--- a/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
@@ -1,0 +1,60 @@
+package org.apache.lucene.analysis.tokenattributes;
+
+import org.apache.lucene.util.AttributeImpl;
+import org.apache.lucene.util.AttributeReflector;
+
+/** Default implementation of {@link SentenceAttribute}.
+ * <p>The current implementation is coincidentally identical to {@link FlagsAttributeImpl}
+ * It was decided to keep it separate because this attribute will NOT be an implied bitmap
+ * */
+public class SentenceAttributeImpl extends AttributeImpl implements SentenceAttribute {
+    private static final int NO_SENTENCE = 0;
+    private int sentence = NO_SENTENCE;
+
+    /** Initialize this attribute to default */
+    public SentenceAttributeImpl() {}
+
+    @Override
+    public void clear() {
+        sentence = NO_SENTENCE;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other instanceof SentenceAttributeImpl) {
+            return ((SentenceAttributeImpl) other).sentence == sentence;
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return sentence;
+    }
+
+    @Override
+    public void copyTo(AttributeImpl target) {
+        SentenceAttribute t = (SentenceAttribute) target;
+        t.setSentence(sentence);
+    }
+
+    @Override
+    public void reflectWith(AttributeReflector reflector) {
+        reflector.reflect(SentenceAttribute.class, "sentences", sentence);
+    }
+
+    @Override
+    public int getSentence() {
+        return sentence;
+    }
+
+    @Override
+    public void setSentence(int sentence) {
+        this.sentence = sentence;
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.lucene.analysis.tokenattributes;
 
 import org.apache.lucene.util.AttributeImpl;

--- a/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
@@ -24,8 +24,8 @@ import org.apache.lucene.util.AttributeReflector;
  * Default implementation of {@link SentenceAttribute}.
  *
  * <p>The current implementation is coincidentally identical to {@link FlagsAttributeImpl} It was
- * decided to keep it separate because this attribute will NOT be an implied bitmap. Also, this class
- * may hold other sentence specific data in the future.
+ * decided to keep it separate because this attribute will NOT be an implied bitmap. Also, this
+ * class may hold other sentence specific data in the future.
  */
 public class SentenceAttributeImpl extends AttributeImpl implements SentenceAttribute {
   private static final int NO_SENTENCE = 0;

--- a/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
@@ -7,7 +7,7 @@ import org.apache.lucene.util.AttributeReflector;
  * Default implementation of {@link SentenceAttribute}.
  *
  * <p>The current implementation is coincidentally identical to {@link FlagsAttributeImpl} It was
- * decided to keep it separate because this attribute will NOT be an implied bitmap Also this class
+ * decided to keep it separate because this attribute will NOT be an implied bitmap. Also, this class
  * may hold other sentence specific data in the future.
  */
 public class SentenceAttributeImpl extends AttributeImpl implements SentenceAttribute {

--- a/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
@@ -6,6 +6,7 @@ import org.apache.lucene.util.AttributeReflector;
 /** Default implementation of {@link SentenceAttribute}.
  * <p>The current implementation is coincidentally identical to {@link FlagsAttributeImpl}
  * It was decided to keep it separate because this attribute will NOT be an implied bitmap
+ * Also this class may hold other sentence specific data in the future.
  * */
 public class SentenceAttributeImpl extends AttributeImpl implements SentenceAttribute {
     private static final int NO_SENTENCE = 0;
@@ -40,7 +41,7 @@ public class SentenceAttributeImpl extends AttributeImpl implements SentenceAttr
     @Override
     public void copyTo(AttributeImpl target) {
         SentenceAttribute t = (SentenceAttribute) target;
-        t.setSentence(sentence);
+        t.setSentenceIndex(sentence);
     }
 
     @Override
@@ -49,12 +50,12 @@ public class SentenceAttributeImpl extends AttributeImpl implements SentenceAttr
     }
 
     @Override
-    public int getSentence() {
+    public int getSentenceIndex() {
         return sentence;
     }
 
     @Override
-    public void setSentence(int sentence) {
+    public void setSentenceIndex(int sentence) {
         this.sentence = sentence;
     }
 }

--- a/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
@@ -28,15 +28,15 @@ import org.apache.lucene.util.AttributeReflector;
  * class may hold other sentence specific data in the future.
  */
 public class SentenceAttributeImpl extends AttributeImpl implements SentenceAttribute {
-  private static final int NO_SENTENCE = 0;
-  private int sentence = NO_SENTENCE;
+
+  private int index = 0;
 
   /** Initialize this attribute to default */
   public SentenceAttributeImpl() {}
 
   @Override
   public void clear() {
-    sentence = NO_SENTENCE;
+    index = 0;
   }
 
   @Override
@@ -46,7 +46,7 @@ public class SentenceAttributeImpl extends AttributeImpl implements SentenceAttr
     }
 
     if (other instanceof SentenceAttributeImpl) {
-      return ((SentenceAttributeImpl) other).sentence == sentence;
+      return ((SentenceAttributeImpl) other).index == index;
     }
 
     return false;
@@ -54,27 +54,27 @@ public class SentenceAttributeImpl extends AttributeImpl implements SentenceAttr
 
   @Override
   public int hashCode() {
-    return sentence;
+    return index;
   }
 
   @Override
   public void copyTo(AttributeImpl target) {
     SentenceAttribute t = (SentenceAttribute) target;
-    t.setSentenceIndex(sentence);
+    t.setSentenceIndex(index);
   }
 
   @Override
   public void reflectWith(AttributeReflector reflector) {
-    reflector.reflect(SentenceAttribute.class, "sentences", sentence);
+    reflector.reflect(SentenceAttribute.class, "sentences", index);
   }
 
   @Override
   public int getSentenceIndex() {
-    return sentence;
+    return index;
   }
 
   @Override
   public void setSentenceIndex(int sentence) {
-    this.sentence = sentence;
+    this.index = sentence;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/tokenattributes/SentenceAttributeImpl.java
@@ -3,59 +3,61 @@ package org.apache.lucene.analysis.tokenattributes;
 import org.apache.lucene.util.AttributeImpl;
 import org.apache.lucene.util.AttributeReflector;
 
-/** Default implementation of {@link SentenceAttribute}.
- * <p>The current implementation is coincidentally identical to {@link FlagsAttributeImpl}
- * It was decided to keep it separate because this attribute will NOT be an implied bitmap
- * Also this class may hold other sentence specific data in the future.
- * */
+/**
+ * Default implementation of {@link SentenceAttribute}.
+ *
+ * <p>The current implementation is coincidentally identical to {@link FlagsAttributeImpl} It was
+ * decided to keep it separate because this attribute will NOT be an implied bitmap Also this class
+ * may hold other sentence specific data in the future.
+ */
 public class SentenceAttributeImpl extends AttributeImpl implements SentenceAttribute {
-    private static final int NO_SENTENCE = 0;
-    private int sentence = NO_SENTENCE;
+  private static final int NO_SENTENCE = 0;
+  private int sentence = NO_SENTENCE;
 
-    /** Initialize this attribute to default */
-    public SentenceAttributeImpl() {}
+  /** Initialize this attribute to default */
+  public SentenceAttributeImpl() {}
 
-    @Override
-    public void clear() {
-        sentence = NO_SENTENCE;
+  @Override
+  public void clear() {
+    sentence = NO_SENTENCE;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
     }
 
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-
-        if (other instanceof SentenceAttributeImpl) {
-            return ((SentenceAttributeImpl) other).sentence == sentence;
-        }
-
-        return false;
+    if (other instanceof SentenceAttributeImpl) {
+      return ((SentenceAttributeImpl) other).sentence == sentence;
     }
 
-    @Override
-    public int hashCode() {
-        return sentence;
-    }
+    return false;
+  }
 
-    @Override
-    public void copyTo(AttributeImpl target) {
-        SentenceAttribute t = (SentenceAttribute) target;
-        t.setSentenceIndex(sentence);
-    }
+  @Override
+  public int hashCode() {
+    return sentence;
+  }
 
-    @Override
-    public void reflectWith(AttributeReflector reflector) {
-        reflector.reflect(SentenceAttribute.class, "sentences", sentence);
-    }
+  @Override
+  public void copyTo(AttributeImpl target) {
+    SentenceAttribute t = (SentenceAttribute) target;
+    t.setSentenceIndex(sentence);
+  }
 
-    @Override
-    public int getSentenceIndex() {
-        return sentence;
-    }
+  @Override
+  public void reflectWith(AttributeReflector reflector) {
+    reflector.reflect(SentenceAttribute.class, "sentences", sentence);
+  }
 
-    @Override
-    public void setSentenceIndex(int sentence) {
-        this.sentence = sentence;
-    }
+  @Override
+  public int getSentenceIndex() {
+    return sentence;
+  }
+
+  @Override
+  public void setSentenceIndex(int sentence) {
+    this.sentence = sentence;
+  }
 }


### PR DESCRIPTION
Fix sentence boundary detection bug in case of repeating tokens (i.e. while using OpenNLP analysis chain in conjunction with a KeywordRepeatFilter) by keeping track of the sentence index and looking ahead one token. Move inner sentence iteration to a component to be shared by the sentence-aware OpenNLP filters.