### PR TITLE
Add monster test for many knn docs

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/document/TestManyKnnDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestManyKnnDocs.java
@@ -32,7 +32,7 @@ import org.apache.lucene.tests.util.TestUtil;
 @Monster("takes ~??? hours and needs extra heap, disk space, file handles")
 public class TestManyKnnDocs extends LuceneTestCase {
   // ./gradlew -p lucene/core test --tests TestManyKnnDocs -Dtests.verbose=true -Dtests.monster=true
-  // -Ptests.heapsize=4g
+  // -Ptests.heapsize=16g
   public void testLargeSegment() throws Exception {
     IndexWriterConfig iwc = new IndexWriterConfig();
     iwc.setCodec(

--- a/lucene/core/src/test/org/apache/lucene/document/TestManyKnnDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestManyKnnDocs.java
@@ -51,6 +51,7 @@ public class TestManyKnnDocs extends LuceneTestCase {
     mp.setMaxMergeAtOnce(128); // avoid intermediate merges (waste of time with HNSW?)
     mp.setSegmentsPerTier(128); // only merge once at the end when we ask
     iwc.setMergePolicy(mp);
+    iwc.setInfoStream(System.out);
 
     String fieldName = "field";
     VectorSimilarityFunction similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;

--- a/lucene/core/src/test/org/apache/lucene/document/TestManyKnnDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestManyKnnDocs.java
@@ -28,7 +28,7 @@ import org.apache.lucene.tests.util.LuceneTestCase.Monster;
 import org.apache.lucene.tests.util.TestUtil;
 
 /** Tests many KNN docs to look for overflows. */
-@TimeoutSuite(millis = 10_800_000) // 3 hour timeout
+@TimeoutSuite(millis = 86_400_000) // 24 hour timeout
 @Monster("takes ~??? hours and needs extra heap, disk space, file handles")
 public class TestManyKnnDocs extends LuceneTestCase {
   // ./gradlew -p lucene/core test --tests TestManyKnnDocs -Dtests.verbose=true -Dtests.monster=true

--- a/lucene/core/src/test/org/apache/lucene/document/TestManyKnnDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestManyKnnDocs.java
@@ -51,7 +51,7 @@ public class TestManyKnnDocs extends LuceneTestCase {
         IndexWriter iw = new IndexWriter(dir, iwc)) {
 
       // This data is enough to trigger the overflow bug in issue #11905
-      int numVectors = 16268814;
+      int numVectors = 16268815;
 
       float[] vector = new float[1];
       Document doc = new Document();


### PR DESCRIPTION
Goal is to reproduce #11905

Basically I adapted the test from #11867 as a start, tweaked the indexing and merging to try to get it running reasonably, since it needs to make single segment of 16M docs for this case.

I'm leaving it running overnight, hopefully it solves the problem or is at least close, as I haven't run it to completion yet. Will look more tomorrow.