### PR TITLE
Fix NPE in BinaryRangeFieldRangeQuery when field does not exist or is of wrong type

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -160,6 +160,9 @@ Bug Fixes
 
 * GITHUB#11954: Remove QueryTimeout#isTimeoutEnabled method and move check to caller. (Shubham Chaudhary)
 
+* GITHUB#11950: Fix NPE in BinaryRangeFieldRangeQuery variants when the queried field doesn't exist
+  in a segment or is of the wrong type. (Greg Miller)
+
 Optimizations
 ---------------------
 * GITHUB#11738: Optimize MultiTermQueryConstantScoreWrapper when a term is present that matches all

--- a/lucene/core/src/java/org/apache/lucene/document/BinaryRangeDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/document/BinaryRangeDocValues.java
@@ -29,6 +29,7 @@ class BinaryRangeDocValues extends BinaryDocValues {
   private int docID = -1;
 
   BinaryRangeDocValues(BinaryDocValues in, int numDims, int numBytesPerDimension) {
+    assert in != null;
     this.in = in;
     this.numBytesPerDimension = numBytesPerDimension;
     this.numDims = numDims;

--- a/lucene/core/src/java/org/apache/lucene/document/BinaryRangeFieldRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/BinaryRangeFieldRangeQuery.java
@@ -20,9 +20,7 @@ package org.apache.lucene.document;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ConstantScoreScorer;
@@ -92,13 +90,15 @@ abstract class BinaryRangeFieldRangeQuery extends Query {
   }
 
   private BinaryRangeDocValues getValues(LeafReader reader, String field) throws IOException {
-    FieldInfo info = reader.getFieldInfos().fieldInfo(field);
-    if (info == null) {
+    if (reader.getFieldInfos().fieldInfo(field) == null) {
+      // Returning null when the field doesn't exist in the segment allows us to return a null
+      // Scorer, which is
+      // just a bit more efficient:
       return null;
     }
-    BinaryDocValues binaryDocValues = DocValues.getBinary(reader, field);
 
-    return new BinaryRangeDocValues(binaryDocValues, numDims, numBytesPerDimension);
+    return new BinaryRangeDocValues(
+        DocValues.getBinary(reader, field), numDims, numBytesPerDimension);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/document/BinaryRangeFieldRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/BinaryRangeFieldRangeQuery.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ConstantScoreScorer;
@@ -91,7 +92,11 @@ abstract class BinaryRangeFieldRangeQuery extends Query {
   }
 
   private BinaryRangeDocValues getValues(LeafReader reader, String field) throws IOException {
-    BinaryDocValues binaryDocValues = reader.getBinaryDocValues(field);
+    FieldInfo info = reader.getFieldInfos().fieldInfo(field);
+    if (info == null) {
+      return null;
+    }
+    BinaryDocValues binaryDocValues = DocValues.getBinary(reader, field);
 
     return new BinaryRangeDocValues(binaryDocValues, numDims, numBytesPerDimension);
   }


### PR DESCRIPTION
### Description

This fixes a bug where variants of `BinaryRangeFieldRangeQuery` will result in an NPE if the field doesn't exist in a segment.