### PR TITLE
count() in BooleanQuery could be early quit

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -160,6 +160,8 @@ Optimizations
 
 * GITHUB#11884: Simplify the logic of matchAll() in IndexSortSortedNumericDocValuesRangeQuery. (Lu Xugang)
 
+* GITHUB#11895: count() in BooleanQuery could be early quit. (Lu Xugang)
+
 Other
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
@@ -414,8 +414,6 @@ final class BooleanWeight extends Weight {
       positiveCount = -1;
     }
 
-
-
     if (positiveCount == 0) {
       return 0;
     }

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
@@ -401,8 +401,9 @@ final class BooleanWeight extends Weight {
     final int numDocs = context.reader().numDocs();
     int positiveCount;
     if (query.isPureDisjunction()) {
-      positiveCount = optCount(context, Occur.SHOULD);
-    } else if ((query.getClauses(Occur.FILTER).isEmpty() == false
+      return optCount(context, Occur.SHOULD);
+    }
+    if ((query.getClauses(Occur.FILTER).isEmpty() == false
             || query.getClauses(Occur.MUST).isEmpty() == false)
         && query.getMinimumNumberShouldMatch() == 0) {
       positiveCount = reqCount(context);
@@ -412,6 +413,8 @@ final class BooleanWeight extends Weight {
       // real-world queries that would benefit from Lucene handling this case?
       positiveCount = -1;
     }
+
+
 
     if (positiveCount == 0) {
       return 0;


### PR DESCRIPTION
Since all queries are pure disjunctional, we could quit early and make the logic much simpler?