### PR TITLE
DISCUSSION: Move Lucene Core's log support to Java Platform Logging (JEP 264) facade instead of java.util.logging implementation module

### DIFF
--- a/gradle/validation/forbidden-apis/defaults.logging.txt
+++ b/gradle/validation/forbidden-apis/defaults.logging.txt
@@ -14,6 +14,9 @@
 #  limitations under the License.
 
 @defaultMessage Lucene should never log below Level.WARNING
+java.lang.System$Logger$Level#TRACE
+java.lang.System$Logger$Level#DEBUG
+java.lang.System$Logger$Level#INFO
 java.util.logging.Level#CONFIG
 java.util.logging.Level#FINE
 java.util.logging.Level#FINER

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -72,22 +72,22 @@ parse differently than before. If you need the exact previous behavior, clone th
 `StandardSyntaxParser` from the previous version of Lucene and create a custom query parser
 with that parser.
 
-### Lucene Core now depends on java.logging (JUL) module (LUCENE-10342)
+### Lucene Core now uses Java Platform Logging (and JUL) module (GITHUB#11873)
 
-Lucene Core now logs certain warnings and errors using Java Util Logging (JUL).
-It is therefore recommended to install wrapper libraries with JUL logging handlers to
-feed the log events into your app's own logging system.
+Lucene Core now logs certain warnings and errors using Java Platform Logging (JEP 264).
+It is therefore recommended to install wrapper libraries with a
+`java.lang.System.LoggerFinder` service provider to feed the log events into your app's
+own logging system. By default Java will log through `java.jutil.logging` (if available).
 
 Under normal circumstances Lucene won't log anything, but in the case of a problem
-users should find the logged information in the usual log files.
+users should find the logged information in the usual log files or `System.err`.
 
-Lucene also provides a `JavaLoggingInfoStream` implementation that logs `IndexWriter`
-events using JUL.
+Lucene also provides a `JavaPlatformLoggingInfoStream` implementation that logs `IndexWriter`
+events using Java Platform Logging.
 
 To feed Lucene's log events into the well-known Log4J system, we refer to
