### PR TITLE
Clean up MR-JAR build, so we do not have hardcoded "19" everywhere in validation tasks

### DIFF
--- a/gradle/validation/ecj-lint.gradle
+++ b/gradle/validation/ecj-lint.gradle
@@ -34,9 +34,7 @@ allprojects {
     // Create a [sourceSetName]EcjLint task for each source set
     // with a non-empty java.srcDirs. These tasks are then
     // attached to project's "ecjLint" task.
-
-    // TODO: Better way to disable on our MR-JAR
-    def lintTasks = sourceSets.findAll { it.name != 'main19' }.collect { sourceSet ->
+    def lintTasks = sourceSets.collect { sourceSet ->
       def srcDirs = sourceSet.java.sourceDirectories
           .filter { dir -> dir.exists() }
 
@@ -54,6 +52,11 @@ allprojects {
         // that don't have any Java source directories.
         enabled = !srcDirs.isEmpty()
 
+        // Ignore MR-JAR sourceSets.
+        if (sourceSet.name ==~ /main\d+/) {
+          enabled = false
+        }
+        
         classpath = rootProject.configurations.ecjDeps
         mainClass = "org.eclipse.jdt.internal.compiler.batch.Main"
 

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -58,8 +58,8 @@ allprojects { prj ->
       }
 
       tasks.withType(JavaCompile) { task ->
-        // TODO: Better way to disable on our MR-JAR
-        if (task.name == 'compileMain19Java') {
+        // Disable errorprone on the MR-JAR tasks
+        if (task.name ==~ /compileMain\d+Java/) {
           options.errorprone.enabled = false
           return
         }

--- a/gradle/validation/forbidden-apis.gradle
+++ b/gradle/validation/forbidden-apis.gradle
@@ -57,7 +57,7 @@ allprojects { prj ->
     }
 
     // Configure defaults for sourceSets.main
-    tasks.matching { it.name in ["forbiddenApisMain", "forbiddenApisMain19"] }.all {
+    tasks.matching { it.name ==~ /forbiddenApisMain\d*/ }.all {
       bundledSignatures += [
           'jdk-unsafe',
           'jdk-deprecated',
@@ -76,10 +76,8 @@ allprojects { prj ->
     // Configure defaults for the MR-JAR feature sourceSets by setting java version and ignore missing classes
     // TODO:
     // - Get hold of warning messages, see https://github.com/policeman-tools/forbidden-apis/issues/207
-    // - Allow using newer bundled signatures, see: https://github.com/policeman-tools/forbidden-apis/issues/207
-    tasks.matching { it.name == "forbiddenApisMain19" }.all {
+    tasks.matching { it.name ==~ /forbiddenApisMain\d+/ }.all {
       failOnMissingClasses = false
-      targetCompatibility = rootProject.minJavaVersion
     }
 
     // Configure defaults for sourceSets.test


### PR DESCRIPTION
This is mostly a cleanup after we added a MR-JAR from #912. The problem was some hacks in the validation tasks.

As long as soureSets are named "mainXX", with XX a feature version, we check everything automatically:
- ECJ is disabled (we can't do a check without forking ECJ as a separate process using toolkit, we may support this later)
- forbiddenapis (we disable checks for missing classes)
- errorprone is disabled (errorprone does not work correctly at moment with forked compiler)