### PR TITLE
Add a note about gradle checks being possibly a subset of all validation checks

### DIFF
--- a/help/tests.txt
+++ b/help/tests.txt
@@ -12,9 +12,14 @@ Run all unit tests:
 
 gradlew test
 
-Run all verification tasks, including tests:
+Run all(*) verification tasks, including tests:
 
 gradlew check
+
+(*) This step may omit certain validation tasks (errorprone, for example)
+    that are slow or require external resources. A pull request runs all 
+    those locally omitted tasks on the CI (jenkins, gh actions).
+    For this reason, it's a good idea to run patches via the CI.
 
 Run all verification tasks, excluding tests (-x is gradle's generic task
 exclusion mechanism):


### PR DESCRIPTION
With errorprone running on the CI only, gradlew check is not a "complete" check anymore. I think it'd be good to make this explicit in the help.