### PR TITLE
Allow building with java 18 now that gradle supports it

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ comprehensive documentation, visit:
 
 ### Basic steps:
   
-1. Install OpenJDK 17 (exactly this version).
+1. Install OpenJDK 17 or 18.
 2. Clone Lucene's git repository (or download the source distribution).
 3. Run gradle launcher script (`gradlew`).
 

--- a/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -61,8 +61,8 @@ public class WrapperDownloader {
 
   public static void checkVersion() {
     int major = Runtime.getRuntime().version().feature();
-    if (major != 17) {
-      throw new IllegalStateException("java version be exactly 17, your version: " + major);
+    if (major < 17 || major > 18) {
+      throw new IllegalStateException("java version be 17 or 18, your version: " + major);
     }
   }
 

--- a/gradlew
+++ b/gradlew
@@ -124,7 +124,7 @@ GRADLE_WRAPPER_JAR="$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
 "$JAVACMD" $JAVA_OPTS --source 11 "$APP_HOME/buildSrc/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java" "$GRADLE_WRAPPER_JAR"
 WRAPPER_STATUS=$?
 if [ "$WRAPPER_STATUS" -eq 1 ]; then
-    echo "ERROR: Something went wrong. Make sure you're using Java 17."
+    echo "ERROR: Something went wrong. Make sure you're using Java 17 or 18."
     exit $WRAPPER_STATUS
 elif [ "$WRAPPER_STATUS" -ne 0 ]; then
     exit $WRAPPER_STATUS

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -97,7 +97,7 @@ goto fail
 
 :failWithJvmMessage
 @rem https://github.com/apache/lucene/pull/819
-echo Error: Something went wrong. Make sure you're using Java 17.
+echo Error: Something went wrong. Make sure you're using Java 17 or 18.
 
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of


### PR DESCRIPTION
Since #11886, java 18 actually works, so let's allow it. unfortunately java 19 still does not work.