### PR TITLE
Fix latent casting bug in BKDWriter

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -137,6 +137,8 @@ Bug Fixes
 
 * GITHUB#11807: Don't rewrite queries in unified highlighter. (Alan Woodward)
 
+* GITHUB#11907: Fix latent casting bugs in BKDWriter. (Ben Trent)
+
 Optimizations
 ---------------------
 * GITHUB#11738: Optimize MultiTermQueryConstantScoreWrapper when a term is present that matches all

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -515,7 +515,7 @@ public class BKDWriter implements Closeable {
 
     checkMaxLeafNodeCount(numLeaves);
 
-    final byte[] splitPackedValues = new byte[numSplits * config.bytesPerDim];
+    final byte[] splitPackedValues = new byte[Math.multiplyExact(numSplits, config.bytesPerDim)];
     final byte[] splitDimensionValues = new byte[numSplits];
     final long[] leafBlockFPs = new long[numLeaves];
 

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -946,7 +946,7 @@ public class BKDWriter implements Closeable {
 
     // Indexed by nodeID, but first (root) nodeID is 1.  We do 1+ because the lead byte at each
     // recursion says which dim we split on.
-    byte[] splitPackedValues = new byte[Math.toIntExact(numSplits * config.bytesPerDim)];
+    byte[] splitPackedValues = new byte[Math.multiplyExact(numSplits, config.bytesPerDim)];
     byte[] splitDimensionValues = new byte[numSplits];
 
     // +1 because leaf count is power of 2 (e.g. 8), and innerNodeCount is power of 2 minus 1 (e.g.


### PR DESCRIPTION
This commit fixes a latent casting bug where int multiplication could roll-over to the negatives. 

`new byte[Math.toIntExact(numSplits * config.bytesPerDim)];`

`toIntExact` does nothing from what I understand. Since both `numSplits` and `config.bytesPerDim` are already `int` values, their multiplication will be an `int` multiplication that will return an `int`. Consequently, `Math.toIntExact` does no work here and we can still get negative numbers.

I will venture to assume that the original author actually wanted `Math.multiplyExact(numSplits, config.bytesPerDim)` which will multiply the two values and throw if there is overflow.