### PR TITLE
Mark TestLongBitSet.testHugeCapacity @Monster as it requires a lot of memory

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/util/TestLongBitSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestLongBitSet.java
@@ -351,7 +351,7 @@ public class TestLongBitSet extends LuceneTestCase {
     assertFalse(newBits.get(1));
   }
 
-  @Nightly
+  @Monster("needs hundreds of MB of heap")
   public void testHugeCapacity() {
     long moreThanMaxInt = (long) Integer.MAX_VALUE + 5;
 


### PR DESCRIPTION
This test case needs hundreds of MB of heap, and causes OOMs in nightly builds. Let's mark it `@Monster` appropriately.

Closes #11842