### PR TITLE
Removed duplicate check in SpanGradientFormatter

### DIFF
--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/SpanGradientFormatter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/SpanGradientFormatter.java
@@ -34,7 +34,6 @@ public class SpanGradientFormatter extends GradientFormatter {
 
   @Override
   public String highlightTerm(String originalText, TokenGroup tokenGroup) {
-    if (tokenGroup.getTotalScore() == 0) return originalText;
     float score = tokenGroup.getTotalScore();
     if (score == 0) {
       return originalText;


### PR DESCRIPTION
### Description

Looks the variable `score` was introduced later and the check was duplicated by accident.