### PR TITLE
WrapperDownloader: add retries for network blips around connect(), too

### DIFF
--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -103,7 +103,16 @@ public class WrapperDownloader {
       HttpURLConnection connection;
       while (true) {
         connection = (HttpURLConnection) url.openConnection();
-        connection.connect();
+        try {
+          connection.connect();
+        } catch (IOException e) {
+          if (retries-- > 0) {
+            // Retry after a short delay
+            System.err.println("Error connecting to server: " + e + ", will retry in " + retryDelay + " seconds.");
+            Thread.sleep(TimeUnit.SECONDS.toMillis(retryDelay));
+            continue;
+          }
+        }
 
         switch (connection.getResponseCode()) {
           case HttpURLConnection.HTTP_INTERNAL_ERROR:


### PR DESCRIPTION
Add retries for common issues such as connect timeout, etc.

This won't solve the problem of read-timeouts happening around the actual transferTo, but it is an easy incremental improvement.

Quickly tested the retries work by taking away gradle's network:
```
$ unshare --user --net ./gradlew test
Downloading gradle-wrapper.jar from https://raw.githubusercontent.com/gradle/gradle/v7.3.3/gradle/wrapper/gradle-wrapper.jar
Error connecting to server: java.net.SocketException: Network is unreachable, will retry in 30 seconds.
Error connecting to server: java.net.SocketException: Network is unreachable, will retry in 30 seconds.
Error connecting to server: java.net.SocketException: Network is unreachable, will retry in 30 seconds.
ERROR: Could not download gradle-wrapper.jar (SocketException: Network is unreachable).
```

Closes #11845 