### PR TITLE
enable errorprone for github check action

### DIFF
--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -43,7 +43,7 @@ jobs:
       run: ./gradlew localSettings --max-workers 2
 
     - name: Run gradle check (without tests)
-      run: ./gradlew check -x test -Ptask.times=true --max-workers 2
+      run: ./gradlew check -x test -Pvalidation.errorprone=true -Ptask.times=true --max-workers 2
 
   # This runs all tests without any other validation checks.
   tests:

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -43,7 +43,7 @@ jobs:
       run: ./gradlew localSettings --max-workers 2
 
     - name: Run gradle check (without tests)
-      run: ./gradlew check -x test -Pvalidation.errorprone=true -Ptask.times=true --max-workers 2
+      run: ./gradlew check -x test -Ptask.times=true --max-workers 2
 
   # This runs all tests without any other validation checks.
   tests:

--- a/lucene/core/src/test/org/apache/lucene/TestDemo.java
+++ b/lucene/core/src/test/org/apache/lucene/TestDemo.java
@@ -73,6 +73,9 @@ public class TestDemo extends LuceneTestCase {
           assertEquals(text, hitDoc.get("fieldname"));
         }
 
+        long x = Integer.MAX_VALUE * Integer.MAX_VALUE;
+        assertEquals(1L, x);
+
         // Test simple phrase query.
         PhraseQuery phraseQuery = new PhraseQuery("fieldname", "to", "be");
         assertEquals(1, searcher.count(phraseQuery));


### PR DESCRIPTION
The idea is to fail faster, prevent new violations from failing nightly builds. If it becomes a hindrance to contributions or an annoyance, we can disable it.

Closes #11943 