### PR TITLE
GITHUB-11761 (part 2): Fix unit tests to cleany work with new TierMer…

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
@@ -1341,11 +1341,12 @@ public class TestIndexWriterDelete extends LuceneTestCase {
     w.addDocument(doc);
     w.addDocument(doc);
     w.addDocument(doc);
+    w.addDocument(doc);
+    w.addDocument(doc);
     doc.add(new StringField("id", "1", Field.Store.YES));
     w.addDocument(doc);
     w.close();
     iwc = new IndexWriterConfig(new MockAnalyzer(random()));
-    ((TieredMergePolicy) iwc.getMergePolicy()).setDeletesPctAllowed(33.0);
     iwc.setOpenMode(IndexWriterConfig.OpenMode.APPEND);
     w = new IndexWriter(d, iwc);
     IndexReader r = DirectoryReader.open(w, false, false);

--- a/lucene/core/src/test/org/apache/lucene/index/TestTieredMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTieredMergePolicy.java
@@ -310,9 +310,9 @@ public class TestTieredMergePolicy extends BaseMergePolicyTestCase {
             ((1024.0 * 1024.0)); // fudge it up, we're trying to catch egregious errors and segbytes
     // don't really reflect the number for original merges.
     tmp.setMaxMergedSegmentMB(mbSize);
-    tmp.setDeletesPctAllowed(33.0);
     conf.setMaxBufferedDocs(100);
     conf.setMergePolicy(tmp);
+    conf.setMergeScheduler(new SerialMergeScheduler());
 
     final IndexWriter w = new IndexWriter(dir, conf);
 


### PR DESCRIPTION
…gePolicy delete pct default

### Description

We recently changed the default delete percentage of `TieredMergePolicy` that broke 2 unit tests. To fix this, we originally change the delete percentage to the old delete percentage. This change makes the unit tests work with new default delete percentages without changing it.
