### PR TITLE
Usability improvements for timeout support in IndexSearcher

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -497,6 +497,13 @@ public class IndexSearcher {
   }
 
   /**
+   * Get a {@link QueryTimeout} for all searches that run through this {@link IndexSearcher} if set.
+   */
+  public QueryTimeout getTimeout() {
+    return this.queryTimeout;
+  }
+
+  /**
    * Finds the top <code>n</code> hits for <code>query</code>.
    *
    * @throws TooManyClauses If a query would exceed {@link IndexSearcher#getMaxClauseCount()}
@@ -519,9 +526,14 @@ public class IndexSearcher {
     search(leafContexts, createWeight(query, results.scoreMode(), 1), results);
   }
 
-  /** Returns true if any search hit the {@link #setTimeout(QueryTimeout) timeout}. */
+  /** Return true if any search hit the {@link #setTimeout(QueryTimeout) timeout}. */
   public boolean timedOut() {
     return partialResult;
+  }
+
+  /** Indicate that at least one search hit the {@link #setTimeout(QueryTimeout) timeout}. */
+  protected void setTimedOut() {
+    partialResult = true;
   }
 
   /**
@@ -750,7 +762,7 @@ public class IndexSearcher {
         } catch (
             @SuppressWarnings("unused")
             TimeLimitingBulkScorer.TimeExceededException e) {
-          partialResult = true;
+          setTimedOut();
         }
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
@@ -28,14 +28,14 @@ import org.apache.lucene.util.Bits;
  *
  * @see org.apache.lucene.index.ExitableDirectoryReader
  */
-final class TimeLimitingBulkScorer extends BulkScorer {
+public final class TimeLimitingBulkScorer extends BulkScorer {
   // We score chunks of documents at a time so as to avoid the cost of checking the timeout for
   // every document we score.
   static final int INTERVAL = 100;
 
   /** Thrown when elapsed search time exceeds allowed search time. */
   @SuppressWarnings("serial")
-  static class TimeExceededException extends RuntimeException {
+  public static class TimeExceededException extends RuntimeException {
 
     private TimeExceededException() {
       super("TimeLimit Exceeded");


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description

The suggested usability improvements are low risk and do not open up any internals:

 - add getter for timeout value to IndexSearcher (only setter exists)
 - open up TimeLimitingBulkScorer and TimeLimitingBulkScorer.TimeExceededException


Closes https://github.com/apache/lucene/issues/11874
