### PR TITLE
fix bug of incorrect cost after upgradeToBitSet in DocIdSetBuilder class

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -199,6 +199,9 @@ Bug Fixes
  This addresses a bug that was introduced in 9.2.0 where having many vectors is not handled well
  in the vector connections reader.
 
+* GITHUB#11939: Fix incorrect cost calculation in DocIdSetBuilder after upgradeToBitSet when doc list is growing.
+  This addresses a bug where the cost of TermRangeQuery/TermInSetQuery and some other queries will be highly underestimated.
+
 Improvements
 ---------------------
 * GITHUB#11912, GITHUB#11918: Port generic exception handling from MemorySegmentIndexInput

--- a/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
@@ -163,12 +163,11 @@ public final class DocIdSetBuilder {
    */
   public void add(DocIdSetIterator iter) throws IOException {
     int cost = (int) Math.min(Integer.MAX_VALUE, iter.cost());
+    BulkAdder adder = grow(cost);
     if (bitSet != null) {
-      grow(cost);
       bitSet.or(iter);
       return;
     }
-    BulkAdder adder = grow(cost);
     for (int i = 0; i < cost; ++i) {
       int doc = iter.nextDoc();
       if (doc == DocIdSetIterator.NO_MORE_DOCS) {

--- a/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
@@ -162,11 +162,12 @@ public final class DocIdSetBuilder {
    * RoaringDocIdSet.Builder}.
    */
   public void add(DocIdSetIterator iter) throws IOException {
+    int cost = (int) Math.min(Integer.MAX_VALUE, iter.cost());
     if (bitSet != null) {
+      grow(cost);
       bitSet.or(iter);
       return;
     }
-    int cost = (int) Math.min(Integer.MAX_VALUE, iter.cost());
     BulkAdder adder = grow(cost);
     for (int i = 0; i < cost; ++i) {
       int doc = iter.nextDoc();

--- a/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
@@ -243,6 +243,18 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
     assertTrue(builder.multivalued);
   }
 
+  public void testCostIsCorrectAfterBitsetUpgrade() throws IOException {
+    final int maxDoc = 1000000;
+    DocIdSetBuilder builder = new DocIdSetBuilder(maxDoc);
+    // 1000000 >> 6 is greater than DocIdSetBuilder.threshold which is 1000000 >> 7
+    for (int i = 0; i < 1000000 >> 6; ++i) {
+      builder.add(DocIdSetIterator.range(i, i + 1));
+    }
+    DocIdSet result = builder.build();
+    assertTrue(result instanceof BitDocIdSet);
+    assertEquals(1000000 >> 6, result.iterator().cost());
+  }
+
   private static class DummyTerms extends Terms {
 
     private final int docCount;


### PR DESCRIPTION
### Description

When we execute TermRangeQuery or TermInSet query, lucene use DocIdSetBuilder to store doc id list. When the doc id list becomes large, it will convert from array to bitset in upgradeToBitSet. When new doc id is added, the `counter` variable of DocIdSetBuilder is unchanged, and the cost is incorrect in DocIdSetBuilder.build.

How to reproduce:

        Directory dir = FSDirectory.open(Files.createTempDirectory(null, new FileAttribute[0]));
        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig());
        for (int i = 100000; i < 300000; ++i) {
            Document doc = new Document();
            doc.add(new StringField("f1", i + "", Field.Store.NO));
            w.addDocument(doc);
        }
        w.forceMerge(1);
        IndexReader reader = DirectoryReader.open(w);
        IndexSearcher searcher = new IndexSearcher(reader);
        searcher.setQueryCache(null);

        Query query = new TermRangeQuery("f1", new BytesRef("200000"), new BytesRef("300000"), true, true);
        Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE, 1);
        ScorerSupplier scorerSupplier = weight.scorerSupplier(searcher.getIndexReader().leaves().get(0));
        System.out.println(scorerSupplier.cost());

it is wrong cost=1026, the actual cost should be 100000. This will cause some performance unexpected issue like lead selection in bool query.
