### PR TITLE
Deprecate LongValueFacetCounts#getTopChildrenSortByCount since it provides redundant functionality

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -9,6 +9,8 @@ API Changes
 ---------------------
 * LUCENE-10577: Add VectorEncoding to enable byte-encoded HNSW vectors (Michael Sokolov, Julie Tibshirani)
 
+* GITHUB#11746: Deprecate LongValueFacetCounts#getTopChildrenSortByCount. (Greg Miller)
+
 New Features
 ---------------------
 * LUCENE-10654: Add new ShapeDocValuesField for LatLonShape and XYShape. (Nick Knize)

--- a/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
@@ -42,8 +42,9 @@ import org.apache.lucene.util.PriorityQueue;
  * {@link Facets} implementation that computes counts for all unique long values, more efficiently
  * counting small values (0-1023) using an int array, and switching to a <code>HashMap</code> for
  * values above 1023. Retrieve all facet counts, in value order, with {@link
- * #getAllChildrenSortByValue}, or get the topN values sorted by count with {@link
- * #getTopChildrenSortByCount}.
+ * #getAllChildrenSortByValue}, or get all children with no ordering requirements with {@link
+ * #getAllChildren(String, String...)}, or get the topN values sorted by count with {@link
+ * #getTopChildren(int, String, String...)}.
  *
  * @lucene.experimental
  */
@@ -385,7 +386,13 @@ public class LongValueFacetCounts extends Facets {
     long value;
   }
 
-  /** Returns the specified top number of facets, sorted by count. */
+  /**
+   * Returns the specified top number of facets, sorted by count.
+   *
+   * @deprecated Please use {@link #getTopChildren(int, String, String...)} instead for the same
+   *     functionality.
+   */
+  @Deprecated
   public FacetResult getTopChildrenSortByCount(int topN) {
     PriorityQueue<Entry> pq =
         new PriorityQueue<>(Math.min(topN, counts.length + hashCounts.size())) {
@@ -434,7 +441,14 @@ public class LongValueFacetCounts extends Facets {
     return new FacetResult(field, new String[0], totCount, results, childCount);
   }
 
-  /** Returns all unique values seen, sorted by value. */
+  /**
+   * Returns all unique values seen, sorted by value. This functionality is very similar to {@link
+   * #getAllChildren(String, String...)}, but it guarantees the returned values will be sorted by
+   * value (while {@code #getAllChildren} doesn't guarantee any sort order).
+   *
+   * <p>Note: If you don't care about the order of children returned, it may be slightly more
+   * efficient to use {@link #getAllChildren(String, String...)}.
+   */
   public FacetResult getAllChildrenSortByValue() {
     List<LabelAndValue> labelValues = new ArrayList<>();
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -399,7 +399,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (VERBOSE) {
         System.out.println("  topN=" + topN);
       }
-      actual = facetCounts.getTopChildrenSortByCount(topN);
+      actual = facetCounts.getTopChildren(topN, "field");
       assertSame(
           "all docs, sort facets by count",
           expectedCounts,
@@ -488,7 +488,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       } else {
         topN = random().nextInt(docCount);
       }
-      actual = facetCounts.getTopChildrenSortByCount(topN);
+      actual = facetCounts.getTopChildren(topN, "field");
       assertSame(
           "id " + minId + "-" + maxId + ", sort facets by count",
           expectedCounts,
@@ -662,7 +662,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (VERBOSE) {
         System.out.println("  topN=" + topN);
       }
-      actual = facetCounts.getTopChildrenSortByCount(topN);
+      actual = facetCounts.getTopChildren(topN, "field");
       assertSame(
           "all docs, sort facets by count",
           expectedCounts,
@@ -729,7 +729,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       } else {
         topN = random().nextInt(docCount);
       }
-      actual = facetCounts.getTopChildrenSortByCount(topN);
+      actual = facetCounts.getTopChildren(topN, "field");
       assertSame(
           "id " + minId + "-" + maxId + ", sort facets by count",
           expectedCounts,


### PR DESCRIPTION
### Description

This is a companion (backport) PR to #11744 that marks functionality deprecated instead of outright removing it.
