### PR TITLE
Give OffsetsRetrievalStrategy implementations public constructors

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -206,6 +206,9 @@ Other
 
 * GITHUB#11752: Added interface to relate a LatLonShape with another shape represented as Component2D. (Navneet Verma)
 
+* GITHUB#11983: Make constructors for OffsetFromPositions and OffsetsFromMatchIterator
+  public. (Alan Woodward)
+
 Build
 ---------------------
 

--- a/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/OffsetsFromMatchIterator.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/OffsetsFromMatchIterator.java
@@ -30,7 +30,7 @@ public final class OffsetsFromMatchIterator implements OffsetsRetrievalStrategy 
   private final String field;
   private final OffsetsFromPositions noOffsetsFallback;
 
-  OffsetsFromMatchIterator(String field, OffsetsFromPositions noOffsetsFallback) {
+  public OffsetsFromMatchIterator(String field, OffsetsFromPositions noOffsetsFallback) {
     this.field = field;
     this.noOffsetsFallback = Objects.requireNonNull(noOffsetsFallback);
   }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/OffsetsFromPositions.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/OffsetsFromPositions.java
@@ -36,7 +36,7 @@ public final class OffsetsFromPositions implements OffsetsRetrievalStrategy {
   private final String field;
   private final Analyzer analyzer;
 
-  OffsetsFromPositions(String field, Analyzer analyzer) {
+  public OffsetsFromPositions(String field, Analyzer analyzer) {
     this.field = field;
     this.analyzer = analyzer;
   }


### PR DESCRIPTION
`OffsetsFromMatchIterator` and `OffsetsFromPositions` both have package-
private constructors, which makes them difficult to use as components in a
separate highlighter implementation.