### PR TITLE
Remove synchronization from OpenNLP integration and add thread-safety tests(checkRandomData)

### DIFF
--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/NLPChunkerOp.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/NLPChunkerOp.java
@@ -29,7 +29,7 @@ public class NLPChunkerOp {
     chunker = new ChunkerME(chunkerModel);
   }
 
-  public synchronized String[] getChunks(String[] words, String[] tags, double[] probs) {
+  public String[] getChunks(String[] words, String[] tags, double[] probs) {
     String[] chunks = chunker.chunk(words, tags);
     if (probs != null) chunker.probs(probs);
     return chunks;

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/NLPNERTaggerOp.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/NLPNERTaggerOp.java
@@ -50,7 +50,7 @@ public class NLPNERTaggerOp {
     return names;
   }
 
-  public synchronized void reset() {
+  public void reset() {
     nameFinder.clearAdaptiveData();
   }
 }

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/NLPPOSTaggerOp.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/NLPPOSTaggerOp.java
@@ -33,7 +33,7 @@ public class NLPPOSTaggerOp {
     tagger = new POSTaggerME(model);
   }
 
-  public synchronized String[] getPOSTags(String[] words) {
+  public String[] getPOSTags(String[] words) {
     return tagger.tag(words);
   }
 }

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/NLPSentenceDetectorOp.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/NLPSentenceDetectorOp.java
@@ -36,7 +36,7 @@ public class NLPSentenceDetectorOp {
     sentenceSplitter = null;
   }
 
-  public synchronized Span[] splitSentences(String line) {
+  public Span[] splitSentences(String line) {
     if (sentenceSplitter != null) {
       return sentenceSplitter.sentPosDetect(line);
     } else {

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/NLPTokenizerOp.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/NLPTokenizerOp.java
@@ -37,7 +37,7 @@ public class NLPTokenizerOp {
     tokenizer = null;
   }
 
-  public synchronized Span[] getTerms(String sentence) {
+  public Span[] getTerms(String sentence) {
     if (tokenizer == null) {
       Span[] span1 = new Span[1];
       span1[0] = new Span(0, sentence.length());

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPChunkerFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPChunkerFilterFactory.java
@@ -126,4 +126,18 @@ public class TestOpenNLPChunkerFilterFactory extends BaseTokenStreamTestCase {
             .build();
     assertAnalyzesTo(analyzer, "", new String[0], null, null, null, null, null, true);
   }
+
+  /** blast some random strings through the analyzer */
+  public void testRandomStrings() throws Exception {
+    CustomAnalyzer analyzer =
+        CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+            .withTokenizer(
+                "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
+            .addTokenFilter("opennlpPOS", "posTaggerModel", posTaggerModelFile)
+            .addTokenFilter("opennlpChunker", "chunkerModel", chunkerModelFile)
+            .addTokenFilter(TypeAsPayloadTokenFilterFactory.class)
+            .build();
+    checkRandomData(random(), analyzer, 200 * RANDOM_MULTIPLIER);
+    analyzer.close();
+  }
 }

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPLemmatizerFilterFactory.java
@@ -367,4 +367,18 @@ public class TestOpenNLPLemmatizerFilterFactory extends BaseTokenStreamTestCase 
             .build();
     assertAnalyzesTo(analyzer, "", new String[0], null, null, null, null, null, true);
   }
+
+  /** blast some random strings through the analyzer */
+  public void testRandomStrings() throws Exception {
+    CustomAnalyzer analyzer =
+        CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+            .withTokenizer(
+                "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
+            .addTokenFilter("opennlpPOS", "posTaggerModel", "en-test-pos-maxent.bin")
+            .addTokenFilter(KeywordRepeatFilterFactory.class)
+            .addTokenFilter("opennlplemmatizer", "dictionary", "en-test-lemmas.dict")
+            .build();
+    checkRandomData(random(), analyzer, 200 * RANDOM_MULTIPLIER);
+    analyzer.close();
+  }
 }

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPPOSFilterFactory.java
@@ -168,4 +168,16 @@ public class TestOpenNLPPOSFilterFactory extends BaseTokenStreamTestCase {
             .build();
     assertAnalyzesTo(analyzer, "", new String[0], null, null, null, null, null, true);
   }
+
+  /** blast some random strings through the analyzer */
+  public void testRandomStrings() throws Exception {
+    CustomAnalyzer analyzer =
+        CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+            .withTokenizer(
+                "opennlp", "tokenizerModel", tokenizerModelFile, "sentenceModel", sentenceModelFile)
+            .addTokenFilter("opennlpPOS", "posTaggerModel", posTaggerModelFile)
+            .build();
+    checkRandomData(random(), analyzer, 200 * RANDOM_MULTIPLIER);
+    analyzer.close();
+  }
 }

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPTokenizerFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPTokenizerFactory.java
@@ -130,4 +130,19 @@ public class TestOpenNLPTokenizerFactory extends BaseTokenStreamTestCase {
     ts.setReader(new StringReader(SENTENCES));
     assertTokenStreamContents(ts, SENTENCES_punc);
   }
+
+  /** blast some random strings through the analyzer */
+  public void testRandomStrings() throws Exception {
+    CustomAnalyzer analyzer =
+        CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
+            .withTokenizer(
+                "opennlp",
+                "sentenceModel",
+                "en-test-sent.bin",
+                "tokenizerModel",
+                "en-test-tokenizer.bin")
+            .build();
+    checkRandomData(random(), analyzer, 200 * RANDOM_MULTIPLIER);
+    analyzer.close();
+  }
 }


### PR DESCRIPTION
The way these are integrated, they won't be accessed by more than one thread anyway. e.g. the factories create a single *Op along with the tokenstream that uses it, all of which is accessed by a single thread.
