### PR TITLE
Remove LongValueFacetCounts#getTopChildrenSortByCount since it provides redundant functionality

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -117,6 +117,8 @@ API Changes
 * GITHUB#12173: TermInSetQuery#getTermData has been deprecated. This exposes internal implementation details that we
   may want to change in the future, and users shouldn't rely on the encoding directly. (Greg Miller)
 
+* GITHUB#11746: Deprecate LongValueFacetCounts#getTopChildrenSortByCount. (Greg Miller)
+
 New Features
 ---------------------
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
@@ -42,8 +42,9 @@ import org.apache.lucene.util.PriorityQueue;
  * {@link Facets} implementation that computes counts for all unique long values, more efficiently
  * counting small values (0-1023) using an int array, and switching to a <code>HashMap</code> for
  * values above 1023. Retrieve all facet counts, in value order, with {@link
- * #getAllChildrenSortByValue}, or get the topN values sorted by count with {@link
- * #getTopChildrenSortByCount}.
+ * #getAllChildrenSortByValue}, or get all children with no ordering requirements with {@link
+ * #getAllChildren(String, String...)}, or get the topN values sorted by count with {@link
+ * #getTopChildren(int, String, String...)}.
  *
  * @lucene.experimental
  */
@@ -376,17 +377,7 @@ public class LongValueFacetCounts extends Facets {
   public FacetResult getTopChildren(int topN, String dim, String... path) {
     validateTopN(topN);
     validateDimAndPathForGetChildren(dim, path);
-    return getTopChildrenSortByCount(topN);
-  }
 
-  /** Reusable hash entry to hold long facet value and int count. */
-  private static class Entry {
-    int count;
-    long value;
-  }
-
-  /** Returns the specified top number of facets, sorted by count. */
-  public FacetResult getTopChildrenSortByCount(int topN) {
     PriorityQueue<Entry> pq =
         new PriorityQueue<>(Math.min(topN, counts.length + hashCounts.size())) {
           @Override
@@ -434,7 +425,20 @@ public class LongValueFacetCounts extends Facets {
     return new FacetResult(field, new String[0], totCount, results, childCount);
   }
 
-  /** Returns all unique values seen, sorted by value. */
+  /** Reusable hash entry to hold long facet value and int count. */
+  private static class Entry {
+    int count;
+    long value;
+  }
+
+  /**
+   * Returns all unique values seen, sorted by value. This functionality is very similar to {@link
+   * #getAllChildren(String, String...)}, but it guarantees the returned values will be sorted by
+   * value (while {@code #getAllChildren} doesn't guarantee any sort order).
+   *
+   * <p>Note: If you don't care about the order of children returned, it may be slightly more
+   * efficient to use {@link #getAllChildren(String, String...)}.
+   */
   public FacetResult getAllChildrenSortByValue() {
     List<LabelAndValue> labelValues = new ArrayList<>();
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -399,7 +399,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (VERBOSE) {
         System.out.println("  topN=" + topN);
       }
-      actual = facetCounts.getTopChildrenSortByCount(topN);
+      actual = facetCounts.getTopChildren(topN, "field");
       assertSame(
           "all docs, sort facets by count",
           expectedCounts,
@@ -488,7 +488,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       } else {
         topN = random().nextInt(docCount);
       }
-      actual = facetCounts.getTopChildrenSortByCount(topN);
+      actual = facetCounts.getTopChildren(topN, "field");
       assertSame(
           "id " + minId + "-" + maxId + ", sort facets by count",
           expectedCounts,
@@ -662,7 +662,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (VERBOSE) {
         System.out.println("  topN=" + topN);
       }
-      actual = facetCounts.getTopChildrenSortByCount(topN);
+      actual = facetCounts.getTopChildren(topN, "field");
       assertSame(
           "all docs, sort facets by count",
           expectedCounts,
@@ -729,7 +729,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       } else {
         topN = random().nextInt(docCount);
       }
-      actual = facetCounts.getTopChildrenSortByCount(topN);
+      actual = facetCounts.getTopChildren(topN, "field");
       assertSame(
           "id " + minId + "-" + maxId + ", sort facets by count",
           expectedCounts,


### PR DESCRIPTION
### Description

`LongValueFacetCounts#getTopChildrenSortByCount` does exactly the same thing as the more standard `LongValueFacetCounts#getTopChildren`, so we can tighten up our API.

Note that this PR would go with 10.0, and I'll put up a separate PR to mark it deprecated against 9.x.