### PR TITLE
fix bad shift amounts and enable check

### DIFF
--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -88,7 +88,7 @@ allprojects { prj ->
             '-Xep:AutoValueBuilderDefaultsInConstructor:ERROR',
             '-Xep:AutoValueConstructorOrderChecker:ERROR',
             '-Xep:BadAnnotationImplementation:ERROR',
-            // '-Xep:BadShiftAmount:OFF',
+            '-Xep:BadShiftAmount:ERROR',
             '-Xep:BanJNDI:ERROR',
             '-Xep:BoxedPrimitiveEquality:ERROR',
             '-Xep:BundleDeserializationCast:ERROR',

--- a/lucene/core/src/test/org/apache/lucene/util/compress/LZ4TestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/compress/LZ4TestCase.java
@@ -243,7 +243,7 @@ public abstract class LZ4TestCase extends LuceneTestCase {
   }
 
   public void testIncompressibleRandom() throws IOException {
-    byte[] b = new byte[TestUtil.nextInt(random(), 1, 1 << 32)];
+    byte[] b = new byte[TestUtil.nextInt(random(), 1, 1 << 18)];
     random().nextBytes(b);
     doTest(b, newHashTable());
     doTestWithDictionary(b, newHashTable());

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
@@ -1931,7 +1931,7 @@ public class TestJoinUtil extends LuceneTestCase {
     document.add(new IntPoint(fieldName + "INT", linkInt));
     document.add(new FloatPoint(fieldName + "FLOAT", linkInt));
 
-    final long linkLong = linkInt << 32 | linkInt;
+    final long linkLong = (long) linkInt << 32 | linkInt;
     document.add(new LongPoint(fieldName + "LONG", linkLong));
     document.add(new DoublePoint(fieldName + "DOUBLE", linkLong));
 


### PR DESCRIPTION
Fix out of range shifts. In these cases it made tests wimpy.

For example, LZ4 incompressible test always used a `byte[1]`. I don't think it wants to make a 2GB byte[] either, so I changed it to use up to 256KB similar to other tests.