### PR TITLE
Upgrade forbiddenapis to 3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
   id "base"
   id "com.palantir.consistent-versions" version "2.11.0"
   id "org.owasp.dependencycheck" version "7.2.0"
-  id 'de.thetaphi.forbiddenapis' version '3.3' apply false
+  id 'de.thetaphi.forbiddenapis' version '3.4' apply false
   id "de.undercouch.download" version "5.2.0" apply false
   id "net.ltgt.errorprone" version "2.0.2" apply false
   id 'com.diffplug.spotless' version "6.5.2" apply false

--- a/gradle/validation/forbidden-apis.gradle
+++ b/gradle/validation/forbidden-apis.gradle
@@ -73,6 +73,21 @@ allprojects { prj ->
       doFirst dynamicSignatures.curry(configurations.compileClasspath, "lucene")
     }
 
+    // Configure defaults for the MR-JAR feature sourceSets
+    // TODO: Get hold of warning messages!
+    tasks.matching { it.name == "forbiddenApisMain19" }.all {
+      failOnMissingClasses = false
+      targetCompatibility = 19
+      
+      bundledSignatures += forbiddenApisMain.bundledSignatures
+
+      suppressAnnotations += [
+          "**.SuppressForbidden"
+      ]
+
+      doFirst dynamicSignatures.curry(configurations.compileClasspath, "lucene")
+    }
+
     // Configure defaults for sourceSets.test
     tasks.matching { it.name in ["forbiddenApisTest", "forbiddenApisTestFixtures"] }.all {
       bundledSignatures += [
@@ -113,11 +128,6 @@ allprojects { prj ->
       doFirst dynamicSignatures.curry(configurations.toolsCompileClasspath, "lucene")
 
       inputs.dir(file(resources))
-    }
-
-    // TODO: Remove this when forbiddenapis supports Java 19 class files
-    tasks.matching { it.name == "forbiddenApisMain19" }.all {
-      enabled = false
     }
 
     // We rely on resolved configurations to compute the relevant set of rule

--- a/gradle/validation/forbidden-apis.gradle
+++ b/gradle/validation/forbidden-apis.gradle
@@ -57,7 +57,7 @@ allprojects { prj ->
     }
 
     // Configure defaults for sourceSets.main
-    forbiddenApisMain {
+    tasks.matching { it.name in ["forbiddenApisMain", "forbiddenApisMain19"] }.all {
       bundledSignatures += [
           'jdk-unsafe',
           'jdk-deprecated',
@@ -73,19 +73,11 @@ allprojects { prj ->
       doFirst dynamicSignatures.curry(configurations.compileClasspath, "lucene")
     }
 
-    // Configure defaults for the MR-JAR feature sourceSets
-    // TODO: Get hold of warning messages!
+    // Configure defaults for the MR-JAR feature sourceSets by setting java version and ignore missing classes
+    // TODO: Get hold of warning messages, see https://github.com/policeman-tools/forbidden-apis/issues/207
     tasks.matching { it.name == "forbiddenApisMain19" }.all {
       failOnMissingClasses = false
       targetCompatibility = 19
-      
-      bundledSignatures += forbiddenApisMain.bundledSignatures
-
-      suppressAnnotations += [
-          "**.SuppressForbidden"
-      ]
-
-      doFirst dynamicSignatures.curry(configurations.compileClasspath, "lucene")
     }
 
     // Configure defaults for sourceSets.test

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -140,7 +140,9 @@ Other
 ---------------------
 * LUCENE-10423: Remove usages of System.currentTimeMillis() from tests. (Marios Trivyzas)
 
-* GITHUB#11811: upgrade google java format to 1.15.0 (Dawid Weiss)
+* GITHUB#11811: Upgrade google java format to 1.15.0 (Dawid Weiss)
+
+* GITHUB#11834: Upgrade forbiddenapis to version 3.4.  (Uwe Schindler)
 
 ======================== Lucene 9.4.0 =======================
 

--- a/lucene/core/src/java19/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java19/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -24,6 +24,7 @@ import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Objects;
+import org.apache.lucene.util.ArrayUtil;
 
 /**
  * Base IndexInput implementation that uses an array of MemorySegments to represent a file.
@@ -408,7 +409,7 @@ abstract class MemorySegmentIndexInput extends IndexInput implements RandomAcces
 
     // we always allocate one more slice, the last one may be a 0 byte one after truncating with
     // asSlice():
-    final MemorySegment slices[] = Arrays.copyOfRange(segments, startIndex, endIndex + 1);
+    final MemorySegment slices[] = ArrayUtil.copyOfSubArray(segments, startIndex, endIndex + 1);
 
     // set the last segment's limit for the sliced view.
     slices[slices.length - 1] = slices[slices.length - 1].asSlice(0L, sliceEnd & chunkSizeMask);


### PR DESCRIPTION
This updates forbiddenapis to 3.4, released today.

This mainly adds Java 19 support. This PR will also uncomment and enable forbiddenapis for the `main19` sourceset in `:lucene:core`.