### PR TITLE
Change ByteBuffersDataInput and ByteBuffersIndexInput to use absolute addressing

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferGuard.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferGuard.java
@@ -134,18 +134,18 @@ final class ByteBufferGuard {
     return receiver.getLong(pos);
   }
 
-  public void getLongs(LongBuffer receiver, long[] dst, int offset, int length) {
+  public void getLongs(LongBuffer receiver, int index, long[] dst, int offset, int length) {
     ensureValid();
-    receiver.get(dst, offset, length);
+    receiver.get(index, dst, offset, length);
   }
 
-  public void getInts(IntBuffer receiver, int[] dst, int offset, int length) {
+  public void getInts(IntBuffer receiver, int index, int[] dst, int offset, int length) {
     ensureValid();
-    receiver.get(dst, offset, length);
+    receiver.get(index, dst, offset, length);
   }
 
-  public void getFloats(FloatBuffer receiver, float[] dst, int offset, int length) {
+  public void getFloats(FloatBuffer receiver, int index, float[] dst, int offset, int length) {
     ensureValid();
-    receiver.get(dst, offset, length);
+    receiver.get(index, dst, offset, length);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -191,7 +191,7 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
       curBuf.position(position + (length << 3));
     } catch (
         @SuppressWarnings("unused")
-        BufferUnderflowException e) {
+        IndexOutOfBoundsException e) {
       super.readLongs(dst, offset, length);
     } catch (NullPointerException e) {
       throw alreadyClosed(e);
@@ -212,7 +212,7 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
       curBuf.position(position + (length << 2));
     } catch (
         @SuppressWarnings("unused")
-        BufferUnderflowException e) {
+        IndexOutOfBoundsException e) {
       super.readInts(dst, offset, length);
     } catch (NullPointerException e) {
       throw alreadyClosed(e);
@@ -233,7 +233,7 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
       curBuf.position(position + (length << 2));
     } catch (
         @SuppressWarnings("unused")
-        BufferUnderflowException e) {
+        IndexOutOfBoundsException e) {
       super.readFloats(floats, offset, length);
     } catch (NullPointerException e) {
       throw alreadyClosed(e);

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -24,6 +24,8 @@ import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 
 /**
  * Base IndexInput implementation that uses an array of ByteBuffers to represent a file.
@@ -151,33 +153,40 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     }
   }
 
+  private <T> T[] createViewBuffers(
+      int size,
+      IntFunction<T[]> arrayFactory,
+      Function<ByteBuffer, T> toViewBuffer,
+      T emptyBuffer) {
+    // ByteBuffer#getX could work but it has some per-long overhead and there
+    // is no ByteBuffer#getXs to read multiple values at once. So we use the
+    // below trick in order to be able to leverage XBuffer#get(value[]) to
+    // read multiple values at once with as little overhead as possible.
+    T[] buffers = arrayFactory.apply(size);
+    for (int i = 0; i < size; ++i) {
+      // Compute a view for each possible alignment. We cache these views
+      // because #asXBuffer() has some cost that we don't want to pay on
+      // each invocation of #readXs.
+      if (i < curBuf.limit()) {
+        buffers[i] =
+            toViewBuffer.apply(curBuf.duplicate().position(i).order(ByteOrder.LITTLE_ENDIAN));
+      } else {
+        buffers[i] = emptyBuffer;
+      }
+    }
+    return buffers;
+  }
+
   @Override
   public void readLongs(long[] dst, int offset, int length) throws IOException {
-    // ByteBuffer#getLong could work but it has some per-long overhead and there
-    // is no ByteBuffer#getLongs to read multiple longs at once. So we use the
-    // below trick in order to be able to leverage LongBuffer#get(long[]) to
-    // read multiple longs at once with as little overhead as possible.
     if (curLongBufferViews == null) {
-      // readLELongs is only used for postings today, so we compute the long
-      // views lazily so that other data-structures don't have to pay for the
-      // associated initialization/memory overhead.
-      curLongBufferViews = new LongBuffer[Long.BYTES];
-      for (int i = 0; i < Long.BYTES; ++i) {
-        // Compute a view for each possible alignment. We cache these views
-        // because #asLongBuffer() has some cost that we don't want to pay on
-        // each invocation of #readLELongs.
-        if (i < curBuf.limit()) {
-          curLongBufferViews[i] =
-              curBuf.duplicate().position(i).order(ByteOrder.LITTLE_ENDIAN).asLongBuffer();
-        } else {
-          curLongBufferViews[i] = EMPTY_LONGBUFFER;
-        }
-      }
+      curLongBufferViews =
+          createViewBuffers(
+              Long.BYTES, LongBuffer[]::new, ByteBuffer::asLongBuffer, EMPTY_LONGBUFFER);
     }
     try {
       final int position = curBuf.position();
-      guard.getLongs(
-          curLongBufferViews[position & 0x07], position >>> 3, dst, offset, length);
+      guard.getLongs(curLongBufferViews[position & 0x07], position >>> 3, dst, offset, length);
       // if the above call succeeded, then we know the below sum cannot overflow
       curBuf.position(position + (length << 3));
     } catch (
@@ -191,22 +200,14 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
 
   @Override
   public void readInts(int[] dst, int offset, int length) throws IOException {
-    // See notes about readLongs above
     if (curIntBufferViews == null) {
-      curIntBufferViews = new IntBuffer[Integer.BYTES];
-      for (int i = 0; i < Integer.BYTES; ++i) {
-        if (i < curBuf.limit()) {
-          curIntBufferViews[i] =
-              curBuf.duplicate().position(i).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
-        } else {
-          curIntBufferViews[i] = EMPTY_INTBUFFER;
-        }
-      }
+      curIntBufferViews =
+          createViewBuffers(
+              Integer.BYTES, IntBuffer[]::new, ByteBuffer::asIntBuffer, EMPTY_INTBUFFER);
     }
     try {
       final int position = curBuf.position();
-      guard.getInts(
-          curIntBufferViews[position & 0x03], position >>> 2, dst, offset, length);
+      guard.getInts(curIntBufferViews[position & 0x03], position >>> 2, dst, offset, length);
       // if the above call succeeded, then we know the below sum cannot overflow
       curBuf.position(position + (length << 2));
     } catch (
@@ -220,23 +221,14 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
 
   @Override
   public final void readFloats(float[] floats, int offset, int length) throws IOException {
-    // See notes about readLongs above
     if (curFloatBufferViews == null) {
-      curFloatBufferViews = new FloatBuffer[Float.BYTES];
-      for (int i = 0; i < Float.BYTES; ++i) {
-        // Compute a view for each possible alignment.
-        if (i < curBuf.limit()) {
-          curFloatBufferViews[i] =
-                curBuf.duplicate().position(i).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
-        } else {
-          curFloatBufferViews[i] = EMPTY_FLOATBUFFER;
-        }
-      }
+      curFloatBufferViews =
+          createViewBuffers(
+              Float.BYTES, FloatBuffer[]::new, ByteBuffer::asFloatBuffer, EMPTY_FLOATBUFFER);
     }
     try {
       final int position = curBuf.position();
-      guard.getFloats(
-              curFloatBufferViews[position & 0x03], position >>> 2, floats, offset, length);
+      guard.getFloats(curFloatBufferViews[position & 0x03], position >>> 2, floats, offset, length);
       // if the above call succeeded, then we know the below sum cannot overflow
       curBuf.position(position + (length << 2));
     } catch (

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
@@ -330,7 +330,11 @@ public final class ByteBuffersDataInput extends DataInput
     int floatBufferIndex = bufferIndex * Float.BYTES + alignment;
     if (floatBuffers[floatBufferIndex] == null) {
       floatBuffers[floatBufferIndex] =
-          blocks[bufferIndex].order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
+          blocks[bufferIndex]
+              .duplicate()
+              .position(alignment)
+              .order(ByteOrder.LITTLE_ENDIAN)
+              .asFloatBuffer();
     }
     return floatBuffers[floatBufferIndex];
   }
@@ -342,7 +346,11 @@ public final class ByteBuffersDataInput extends DataInput
     int longBufferIndex = bufferIndex * Long.BYTES + alignment;
     if (longBuffers[longBufferIndex] == null) {
       longBuffers[longBufferIndex] =
-          blocks[bufferIndex].order(ByteOrder.LITTLE_ENDIAN).asLongBuffer();
+          blocks[bufferIndex]
+              .duplicate()
+              .position(alignment)
+              .order(ByteOrder.LITTLE_ENDIAN)
+              .asLongBuffer();
     }
     return longBuffers[longBufferIndex];
   }

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
@@ -118,7 +118,7 @@ public final class ByteBuffersDataInput extends DataInput
       while (len > 0) {
         ByteBuffer block = blocks[blockIndex(pos)];
         int blockOffset = blockOffset(pos);
-        int chunk = Math.min(len, block.limit()-blockOffset);
+        int chunk = Math.min(len, block.limit() - blockOffset);
         if (chunk == 0) {
           throw new EOFException();
         }
@@ -145,7 +145,7 @@ public final class ByteBuffersDataInput extends DataInput
       while (len > 0) {
         ByteBuffer block = blocks[blockIndex(pos)];
         int blockOffset = blockOffset(pos);
-        int chunk = Math.min(len, block.limit()-blockOffset);
+        int chunk = Math.min(len, block.limit() - blockOffset);
         if (chunk == 0) {
           throw new EOFException();
         }
@@ -329,7 +329,8 @@ public final class ByteBuffersDataInput extends DataInput
     int alignment = (int) pos & 0x3;
     int floatBufferIndex = bufferIndex * Float.BYTES + alignment;
     if (floatBuffers[floatBufferIndex] == null) {
-      floatBuffers[floatBufferIndex] = blocks[bufferIndex].order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
+      floatBuffers[floatBufferIndex] =
+          blocks[bufferIndex].order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
     }
     return floatBuffers[floatBufferIndex];
   }
@@ -340,7 +341,8 @@ public final class ByteBuffersDataInput extends DataInput
     int alignment = (int) pos & 0x7;
     int longBufferIndex = bufferIndex * Long.BYTES + alignment;
     if (longBuffers[longBufferIndex] == null) {
-      longBuffers[longBufferIndex] = blocks[bufferIndex].order(ByteOrder.LITTLE_ENDIAN).asLongBuffer();
+      longBuffers[longBufferIndex] =
+          blocks[bufferIndex].order(ByteOrder.LITTLE_ENDIAN).asLongBuffer();
     }
     return longBuffers[longBufferIndex];
   }

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDirectory.java
@@ -108,7 +108,7 @@ public final class ByteBuffersDirectory extends BaseDirectory {
                 new ByteBufferGuard("none", (String resourceDescription, ByteBuffer b) -> {});
             return ByteBufferIndexInput.newInstance(
                 inputName,
-                bufferList.toArray(new ByteBuffer[bufferList.size()]),
+                bufferList.toArray(ByteBuffer[]::new),
                 output.size(),
                 chunkSizePower,
                 guard);


### PR DESCRIPTION
Use absolute ByteBuffer addressing in `ByteBuffersDataInput` and some of `ByteBuffersIndexInput`, rather than relative addressing on duplicated bytebuffers.

This shows 10-20% improvement in SSDVFacets and IntNRQ tests in lucenebench,

This is to address #11430