### PR TITLE
Guard FieldExistsQuery against null pointers

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -169,6 +169,8 @@ Bug Fixes
 
 * LUCENE-10674: Ensure BitSetConjDISI returns NO_MORE_DOCS when sub-iterator exhausts. (Jack Mazanec)
 
+* GITHUB#11794: Guard FieldExistsQuery against null pointers (Luca Cavanna)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -233,7 +233,8 @@ public class FieldExistsQuery extends Query {
               PointValues pointValues = reader.getPointValues(field);
               return pointValues == null ? 0 : pointValues.getDocCount();
             } else if (fieldInfo.getIndexOptions() != IndexOptions.NONE) {
-              return reader.terms(field).getDocCount();
+              Terms terms = reader.terms(field);
+              return terms == null ? 0 : terms.getDocCount();
             }
           }
 

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -230,7 +230,8 @@ public class FieldExistsQuery extends Query {
             != DocValuesType.NONE) { // the field indexes doc values
           if (reader.hasDeletions() == false) {
             if (fieldInfo.getPointDimensionCount() > 0) {
-              return reader.getPointValues(field).getDocCount();
+              PointValues pointValues = reader.getPointValues(field);
+              return pointValues == null ? 0 : pointValues.getDocCount();
             } else if (fieldInfo.getIndexOptions() != IndexOptions.NONE) {
               return reader.terms(field).getDocCount();
             }

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
@@ -702,6 +702,28 @@ public class TestFieldExistsQuery extends LuceneTestCase {
     return v;
   }
 
+  public void testDeleteAllPointDocs() throws Exception {
+    try (Directory dir = newDirectory();
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+
+      Document doc = new Document();
+      doc.add(new StringField("id", "0", Field.Store.NO));
+      doc.add(new LongPoint("long", 17));
+      doc.add(new NumericDocValuesField("long", 17));
+      iw.addDocument(doc);
+      iw.addDocument(new Document());
+      iw.commit();
+
+      iw.deleteDocuments(new Term("id", "0"));
+      iw.forceMerge(1);
+
+      try (IndexReader reader = iw.getReader()) {
+        IndexSearcher searcher = newSearcher(reader);
+        assertEquals(0, searcher.count(new FieldExistsQuery("long")));
+      }
+    }
+  }
+
   private void assertSameMatches(IndexSearcher searcher, Query q1, Query q2, boolean scores)
       throws IOException {
     final int maxDoc = searcher.getIndexReader().maxDoc();

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
@@ -17,6 +17,8 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
+
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.BinaryPoint;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoubleDocValuesField;
@@ -719,7 +721,7 @@ public class TestFieldExistsQuery extends LuceneTestCase {
       iw.forceMerge(1);
 
       try (IndexReader reader = iw.getReader()) {
-        assert reader.leaves().size() == 1 && reader.hasDeletions() == false;
+        assertTrue(reader.leaves().size() == 1 && reader.hasDeletions() == false);
         IndexSearcher searcher = newSearcher(reader);
         assertEquals(0, searcher.count(new FieldExistsQuery("long")));
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
-
 import org.apache.lucene.document.BinaryPoint;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoubleDocValuesField;
@@ -712,10 +711,11 @@ public class TestFieldExistsQuery extends LuceneTestCase {
       doc.add(new LongPoint("long", 17));
       doc.add(new NumericDocValuesField("long", 17));
       iw.addDocument(doc);
-      //add another document before the flush, otherwise the segment only has the document that
-      // we are going to delete and the merge simply ignores the segment without carrying over its field infos
+      // add another document before the flush, otherwise the segment only has the document that
+      // we are going to delete and the merge simply ignores the segment without carrying over its
+      // field infos
       iw.addDocument(new Document());
-      //make sure there are two segments or force merge will be a no-op
+      // make sure there are two segments or force merge will be a no-op
       iw.flush();
       iw.addDocument(new Document());
       iw.commit();
@@ -733,17 +733,18 @@ public class TestFieldExistsQuery extends LuceneTestCase {
 
   public void testDeleteAllTermDocs() throws Exception {
     try (Directory dir = newDirectory();
-         RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
 
       Document doc = new Document();
       doc.add(new StringField("id", "0", Field.Store.NO));
       doc.add(new StringField("str", "foo", Store.NO));
       doc.add(new SortedDocValuesField("str", new BytesRef("foo")));
       iw.addDocument(doc);
-      //add another document before the flush, otherwise the segment only has the document that
-      // we are going to delete and the merge simply ignores the segment without carrying over its field infos
+      // add another document before the flush, otherwise the segment only has the document that
+      // we are going to delete and the merge simply ignores the segment without carrying over its
+      // field infos
       iw.addDocument(new Document());
-      //make sure there are two segments or force merge will be a no-op
+      // make sure there are two segments or force merge will be a no-op
       iw.flush();
       iw.addDocument(new Document());
       iw.commit();

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
@@ -713,6 +713,10 @@ public class TestFieldExistsQuery extends LuceneTestCase {
       doc.add(new LongPoint("long", 17));
       doc.add(new NumericDocValuesField("long", 17));
       iw.addDocument(doc);
+      //add another document before the flush, otherwise the segment only has the document that
+      // we are going to delete and the merge simply ignores the segment without carrying over its field infos
+      iw.addDocument(new Document());
+      //make sure there are two segments or force merge will be a no-op
       iw.flush();
       iw.addDocument(new Document());
       iw.commit();
@@ -724,6 +728,34 @@ public class TestFieldExistsQuery extends LuceneTestCase {
         assertTrue(reader.leaves().size() == 1 && reader.hasDeletions() == false);
         IndexSearcher searcher = newSearcher(reader);
         assertEquals(0, searcher.count(new FieldExistsQuery("long")));
+      }
+    }
+  }
+
+  public void testDeleteAllTermDocs() throws Exception {
+    try (Directory dir = newDirectory();
+         RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+
+      Document doc = new Document();
+      doc.add(new StringField("id", "0", Field.Store.NO));
+      doc.add(new StringField("str", "foo", Store.NO));
+      doc.add(new SortedDocValuesField("str", new BytesRef("foo")));
+      iw.addDocument(doc);
+      //add another document before the flush, otherwise the segment only has the document that
+      // we are going to delete and the merge simply ignores the segment without carrying over its field infos
+      iw.addDocument(new Document());
+      //make sure there are two segments or force merge will be a no-op
+      iw.flush();
+      iw.addDocument(new Document());
+      iw.commit();
+
+      iw.deleteDocuments(new Term("id", "0"));
+      iw.forceMerge(1);
+
+      try (IndexReader reader = iw.getReader()) {
+        assertTrue(reader.leaves().size() == 1 && reader.hasDeletions() == false);
+        IndexSearcher searcher = newSearcher(reader);
+        assertEquals(0, searcher.count(new FieldExistsQuery("str")));
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
@@ -18,7 +18,6 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 
-import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.BinaryPoint;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoubleDocValuesField;

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldExistsQuery.java
@@ -711,6 +711,7 @@ public class TestFieldExistsQuery extends LuceneTestCase {
       doc.add(new LongPoint("long", 17));
       doc.add(new NumericDocValuesField("long", 17));
       iw.addDocument(doc);
+      iw.flush();
       iw.addDocument(new Document());
       iw.commit();
 
@@ -718,6 +719,7 @@ public class TestFieldExistsQuery extends LuceneTestCase {
       iw.forceMerge(1);
 
       try (IndexReader reader = iw.getReader()) {
+        assert reader.leaves().size() == 1 && reader.hasDeletions() == false;
         IndexSearcher searcher = newSearcher(reader);
         assertEquals(0, searcher.count(new FieldExistsQuery("long")));
       }


### PR DESCRIPTION
FieldExistsQuery checks if there are points for a certain field, and then retrieves the corresponding point values. When all documents that had points for a certain field have been deleted from a certain segments, as well as merged away, field info may report that there are points yet the corresponding point values are null. The same can happen when terms are accessed.

With this change we add null checks to FieldExistsQuery. Long term, we will likely want to prevent this situation from happening.

Relates #11393