### PR TITLE
Automatically preload index files that are both tiny and very hot.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -42,6 +42,7 @@ import org.apache.lucene.index.TermsEnum.SeekStatus;
 import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.BytesRef;
@@ -82,7 +83,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     merging = false;
 
     // read in the entries from the metadata file.
-    try (ChecksumIndexInput in = state.directory.openChecksumInput(metaName, state.context)) {
+    try (ChecksumIndexInput in = state.directory.openChecksumInput(metaName, IOContext.READONCE)) {
       Throwable priorE = null;
 
       try {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.IOUtils;
@@ -60,7 +61,7 @@ final class Lucene90NormsProducer extends NormsProducer implements Cloneable {
     int version = -1;
 
     // read in the entries from the metadata file.
-    try (ChecksumIndexInput in = state.directory.openChecksumInput(metaName, state.context)) {
+    try (ChecksumIndexInput in = state.directory.openChecksumInput(metaName, IOContext.READONCE)) {
       Throwable priorE = null;
       try {
         version =

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsReader.java
@@ -27,6 +27,7 @@ import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.bkd.BKDReader;
@@ -59,7 +60,7 @@ public class Lucene90PointsReader extends PointsReader {
 
     boolean success = false;
     try {
-      indexIn = readState.directory.openInput(indexFileName, readState.context);
+      indexIn = readState.directory.openInput(indexFileName, IOContext.LOAD);
       CodecUtil.checkIndexHeader(
           indexIn,
           Lucene90PointsFormat.INDEX_CODEC_NAME,
@@ -81,7 +82,7 @@ public class Lucene90PointsReader extends PointsReader {
 
       long indexLength = -1, dataLength = -1;
       try (ChecksumIndexInput metaIn =
-          readState.directory.openChecksumInput(metaFileName, readState.context)) {
+          readState.directory.openChecksumInput(metaFileName, IOContext.READONCE)) {
         Throwable priorE = null;
         try {
           CodecUtil.checkIndexHeader(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
@@ -33,6 +33,7 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
@@ -134,7 +135,7 @@ public final class Lucene90BlockTreeTermsReader extends FieldsProducer {
 
       String indexName =
           IndexFileNames.segmentFileName(segment, state.segmentSuffix, TERMS_INDEX_EXTENSION);
-      indexIn = state.directory.openInput(indexName, state.context);
+      indexIn = state.directory.openInput(indexName, IOContext.LOAD);
       CodecUtil.checkIndexHeader(
           indexIn,
           TERMS_INDEX_CODEC_NAME,
@@ -149,7 +150,8 @@ public final class Lucene90BlockTreeTermsReader extends FieldsProducer {
       Map<String, FieldReader> fieldMap = null;
       Throwable priorE = null;
       long indexLength = -1, termsLength = -1;
-      try (ChecksumIndexInput metaIn = state.directory.openChecksumInput(metaName, state.context)) {
+      try (ChecksumIndexInput metaIn =
+          state.directory.openChecksumInput(metaName, IOContext.READONCE)) {
         try {
           CodecUtil.checkIndexHeader(
               metaIn,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/FieldsIndexReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/FieldsIndexReader.java
@@ -65,7 +65,7 @@ final class FieldsIndexReader extends FieldsIndex {
     maxPointer = metaIn.readLong();
 
     indexInput =
-        dir.openInput(IndexFileNames.segmentFileName(name, suffix, extension), IOContext.READ);
+        dir.openInput(IndexFileNames.segmentFileName(name, suffix, extension), IOContext.LOAD);
     boolean success = false;
     try {
       CodecUtil.checkIndexHeader(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene94/Lucene94HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene94/Lucene94HnswVectorsReader.java
@@ -38,6 +38,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
@@ -89,7 +90,8 @@ public final class Lucene94HnswVectorsReader extends KnnVectorsReader {
         IndexFileNames.segmentFileName(
             state.segmentInfo.name, state.segmentSuffix, Lucene94HnswVectorsFormat.META_EXTENSION);
     int versionMeta = -1;
-    try (ChecksumIndexInput meta = state.directory.openChecksumInput(metaFileName, state.context)) {
+    try (ChecksumIndexInput meta =
+        state.directory.openChecksumInput(metaFileName, IOContext.READONCE)) {
       Throwable priorE = null;
       try {
         versionMeta =

--- a/lucene/core/src/java/org/apache/lucene/store/IOContext.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IOContext.java
@@ -45,8 +45,8 @@ public class IOContext {
   public final boolean readOnce;
 
   /**
-   * This flag indicates that the file is expected to be heavily accessed in a random-access fashion
-   * and should have its content in memory.
+   * This flag indicates that the file is expected to be heavily accessed in a random-access
+   * fashion.
    */
   public final boolean load;
 

--- a/lucene/core/src/java/org/apache/lucene/store/IOContext.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IOContext.java
@@ -41,16 +41,25 @@ public class IOContext {
 
   public final FlushInfo flushInfo;
 
+  /** This flag indicates that the file will be opened, then fully read sequentially then closed. */
   public final boolean readOnce;
+
+  /**
+   * This flag indicates that the file is expected to be heavily accessed in a random-access fashion
+   * and should have its content in memory.
+   */
+  public final boolean load;
 
   public static final IOContext DEFAULT = new IOContext(Context.DEFAULT);
 
-  public static final IOContext READONCE = new IOContext(true);
+  public static final IOContext READONCE = new IOContext(true, false);
 
-  public static final IOContext READ = new IOContext(false);
+  public static final IOContext READ = new IOContext(false, false);
+
+  public static final IOContext LOAD = new IOContext(false, true);
 
   public IOContext() {
-    this(false);
+    this(false, false);
   }
 
   public IOContext(FlushInfo flushInfo) {
@@ -58,6 +67,7 @@ public class IOContext {
     this.context = Context.FLUSH;
     this.mergeInfo = null;
     this.readOnce = false;
+    this.load = false;
     this.flushInfo = flushInfo;
   }
 
@@ -65,10 +75,11 @@ public class IOContext {
     this(context, null);
   }
 
-  private IOContext(boolean readOnce) {
+  private IOContext(boolean readOnce, boolean load) {
     this.context = Context.READ;
     this.mergeInfo = null;
     this.readOnce = readOnce;
+    this.load = load;
     this.flushInfo = null;
   }
 
@@ -82,6 +93,7 @@ public class IOContext {
     assert context != Context.FLUSH : "Use IOContext(FlushInfo) to create a FLUSH IOContext";
     this.context = context;
     this.readOnce = false;
+    this.load = false;
     this.mergeInfo = mergeInfo;
     this.flushInfo = null;
   }
@@ -99,6 +111,7 @@ public class IOContext {
     this.mergeInfo = ctxt.mergeInfo;
     this.flushInfo = ctxt.flushInfo;
     this.readOnce = readOnce;
+    this.load = false;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -235,7 +235,7 @@ public class MMapDirectory extends FSDirectory {
     ensureOpen();
     ensureCanRead(name);
     Path path = directory.resolve(name);
-    return PROVIDER.openInput(path, context, chunkSizePower, preload, useUnmapHack);
+    return PROVIDER.openInput(path, context, chunkSizePower, preload || context.load, useUnmapHack);
   }
 
   // visible for tests:

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -85,25 +85,23 @@ public class MMapDirectory extends FSDirectory {
    * Argument for {@link #setPreload(BiPredicate)} that configures all files to be preloaded upon
    * opening them.
    */
-  public static final BiPredicate<String, IOContext> PRELOAD_ALL_FILES =
-      (filename, context) -> true;
+  public static final BiPredicate<String, IOContext> ALL_FILES = (filename, context) -> true;
 
   /**
    * Argument for {@link #setPreload(BiPredicate)} that configures no files to be preloaded upon
    * opening them.
    */
-  public static final BiPredicate<String, IOContext> PRELOAD_NO_FILES =
-      (filename, context) -> false;
+  public static final BiPredicate<String, IOContext> NO_FILES = (filename, context) -> false;
 
   /**
    * Argument for {@link #setPreload(BiPredicate)} that configures all files that use the {@link
    * IOContext#LOAD} to be preloaded upon opening them. This is the default.
    */
-  public static final BiPredicate<String, IOContext> PRELOAD_BASED_ON_IO_CONTEXT =
+  public static final BiPredicate<String, IOContext> BASED_ON_IO_CONTEXT =
       (filename, context) -> context.load;
 
   private boolean useUnmapHack = UNMAP_SUPPORTED;
-  private BiPredicate<String, IOContext> preload = PRELOAD_BASED_ON_IO_CONTEXT;
+  private BiPredicate<String, IOContext> preload = BASED_ON_IO_CONTEXT;
 
   /**
    * Default max chunk size:
@@ -238,9 +236,9 @@ public class MMapDirectory extends FSDirectory {
    *
    * @param preload a {@link BiPredicate} whose first argument is the file name, and second argument
    *     is the {@link IOContext} used to open the file
-   * @see #PRELOAD_ALL_FILES
-   * @see #PRELOAD_NO_FILES
-   * @see #PRELOAD_BASED_ON_IO_CONTEXT
+   * @see #ALL_FILES
+   * @see #NO_FILES
+   * @see #BASED_ON_IO_CONTEXT
    */
   public void setPreload(BiPredicate<String, IOContext> preload) {
     this.preload = preload;
@@ -254,7 +252,7 @@ public class MMapDirectory extends FSDirectory {
    */
   @Deprecated
   public void setPreload(boolean preload) {
-    this.preload = preload ? PRELOAD_ALL_FILES : PRELOAD_NO_FILES;
+    this.preload = preload ? ALL_FILES : NO_FILES;
   }
 
   /**
@@ -266,7 +264,7 @@ public class MMapDirectory extends FSDirectory {
    */
   @Deprecated
   public boolean getPreload() {
-    return preload == PRELOAD_ALL_FILES;
+    return preload == ALL_FILES;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -97,11 +97,11 @@ public class MMapDirectory extends FSDirectory {
    * Argument for {@link #setPreload(BiPredicate)} that configures all files that use the {@link
    * IOContext#LOAD} to be preloaded upon opening them. This is the default.
    */
-  public static final BiPredicate<String, IOContext> BASED_ON_IO_CONTEXT =
+  public static final BiPredicate<String, IOContext> BASED_ON_LOAD_IO_CONTEXT =
       (filename, context) -> context.load;
 
   private boolean useUnmapHack = UNMAP_SUPPORTED;
-  private BiPredicate<String, IOContext> preload = BASED_ON_IO_CONTEXT;
+  private BiPredicate<String, IOContext> preload = BASED_ON_LOAD_IO_CONTEXT;
 
   /**
    * Default max chunk size:
@@ -238,7 +238,7 @@ public class MMapDirectory extends FSDirectory {
    *     is the {@link IOContext} used to open the file
    * @see #ALL_FILES
    * @see #NO_FILES
-   * @see #BASED_ON_IO_CONTEXT
+   * @see #BASED_ON_LOAD_IO_CONTEXT
    */
   public void setPreload(BiPredicate<String, IOContext> preload) {
     this.preload = preload;

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -93,15 +93,8 @@ public class MMapDirectory extends FSDirectory {
    */
   public static final BiPredicate<String, IOContext> NO_FILES = (filename, context) -> false;
 
-  /**
-   * Argument for {@link #setPreload(BiPredicate)} that configures all files that use the {@link
-   * IOContext#LOAD} to be preloaded upon opening them. This is the default.
-   */
-  public static final BiPredicate<String, IOContext> BASED_ON_LOAD_IO_CONTEXT =
-      (filename, context) -> context.load;
-
   private boolean useUnmapHack = UNMAP_SUPPORTED;
-  private BiPredicate<String, IOContext> preload = BASED_ON_LOAD_IO_CONTEXT;
+  private BiPredicate<String, IOContext> preload = NO_FILES;
 
   /**
    * Default max chunk size:
@@ -231,14 +224,12 @@ public class MMapDirectory extends FSDirectory {
 
   /**
    * Configure which files to preload in physical memory upon opening. The default implementation
-   * preloads files that use the {@link IOContext#LOAD} I/O context. The behavior is best effort and
-   * operating system-dependent.
+   * does not preload anything. The behavior is best effort and operating system-dependent.
    *
    * @param preload a {@link BiPredicate} whose first argument is the file name, and second argument
    *     is the {@link IOContext} used to open the file
    * @see #ALL_FILES
    * @see #NO_FILES
-   * @see #BASED_ON_LOAD_IO_CONTEXT
    */
   public void setPreload(BiPredicate<String, IOContext> preload) {
     this.preload = preload;

--- a/lucene/core/src/test/org/apache/lucene/store/TestMmapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMmapDirectory.java
@@ -32,7 +32,7 @@ public class TestMmapDirectory extends BaseDirectoryTestCase {
   @Override
   protected Directory getDirectory(Path path) throws IOException {
     MMapDirectory m = new MMapDirectory(path);
-    m.setPreload(random().nextBoolean());
+    m.setPreload((file, context) -> random().nextBoolean());
     return m;
   }
 


### PR DESCRIPTION
The default codec has a number of small and hot files, that actually used to be fully loaded in memory before we moved them off-heap. In the general case, these files are expected to fully fit into the page cache for things to work well. Should we give control over preloading to codecs? This is what this commit does for the following files:
 - Terms index (`tip`)
 - Points index (`kdi`)
 - Stored fields index (`fdx`)
 - Terms vector index (`tvx`)

This only has an effect on `MMapDirectory`.