### PR TITLE
Fix a few calls to `Directory#openChecksumInput` to pass the right `IOContext`.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90LiveDocsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90LiveDocsFormat.java
@@ -68,7 +68,7 @@ public final class Lucene90LiveDocsFormat extends LiveDocsFormat {
     long gen = info.getDelGen();
     String name = IndexFileNames.fileNameFromGeneration(info.info.name, EXTENSION, gen);
     final int length = info.info.maxDoc();
-    try (ChecksumIndexInput input = dir.openChecksumInput(name, context)) {
+    try (ChecksumIndexInput input = dir.openChecksumInput(name, IOContext.READONCE)) {
       Throwable priorE = null;
       try {
         CodecUtil.checkIndexHeader(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90SegmentInfoFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90SegmentInfoFormat.java
@@ -99,7 +99,7 @@ public class Lucene90SegmentInfoFormat extends SegmentInfoFormat {
   public SegmentInfo read(Directory dir, String segment, byte[] segmentID, IOContext context)
       throws IOException {
     final String fileName = IndexFileNames.segmentFileName(segment, "", SI_EXTENSION);
-    try (ChecksumIndexInput input = dir.openChecksumInput(fileName, context)) {
+    try (ChecksumIndexInput input = dir.openChecksumInput(fileName, IOContext.READONCE)) {
       Throwable priorE = null;
       SegmentInfo si = null;
       try {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene94/Lucene94FieldInfosFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene94/Lucene94FieldInfosFormat.java
@@ -127,7 +127,7 @@ public final class Lucene94FieldInfosFormat extends FieldInfosFormat {
       throws IOException {
     final String fileName =
         IndexFileNames.segmentFileName(segmentInfo.name, segmentSuffix, EXTENSION);
-    try (ChecksumIndexInput input = directory.openChecksumInput(fileName, context)) {
+    try (ChecksumIndexInput input = directory.openChecksumInput(fileName, IOContext.READONCE)) {
       Throwable priorE = null;
       FieldInfo[] infos = null;
       try {


### PR DESCRIPTION
These calls should use `IOContext.READONCE` rather than forward the default `IOContext`.