### PR TITLE
DRAFT: TermInSetQuery refactored to extend MultiTermsQuery

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/SortedDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedDocValuesField.java
@@ -17,12 +17,15 @@
 package org.apache.lucene.document;
 
 import java.io.IOException;
+import java.util.Collection;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.DocValuesRewriteMethod;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -68,8 +71,8 @@ public class SortedDocValuesField extends Field {
    *
    * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
    * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
-   * in an {@link IndexOrDocValuesQuery}, alongside a range query that executes on points, such as
-   * {@link BinaryPoint#newRangeQuery}.
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link TermInSetQuery} containing all terms in
+   * the range.
    */
   public static Query newSlowRangeQuery(
       String field,
@@ -91,10 +94,21 @@ public class SortedDocValuesField extends Field {
    *
    * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
    * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
-   * in an {@link IndexOrDocValuesQuery}, alongside a range query that executes on points, such as
-   * {@link BinaryPoint#newExactQuery}.
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link org.apache.lucene.search.TermQuery}.
    */
   public static Query newSlowExactQuery(String field, BytesRef value) {
     return newSlowRangeQuery(field, value, value, true, true);
+  }
+
+  /**
+   * Create a query for matching against a set of {@link BytesRef} values.
+   *
+   * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
+   * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link TermInSetQuery} that uses the indexed
+   * terms.
+   */
+  public static Query newSlowTermInSetQuery(String field, Collection<BytesRef> terms) {
+    return new TermInSetQuery(DocValuesRewriteMethod.DOC_VALUES_REWRITE_METHOD, field, terms);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesField.java
@@ -17,12 +17,15 @@
 package org.apache.lucene.document;
 
 import java.io.IOException;
+import java.util.Collection;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.DocValuesRewriteMethod;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -68,8 +71,8 @@ public class SortedSetDocValuesField extends Field {
    *
    * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
    * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
-   * in an {@link IndexOrDocValuesQuery}, alongside a range query that executes on points, such as
-   * {@link BinaryPoint#newRangeQuery}.
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link TermInSetQuery} containing all terms in
+   * the range.
    */
   public static Query newSlowRangeQuery(
       String field,
@@ -93,10 +96,23 @@ public class SortedSetDocValuesField extends Field {
    *
    * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
    * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
-   * in an {@link IndexOrDocValuesQuery}, alongside a range query that executes on points, such as
-   * {@link BinaryPoint#newExactQuery}.
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link org.apache.lucene.search.TermQuery}.
    */
   public static Query newSlowExactQuery(String field, BytesRef value) {
     return newSlowRangeQuery(field, value, value, true, true);
+  }
+
+  /**
+   * Create a query for matching against a set of {@link BytesRef} values.
+   *
+   * <p>This query also works with fields that have indexed {@link SortedDocValuesField}s.
+   *
+   * <p><b>NOTE</b>: Such queries cannot efficiently advance to the next match, which makes them
+   * slow if they are not ANDed with a selective query. As a consequence, they are best used wrapped
+   * in an {@link IndexOrDocValuesQuery}, alongside a {@link TermInSetQuery} that uses the indexed
+   * terms.
+   */
+  public static Query newSlowTermInSetQuery(String field, Collection<BytesRef> terms) {
+    return new TermInSetQuery(DocValuesRewriteMethod.DOC_VALUES_REWRITE_METHOD, field, terms);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesRewriteMethod.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesRewriteMethod.java
@@ -35,6 +35,9 @@ import org.apache.lucene.util.LongBitSet;
  */
 public final class DocValuesRewriteMethod extends MultiTermQuery.RewriteMethod {
 
+  public static final DocValuesRewriteMethod DOC_VALUES_REWRITE_METHOD =
+      new DocValuesRewriteMethod();
+
   @Override
   public Query rewrite(IndexReader reader, MultiTermQuery query) {
     return new ConstantScoreQuery(new MultiTermQueryDocValuesWrapper(query));

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -275,6 +275,14 @@ public abstract class MultiTermQuery extends Query {
   }
 
   /**
+   * Return the number of unique terms contained in this query, if known up-front. If not known, -1
+   * will be returned.
+   */
+  public long getTermsCount() throws IOException {
+    return -1;
+  }
+
+  /**
    * To rewrite to a simpler form, instead return a simpler enum from {@link #getTermsEnum(Terms,
    * AttributeSource)}. For example, to rewrite to a single term, return a {@link SingleTermsEnum}
    */

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
@@ -124,99 +124,94 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
       throws IOException {
     return new ConstantScoreWeight(this, boost) {
 
-      /**
-       * Try to collect terms from the given terms enum and return true iff all terms could be
-       * collected. If {@code false} is returned, the enum is left positioned on the next term.
-       */
-      private boolean collectTerms(
-          LeafReaderContext context, TermsEnum termsEnum, List<TermAndState> terms)
-          throws IOException {
-        final int threshold =
-            Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
-        for (int i = 0; i < threshold; ++i) {
-          final BytesRef term = termsEnum.next();
-          if (term == null) {
-            return true;
-          }
-          TermState state = termsEnum.termState();
-          terms.add(
-              new TermAndState(
-                  BytesRef.deepCopyOf(term),
-                  state,
-                  termsEnum.docFreq(),
-                  termsEnum.totalTermFreq()));
-        }
-        return termsEnum.next() == null;
-      }
-
-      /**
-       * On the given leaf context, try to either rewrite to a disjunction if there are few terms,
-       * or build a bitset containing matching docs.
-       */
-      private WeightOrDocIdSet rewrite(LeafReaderContext context) throws IOException {
-        final Terms terms = context.reader().terms(query.field);
-        if (terms == null) {
-          // field does not exist
-          return new WeightOrDocIdSet((DocIdSet) null);
-        }
-
-        final TermsEnum termsEnum = query.getTermsEnum(terms);
-        assert termsEnum != null;
-
-        PostingsEnum docs = null;
-
-        final List<TermAndState> collectedTerms = new ArrayList<>();
-        if (collectTerms(context, termsEnum, collectedTerms)) {
-          // build a boolean query
-          BooleanQuery.Builder bq = new BooleanQuery.Builder();
-          for (TermAndState t : collectedTerms) {
-            final TermStates termStates = new TermStates(searcher.getTopReaderContext());
-            termStates.register(t.state, context.ord, t.docFreq, t.totalTermFreq);
-            bq.add(new TermQuery(new Term(query.field, t.term), termStates), Occur.SHOULD);
-          }
-          Query q = new ConstantScoreQuery(bq.build());
-          final Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
-          return new WeightOrDocIdSet(weight);
-        }
-
-        // Too many terms: go back to the terms we already collected and start building the bit set
-        DocIdSetBuilder builder = new DocIdSetBuilder(context.reader().maxDoc(), terms);
-        if (collectedTerms.isEmpty() == false) {
-          TermsEnum termsEnum2 = terms.iterator();
-          for (TermAndState t : collectedTerms) {
-            termsEnum2.seekExact(t.term, t.state);
-            docs = termsEnum2.postings(docs, PostingsEnum.NONE);
-            builder.add(docs);
-          }
-        }
-
-        // Then keep filling the bit set with remaining terms
-        do {
-          docs = termsEnum.postings(docs, PostingsEnum.NONE);
-          builder.add(docs);
-        } while (termsEnum.next() != null);
-
-        return new WeightOrDocIdSet(builder.build());
-      }
-
-      private Scorer scorer(DocIdSet set) throws IOException {
-        if (set == null) {
+      @Override
+      public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+        final Terms indexTerms = context.reader().terms(query.getField());
+        if (indexTerms == null) {
           return null;
         }
-        final DocIdSetIterator disi = set.iterator();
-        if (disi == null) {
+
+        // Estimate the cost. If the MTQ can provide its term count, we can do a better job
+        // estimating.
+        // Cost estimation reasoning is:
+        // 1. If we don't know how many query terms there are, we assume that every term could be
+        //    in the MTQ and estimate the work as the total docs across all terms.
+        // 2. If we know how many query terms there are...
+        //    2a. Assume every query term matches at least one document (queryTermsCount).
+        //    2b. Determine the total number of docs beyond the first one for each term.
+        //        That count provides a ceiling on the number of extra docs that could match beyond
+        //        that first one. (We omit the first since it's already been counted in 2a).
+        // See: LUCENE-10207
+
+        // TODO: This cost estimation may grossly overestimate since we have no index statistics
+        // for the specific query terms. While it's nice to avoid the cost of intersecting the
+        // query terms with the index, it could be beneficial to do that work and get better
+        // cost estimates.
+        final long cost;
+        final long queryTermsCount = query.getTermsCount();
+        if (queryTermsCount == -1) {
+          cost = indexTerms.getSumDocFreq();
+        } else {
+          long potentialExtraCost = indexTerms.getSumDocFreq();
+          final long indexedTermCount = indexTerms.size();
+          if (indexedTermCount != -1) {
+            potentialExtraCost -= indexedTermCount;
+          }
+          cost = queryTermsCount + potentialExtraCost;
+        }
+
+        final Weight weight = this;
+        return new ScorerSupplier() {
+          @Override
+          public Scorer get(long leadCost) throws IOException {
+            WeightOrDocIdSet weightOrBitSet = rewrite(context, indexTerms);
+            final Scorer scorer;
+            if (weightOrBitSet.weight != null) {
+              scorer = weightOrBitSet.weight.scorer(context);
+            } else {
+              scorer = scorerForDocIdSet(weight, score(), scoreMode, weightOrBitSet.set);
+            }
+
+            // It's against the API contract to return a null scorer from a non-null ScoreSupplier.
+            // So if our ScoreSupplier was non-null (i.e., thought there might be hits) but we now
+            // find that there are actually no hits, we need to return an empty Scorer as opposed
+            // to null:
+            return Objects.requireNonNullElseGet(
+                scorer,
+                () ->
+                    new ConstantScoreScorer(weight, score(), scoreMode, DocIdSetIterator.empty()));
+          }
+
+          @Override
+          public long cost() {
+            return cost;
+          }
+        };
+      }
+
+      @Override
+      public Scorer scorer(LeafReaderContext context) throws IOException {
+        final ScorerSupplier scorerSupplier = scorerSupplier(context);
+        if (scorerSupplier == null) {
           return null;
         }
-        return new ConstantScoreScorer(this, score(), scoreMode, disi);
+        return scorerSupplier.get(Long.MAX_VALUE);
       }
 
       @Override
       public BulkScorer bulkScorer(LeafReaderContext context) throws IOException {
-        final WeightOrDocIdSet weightOrBitSet = rewrite(context);
+        final Terms indexTerms = context.reader().terms(query.getField());
+        if (indexTerms == null) {
+          return null;
+        }
+
+        final WeightOrDocIdSet weightOrBitSet = rewrite(context, indexTerms);
         if (weightOrBitSet.weight != null) {
+          // If we're using a Weight, let it provide its bulk scorer:
           return weightOrBitSet.weight.bulkScorer(context);
         } else {
-          final Scorer scorer = scorer(weightOrBitSet.set);
+          // If we're using a pre-populated DocIdSet, produce a DefaultBulkScorer over it:
+          final Scorer scorer = scorerForDocIdSet(this, score(), scoreMode, weightOrBitSet.set);
           if (scorer == null) {
             return null;
           }
@@ -226,30 +221,95 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
 
       @Override
       public Matches matches(LeafReaderContext context, int doc) throws IOException {
-        final Terms terms = context.reader().terms(query.field);
-        if (terms == null) {
+        final Terms indexTerms = context.reader().terms(query.field);
+        if (indexTerms == null) {
           return null;
         }
         return MatchesUtils.forField(
             query.field,
             () ->
                 DisjunctionMatchesIterator.fromTermsEnum(
-                    context, doc, query, query.field, query.getTermsEnum(terms)));
-      }
-
-      @Override
-      public Scorer scorer(LeafReaderContext context) throws IOException {
-        final WeightOrDocIdSet weightOrBitSet = rewrite(context);
-        if (weightOrBitSet.weight != null) {
-          return weightOrBitSet.weight.scorer(context);
-        } else {
-          return scorer(weightOrBitSet.set);
-        }
+                    context, doc, query, query.field, query.getTermsEnum(indexTerms)));
       }
 
       @Override
       public boolean isCacheable(LeafReaderContext ctx) {
         return true;
+      }
+
+      /**
+       * On the given leaf context, try to either rewrite to a disjunction if there are few terms,
+       * or build a bitset containing matching docs.
+       */
+      private WeightOrDocIdSet rewrite(LeafReaderContext context, Terms indexTerms)
+          throws IOException {
+        assert indexTerms != null;
+
+        // Create a TermsEnum that will produce the intersection of the query terms with the indexed
+        // terms:
+        final TermsEnum termsEnum = query.getTermsEnum(indexTerms);
+        assert termsEnum != null;
+
+        // Collect terms up to BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD:
+        final List<TermAndState> collectedTerms = new ArrayList<>();
+        if (collectTerms(termsEnum, collectedTerms)) {
+          // If there were fewer than BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD terms, build a BQ:
+          final BooleanQuery.Builder bq = new BooleanQuery.Builder();
+          for (TermAndState t : collectedTerms) {
+            final TermStates termStates = new TermStates(searcher.getTopReaderContext());
+            termStates.register(t.state, context.ord, t.docFreq, t.totalTermFreq);
+            bq.add(new TermQuery(new Term(query.field, t.term), termStates), Occur.SHOULD);
+          }
+          final Query q = new ConstantScoreQuery(bq.build());
+          final Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
+          return new WeightOrDocIdSet(weight);
+        }
+
+        // More than BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD terms, so we'll build a bit set of the
+        // matching docs. First, go back through the terms already collected and add their docs:
+        PostingsEnum docs = null;
+        final DocIdSetBuilder builder = new DocIdSetBuilder(context.reader().maxDoc(), indexTerms);
+        if (collectedTerms.isEmpty() == false) {
+          final TermsEnum termsEnum2 = indexTerms.iterator();
+          for (TermAndState t : collectedTerms) {
+            termsEnum2.seekExact(t.term, t.state);
+            docs = termsEnum2.postings(docs, PostingsEnum.NONE);
+            builder.add(docs);
+          }
+        }
+
+        // Iterate the remaining terms and finish filling the bit set:
+        do {
+          // (remember that termsEnum was left positioned on the next term beyond the threshold):
+          docs = termsEnum.postings(docs, PostingsEnum.NONE);
+          builder.add(docs);
+        } while (termsEnum.next() != null);
+
+        return new WeightOrDocIdSet(builder.build());
+      }
+
+      /**
+       * Try to collect terms from the given terms enum and return true iff all terms could be
+       * collected. If {@code false} is returned, the enum is left positioned on the next term.
+       */
+      private boolean collectTerms(TermsEnum termsEnum, List<TermAndState> terms)
+          throws IOException {
+        final int threshold =
+            Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
+        for (int i = 0; i < threshold; i++) {
+          final BytesRef term = termsEnum.next();
+          if (term == null) {
+            return true;
+          }
+          final TermState state = termsEnum.termState();
+          terms.add(
+              new TermAndState(
+                  BytesRef.deepCopyOf(term),
+                  state,
+                  termsEnum.docFreq(),
+                  termsEnum.totalTermFreq()));
+        }
+        return termsEnum.next() == null;
       }
     };
   }
@@ -259,5 +319,18 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
     if (visitor.acceptField(getField())) {
       query.visit(visitor.getSubVisitor(Occur.FILTER, this));
     }
+  }
+
+  /** Provide a ConstantScoreScorer over the pre-populated DocIdSet */
+  private static Scorer scorerForDocIdSet(
+      Weight weight, float score, ScoreMode scoreMode, DocIdSet set) throws IOException {
+    if (set == null) {
+      return null;
+    }
+    final DocIdSetIterator disi = set.iterator();
+    if (disi == null) {
+      return null;
+    }
+    return new ConstantScoreScorer(weight, score, scoreMode, disi);
   }
 }

--- a/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
@@ -95,6 +95,11 @@ class TermsQuery extends MultiTermQuery implements Accountable {
   }
 
   @Override
+  public long getTermsCount() throws IOException {
+    return terms.size();
+  }
+
+  @Override
   public String toString(String string) {
     return "TermsQuery{" + "field=" + field + "fromQuery=" + fromQuery.toString(field) + '}';
   }


### PR DESCRIPTION
### Description

This is a demo PR to show how we can make `TermInSetQuery` extend `MultiTermsQuery` and add "slow" doc-value-based queries by doing so.

We'd need to benchmark to understand any potential regressions to the "standard" index-based term-in-set query functionality before merging this. Marking as a "draft" for now.