### PR TITLE
GITHUB#11911: improve checkindex to be more thorough for vectors

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -187,6 +187,10 @@ Build
 
 ======================== Lucene 9.4.2 =======================
 
+Improvements
+---------------------
+* GITHUB#11916: improve checkindex to be more thorough for vectors. (Ben Trent)
+
 Bug Fixes
 ---------------------
 * GITHUB#11905: Fix integer overflow when seeking the vector index for connections in a single segment.

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2590,12 +2590,11 @@ public final class CheckIndex implements Closeable {
 
             int docCount = 0;
             final Bits bits = reader.getLiveDocs();
-            int numSearces = 0;
-            final int maxNumSearches = 64;
+            int everyNdoc = Math.max(values.size() / 64, 1);
             while (values.nextDoc() != NO_MORE_DOCS) {
               float[] vectorValue = values.vectorValue();
               // search the first maxNumSearches vectors to exercise the graph
-              if (numSearces++ < maxNumSearches) {
+              if (values.docID() % everyNdoc == 0) {
                 TopDocs docs =
                     reader
                         .getVectorReader()

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2597,7 +2597,7 @@ public final class CheckIndex implements Closeable {
               // search the first maxNumSearches vectors to exercise the graph
               if (numSearces++ < maxNumSearches) {
                 TopDocs docs =
-                    reader.getVectorReader().search(fieldInfo.name, vectorValue, 10, bits, 100);
+                    reader.getVectorReader().search(fieldInfo.name, vectorValue, 10, bits, Integer.MAX_VALUE);
                 if (docs.scoreDocs.length == 0) {
                   throw new CheckIndexException(
                       "Field \"" + fieldInfo.name + "\" failed to search k nearest neighbors");

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2597,7 +2597,9 @@ public final class CheckIndex implements Closeable {
               // search the first maxNumSearches vectors to exercise the graph
               if (numSearces++ < maxNumSearches) {
                 TopDocs docs =
-                    reader.getVectorReader().search(fieldInfo.name, vectorValue, 10, bits, Integer.MAX_VALUE);
+                    reader
+                        .getVectorReader()
+                        .search(fieldInfo.name, vectorValue, 10, bits, Integer.MAX_VALUE);
                 if (docs.scoreDocs.length == 0) {
                   throw new CheckIndexException(
                       "Field \"" + fieldInfo.name + "\" failed to search k nearest neighbors");


### PR DESCRIPTION
Checkindex with vectors should exercise the graph and seek operations. These are exposed via the search interface.

There is the option to search EVERY stored vector value as we iterate it, but this seemed excessive. 

So, only 64 vectors are searched, skipping every N vectors (where N allows around 64 searches to be executed).

closes: https://github.com/apache/lucene/issues/11911