### PR TITLE
GH#11922: Allow DisjunctionDISIApproximation to short-circuit

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -65,9 +65,6 @@ Optimizations
 
 * GITHUB#11857, GITHUB#11859: Hunspell: improved suggestion performance
 
-* GITHUB#11922: Allow DisjunctionDISIApproximation to short-circuit when advancing once a doc
-  is found. (Greg Miller)
-
 Bug Fixes
 ---------------------
 
@@ -167,6 +164,9 @@ Optimizations
   and borrowing some concepts from "min should match" scoring. (Greg Miller)
 
 * GITHUB#11884: Simplify the logic of matchAll() in IndexSortSortedNumericDocValuesRangeQuery. (Lu Xugang)
+
+* GITHUB#11922: Allow DisjunctionDISIApproximation to short-circuit when advancing once a doc
+  is found. (Greg Miller)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -65,6 +65,9 @@ Optimizations
 
 * GITHUB#11857, GITHUB#11859: Hunspell: improved suggestion performance
 
+* GITHUB#11922: Allow DisjunctionDISIApproximation to short-circuit when advancing once a doc
+  is found. (Greg Miller)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -102,6 +102,12 @@ Lucene 9.2 or stay with 9.0.
 
 See LUCENE-10558 for more details and workarounds.
 
+### DisjunctionDISIApproximation behavior change
+
+`DisjunctionDISIApproximation` no longer guarantees that all sub-iterators are positioned on the
+current doc after calls to `#nextDoc` and `#advance`. Users that rely on this implementation
+can call the newly-added `#advanceAll` method to ensure sub-iterators a positioned as necessary.
+
 ## Migration from Lucene 8.x to Lucene 9.0
 
 ### Rename of binary artifacts from '**-analyzers-**' to '**-analysis-**' (LUCENE-9562)

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -102,12 +102,6 @@ Lucene 9.2 or stay with 9.0.
 
 See LUCENE-10558 for more details and workarounds.
 