-the [Log4j JDK Logging Adapter](https://logging.apache.org/log4j/2.x/log4j-jul/index.html)
-in combination with the corresponding system property:
-`java.util.logging.manager=org.apache.logging.log4j.jul.LogManager`.
+the [Log4j JDK Platform Logging Adapter](https://logging.apache.org/log4j/2.x/log4j-jpl/index.html)
+(`log4j-jpl.jar`) that needs to be added to classpath.
 
 ### Kuromoji and Nori analysis component constructors for custom dictionaries
 

--- a/lucene/core/src/java/module-info.java
+++ b/lucene/core/src/java/module-info.java
@@ -21,7 +21,7 @@ import org.apache.lucene.codecs.lucene94.Lucene94HnswVectorsFormat;
 /** Lucene Core. */
 @SuppressWarnings("module") // the test framework is compiled after the core...
 module org.apache.lucene.core {
-  requires java.logging;
+  requires static java.logging; // optional at runtime, on JavaLoggingInfoStream implements it
   requires static jdk.unsupported; // this is optional but without it MMapDirectory won't be enabled
   requires static jdk.management; // this is optional but explicit declaration is recommended
 

--- a/lucene/core/src/java/module-info.java
+++ b/lucene/core/src/java/module-info.java
@@ -21,7 +21,7 @@ import org.apache.lucene.codecs.lucene94.Lucene94HnswVectorsFormat;
 /** Lucene Core. */
 @SuppressWarnings("module") // the test framework is compiled after the core...
 module org.apache.lucene.core {
-  requires static java.logging; // optional at runtime, on JavaLoggingInfoStream implements it
+  requires static java.logging; // optional at runtime, only JavaLoggingInfoStream implements it
   requires static jdk.unsupported; // this is optional but without it MMapDirectory won't be enabled
   requires static jdk.management; // this is optional but explicit declaration is recommended
 

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -17,13 +17,13 @@
 package org.apache.lucene.store;
 
 import java.io.IOException;
+import java.lang.System.Logger.Level;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.nio.channels.ClosedChannelException; // javadoc @link
 import java.nio.file.Path;
 import java.util.Locale;
 import java.util.concurrent.Future;
-import java.util.logging.Logger;
 import org.apache.lucene.util.Constants;
 
 /**
@@ -326,12 +326,14 @@ public class MMapDirectory extends FSDirectory {
     } catch (
         @SuppressWarnings("unused")
         UnsupportedClassVersionError e) {
-      var log = Logger.getLogger(lookup.lookupClass().getName());
+      final var logger = System.getLogger(lookup.lookupClass().getName());
       if (Runtime.version().feature() == 19) {
-        log.warning(
+        logger.log(
+            Level.WARNING,
             "You are running with Java 19. To make full use of MMapDirectory, please pass '--enable-preview' to the Java command line.");
       } else {
-        log.warning(
+        logger.log(
+            Level.WARNING,
             "You are running with Java 20 or later. To make full use of MMapDirectory, please update Apache Lucene.");
       }
       return new MappedByteBufferIndexInputProvider();

--- a/lucene/core/src/java/org/apache/lucene/store/MappedByteBufferIndexInputProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MappedByteBufferIndexInputProvider.java
@@ -20,6 +20,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 import static java.lang.invoke.MethodType.methodType;
 
 import java.io.IOException;
+import java.lang.System.Logger.Level;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Field;
@@ -33,7 +34,6 @@ import java.nio.file.StandardOpenOption;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Objects;
-import java.util.logging.Logger;
 import org.apache.lucene.store.ByteBufferGuard.BufferCleaner;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SuppressForbidden;
@@ -55,7 +55,7 @@ final class MappedByteBufferIndexInputProvider implements MMapDirectory.MMapInde
       cleaner = null;
       unmapSupported = false;
       unmapNotSupportedReason = hack.toString();
-      Logger.getLogger(getClass().getName()).warning(unmapNotSupportedReason);
+      System.getLogger(getClass().getName()).log(Level.WARNING, unmapNotSupportedReason);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.util;
 
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -30,7 +32,6 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.logging.Logger;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.Query;
@@ -153,17 +154,19 @@ public final class RamUsageEstimator {
         }
       } catch (@SuppressWarnings("unused") ReflectiveOperationException | RuntimeException e) {
         isHotspot = false;
-        final Logger log = Logger.getLogger(RamUsageEstimator.class.getName());
+        final Logger logger = System.getLogger(RamUsageEstimator.class.getName());
         final Module module = RamUsageEstimator.class.getModule();
         final ModuleLayer layer = module.getLayer();
         // classpath / unnamed module has no layer, so we need to check:
         if (layer != null
             && layer.findModule("jdk.management").map(module::canRead).orElse(false) == false) {
-          log.warning(
+          logger.log(
+              Level.WARNING,
               "Lucene cannot correctly calculate object sizes on 64bit JVMs, unless the 'jdk.management' Java module "
                   + "is readable [please add 'jdk.management' to modular application either by command line or its module descriptor]");
         } else {
-          log.warning(
+          logger.log(
+              Level.WARNING,
               "Lucene cannot correctly calculate object sizes on 64bit JVMs that are not based on Hotspot or a compatible implementation.");
         }
       }

--- a/lucene/core/src/java19/org/apache/lucene/store/MemorySegmentIndexInputProvider.java
+++ b/lucene/core/src/java19/org/apache/lucene/store/MemorySegmentIndexInputProvider.java
@@ -17,13 +17,13 @@
 package org.apache.lucene.store;
 
 import java.io.IOException;
+import java.lang.System.Logger.Level;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.logging.Logger;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.Unwrappable;
 
@@ -31,7 +31,8 @@ import org.apache.lucene.util.Unwrappable;
 final class MemorySegmentIndexInputProvider implements MMapDirectory.MMapIndexInputProvider {
 
   public MemorySegmentIndexInputProvider() {
-    Logger.getLogger(getClass().getName()).info("Using MemorySegmentIndexInput with Java 19");
+    System.getLogger(getClass().getName())
+        .log(Level.INFO, "Using MemorySegmentIndexInput with Java 19");
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/util/TestLoggingInfoStream.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestLoggingInfoStream.java
@@ -26,9 +26,25 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
-public class TestJavaLoggingInfoStream extends LuceneTestCase {
+public class TestLoggingInfoStream extends LuceneTestCase {
 
-  public void test() throws Exception {
+  public void testPlatformLogging() throws Exception {
+    assumeTrue(
+        "invalid logging configuration for testing", Logger.getGlobal().isLoggable(Level.WARNING));
+    final var component = "TESTCOMPONENT" + random().nextInt();
+    final var loggerName = "org.apache.lucene." + component;
+    try (var stream = new JavaPlatformLoggingInfoStream(System.Logger.Level.WARNING)) {
+      assertTrue(stream.isEnabled(component));
+      stream.message(component, "Test message to be logged.");
+    }
+    assertTrue(
+        "logger with correct name not found",
+        streamOfEnumeration(LogManager.getLogManager().getLoggerNames())
+            .anyMatch(loggerName::equals));
+  }
+
+  @Deprecated
+  public void testJavaUtilLogging() throws Exception {
     assumeTrue(
         "invalid logging configuration for testing", Logger.getGlobal().isLoggable(Level.WARNING));
     final var component = "TESTCOMPONENT" + random().nextInt();

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/SpatialTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/SpatialTestCase.java
@@ -19,9 +19,9 @@ package org.apache.lucene.spatial;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.*;
 
 import java.io.IOException;
+import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
@@ -35,6 +35,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressSysoutChecks;
 import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.distance.DistanceUtils;
 import org.locationtech.spatial4j.shape.Point;
@@ -44,7 +45,7 @@ import org.locationtech.spatial4j.shape.Rectangle;
 @SuppressSysoutChecks(bugUrl = "These tests use JUL extensively.")
 public abstract class SpatialTestCase extends LuceneTestCase {
 
-  protected Logger log = Logger.getLogger(getClass().getName());
+  protected Logger logger = System.getLogger(RamUsageEstimator.class.getName());
 
   private DirectoryReader indexReader;
   protected RandomIndexWriter indexWriter;

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/SpatialTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/SpatialTestCase.java
@@ -35,7 +35,6 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressSysoutChecks;
 import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.distance.DistanceUtils;
 import org.locationtech.spatial4j.shape.Point;
@@ -45,7 +44,7 @@ import org.locationtech.spatial4j.shape.Rectangle;
 @SuppressSysoutChecks(bugUrl = "These tests use JUL extensively.")
 public abstract class SpatialTestCase extends LuceneTestCase {
 
-  protected Logger logger = System.getLogger(RamUsageEstimator.class.getName());
+  protected Logger logger = System.getLogger(getClass().getName());
 
   private DirectoryReader indexReader;
   protected RandomIndexWriter indexWriter;

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/StrategyTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/StrategyTestCase.java
@@ -19,6 +19,8 @@ package org.apache.lucene.spatial;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,7 +28,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StoredField;
@@ -40,6 +41,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialArgsParser;
 import org.apache.lucene.spatial.query.SpatialOperation;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.shape.Shape;
 
@@ -57,7 +59,7 @@ public abstract class StrategyTestCase extends SpatialTestCase {
   public static final String QTEST_Cities_Intersects_BBox = "cities-Intersects-BBox.txt";
   public static final String QTEST_Simple_Queries_BBox = "simple-Queries-BBox.txt";
 
-  protected Logger log = Logger.getLogger(getClass().getName());
+  protected Logger logger = System.getLogger(RamUsageEstimator.class.getName());
 
   protected final SpatialArgsParser argsParser = new SpatialArgsParser();
 
@@ -66,7 +68,7 @@ public abstract class StrategyTestCase extends SpatialTestCase {
 
   protected void executeQueries(SpatialMatchConcern concern, String... testQueryFile)
       throws IOException {
-    log.info("testing queried for strategy " + strategy); // nowarn
+    logger.log(Level.INFO, "testing queried for strategy " + strategy); // nowarn
     for (String path : testQueryFile) {
       Iterator<SpatialTestQuery> testQueryIterator = getTestQueries(path, ctx);
       runTestQueries(testQueryIterator, concern);

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/StrategyTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/StrategyTestCase.java
@@ -41,7 +41,6 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialArgsParser;
 import org.apache.lucene.spatial.query.SpatialOperation;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.shape.Shape;
 
@@ -59,7 +58,7 @@ public abstract class StrategyTestCase extends SpatialTestCase {
   public static final String QTEST_Cities_Intersects_BBox = "cities-Intersects-BBox.txt";
   public static final String QTEST_Simple_Queries_BBox = "simple-Queries-BBox.txt";
 
-  protected Logger logger = System.getLogger(RamUsageEstimator.class.getName());
+  protected Logger logger = System.getLogger(getClass().getName());
 
   protected final SpatialArgsParser argsParser = new SpatialArgsParser();
 

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestHeatmapFacetCounter.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestHeatmapFacetCounter.java
@@ -21,6 +21,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween
 
 import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import java.io.IOException;
+import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.search.Query;
@@ -66,7 +67,8 @@ public class TestHeatmapFacetCounter extends StrategyTestCase {
 
   @After
   public void after() {
-    log.info(
+    logger.log(
+        Level.INFO,
         "Validated " + cellsValidated + " cells, " + cellValidatedNonZero + " non-zero"); // nowarn
   }
 

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestRandomSpatialOpFuzzyPrefixTree.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestRandomSpatialOpFuzzyPrefixTree.java
@@ -21,6 +21,7 @@ import static org.locationtech.spatial4j.shape.SpatialRelation.*;
 
 import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import java.io.IOException;
+import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -81,7 +82,7 @@ public class TestRandomSpatialOpFuzzyPrefixTree extends StrategyTestCase {
       ((PrefixTreeStrategy) strategy).setPointsOnly(true);
     }
 
-    log.info("Strategy: " + strategy.toString()); // nowarn
+    logger.log(Level.INFO, "Strategy: " + strategy.toString()); // nowarn
   }
 
   private void setupCtx2D(SpatialContext ctx) {


### PR DESCRIPTION
This is an issue and PR for discussion, because I changed my mind (after discussing with @ChrisHegarty).

It was previouly mentioned by some people that when we moved to Java 11, we should have used Java Platform Logging (JEP 264, https://openjdk.org/jeps/264) instead of using "outdated" java.util.logging.

When reading the JEP, the main difference is:
- Java Platform Logging is only a Facade. It does not have a logging implementation available, instead like slf4j or other modern logging framework it splits implementation from facade.
- Actually, the "default" implementation of Java Platform Logging is JUL. It can be still used, but it contains a logging implementation that complicates things.

The JDK has started with Java 9 to move all internal logging to Java Platform Logging. JUL is only used as implementation if nothing else is found. It only persists

Lucene should use the facade instead of the iplementations, so this PR changes all logging in Lucene core (and some tests) to use Java Platform Logging Facade. Because of this the Lucene Core module is now free of any mandatory modules except java.base.

Luke is not affected, as Luke by default requires a Logging Framework to actually show the log messages in the GUI. Lucene itsself is a library and needs no logging implementation.

For our users there is not much to do:
- Because ethe default implementation of Platform Loggin is JUL, all messages by MMapDirectory and RamUsageEstimator are logged to JUL, unless somebody uses a logging framework like log4j as implementation (with correct adaptor).
- The example implementation of an InfoStream that logs to JUL was deprecated and will be removed in main branch (10.0). Until this is done, JUL is still an optional dependency of Lucene core.

I also added forbiddenapis rules to not log with DEBUG/INFO/...

What do others think? @rmuir @dweiss @ChrisHegarty 

P.S.: Sorry for moving the code with 9.0 to wrong framework -> my fault.