### PR TITLE
FacetsCollector#collect is no longer final to allow extension

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -93,6 +93,8 @@ API Changes
 * GITHUB#11772: Removed native subproject and WindowsDirectory implementation from lucene.misc. Recommendation:
   use MMapDirectory implementation on Windows. (Robert Muir, Uwe Schindler, Dawid Weiss)
 
+* GITHUB#11804: FacetsCollector#collect is no longer final, allowing extension. (Greg Miller)
+
 Improvements
 ---------------------
 * GITHUB#11778: Detailed part-of-speech information for particle(조사) and ending(어미) on Nori

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollector.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollector.java
@@ -114,7 +114,7 @@ public class FacetsCollector extends SimpleCollector {
   }
 
   @Override
-  public final void collect(int doc) throws IOException {
+  public void collect(int doc) throws IOException {
     docsBuilder.grow(1).add(doc);
     if (keepScores) {
       if (totalHits >= scores.length) {


### PR DESCRIPTION
### Description

I'd like to propose removing the `final` restriction on `FacetsCollector#collect` to allow extension. I have a use-case where I'd like to be able to throw a `CollectionTerminatedException` from a `FacetsCollector` after collecting a specified number of hits (this is a runtime optimization where we're OK faceting over a subset of all actual matches). Being able to extend `collect` would make this much simpler to achieve.