### PR TITLE
GH-11819: Exclude MR-JAR sourceSet and folders from Idea Sync

### DIFF
--- a/gradle/ide/intellij-idea.gradle
+++ b/gradle/ide/intellij-idea.gradle
@@ -41,12 +41,11 @@ if (isIdeaSync) {
   allprojects {
     // disable all MR-JAR folders by hiding them from IDE after evaluation:
     plugins.withType(JavaPlugin) {
-      project.afterEvaluate {
-        sourceSets.matching{ it.name ==~ /main\d+/ }.all{ sourceSet ->
+      sourceSets.matching{ it.name ==~ /main\d+/ }.all{ SourceSet sourceSet ->
+        project.afterEvaluate {
           logger.lifecycle("Skipping MR-JAR sourceSet on IntelliJ Idea: " + sourceSet.name)
-          project.idea.module.excludeDirs += sourceSet.java.srcDirs
           sourceSet.java.srcDirs = []
-          logger.debug("New excludeDirs: " + project.idea.module.excludeDirs)
+          sourceSet.resources.srcDirs = []
         }
       }
     }

--- a/gradle/ide/intellij-idea.gradle
+++ b/gradle/ide/intellij-idea.gradle
@@ -37,6 +37,22 @@ if (isIdea) {
   }
 }
 
+if (isIdeaSync) {
+  allprojects {
+    // disable all MR-JAR folders by hiding them from IDE after evaluation:
+    plugins.withType(JavaPlugin) {
+      project.afterEvaluate {
+        sourceSets.matching{ it.name ==~ /main\d+/ }.all{ sourceSet ->
+          logger.lifecycle("Skipping MR-JAR sourceSet on IntelliJ Idea: " + sourceSet.name)
+          project.idea.module.excludeDirs += sourceSet.java.srcDirs
+          sourceSet.java.srcDirs = []
+          logger.debug("New excludeDirs: " + project.idea.module.excludeDirs)
+        }
+      }
+    }
+  }
+}
+
 if (isIdeaBuild) {
   // Skip certain long tasks that are dependencies
   // of 'assemble' if we're building from within IntelliJ.


### PR DESCRIPTION
This closes #11819.

This is a bit of hack, but after trying a few times with Intellij Idea: When Gradle is running in ideaSync mode, we do some late evaluation:
- remove all source folders from the `/main\d+/` sourceSets
- exclude those directories explicit from Idea Config

For me this works with Idea 2022.2.2 (Community Edition). 

To test delete your .idea folder from checkout. Restart Idea and tell it to reapply it as "Gradle project". The alternative is to go to  "View -> Tool Windows -> Gradle" or the "Gradle button on the very right side next to "Notifications". Then click on "Reload" icon, in the console it should show that it rebuilds the project config:

```
> Configure project :
IntelliJ Idea IDE detected.

> Configure project :lucene:core
Skipping MR-JAR sourceSet on IntelliJ Idea: main19

> Task :prepareKotlinBuildScriptModel UP-TO-DATE

BUILD SUCCESSFUL in 8s
2 actionable tasks: 2 up-to-date
> Task :prepareKotlinBuildScriptModel UP-TO-DATE

BUILD SUCCESSFUL in 655ms
```

When you build the project using gradle inside IDEA it will of course also generate the MR-JAR and compile the Java 19 classes (using Gradle's toolkit API). You can also edit the Java source files, but because of missing JDK you can't get autocomplete and syntax checks.