### PR TITLE
fix variable assigned to itself in test and enable check

### DIFF
--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -221,7 +221,7 @@ allprojects { prj ->
             '-Xep:RequiredModifiers:ERROR',
             '-Xep:RestrictedApiChecker:ERROR',
             // '-Xep:ReturnValueIgnored:OFF',
-            // '-Xep:SelfAssignment:OFF',
+            '-Xep:SelfAssignment:ERROR',
             '-Xep:SelfComparison:ERROR',
             '-Xep:SelfEquals:ERROR',
             '-Xep:ShouldHaveEvenArgs:ERROR',

--- a/lucene/core/src/test/org/apache/lucene/index/TestNRTReaderWithThreads.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestNRTReaderWithThreads.java
@@ -105,7 +105,7 @@ public class TestNRTReaderWithThreads extends LuceneTestCase {
         }
       } catch (Throwable ex) {
         ex.printStackTrace(System.out);
-        this.failure = failure;
+        this.failure = ex;
         throw new RuntimeException(ex);
       }
     }


### PR DESCRIPTION
Test assigns a variable to itself, which is useless:

```
/home/rmuir/workspace/lucene/lucene/core/src/test/org/apache/lucene/index/TestNRTReaderWithThreads.java:108: error: [SelfAssignment] Variable assigned to itself
        this.failure = failure;
                     ^
    (see https://errorprone.info/bugpattern/SelfAssignment)
  Did you mean to remove this line?
```
