### PR TITLE
Ensure collections are properly sized on creation

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/NormalizeCharMap.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/NormalizeCharMap.java
@@ -94,10 +94,9 @@ public class NormalizeCharMap {
       if (match.length() == 0) {
         throw new IllegalArgumentException("cannot match the empty string");
       }
-      if (pendingPairs.containsKey(match)) {
+      if (pendingPairs.putIfAbsent(match, replacement) != null) {
         throw new IllegalArgumentException("match \"" + match + "\" was already added");
       }
-      pendingPairs.put(match, replacement);
     }
 
     /** Builds the NormalizeCharMap; call this once you are done calling {@link #add}. */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/hyphenation/HyphenationTree.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/hyphenation/HyphenationTree.java
@@ -313,17 +313,17 @@ public class HyphenationTree extends TernaryTree implements PatternConsumer {
 
     // check exception list first
     String sw = new String(word, 1, len);
-    if (stoplist.containsKey(sw)) {
+    ArrayList<Object> hw;
+    if ((hw = stoplist.get(sw)) != null) {
       // assume only simple hyphens (Hyphen.pre="-", Hyphen.post = Hyphen.no =
       // null)
-      ArrayList<Object> hw = stoplist.get(sw);
       int j = 0;
       for (i = 0; i < hw.size(); i++) {
         Object o = hw.get(i);
         // j = index(sw) = letterindex(word)?
         // result[k] = corresponding index(w)
-        if (o instanceof String) {
-          j += ((String) o).length();
+        if (o instanceof String s) {
+          j += s.length();
           if (j >= remainCharCount && j < (len - pushCharCount)) {
             result[k++] = j + iIgnoreAtBeginning;
           }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
@@ -16,7 +16,23 @@
  */
 package org.apache.lucene.analysis.custom;
 
-import static org.apache.lucene.analysis.AnalysisSPILoader.newFactoryClassInstance;
+import org.apache.lucene.analysis.AbstractAnalysisFactory;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CharFilterFactory;
+import org.apache.lucene.analysis.TokenFilterFactory;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.TokenizerFactory;
+import org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilter;
+import org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilterFactory;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.util.FilesystemResourceLoader;
+import org.apache.lucene.util.ClasspathResourceLoader;
+import org.apache.lucene.util.CollectionUtil;
+import org.apache.lucene.util.ResourceLoader;
+import org.apache.lucene.util.ResourceLoaderAware;
+import org.apache.lucene.util.SetOnce;
+import org.apache.lucene.util.Version;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -29,18 +45,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import org.apache.lucene.analysis.AbstractAnalysisFactory;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.CharFilterFactory;
-import org.apache.lucene.analysis.TokenFilterFactory;
-import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.TokenizerFactory;
-import org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilter;
-import org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilterFactory;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.lucene.analysis.util.FilesystemResourceLoader;
-import org.apache.lucene.util.*;
+
+import static org.apache.lucene.analysis.AnalysisSPILoader.newFactoryClassInstance;
 
 /**
  * A general-purpose Analyzer that can be created with a builder-style API. Under the hood it uses
@@ -589,8 +595,8 @@ public final class CustomAnalyzer extends Analyzer {
     }
 
     private Map<String, String> applyDefaultParams(Map<String, String> map) {
-      Version v;
-      if ((v = defaultMatchVersion.get()) != null) {
+      Version v = defaultMatchVersion.get();
+      if (v != null) {
         map.putIfAbsent(AbstractAnalysisFactory.LUCENE_MATCH_VERSION_PARAM, v.toString());
       }
       return map;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
@@ -41,11 +41,7 @@ import org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilter;
 import org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilterFactory;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.util.FilesystemResourceLoader;
-import org.apache.lucene.util.ClasspathResourceLoader;
-import org.apache.lucene.util.ResourceLoader;
-import org.apache.lucene.util.ResourceLoaderAware;
-import org.apache.lucene.util.SetOnce;
-import org.apache.lucene.util.Version;
+import org.apache.lucene.util.*;
 
 /**
  * A general-purpose Analyzer that can be created with a builder-style API. Under the hood it uses
@@ -594,11 +590,9 @@ public final class CustomAnalyzer extends Analyzer {
     }
 
     private Map<String, String> applyDefaultParams(Map<String, String> map) {
-      if (defaultMatchVersion.get() != null
-          && !map.containsKey(AbstractAnalysisFactory.LUCENE_MATCH_VERSION_PARAM)) {
-        map.put(
-            AbstractAnalysisFactory.LUCENE_MATCH_VERSION_PARAM,
-            defaultMatchVersion.get().toString());
+      Version v;
+      if ((v = defaultMatchVersion.get()) != null) {
+        map.putIfAbsent(AbstractAnalysisFactory.LUCENE_MATCH_VERSION_PARAM, v.toString());
       }
       return map;
     }
@@ -608,7 +602,7 @@ public final class CustomAnalyzer extends Analyzer {
         throw new IllegalArgumentException(
             "Key-value pairs expected, so the number of params must be even.");
       }
-      final Map<String, String> map = new HashMap<>();
+      final Map<String, String> map = CollectionUtil.newHashMap(params.length);
       for (int i = 0; i < params.length; i += 2) {
         Objects.requireNonNull(params[i], "Key of param may not be null.");
         map.put(params[i], params[i + 1]);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
@@ -16,6 +16,19 @@
  */
 package org.apache.lucene.analysis.custom;
 
+import static org.apache.lucene.analysis.AnalysisSPILoader.newFactoryClassInstance;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import org.apache.lucene.analysis.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharFilterFactory;
@@ -33,20 +46,6 @@ import org.apache.lucene.util.ResourceLoader;
 import org.apache.lucene.util.ResourceLoaderAware;
 import org.apache.lucene.util.SetOnce;
 import org.apache.lucene.util.Version;
-
-import java.io.IOException;
-import java.io.Reader;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
-import java.util.function.Predicate;
-
-import static org.apache.lucene.analysis.AnalysisSPILoader.newFactoryClassInstance;
 
 /**
  * A general-purpose Analyzer that can be created with a builder-style API. Under the hood it uses

--- a/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/PhoneticFilterFactory.java
+++ b/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/PhoneticFilterFactory.java
@@ -83,18 +83,14 @@ public class PhoneticFilterFactory extends TokenFilterFactory implements Resourc
 
   private static final String PACKAGE_CONTAINING_ENCODERS = "org.apache.commons.codec.language.";
 
-  // Effectively constants; uppercase keys
-  private static final Map<String, Class<? extends Encoder>> registry = new HashMap<>(6);
-
-  static {
-    registry.put("DoubleMetaphone".toUpperCase(Locale.ROOT), DoubleMetaphone.class);
-    registry.put("Metaphone".toUpperCase(Locale.ROOT), Metaphone.class);
-    registry.put("Soundex".toUpperCase(Locale.ROOT), Soundex.class);
-    registry.put("RefinedSoundex".toUpperCase(Locale.ROOT), RefinedSoundex.class);
-    registry.put("Caverphone".toUpperCase(Locale.ROOT), Caverphone2.class);
-    registry.put("ColognePhonetic".toUpperCase(Locale.ROOT), ColognePhonetic.class);
-    registry.put("Nysiis".toUpperCase(Locale.ROOT), Nysiis.class);
-  }
+  private static final Map<String, Class<? extends Encoder>> registry = Map.of(
+          "DoubleMetaphone".toUpperCase(Locale.ROOT), DoubleMetaphone.class,
+          "Metaphone".toUpperCase(Locale.ROOT), Metaphone.class,
+          "Soundex".toUpperCase(Locale.ROOT), Soundex.class,
+          "RefinedSoundex".toUpperCase(Locale.ROOT), RefinedSoundex.class,
+          "Caverphone".toUpperCase(Locale.ROOT), Caverphone2.class,
+          "ColognePhonetic".toUpperCase(Locale.ROOT), ColognePhonetic.class,
+          "Nysiis".toUpperCase(Locale.ROOT), Nysiis.class);
 
   final boolean inject; // accessed by the test
   private final String name;

--- a/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/PhoneticFilterFactory.java
+++ b/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/PhoneticFilterFactory.java
@@ -19,7 +19,6 @@ package org.apache.lucene.analysis.phonetic;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.apache.commons.codec.Encoder;
@@ -83,7 +82,8 @@ public class PhoneticFilterFactory extends TokenFilterFactory implements Resourc
 
   private static final String PACKAGE_CONTAINING_ENCODERS = "org.apache.commons.codec.language.";
 
-  private static final Map<String, Class<? extends Encoder>> registry = Map.of(
+  private static final Map<String, Class<? extends Encoder>> registry =
+      Map.of(
           "DoubleMetaphone".toUpperCase(Locale.ROOT), DoubleMetaphone.class,
           "Metaphone".toUpperCase(Locale.ROOT), Metaphone.class,
           "Soundex".toUpperCase(Locale.ROOT), Soundex.class,

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene40/blocktree/Lucene40BlockTreeTermsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene40/blocktree/Lucene40BlockTreeTermsReader.java
@@ -19,7 +19,6 @@ package org.apache.lucene.backward_codecs.lucene40.blocktree;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene40/blocktree/Lucene40BlockTreeTermsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene40/blocktree/Lucene40BlockTreeTermsReader.java
@@ -36,6 +36,7 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.fst.ByteSequenceOutputs;
 import org.apache.lucene.util.fst.Outputs;
@@ -198,7 +199,7 @@ public final class Lucene40BlockTreeTermsReader extends FieldsProducer {
           if (numFields < 0) {
             throw new CorruptIndexException("invalid numFields: " + numFields, termsMetaIn);
           }
-          fieldMap = new HashMap<>((int) (numFields / 0.75f) + 1);
+          fieldMap = CollectionUtil.newHashMap(numFields);
           for (int i = 0; i < numFields; ++i) {
             final int field = termsMetaIn.readVInt();
             final long numTerms = termsMetaIn.readVLong();

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/Lucene50CompoundReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/Lucene50CompoundReader.java
@@ -32,6 +32,7 @@ import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.IOUtils;
 
 /**
@@ -132,7 +133,7 @@ final class Lucene50CompoundReader extends CompoundDirectory {
 
   private Map<String, FileEntry> readMapping(IndexInput entriesStream) throws IOException {
     final int numEntries = entriesStream.readVInt();
-    Map<String, FileEntry> mapping = new HashMap<>(numEntries);
+    Map<String, FileEntry> mapping = CollectionUtil.newHashMap(numEntries);
     for (int i = 0; i < numEntries; i++) {
       final FileEntry fileEntry = new FileEntry();
       final String id = entriesStream.readString();

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/Lucene50CompoundReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/Lucene50CompoundReader.java
@@ -19,7 +19,6 @@ package org.apache.lucene.backward_codecs.lucene50;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.apache.lucene.backward_codecs.store.EndiannessReverserUtil;

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/TestDocValuesCompression.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/TestDocValuesCompression.java
@@ -41,6 +41,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.Nightly;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.CollectionUtil;
 
 @Nightly // N-2 formats are only tested on nightly runs
 public class TestDocValuesCompression extends LuceneTestCase {
@@ -89,7 +90,7 @@ public class TestDocValuesCompression extends LuceneTestCase {
 
   public void testReseekAfterSkipDecompression() throws IOException {
     final int CARDINALITY = (Lucene80DocValuesFormat.TERMS_DICT_BLOCK_LZ4_SIZE << 1) + 11;
-    Set<String> valueSet = new HashSet<>(CARDINALITY);
+    Set<String> valueSet = CollectionUtil.newHashSet(CARDINALITY);
     for (int i = 0; i < CARDINALITY; i++) {
       valueSet.add(TestUtil.randomSimpleString(random(), 64));
     }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
@@ -16,6 +16,12 @@
  */
 package org.apache.lucene.codecs.simpletext;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
 import org.apache.lucene.codecs.SegmentInfoFormat;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFileNames;
@@ -36,13 +42,6 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * plain text segments file format.

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
@@ -16,12 +16,6 @@
  */
 package org.apache.lucene.codecs.simpletext;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
 import org.apache.lucene.codecs.SegmentInfoFormat;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFileNames;
@@ -36,7 +30,19 @@ import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
-import org.apache.lucene.util.*;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.CollectionUtil;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * plain text segments file format.

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.lucene.codecs.SegmentInfoFormat;

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
@@ -38,11 +38,7 @@ import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
-import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.StringHelper;
-import org.apache.lucene.util.Version;
+import org.apache.lucene.util.*;
 
 /**
  * plain text segments file format.
@@ -117,7 +113,7 @@ public class SimpleTextSegmentInfoFormat extends SegmentInfoFormat {
       SimpleTextUtil.readLine(input, scratch);
       assert StringHelper.startsWith(scratch.get(), SI_NUM_DIAG);
       int numDiag = Integer.parseInt(readString(SI_NUM_DIAG.length, scratch));
-      Map<String, String> diagnostics = new HashMap<>();
+      Map<String, String> diagnostics = CollectionUtil.newHashMap(numDiag);
 
       for (int i = 0; i < numDiag; i++) {
         SimpleTextUtil.readLine(input, scratch);
@@ -133,7 +129,7 @@ public class SimpleTextSegmentInfoFormat extends SegmentInfoFormat {
       SimpleTextUtil.readLine(input, scratch);
       assert StringHelper.startsWith(scratch.get(), SI_NUM_ATT);
       int numAtt = Integer.parseInt(readString(SI_NUM_ATT.length, scratch));
-      Map<String, String> attributes = new HashMap<>(numAtt);
+      Map<String, String> attributes = CollectionUtil.newHashMap(numAtt);
 
       for (int i = 0; i < numAtt; i++) {
         SimpleTextUtil.readLine(input, scratch);
@@ -149,7 +145,7 @@ public class SimpleTextSegmentInfoFormat extends SegmentInfoFormat {
       SimpleTextUtil.readLine(input, scratch);
       assert StringHelper.startsWith(scratch.get(), SI_NUM_FILES);
       int numFiles = Integer.parseInt(readString(SI_NUM_FILES.length, scratch));
-      Set<String> files = new HashSet<>();
+      Set<String> files = CollectionUtil.newHashSet(numFiles);
 
       for (int i = 0; i < numFiles; i++) {
         SimpleTextUtil.readLine(input, scratch);

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/uniformsplit/sharedterms/STUniformSplitTermsWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/uniformsplit/sharedterms/STUniformSplitTermsWriter.java
@@ -332,7 +332,8 @@ public class STUniformSplitTermsWriter extends UniformSplitTermsWriter {
         createMergingFieldTermsMap(fieldMetadataList, mergeState.fieldsProducers.length);
     TermIteratorQueue<SegmentTerms> segmentTermsQueue = createSegmentTermsQueue(segmentTermsList);
     List<TermIterator<SegmentTerms>> groupedSegmentTerms = new ArrayList<>(segmentTermsList.size());
-    Map<String, List<SegmentPostings>> fieldPostingsMap = CollectionUtil.newHashMap(mergeState.fieldInfos.length);
+    Map<String, List<SegmentPostings>> fieldPostingsMap =
+        CollectionUtil.newHashMap(mergeState.fieldInfos.length);
     List<MergingFieldTerms> groupedFieldTerms = new ArrayList<>(mergeState.fieldInfos.length);
     List<FieldMetadataTermState> termStates = new ArrayList<>(mergeState.fieldInfos.length);
 
@@ -351,7 +352,8 @@ public class STUniformSplitTermsWriter extends UniformSplitTermsWriter {
 
   private Map<String, MergingFieldTerms> createMergingFieldTermsMap(
       List<FieldMetadata> fieldMetadataList, int numSegments) {
-    Map<String, MergingFieldTerms> fieldTermsMap = CollectionUtil.newHashMap(fieldMetadataList.size());
+    Map<String, MergingFieldTerms> fieldTermsMap =
+        CollectionUtil.newHashMap(fieldMetadataList.size());
     for (FieldMetadata fieldMetadata : fieldMetadataList) {
       FieldInfo fieldInfo = fieldMetadata.getFieldInfo();
       fieldTermsMap.put(
@@ -382,8 +384,9 @@ public class STUniformSplitTermsWriter extends UniformSplitTermsWriter {
       SegmentTerms segmentTerms = (SegmentTerms) segmentTermIterator;
       for (Map.Entry<String, BlockTermState> fieldTermState :
           segmentTerms.fieldTermStatesMap.entrySet()) {
-        List<SegmentPostings> segmentPostingsList = fieldPostingsMap.computeIfAbsent(fieldTermState.getKey(),
-                k -> new ArrayList<>(groupedSegmentTerms.size()));
+        List<SegmentPostings> segmentPostingsList =
+            fieldPostingsMap.computeIfAbsent(
+                fieldTermState.getKey(), k -> new ArrayList<>(groupedSegmentTerms.size()));
         segmentPostingsList.add(
             new SegmentPostings(
                 segmentTerms.segmentIndex,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
@@ -19,7 +19,6 @@ package org.apache.lucene.codecs.lucene90;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.apache.lucene.codecs.CodecUtil;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
@@ -31,6 +31,7 @@ import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.IOUtils;
 
 /**
@@ -132,7 +133,7 @@ final class Lucene90CompoundReader extends CompoundDirectory {
 
   private Map<String, FileEntry> readMapping(IndexInput entriesStream) throws IOException {
     final int numEntries = entriesStream.readVInt();
-    Map<String, FileEntry> mapping = new HashMap<>(numEntries);
+    Map<String, FileEntry> mapping = CollectionUtil.newHashMap(numEntries);
     for (int i = 0; i < numEntries; i++) {
       final FileEntry fileEntry = new FileEntry();
       final String id = entriesStream.readString();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
@@ -36,6 +36,7 @@ import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.fst.ByteSequenceOutputs;
 import org.apache.lucene.util.fst.Outputs;
@@ -166,7 +167,7 @@ public final class Lucene90BlockTreeTermsReader extends FieldsProducer {
           if (numFields < 0) {
             throw new CorruptIndexException("invalid numFields: " + numFields, metaIn);
           }
-          fieldMap = new HashMap<>((int) (numFields / 0.75f) + 1);
+          fieldMap = CollectionUtil.newHashMap(numFields);
           for (int i = 0; i < numFields; ++i) {
             final int field = metaIn.readVInt();
             final long numTerms = metaIn.readVLong();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
@@ -19,7 +19,6 @@ package org.apache.lucene.codecs.lucene90.blocktree;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
@@ -266,7 +266,8 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
         fieldInfo.putAttribute(PER_FIELD_SUFFIX_KEY, Integer.toString(groupBuilder.suffix));
       }
 
-      Map<PostingsFormat, FieldsGroup> formatToGroups = CollectionUtil.newHashMap(formatToGroupBuilders.size());
+      Map<PostingsFormat, FieldsGroup> formatToGroups =
+          CollectionUtil.newHashMap(formatToGroupBuilders.size());
       formatToGroupBuilders.forEach(
           (postingsFormat, builder) -> formatToGroups.put(postingsFormat, builder.build()));
       return formatToGroups;

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
@@ -43,6 +43,7 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Terms;
+import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.MergedIterator;
 
@@ -265,8 +266,7 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
         fieldInfo.putAttribute(PER_FIELD_SUFFIX_KEY, Integer.toString(groupBuilder.suffix));
       }
 
-      Map<PostingsFormat, FieldsGroup> formatToGroups =
-          new HashMap<>((int) (formatToGroupBuilders.size() / 0.75f) + 1);
+      Map<PostingsFormat, FieldsGroup> formatToGroups = CollectionUtil.newHashMap(formatToGroupBuilders.size());
       formatToGroupBuilders.forEach(
           (postingsFormat, builder) -> formatToGroups.put(postingsFormat, builder.build()));
       return formatToGroups;

--- a/lucene/core/src/java/org/apache/lucene/document/DocumentStoredFieldVisitor.java
+++ b/lucene/core/src/java/org/apache/lucene/document/DocumentStoredFieldVisitor.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.document;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -49,10 +50,7 @@ public class DocumentStoredFieldVisitor extends StoredFieldVisitor {
 
   /** Load only fields named in the provided fields. */
   public DocumentStoredFieldVisitor(String... fields) {
-    fieldsToAdd = new HashSet<>(fields.length);
-    for (String field : fields) {
-      fieldsToAdd.add(field);
-    }
+    fieldsToAdd = new HashSet<>(Arrays.asList(fields));
   }
 
   /** Load all stored fields. */

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -43,6 +43,7 @@ import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
@@ -439,7 +440,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
       if (numDVFields == 0) {
         dvUpdateFiles = Collections.emptyMap();
       } else {
-        Map<Integer, Set<String>> map = new HashMap<>(numDVFields);
+        Map<Integer, Set<String>> map = CollectionUtil.newHashMap(numDVFields);
         for (int i = 0; i < numDVFields; i++) {
           map.put(CodecUtil.readBEInt(input), input.readSetOfStrings());
         }

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -31,10 +31,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
-import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.IOFunction;
-import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.Version;
+import org.apache.lucene.util.*;
 
 /** Default implementation of {@link DirectoryReader}. */
 public final class StandardDirectoryReader extends DirectoryReader {
@@ -184,10 +181,10 @@ public final class StandardDirectoryReader extends DirectoryReader {
 
     // we put the old SegmentReaders in a map, that allows us
     // to lookup a reader using its segment name
-    final Map<String, Integer> segmentReaders =
-        (oldReaders == null ? Collections.emptyMap() : new HashMap<>(oldReaders.size()));
+    Map<String, Integer> segmentReaders = Collections.emptyMap();
 
     if (oldReaders != null) {
+      segmentReaders = CollectionUtil.newHashMap(oldReaders.size());
       // create a Map SegmentName->SegmentReader
       for (int i = 0, c = oldReaders.size(); i < c; i++) {
         final SegmentReader sr = (SegmentReader) oldReaders.get(i);

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -16,15 +16,6 @@
  */
 package org.apache.lucene.index;
 
-import org.apache.lucene.store.AlreadyClosedException;
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.IOContext;
-import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.CollectionUtil;
-import org.apache.lucene.util.IOFunction;
-import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.Version;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,6 +27,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.CollectionUtil;
+import org.apache.lucene.util.IOFunction;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.Version;
 
 /** Default implementation of {@link DirectoryReader}. */
 public final class StandardDirectoryReader extends DirectoryReader {

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -16,6 +16,15 @@
  */
 package org.apache.lucene.index;
 
+import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.CollectionUtil;
+import org.apache.lucene.util.IOFunction;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.Version;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,10 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import org.apache.lucene.store.AlreadyClosedException;
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.IOContext;
-import org.apache.lucene.util.*;
 
 /** Default implementation of {@link DirectoryReader}. */
 public final class StandardDirectoryReader extends DirectoryReader {

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/lucene/core/src/java/org/apache/lucene/util/CollectionUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/CollectionUtil.java
@@ -16,13 +16,10 @@
  */
 package org.apache.lucene.util;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.RandomAccess;
+import java.util.*;
 
 /**
- * Methods for manipulating (sorting) collections. Sort methods work directly on the supplied lists
+ * Methods for manipulating (sorting) and creating collections. Sort methods work directly on the supplied lists
  * and don't copy to/from arrays before/after. For medium size collections as used in the Lucene
  * indexer that is much more efficient.
  *
@@ -31,6 +28,22 @@ import java.util.RandomAccess;
 public final class CollectionUtil {
 
   private CollectionUtil() {} // no instance
+
+  /**
+   * Returns a new {@link HashMap} sized to contain {@code size} items
+   * without resizing the internal array.
+   */
+  public static <K, V> HashMap<K, V> newHashMap(int size) {
+    return new HashMap<>((int)(size / 0.75f) + 1);
+  }
+
+  /**
+   * Returns a new {@link HashSet} sized to contain {@code size} items
+   * without resizing the internal array.
+   */
+  public static <E> HashSet<E> newHashSet(int size) {
+    return new HashSet<>((int)(size / 0.75f) + 1);
+  }
 
   private static final class ListIntroSorter<T> extends IntroSorter {
 

--- a/lucene/core/src/java/org/apache/lucene/util/CollectionUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/CollectionUtil.java
@@ -16,7 +16,12 @@
  */
 package org.apache.lucene.util;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.RandomAccess;
 
 /**
  * Methods for manipulating (sorting) and creating collections. Sort methods work directly on the

--- a/lucene/core/src/java/org/apache/lucene/util/CollectionUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/CollectionUtil.java
@@ -19,9 +19,9 @@ package org.apache.lucene.util;
 import java.util.*;
 
 /**
- * Methods for manipulating (sorting) and creating collections. Sort methods work directly on the supplied lists
- * and don't copy to/from arrays before/after. For medium size collections as used in the Lucene
- * indexer that is much more efficient.
+ * Methods for manipulating (sorting) and creating collections. Sort methods work directly on the
+ * supplied lists and don't copy to/from arrays before/after. For medium size collections as used in
+ * the Lucene indexer that is much more efficient.
  *
  * @lucene.internal
  */
@@ -30,19 +30,19 @@ public final class CollectionUtil {
   private CollectionUtil() {} // no instance
 
   /**
-   * Returns a new {@link HashMap} sized to contain {@code size} items
-   * without resizing the internal array.
+   * Returns a new {@link HashMap} sized to contain {@code size} items without resizing the internal
+   * array.
    */
   public static <K, V> HashMap<K, V> newHashMap(int size) {
-    return new HashMap<>((int)(size / 0.75f) + 1);
+    return new HashMap<>((int) (size / 0.75f) + 1);
   }
 
   /**
-   * Returns a new {@link HashSet} sized to contain {@code size} items
-   * without resizing the internal array.
+   * Returns a new {@link HashSet} sized to contain {@code size} items without resizing the internal
+   * array.
    */
   public static <E> HashSet<E> newHashSet(int size) {
-    return new HashSet<>((int)(size / 0.75f) + 1);
+    return new HashSet<>((int) (size / 0.75f) + 1);
   }
 
   private static final class ListIntroSorter<T> extends IntroSorter {

--- a/lucene/core/src/java/org/apache/lucene/util/CollectionUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/CollectionUtil.java
@@ -34,6 +34,7 @@ public final class CollectionUtil {
    * array.
    */
   public static <K, V> HashMap<K, V> newHashMap(int size) {
+    // This should be replaced with HashMap.newHashMap when lucene moves to jdk19 minimum version
     return new HashMap<>((int) (size / 0.75f) + 1);
   }
 
@@ -42,6 +43,7 @@ public final class CollectionUtil {
    * array.
    */
   public static <E> HashSet<E> newHashSet(int size) {
+    // This should be replaced with HashSet.newHashSet when lucene moves to jdk19 minimum version
     return new HashSet<>((int) (size / 0.75f) + 1);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/MapOfSets.java
+++ b/lucene/core/src/java/org/apache/lucene/util/MapOfSets.java
@@ -52,13 +52,7 @@ public class MapOfSets<K, V> {
    * @return the size of the Set associated with key once val is added to it.
    */
   public int put(K key, V val) {
-    final Set<V> theSet;
-    if (theMap.containsKey(key)) {
-      theSet = theMap.get(key);
-    } else {
-      theSet = new HashSet<>(23);
-      theMap.put(key, theSet);
-    }
+    final Set<V> theSet = theMap.computeIfAbsent(key, k -> new HashSet<>(23));
     theSet.add(val);
     return theSet.size();
   }
@@ -69,13 +63,7 @@ public class MapOfSets<K, V> {
    * @return the size of the Set associated with key once val is added to it.
    */
   public int putAll(K key, Collection<? extends V> vals) {
-    final Set<V> theSet;
-    if (theMap.containsKey(key)) {
-      theSet = theMap.get(key);
-    } else {
-      theSet = new HashSet<>(23);
-      theMap.put(key, theSet);
-    }
+    final Set<V> theSet = theMap.computeIfAbsent(key, k -> new HashSet<>(23));
     theSet.addAll(vals);
     return theSet.size();
   }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormat.java
@@ -69,6 +69,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.CollectionUtil;
 
 /** Tests Lucene90DocValuesFormat */
 public class TestLucene90DocValuesFormat extends BaseCompressingDocValuesFormatTestCase {
@@ -778,7 +779,7 @@ public class TestLucene90DocValuesFormat extends BaseCompressingDocValuesFormatT
 
   public void testReseekAfterSkipDecompression() throws IOException {
     final int CARDINALITY = (Lucene90DocValuesFormat.TERMS_DICT_BLOCK_LZ4_SIZE << 1) + 11;
-    Set<String> valueSet = new HashSet<>(CARDINALITY);
+    Set<String> valueSet = CollectionUtil.newHashSet(CARDINALITY);
     for (int i = 0; i < CARDINALITY; i++) {
       valueSet.add(TestUtil.randomSimpleString(random(), 64));
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestCollectorManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestCollectorManager.java
@@ -22,7 +22,6 @@ import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
@@ -102,10 +101,10 @@ public class TestCollectorManager extends LuceneTestCase {
   }
 
   /**
-   * Generate test doc ids. This will de-dupe and create a sorted collection to be more realistic with
-   * real-world use-cases. Note that it's possible this will generate fewer than 'count' entries
-   * because of de-duping, but that should be quite rare and probably isn't worth worrying about for
-   * these testing purposes.
+   * Generate test doc ids. This will de-dupe and create a sorted collection to be more realistic
+   * with real-world use-cases. Note that it's possible this will generate fewer than 'count'
+   * entries because of de-duping, but that should be quite rare and probably isn't worth worrying
+   * about for these testing purposes.
    */
   private static SortedSet<Integer> generateDocIds(int count, Random random) {
     SortedSet<Integer> generated = new TreeSet<>();

--- a/lucene/core/src/test/org/apache/lucene/search/TestCollectorManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestCollectorManager.java
@@ -16,14 +16,9 @@
  */
 package org.apache.lucene.search;
 
-import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.apache.lucene.tests.util.LuceneTestCase;
+import static org.hamcrest.CoreMatchers.instanceOf;
 
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,8 +30,12 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestCollectorManager extends LuceneTestCase {
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestCollectorManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestCollectorManager.java
@@ -16,19 +16,27 @@
  */
 package org.apache.lucene.search;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
-import java.io.IOException;
-import java.util.*;
-import java.util.function.Predicate;
-import java.util.stream.IntStream;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class TestCollectorManager extends LuceneTestCase {
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestCollectorManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestCollectorManager.java
@@ -20,14 +20,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -57,7 +50,7 @@ public class TestCollectorManager extends LuceneTestCase {
 
     for (int iter = 0; iter < 100; iter++) {
       int docs = RandomNumbers.randomIntBetween(random(), 1000, 10000);
-      List<Integer> expected = generateDocIds(docs, random());
+      Collection<Integer> expected = generateDocIds(docs, random());
       IntStream expectedEven = expected.stream().filter(evenPredicate).mapToInt(i -> i);
       IntStream expectedOdd = expected.stream().filter(oddPredicate).mapToInt(i -> i);
 
@@ -91,7 +84,7 @@ public class TestCollectorManager extends LuceneTestCase {
   }
 
   private static <C extends Collector> Object collectAll(
-      LeafReaderContext ctx, List<Integer> values, CollectorManager<C, ?> collectorManager)
+      LeafReaderContext ctx, Collection<Integer> values, CollectorManager<C, ?> collectorManager)
       throws IOException {
     List<C> collectors = new ArrayList<>();
     C collector = collectorManager.newCollector();
@@ -109,18 +102,17 @@ public class TestCollectorManager extends LuceneTestCase {
   }
 
   /**
-   * Generate test doc ids. This will de-dupe and create a sorted list to be more realistic with
+   * Generate test doc ids. This will de-dupe and create a sorted collection to be more realistic with
    * real-world use-cases. Note that it's possible this will generate fewer than 'count' entries
    * because of de-duping, but that should be quite rare and probably isn't worth worrying about for
    * these testing purposes.
    */
-  private List<Integer> generateDocIds(int count, Random random) {
-    Set<Integer> generated = new HashSet<>(count);
+  private static SortedSet<Integer> generateDocIds(int count, Random random) {
+    SortedSet<Integer> generated = new TreeSet<>();
     for (int i = 0; i < count; i++) {
       generated.add(random.nextInt());
     }
-
-    return generated.stream().sorted().collect(Collectors.toList());
+    return generated;
   }
 
   private static final class CompositeCollectorManager

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiCollectorManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiCollectorManager.java
@@ -17,13 +17,6 @@
 package org.apache.lucene.search;
 
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.apache.lucene.tests.util.LuceneTestCase;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,6 +26,12 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestMultiCollectorManager extends LuceneTestCase {
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiCollectorManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiCollectorManager.java
@@ -17,16 +17,22 @@
 package org.apache.lucene.search;
 
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
-import java.io.IOException;
-import java.util.*;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class TestMultiCollectorManager extends LuceneTestCase {
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiCollectorManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiCollectorManager.java
@@ -205,10 +205,10 @@ public class TestMultiCollectorManager extends LuceneTestCase {
   }
 
   /**
-   * Generate test doc ids. This will de-dupe and create a sorted collection to be more realistic with
-   * real-world use-cases. Note that it's possible this will generate fewer than 'count' entries
-   * because of de-duping, but that should be quite rare and probably isn't worth worrying about for
-   * these testing purposes.
+   * Generate test doc ids. This will de-dupe and create a sorted collection to be more realistic
+   * with real-world use-cases. Note that it's possible this will generate fewer than 'count'
+   * entries because of de-duping, but that should be quite rare and probably isn't worth worrying
+   * about for these testing purposes.
    */
   private static SortedSet<Integer> generateDocIds(int count, Random random) {
     SortedSet<Integer> generated = new TreeSet<>();

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiCollectorManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiCollectorManager.java
@@ -18,12 +18,7 @@ package org.apache.lucene.search;
 
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.lucene.document.Document;
@@ -52,7 +47,7 @@ public class TestMultiCollectorManager extends LuceneTestCase {
 
     for (int iter = 0; iter < 100; iter++) {
       int docs = RandomNumbers.randomIntBetween(random(), 1000, 10000);
-      List<Integer> expected = generateDocIds(docs, random());
+      SortedSet<Integer> expected = generateDocIds(docs, random());
       List<Integer> expectedEven =
           expected.stream().filter(evenPredicate).collect(Collectors.toList());
       List<Integer> expectedOdd =
@@ -157,7 +152,7 @@ public class TestMultiCollectorManager extends LuceneTestCase {
     LeafReaderContext ctx = reader.leaves().get(0);
 
     int docs = RandomNumbers.randomIntBetween(random(), 1000, 10000);
-    List<Integer> expected = generateDocIds(docs, random());
+    Collection<Integer> expected = generateDocIds(docs, random());
 
     // The first collector manager should collect all docs even though the second throws
     // CollectionTerminatedException immediately:
@@ -192,7 +187,7 @@ public class TestMultiCollectorManager extends LuceneTestCase {
   }
 
   private static <C extends Collector> Object collectAll(
-      LeafReaderContext ctx, List<Integer> values, CollectorManager<C, ?> collectorManager)
+      LeafReaderContext ctx, Collection<Integer> values, CollectorManager<C, ?> collectorManager)
       throws IOException {
     List<C> collectors = new ArrayList<>();
     C collector = collectorManager.newCollector();
@@ -210,18 +205,17 @@ public class TestMultiCollectorManager extends LuceneTestCase {
   }
 
   /**
-   * Generate test doc ids. This will de-dupe and create a sorted list to be more realistic with
+   * Generate test doc ids. This will de-dupe and create a sorted collection to be more realistic with
    * real-world use-cases. Note that it's possible this will generate fewer than 'count' entries
    * because of de-duping, but that should be quite rare and probably isn't worth worrying about for
    * these testing purposes.
    */
-  private List<Integer> generateDocIds(int count, Random random) {
-    Set<Integer> generated = new HashSet<>(count);
+  private static SortedSet<Integer> generateDocIds(int count, Random random) {
+    SortedSet<Integer> generated = new TreeSet<>();
     for (int i = 0; i < count; i++) {
       generated.add(random.nextInt());
     }
-
-    return generated.stream().sorted().collect(Collectors.toList());
+    return generated;
   }
 
   private static final class SimpleCollectorManager

--- a/lucene/core/src/test/org/apache/lucene/util/TestSentinelIntSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSentinelIntSet.java
@@ -51,7 +51,7 @@ public class TestSentinelIntSet extends LuceneTestCase {
       int maxVal =
           (random().nextBoolean() ? random().nextInt(50) : random().nextInt(Integer.MAX_VALUE)) + 1;
 
-      HashSet<Integer> a = new HashSet<>(initSz);
+      HashSet<Integer> a = CollectionUtil.newHashSet(initSz);
       SentinelIntSet b = new SentinelIntSet(initSz, -1);
 
       for (int j = 0; j < num; j++) {

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -28,6 +28,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.CollectionUtil;
 
 public class TestDocIdsWriter extends LuceneTestCase {
 
@@ -80,7 +81,7 @@ public class TestDocIdsWriter extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       for (int iter = 0; iter < numIters; ++iter) {
         int size = 1 + random().nextInt(5000);
-        Set<Integer> set = new HashSet<>(size);
+        Set<Integer> set = CollectionUtil.newHashSet(size);
         int small = random().nextInt(1000);
         while (set.size() < size) {
           set.add(small + random().nextInt(size * 16));

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -18,7 +18,6 @@ package org.apache.lucene.util.bkd;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/FirstPassGroupingCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/FirstPassGroupingCollector.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SimpleCollector;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.util.CollectionUtil;
 
 /**
  * FirstPassGroupingCollector is the first of two passes necessary to collect grouped hits. This
@@ -97,7 +98,7 @@ public class FirstPassGroupingCollector<T> extends SimpleCollector {
     }
 
     spareSlot = topNGroups;
-    groupMap = new HashMap<>(topNGroups);
+    groupMap = CollectionUtil.newHashMap(topNGroups);
   }
 
   @Override

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/QueryScorer.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/QueryScorer.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.search.highlight;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -58,6 +58,7 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InPlaceMergeSorter;
 
@@ -953,7 +954,7 @@ public class UnifiedHighlighter {
     //    caller simply iterates it to build another structure.
 
     // field -> object highlights parallel to docIdsIn
-    Map<String, Object[]> resultMap = new HashMap<>(fields.length);
+    Map<String, Object[]> resultMap = CollectionUtil.newHashMap(fields.length);
     for (int f = 0; f < fields.length; f++) {
       resultMap.put(fields[f], highlightDocsInByField[f]);
     }

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.CollectionUtil;
 
 /**
  * Split a disjunction query into its consituent parts, so that they can be indexed and run
@@ -103,7 +104,7 @@ public class QueryDecomposer {
 
     // If there are exclusions, then we need to add them to all the decomposed
     // queries
-    Set<Query> rewrittenSubqueries = new HashSet<>(subqueries.size());
+    Set<Query> rewrittenSubqueries = CollectionUtil.newHashSet(subqueries.size());
     for (Query subquery : subqueries) {
       BooleanQuery.Builder bq = new BooleanQuery.Builder();
       bq.add(subquery, BooleanClause.Occur.MUST);

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/messages/NLS.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/messages/NLS.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.queryparser.flexible.messages;
 
+import org.apache.lucene.util.CollectionUtil;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.text.MessageFormat;
@@ -41,7 +43,7 @@ import java.util.ResourceBundle;
  */
 public class NLS {
 
-  private static Map<String, Class<? extends NLS>> bundles = new HashMap<>(0);
+  private static final Map<String, Class<? extends NLS>> bundles = new HashMap<>(0);
 
   protected NLS() {
     // Do not instantiate
@@ -83,7 +85,7 @@ public class NLS {
   protected static void initializeMessages(String bundleName, Class<? extends NLS> clazz) {
     try {
       load(clazz);
-      if (!bundles.containsKey(bundleName)) bundles.put(bundleName, clazz);
+      bundles.putIfAbsent(bundleName, clazz);
     } catch (
         @SuppressWarnings("unused")
         Throwable e) {
@@ -96,16 +98,15 @@ public class NLS {
 
     // slow resource checking
     // need to loop thru all registered resource bundles
-    for (Iterator<String> it = bundles.keySet().iterator(); it.hasNext(); ) {
-      Class<? extends NLS> clazz = bundles.get(it.next());
+    for (Class<? extends NLS> clazz : bundles.values()) {
       ResourceBundle resourceBundle = ResourceBundle.getBundle(clazz.getName(), locale);
       if (resourceBundle != null) {
         try {
           Object obj = resourceBundle.getObject(messageKey);
           if (obj != null) return obj;
         } catch (
-            @SuppressWarnings("unused")
-            MissingResourceException e) {
+                @SuppressWarnings("unused")
+                MissingResourceException e) {
           // just continue it might be on the next resource bundle
         }
       }
@@ -119,10 +120,10 @@ public class NLS {
 
     // build a map of field names to Field objects
     final int len = fieldArray.length;
-    Map<String, Field> fields = new HashMap<>(len * 2);
-    for (int i = 0; i < len; i++) {
-      fields.put(fieldArray[i].getName(), fieldArray[i]);
-      loadfieldValue(fieldArray[i], clazz);
+    Map<String, Field> fields = CollectionUtil.newHashMap(len);
+    for (Field field : fieldArray) {
+      fields.put(field.getName(), field);
+      loadfieldValue(field, clazz);
     }
   }
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/messages/NLS.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/messages/NLS.java
@@ -16,17 +16,15 @@
  */
 package org.apache.lucene.queryparser.flexible.messages;
 
-import org.apache.lucene.util.CollectionUtil;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.text.MessageFormat;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
+import org.apache.lucene.util.CollectionUtil;
 
 /**
  * MessageBundles classes extend this class, to implement a bundle.
@@ -105,8 +103,8 @@ public class NLS {
           Object obj = resourceBundle.getObject(messageKey);
           if (obj != null) return obj;
         } catch (
-                @SuppressWarnings("unused")
-                MissingResourceException e) {
+            @SuppressWarnings("unused")
+            MissingResourceException e) {
           // just continue it might be on the next resource bundle
         }
       }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerBreakdown.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerBreakdown.java
@@ -17,6 +17,8 @@
 
 package org.apache.lucene.sandbox.search;
 
+import org.apache.lucene.util.CollectionUtil;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +46,7 @@ class QueryProfilerBreakdown {
 
   /** Build a timing count breakdown. */
   public final Map<String, Long> toBreakdownMap() {
-    Map<String, Long> map = new HashMap<>(timers.length * 2);
+    Map<String, Long> map = CollectionUtil.newHashMap(timers.length * 2);
     for (QueryProfilerTimingType type : QueryProfilerTimingType.values()) {
       map.put(type.toString(), timers[type.ordinal()].getApproximateTiming());
       map.put(type.toString() + "_count", timers[type.ordinal()].getCount());

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerBreakdown.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerBreakdown.java
@@ -17,11 +17,9 @@
 
 package org.apache.lucene.sandbox.search;
 
-import org.apache.lucene.util.CollectionUtil;
-
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import org.apache.lucene.util.CollectionUtil;
 
 /**
  * A record of timings for the various operations that may happen during query execution. A node's

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/S2PrefixTreeCell.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/S2PrefixTreeCell.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.CollectionUtil;
 import org.locationtech.spatial4j.shape.Shape;
 import org.locationtech.spatial4j.shape.SpatialRelation;
 

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/S2PrefixTreeCell.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/S2PrefixTreeCell.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.CollectionUtil;
 import org.locationtech.spatial4j.shape.Shape;
 import org.locationtech.spatial4j.shape.SpatialRelation;
 
@@ -35,7 +36,7 @@ import org.locationtech.spatial4j.shape.SpatialRelation;
 class S2PrefixTreeCell implements CellCanPrune {
 
   // Faces of S2 Geometry
-  private static S2CellId[] FACES = new S2CellId[6];
+  private static final S2CellId[] FACES = new S2CellId[6];
 
   static {
     FACES[0] = S2CellId.fromFacePosLevel(0, 0, 0);
@@ -59,10 +60,11 @@ class S2PrefixTreeCell implements CellCanPrune {
   private static final Map<Byte, Integer> PIXELS;
 
   static {
-    PIXELS = new HashMap<>(TOKENS.length);
+    Map<Byte, Integer> pixels = new HashMap<>();
     for (int i = 0; i < TOKENS.length; i++) {
-      PIXELS.put(TOKENS[i], i);
+      pixels.put(TOKENS[i], i);
     }
+    PIXELS = Map.copyOf(pixels);
   }
 
   S2CellId cellId;

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConcavePolygon.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConcavePolygon.java
@@ -16,16 +16,14 @@
  */
 package org.apache.lucene.spatial3d.geom;
 
-import org.apache.lucene.util.CollectionUtil;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.lucene.util.CollectionUtil;
 
 /**
  * GeoConcavePolygon objects are generic building blocks of more complex structures. The only

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConcavePolygon.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConcavePolygon.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.spatial3d.geom;
 
+import org.apache.lucene.util.CollectionUtil;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -245,9 +247,9 @@ class GeoConcavePolygon extends GeoBasePolygon {
     }
 
     // For each edge, create a bounds object.
-    eitherBounds = new HashMap<>(edges.length);
-    prevBrotherMap = new HashMap<>(edges.length);
-    nextBrotherMap = new HashMap<>(edges.length);
+    eitherBounds = CollectionUtil.newHashMap(edges.length);
+    prevBrotherMap = CollectionUtil.newHashMap(edges.length);
+    nextBrotherMap = CollectionUtil.newHashMap(edges.length);
     for (int edgeIndex = 0; edgeIndex < edges.length; edgeIndex++) {
       final SidedPlane edge = edges[edgeIndex];
       final SidedPlane invertedEdge = invertedEdges[edgeIndex];

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConvexPolygon.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConvexPolygon.java
@@ -16,16 +16,14 @@
  */
 package org.apache.lucene.spatial3d.geom;
 
-import org.apache.lucene.util.CollectionUtil;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.lucene.util.CollectionUtil;
 
 /**
  * GeoConvexPolygon objects are generic building blocks of more complex structures. The only

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConvexPolygon.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConvexPolygon.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.spatial3d.geom;
 
+import org.apache.lucene.util.CollectionUtil;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -239,9 +241,9 @@ class GeoConvexPolygon extends GeoBasePolygon {
     }
 
     // For each edge, create a bounds object.
-    eitherBounds = new HashMap<>(edges.length);
-    prevBrotherMap = new HashMap<>(edges.length);
-    nextBrotherMap = new HashMap<>(edges.length);
+    eitherBounds = CollectionUtil.newHashMap(edges.length);
+    prevBrotherMap = CollectionUtil.newHashMap(edges.length);
+    nextBrotherMap = CollectionUtil.newHashMap(edges.length);
     for (int edgeIndex = 0; edgeIndex < edges.length; edgeIndex++) {
       final SidedPlane edge = edges[edgeIndex];
       int bound1Index = legalIndex(edgeIndex + 1);

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionFieldsProducer.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionFieldsProducer.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionFieldsProducer.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionFieldsProducer.java
@@ -41,6 +41,7 @@ import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
+import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.IOUtils;
 
 /**
@@ -104,7 +105,7 @@ final class CompletionFieldsProducer extends FieldsProducer implements Accountab
 
       // read suggest field numbers and their offsets in the terms file from index
       int numFields = index.readVInt();
-      readers = new HashMap<>(numFields);
+      readers = CollectionUtil.newHashMap(numFields);
       for (int i = 0; i < numFields; i++) {
         int fieldNumber = index.readVInt();
         long offset = index.readVLong();

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
@@ -26,12 +26,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.IntsRef;
-import org.apache.lucene.util.IntsRefBuilder;
-import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.*;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
@@ -197,7 +192,7 @@ public class ContextQuery extends CompletionQuery implements Accountable {
     contextsAutomaton =
         Operations.determinize(contextsAutomaton, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
 
-    final Map<IntsRef, Float> contextMap = new HashMap<>(contexts.size());
+    final Map<IntsRef, Float> contextMap = CollectionUtil.newHashMap(contexts.size());
     final TreeSet<Integer> contextLengths = new TreeSet<>();
     for (Map.Entry<IntsRef, ContextMetaData> entry : contexts.entrySet()) {
       ContextMetaData contextMetaData = entry.getValue();

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
@@ -16,6 +16,11 @@
  */
 package org.apache.lucene.search.suggest.document;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeSet;
 import org.apache.lucene.analysis.miscellaneous.ConcatenateGraphFilter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.QueryVisitor;
@@ -32,12 +37,6 @@ import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.fst.Util;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.TreeSet;
 
 /**
  * A {@link CompletionQuery} that matches documents specified by a wrapped {@link CompletionQuery}

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
@@ -16,21 +16,28 @@
  */
 package org.apache.lucene.search.suggest.document;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.TreeSet;
 import org.apache.lucene.analysis.miscellaneous.ConcatenateGraphFilter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.*;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.CollectionUtil;
+import org.apache.lucene.util.IntsRef;
+import org.apache.lucene.util.IntsRefBuilder;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.fst.Util;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeSet;
 
 /**
  * A {@link CompletionQuery} that matches documents specified by a wrapped {@link CompletionQuery}

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextSuggestField.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextSuggestField.java
@@ -18,12 +18,10 @@ package org.apache.lucene.search.suggest.document;
 
 import java.io.IOException;
 import java.util.*;
-
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
-import org.apache.lucene.util.CollectionUtil;
 
 /**
  * {@link SuggestField} which additionally takes in a set of contexts. Example usage of adding a
@@ -62,7 +60,8 @@ public class ContextSuggestField extends SuggestField {
   public ContextSuggestField(String name, String value, int weight, CharSequence... contexts) {
     super(name, value, weight);
     validate(value);
-    Collection<CharSequence> contextColl = contexts != null ? Arrays.asList(contexts) : Collections.emptyList();
+    Collection<CharSequence> contextColl =
+        contexts != null ? Arrays.asList(contexts) : Collections.emptyList();
     this.contexts = new HashSet<>(contextColl);
   }
 

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextSuggestField.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextSuggestField.java
@@ -16,12 +16,18 @@
  */
 package org.apache.lucene.search.suggest.document;
 
-import java.io.IOException;
-import java.util.*;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 /**
  * {@link SuggestField} which additionally takes in a set of contexts. Example usage of adding a

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextSuggestField.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextSuggestField.java
@@ -17,14 +17,13 @@
 package org.apache.lucene.search.suggest.document;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.*;
+
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.util.CollectionUtil;
 
 /**
  * {@link SuggestField} which additionally takes in a set of contexts. Example usage of adding a
@@ -63,10 +62,8 @@ public class ContextSuggestField extends SuggestField {
   public ContextSuggestField(String name, String value, int weight, CharSequence... contexts) {
     super(name, value, weight);
     validate(value);
-    this.contexts = new HashSet<>((contexts != null) ? contexts.length : 0);
-    if (contexts != null) {
-      Collections.addAll(this.contexts, contexts);
-    }
+    Collection<CharSequence> contextColl = contexts != null ? Arrays.asList(contexts) : Collections.emptyList();
+    this.contexts = new HashSet<>(contextColl);
   }
 
   /** Expert: Sub-classes can inject contexts at index-time */

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextSuggestField.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextSuggestField.java
@@ -16,11 +16,6 @@
  */
 package org.apache.lucene.search.suggest.document;
 
-import org.apache.lucene.analysis.TokenFilter;
-import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -28,6 +23,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 
 /**
  * {@link SuggestField} which additionally takes in a set of contexts. Example usage of adding a

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestSuggestStopFilterFactory.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestSuggestStopFilterFactory.java
@@ -23,6 +23,7 @@ import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.util.ClasspathResourceLoader;
+import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.ResourceLoader;
 import org.apache.lucene.util.Version;
 
@@ -108,7 +109,7 @@ public class TestSuggestStopFilterFactory extends BaseTokenStreamTestCase {
     if (params.length % 2 != 0) {
       throw new IllegalArgumentException("invalid keysAndValues map");
     }
-    Map<String, String> args = new HashMap<>(params.length / 2);
+    Map<String, String> args = CollectionUtil.newHashMap(params.length / 2);
     for (int i = 0; i < params.length; i += 2) {
       String previous = args.put(params[i], params[i + 1]);
       assertNull("duplicate values for key: " + params[i], previous);

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestSuggestStopFilterFactory.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestSuggestStopFilterFactory.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.search.suggest.analyzing;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
@@ -282,7 +282,7 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     RandomIndexWriter iwriter = new RandomIndexWriter(random(), directory);
     int numDocs = 1 + random().nextInt(100);
 
-    HashMap<Integer, BytesRef> writtenValues = new HashMap<>(numDocs);
+    HashMap<Integer, BytesRef> writtenValues = new HashMap<>();
 
     // Small vocabulary ranges will be highly compressible
     int vocabRange = 1 + random().nextInt(Byte.MAX_VALUE - 1);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
@@ -71,10 +71,7 @@ import org.apache.lucene.tests.analysis.CannedTokenStream;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.analysis.Token;
 import org.apache.lucene.tests.util.TestUtil;
-import org.apache.lucene.util.AttributeImpl;
-import org.apache.lucene.util.AttributeReflector;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.*;
 
 /**
  * Base class aiming at testing {@link TermVectorsFormat term vectors formats}. To test a new
@@ -250,26 +247,20 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
         }
       }
 
-      positionToTerms = new HashMap<>(len);
-      startOffsetToTerms = new HashMap<>(len);
+      positionToTerms = CollectionUtil.newHashMap(len);
+      startOffsetToTerms = CollectionUtil.newHashMap(len);
       for (int i = 0; i < len; ++i) {
-        if (!positionToTerms.containsKey(positions[i])) {
-          positionToTerms.put(positions[i], new HashSet<Integer>(1));
-        }
-        positionToTerms.get(positions[i]).add(i);
-        if (!startOffsetToTerms.containsKey(startOffsets[i])) {
-          startOffsetToTerms.put(startOffsets[i], new HashSet<Integer>(1));
-        }
-        startOffsetToTerms.get(startOffsets[i]).add(i);
+        positionToTerms
+                .computeIfAbsent(positions[i], k -> new HashSet<>(1))
+                .add(i);
+        startOffsetToTerms
+                .computeIfAbsent(startOffsets[i], k -> new HashSet<>(1))
+                .add(i);
       }
 
       freqs = new HashMap<>();
       for (String term : terms) {
-        if (freqs.containsKey(term)) {
-          freqs.put(term, freqs.get(term) + 1);
-        } else {
-          freqs.put(term, 1);
-        }
+        freqs.merge(term, 1, Integer::sum);
       }
 
       addAttributeImpl(new PermissiveOffsetAttributeImpl());

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
@@ -16,26 +16,7 @@
  */
 package org.apache.lucene.tests.index;
 
-import static org.apache.lucene.index.PostingsEnum.ALL;
-import static org.apache.lucene.index.PostingsEnum.FREQS;
-import static org.apache.lucene.index.PostingsEnum.NONE;
-import static org.apache.lucene.index.PostingsEnum.OFFSETS;
-import static org.apache.lucene.index.PostingsEnum.PAYLOADS;
-import static org.apache.lucene.index.PostingsEnum.POSITIONS;
-
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -71,7 +52,31 @@ import org.apache.lucene.tests.analysis.CannedTokenStream;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.analysis.Token;
 import org.apache.lucene.tests.util.TestUtil;
-import org.apache.lucene.util.*;
+import org.apache.lucene.util.AttributeImpl;
+import org.apache.lucene.util.AttributeReflector;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.CollectionUtil;
+import org.apache.lucene.util.IOUtils;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.lucene.index.PostingsEnum.ALL;
+import static org.apache.lucene.index.PostingsEnum.FREQS;
+import static org.apache.lucene.index.PostingsEnum.NONE;
+import static org.apache.lucene.index.PostingsEnum.OFFSETS;
+import static org.apache.lucene.index.PostingsEnum.PAYLOADS;
+import static org.apache.lucene.index.PostingsEnum.POSITIONS;
 
 /**
  * Base class aiming at testing {@link TermVectorsFormat term vectors formats}. To test a new

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
@@ -250,12 +250,8 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
       positionToTerms = CollectionUtil.newHashMap(len);
       startOffsetToTerms = CollectionUtil.newHashMap(len);
       for (int i = 0; i < len; ++i) {
-        positionToTerms
-                .computeIfAbsent(positions[i], k -> new HashSet<>(1))
-                .add(i);
-        startOffsetToTerms
-                .computeIfAbsent(startOffsets[i], k -> new HashSet<>(1))
-                .add(i);
+        positionToTerms.computeIfAbsent(positions[i], k -> new HashSet<>(1)).add(i);
+        startOffsetToTerms.computeIfAbsent(startOffsets[i], k -> new HashSet<>(1)).add(i);
       }
 
       freqs = new HashMap<>();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
@@ -16,7 +16,26 @@
  */
 package org.apache.lucene.tests.index;
 
+import static org.apache.lucene.index.PostingsEnum.ALL;
+import static org.apache.lucene.index.PostingsEnum.FREQS;
+import static org.apache.lucene.index.PostingsEnum.NONE;
+import static org.apache.lucene.index.PostingsEnum.OFFSETS;
+import static org.apache.lucene.index.PostingsEnum.PAYLOADS;
+import static org.apache.lucene.index.PostingsEnum.POSITIONS;
+
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -57,26 +76,6 @@ import org.apache.lucene.util.AttributeReflector;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.IOUtils;
-
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.apache.lucene.index.PostingsEnum.ALL;
-import static org.apache.lucene.index.PostingsEnum.FREQS;
-import static org.apache.lucene.index.PostingsEnum.NONE;
-import static org.apache.lucene.index.PostingsEnum.OFFSETS;
-import static org.apache.lucene.index.PostingsEnum.PAYLOADS;
-import static org.apache.lucene.index.PostingsEnum.POSITIONS;
 
 /**
  * Base class aiming at testing {@link TermVectorsFormat term vectors formats}. To test a new


### PR DESCRIPTION
Change calls to `new HashMap(int)`/`new HashSet(int)` to a method that ensures the backing array won't be resized.

A few other optimisations around map methods I picked up along the way