### PR TITLE
Add exponential growth to TimeLimitingBulkScorer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -125,6 +125,10 @@ API Changes
 
 * GITHUB#11962: VectorValues#cost() now delegates to VectorValues#size().
   (Adrien Grand)
+  
+* GITHUB#11984: Improved TimeLimitBulkScorer to check the timeout at exponantial rate.
+  (Costin Leau)
+
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
@@ -64,7 +64,8 @@ final class TimeLimitingBulkScorer extends BulkScorer {
     int interval = INTERVAL;
     while (min < max) {
       final int newMax = (int) Math.min((long) min + interval, max);
-      final int newInterval = interval + (interval >> 1); // increase the interval by 50% on each iteration
+      final int newInterval =
+          interval + (interval >> 1); // increase the interval by 50% on each iteration
       // overflow check
       if (interval < newInterval) {
         interval = newInterval;

--- a/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
@@ -61,8 +61,14 @@ final class TimeLimitingBulkScorer extends BulkScorer {
 
   @Override
   public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+    int interval = INTERVAL;
     while (min < max) {
-      final int newMax = (int) Math.min((long) min + INTERVAL, max);
+      final int newMax = (int) Math.min((long) min + interval, max);
+      final int newInterval = interval + (interval >> 1); // increase the interval by 50% on each iteration
+      // overflow check
+      if (interval < newInterval) {
+        interval = newInterval;
+      }
       if (queryTimeout.shouldExit()) {
         throw new TimeLimitingBulkScorer.TimeExceededException();
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestTimeLimitingBulkScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTimeLimitingBulkScorer.java
@@ -28,7 +28,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.Bits;
 
 /** Tests the {@link TimeLimitingBulkScorer}. */
@@ -67,11 +66,12 @@ public class TestTimeLimitingBulkScorer extends LuceneTestCase {
   }
 
   public void testExponentialRate() throws Exception {
+    int MAX_DOCS = DocIdSetIterator.NO_MORE_DOCS - 1;
     var bulkScorer =
         new BulkScorer() {
           int expectedInterval = TimeLimitingBulkScorer.INTERVAL;
+          int lastMax = 0;
           int lastInterval = 0;
-          int runs = TestUtil.nextInt(random(), 1, 100);
 
           @Override
           public int score(LeafCollector collector, Bits acceptDocs, int min, int max)
@@ -79,9 +79,17 @@ public class TestTimeLimitingBulkScorer extends LuceneTestCase {
             var difference = max - min;
             // the rate shouldn't overflow - only increase or remain equal
             assertTrue("Rate should only go up", difference >= lastInterval);
-            assertEquals("Incorrect rate encountered", expectedInterval, difference);
+            // make sure no documents end up being skipped
+            assertTrue("Documents skipped", lastMax == min);
+            // the difference should be exactly the step except the last run where the difference is
+            // smaller since there are not enough docs
+            assertTrue(
+                "Incorrect rate encountered",
+                max == MAX_DOCS ? expectedInterval >= difference : expectedInterval == difference);
 
+            lastMax = max;
             lastInterval = difference;
+
             // use integer sum since the exponential growth formula yields different result due to
             // rounding
             expectedInterval = expectedInterval + expectedInterval / 2;
@@ -89,8 +97,7 @@ public class TestTimeLimitingBulkScorer extends LuceneTestCase {
             if (expectedInterval < 0) {
               expectedInterval = lastInterval;
             }
-            // keep going or finish the test?
-            return --runs == 0 ? DocIdSetIterator.NO_MORE_DOCS : 0;
+            return max;
           }
 
           @Override
@@ -100,8 +107,7 @@ public class TestTimeLimitingBulkScorer extends LuceneTestCase {
         };
 
     var scorer = new TimeLimitingBulkScorer(bulkScorer, new QueryTimeoutImpl(-1));
-    scorer.score(
-        dummyCollector(), new Bits.MatchAllBits(Integer.MAX_VALUE), 0, Integer.MAX_VALUE - 1);
+    scorer.score(dummyCollector(), new Bits.MatchAllBits(Integer.MAX_VALUE), 0, MAX_DOCS);
   }
 
   private static QueryTimeout countingQueryTimeout(int timeallowed) {


### PR DESCRIPTION
Increase the timeout check inside TimeLimitBulkScorer at exponential rate.

Fix #11676