### PR TITLE
DrillSideways optimizations

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -129,6 +129,9 @@ Optimizations
 * GITHUB#11771: KeywordRepeatFilter + OpenNLPLemmatizer sometimes arbitrarily exits token stream.
   (Luke Kot-Zaniewski)
 
+* GITHUB#11797: DrillSidewaysScorer has improved logic to "advance" baseIterator instead of using
+  "next" when more than one dim misses. (Greg Miller)
+
 Other
 ---------------------
 * LUCENE-10423: Remove usages of System.currentTimeMillis() from tests. (Marios Trivyzas)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -129,8 +129,8 @@ Optimizations
 * GITHUB#11771: KeywordRepeatFilter + OpenNLPLemmatizer sometimes arbitrarily exits token stream.
   (Luke Kot-Zaniewski)
 
-* GITHUB#11797: DrillSidewaysScorer has improved logic to "advance" baseIterator instead of using
-  "next" when more than one dim misses. (Greg Miller)
+* GITHUB#11797: DrillSidewaysScorer has improved to leverage "advance" instead of "next" where
+  possible, and splits out first and second phase checks to delay match confirmation. (Greg Miller)
 
 Other
 ---------------------

--- a/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysScorer.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysScorer.java
@@ -255,9 +255,6 @@ class DrillSidewaysScorer extends BulkScorer {
         }
       }
 
-      assert (validateState(
-          docID, baseApproximation, baseTwoPhase, allDims, twoPhaseDims, failedDim, acceptDocs));
-
       collectDocID = docID;
       if (failedDim == null) {
         // Hit passed all filters, so it's "real":
@@ -269,43 +266,6 @@ class DrillSidewaysScorer extends BulkScorer {
 
       docID = baseApproximation.nextDoc();
     }
-  }
-
-  private static boolean validateState(
-      int currentDocID,
-      DocIdSetIterator baseApproximation,
-      TwoPhaseIterator baseTwoPhase,
-      List<DocsAndCost> allDims,
-      List<DocsAndCost> twoPhaseDims,
-      DocsAndCost failedDim,
-      Bits acceptDocs)
-      throws IOException {
-    if (acceptDocs != null && acceptDocs.get(currentDocID) == false) {
-      return false;
-    }
-    if (baseApproximation.docID() != currentDocID) {
-      return false;
-    }
-    if (baseTwoPhase != null && baseTwoPhase.matches() == false) {
-      return false;
-    }
-    for (DocsAndCost dim : allDims) {
-      if (dim.approximation.docID() < currentDocID) {
-        return false;
-      }
-      if (dim.approximation.docID() != currentDocID && failedDim != dim) {
-        return false;
-      }
-    }
-    if (twoPhaseDims != null) {
-      for (DocsAndCost dim : twoPhaseDims) {
-        if (dim.twoPhase.matches() == false && dim != failedDim) {
-          return false;
-        }
-      }
-    }
-
-    return true;
   }
 
   /** Used when drill downs are highly constraining vs baseQuery. */

--- a/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysScorer.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysScorer.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.search.BulkScorer;
@@ -178,12 +177,14 @@ class DrillSidewaysScorer extends BulkScorer {
       }
     }
     if (twoPhaseDims != null) {
-      CollectionUtil.timSort(twoPhaseDims, new Comparator<DocsAndCost>() {
-        @Override
-        public int compare(DocsAndCost o1, DocsAndCost o2) {
-          return Float.compare(o1.twoPhase.matchCost(), o2.twoPhase.matchCost());
-        }
-      });
+      CollectionUtil.timSort(
+          twoPhaseDims,
+          new Comparator<DocsAndCost>() {
+            @Override
+            public int compare(DocsAndCost o1, DocsAndCost o2) {
+              return Float.compare(o1.twoPhase.matchCost(), o2.twoPhase.matchCost());
+            }
+          });
     }
 
     int docID = baseApproximation.docID();
@@ -250,7 +251,8 @@ class DrillSidewaysScorer extends BulkScorer {
         }
       }
 
-      assert(validateState(docID, baseApproximation, baseTwoPhase, allDims, twoPhaseDims, failedDim, acceptDocs));
+      assert (validateState(
+          docID, baseApproximation, baseTwoPhase, allDims, twoPhaseDims, failedDim, acceptDocs));
       collectDocID = docID;
       if (failedDim == null) {
         // Hit passed all filters, so it's "real":
@@ -264,13 +266,15 @@ class DrillSidewaysScorer extends BulkScorer {
     }
   }
 
-  private static boolean validateState(int currentDocID,
-                                       DocIdSetIterator baseApproximation,
-                                       TwoPhaseIterator baseTwoPhase,
-                                       List<DocsAndCost> allDims,
-                                       List<DocsAndCost> twoPhaseDims,
-                                       DocsAndCost failedDim,
-                                       Bits acceptDocs) throws IOException {
+  private static boolean validateState(
+      int currentDocID,
+      DocIdSetIterator baseApproximation,
+      TwoPhaseIterator baseTwoPhase,
+      List<DocsAndCost> allDims,
+      List<DocsAndCost> twoPhaseDims,
+      DocsAndCost failedDim,
+      Bits acceptDocs)
+      throws IOException {
     if (acceptDocs != null && acceptDocs.get(currentDocID) == false) {
       return false;
     }

--- a/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysScorer.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysScorer.java
@@ -225,11 +225,11 @@ class DrillSidewaysScorer extends BulkScorer {
       if (twoPhaseDims != null) {
         if (failedDim == null) {
           for (DocsAndCost dim : twoPhaseDims) {
-            assert dim.approximation.docID() == docID;
+            assert dim.approximation.docID() == baseApproximation.docID();
             if (dim.twoPhase.matches() == false) {
               if (failedDim != null) {
-                assert dim.approximation.docID() + 1 <= failedDim.approximation.docID();
-                docID = baseApproximation.advance(dim.approximation.docID() + 1);
+                int next = Math.min(dim.approximation.nextDoc(), failedDim.approximation.nextDoc());
+                docID = baseApproximation.advance(next);
                 continue nextDoc;
               } else {
                 failedDim = dim;
@@ -241,10 +241,10 @@ class DrillSidewaysScorer extends BulkScorer {
             if (failedDim == dim) {
               continue;
             }
-            assert dim.approximation.docID() == docID;
+            assert dim.approximation.docID() == baseApproximation.docID();
             if (dim.twoPhase.matches() == false) {
-              assert dim.approximation.docID() + 1 <= failedDim.approximation.docID();
-              docID = baseApproximation.advance(dim.approximation.docID() + 1);
+              int next = Math.min(failedDim.approximation.docID(), dim.approximation.nextDoc());
+              docID = baseApproximation.advance(next);
               continue nextDoc;
             }
           }


### PR DESCRIPTION
### Description

This change makes use of `advance` instead of `next` where possible and splits out 1st and 2nd phase checking to avoid match confirmation when unnecessary.

Note that I only focused on the `doQueryFirstScoring` implementation here and didn't modify the other two scoring approaches. "Progress not perfection" and all that (plus, I think we should strongly consider removing these other two implementations, but we'd want to benchmark to be certain).

Unfortunately, `luceneutil` doesn't have dedicated drill sideways benchmarks, but some benchmarks on our internal software that makes use of drill sideways showed a +2% QPS improvement and no obvious regressions.