### PR TITLE
PrimaryNode: add configurable timeout to waitForAllRemotesToClose

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -102,6 +102,8 @@ API Changes
 * GITHUB#11761: TieredMergePolicy now allowed a maximum allowable deletes percentage of down to 5%, and the default
   maximum allowable deletes percentage is changed from 33% to 20%. (Marc D'Mello)
 
+* GITHUB#11822: Configure replicator PrimaryNode replia shutdown timeout. (Steven Schlansker)
+
 Improvements
 ---------------------
 * GITHUB#11778: Detailed part-of-speech information for particle(조사) and ending(어미) on Nori

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/NodeProcess.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/NodeProcess.java
@@ -189,6 +189,22 @@ class NodeProcess implements Closeable {
     }
   }
 
+  // Simulate a replica holding a copy state open forever, by just leaking it.
+  public void leakCopyState() throws IOException {
+    try (Connection c = new Connection(tcpPort)) {
+      c.out.writeByte(SimplePrimaryNode.CMD_LEAK_COPY_STATE);
+      c.flush();
+    }
+  }
+
+  public void setRemoteCloseTimeoutMs(int timeoutMs) throws IOException {
+    try (Connection c = new Connection(tcpPort)) {
+      c.out.writeByte(SimplePrimaryNode.CMD_SET_CLOSE_WAIT_MS);
+      c.out.writeInt(timeoutMs);
+      c.flush();
+    }
+  }
+
   public void addOrUpdateDocument(Connection c, Document doc, boolean isUpdate) throws IOException {
     if (isPrimary == false) {
       throw new IllegalStateException("only primary can index");

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimplePrimaryNode.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimplePrimaryNode.java
@@ -650,6 +650,10 @@ class SimplePrimaryNode extends PrimaryNode {
   // merges:
   static final byte CMD_NEW_REPLICA = 20;
 
+  // Leak a CopyState to simulate failure
+  static final byte CMD_LEAK_COPY_STATE = 24;
+  static final byte CMD_SET_CLOSE_WAIT_MS = 25;
+
   /** Handles incoming request to the naive TCP server wrapping this node */
   void handleOneConnection(
       Random random,
@@ -820,6 +824,15 @@ class SimplePrimaryNode extends PrimaryNode {
             }
           }
           break;
+
+        case CMD_LEAK_COPY_STATE:
+          message("leaking a CopyState");
+          getCopyState();
+          continue outer;
+
+        case CMD_SET_CLOSE_WAIT_MS:
+          setRemoteCloseTimeoutMs(in.readInt());
+          continue outer;
 
         default:
           throw new IllegalArgumentException("unrecognized cmd=" + cmd + " via socket=" + socket);

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestNRTReplication.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestNRTReplication.java
@@ -806,6 +806,70 @@ public class TestNRTReplication extends LuceneTestCase {
   }
 
   @Nightly
+  public void testPrimaryCloseWhileCopyingNoWait() throws Exception {
+    Path path1 = createTempDir("A");
+    NodeProcess primary = startNode(-1, 0, path1, -1, true);
+
+    Path path2 = createTempDir("B");
+    NodeProcess replica = startNode(primary.tcpPort, 1, path2, -1, true);
+
+    assertWriteLockHeld(path2);
+
+    sendReplicasToPrimary(primary, replica);
+
+    LineFileDocs docs = new LineFileDocs(random());
+    try (Connection c = new Connection(primary.tcpPort)) {
+      c.out.writeByte(SimplePrimaryNode.CMD_INDEXING);
+      Document doc = docs.nextDoc();
+      primary.addOrUpdateDocument(c, doc, false);
+    }
+
+    // Refresh primary, which also pushes to replica:
+    long primaryVersion1 = primary.flush(0);
+    assertTrue(primaryVersion1 > 0);
+
+    // Wait for replica to sync up:
+    waitForVersionAndHits(replica, primaryVersion1, 1);
+
+    primary.setRemoteCloseTimeoutMs(0);
+    primary.leakCopyState();
+    primary.close();
+    replica.close();
+  }
+
+  @Nightly
+  public void testPrimaryCloseWhileCopyingShortWait() throws Exception {
+    Path path1 = createTempDir("A");
+    NodeProcess primary = startNode(-1, 0, path1, -1, true);
+
+    Path path2 = createTempDir("B");
+    NodeProcess replica = startNode(primary.tcpPort, 1, path2, -1, true);
+
+    assertWriteLockHeld(path2);
+
+    sendReplicasToPrimary(primary, replica);
+
+    LineFileDocs docs = new LineFileDocs(random());
+    try (Connection c = new Connection(primary.tcpPort)) {
+      c.out.writeByte(SimplePrimaryNode.CMD_INDEXING);
+      Document doc = docs.nextDoc();
+      primary.addOrUpdateDocument(c, doc, false);
+    }
+
+    // Refresh primary, which also pushes to replica:
+    long primaryVersion1 = primary.flush(0);
+    assertTrue(primaryVersion1 > 0);
+
+    // Wait for replica to sync up:
+    waitForVersionAndHits(replica, primaryVersion1, 1);
+
+    primary.setRemoteCloseTimeoutMs(1000);
+    primary.leakCopyState();
+    primary.close();
+    replica.close();
+  }
+
+  @Nightly
   public void testFullClusterCrash() throws Exception {
 
     Path path1 = createTempDir("1");


### PR DESCRIPTION
Adds a configurable timeout for PrimaryNode waiting for remotes to close.
The default matches existing behavior. In the long run, maybe this wait loop goes away entirely, but I elected to make the most compatible change first.

Fixes #11674
