### PR TITLE
Remove VectorValues#EMPTY.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -117,6 +117,10 @@ API Changes
   to avoid possible exceptions when building queries from an empty term list.  The helper
   TermAndBoost class now holds a BytesRef rather than a Term. (Alan Woodward)
 
+* GITHUB#11961: VectorValues#EMPTY was removed as this instance was not
+  necessary and also illegal as it reported a number of dimensions equal to
+  zero. (Adrien Grand)
+
 New Features
 ---------------------
 * GITHUB#11795: Add ByteWritesTrackingDirectoryWrapper to expose metrics for bytes merged, flushed, and overall

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
@@ -120,7 +120,8 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
     }
     int dimension = info.getVectorDimension();
     if (dimension == 0) {
-      return VectorValues.EMPTY;
+      throw new IllegalStateException(
+          "KNN vectors readers should not be called on fields that don't enable KNN vectors");
     }
     FieldEntry fieldEntry = fieldEntries.get(field);
     if (fieldEntry == null) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -22,7 +22,6 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.NamedSPILoader;
 
@@ -95,13 +94,13 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
 
             @Override
             public VectorValues getVectorValues(String field) {
-              return VectorValues.EMPTY;
+              throw new UnsupportedOperationException();
             }
 
             @Override
             public TopDocs search(
                 String field, float[] target, int k, Bits acceptDocs, int visitedLimit) {
-              return TopDocsCollector.EMPTY_TOPDOCS;
+              throw new UnsupportedOperationException();
             }
 
             @Override

--- a/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
@@ -68,50 +68,6 @@ public abstract class VectorValues extends DocIdSetIterator {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Represents the lack of vector values. It is returned by providers that do not support
-   * VectorValues.
-   */
-  public static final VectorValues EMPTY =
-      new VectorValues() {
-
-        @Override
-        public int size() {
-          return 0;
-        }
-
-        @Override
-        public int dimension() {
-          return 0;
-        }
-
-        @Override
-        public float[] vectorValue() {
-          throw new IllegalStateException(
-              "Attempt to get vectors from EMPTY values (which was not advanced)");
-        }
-
-        @Override
-        public int docID() {
-          throw new IllegalStateException("VectorValues is EMPTY, and not positioned on a doc");
-        }
-
-        @Override
-        public int nextDoc() {
-          return NO_MORE_DOCS;
-        }
-
-        @Override
-        public int advance(int target) {
-          return NO_MORE_DOCS;
-        }
-
-        @Override
-        public long cost() {
-          return 0;
-        }
-      };
-
   /** Sorting VectorValues that iterate over documents in the order of the provided sortMap */
   public static class SortingVectorValues extends VectorValues {
     private final RandomAccessVectorValues randomAccess;


### PR DESCRIPTION
This instance is illegal as it reports a number of dimensions equal to zero.
