### PR TITLE
Remove QueryTimeout#isTimeoutEnabled method and move check to caller

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -158,6 +158,8 @@ Bug Fixes
 
 * GITHUB#11907: Fix latent casting bugs in BKDWriter. (Ben Trent)
 
+* GITHUB#11954: Remove QueryTimeout#isTimeoutEnabled method and move check to caller. (Shubham Chaudhary)
+
 Optimizations
 ---------------------
 * GITHUB#11738: Optimize MultiTermQueryConstantScoreWrapper when a term is present that matches all

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -81,7 +81,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (pointValues == null) {
         return null;
       }
-      return (queryTimeout.isTimeoutEnabled())
+      return (queryTimeout != null)
           ? new ExitablePointValues(pointValues, queryTimeout)
           : pointValues;
     }
@@ -92,7 +92,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (terms == null) {
         return null;
       }
-      return (queryTimeout.isTimeoutEnabled()) ? new ExitableTerms(terms, queryTimeout) : terms;
+      return (queryTimeout != null) ? new ExitableTerms(terms, queryTimeout) : terms;
     }
 
     // this impl does not change deletes or data so we can delegate the
@@ -113,7 +113,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (numericDocValues == null) {
         return null;
       }
-      return (queryTimeout.isTimeoutEnabled())
+      return (queryTimeout != null)
           ? new FilterNumericDocValues(numericDocValues) {
             private int docToCheck = 0;
 
@@ -156,7 +156,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (binaryDocValues == null) {
         return null;
       }
-      return (queryTimeout.isTimeoutEnabled())
+      return (queryTimeout != null)
           ? new FilterBinaryDocValues(binaryDocValues) {
             private int docToCheck = 0;
 
@@ -199,7 +199,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (sortedDocValues == null) {
         return null;
       }
-      return (queryTimeout.isTimeoutEnabled())
+      return (queryTimeout != null)
           ? new FilterSortedDocValues(sortedDocValues) {
 
             private int docToCheck = 0;
@@ -243,7 +243,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (sortedNumericDocValues == null) {
         return null;
       }
-      return (queryTimeout.isTimeoutEnabled())
+      return (queryTimeout != null)
           ? new FilterSortedNumericDocValues(sortedNumericDocValues) {
 
             private int docToCheck = 0;
@@ -287,7 +287,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (sortedSetDocValues == null) {
         return null;
       }
-      return (queryTimeout.isTimeoutEnabled())
+      return (queryTimeout != null)
           ? new FilterSortedSetDocValues(sortedSetDocValues) {
 
             private int docToCheck = 0;
@@ -331,9 +331,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (vectorValues == null) {
         return null;
       }
-      return (queryTimeout.isTimeoutEnabled())
-          ? new ExitableVectorValues(vectorValues)
-          : vectorValues;
+      return (queryTimeout != null) ? new ExitableVectorValues(vectorValues) : vectorValues;
     }
 
     @Override
@@ -369,7 +367,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
 
     private void checkAndThrowForSearchVectors() {
-      if (queryTimeout.shouldExit()) {
+      if (queryTimeout != null && queryTimeout.shouldExit()) {
         throw new ExitingReaderException(
             "The request took too long to search nearest vectors. Timeout: "
                 + queryTimeout.toString()
@@ -388,7 +386,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
      * @param in underneath docValues
      */
     private void checkAndThrow(DocIdSetIterator in) {
-      if (queryTimeout.shouldExit()) {
+      if (queryTimeout != null && queryTimeout.shouldExit()) {
         throw new ExitingReaderException(
             "The request took too long to iterate over doc values. Timeout: "
                 + queryTimeout.toString()
@@ -443,7 +441,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
        * if {@link Thread#interrupted()} returns true.
        */
       private void checkAndThrow() {
-        if (queryTimeout.shouldExit()) {
+        if (queryTimeout != null && queryTimeout.shouldExit()) {
           throw new ExitingReaderException(
               "The request took too long to iterate over vector values. Timeout: "
                   + queryTimeout.toString()
@@ -474,7 +472,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
      * if {@link Thread#interrupted()} returns true.
      */
     private void checkAndThrow() {
-      if (queryTimeout.shouldExit()) {
+      if (queryTimeout != null && queryTimeout.shouldExit()) {
         throw new ExitingReaderException(
             "The request took too long to iterate over point values. Timeout: "
                 + queryTimeout.toString()
@@ -564,7 +562,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
 
     private void checkAndThrow() {
-      if (queryTimeout.shouldExit()) {
+      if (queryTimeout != null && queryTimeout.shouldExit()) {
         throw new ExitingReaderException(
             "The request took too long to intersect point values. Timeout: "
                 + queryTimeout.toString()
@@ -659,7 +657,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
 
     private void checkAndThrow() {
-      if (queryTimeout.shouldExit()) {
+      if (queryTimeout != null && queryTimeout.shouldExit()) {
         throw new ExitingReaderException(
             "The request took too long to intersect point values. Timeout: "
                 + queryTimeout.toString()
@@ -741,7 +739,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
      */
     private void checkTimeoutWithSampling() {
       if ((calls++ & NUM_CALLS_PER_TIMEOUT_CHECK) == 0) {
-        if (queryTimeout.shouldExit()) {
+        if (queryTimeout != null && queryTimeout.shouldExit()) {
           throw new ExitingReaderException(
               "The request took too long to iterate over terms. Timeout: "
                   + queryTimeout.toString()

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -81,9 +81,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (pointValues == null) {
         return null;
       }
-      return (queryTimeout != null)
-          ? new ExitablePointValues(pointValues, queryTimeout)
-          : pointValues;
+      return new ExitablePointValues(pointValues, queryTimeout);
     }
 
     @Override
@@ -92,7 +90,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (terms == null) {
         return null;
       }
-      return (queryTimeout != null) ? new ExitableTerms(terms, queryTimeout) : terms;
+      return new ExitableTerms(terms, queryTimeout);
     }
 
     // this impl does not change deletes or data so we can delegate the
@@ -113,41 +111,39 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (numericDocValues == null) {
         return null;
       }
-      return (queryTimeout != null)
-          ? new FilterNumericDocValues(numericDocValues) {
-            private int docToCheck = 0;
+      return new FilterNumericDocValues(numericDocValues) {
+        private int docToCheck = 0;
 
-            @Override
-            public int advance(int target) throws IOException {
-              final int advance = super.advance(target);
-              if (advance >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = advance + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return advance;
-            }
-
-            @Override
-            public boolean advanceExact(int target) throws IOException {
-              final boolean advanceExact = super.advanceExact(target);
-              if (target >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return advanceExact;
-            }
-
-            @Override
-            public int nextDoc() throws IOException {
-              final int nextDoc = super.nextDoc();
-              if (nextDoc >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = nextDoc + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return nextDoc;
-            }
+        @Override
+        public int advance(int target) throws IOException {
+          final int advance = super.advance(target);
+          if (advance >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = advance + DOCS_BETWEEN_TIMEOUT_CHECK;
           }
-          : numericDocValues;
+          return advance;
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          final boolean advanceExact = super.advanceExact(target);
+          if (target >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
+          }
+          return advanceExact;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+          final int nextDoc = super.nextDoc();
+          if (nextDoc >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = nextDoc + DOCS_BETWEEN_TIMEOUT_CHECK;
+          }
+          return nextDoc;
+        }
+      };
     }
 
     @Override
@@ -156,41 +152,39 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (binaryDocValues == null) {
         return null;
       }
-      return (queryTimeout != null)
-          ? new FilterBinaryDocValues(binaryDocValues) {
-            private int docToCheck = 0;
+      return new FilterBinaryDocValues(binaryDocValues) {
+        private int docToCheck = 0;
 
-            @Override
-            public int advance(int target) throws IOException {
-              final int advance = super.advance(target);
-              if (target >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return advance;
-            }
-
-            @Override
-            public boolean advanceExact(int target) throws IOException {
-              final boolean advanceExact = super.advanceExact(target);
-              if (target >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return advanceExact;
-            }
-
-            @Override
-            public int nextDoc() throws IOException {
-              final int nextDoc = super.nextDoc();
-              if (nextDoc >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = nextDoc + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return nextDoc;
-            }
+        @Override
+        public int advance(int target) throws IOException {
+          final int advance = super.advance(target);
+          if (target >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
           }
-          : binaryDocValues;
+          return advance;
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          final boolean advanceExact = super.advanceExact(target);
+          if (target >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
+          }
+          return advanceExact;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+          final int nextDoc = super.nextDoc();
+          if (nextDoc >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = nextDoc + DOCS_BETWEEN_TIMEOUT_CHECK;
+          }
+          return nextDoc;
+        }
+      };
     }
 
     @Override
@@ -199,42 +193,40 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (sortedDocValues == null) {
         return null;
       }
-      return (queryTimeout != null)
-          ? new FilterSortedDocValues(sortedDocValues) {
+      return new FilterSortedDocValues(sortedDocValues) {
 
-            private int docToCheck = 0;
+        private int docToCheck = 0;
 
-            @Override
-            public int advance(int target) throws IOException {
-              final int advance = super.advance(target);
-              if (advance >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = advance + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return advance;
-            }
-
-            @Override
-            public boolean advanceExact(int target) throws IOException {
-              final boolean advanceExact = super.advanceExact(target);
-              if (target >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return advanceExact;
-            }
-
-            @Override
-            public int nextDoc() throws IOException {
-              final int nextDoc = super.nextDoc();
-              if (nextDoc >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = nextDoc + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return nextDoc;
-            }
+        @Override
+        public int advance(int target) throws IOException {
+          final int advance = super.advance(target);
+          if (advance >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = advance + DOCS_BETWEEN_TIMEOUT_CHECK;
           }
-          : sortedDocValues;
+          return advance;
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          final boolean advanceExact = super.advanceExact(target);
+          if (target >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
+          }
+          return advanceExact;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+          final int nextDoc = super.nextDoc();
+          if (nextDoc >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = nextDoc + DOCS_BETWEEN_TIMEOUT_CHECK;
+          }
+          return nextDoc;
+        }
+      };
     }
 
     @Override
@@ -243,42 +235,40 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (sortedNumericDocValues == null) {
         return null;
       }
-      return (queryTimeout != null)
-          ? new FilterSortedNumericDocValues(sortedNumericDocValues) {
+      return new FilterSortedNumericDocValues(sortedNumericDocValues) {
 
-            private int docToCheck = 0;
+        private int docToCheck = 0;
 
-            @Override
-            public int advance(int target) throws IOException {
-              final int advance = super.advance(target);
-              if (advance >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = advance + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return advance;
-            }
-
-            @Override
-            public boolean advanceExact(int target) throws IOException {
-              final boolean advanceExact = super.advanceExact(target);
-              if (target >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return advanceExact;
-            }
-
-            @Override
-            public int nextDoc() throws IOException {
-              final int nextDoc = super.nextDoc();
-              if (nextDoc >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = nextDoc + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return nextDoc;
-            }
+        @Override
+        public int advance(int target) throws IOException {
+          final int advance = super.advance(target);
+          if (advance >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = advance + DOCS_BETWEEN_TIMEOUT_CHECK;
           }
-          : sortedNumericDocValues;
+          return advance;
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          final boolean advanceExact = super.advanceExact(target);
+          if (target >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
+          }
+          return advanceExact;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+          final int nextDoc = super.nextDoc();
+          if (nextDoc >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = nextDoc + DOCS_BETWEEN_TIMEOUT_CHECK;
+          }
+          return nextDoc;
+        }
+      };
     }
 
     @Override
@@ -287,42 +277,40 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (sortedSetDocValues == null) {
         return null;
       }
-      return (queryTimeout != null)
-          ? new FilterSortedSetDocValues(sortedSetDocValues) {
+      return new FilterSortedSetDocValues(sortedSetDocValues) {
 
-            private int docToCheck = 0;
+        private int docToCheck = 0;
 
-            @Override
-            public int advance(int target) throws IOException {
-              final int advance = super.advance(target);
-              if (advance >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = advance + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return advance;
-            }
-
-            @Override
-            public boolean advanceExact(int target) throws IOException {
-              final boolean advanceExact = super.advanceExact(target);
-              if (target >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return advanceExact;
-            }
-
-            @Override
-            public int nextDoc() throws IOException {
-              final int nextDoc = super.nextDoc();
-              if (nextDoc >= docToCheck) {
-                checkAndThrow(in);
-                docToCheck = nextDoc + DOCS_BETWEEN_TIMEOUT_CHECK;
-              }
-              return nextDoc;
-            }
+        @Override
+        public int advance(int target) throws IOException {
+          final int advance = super.advance(target);
+          if (advance >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = advance + DOCS_BETWEEN_TIMEOUT_CHECK;
           }
-          : sortedSetDocValues;
+          return advance;
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          final boolean advanceExact = super.advanceExact(target);
+          if (target >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = target + DOCS_BETWEEN_TIMEOUT_CHECK;
+          }
+          return advanceExact;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+          final int nextDoc = super.nextDoc();
+          if (nextDoc >= docToCheck) {
+            checkAndThrow(in);
+            docToCheck = nextDoc + DOCS_BETWEEN_TIMEOUT_CHECK;
+          }
+          return nextDoc;
+        }
+      };
     }
 
     @Override
@@ -331,7 +319,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       if (vectorValues == null) {
         return null;
       }
-      return (queryTimeout != null) ? new ExitableVectorValues(vectorValues) : vectorValues;
+      return new ExitableVectorValues(vectorValues);
     }
 
     @Override
@@ -367,7 +355,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
 
     private void checkAndThrowForSearchVectors() {
-      if (queryTimeout != null && queryTimeout.shouldExit()) {
+      if (queryTimeout.shouldExit()) {
         throw new ExitingReaderException(
             "The request took too long to search nearest vectors. Timeout: "
                 + queryTimeout.toString()
@@ -386,7 +374,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
      * @param in underneath docValues
      */
     private void checkAndThrow(DocIdSetIterator in) {
-      if (queryTimeout != null && queryTimeout.shouldExit()) {
+      if (queryTimeout.shouldExit()) {
         throw new ExitingReaderException(
             "The request took too long to iterate over doc values. Timeout: "
                 + queryTimeout.toString()
@@ -441,7 +429,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
        * if {@link Thread#interrupted()} returns true.
        */
       private void checkAndThrow() {
-        if (queryTimeout != null && queryTimeout.shouldExit()) {
+        if (queryTimeout.shouldExit()) {
           throw new ExitingReaderException(
               "The request took too long to iterate over vector values. Timeout: "
                   + queryTimeout.toString()
@@ -472,7 +460,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
      * if {@link Thread#interrupted()} returns true.
      */
     private void checkAndThrow() {
-      if (queryTimeout != null && queryTimeout.shouldExit()) {
+      if (queryTimeout.shouldExit()) {
         throw new ExitingReaderException(
             "The request took too long to iterate over point values. Timeout: "
                 + queryTimeout.toString()
@@ -562,7 +550,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
 
     private void checkAndThrow() {
-      if (queryTimeout != null && queryTimeout.shouldExit()) {
+      if (queryTimeout.shouldExit()) {
         throw new ExitingReaderException(
             "The request took too long to intersect point values. Timeout: "
                 + queryTimeout.toString()
@@ -657,7 +645,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
 
     private void checkAndThrow() {
-      if (queryTimeout != null && queryTimeout.shouldExit()) {
+      if (queryTimeout.shouldExit()) {
         throw new ExitingReaderException(
             "The request took too long to intersect point values. Timeout: "
                 + queryTimeout.toString()
@@ -739,7 +727,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
      */
     private void checkTimeoutWithSampling() {
       if ((calls++ & NUM_CALLS_PER_TIMEOUT_CHECK) == 0) {
-        if (queryTimeout != null && queryTimeout.shouldExit()) {
+        if (queryTimeout.shouldExit()) {
           throw new ExitingReaderException(
               "The request took too long to iterate over terms. Timeout: "
                   + queryTimeout.toString()
@@ -782,7 +770,10 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
    */
   public static DirectoryReader wrap(DirectoryReader in, QueryTimeout queryTimeout)
       throws IOException {
-    return new ExitableDirectoryReader(in, queryTimeout);
+    if (queryTimeout != null) {
+      return new ExitableDirectoryReader(in, queryTimeout);
+    }
+    return in;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.util.Objects;
 import org.apache.lucene.index.FilterLeafReader.FilterTerms;
 import org.apache.lucene.index.FilterLeafReader.FilterTermsEnum;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -53,7 +54,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
 
     /** Constructor * */
     public ExitableSubReaderWrapper(QueryTimeout queryTimeout) {
-      this.queryTimeout = queryTimeout;
+      this.queryTimeout = Objects.requireNonNull(queryTimeout);
     }
 
     @Override
@@ -72,7 +73,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     /** Constructor * */
     public ExitableFilterAtomicReader(LeafReader in, QueryTimeout queryTimeout) {
       super(in);
-      this.queryTimeout = queryTimeout;
+      this.queryTimeout = Objects.requireNonNull(queryTimeout);
     }
 
     @Override
@@ -451,7 +452,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
 
     private ExitablePointValues(PointValues in, QueryTimeout queryTimeout) {
       this.in = in;
-      this.queryTimeout = queryTimeout;
+      this.queryTimeout = Objects.requireNonNull(queryTimeout);
       checkAndThrow();
     }
 
@@ -535,7 +536,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
         PointValues pointValues, PointValues.PointTree in, QueryTimeout queryTimeout) {
       this.pointValues = pointValues;
       this.in = in;
-      this.queryTimeout = queryTimeout;
+      this.queryTimeout = Objects.requireNonNull(queryTimeout);
       this.exitableIntersectVisitor = new ExitableIntersectVisitor(queryTimeout);
     }
 
@@ -627,7 +628,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     private int calls;
 
     private ExitableIntersectVisitor(QueryTimeout queryTimeout) {
-      this.queryTimeout = queryTimeout;
+      this.queryTimeout = Objects.requireNonNull(queryTimeout);
     }
 
     private void setIntersectVisitor(PointValues.IntersectVisitor in) {
@@ -690,7 +691,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     /** Constructor * */
     public ExitableTerms(Terms terms, QueryTimeout queryTimeout) {
       super(terms);
-      this.queryTimeout = queryTimeout;
+      this.queryTimeout = Objects.requireNonNull(queryTimeout);
     }
 
     @Override
@@ -717,7 +718,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     /** Constructor * */
     public ExitableTermsEnum(TermsEnum termsEnum, QueryTimeout queryTimeout) {
       super(termsEnum);
-      this.queryTimeout = queryTimeout;
+      this.queryTimeout = Objects.requireNonNull(queryTimeout);
       checkTimeoutWithSampling();
     }
 
@@ -756,11 +757,12 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
    */
   public ExitableDirectoryReader(DirectoryReader in, QueryTimeout queryTimeout) throws IOException {
     super(in, new ExitableSubReaderWrapper(queryTimeout));
-    this.queryTimeout = queryTimeout;
+    this.queryTimeout = Objects.requireNonNull(queryTimeout);
   }
 
   @Override
   protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
+    Objects.requireNonNull(queryTimeout, "Query timeout must not be null");
     return new ExitableDirectoryReader(in, queryTimeout);
   }
 
@@ -770,10 +772,8 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
    */
   public static DirectoryReader wrap(DirectoryReader in, QueryTimeout queryTimeout)
       throws IOException {
-    if (queryTimeout != null) {
-      return new ExitableDirectoryReader(in, queryTimeout);
-    }
-    return in;
+    Objects.requireNonNull(queryTimeout, "Query timeout must not be null");
+    return new ExitableDirectoryReader(in, queryTimeout);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/QueryTimeout.java
+++ b/lucene/core/src/java/org/apache/lucene/index/QueryTimeout.java
@@ -27,11 +27,4 @@ public interface QueryTimeout {
    * stop processing a query.
    */
   public abstract boolean shouldExit();
-
-  /**
-   * Returns true if timeouts are enabled for this query (i.e. if shouldExit would ever return true)
-   */
-  public default boolean isTimeoutEnabled() {
-    return true;
-  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -737,7 +737,7 @@ public class IndexSearcher {
       }
       BulkScorer scorer = weight.bulkScorer(ctx);
       if (scorer != null) {
-        if (queryTimeout != null && queryTimeout.isTimeoutEnabled()) {
+        if (queryTimeout != null) {
           scorer = new TimeLimitingBulkScorer(scorer, queryTimeout);
         }
         try {

--- a/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
@@ -18,6 +18,7 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
+import java.util.Objects;
 import org.apache.lucene.index.QueryTimeout;
 import org.apache.lucene.util.Bits;
 
@@ -55,7 +56,7 @@ final class TimeLimitingBulkScorer extends BulkScorer {
    */
   public TimeLimitingBulkScorer(BulkScorer bulkScorer, QueryTimeout queryTimeout) {
     this.in = bulkScorer;
-    this.queryTimeout = queryTimeout;
+    this.queryTimeout = Objects.requireNonNull(queryTimeout);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
@@ -62,7 +62,7 @@ final class TimeLimitingBulkScorer extends BulkScorer {
   public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
     while (min < max) {
       final int newMax = (int) Math.min((long) min + INTERVAL, max);
-      if (queryTimeout.shouldExit() == true) {
+      if (queryTimeout.shouldExit()) {
         throw new TimeLimitingBulkScorer.TimeExceededException();
       }
       min = in.score(collector, acceptDocs, min, newMax); // in is the wrapped bulk scorer

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -169,7 +169,11 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     // Not checking the validity of the result, all we are bothered about in this test is the timing
     // out.
     directoryReader = DirectoryReader.open(directory);
-    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, disabledQueryTimeout());
+    exitableDirectoryReader = directoryReader;
+    if (disabledQueryTimeout() != null) {
+      exitableDirectoryReader =
+          new ExitableDirectoryReader(directoryReader, disabledQueryTimeout());
+    }
     reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
     searcher = new IndexSearcher(reader);
     searcher.search(query, 10);
@@ -292,7 +296,11 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     // Not checking the validity of the result, all we are bothered about in this test is the timing
     // out.
     directoryReader = DirectoryReader.open(directory);
-    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, disabledQueryTimeout());
+    exitableDirectoryReader = directoryReader;
+    if (disabledQueryTimeout() != null) {
+      exitableDirectoryReader =
+          new ExitableDirectoryReader(directoryReader, disabledQueryTimeout());
+    }
     reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
     searcher = new IndexSearcher(reader);
     searcher.search(query, 10);
@@ -381,10 +389,12 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
       }
 
       directoryReader = DirectoryReader.open(directory);
-      exitableDirectoryReader =
-          new ExitableDirectoryReader(
-              directoryReader,
-              random().nextBoolean() ? infiniteQueryTimeout() : disabledQueryTimeout());
+      exitableDirectoryReader = directoryReader;
+      QueryTimeout queryTimeout =
+          random().nextBoolean() ? infiniteQueryTimeout() : disabledQueryTimeout();
+      if (queryTimeout != null) {
+        exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, queryTimeout);
+      }
       {
         IndexReader reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
         final LeafReader leaf = reader.leaves().get(0).reader();
@@ -447,8 +457,10 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     }
 
     DirectoryReader directoryReader = DirectoryReader.open(directory);
-    DirectoryReader exitableDirectoryReader =
-        new ExitableDirectoryReader(directoryReader, queryTimeout);
+    DirectoryReader exitableDirectoryReader = directoryReader;
+    if (queryTimeout != null) {
+      exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, queryTimeout);
+    }
     IndexReader reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
 
     LeafReaderContext context = reader.leaves().get(0);

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -302,33 +302,11 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
   }
 
   private static QueryTimeout disabledQueryTimeout() {
-    return new QueryTimeout() {
-
-      @Override
-      public boolean shouldExit() {
-        return false;
-      }
-
-      @Override
-      public boolean isTimeoutEnabled() {
-        return false;
-      }
-    };
+    return null;
   }
 
   private static QueryTimeout infiniteQueryTimeout() {
-    return new QueryTimeout() {
-
-      @Override
-      public boolean shouldExit() {
-        return false;
-      }
-
-      @Override
-      public boolean isTimeoutEnabled() {
-        return true;
-      }
-    };
+    return () -> false;
   }
 
   private static class CountingQueryTimeout implements QueryTimeout {
@@ -340,29 +318,13 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
       return false;
     }
 
-    @Override
-    public boolean isTimeoutEnabled() {
-      return true;
-    }
-
     public int getShouldExitCallCount() {
       return counter;
     }
   }
 
   private static QueryTimeout immediateQueryTimeout() {
-    return new QueryTimeout() {
-
-      @Override
-      public boolean shouldExit() {
-        return true;
-      }
-
-      @Override
-      public boolean isTimeoutEnabled() {
-        return true;
-      }
-    };
+    return () -> true;
   }
 
   @FunctionalInterface
@@ -492,7 +454,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     LeafReaderContext context = reader.leaves().get(0);
     LeafReader leaf = context.reader();
 
-    if (queryTimeout.shouldExit()) {
+    if (queryTimeout != null && queryTimeout.shouldExit()) {
       expectThrows(
           ExitingReaderException.class,
           () -> {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTimeLimitingBulkScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTimeLimitingBulkScorer.java
@@ -75,11 +75,6 @@ public class TestTimeLimitingBulkScorer extends LuceneTestCase {
         }
         return false;
       }
-
-      @Override
-      public boolean isTimeoutEnabled() {
-        return true;
-      }
     };
   }
 }


### PR DESCRIPTION
### Description

This removes the method `QueryTimeout#isTimeoutEnabled` and moves the responsibility to ensure timeout is not null to the caller. 
Initially I went with the approach to allow `QueryTimeout` to be null (and removing `#isTimeoutEnabled`) and allow wrapping `TimeLimitingBulkScorer` and `ExitableDirectoryReader` with null timeouts which is equivalent of timeout not enabled as this makes work easy for the caller but giving a thought again it made more sense to only wrap the classes if there is an actual timeout and moving the responsibility to ensure timeout is configured to caller method as mentioned in the issue.

Closes #11914

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
