### PR TITLE
Added interface to relate a LatLonShape with another shape represented as Component2D

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -107,7 +107,7 @@ API Changes
 
 * GITHUB#11761: TieredMergePolicy now allowed a maximum allowable deletes percentage of down to 5%, and the default
   maximum allowable deletes percentage is changed from 33% to 20%. (Marc D'Mello)
-  
+
 * GITHUB#11822: Configure replicator PrimaryNode replia shutdown timeout. (Steven Schlansker)
 
 New Features
@@ -167,6 +167,8 @@ Other
 * GITHUB#11834: Upgrade forbiddenapis to version 3.4.  (Uwe Schindler)
 
 * LUCENE-10635: Ensure test coverage for WANDScorer by using a test query. (Zach Chen, Adrien Grand)
+
+* GITHUB#11752: Added interface to relate a LatLonShape with another shape represented as Component2D. (Navneet Verma)
 
 Build
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonShape.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonShape.java
@@ -66,6 +66,7 @@ import org.apache.lucene.util.BytesRef;
  *       QueryRelation} with a polygon.
  *   <li>{@link #newGeometryQuery newGeometryQuery()} for matching geo shapes that have some {@link
  *       QueryRelation} with one or more {@link LatLonGeometry}.
+ *   <li>{@link #createLatLonShapeDocValues(BytesRef)} for creating the {@link LatLonShapeDocValues}
  * </ul>
  *
  * <b>WARNING</b>: Like {@link LatLonPoint}, vertex values are indexed with some loss of precision
@@ -339,6 +340,16 @@ public class LatLonShape {
         return new LatLonShapeQuery(field, queryRelation, latLonGeometries);
       }
     }
+  }
+
+  /**
+   * Factory method for creating the {@link LatLonShapeDocValues}
+   *
+   * @param bytesRef {@link BytesRef}
+   * @return {@link LatLonShapeDocValues}
+   */
+  public static LatLonShapeDocValues createLatLonShapeDocValues(BytesRef bytesRef) {
+    return new LatLonShapeDocValues(bytesRef);
   }
 
   private static Query makeContainsGeometryQuery(String field, LatLonGeometry... latLonGeometries) {

--- a/lucene/core/src/java/org/apache/lucene/document/XYShape.java
+++ b/lucene/core/src/java/org/apache/lucene/document/XYShape.java
@@ -65,6 +65,7 @@ import org.apache.lucene.util.BytesRef;
  *       QueryRelation} with a polygon.
  *   <li>{@link #newGeometryQuery newGeometryQuery()} for matching cartesian shapes that have some
  *       {@link QueryRelation} with one or more {@link XYGeometry}.
+ *   <li>{@link #createXYShapeDocValues(BytesRef)} for creating the {@link XYShapeDocValues}
  * </ul>
  *
  * <b>WARNING</b>: Like {@link LatLonPoint}, vertex values are indexed with some loss of precision
@@ -268,5 +269,15 @@ public class XYShape {
       return new ConstantScoreQuery(builder.build());
     }
     return new XYShapeQuery(field, queryRelation, xyGeometries);
+  }
+
+  /**
+   * Factory method for creating the {@link XYShapeDocValues}
+   *
+   * @param bytesRef {@link BytesRef}
+   * @return {@link XYShapeDocValues}
+   */
+  public static XYShapeDocValues createXYShapeDocValues(BytesRef bytesRef) {
+    return new XYShapeDocValues(bytesRef);
   }
 }


### PR DESCRIPTION
### Description
Added interface to relate a LatLonShape with another shape represented as Component2D.

The code needs to be backported to 9.x branch.

### Issues
#11752 
