### PR TITLE
Simplify the logic of matchAll() in IndexSortSortedNumericDocValuesRangeQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -158,6 +158,8 @@ Optimizations
 * GITHUB#11876: Use ByteArrayComparator to speed up PointInSetQuery in single dimension case.
   (Guo Feng)
 
+* GITHUB#11884: Simplify the logic of matchAll() in IndexSortSortedNumericDocValuesRangeQuery. (Lu Xugang)
+
 Other
 ---------------------
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -298,18 +298,12 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
         ArrayUtil.getUnsignedComparator(points.getBytesPerDimension());
     for (int dim = 0; dim < points.getNumDimensions(); dim++) {
       int offset = dim * points.getBytesPerDimension();
-      if (comparator.compare(points.getMinPackedValue(), offset, queryUpperPoint, offset) > 0) {
-        return false;
-      }
-      if (comparator.compare(points.getMaxPackedValue(), offset, queryLowerPoint, offset) < 0) {
-        return false;
-      }
-      if (comparator.compare(points.getMinPackedValue(), offset, queryLowerPoint, offset) < 0
-          || comparator.compare(points.getMaxPackedValue(), offset, queryUpperPoint, offset) > 0) {
-        return false;
+      if (comparator.compare(points.getMinPackedValue(), offset, queryLowerPoint, offset) >= 0
+          && comparator.compare(points.getMaxPackedValue(), offset, queryUpperPoint, offset) <= 0) {
+        return true;
       }
     }
-    return true;
+    return false;
   }
 
   private BoundedDocIdSetIterator getDocIdSetIteratorOrNullFromBkd(

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestIndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestIndexSortSortedNumericDocValuesRangeQuery.java
@@ -688,6 +688,13 @@ public class TestIndexSortSortedNumericDocValuesRangeQuery extends LuceneTestCas
       assertEquals(2500, weight.count(context));
     }
 
+    fallbackQuery = LongPoint.newRangeQuery(filedName, 5, 9);
+    query = new IndexSortSortedNumericDocValuesRangeQuery(filedName, 2, 10, fallbackQuery);
+    weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
+    for (LeafReaderContext context : searcher.getLeafContexts()) {
+      assertEquals(2500, weight.count(context));
+    }
+
     fallbackQuery = LongPoint.newRangeQuery(filedName, 2, 3);
     query = new IndexSortSortedNumericDocValuesRangeQuery(filedName, 2, 3, fallbackQuery);
     weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);


### PR DESCRIPTION
Could we do this simplification, make it more readable？