### PR TITLE
fix wrong serialization by ShapeDocValues

### DIFF
--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -375,7 +375,7 @@ allprojects { prj ->
             '-Xep:LiteEnumValueOf:WARN',
             '-Xep:LiteProtoToString:WARN',
             // '-Xep:LockNotBeforeTry:OFF',
-            // '-Xep:LogicalAssignment:OFF',
+            '-Xep:LogicalAssignment:WARN',
             // '-Xep:LongDoubleConversion:OFF',
             '-Xep:LongFloatConversion:WARN',
             '-Xep:LoopOverCharArray:WARN',

--- a/lucene/core/src/java/org/apache/lucene/document/ShapeDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/document/ShapeDocValues.java
@@ -550,7 +550,7 @@ abstract class ShapeDocValues {
       if (node.triangle.bc == true) {
         header |= 0x20;
       }
-      if (node.triangle.ca = true) {
+      if (node.triangle.ca == true) {
         header |= 0x40;
       }
 


### PR DESCRIPTION
Here's a fix, and also enabling the error-prone check. But I feel like some sort of testcase should have been failing here all along?

Closes #11973