### PR TITLE
speed up javac and error-prone tasks by using less resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
   id "org.owasp.dependencycheck" version "7.2.0"
   id 'de.thetaphi.forbiddenapis' version '3.4' apply false
   id "de.undercouch.download" version "5.2.0" apply false
-  id "net.ltgt.errorprone" version "2.0.2" apply false
+  id "net.ltgt.errorprone" version "3.0.1" apply false
   id 'com.diffplug.spotless' version "6.5.2" apply false
   id 'org.barfuin.gradle.jacocolog' version "3.0.0-RC2" apply false
 }

--- a/gradle/generation/local-settings.gradle
+++ b/gradle/generation/local-settings.gradle
@@ -68,7 +68,7 @@ systemProp.file.encoding=UTF-8
 # The heap seems huge but gradle runs out of memory on lower values (don't know why).
 #
 # We also open up internal compiler modules for spotless/ google java format.
-org.gradle.jvmargs=-Xmx3g \\
+org.gradle.jvmargs=-Xmx3g -XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 \\
  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \\
  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \\
  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \\

--- a/gradle/hacks/turbocharge-jvm-opts.gradle
+++ b/gradle/hacks/turbocharge-jvm-opts.gradle
@@ -47,7 +47,7 @@ allprojects {
         // The 'non-forked' version of 'gradlew clean classes' runs in 15s for me,
         // while forcing fork = true below completes in 22s.
         //
-        // task.options.fork = true
+        task.options.fork = true
         task.options.forkOptions.jvmArgs += vmOpts
         task.options.forkOptions.jvmArgs += [
             "-XX:+PrintFlagsFinal",

--- a/gradle/hacks/turbocharge-jvm-opts.gradle
+++ b/gradle/hacks/turbocharge-jvm-opts.gradle
@@ -38,4 +38,19 @@ allprojects {
 
         jvmArgs += vmOpts
     }
+
+    // Tweak javac to not be too resource-hungry. Note that
+    // java compile can run in-process with gradle; if this is the case then
+    // no jvmArgs are passed. We can force javac to run as a forked process but
+    // I don't know if it makes sense in all circumstances.
+    tasks.withType(JavaCompile) { JavaCompile task ->
+        // The 'non-forked' version of 'gradlew clean classes' runs in 15s for me,
+        // while forcing fork = true below completes in 22s.
+        //
+        // task.options.fork = true
+        task.options.forkOptions.jvmArgs += vmOpts
+        task.options.forkOptions.jvmArgs += [
+            "-XX:ActiveProcessorCount=1"
+        ]
+    }
 }

--- a/gradle/hacks/turbocharge-jvm-opts.gradle
+++ b/gradle/hacks/turbocharge-jvm-opts.gradle
@@ -19,7 +19,7 @@
 allprojects {
     def vmOpts = [
         '-XX:+UseParallelGC',
-        '-XX:TieredStopAtLevel=1'
+        '-XX:TieredStopAtLevel=1',
         '-XX:ActiveProcessorCount=1'
     ]
 

--- a/gradle/hacks/turbocharge-jvm-opts.gradle
+++ b/gradle/hacks/turbocharge-jvm-opts.gradle
@@ -47,7 +47,7 @@ allprojects {
         // The 'non-forked' version of 'gradlew clean classes' runs in 15s for me,
         // while forcing fork = true below completes in 22s.
         //
-        task.options.fork = true
+        // task.options.fork = true
         task.options.forkOptions.jvmArgs += vmOpts
         task.options.forkOptions.jvmArgs += [
             "-XX:+PrintFlagsFinal",

--- a/gradle/hacks/turbocharge-jvm-opts.gradle
+++ b/gradle/hacks/turbocharge-jvm-opts.gradle
@@ -50,6 +50,7 @@ allprojects {
         // task.options.fork = true
         task.options.forkOptions.jvmArgs += vmOpts
         task.options.forkOptions.jvmArgs += [
+            "-XX:+PrintFlagsFinal",
             "-XX:ActiveProcessorCount=1"
         ]
     }

--- a/gradle/hacks/turbocharge-jvm-opts.gradle
+++ b/gradle/hacks/turbocharge-jvm-opts.gradle
@@ -20,6 +20,7 @@ allprojects {
     def vmOpts = [
         '-XX:+UseParallelGC',
         '-XX:TieredStopAtLevel=1'
+        '-XX:ActiveProcessorCount=1'
     ]
 
     // Inject vm options into custom javadoc rendering. We can't refer
@@ -39,19 +40,10 @@ allprojects {
         jvmArgs += vmOpts
     }
 
-    // Tweak javac to not be too resource-hungry. Note that
-    // java compile can run in-process with gradle; if this is the case then
-    // no jvmArgs are passed. We can force javac to run as a forked process but
-    // I don't know if it makes sense in all circumstances.
+    // Tweak javac to not be too resource-hungry.
+    // This applies to any JVM when javac runs forked (e.g. error-prone)
+    // Avoiding the fork entirely is best.
     tasks.withType(JavaCompile) { JavaCompile task ->
-        // The 'non-forked' version of 'gradlew clean classes' runs in 15s for me,
-        // while forcing fork = true below completes in 22s.
-        //
-        // task.options.fork = true
         task.options.forkOptions.jvmArgs += vmOpts
-        task.options.forkOptions.jvmArgs += [
-            "-XX:+PrintFlagsFinal",
-            "-XX:ActiveProcessorCount=1"
-        ]
     }
 }

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -47,7 +47,7 @@ allprojects {
            description: "Number of forked test JVMs"],
           [propName: 'tests.haltonfailure', value: true, description: "Halt processing on test failure."],
           [propName: 'tests.jvmargs',
-           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", "-XX:TieredStopAtLevel=1") },
+           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", "-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1") },
            description: "Arguments passed to each forked JVM."],
           // Other settings.
           [propName: 'tests.neverUpToDate', value: true,

--- a/help/localSettings.txt
+++ b/help/localSettings.txt
@@ -47,7 +47,7 @@ separately from the gradle workers, for example:
 tests.jvms=3
 tests.heapsize=512m
 tests.minheapsize=512m
-tests.jvmargs=-XX:+UseParallelGC -XX:TieredStopAtLevel=1
+tests.jvmargs=-XX:+UseParallelGC -XX:TieredStopAtLevel=1 -XX:ActiveProcessorCount=1
 
 Gradle Daemon
 -------------


### PR DESCRIPTION
Speed up javac and error-prone tasks, by using less resources

closes #11924
closes #11925