### PR TITLE
Disable useless error-prone checks (libraries/frameworks we do not use)

### DIFF
--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -76,7 +76,7 @@ allprojects { prj ->
 
             // On by Default : ERROR
 
-            '-Xep:AlwaysThrows:ERROR',
+            // '-Xep:AlwaysThrows:OFF', // we don't use google collections
             // '-Xep:AndroidInjectionBeforeSuper:OFF', // we don't use android
             // '-Xep:ArrayEquals:OFF',
             '-Xep:ArrayFillIncompatibleType:ERROR',
@@ -84,7 +84,7 @@ allprojects { prj ->
             // '-Xep:ArrayToString:OFF',
             '-Xep:ArraysAsListPrimitiveArray:ERROR',
             '-Xep:AsyncCallableReturnsNull:ERROR',
-            '-Xep:AsyncFunctionReturnsNull:ERROR',
+            // '-Xep:AsyncFunctionReturnsNull:OFF', // we don't use guava
             // '-Xep:AutoValueBuilderDefaultsInConstructor:OFF', // we don't use autovalue
             // '-Xep:AutoValueConstructorOrderChecker:OFF', // we don't use autovalue
             '-Xep:BadAnnotationImplementation:ERROR',
@@ -93,8 +93,8 @@ allprojects { prj ->
             '-Xep:BoxedPrimitiveEquality:ERROR',
             // '-Xep:BundleDeserializationCast:OFF', // we don't use android
             '-Xep:ChainingConstructorIgnoresParameter:ERROR',
-            '-Xep:CheckNotNullMultipleTimes:ERROR',
-            '-Xep:CheckReturnValue:ERROR',
+            // '-Xep:CheckNotNullMultipleTimes:OFF', // we don't use guava
+            // '-Xep:CheckReturnValue:oFF', // we don't use these annotations
             '-Xep:CollectionToArraySafeParameter:ERROR',
             // '-Xep:ComparableType:OFF',
             '-Xep:ComparingThisWithNull:ERROR',
@@ -131,8 +131,8 @@ allprojects { prj ->
             // '-Xep:FormatStringAnnotation:OFF', // we don't use this annotation
             // '-Xep:FromTemporalAccessor:OFF', // we don't use .from(LocalDate) etc
             '-Xep:FunctionalInterfaceMethodChanged:ERROR',
-            '-Xep:FuturesGetCheckedIllegalExceptionType:ERROR',
-            '-Xep:FuzzyEqualsShouldNotBeUsedInEqualsMethod:ERROR',
+            // '-Xep:FuturesGetCheckedIllegalExceptionType:OFF', // we don't use guava
+            // '-Xep:FuzzyEqualsShouldNotBeUsedInEqualsMethod:OFF', // we don't use guava
             '-Xep:GetClassOnAnnotation:ERROR',
             '-Xep:GetClassOnClass:ERROR',
             // '-Xep:GuardedBy:OFF', // we don't use this annotation

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -73,6 +73,8 @@ allprojects { prj ->
 
             // List of enabled/disabled checks
             // Please keep this synced with https://errorprone.info/bugpatterns when upgrading!
+            // Do *NOT* enable checks based on their name or description. Read the source code and make sure they are useful!
+            // Most error-prone checks are not useful for non-google software.
 
             // On by Default : ERROR
 
@@ -270,8 +272,8 @@ allprojects { prj ->
             // '-Xep:BadImport:OFF', // TODO: there are problems
             // '-Xep:BadInstanceof:OFF', // TODO: there are problems
             '-Xep:BareDotMetacharacter:WARN',
-            '-Xep:BigDecimalEquals:WARN',
-            '-Xep:BigDecimalLiteralDouble:WARN',
+            // '-Xep:BigDecimalEquals:OFF', // BigDecimal barely used, can use forbidden-apis for this
+            // '-Xep:BigDecimalLiteralDouble:OFF', // BigDecimal barely used, can use forbidden-apis for this
             // '-Xep:BoxedPrimitiveConstructor:OFF', // we have forbiddenapis for that
             // '-Xep:BugPatternNaming:OFF', // we don't use this annotation
             // '-Xep:ByteBufferBackingArray:OFF',
@@ -289,7 +291,7 @@ allprojects { prj ->
             '-Xep:ComparableAndComparator:WARN',
             '-Xep:CompareToZero:WARN',
             // '-Xep:ComplexBooleanConstant:OFF', // TODO: there are problems
-            '-Xep:DateChecker:WARN',
+            // '-Xep:DateChecker:OFF', // we don't use these Date setters/ctors
             // '-Xep:DateFormatConstant:OFF', // we don't use Date setters
             // '-Xep:DefaultCharset:OFF', // we have forbiddenapis for that
             // '-Xep:DefaultPackage:OFF',
@@ -350,8 +352,8 @@ allprojects { prj ->
             '-Xep:InvalidThrowsLink:WARN',
             '-Xep:IterableAndIterator:WARN',
             // '-Xep:JUnit3FloatingPointComparisonWithoutDelta:OFF', // we don't use junit3
-            '-Xep:JUnit4ClassUsedInJUnit3:WARN',
-            '-Xep:JUnitAmbiguousTestClass:WARN',
+            // '-Xep:JUnit4ClassUsedInJUnit3:OFF', // we don't use junit3
+            // '-Xep:JUnitAmbiguousTestClass:OFF', // we don't use junit3
             // '-Xep:JavaDurationGetSecondsGetNano:OFF', // we don't use these Duration methods
             // '-Xep:JavaDurationWithNanos:OFF', // we don't use these Duration methods
             // '-Xep:JavaDurationWithSeconds:OFF', // we don't use these Duration methods
@@ -433,7 +435,7 @@ allprojects { prj ->
             // '-Xep:RobolectricShadowDirectlyOn:OFF', // we don't use robolectric
             // '-Xep:RxReturnValueIgnored:OFF', // we don't use rxjava
             // '-Xep:SameNameButDifferent:OFF', // TODO: there are problems
-            '-Xep:SelfAlwaysReturnsThis:WARN',
+            // '-Xep:SelfAlwaysReturnsThis:OFF', // we don't use self() methods, this isn't python.
             // '-Xep:ShortCircuitBoolean:OFF', // TODO: there are problems
             // '-Xep:StaticAssignmentInConstructor:OFF',
             // '-Xep:StaticAssignmentOfThrowable:OFF', // noisy

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -382,7 +382,7 @@ allprojects { prj ->
             '-Xep:MalformedInlineTag:WARN',
             // '-Xep:MathAbsoluteRandom:OFF',
             // '-Xep:MemoizeConstantVisitorStateLookups:OFF', // we don't use this class
-            '-Xep:MissingCasesInEnumSwitch:WARN',
+            // '-Xep:MissingCasesInEnumSwitch:OFF', // redundant with ECJ incompleteEnumSwitch/missingEnumCaseDespiteDefault
             // '-Xep:MissingFail:OFF',
             '-Xep:MissingImplementsComparable:WARN',
             // '-Xep:MissingOverride:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -481,7 +481,7 @@ allprojects { prj ->
             '-Xep:VariableNameSameAsType:WARN',
             // '-Xep:WaitNotInLoop:OFF',
             // '-Xep:WakelockReleasedDangerously:OFF', // we don't use android
-            '-Xep:WithSignatureDiscouraged:WARN',
+            // '-Xep:WithSignatureDiscouraged:OFF', // we aren't using this error-prone internal api
         ]
       }
     }

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -255,7 +255,7 @@ allprojects { prj ->
 
             // On by Default : WARNING
 
-            // '-Xep:AlmostJavadoc:OFF', // TODO: there are problems
+            // '-Xep:AlmostJavadoc:OFF', // noisy (e.g. commented-out code misinterpreted as javadocs)
             // '-Xep:AlreadyChecked:OFF', // TODO: there are problems
             // '-Xep:AmbiguousMethodReference:OFF',
             // '-Xep:AnnotateFormatMethod:OFF', // we don't use this annotation

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -163,9 +163,9 @@ allprojects { prj ->
             // '-Xep:IsLoggableTagLength:OFF', // we don't use android
             // '-Xep:JUnit3TestNotRun:OFF', // we don't use junit3
             '-Xep:JUnit4ClassAnnotationNonStatic:ERROR',
-            '-Xep:JUnit4SetUpNotRun:ERROR',
-            '-Xep:JUnit4TearDownNotRun:ERROR',
-            //'-Xep:JUnit4TestNotRun:OFF',
+            // '-Xep:JUnit4SetUpNotRun:OFF', // LuceneTestCase takes care
+            // '-Xep:JUnit4TearDownNotRun:OFF', // LuceneTestCase takes care
+            // '-Xep:JUnit4TestNotRun:OFF',
             '-Xep:JUnit4TestsNotRunWithinEnclosed:ERROR',
             '-Xep:JUnitAssertSameCheck:ERROR',
             '-Xep:JUnitParameterMethodNotFound:ERROR',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -89,7 +89,7 @@ allprojects { prj ->
             // '-Xep:AutoValueConstructorOrderChecker:OFF', // we don't use autovalue
             '-Xep:BadAnnotationImplementation:ERROR',
             // '-Xep:BadShiftAmount:OFF',
-            '-Xep:BanJNDI:ERROR', // TODO: implement via forbidden APIs which is much faster
+            // '-Xep:BanJNDI:OFF', // implemented with forbidden APIs instead
             '-Xep:BoxedPrimitiveEquality:ERROR',
             // '-Xep:BundleDeserializationCast:OFF', // we don't use android
             '-Xep:ChainingConstructorIgnoresParameter:ERROR',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -150,7 +150,7 @@ allprojects { prj ->
             '-Xep:IndexOfChar:ERROR',
             '-Xep:InexactVarargsConditional:ERROR',
             // '-Xep:InfiniteRecursion:OFF',
-            '-Xep:InjectMoreThanOneScopeAnnotationOnClass:ERROR',
+            // '-Xep:InjectMoreThanOneScopeAnnotationOnClass:OFF', // we don't use this annotation
             // '-Xep:InjectOnMemberAndConstructor:OFF', // we don't use this annotation
             // '-Xep:InlineMeValidator:OFF', // we don't use this annotation
             '-Xep:InstantTemporalUnit:ERROR',
@@ -178,7 +178,7 @@ allprojects { prj ->
             '-Xep:LossyPrimitiveCompare:ERROR',
             '-Xep:MathRoundIntLong:ERROR',
             // '-Xep:MislabeledAndroidString:OFF', // we don't use android
-            '-Xep:MisplacedScopeAnnotations:ERROR',
+            // '-Xep:MisplacedScopeAnnotations:OFF', // we don't use this annotation
             // '-Xep:MissingSuperCall:OFF', // we don't use this annotation
             // '-Xep:MissingTestCall:OFF', // we don't use guava
             // '-Xep:MisusedDayOfYear:OFF',
@@ -199,7 +199,7 @@ allprojects { prj ->
             '-Xep:OptionalEquality:ERROR',
             '-Xep:OptionalMapUnusedValue:ERROR',
             '-Xep:OptionalOfRedundantMethod:ERROR',
-            '-Xep:OverlappingQualifierAndScopeAnnotation:ERROR',
+            // '-Xep:OverlappingQualifierAndScopeAnnotation:OFF', // we don't use this annotation
             // '-Xep:OverridesJavaxInjectableMethod:OFF', // we don't use this annotation
             '-Xep:PackageInfo:ERROR',
             '-Xep:ParametersButNotParameterized:ERROR',
@@ -283,7 +283,7 @@ allprojects { prj ->
             // '-Xep:CharacterGetNumericValue:OFF',
             // '-Xep:ClassCanBeStatic:OFF',
             '-Xep:ClassNewInstance:WARN',
-            '-Xep:CloseableProvides:WARN',
+            // '-Xep:CloseableProvides:OFF', // we don't use this annotation
             // '-Xep:CollectionUndefinedEquality:OFF',
             '-Xep:CollectorShouldNotUseState:WARN',
             '-Xep:ComparableAndComparator:WARN',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -77,7 +77,7 @@ allprojects { prj ->
             // On by Default : ERROR
 
             '-Xep:AlwaysThrows:ERROR',
-            '-Xep:AndroidInjectionBeforeSuper:ERROR',
+            // '-Xep:AndroidInjectionBeforeSuper:OFF', // we don't use android
             // '-Xep:ArrayEquals:OFF',
             '-Xep:ArrayFillIncompatibleType:ERROR',
             // '-Xep:ArrayHashCode:OFF',
@@ -85,13 +85,13 @@ allprojects { prj ->
             '-Xep:ArraysAsListPrimitiveArray:ERROR',
             '-Xep:AsyncCallableReturnsNull:ERROR',
             '-Xep:AsyncFunctionReturnsNull:ERROR',
-            '-Xep:AutoValueBuilderDefaultsInConstructor:ERROR',
-            '-Xep:AutoValueConstructorOrderChecker:ERROR',
+            // '-Xep:AutoValueBuilderDefaultsInConstructor:OFF', // we don't use autovalue
+            // '-Xep:AutoValueConstructorOrderChecker:OFF', // we don't use autovalue
             '-Xep:BadAnnotationImplementation:ERROR',
             // '-Xep:BadShiftAmount:OFF',
-            '-Xep:BanJNDI:ERROR',
+            '-Xep:BanJNDI:ERROR', // TODO: implement via forbidden APIs which is much faster
             '-Xep:BoxedPrimitiveEquality:ERROR',
-            '-Xep:BundleDeserializationCast:ERROR',
+            // '-Xep:BundleDeserializationCast:OFF', // we don't use android
             '-Xep:ChainingConstructorIgnoresParameter:ERROR',
             '-Xep:CheckNotNullMultipleTimes:ERROR',
             '-Xep:CheckReturnValue:ERROR',
@@ -99,18 +99,18 @@ allprojects { prj ->
             // '-Xep:ComparableType:OFF',
             '-Xep:ComparingThisWithNull:ERROR',
             '-Xep:ComparisonOutOfRange:ERROR',
-            '-Xep:CompatibleWithAnnotationMisuse:ERROR',
-            '-Xep:CompileTimeConstant:ERROR',
+            // '-Xep:CompatibleWithAnnotationMisuse:OFF', // we don't use this annotation
+            // '-Xep:CompileTimeConstant:OFF', // we don't use this annotation
             '-Xep:ComputeIfAbsentAmbiguousReference:ERROR',
             '-Xep:ConditionalExpressionNumericPromotion:ERROR',
             '-Xep:ConstantOverflow:ERROR',
-            '-Xep:DaggerProvidesNull:ERROR',
+            // '-Xep:DaggerProvidesNull:OFF', // we don't use dagger
             '-Xep:DangerousLiteralNull:ERROR',
             '-Xep:DeadException:ERROR',
             '-Xep:DeadThread:ERROR',
             '-Xep:DiscardedPostfixExpression:ERROR',
             // '-Xep:DoNotCall:OFF',
-            '-Xep:DoNotMock:ERROR',
+            // '-Xep:DoNotMock:OFF', // we don't use mocking libraries
             // '-Xep:DoubleBraceInitialization:OFF',
             '-Xep:DuplicateMapKeys:ERROR',
             '-Xep:DurationFrom:ERROR',
@@ -123,36 +123,36 @@ allprojects { prj ->
             '-Xep:EqualsNull:ERROR',
             '-Xep:EqualsReference:ERROR',
             '-Xep:EqualsWrongThing:ERROR',
-            '-Xep:FloggerFormatString:ERROR',
-            '-Xep:FloggerLogVarargs:ERROR',
-            '-Xep:FloggerSplitLogStatement:ERROR',
-            '-Xep:ForOverride:ERROR',
+            // '-Xep:FloggerFormatString:OFF', // we don't use flogger
+            // '-Xep:FloggerLogVarargs:OFF', // we don't use flogger
+            // '-Xep:FloggerSplitLogStatement:OFF', // we don't use flogger
+            // '-Xep:ForOverride:OFF', // we don't use this annotation
             // '-Xep:FormatString:OFF',
-            '-Xep:FormatStringAnnotation:ERROR',
+            // '-Xep:FormatStringAnnotation:OFF', // we don't use this annotation
             '-Xep:FromTemporalAccessor:ERROR',
             '-Xep:FunctionalInterfaceMethodChanged:ERROR',
             '-Xep:FuturesGetCheckedIllegalExceptionType:ERROR',
             '-Xep:FuzzyEqualsShouldNotBeUsedInEqualsMethod:ERROR',
             '-Xep:GetClassOnAnnotation:ERROR',
             '-Xep:GetClassOnClass:ERROR',
-            '-Xep:GuardedBy:ERROR',
-            '-Xep:GuiceAssistedInjectScoping:ERROR',
-            '-Xep:GuiceAssistedParameters:ERROR',
-            '-Xep:GuiceInjectOnFinalField:ERROR',
+            // '-Xep:GuardedBy:OFF', // we don't use this annotation
+            // '-Xep:GuiceAssistedInjectScoping:OFF', // we don't use guice
+            // '-Xep:GuiceAssistedParameters:OFF', // we don't use guice
+            // '-Xep:GuiceInjectOnFinalField:OFF', // we don't use guice
             '-Xep:HashtableContains:ERROR',
             // '-Xep:IdentityBinaryExpression:OFF',
             '-Xep:IdentityHashMapBoxing:ERROR',
-            '-Xep:IgnoredPureGetter:ERROR',
-            '-Xep:Immutable:ERROR',
+            // '-Xep:IgnoredPureGetter:OFF', // we don't use these annotations
+            // '-Xep:Immutable:OFF', // we don't use this annotation
             '-Xep:Incomparable:ERROR',
-            '-Xep:IncompatibleArgumentType:ERROR',
-            '-Xep:IncompatibleModifiers:ERROR',
+            // '-Xep:IncompatibleArgumentType:OFF', // we don't use this annotation
+            // '-Xep:IncompatibleModifiers:OFF', // we don't use this annotation
             '-Xep:IndexOfChar:ERROR',
             '-Xep:InexactVarargsConditional:ERROR',
             // '-Xep:InfiniteRecursion:OFF',
             '-Xep:InjectMoreThanOneScopeAnnotationOnClass:ERROR',
-            '-Xep:InjectOnMemberAndConstructor:ERROR',
-            '-Xep:InlineMeValidator:ERROR',
+            // '-Xep:InjectOnMemberAndConstructor:OFF', // we don't use this annotation
+            // '-Xep:InlineMeValidator:OFF', // we don't use this annotation
             '-Xep:InstantTemporalUnit:ERROR',
             '-Xep:InvalidJavaTimeConstant:ERROR',
             // '-Xep:InvalidPatternSyntax:OFF',
@@ -161,7 +161,7 @@ allprojects { prj ->
             '-Xep:IsInstanceIncompatibleType:ERROR',
             '-Xep:IsInstanceOfClass:ERROR',
             '-Xep:IsLoggableTagLength:ERROR',
-            '-Xep:JUnit3TestNotRun:ERROR',
+            // '-Xep:JUnit3TestNotRun:OFF', // we don't use junit3
             '-Xep:JUnit4ClassAnnotationNonStatic:ERROR',
             '-Xep:JUnit4SetUpNotRun:ERROR',
             '-Xep:JUnit4TearDownNotRun:ERROR',
@@ -169,57 +169,57 @@ allprojects { prj ->
             '-Xep:JUnit4TestsNotRunWithinEnclosed:ERROR',
             '-Xep:JUnitAssertSameCheck:ERROR',
             '-Xep:JUnitParameterMethodNotFound:ERROR',
-            '-Xep:JavaxInjectOnAbstractMethod:ERROR',
-            '-Xep:JodaToSelf:ERROR',
-            '-Xep:LiteByteStringUtf8:ERROR',
+            // '-Xep:JavaxInjectOnAbstractMethod:OFF', // we don't this annotation
+            // '-Xep:JodaToSelf:OFF', // we don't use joda-time
+            // '-Xep:LiteByteStringUtf8:OFF', // we don't use protobuf
             '-Xep:LocalDateTemporalAmount:ERROR',
             '-Xep:LockOnBoxedPrimitive:ERROR',
             '-Xep:LoopConditionChecker:ERROR',
             '-Xep:LossyPrimitiveCompare:ERROR',
             '-Xep:MathRoundIntLong:ERROR',
-            '-Xep:MislabeledAndroidString:ERROR',
+            // '-Xep:MislabeledAndroidString:OFF', // we don't use android
             '-Xep:MisplacedScopeAnnotations:ERROR',
-            '-Xep:MissingSuperCall:ERROR',
-            '-Xep:MissingTestCall:ERROR',
+            // '-Xep:MissingSuperCall:OFF', // we don't use this annotation
+            // '-Xep:MissingTestCall:OFF', // we don't use guava
             // '-Xep:MisusedDayOfYear:OFF',
             '-Xep:MisusedWeekYear:ERROR',
-            '-Xep:MixedDescriptors:ERROR',
-            '-Xep:MockitoUsage:ERROR',
+            // '-Xep:MixedDescriptors:OFF', // we don't use protobuf
+            // '-Xep:MockitoUsage:OFF', // we don't use mockito
             '-Xep:ModifyingCollectionWithItself:ERROR',
-            '-Xep:MoreThanOneInjectableConstructor:ERROR',
-            '-Xep:MustBeClosedChecker:ERROR',
+            // '-Xep:MoreThanOneInjectableConstructor:OFF', // we don't use this annotation
+            // '-Xep:MustBeClosedChecker:OFF', // we don't use this annotation
             '-Xep:NCopiesOfChar:ERROR',
-            '-Xep:NoCanIgnoreReturnValueOnClasses:ERROR',
+            // '-Xep:NoCanIgnoreReturnValueOnClasses:OFF', // we don't use this annotation
             '-Xep:NonCanonicalStaticImport:ERROR',
-            '-Xep:NonFinalCompileTimeConstant:ERROR',
+            // '-Xep:NonFinalCompileTimeConstant:OFF', // we don't use this annotation
             '-Xep:NonRuntimeAnnotation:ERROR',
-            '-Xep:NullArgumentForNonNullParameter:ERROR',
+            // '-Xep:NullArgumentForNonNullParameter:OFF', // we don't use this annotation
             '-Xep:NullTernary:ERROR',
-            '-Xep:NullableOnContainingClass:ERROR',
+            // '-Xep:NullableOnContainingClass:OFF', // we don't use this annotation
             '-Xep:OptionalEquality:ERROR',
             '-Xep:OptionalMapUnusedValue:ERROR',
             '-Xep:OptionalOfRedundantMethod:ERROR',
             '-Xep:OverlappingQualifierAndScopeAnnotation:ERROR',
-            '-Xep:OverridesJavaxInjectableMethod:ERROR',
+            // '-Xep:OverridesJavaxInjectableMethod:OFF', // we don't use this annotation
             '-Xep:PackageInfo:ERROR',
             '-Xep:ParametersButNotParameterized:ERROR',
-            '-Xep:ParcelableCreator:ERROR',
+            // '-Xep:ParcelableCreator:OFF', // we don't use android
             '-Xep:PeriodFrom:ERROR',
             '-Xep:PeriodGetTemporalUnit:ERROR',
             '-Xep:PeriodTimeMath:ERROR',
-            '-Xep:PreconditionsInvalidPlaceholder:ERROR',
-            '-Xep:PrivateSecurityContractProtoAccess:ERROR',
-            '-Xep:ProtoBuilderReturnValueIgnored:ERROR',
-            '-Xep:ProtoFieldNullComparison:ERROR',
-            '-Xep:ProtoStringFieldReferenceEquality:ERROR',
-            '-Xep:ProtoTruthMixedDescriptors:ERROR',
-            '-Xep:ProtocolBufferOrdinal:ERROR',
-            '-Xep:ProvidesMethodOutsideOfModule:ERROR',
+            // '-Xep:PreconditionsInvalidPlaceholder:OFF', // we don't use guava
+            // '-Xep:PrivateSecurityContractProtoAccess:OFF', // we don't use protobuf
+            // '-Xep:ProtoBuilderReturnValueIgnored:OFF', // we don't use protobuf
+            // '-Xep:ProtoFieldNullComparison:OFF', // we don't use protobuf
+            // '-Xep:ProtoStringFieldReferenceEquality:OFF', // we don't use protobuf
+            // '-Xep:ProtoTruthMixedDescriptors:OFF', // we don't use protobuf
+            // '-Xep:ProtocolBufferOrdinal:OFF', // we don't use protobuf
+            // '-Xep:ProvidesMethodOutsideOfModule:OFF', // we don't use guice
             '-Xep:RandomCast:ERROR',
             '-Xep:RandomModInteger:ERROR',
-            '-Xep:RectIntersectReturnValueIgnored:ERROR',
-            '-Xep:RequiredModifiers:ERROR',
-            '-Xep:RestrictedApiChecker:ERROR',
+            // '-Xep:RectIntersectReturnValueIgnored:OFF', // we don't use android
+            // '-Xep:RequiredModifiers:OFF', // we don't use this annotation
+            // '-Xep:RestrictedApiChecker:OFF', // we don't use this annotation
             // '-Xep:ReturnValueIgnored:OFF',
             // '-Xep:SelfAssignment:OFF',
             '-Xep:SelfComparison:ERROR',
@@ -236,7 +236,7 @@ allprojects { prj ->
             '-Xep:ThrowIfUncheckedKnownChecked:ERROR',
             // '-Xep:ThrowNull:OFF',
             '-Xep:TreeToString:ERROR',
-            '-Xep:TruthSelfEquals:ERROR',
+            // '-Xep:TruthSelfEquals:OFF', // we don't use truth
             // '-Xep:TryFailThrowable:OFF',
             '-Xep:TypeParameterQualifier:ERROR',
             '-Xep:UnicodeDirectionalityCharacters:ERROR',
@@ -247,7 +247,7 @@ allprojects { prj ->
             '-Xep:UnusedAnonymousClass:ERROR',
             '-Xep:UnusedCollectionModifiedInPlace:ERROR',
             '-Xep:VarTypeName:ERROR',
-            '-Xep:WrongOneof:ERROR',
+            // '-Xep:WrongOneof:OFF', // we don't use protobuf
             '-Xep:XorPower:ERROR',
             '-Xep:ZoneIdOfZ:ERROR',
 
@@ -256,16 +256,16 @@ allprojects { prj ->
             // '-Xep:AlmostJavadoc:OFF',
             // '-Xep:AlreadyChecked:OFF',
             // '-Xep:AmbiguousMethodReference:OFF',
-            '-Xep:AnnotateFormatMethod:WARN',
+            // '-Xep:AnnotateFormatMethod:OFF', // we don't use this annotation
             // '-Xep:ArgumentSelectionDefectChecker:OFF',
             // '-Xep:ArrayAsKeyOfSetOrMap:OFF',
             '-Xep:AssertEqualsArgumentOrderChecker:WARN',
             '-Xep:AssertThrowsMultipleStatements:WARN',
             // '-Xep:AssertionFailureIgnored:OFF',
-            '-Xep:AssistedInjectAndInjectOnSameConstructor:WARN',
-            '-Xep:AutoValueFinalMethods:WARN',
-            '-Xep:AutoValueImmutableFields:WARN',
-            '-Xep:AutoValueSubclassLeaked:WARN',
+            // '-Xep:AssistedInjectAndInjectOnSameConstructor:OFF', // we don't use this annotation
+            // '-Xep:AutoValueFinalMethods:OFF', // we don't use autovalue
+            // '-Xep:AutoValueImmutableFields:OFF', // we don't use autovalue
+            // '-Xep:AutoValueSubclassLeaked:OFF', // we don't use autovalue
             '-Xep:BadComparable:WARN',
             // '-Xep:BadImport:OFF',
             // '-Xep:BadInstanceof:OFF',
@@ -273,13 +273,13 @@ allprojects { prj ->
             '-Xep:BigDecimalEquals:WARN',
             '-Xep:BigDecimalLiteralDouble:WARN',
             // '-Xep:BoxedPrimitiveConstructor:OFF', // we have forbiddenapis for that
-            '-Xep:BugPatternNaming:WARN',
+            // '-Xep:BugPatternNaming:OFF', // we don't use this annotation
             // '-Xep:ByteBufferBackingArray:OFF',
-            '-Xep:CacheLoaderNull:WARN',
+            // '-Xep:CacheLoaderNull:OFF', // we don't use guava
             '-Xep:CanonicalDuration:WARN',
             // '-Xep:CatchAndPrintStackTrace:OFF',
             // '-Xep:CatchFail:OFF',
-            '-Xep:ChainedAssertionLosesContext:WARN',
+            // '-Xep:ChainedAssertionLosesContext:OFF', // we don't use truth
             // '-Xep:CharacterGetNumericValue:OFF',
             // '-Xep:ClassCanBeStatic:OFF',
             '-Xep:ClassNewInstance:WARN',
@@ -291,18 +291,18 @@ allprojects { prj ->
             // '-Xep:ComplexBooleanConstant:OFF',
             '-Xep:DateChecker:WARN',
             '-Xep:DateFormatConstant:WARN',
-            '-Xep:DefaultCharset:WARN',
+            // '-Xep:DefaultCharset:OFF', // we have forbiddenapis for that
             // '-Xep:DefaultPackage:OFF',
             '-Xep:DeprecatedVariable:WARN',
-            '-Xep:DirectInvocationOnMock:WARN',
+            // '-Xep:DirectInvocationOnMock:OFF', // we don't use mocking libraries
             '-Xep:DistinctVarargsChecker:WARN',
             // '-Xep:DoNotCallSuggester:OFF',
             '-Xep:DoNotClaimAnnotations:WARN',
-            '-Xep:DoNotMockAutoValue:WARN',
+            // '-Xep:DoNotMockAutoValue:OFF', // we don't use autovalue
             // '-Xep:DoubleCheckedLocking:OFF',
             '-Xep:EmptyBlockTag:WARN',
             // '-Xep:EmptyCatch:OFF',
-            '-Xep:EmptySetMultibindingContributions:WARN',
+            // '-Xep:EmptySetMultibindingContributions:OFF', // we don't use this annotation
             // '-Xep:EqualsGetClass:OFF',
             // '-Xep:EqualsIncompatibleType:OFF',
             // '-Xep:EqualsUnsafeCast:OFF',
@@ -317,27 +317,27 @@ allprojects { prj ->
             '-Xep:FloatCast:WARN',
             '-Xep:FloatingPointAssertionWithinEpsilon:WARN',
             // '-Xep:FloatingPointLiteralPrecision:OFF',
-            '-Xep:FloggerArgumentToString:WARN',
-            '-Xep:FloggerStringConcatenation:WARN',
-            '-Xep:FragmentInjection:WARN',
-            '-Xep:FragmentNotInstantiable:WARN',
+            // '-Xep:FloggerArgumentToString:OFF', // we don't use flogger
+            // '-Xep:FloggerStringConcatenation:OFF', // we don't use flogger
+            // '-Xep:FragmentInjection:OFF', // we don't use android
+            // '-Xep:FragmentNotInstantiable:OFF', // we don't use android
             // '-Xep:FutureReturnValueIgnored:OFF',
             '-Xep:GetClassOnEnum:WARN',
             // '-Xep:HidingField:OFF',
             // '-Xep:IdentityHashMapUsage:OFF',
-            '-Xep:ImmutableAnnotationChecker:WARN',
+            // '-Xep:ImmutableAnnotationChecker:OFF', // we don't use this annotation
             // '-Xep:ImmutableEnumChecker:OFF',
             // '-Xep:InconsistentCapitalization:OFF',
             // '-Xep:InconsistentHashCode:OFF',
             '-Xep:IncorrectMainMethod:WARN',
             '-Xep:IncrementInForLoopAndHeader:WARN',
             '-Xep:InheritDoc:WARN',
-            '-Xep:InjectInvalidTargetingOnScopingAnnotation:WARN',
-            '-Xep:InjectOnConstructorOfAbstractClass:WARN',
-            '-Xep:InjectScopeAnnotationOnInterfaceOrAbstractClass:WARN',
-            '-Xep:InjectedConstructorAnnotations:WARN',
+            // '-Xep:InjectInvalidTargetingOnScopingAnnotation:OFF', // we don't use this annotation
+            // '-Xep:InjectOnConstructorOfAbstractClass:OFF', // we don't use this annotation
+            // '-Xep:InjectScopeAnnotationOnInterfaceOrAbstractClass:OFF', // we don't use this annotation
+            // '-Xep:InjectedConstructorAnnotations:OFF', // we don't use this annotation
             // '-Xep:InlineFormatString:OFF',
-            '-Xep:InlineMeInliner:WARN',
+            // '-Xep:InlineMeInliner:OFF', // we don't use this annotation
             // '-Xep:InlineMeSuggester:OFF',
             // '-Xep:InputStreamSlowMultibyteRead:OFF',
             '-Xep:InstanceOfAndCastMatchWrongType:WARN',
@@ -349,7 +349,7 @@ allprojects { prj ->
             '-Xep:InvalidThrows:WARN',
             '-Xep:InvalidThrowsLink:WARN',
             '-Xep:IterableAndIterator:WARN',
-            '-Xep:JUnit3FloatingPointComparisonWithoutDelta:WARN',
+            // '-Xep:JUnit3FloatingPointComparisonWithoutDelta:OFF', // we don't use junit3
             '-Xep:JUnit4ClassUsedInJUnit3:WARN',
             '-Xep:JUnitAmbiguousTestClass:WARN',
             '-Xep:JavaDurationGetSecondsGetNano:WARN',
@@ -362,18 +362,18 @@ allprojects { prj ->
             '-Xep:JavaPeriodGetDays:WARN',
             '-Xep:JavaTimeDefaultTimeZone:WARN',
             // '-Xep:JavaUtilDate:OFF',
-            '-Xep:JavaxInjectOnFinalField:WARN',
+            // '-Xep:JavaxInjectOnFinalField:OFF', // we don't use this annotation
             // '-Xep:JdkObsolete:OFF',
-            '-Xep:JodaConstructors:WARN',
-            '-Xep:JodaDateTimeConstants:WARN',
-            '-Xep:JodaDurationWithMillis:WARN',
-            '-Xep:JodaInstantWithMillis:WARN',
-            '-Xep:JodaNewPeriod:WARN',
-            '-Xep:JodaPlusMinusLong:WARN',
-            '-Xep:JodaTimeConverterManager:WARN',
-            '-Xep:JodaWithDurationAddedLong:WARN',
-            '-Xep:LiteEnumValueOf:WARN',
-            '-Xep:LiteProtoToString:WARN',
+            // '-Xep:JodaConstructors:OFF', // we don't use joda-time
+            // '-Xep:JodaDateTimeConstants:OFF', // we don't use joda-time
+            // '-Xep:JodaDurationWithMillis:OFF', // we don't use joda-time
+            // '-Xep:JodaInstantWithMillis:OFF', // we don't use joda-time
+            // '-Xep:JodaNewPeriod:OFF', // we don't use joda-time
+            // '-Xep:JodaPlusMinusLong:OFF', // we don't use joda-time
+            // '-Xep:JodaTimeConverterManager:OFF', // we don't use joda-time
+            // '-Xep:JodaWithDurationAddedLong:OFF', // we don't use joda-time
+            // '-Xep:LiteEnumValueOf:OFF', // we don't use protobuf
+            // '-Xep:LiteProtoToString:OFF', // we don't use protobuf
             // '-Xep:LockNotBeforeTry:OFF',
             // '-Xep:LogicalAssignment:OFF',
             // '-Xep:LongDoubleConversion:OFF',
@@ -381,14 +381,14 @@ allprojects { prj ->
             '-Xep:LoopOverCharArray:WARN',
             '-Xep:MalformedInlineTag:WARN',
             // '-Xep:MathAbsoluteRandom:OFF',
-            '-Xep:MemoizeConstantVisitorStateLookups:WARN',
+            // '-Xep:MemoizeConstantVisitorStateLookups:OFF', // we don't use this class
             '-Xep:MissingCasesInEnumSwitch:WARN',
             // '-Xep:MissingFail:OFF',
             '-Xep:MissingImplementsComparable:WARN',
             // '-Xep:MissingOverride:OFF',
             // '-Xep:MissingSummary:OFF',
             // '-Xep:MixedMutabilityReturnType:OFF',
-            '-Xep:MockNotUsedInProduction:WARN',
+            // '-Xep:MockNotUsedInProduction:OFF', // we don't use mocking libraries
             // '-Xep:ModifiedButNotUsed:OFF',
             '-Xep:ModifyCollectionInEnhancedForLoop:WARN',
             '-Xep:ModifySourceCollectionInStream:WARN',
@@ -403,10 +403,10 @@ allprojects { prj ->
             // '-Xep:NonCanonicalType:OFF',
             '-Xep:NonOverridingEquals:WARN',
             '-Xep:NullOptional:WARN',
-            '-Xep:NullableConstructor:WARN',
-            '-Xep:NullablePrimitive:WARN',
-            '-Xep:NullablePrimitiveArray:WARN',
-            '-Xep:NullableVoid:WARN',
+            // '-Xep:NullableConstructor:OFF', // we don't use this annotation
+            // '-Xep:NullablePrimitive:OFF', // we don't use this annotation
+            // '-Xep:NullablePrimitiveArray:OFF', // we don't use this annotation
+            // '-Xep:NullableVoid:OFF', // we don't use this annotation
             '-Xep:ObjectEqualsForPrimitives:WARN',
             // '-Xep:ObjectToString:OFF',
             // '-Xep:ObjectsHashCodePrimitive:OFF',
@@ -417,21 +417,21 @@ allprojects { prj ->
             '-Xep:OutlineNone:WARN',
             '-Xep:OverrideThrowableToString:WARN',
             '-Xep:Overrides:WARN',
-            '-Xep:OverridesGuiceInjectableMethod:WARN',
+            // '-Xep:OverridesGuiceInjectableMethod:OFF', // we don't use guice
             '-Xep:ParameterName:WARN',
-            '-Xep:PreconditionsCheckNotNullRepeated:WARN',
+            // '-Xep:PreconditionsCheckNotNullRepeated:OFF', // we don't use guava
             '-Xep:PrimitiveAtomicReference:WARN',
-            // '-Xep:ProtectedMembersInFinalClass:OFF',
-            '-Xep:ProtoDurationGetSecondsGetNano:WARN',
-            '-Xep:ProtoRedundantSet:WARN',
-            '-Xep:ProtoTimestampGetSecondsGetNano:WARN',
-            '-Xep:QualifierOrScopeOnInjectMethod:WARN',
+            // '-Xep:ProtectedMembersInFinalClass:OFF', // we don't use protobuf
+            // '-Xep:ProtoDurationGetSecondsGetNano:OFF', // we don't use protobuf
+            // '-Xep:ProtoRedundantSet:OFF', // we don't use protobuf
+            // '-Xep:ProtoTimestampGetSecondsGetNano:OFF', // we don't use protobuf
+            // '-Xep:QualifierOrScopeOnInjectMethod:OFF', // we don't use this annotation
             '-Xep:ReachabilityFenceUsage:WARN',
             // '-Xep:ReferenceEquality:OFF',
             '-Xep:RethrowReflectiveOperationExceptionAsLinkageError:WARN',
             '-Xep:ReturnFromVoid:WARN',
-            '-Xep:RobolectricShadowDirectlyOn:WARN',
-            '-Xep:RxReturnValueIgnored:WARN',
+            // '-Xep:RobolectricShadowDirectlyOn:OFF', // we don't use robolectric
+            // '-Xep:RxReturnValueIgnored:OFF', // we don't use rxjava
             // '-Xep:SameNameButDifferent:OFF',
             '-Xep:SelfAlwaysReturnsThis:WARN',
             // '-Xep:ShortCircuitBoolean:OFF',
@@ -442,7 +442,7 @@ allprojects { prj ->
             // '-Xep:StreamResourceLeak:OFF',
             '-Xep:StreamToIterable:WARN',
             '-Xep:StringSplitter:OFF',
-            '-Xep:SwigMemoryLeak:WARN',
+            // '-Xep:SwigMemoryLeak:OFF', // we don't use swig
             // '-Xep:SynchronizeOnNonFinalField:OFF',
             // '-Xep:ThreadJoinLoop:OFF',
             // '-Xep:ThreadLocalUsage:OFF',
@@ -450,10 +450,10 @@ allprojects { prj ->
             '-Xep:ThreeLetterTimeZoneID:WARN',
             '-Xep:TimeUnitConversionChecker:WARN',
             // '-Xep:ToStringReturnsNull:OFF',
-            '-Xep:TruthAssertExpected:WARN',
-            '-Xep:TruthConstantAsserts:WARN',
-            '-Xep:TruthGetOrDefault:WARN',
-            '-Xep:TruthIncompatibleType:WARN',
+            // '-Xep:TruthAssertExpected:OFF', // we don't use truth
+            // '-Xep:TruthConstantAsserts:OFF', // we don't use truth
+            // '-Xep:TruthGetOrDefault:OFF', // we don't use truth
+            // '-Xep:TruthIncompatibleType:OFF', // we don't use truth
             '-Xep:TypeEquals:WARN',
             '-Xep:TypeNameShadowing:WARN',
             // '-Xep:TypeParameterShadowing:OFF',
@@ -465,7 +465,7 @@ allprojects { prj ->
             '-Xep:UnnecessaryAssignment:WARN',
             // '-Xep:UnnecessaryLambda:OFF',
             // '-Xep:UnnecessaryLongToIntConversion:OFF',
-            '-Xep:UnnecessaryMethodInvocationMatcher:WARN',
+            // '-Xep:UnnecessaryMethodInvocationMatcher:OFF', // we don't use spring
             '-Xep:UnnecessaryMethodReference:WARN',
             // '-Xep:UnnecessaryParentheses:OFF',
             '-Xep:UnrecognisedJavadocTag:WARN',
@@ -476,11 +476,11 @@ allprojects { prj ->
             '-Xep:UnusedNestedClass:WARN',
             // '-Xep:UnusedTypeParameter:OFF',
             // '-Xep:UnusedVariable:OFF',
-            '-Xep:UseBinds:WARN',
+            // '-Xep:UseBinds:OFF', // we don't use this annotation
             // '-Xep:UseCorrectAssertInTests:OFF',
             '-Xep:VariableNameSameAsType:WARN',
             // '-Xep:WaitNotInLoop:OFF',
-            '-Xep:WakelockReleasedDangerously:WARN',
+            // '-Xep:WakelockReleasedDangerously:OFF', // we don't use android
             '-Xep:WithSignatureDiscouraged:WARN',
         ]
       }

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -295,9 +295,9 @@ allprojects { prj ->
             // '-Xep:DefaultPackage:OFF',
             '-Xep:DeprecatedVariable:WARN',
             // '-Xep:DirectInvocationOnMock:OFF', // we don't use mocking libraries
-            '-Xep:DistinctVarargsChecker:WARN',
+            // '-Xep:DistinctVarargsChecker:OFF', // we don't use google collections
             // '-Xep:DoNotCallSuggester:OFF',
-            '-Xep:DoNotClaimAnnotations:WARN',
+            // '-Xep:DoNotClaimAnnotations:OFF', // we don't use annotation processors
             // '-Xep:DoNotMockAutoValue:OFF', // we don't use autovalue
             // '-Xep:DoubleCheckedLocking:OFF',
             '-Xep:EmptyBlockTag:WARN',
@@ -418,7 +418,7 @@ allprojects { prj ->
             '-Xep:OverrideThrowableToString:WARN',
             '-Xep:Overrides:WARN',
             // '-Xep:OverridesGuiceInjectableMethod:OFF', // we don't use guice
-            '-Xep:ParameterName:WARN',
+            // '-Xep:ParameterName:OFF', // we don't pass parameters with comments in this way
             // '-Xep:PreconditionsCheckNotNullRepeated:OFF', // we don't use guava
             '-Xep:PrimitiveAtomicReference:WARN',
             // '-Xep:ProtectedMembersInFinalClass:OFF', // we don't use protobuf
@@ -438,10 +438,10 @@ allprojects { prj ->
             // '-Xep:StaticAssignmentInConstructor:OFF',
             // '-Xep:StaticAssignmentOfThrowable:OFF',
             // '-Xep:StaticGuardedByInstance:OFF',
-            '-Xep:StaticMockMember:WARN',
+            // '-Xep:StaticMockMember:OFF', // we don't use mock libraries
             // '-Xep:StreamResourceLeak:OFF',
             '-Xep:StreamToIterable:WARN',
-            '-Xep:StringSplitter:OFF',
+            // '-Xep:StringSplitter:OFF',
             // '-Xep:SwigMemoryLeak:OFF', // we don't use swig
             // '-Xep:SynchronizeOnNonFinalField:OFF',
             // '-Xep:ThreadJoinLoop:OFF',
@@ -454,7 +454,7 @@ allprojects { prj ->
             // '-Xep:TruthConstantAsserts:OFF', // we don't use truth
             // '-Xep:TruthGetOrDefault:OFF', // we don't use truth
             // '-Xep:TruthIncompatibleType:OFF', // we don't use truth
-            '-Xep:TypeEquals:WARN',
+            // '-Xep:TypeEquals:OFF', // we don't use this internal javac api
             '-Xep:TypeNameShadowing:WARN',
             // '-Xep:TypeParameterShadowing:OFF',
             // '-Xep:TypeParameterUnusedInFormals:OFF',
@@ -469,7 +469,7 @@ allprojects { prj ->
             '-Xep:UnnecessaryMethodReference:WARN',
             // '-Xep:UnnecessaryParentheses:OFF',
             '-Xep:UnrecognisedJavadocTag:WARN',
-            '-Xep:UnsafeFinalization:WARN',
+            // '-Xep:UnsafeFinalization:OFF', // we don't use finalizers, deprecated for removal, fails build
             '-Xep:UnsafeReflectiveConstructionCast:WARN',
             // '-Xep:UnsynchronizedOverridesSynchronized:OFF',
             // '-Xep:UnusedMethod:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -414,7 +414,7 @@ allprojects { prj ->
             '-Xep:OptionalMapToOptional:WARN',
             '-Xep:OptionalNotPresent:WARN',
             '-Xep:OrphanedFormatString:WARN',
-            '-Xep:OutlineNone:WARN',
+            // '-Xep:OutlineNone:OFF', // we don't use gwt
             '-Xep:OverrideThrowableToString:WARN',
             '-Xep:Overrides:WARN',
             // '-Xep:OverridesGuiceInjectableMethod:OFF', // we don't use guice

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -113,10 +113,10 @@ allprojects { prj ->
             // '-Xep:DoNotMock:OFF', // we don't use mocking libraries
             // '-Xep:DoubleBraceInitialization:OFF',
             '-Xep:DuplicateMapKeys:ERROR',
-            '-Xep:DurationFrom:ERROR',
-            '-Xep:DurationGetTemporalUnit:ERROR',
-            '-Xep:DurationTemporalUnit:ERROR',
-            '-Xep:DurationToLongTimeUnit:ERROR',
+            // '-Xep:DurationFrom:OFF', // we don't use Duration.from()
+            // '-Xep:DurationGetTemporalUnit:OFF', // we don't use Duration.get()
+            // '-Xep:DurationTemporalUnit:OFF', // we don't use Duration.of() etc
+            // '-Xep:DurationToLongTimeUnit:OFF', // we don't use TimeUnit.convert Duration, etc
             // '-Xep:EmptyTopLevelDeclaration:OFF',
             '-Xep:EqualsHashCode:ERROR',
             '-Xep:EqualsNaN:ERROR',
@@ -129,7 +129,7 @@ allprojects { prj ->
             // '-Xep:ForOverride:OFF', // we don't use this annotation
             // '-Xep:FormatString:OFF',
             // '-Xep:FormatStringAnnotation:OFF', // we don't use this annotation
-            '-Xep:FromTemporalAccessor:ERROR',
+            // '-Xep:FromTemporalAccessor:OFF', // we don't use .from(LocalDate) etc
             '-Xep:FunctionalInterfaceMethodChanged:ERROR',
             '-Xep:FuturesGetCheckedIllegalExceptionType:ERROR',
             '-Xep:FuzzyEqualsShouldNotBeUsedInEqualsMethod:ERROR',
@@ -153,11 +153,11 @@ allprojects { prj ->
             // '-Xep:InjectMoreThanOneScopeAnnotationOnClass:OFF', // we don't use this annotation
             // '-Xep:InjectOnMemberAndConstructor:OFF', // we don't use this annotation
             // '-Xep:InlineMeValidator:OFF', // we don't use this annotation
-            '-Xep:InstantTemporalUnit:ERROR',
-            '-Xep:InvalidJavaTimeConstant:ERROR',
+            // '-Xep:InstantTemporalUnit:OFF', // we don't use Instant apis with strange temporal units
+            // '-Xep:InvalidJavaTimeConstant:OFF', // we don't use impacted java.time classes (Month, etc)
             // '-Xep:InvalidPatternSyntax:OFF',
-            '-Xep:InvalidTimeZoneID:ERROR',
-            '-Xep:InvalidZoneId:ERROR',
+            // '-Xep:InvalidTimeZoneID:OFF', // we don't use getTimeZone with constant IDs except UTC/GMT
+            // '-Xep:InvalidZoneId:OFF', // we don't use ZoneId.of
             '-Xep:IsInstanceIncompatibleType:ERROR',
             '-Xep:IsInstanceOfClass:ERROR',
             // '-Xep:IsLoggableTagLength:OFF', // we don't use android
@@ -172,7 +172,7 @@ allprojects { prj ->
             // '-Xep:JavaxInjectOnAbstractMethod:OFF', // we don't this annotation
             // '-Xep:JodaToSelf:OFF', // we don't use joda-time
             // '-Xep:LiteByteStringUtf8:OFF', // we don't use protobuf
-            '-Xep:LocalDateTemporalAmount:ERROR',
+            // '-Xep:LocalDateTemporalAmount:OFF', // we don't use LocalDate math
             '-Xep:LockOnBoxedPrimitive:ERROR',
             '-Xep:LoopConditionChecker:ERROR',
             '-Xep:LossyPrimitiveCompare:ERROR',
@@ -181,8 +181,8 @@ allprojects { prj ->
             // '-Xep:MisplacedScopeAnnotations:OFF', // we don't use this annotation
             // '-Xep:MissingSuperCall:OFF', // we don't use this annotation
             // '-Xep:MissingTestCall:OFF', // we don't use guava
-            // '-Xep:MisusedDayOfYear:OFF',
-            '-Xep:MisusedWeekYear:ERROR',
+            // '-Xep:MisusedDayOfYear:OFF', // we don't use date patterns
+            // '-Xep:MisusedWeekYear:OFF', // we don't use date patterns
             // '-Xep:MixedDescriptors:OFF', // we don't use protobuf
             // '-Xep:MockitoUsage:OFF', // we don't use mockito
             '-Xep:ModifyingCollectionWithItself:ERROR',
@@ -204,9 +204,9 @@ allprojects { prj ->
             '-Xep:PackageInfo:ERROR',
             '-Xep:ParametersButNotParameterized:ERROR',
             // '-Xep:ParcelableCreator:OFF', // we don't use android
-            '-Xep:PeriodFrom:ERROR',
-            '-Xep:PeriodGetTemporalUnit:ERROR',
-            '-Xep:PeriodTimeMath:ERROR',
+            // '-Xep:PeriodFrom:OFF', // we don't use Period
+            // '-Xep:PeriodGetTemporalUnit:OFF', // we don't use Period
+            // '-Xep:PeriodTimeMath:OFF', // we don't use Period
             // '-Xep:PreconditionsInvalidPlaceholder:OFF', // we don't use guava
             // '-Xep:PrivateSecurityContractProtoAccess:OFF', // we don't use protobuf
             // '-Xep:ProtoBuilderReturnValueIgnored:OFF', // we don't use protobuf
@@ -230,7 +230,7 @@ allprojects { prj ->
             '-Xep:StringBuilderInitWithChar:ERROR',
             '-Xep:SubstringOfZero:ERROR',
             '-Xep:SuppressWarningsDeprecated:ERROR',
-            '-Xep:TemporalAccessorGetChronoField:ERROR',
+            // '-Xep:TemporalAccessorGetChronoField:OFF', // we don't use TemporalAccessor.get
             '-Xep:TestParametersNotInitialized:ERROR',
             // '-Xep:TheoryButNoTheories:OFF', // we don't use junit theory apis/runner
             '-Xep:ThrowIfUncheckedKnownChecked:ERROR',
@@ -249,7 +249,7 @@ allprojects { prj ->
             '-Xep:VarTypeName:ERROR',
             // '-Xep:WrongOneof:OFF', // we don't use protobuf
             '-Xep:XorPower:ERROR',
-            '-Xep:ZoneIdOfZ:ERROR',
+            // '-Xep:ZoneIdOfZ:OFF', // we don't use ZoneId.of
 
             // On by Default : WARNING
 
@@ -276,7 +276,7 @@ allprojects { prj ->
             // '-Xep:BugPatternNaming:OFF', // we don't use this annotation
             // '-Xep:ByteBufferBackingArray:OFF',
             // '-Xep:CacheLoaderNull:OFF', // we don't use guava
-            '-Xep:CanonicalDuration:WARN',
+            // '-Xep:CanonicalDuration:OFF', // barely use Duration.of (one test), just a style thing
             // '-Xep:CatchAndPrintStackTrace:OFF',
             // '-Xep:CatchFail:OFF',
             // '-Xep:ChainedAssertionLosesContext:OFF', // we don't use truth
@@ -290,7 +290,7 @@ allprojects { prj ->
             '-Xep:CompareToZero:WARN',
             // '-Xep:ComplexBooleanConstant:OFF',
             '-Xep:DateChecker:WARN',
-            '-Xep:DateFormatConstant:WARN',
+            // '-Xep:DateFormatConstant:OFF', // we don't use Date setters
             // '-Xep:DefaultCharset:OFF', // we have forbiddenapis for that
             // '-Xep:DefaultPackage:OFF',
             '-Xep:DeprecatedVariable:WARN',
@@ -352,15 +352,15 @@ allprojects { prj ->
             // '-Xep:JUnit3FloatingPointComparisonWithoutDelta:OFF', // we don't use junit3
             '-Xep:JUnit4ClassUsedInJUnit3:WARN',
             '-Xep:JUnitAmbiguousTestClass:WARN',
-            '-Xep:JavaDurationGetSecondsGetNano:WARN',
-            '-Xep:JavaDurationWithNanos:WARN',
-            '-Xep:JavaDurationWithSeconds:WARN',
-            '-Xep:JavaInstantGetSecondsGetNano:WARN',
+            // '-Xep:JavaDurationGetSecondsGetNano:OFF', // we don't use these Duration methods
+            // '-Xep:JavaDurationWithNanos:OFF', // we don't use these Duration methods
+            // '-Xep:JavaDurationWithSeconds:OFF', // we don't use these Duration methods
+            // '-Xep:JavaInstantGetSecondsGetNano:OFF', // we don't use these Instant methods
             // '-Xep:JavaLangClash:OFF',
-            '-Xep:JavaLocalDateTimeGetNano:WARN',
-            '-Xep:JavaLocalTimeGetNano:WARN',
-            '-Xep:JavaPeriodGetDays:WARN',
-            '-Xep:JavaTimeDefaultTimeZone:WARN',
+            // '-Xep:JavaLocalDateTimeGetNano:OFF', // we don't use LocalDateTime
+            // '-Xep:JavaLocalTimeGetNano:OFF', // we don't use LocalTime
+            // '-Xep:JavaPeriodGetDays:OFF', // we don't use Period
+            // '-Xep:JavaTimeDefaultTimeZone:OFF', // forbidden-apis checks this
             // '-Xep:JavaUtilDate:OFF',
             // '-Xep:JavaxInjectOnFinalField:OFF', // we don't use this annotation
             // '-Xep:JdkObsolete:OFF',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -160,7 +160,7 @@ allprojects { prj ->
             '-Xep:InvalidZoneId:ERROR',
             '-Xep:IsInstanceIncompatibleType:ERROR',
             '-Xep:IsInstanceOfClass:ERROR',
-            '-Xep:IsLoggableTagLength:ERROR',
+            // '-Xep:IsLoggableTagLength:OFF', // we don't use android
             // '-Xep:JUnit3TestNotRun:OFF', // we don't use junit3
             '-Xep:JUnit4ClassAnnotationNonStatic:ERROR',
             '-Xep:JUnit4SetUpNotRun:ERROR',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -232,7 +232,7 @@ allprojects { prj ->
             '-Xep:SuppressWarningsDeprecated:ERROR',
             '-Xep:TemporalAccessorGetChronoField:ERROR',
             '-Xep:TestParametersNotInitialized:ERROR',
-            '-Xep:TheoryButNoTheories:ERROR',
+            // '-Xep:TheoryButNoTheories:OFF', // we don't use junit theory apis/runner
             '-Xep:ThrowIfUncheckedKnownChecked:ERROR',
             // '-Xep:ThrowNull:OFF',
             '-Xep:TreeToString:ERROR',

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -78,23 +78,23 @@ allprojects { prj ->
 
             // '-Xep:AlwaysThrows:OFF', // we don't use google collections
             // '-Xep:AndroidInjectionBeforeSuper:OFF', // we don't use android
-            // '-Xep:ArrayEquals:OFF',
+            // '-Xep:ArrayEquals:OFF', // TODO: there are problems
             '-Xep:ArrayFillIncompatibleType:ERROR',
             // '-Xep:ArrayHashCode:OFF',
-            // '-Xep:ArrayToString:OFF',
+            // '-Xep:ArrayToString:OFF', // TODO: there are problems
             '-Xep:ArraysAsListPrimitiveArray:ERROR',
             '-Xep:AsyncCallableReturnsNull:ERROR',
             // '-Xep:AsyncFunctionReturnsNull:OFF', // we don't use guava
             // '-Xep:AutoValueBuilderDefaultsInConstructor:OFF', // we don't use autovalue
             // '-Xep:AutoValueConstructorOrderChecker:OFF', // we don't use autovalue
             '-Xep:BadAnnotationImplementation:ERROR',
-            // '-Xep:BadShiftAmount:OFF',
+            // '-Xep:BadShiftAmount:OFF', // TODO: there are problems
             // '-Xep:BanJNDI:OFF', // implemented with forbidden APIs instead
             '-Xep:BoxedPrimitiveEquality:ERROR',
             // '-Xep:BundleDeserializationCast:OFF', // we don't use android
             '-Xep:ChainingConstructorIgnoresParameter:ERROR',
             // '-Xep:CheckNotNullMultipleTimes:OFF', // we don't use guava
-            // '-Xep:CheckReturnValue:oFF', // we don't use these annotations
+            // '-Xep:CheckReturnValue:OFF', // we don't use these annotations
             '-Xep:CollectionToArraySafeParameter:ERROR',
             // '-Xep:ComparableType:OFF',
             '-Xep:ComparingThisWithNull:ERROR',
@@ -109,15 +109,15 @@ allprojects { prj ->
             '-Xep:DeadException:ERROR',
             '-Xep:DeadThread:ERROR',
             '-Xep:DiscardedPostfixExpression:ERROR',
-            // '-Xep:DoNotCall:OFF',
+            // '-Xep:DoNotCall:OFF', // we don't use this annotation
             // '-Xep:DoNotMock:OFF', // we don't use mocking libraries
-            // '-Xep:DoubleBraceInitialization:OFF',
+            // '-Xep:DoubleBraceInitialization:OFF', // we don't use guava
             '-Xep:DuplicateMapKeys:ERROR',
             // '-Xep:DurationFrom:OFF', // we don't use Duration.from()
             // '-Xep:DurationGetTemporalUnit:OFF', // we don't use Duration.get()
             // '-Xep:DurationTemporalUnit:OFF', // we don't use Duration.of() etc
             // '-Xep:DurationToLongTimeUnit:OFF', // we don't use TimeUnit.convert Duration, etc
-            // '-Xep:EmptyTopLevelDeclaration:OFF',
+            // '-Xep:EmptyTopLevelDeclaration:OFF', // noisy
             '-Xep:EqualsHashCode:ERROR',
             '-Xep:EqualsNaN:ERROR',
             '-Xep:EqualsNull:ERROR',
@@ -165,7 +165,7 @@ allprojects { prj ->
             '-Xep:JUnit4ClassAnnotationNonStatic:ERROR',
             // '-Xep:JUnit4SetUpNotRun:OFF', // LuceneTestCase takes care
             // '-Xep:JUnit4TearDownNotRun:OFF', // LuceneTestCase takes care
-            // '-Xep:JUnit4TestNotRun:OFF',
+            // '-Xep:JUnit4TestNotRun:OFF', // noisy
             '-Xep:JUnit4TestsNotRunWithinEnclosed:ERROR',
             '-Xep:JUnitAssertSameCheck:ERROR',
             '-Xep:JUnitParameterMethodNotFound:ERROR',
@@ -220,8 +220,8 @@ allprojects { prj ->
             // '-Xep:RectIntersectReturnValueIgnored:OFF', // we don't use android
             // '-Xep:RequiredModifiers:OFF', // we don't use this annotation
             // '-Xep:RestrictedApiChecker:OFF', // we don't use this annotation
-            // '-Xep:ReturnValueIgnored:OFF',
-            // '-Xep:SelfAssignment:OFF',
+            // '-Xep:ReturnValueIgnored:OFF', // noisy
+            // '-Xep:SelfAssignment:OFF', // TODO: there are problems
             '-Xep:SelfComparison:ERROR',
             '-Xep:SelfEquals:ERROR',
             '-Xep:ShouldHaveEvenArgs:ERROR',
@@ -234,13 +234,13 @@ allprojects { prj ->
             '-Xep:TestParametersNotInitialized:ERROR',
             // '-Xep:TheoryButNoTheories:OFF', // we don't use junit theory apis/runner
             '-Xep:ThrowIfUncheckedKnownChecked:ERROR',
-            // '-Xep:ThrowNull:OFF',
+            // '-Xep:ThrowNull:OFF', // noisy (LuceneTestCase)
             '-Xep:TreeToString:ERROR',
             // '-Xep:TruthSelfEquals:OFF', // we don't use truth
             // '-Xep:TryFailThrowable:OFF',
             '-Xep:TypeParameterQualifier:ERROR',
             '-Xep:UnicodeDirectionalityCharacters:ERROR',
-            // '-Xep:UnicodeInCode:OFF',
+            // '-Xep:UnicodeInCode:OFF', // noisy (spatial3d)
             '-Xep:UnnecessaryCheckNotNull:ERROR',
             '-Xep:UnnecessaryTypeArgument:ERROR',
             '-Xep:UnsafeWildcard:ERROR',
@@ -253,22 +253,22 @@ allprojects { prj ->
 
             // On by Default : WARNING
 
-            // '-Xep:AlmostJavadoc:OFF',
-            // '-Xep:AlreadyChecked:OFF',
+            // '-Xep:AlmostJavadoc:OFF', // TODO: there are problems
+            // '-Xep:AlreadyChecked:OFF', // TODO: there are problems
             // '-Xep:AmbiguousMethodReference:OFF',
             // '-Xep:AnnotateFormatMethod:OFF', // we don't use this annotation
-            // '-Xep:ArgumentSelectionDefectChecker:OFF',
-            // '-Xep:ArrayAsKeyOfSetOrMap:OFF',
+            // '-Xep:ArgumentSelectionDefectChecker:OFF', // noisy
+            // '-Xep:ArrayAsKeyOfSetOrMap:OFF', // TODO: there are problems
             '-Xep:AssertEqualsArgumentOrderChecker:WARN',
             '-Xep:AssertThrowsMultipleStatements:WARN',
-            // '-Xep:AssertionFailureIgnored:OFF',
+            // '-Xep:AssertionFailureIgnored:OFF', // TODO: there are problems
             // '-Xep:AssistedInjectAndInjectOnSameConstructor:OFF', // we don't use this annotation
             // '-Xep:AutoValueFinalMethods:OFF', // we don't use autovalue
             // '-Xep:AutoValueImmutableFields:OFF', // we don't use autovalue
             // '-Xep:AutoValueSubclassLeaked:OFF', // we don't use autovalue
             '-Xep:BadComparable:WARN',
-            // '-Xep:BadImport:OFF',
-            // '-Xep:BadInstanceof:OFF',
+            // '-Xep:BadImport:OFF', // TODO: there are problems
+            // '-Xep:BadInstanceof:OFF', // TODO: there are problems
             '-Xep:BareDotMetacharacter:WARN',
             '-Xep:BigDecimalEquals:WARN',
             '-Xep:BigDecimalLiteralDouble:WARN',
@@ -277,18 +277,18 @@ allprojects { prj ->
             // '-Xep:ByteBufferBackingArray:OFF',
             // '-Xep:CacheLoaderNull:OFF', // we don't use guava
             // '-Xep:CanonicalDuration:OFF', // barely use Duration.of (one test), just a style thing
-            // '-Xep:CatchAndPrintStackTrace:OFF',
-            // '-Xep:CatchFail:OFF',
+            // '-Xep:CatchAndPrintStackTrace:OFF', // noisy
+            // '-Xep:CatchFail:OFF', // TODO: there are problems
             // '-Xep:ChainedAssertionLosesContext:OFF', // we don't use truth
-            // '-Xep:CharacterGetNumericValue:OFF',
-            // '-Xep:ClassCanBeStatic:OFF',
+            // '-Xep:CharacterGetNumericValue:OFF', // noisy
+            // '-Xep:ClassCanBeStatic:OFF', // noisy
             '-Xep:ClassNewInstance:WARN',
             // '-Xep:CloseableProvides:OFF', // we don't use this annotation
-            // '-Xep:CollectionUndefinedEquality:OFF',
+            // '-Xep:CollectionUndefinedEquality:OFF', // TODO: there are problems
             '-Xep:CollectorShouldNotUseState:WARN',
             '-Xep:ComparableAndComparator:WARN',
             '-Xep:CompareToZero:WARN',
-            // '-Xep:ComplexBooleanConstant:OFF',
+            // '-Xep:ComplexBooleanConstant:OFF', // TODO: there are problems
             '-Xep:DateChecker:WARN',
             // '-Xep:DateFormatConstant:OFF', // we don't use Date setters
             // '-Xep:DefaultCharset:OFF', // we have forbiddenapis for that
@@ -296,39 +296,39 @@ allprojects { prj ->
             '-Xep:DeprecatedVariable:WARN',
             // '-Xep:DirectInvocationOnMock:OFF', // we don't use mocking libraries
             // '-Xep:DistinctVarargsChecker:OFF', // we don't use google collections
-            // '-Xep:DoNotCallSuggester:OFF',
+            // '-Xep:DoNotCallSuggester:OFF', // we don't use this annotation
             // '-Xep:DoNotClaimAnnotations:OFF', // we don't use annotation processors
             // '-Xep:DoNotMockAutoValue:OFF', // we don't use autovalue
-            // '-Xep:DoubleCheckedLocking:OFF',
+            // '-Xep:DoubleCheckedLocking:OFF', // TODO: there are problems
             '-Xep:EmptyBlockTag:WARN',
-            // '-Xep:EmptyCatch:OFF',
+            // '-Xep:EmptyCatch:OFF', // ECJ takes care
             // '-Xep:EmptySetMultibindingContributions:OFF', // we don't use this annotation
-            // '-Xep:EqualsGetClass:OFF',
+            // '-Xep:EqualsGetClass:OFF', // noisy
             // '-Xep:EqualsIncompatibleType:OFF',
-            // '-Xep:EqualsUnsafeCast:OFF',
+            // '-Xep:EqualsUnsafeCast:OFF', // noisy
             '-Xep:EqualsUsingHashCode:WARN',
             '-Xep:ErroneousBitwiseExpression:WARN',
             '-Xep:ErroneousThreadPoolConstructorChecker:WARN',
             // '-Xep:EscapedEntity:OFF',
-            // '-Xep:ExtendingJUnitAssert:OFF',
-            // '-Xep:ExtendsObject:OFF',
-            // '-Xep:FallThrough:OFF',
-            // '-Xep:Finally:OFF',
+            // '-Xep:ExtendingJUnitAssert:OFF', // noisy
+            // '-Xep:ExtendsObject:OFF', // TODO: there are problems
+            // '-Xep:FallThrough:OFF', // TODO: there are problems
+            // '-Xep:Finally:OFF', // TODO: there are problems
             '-Xep:FloatCast:WARN',
             '-Xep:FloatingPointAssertionWithinEpsilon:WARN',
-            // '-Xep:FloatingPointLiteralPrecision:OFF',
+            // '-Xep:FloatingPointLiteralPrecision:OFF', // TODO: there are problems
             // '-Xep:FloggerArgumentToString:OFF', // we don't use flogger
             // '-Xep:FloggerStringConcatenation:OFF', // we don't use flogger
             // '-Xep:FragmentInjection:OFF', // we don't use android
             // '-Xep:FragmentNotInstantiable:OFF', // we don't use android
-            // '-Xep:FutureReturnValueIgnored:OFF',
+            // '-Xep:FutureReturnValueIgnored:OFF', // TODO: there are problems
             '-Xep:GetClassOnEnum:WARN',
-            // '-Xep:HidingField:OFF',
-            // '-Xep:IdentityHashMapUsage:OFF',
+            // '-Xep:HidingField:OFF', // noisy
+            // '-Xep:IdentityHashMapUsage:OFF', // noisy
             // '-Xep:ImmutableAnnotationChecker:OFF', // we don't use this annotation
-            // '-Xep:ImmutableEnumChecker:OFF',
-            // '-Xep:InconsistentCapitalization:OFF',
-            // '-Xep:InconsistentHashCode:OFF',
+            // '-Xep:ImmutableEnumChecker:OFF', // noisy
+            // '-Xep:InconsistentCapitalization:OFF', // TODO: there are problems
+            // '-Xep:InconsistentHashCode:OFF', // noisy
             '-Xep:IncorrectMainMethod:WARN',
             '-Xep:IncrementInForLoopAndHeader:WARN',
             '-Xep:InheritDoc:WARN',
@@ -336,16 +336,16 @@ allprojects { prj ->
             // '-Xep:InjectOnConstructorOfAbstractClass:OFF', // we don't use this annotation
             // '-Xep:InjectScopeAnnotationOnInterfaceOrAbstractClass:OFF', // we don't use this annotation
             // '-Xep:InjectedConstructorAnnotations:OFF', // we don't use this annotation
-            // '-Xep:InlineFormatString:OFF',
+            // '-Xep:InlineFormatString:OFF', // noisy
             // '-Xep:InlineMeInliner:OFF', // we don't use this annotation
-            // '-Xep:InlineMeSuggester:OFF',
+            // '-Xep:InlineMeSuggester:OFF', // we don't use this annotation
             // '-Xep:InputStreamSlowMultibyteRead:OFF',
             '-Xep:InstanceOfAndCastMatchWrongType:WARN',
-            // '-Xep:IntLongMath:OFF',
-            // '-Xep:InvalidBlockTag:OFF',
-            // '-Xep:InvalidInlineTag:OFF',
+            // '-Xep:IntLongMath:OFF', // noisy
+            // '-Xep:InvalidBlockTag:OFF', // noisy (e.g. lucene.experimental)
+            // '-Xep:InvalidInlineTag:OFF', // TODO: there are problems
             '-Xep:InvalidLink:WARN',
-            // '-Xep:InvalidParam:OFF',
+            // '-Xep:InvalidParam:OFF', // TODO: there are problems
             '-Xep:InvalidThrows:WARN',
             '-Xep:InvalidThrowsLink:WARN',
             '-Xep:IterableAndIterator:WARN',
@@ -356,14 +356,14 @@ allprojects { prj ->
             // '-Xep:JavaDurationWithNanos:OFF', // we don't use these Duration methods
             // '-Xep:JavaDurationWithSeconds:OFF', // we don't use these Duration methods
             // '-Xep:JavaInstantGetSecondsGetNano:OFF', // we don't use these Instant methods
-            // '-Xep:JavaLangClash:OFF',
+            // '-Xep:JavaLangClash:OFF', // TODO: there are problems
             // '-Xep:JavaLocalDateTimeGetNano:OFF', // we don't use LocalDateTime
             // '-Xep:JavaLocalTimeGetNano:OFF', // we don't use LocalTime
             // '-Xep:JavaPeriodGetDays:OFF', // we don't use Period
             // '-Xep:JavaTimeDefaultTimeZone:OFF', // forbidden-apis checks this
-            // '-Xep:JavaUtilDate:OFF',
+            // '-Xep:JavaUtilDate:OFF', // noisy
             // '-Xep:JavaxInjectOnFinalField:OFF', // we don't use this annotation
-            // '-Xep:JdkObsolete:OFF',
+            // '-Xep:JdkObsolete:OFF', // noisy
             // '-Xep:JodaConstructors:OFF', // we don't use joda-time
             // '-Xep:JodaDateTimeConstants:OFF', // we don't use joda-time
             // '-Xep:JodaDurationWithMillis:OFF', // we don't use joda-time
@@ -374,33 +374,33 @@ allprojects { prj ->
             // '-Xep:JodaWithDurationAddedLong:OFF', // we don't use joda-time
             // '-Xep:LiteEnumValueOf:OFF', // we don't use protobuf
             // '-Xep:LiteProtoToString:OFF', // we don't use protobuf
-            // '-Xep:LockNotBeforeTry:OFF',
-            // '-Xep:LogicalAssignment:OFF',
-            // '-Xep:LongDoubleConversion:OFF',
+            // '-Xep:LockNotBeforeTry:OFF', // TODO: there are problems
+            // '-Xep:LogicalAssignment:OFF', // TODO: there are problems
+            // '-Xep:LongDoubleConversion:OFF', // TODO: there are problems
             '-Xep:LongFloatConversion:WARN',
             '-Xep:LoopOverCharArray:WARN',
             '-Xep:MalformedInlineTag:WARN',
-            // '-Xep:MathAbsoluteRandom:OFF',
+            // '-Xep:MathAbsoluteRandom:OFF', // TODO: there are problems
             // '-Xep:MemoizeConstantVisitorStateLookups:OFF', // we don't use this class
             // '-Xep:MissingCasesInEnumSwitch:OFF', // redundant with ECJ incompleteEnumSwitch/missingEnumCaseDespiteDefault
-            // '-Xep:MissingFail:OFF',
+            // '-Xep:MissingFail:OFF', // TODO: there are problems
             '-Xep:MissingImplementsComparable:WARN',
-            // '-Xep:MissingOverride:OFF',
-            // '-Xep:MissingSummary:OFF',
-            // '-Xep:MixedMutabilityReturnType:OFF',
+            // '-Xep:MissingOverride:OFF', // ECJ takes care of this
+            // '-Xep:MissingSummary:OFF', // TODO: there are problems
+            // '-Xep:MixedMutabilityReturnType:OFF', // noisy
             // '-Xep:MockNotUsedInProduction:OFF', // we don't use mocking libraries
-            // '-Xep:ModifiedButNotUsed:OFF',
+            // '-Xep:ModifiedButNotUsed:OFF', // TODO: there are problems
             '-Xep:ModifyCollectionInEnhancedForLoop:WARN',
             '-Xep:ModifySourceCollectionInStream:WARN',
             '-Xep:MultipleParallelOrSequentialCalls:WARN',
             '-Xep:MultipleUnaryOperatorsInMethodCall:WARN',
-            // '-Xep:MutablePublicArray:OFF',
+            // '-Xep:MutablePublicArray:OFF', // TODO: there are problems
             '-Xep:NarrowCalculation:WARN',
-            // '-Xep:NarrowingCompoundAssignment:OFF',
+            // '-Xep:NarrowingCompoundAssignment:OFF', // noisy
             '-Xep:NegativeCharLiteral:WARN',
             '-Xep:NestedInstanceOfConditions:WARN',
-            // '-Xep:NonAtomicVolatileUpdate:OFF',
-            // '-Xep:NonCanonicalType:OFF',
+            // '-Xep:NonAtomicVolatileUpdate:OFF', // TODO: there are problems
+            // '-Xep:NonCanonicalType:OFF', // noisy
             '-Xep:NonOverridingEquals:WARN',
             '-Xep:NullOptional:WARN',
             // '-Xep:NullableConstructor:OFF', // we don't use this annotation
@@ -408,9 +408,9 @@ allprojects { prj ->
             // '-Xep:NullablePrimitiveArray:OFF', // we don't use this annotation
             // '-Xep:NullableVoid:OFF', // we don't use this annotation
             '-Xep:ObjectEqualsForPrimitives:WARN',
-            // '-Xep:ObjectToString:OFF',
-            // '-Xep:ObjectsHashCodePrimitive:OFF',
-            // '-Xep:OperatorPrecedence:OFF',
+            // '-Xep:ObjectToString:OFF', // TODO: there are problems
+            // '-Xep:ObjectsHashCodePrimitive:OFF', // TODO: there are problems
+            // '-Xep:OperatorPrecedence:OFF', // noisy
             '-Xep:OptionalMapToOptional:WARN',
             '-Xep:OptionalNotPresent:WARN',
             '-Xep:OrphanedFormatString:WARN',
@@ -427,29 +427,29 @@ allprojects { prj ->
             // '-Xep:ProtoTimestampGetSecondsGetNano:OFF', // we don't use protobuf
             // '-Xep:QualifierOrScopeOnInjectMethod:OFF', // we don't use this annotation
             '-Xep:ReachabilityFenceUsage:WARN',
-            // '-Xep:ReferenceEquality:OFF',
+            // '-Xep:ReferenceEquality:OFF', // noisy
             '-Xep:RethrowReflectiveOperationExceptionAsLinkageError:WARN',
             '-Xep:ReturnFromVoid:WARN',
             // '-Xep:RobolectricShadowDirectlyOn:OFF', // we don't use robolectric
             // '-Xep:RxReturnValueIgnored:OFF', // we don't use rxjava
-            // '-Xep:SameNameButDifferent:OFF',
+            // '-Xep:SameNameButDifferent:OFF', // TODO: there are problems
             '-Xep:SelfAlwaysReturnsThis:WARN',
-            // '-Xep:ShortCircuitBoolean:OFF',
+            // '-Xep:ShortCircuitBoolean:OFF', // TODO: there are problems
             // '-Xep:StaticAssignmentInConstructor:OFF',
-            // '-Xep:StaticAssignmentOfThrowable:OFF',
+            // '-Xep:StaticAssignmentOfThrowable:OFF', // noisy
             // '-Xep:StaticGuardedByInstance:OFF',
             // '-Xep:StaticMockMember:OFF', // we don't use mock libraries
-            // '-Xep:StreamResourceLeak:OFF',
+            // '-Xep:StreamResourceLeak:OFF', // TODO: there are problems
             '-Xep:StreamToIterable:WARN',
-            // '-Xep:StringSplitter:OFF',
+            // '-Xep:StringSplitter:OFF', // noisy, can use forbidden-apis for this
             // '-Xep:SwigMemoryLeak:OFF', // we don't use swig
-            // '-Xep:SynchronizeOnNonFinalField:OFF',
+            // '-Xep:SynchronizeOnNonFinalField:OFF', // noisy
             // '-Xep:ThreadJoinLoop:OFF',
-            // '-Xep:ThreadLocalUsage:OFF',
-            // '-Xep:ThreadPriorityCheck:OFF',
+            // '-Xep:ThreadLocalUsage:OFF', // noisy
+            // '-Xep:ThreadPriorityCheck:OFF', // noisy, forbidden APIs can do this
             '-Xep:ThreeLetterTimeZoneID:WARN',
             '-Xep:TimeUnitConversionChecker:WARN',
-            // '-Xep:ToStringReturnsNull:OFF',
+            // '-Xep:ToStringReturnsNull:OFF', // TODO: there are problems
             // '-Xep:TruthAssertExpected:OFF', // we don't use truth
             // '-Xep:TruthConstantAsserts:OFF', // we don't use truth
             // '-Xep:TruthGetOrDefault:OFF', // we don't use truth
@@ -459,27 +459,27 @@ allprojects { prj ->
             // '-Xep:TypeParameterShadowing:OFF',
             // '-Xep:TypeParameterUnusedInFormals:OFF',
             '-Xep:URLEqualsHashCode:WARN',
-            // '-Xep:UndefinedEquals:OFF',
-            // '-Xep:UnescapedEntity:OFF',
-            // '-Xep:UnicodeEscape:OFF',
+            // '-Xep:UndefinedEquals:OFF', // TODO: there are problems
+            // '-Xep:UnescapedEntity:OFF', // TODO: there are problems
+            // '-Xep:UnicodeEscape:OFF', // noisy
             // '-Xep:UnnecessaryAssignment:OFF', // we don't use these annotations
-            // '-Xep:UnnecessaryLambda:OFF',
-            // '-Xep:UnnecessaryLongToIntConversion:OFF',
+            // '-Xep:UnnecessaryLambda:OFF', // TODO: there are problems
+            // '-Xep:UnnecessaryLongToIntConversion:OFF', // TODO: there are problems
             // '-Xep:UnnecessaryMethodInvocationMatcher:OFF', // we don't use spring
             '-Xep:UnnecessaryMethodReference:WARN',
-            // '-Xep:UnnecessaryParentheses:OFF',
+            // '-Xep:UnnecessaryParentheses:OFF', // noisy
             '-Xep:UnrecognisedJavadocTag:WARN',
             // '-Xep:UnsafeFinalization:OFF', // we don't use finalizers, deprecated for removal, fails build
             '-Xep:UnsafeReflectiveConstructionCast:WARN',
-            // '-Xep:UnsynchronizedOverridesSynchronized:OFF',
-            // '-Xep:UnusedMethod:OFF',
+            // '-Xep:UnsynchronizedOverridesSynchronized:OFF', // TODO: there are problems
+            // '-Xep:UnusedMethod:OFF', // TODO: there are problems
             '-Xep:UnusedNestedClass:WARN',
-            // '-Xep:UnusedTypeParameter:OFF',
-            // '-Xep:UnusedVariable:OFF',
+            // '-Xep:UnusedTypeParameter:OFF', // TODO: there are problems
+            // '-Xep:UnusedVariable:OFF', // noisy, can use ECJ
             // '-Xep:UseBinds:OFF', // we don't use this annotation
-            // '-Xep:UseCorrectAssertInTests:OFF',
+            // '-Xep:UseCorrectAssertInTests:OFF', // noisy
             '-Xep:VariableNameSameAsType:WARN',
-            // '-Xep:WaitNotInLoop:OFF',
+            // '-Xep:WaitNotInLoop:OFF', // TODO: there are problems
             // '-Xep:WakelockReleasedDangerously:OFF', // we don't use android
             // '-Xep:WithSignatureDiscouraged:OFF', // we aren't using this error-prone internal api
         ]

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -462,7 +462,7 @@ allprojects { prj ->
             // '-Xep:UndefinedEquals:OFF',
             // '-Xep:UnescapedEntity:OFF',
             // '-Xep:UnicodeEscape:OFF',
-            '-Xep:UnnecessaryAssignment:WARN',
+            // '-Xep:UnnecessaryAssignment:OFF', // we don't use these annotations
             // '-Xep:UnnecessaryLambda:OFF',
             // '-Xep:UnnecessaryLongToIntConversion:OFF',
             // '-Xep:UnnecessaryMethodInvocationMatcher:OFF', // we don't use spring

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -82,8 +82,8 @@ allprojects { prj ->
             '-Xep:ArrayFillIncompatibleType:ERROR',
             // '-Xep:ArrayHashCode:OFF',
             // '-Xep:ArrayToString:OFF', // TODO: there are problems
-            '-Xep:ArraysAsListPrimitiveArray:ERROR',
-            '-Xep:AsyncCallableReturnsNull:ERROR',
+            // '-Xep:ArraysAsListPrimitiveArray:OFF', // we don't use guava
+            // '-Xep:AsyncCallableReturnsNull:OFF', // we don't use guava
             // '-Xep:AsyncFunctionReturnsNull:OFF', // we don't use guava
             // '-Xep:AutoValueBuilderDefaultsInConstructor:OFF', // we don't use autovalue
             // '-Xep:AutoValueConstructorOrderChecker:OFF', // we don't use autovalue
@@ -224,18 +224,18 @@ allprojects { prj ->
             // '-Xep:SelfAssignment:OFF', // TODO: there are problems
             '-Xep:SelfComparison:ERROR',
             '-Xep:SelfEquals:ERROR',
-            '-Xep:ShouldHaveEvenArgs:ERROR',
+            // '-Xep:ShouldHaveEvenArgs:OFF', // we don't use truth
             '-Xep:SizeGreaterThanOrEqualsZero:ERROR',
             '-Xep:StreamToString:ERROR',
             '-Xep:StringBuilderInitWithChar:ERROR',
             '-Xep:SubstringOfZero:ERROR',
             '-Xep:SuppressWarningsDeprecated:ERROR',
             // '-Xep:TemporalAccessorGetChronoField:OFF', // we don't use TemporalAccessor.get
-            '-Xep:TestParametersNotInitialized:ERROR',
+            // '-Xep:TestParametersNotInitialized:OFF', // we don't use this annotation
             // '-Xep:TheoryButNoTheories:OFF', // we don't use junit theory apis/runner
-            '-Xep:ThrowIfUncheckedKnownChecked:ERROR',
+            // '-Xep:ThrowIfUncheckedKnownChecked:OFF', // we don't use this annotation
             // '-Xep:ThrowNull:OFF', // noisy (LuceneTestCase)
-            '-Xep:TreeToString:ERROR',
+            // '-Xep:TreeToString:OFF', // we don't use javac API
             // '-Xep:TruthSelfEquals:OFF', // we don't use truth
             // '-Xep:TryFailThrowable:OFF',
             '-Xep:TypeParameterQualifier:ERROR',

--- a/gradle/validation/forbidden-apis/defaults.all.txt
+++ b/gradle/validation/forbidden-apis/defaults.all.txt
@@ -54,3 +54,15 @@ java.lang.Double#<init>(**)
 @defaultMessage Java deserialization is unsafe when the data is untrusted. The java developer is powerless: no checks or casts help, exploitation can happen in places such as clinit or finalize!
 java.io.ObjectInputStream
 java.io.ObjectOutputStream
+
+@defaultMessage JNDI is RCE-in-a-box, avoid it.
+javax.naming.Context
+javax.management.remote.JMXConnectorFactory
+javax.management.remote.rmi.RMIConnector
+javax.naming.directory.InitialDirContext
+javax.naming.InitialContext
+javax.naming.spi.ContinuationContext
+javax.naming.spi.ContinuationDirContext
+javax.sql.rowset.spi.ProviderImpl
+javax.sql.rowset.spi.SyncFactory
+


### PR DESCRIPTION
These are easy/obvious ones to disable since we don't use the functionality at all: the checks are literally useless.

This gives some performance boost to the error-prone, although it is still pretty slow.