### PR TITLE
Mark HNSW search results incomplete when fewer than topK are found

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -267,6 +267,9 @@ public class HnswGraphSearcher<T> {
     while (results.size() > topK) {
       results.pop();
     }
+    if (level == 0 && results.size() < topK && numVisited < size) {
+      results.markIncomplete();
+    }
     results.setVisitedCount(numVisited);
     return results;
   }


### PR DESCRIPTION
This addresses a random test failure that came up recently due to another fix. I think this failure exposed a hole in our logic; when a search returns fewer results than requested *and we have not explored the entire graph*, we should fall back to exhaustive search. This can happen in degenerate cases such as this test creates.
