### PR TITLE
fix use of wrong array equals() method in test, enable check

### DIFF
--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -78,7 +78,7 @@ allprojects { prj ->
 
             '-Xep:AlwaysThrows:ERROR',
             '-Xep:AndroidInjectionBeforeSuper:ERROR',
-            // '-Xep:ArrayEquals:OFF',
+            '-Xep:ArrayEquals:ERROR',
             '-Xep:ArrayFillIncompatibleType:ERROR',
             // '-Xep:ArrayHashCode:OFF',
             // '-Xep:ArrayToString:OFF',

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/TestSynonymGraphFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/TestSynonymGraphFilter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -1401,7 +1402,7 @@ public class TestSynonymGraphFilter extends BaseTokenStreamTestCase {
         for (int j = 0; j < synCount; j++) {
           OneSyn syn2 = syns.get(i);
           keepOrig |= syn2.keepOrig;
-          if (syn1.in.equals(syn2.in)) {
+          if (Arrays.equals(syn1.in, syn2.in)) {
             count += syn2.out.length;
           }
         }


### PR DESCRIPTION
In this test, `in` member is always a fresh `char []`: test uses the wrong equals.

```
/home/rmuir/workspace/lucene/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/TestSynonymGraphFilter.java:1404: error: [ArrayEquals] Reference equality used to compare arrays
          if (syn1.in.equals(syn2.in)) {
                            ^
    (see https://errorprone.info/bugpattern/ArrayEquals)
  Did you mean 'if (Arrays.equals(syn1.in, syn2.in)) {'?
```