### PR TITLE
Remove cancellation check on every vector

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -430,13 +430,11 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
 
       @Override
       public float[] vectorValue() throws IOException {
-        checkAndThrow();
         return in.vectorValue();
       }
 
       @Override
       public BytesRef binaryValue() throws IOException {
-        checkAndThrow();
         return in.binaryValue();
       }
 


### PR DESCRIPTION
PR: https://github.com/apache/lucene/pull/833 helpfully introduced query cancellation checks for KNN vector queries. 

However, checking for cancellation on every vector read has a negative impact on performance. 

This change proposes that we no longer check on every vector. 

This performance hit was noticed first in Elasticsearch benching nightlies.

 - Performance numbers: https://elasticsearch-benchmarks.elastic.co/#tracks/dense_vector/nightly/default/90d (notice `nightly-dense_vector-add-4g-1node-script-score-query-latency`)

Lucene benches indicate no dramatic change in VectorSearch around May (when the change was merged...I may be missing where to look). I wonder if we are running benchmarks with the cancellation/timeout checker? 

Other exitable iterators don't check on every value read and usually sample (see `ExitableTermsEnum` as prior art).