### PR TITLE
make 'gradle coverage' print test coverage summaries.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ plugins {
   id "de.undercouch.download" version "5.2.0" apply false
   id "net.ltgt.errorprone" version "2.0.2" apply false
   id 'com.diffplug.spotless' version "6.5.2" apply false
+  id 'org.barfuin.gradle.jacocolog' version "2.0.0" apply false
 }
 
 apply from: file('gradle/globals.gradle')

--- a/gradle/testing/coverage.gradle
+++ b/gradle/testing/coverage.gradle
@@ -26,7 +26,7 @@ if (withCoverage) {
   allprojects {
     plugins.withType(JavaPlugin) {
       // Apply jacoco once we know the project has a Java plugin too.
-      project.plugins.apply("jacoco")
+      project.plugins.apply("org.barfuin.gradle.jacocolog")
 
       // Synthetic task to enable test coverage (and reports).
       task coverage() {


### PR DESCRIPTION
Currently, this task is too silent and just writes HTML reports. It is a nice improvement to print the summary to the console.

Before:

```
> Task :lucene:analysis:icu:jacocoTestReport
Code coverage report at: /home/rmuir/workspace/lucene/lucene/analysis/icu/build/reports/jacoco/test/html.
```

After:

```
> Task :lucene:analysis:icu:jacocoTestReport
Code coverage report at: /home/rmuir/workspace/lucene/lucene/analysis/icu/build/reports/jacoco/test/html.

> Task :lucene:analysis:icu:jacocoLogTestCoverage
Test Coverage:
    - Class Coverage: 100%
    - Method Coverage: 87.9%
    - Branch Coverage: 82.7%
    - Line Coverage: 92.8%
    - Instruction Coverage: 92.7%
    - Complexity Coverage: 78.8%
```

More information: https://gitlab.com/barfuin/gradle-jacoco-log/-/blob/master/README.md
