### PR TITLE
gradle aggregated coverage console log and html location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
   id "de.undercouch.download" version "5.2.0" apply false
   id "net.ltgt.errorprone" version "2.0.2" apply false
   id 'com.diffplug.spotless' version "6.5.2" apply false
-  id 'org.barfuin.gradle.jacocolog' version "2.0.0" apply false
+  id 'org.barfuin.gradle.jacocolog' version "3.0.0-RC2" apply false
 }
 
 apply from: file('gradle/globals.gradle')

--- a/gradle/testing/coverage.gradle
+++ b/gradle/testing/coverage.gradle
@@ -23,6 +23,21 @@ def withCoverage = gradle.startParameter.taskNames.contains("coverage") ||
     Boolean.parseBoolean(propertyOrDefault("tests.coverage", "false"))
 
 if (withCoverage) {
+  configure(rootProject) {
+    plugins.apply("org.barfuin.gradle.jacocolog")
+
+    // Synthetic task to enable test coverage (and aggregated reports).
+    task coverage() {
+      dependsOn jacocoAggregatedReport
+    }
+
+    configure(jacocoAggregatedReport) {
+      doLast {
+        logger.lifecycle("Code coverage report at: ${reports.html.destination}.\n")
+      }
+    }
+  }
+
   allprojects {
     plugins.withType(JavaPlugin) {
       // Apply jacoco once we know the project has a Java plugin too.
@@ -30,7 +45,7 @@ if (withCoverage) {
 
       // Synthetic task to enable test coverage (and reports).
       task coverage() {
-        dependsOn jacocoAggregatedReport
+        dependsOn jacocoTestReport
       }
 
       tasks.withType(Test) { Task testTask ->
@@ -41,15 +56,13 @@ if (withCoverage) {
           destinationFile = file("${testTask.workingDir}/jacoco.exec")
         }
 
-        // Test reports, if any, must be preceded by test execution.
-        jacocoTestReport.dependsOn testTask
+        // Test reports run after the test task, if it's run at all.
+        testTask.finalizedBy jacocoTestReport
       }
 
-      if (project.subprojects.size() > 0) {
-        configure(jacocoAggregatedReport) {
-          doLast {
-            logger.lifecycle("Aggregated code coverage report at: ${reports.html.destination}.\n")
-          }
+      configure(jacocoTestReport) {
+        doLast {
+          logger.lifecycle("Code coverage report at: ${reports.html.destination}.\n")
         }
       }
     }

--- a/gradle/testing/coverage.gradle
+++ b/gradle/testing/coverage.gradle
@@ -45,7 +45,7 @@ if (withCoverage) {
 
       // Synthetic task to enable test coverage (and reports).
       task coverage() {
-        dependsOn jacocoTestReport
+        dependsOn test, jacocoTestReport
       }
 
       tasks.withType(Test) { Task testTask ->

--- a/gradle/testing/coverage.gradle
+++ b/gradle/testing/coverage.gradle
@@ -30,7 +30,7 @@ if (withCoverage) {
 
       // Synthetic task to enable test coverage (and reports).
       task coverage() {
-        dependsOn jacocoTestReport
+        dependsOn jacocoAggregatedReport
       }
 
       tasks.withType(Test) { Task testTask ->
@@ -45,9 +45,11 @@ if (withCoverage) {
         jacocoTestReport.dependsOn testTask
       }
 
-      configure(jacocoTestReport) {
-        doLast {
-          logger.lifecycle("Code coverage report at: ${reports.html.destination}.\n")
+      if (project.subprojects.size() > 0) {
+        configure(jacocoAggregatedReport) {
+          doLast {
+            logger.lifecycle("Aggregated code coverage report at: ${reports.html.destination}.\n")
+          }
         }
       }
     }

--- a/lucene/build.gradle
+++ b/lucene/build.gradle
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-apply plugin: 'java'
-
 description = 'Parent project for Apache Lucene Core'
 
 subprojects {

--- a/lucene/build.gradle
+++ b/lucene/build.gradle
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+apply plugin: 'java'
+
 description = 'Parent project for Apache Lucene Core'
 
 subprojects {


### PR DESCRIPTION
### Description

issue #11839
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

It's my first time really working on gradle script so I'm pretty uncertain whether I've done something wrong :) I tested with `./gradlew coverage` and it works as expected.

* Add `java` plugin to `:lucene` so that it will apply the "org.barfuin.gradle.jacocolog" plugin as well
* `coverage` depend on `jacocoAggregatedReport` so it will print aggregated coverage, for subproject it just print out the  coverage for that module
* Show html location only for parent project (which is only lucene?) because the printout for subproject also point to the same location, and the report is already aggregated.