### PR TITLE
ExitableTerms to override getMin and getMax

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -703,6 +703,16 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     public TermsEnum iterator() throws IOException {
       return new ExitableTermsEnum(in.iterator(), queryTimeout);
     }
+
+    @Override
+    public BytesRef getMin() throws IOException {
+      return in.getMin();
+    }
+
+    @Override
+    public BytesRef getMax() throws IOException {
+      return in.getMax();
+    }
   }
 
   /**


### PR DESCRIPTION
ExitableTerms should not iterate through the terms to retrieve min and max when the wrapped implementation has the values cached (e.g. OrdsFieldReader, FieldReader)

I am not entirely sure which other implementations of `FilterTerms `should do the same, possibly all of them? Maybe we'll want to make a breaking change and make the methods abstract like they are in `PointValues`?