### PR TITLE
Retry gradle wrapper download on http 500 and 503.

### DIFF
--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -92,7 +92,7 @@ public class WrapperDownloader {
       }
     }
 
-    URL url = new URL("https://github.com/gradle/gradle/raw/v" + wrapperVersion + "/gradle/wrapper/gradle-wrapper.jar");
+    URL url = new URL("https://raw.githubusercontent.com/gradle/gradle/v" + wrapperVersion + "/gradle/wrapper/gradle-wrapper.jar");
     System.err.println("Downloading gradle-wrapper.jar from " + url);
 
     // Zero-copy save the jar to a temp file

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -17,7 +17,11 @@
 package org.apache.lucene.gradle;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
@@ -29,6 +33,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.EnumSet;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.nio.file.StandardOpenOption.APPEND;
@@ -90,18 +95,34 @@ public class WrapperDownloader {
     URL url = new URL("https://github.com/gradle/gradle/raw/v" + wrapperVersion + "/gradle/wrapper/gradle-wrapper.jar");
     System.err.println("Downloading gradle-wrapper.jar from " + url);
 
-    // As of v6.0.1 the wrapper is approximately 60K
-    // Can increase this if gradle wrapper ever goes beyond 500K, but keep a safety check
-    final int maxSize = 512 * 1024;
-
     // Zero-copy save the jar to a temp file
     Path temp = Files.createTempFile(destination.getParent(), ".gradle-wrapper", ".tmp");
     try {
-      try (ReadableByteChannel in = Channels.newChannel(url.openStream());
-           FileChannel out = FileChannel.open(temp, EnumSet.of(APPEND))) {
-        out.transferFrom(in, 0, maxSize);
-      } catch (IOException e) {
-        throw new IOException("Could not download gradle-wrapper.jar (" + e.getMessage() + ").");
+      int retries = 3;
+      int retryDelay = 30;
+      HttpURLConnection connection;
+      while (true) {
+        connection = (HttpURLConnection) url.openConnection();
+        connection.connect();
+
+        switch (connection.getResponseCode()) {
+          case HttpURLConnection.HTTP_INTERNAL_ERROR:
+          case HttpURLConnection.HTTP_UNAVAILABLE:
+            if (retries-- > 0) {
+              // Retry after a short delay.
+              System.err.println("Server returned HTTP " + connection.getResponseCode() + ", will retry in " + retryDelay + " seconds.");
+              Thread.sleep(TimeUnit.SECONDS.toMillis(retryDelay));
+              continue;
+            }
+        }
+
+        // fall through, let getInputStream() throw IOException if there's a failure.
+        break;
+      }
+
+      try (InputStream is = connection.getInputStream();
+           OutputStream out = Files.newOutputStream(temp)){
+        is.transferTo(out);
       }
 
       String checksum = checksum(digest, temp);
@@ -114,6 +135,9 @@ public class WrapperDownloader {
 
       Files.move(temp, destination, REPLACE_EXISTING);
       temp = null;
+    } catch (IOException | InterruptedException e) {
+      throw new IOException("Could not download gradle-wrapper.jar (" +
+          e.getClass().getSimpleName() + ": " + e.getMessage() + ").");
     } finally {
       if (temp != null) {
         Files.deleteIfExists(temp);

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -108,6 +108,7 @@ public class WrapperDownloader {
         switch (connection.getResponseCode()) {
           case HttpURLConnection.HTTP_INTERNAL_ERROR:
           case HttpURLConnection.HTTP_UNAVAILABLE:
+          case HttpURLConnection.HTTP_BAD_GATEWAY:
             if (retries-- > 0) {
               // Retry after a short delay.
               System.err.println("Server returned HTTP " + connection.getResponseCode() + ", will retry in " + retryDelay + " seconds.");


### PR DESCRIPTION
We have more and more frequent CI failures due to http 500 and 503 when downloading the gradle wrapper. I added a simple retry mechanism (compatible with JDK11 for ease of backport) - perhaps it'll limit the failures slightly.