### PR TITLE
DrillSideways uses advance instead of next when multiple dims miss

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -90,6 +90,11 @@ API Changes
 * GITHUB#11742: MatchingFacetSetsCounts#getTopChildren now properly returns "top" children instead
   of all children. (Greg Miller)
 
+Optimizations
+---------------------
+* GITHUB#11797: DrillSidewaysScorer has improved logic to "advance" baseIterator instead of using
+  "next" when more than one dim misses. (Greg Miller)
+
 Bug Fixes
 ---------------------
 


### PR DESCRIPTION
### Description

We can do better than calling `next` in drill sideways when two "sideways" dims miss. When two dims miss, we know that the next candidate doc we need to consider can't come before the `min` of the docs for the dim misses.