-### DisjunctionDISIApproximation behavior change
-
-`DisjunctionDISIApproximation` no longer guarantees that all sub-iterators are positioned on the
-current doc after calls to `#nextDoc` and `#advance`. Users that rely on this implementation
-can call the newly-added `#advanceAll` method to ensure sub-iterators a positioned as necessary.
-
 ## Migration from Lucene 8.x to Lucene 9.0
 
 ### Rename of binary artifacts from '**-analyzers-**' to '**-analysis-**' (LUCENE-9562)

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionDISIApproximation.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionDISIApproximation.java
@@ -55,11 +55,6 @@ public class DisjunctionDISIApproximation extends DocIdSetIterator {
   }
 
   private int doNext(int target) throws IOException {
-    if (target == DocIdSetIterator.NO_MORE_DOCS) {
-      docID = DocIdSetIterator.NO_MORE_DOCS;
-      return docID;
-    }
-
     DisiWrapper top = subIterators.top();
     do {
       top.doc = top.approximation.advance(target);
@@ -77,9 +72,6 @@ public class DisjunctionDISIApproximation extends DocIdSetIterator {
 
   @Override
   public int nextDoc() throws IOException {
-    if (docID == DocIdSetIterator.NO_MORE_DOCS) {
-      return docID;
-    }
     return doNext(docID + 1);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/IndriDisjunctionScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndriDisjunctionScorer.java
@@ -27,19 +27,18 @@ import java.util.List;
 public abstract class IndriDisjunctionScorer extends IndriScorer {
 
   private final List<Scorer> subScorersList;
-  private final DisiPriorityQueue subScorers;
-  private final DocIdSetIterator approximation;
+  private final DisjunctionDISIApproximation approximation;
 
   protected IndriDisjunctionScorer(
       Weight weight, List<Scorer> subScorersList, ScoreMode scoreMode, float boost) {
     super(weight, boost);
     this.subScorersList = subScorersList;
-    this.subScorers = new DisiPriorityQueue(subScorersList.size());
+    final DisiPriorityQueue subScorers = new DisiPriorityQueue(subScorersList.size());
     for (Scorer scorer : subScorersList) {
       final DisiWrapper w = new DisiWrapper(scorer);
-      this.subScorers.add(w);
+      subScorers.add(w);
     }
-    this.approximation = new DisjunctionDISIApproximation(this.subScorers);
+    this.approximation = new DisjunctionDISIApproximation(subScorers);
   }
 
   @Override
@@ -53,6 +52,7 @@ public abstract class IndriDisjunctionScorer extends IndriScorer {
   }
 
   public List<Scorer> getSubMatches() throws IOException {
+    approximation.advanceAll();
     return subScorersList;
   }
 
@@ -72,6 +72,6 @@ public abstract class IndriDisjunctionScorer extends IndriScorer {
 
   @Override
   public int docID() {
-    return subScorers.top().doc;
+    return approximation.docID();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
@@ -318,7 +318,9 @@ public final class SynonymQuery extends Query {
       }
       // Even though it is called approximation, it is accurate since none of
       // the sub iterators are two-phase iterators.
-      DocIdSetIterator iterator = new DisjunctionDISIApproximation(queue);
+      DisjunctionDISIApproximation disjunctionDISIApproximation =
+          new DisjunctionDISIApproximation(queue);
+      DocIdSetIterator iterator = disjunctionDISIApproximation;
 
       float[] boosts = new float[impacts.size()];
       for (int i = 0; i < boosts.length; i++) {
@@ -331,7 +333,8 @@ public final class SynonymQuery extends Query {
         iterator = impactsDisi;
       }
 
-      return new SynonymScorer(this, queue, iterator, impactsDisi, simScorer);
+      return new SynonymScorer(
+          this, queue, disjunctionDISIApproximation, iterator, impactsDisi, simScorer);
     }
 
     @Override
@@ -511,6 +514,7 @@ public final class SynonymQuery extends Query {
   private static class SynonymScorer extends Scorer {
 
     private final DisiPriorityQueue queue;
+    private final DisjunctionDISIApproximation disjunctionDISIApproximation;
     private final DocIdSetIterator iterator;
     private final ImpactsDISI impactsDisi;
     private final LeafSimScorer simScorer;
@@ -518,11 +522,13 @@ public final class SynonymQuery extends Query {
     SynonymScorer(
         Weight weight,
         DisiPriorityQueue queue,
+        DisjunctionDISIApproximation disjunctionDISIApproximation,
         DocIdSetIterator iterator,
         ImpactsDISI impactsDisi,
         LeafSimScorer simScorer) {
       super(weight);
       this.queue = queue;
+      this.disjunctionDISIApproximation = disjunctionDISIApproximation;
       this.iterator = iterator;
       this.impactsDisi = impactsDisi;
       this.simScorer = simScorer;
@@ -534,6 +540,7 @@ public final class SynonymQuery extends Query {
     }
 
     float freq() throws IOException {
+      disjunctionDISIApproximation.advanceAll();
       DisiWrapperFreq w = (DisiWrapperFreq) queue.topList();
       float freq = w.freq();
       for (w = (DisiWrapperFreq) w.next; w != null; w = (DisiWrapperFreq) w.next) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQueryVisitSubscorers.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQueryVisitSubscorers.java
@@ -173,6 +173,7 @@ public class TestBooleanQueryVisitSubscorers extends LuceneTestCase {
 
         @Override
         public void collect(int doc) throws IOException {
+          super.collect(doc);
           int freq = 0;
           for (Scorer scorer : tqsSet) {
             if (doc == scorer.docID()) {
@@ -180,7 +181,6 @@ public class TestBooleanQueryVisitSubscorers extends LuceneTestCase {
             }
           }
           docCounts.put(doc + docBase, freq);
-          super.collect(doc);
         }
       };
     }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
@@ -432,7 +432,7 @@ public final class CombinedFieldQuery extends Query implements Accountable {
       }
       // Even though it is called approximation, it is accurate since none of
       // the sub iterators are two-phase iterators.
-      DocIdSetIterator iterator = new DisjunctionDISIApproximation(queue);
+      DisjunctionDISIApproximation iterator = new DisjunctionDISIApproximation(queue);
       return new CombinedFieldScorer(this, queue, iterator, scoringSimScorer);
     }
 
@@ -457,13 +457,13 @@ public final class CombinedFieldQuery extends Query implements Accountable {
 
   private static class CombinedFieldScorer extends Scorer {
     private final DisiPriorityQueue queue;
-    private final DocIdSetIterator iterator;
+    private final DisjunctionDISIApproximation iterator;
     private final MultiNormsLeafSimScorer simScorer;
 
     CombinedFieldScorer(
         Weight weight,
         DisiPriorityQueue queue,
-        DocIdSetIterator iterator,
+        DisjunctionDISIApproximation iterator,
         MultiNormsLeafSimScorer simScorer) {
       super(weight);
       this.queue = queue;
@@ -477,6 +477,7 @@ public final class CombinedFieldQuery extends Query implements Accountable {
     }
 
     float freq() throws IOException {
+      iterator.advanceAll();
       DisiWrapper w = queue.topList();
       float freq = ((WeightedDisiWrapper) w).freq();
       for (w = w.next; w != null; w = w.next) {


### PR DESCRIPTION
### Description

This PR explores allowing `DisjunctionDISIApproximation` to short-circuit after "finding" a doc, allowing sub-iterators to only be exhaustively advanced when necessary. This could be useful for non-scoring disjunction clauses.

Note: I've only changed the approximation implementation to start. `DisjunctionScorer` exhaustively advances all sub-iterators in this implementation if it needs to do two-phase match confirmation (which is what we do today). Ideally, we'd only advance as necessary in this step as well.