### PR TITLE
Added static factory method for loading VectorValues

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2587,7 +2587,8 @@ public final class CheckIndex implements Closeable {
             }
             VectorValues values = reader.getVectorValues(fieldInfo.name);
             if (values == null) {
-              continue;
+              throw new CheckIndexException(
+                  "Field \"" + fieldInfo.name + "\" has null vector values");
             }
 
             status.totalKnnVectorFields++;

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
@@ -163,7 +163,7 @@ public final class SlowCodecReaderWrapper {
     return new KnnVectorsReader() {
       @Override
       public VectorValues getVectorValues(String field) throws IOException {
-        return reader.getVectorValues(field);
+        return VectorValues.getVectorValues(reader, field);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
@@ -35,6 +35,27 @@ public abstract class VectorValues extends DocIdSetIterator {
   /** Sole constructor */
   protected VectorValues() {}
 
+  /**
+   * Returns the {@link VectorValues} instance for this field, or {@link #EMPTY} if it has none.
+   *
+   * @param reader Leaf reader instance
+   * @param field Field name
+   * @return VectorValues instance, or an empty instance if {@code field} does not exist in this
+   *     reader
+   * @throws IOException if the field exists but does not have any vector values
+   */
+  public static VectorValues getVectorValues(LeafReader reader, String field) throws IOException {
+    VectorValues values = reader.getVectorValues(field);
+    if (values == null) {
+      FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
+      if (fieldInfo != null) {
+        throw new IllegalArgumentException("Field does not have any vector values");
+      }
+      return EMPTY;
+    }
+    return values;
+  }
+
   /** Return the dimension of the vectors */
   public abstract int dimension();
 

--- a/lucene/core/src/test/org/apache/lucene/document/TestField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestField.java
@@ -535,14 +535,15 @@ public class TestField extends LuceneTestCase {
       doc.add(field2);
       w.addDocument(doc);
       try (IndexReader r = DirectoryReader.open(w)) {
-        VectorValues binary = r.leaves().get(0).reader().getVectorValues("binary");
+        VectorValues binary = VectorValues.getVectorValues(r.leaves().get(0).reader(), "binary");
         assertEquals(1, binary.size());
         assertNotEquals(NO_MORE_DOCS, binary.nextDoc());
         assertEquals(br, binary.binaryValue());
         assertNotNull(binary.vectorValue());
         assertEquals(NO_MORE_DOCS, binary.nextDoc());
 
-        VectorValues floatValues = r.leaves().get(0).reader().getVectorValues("float");
+        VectorValues floatValues =
+            VectorValues.getVectorValues(r.leaves().get(0).reader(), "float");
         assertEquals(1, floatValues.size());
         assertNotEquals(NO_MORE_DOCS, floatValues.nextDoc());
         assertNotNull(floatValues.binaryValue());

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -486,7 +486,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
       expectThrows(
           ExitingReaderException.class,
           () -> {
-            DocIdSetIterator iter = leaf.getVectorValues("vector");
+            DocIdSetIterator iter = VectorValues.getVectorValues(leaf, "vector");
             scanAndRetrieve(leaf, iter);
           });
 
@@ -496,7 +496,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
               leaf.searchNearestVectors(
                   "vector", new float[dimension], 5, leaf.getLiveDocs(), Integer.MAX_VALUE));
     } else {
-      DocIdSetIterator iter = leaf.getVectorValues("vector");
+      DocIdSetIterator iter = VectorValues.getVectorValues(leaf, "vector");
       scanAndRetrieve(leaf, iter);
 
       leaf.searchNearestVectors(

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -480,11 +480,7 @@ public class TestKnnGraph extends LuceneTestCase {
           continue;
         }
         HnswGraph graphValues = vectorReader.getGraph(vectorField);
-        VectorValues vectorValues = reader.getVectorValues(vectorField);
-        if (vectorValues == null) {
-          assert graphValues == null;
-          continue;
-        }
+        VectorValues vectorValues = VectorValues.getVectorValues(reader, vectorField);
 
         // assert vector values:
         // stored vector values are the same as original

--- a/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
@@ -238,7 +238,7 @@ public class TestSortingCodecReader extends LuceneTestCase {
                 leaf.getSortedNumericDocValues("sorted_numeric_dv");
             SortedSetDocValues sorted_set_dv = leaf.getSortedSetDocValues("sorted_set_dv");
             SortedDocValues binary_sorted_dv = leaf.getSortedDocValues("binary_sorted_dv");
-            VectorValues vectorValues = leaf.getVectorValues("vector");
+            VectorValues vectorValues = VectorValues.getVectorValues(leaf, "vector");
             NumericDocValues ids = leaf.getNumericDocValues("id");
             long prevValue = -1;
             boolean usingAltIds = false;
@@ -253,7 +253,7 @@ public class TestSortingCodecReader extends LuceneTestCase {
                 sorted_numeric_dv = leaf.getSortedNumericDocValues("sorted_numeric_dv");
                 sorted_set_dv = leaf.getSortedSetDocValues("sorted_set_dv");
                 binary_sorted_dv = leaf.getSortedDocValues("binary_sorted_dv");
-                vectorValues = leaf.getVectorValues("vector");
+                vectorValues = VectorValues.getVectorValues(leaf, "vector");
                 prevValue = -1;
               }
               assertTrue(prevValue + " < " + ids.longValue(), prevValue < ids.longValue());

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswGraph.java
@@ -124,7 +124,7 @@ public class TestHnswGraph extends LuceneTestCase {
       }
       try (IndexReader reader = DirectoryReader.open(dir)) {
         for (LeafReaderContext ctx : reader.leaves()) {
-          VectorValues values = ctx.reader().getVectorValues("field");
+          VectorValues values = VectorValues.getVectorValues(ctx.reader(), "field");
           assertEquals(dim, values.dimension());
           assertEquals(nVec, values.size());
           assertEquals(indexedDoc, ctx.reader().maxDoc());


### PR DESCRIPTION
I have added a static factory method `getVectorValues` in `VectorValues` which returns the EMPTY `VectorValues` instance if the field is not found in the segment or if its not a vector field it throws an IAE else returns the  `VectorValues` instance. Looking forward to the feedback.

Closes #11462
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
