### PR TITLE
Improve test introduced in #11918 to also check that reported invalid position is transformed back original position by slicing code

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/store/TestMultiMMap.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMultiMMap.java
@@ -16,9 +16,11 @@
  */
 package org.apache.lucene.store;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import org.apache.lucene.tests.store.BaseChunkedDirectoryTestCase;
 import org.apache.lucene.util.BytesRef;
 import org.junit.BeforeClass;
@@ -41,22 +43,39 @@ public class TestMultiMMap extends BaseChunkedDirectoryTestCase {
     assertTrue(MMapDirectory.UNMAP_NOT_SUPPORTED_REASON, MMapDirectory.UNMAP_SUPPORTED);
   }
 
-  public void testSeekNegative() throws IOException {
-    try (Directory dir = getDirectory(createTempDir())) {
+  public void testSeekingExceptions() throws IOException {
+    final int sliceSize = 128;
+    try (Directory dir = getDirectory(createTempDir(), sliceSize)) {
+      final int size = 128 + 63;
       try (IndexOutput out = dir.createOutput("a", IOContext.DEFAULT)) {
-        for (int i = 0; i < 2048; ++i) {
+        for (int i = 0; i < size; ++i) {
           out.writeByte((byte) 0);
         }
       }
       try (IndexInput in = dir.openInput("a", IOContext.DEFAULT)) {
-        in.seek(1234);
-        assertEquals(1234, in.getFilePointer());
+        final long negativePos = -1234;
         var e =
             expectThrowsAnyOf(
                 List.of(IllegalArgumentException.class, AssertionError.class),
-                () -> in.seek(-1234));
+                () -> in.seek(negativePos));
         assertTrue(
             "does not mention negative position", e.getMessage().contains("negative position"));
+
+        final long posAfterEOF = size + 123;
+        var eof = expectThrows(EOFException.class, () -> in.seek(posAfterEOF));
+        assertTrue(
+            "wrong position in error message: " + eof,
+            eof.getMessage().contains(String.format(Locale.ROOT, "(pos=%d)", posAfterEOF)));
+
+        // this test verifies that the invalid position is transformed back to original one for
+        // exception by slicing:
+        IndexInput slice = in.slice("slice", 33, sliceSize + 15);
+        // ensure that the slice uses multi-mmap:
+        assertCorrectImpl(false, slice);
+        eof = expectThrows(EOFException.class, () -> slice.seek(posAfterEOF));
+        assertTrue(
+            "wrong position in error message: " + eof,
+            eof.getMessage().contains(String.format(Locale.ROOT, "(pos=%d)", posAfterEOF)));
       }
     }
   }


### PR DESCRIPTION
This improves the test a bit, especially regarding this code (and I'm glad: code is fine):
- https://github.com/apache/lucene/blob/98b26e0885dcc4dc0b7a085f5d23d5099d59808a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java#L626-L630
- https://github.com/apache/lucene/blob/98b26e0885dcc4dc0b7a085f5d23d5099d59808a/lucene/core/src/java19/org/apache/lucene/store/MemorySegmentIndexInput.java#L548-L552

It also uses smaller file with fixed chunk size to reduce I/O.