### PR TITLE
Make Decompressor release memory buffer

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
@@ -237,6 +237,7 @@ public abstract class CompressionMode {
         }
       } finally {
         decompressor.end();
+        compressed = new byte[0];
       }
       if (bytes.length != originalLength) {
         throw new CorruptIndexException(

--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
@@ -211,7 +211,7 @@ public abstract class CompressionMode {
       // pad with extra "dummy byte": see javadocs for using Inflater(true)
       // we do it for compliance, but it's unnecessary for years in zlib.
       final int paddedLength = compressedLength + 1;
-      compressed = ArrayUtil.growNoCopy(compressed, paddedLength);
+      compressed = new byte[paddedLength];
       in.readBytes(compressed, 0, compressedLength);
       compressed[compressedLength] = 0; // explicitly set dummy byte to 0
 
@@ -237,7 +237,7 @@ public abstract class CompressionMode {
         }
       } finally {
         decompressor.end();
-        compressed = new byte[0];
+        compressed = null;
       }
       if (bytes.length != originalLength) {
         throw new CorruptIndexException(

--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
@@ -193,11 +193,7 @@ public abstract class CompressionMode {
 
   private static final class DeflateDecompressor extends Decompressor {
 
-    byte[] compressed;
-
-    DeflateDecompressor() {
-      compressed = new byte[0];
-    }
+    DeflateDecompressor() {}
 
     @Override
     public void decompress(DataInput in, int originalLength, int offset, int length, BytesRef bytes)
@@ -211,14 +207,14 @@ public abstract class CompressionMode {
       // pad with extra "dummy byte": see javadocs for using Inflater(true)
       // we do it for compliance, but it's unnecessary for years in zlib.
       final int paddedLength = compressedLength + 1;
-      compressed = new byte[paddedLength];
-      in.readBytes(compressed, 0, compressedLength);
-      compressed[compressedLength] = 0; // explicitly set dummy byte to 0
+      bytes.buffer = ArrayUtil.growNoCopy(bytes.buffer, paddedLength);
+      in.readBytes(bytes.buffer, 0, compressedLength);
+      bytes.buffer[compressedLength] = 0; // explicitly set dummy byte to 0
 
       final Inflater decompressor = new Inflater(true);
       try {
         // extra "dummy byte"
-        decompressor.setInput(compressed, 0, paddedLength);
+        decompressor.setInput(bytes.buffer, 0, paddedLength);
 
         bytes.offset = bytes.length = 0;
         bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, originalLength);
@@ -237,7 +233,6 @@ public abstract class CompressionMode {
         }
       } finally {
         decompressor.end();
-        compressed = null;
       }
       if (bytes.length != originalLength) {
         throw new CorruptIndexException(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
@@ -67,11 +67,7 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
 
   private static final class DeflateWithPresetDictDecompressor extends Decompressor {
 
-    byte[] compressed;
-
-    DeflateWithPresetDictDecompressor() {
-      compressed = new byte[0];
-    }
+    DeflateWithPresetDictDecompressor() {}
 
     private void doDecompress(DataInput in, Inflater decompressor, BytesRef bytes)
         throws IOException {
@@ -82,12 +78,12 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
       // pad with extra "dummy byte": see javadocs for using Inflater(true)
       // we do it for compliance, but it's unnecessary for years in zlib.
       final int paddedLength = compressedLength + 1;
-      compressed = ArrayUtil.growNoCopy(compressed, paddedLength);
-      in.readBytes(compressed, 0, compressedLength);
-      compressed[compressedLength] = 0; // explicitly set dummy byte to 0
+      bytes.buffer = ArrayUtil.growNoCopy(bytes.buffer, paddedLength);
+      in.readBytes(bytes.buffer, 0, compressedLength);
+      bytes.buffer[compressedLength] = 0; // explicitly set dummy byte to 0
 
       // extra "dummy byte"
-      decompressor.setInput(compressed, 0, paddedLength);
+      decompressor.setInput(bytes.buffer, 0, paddedLength);
       try {
         bytes.length +=
             decompressor.inflate(bytes.bytes, bytes.length, bytes.bytes.length - bytes.length);
@@ -150,7 +146,6 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
         assert bytes.isValid();
       } finally {
         decompressor.end();
-        compressed = new byte[0];
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
@@ -150,6 +150,7 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
         assert bytes.isValid();
       } finally {
         decompressor.end();
+        compressed = new byte[0];
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -75,7 +75,6 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
       in.readVInt(); // compressed length of the dictionary, unused
       int totalLength = dictLength;
       int i = 0;
-      compressedLengths = ArrayUtil.growNoCopy(compressedLengths, originalLength / blockLength + 1);
       while (totalLength < originalLength) {
 
         compressedLengths[i++] = in.readVInt();
@@ -96,10 +95,10 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
 
       final int dictLength = in.readVInt();
       final int blockLength = in.readVInt();
-
+      buffer = new byte[dictLength + blockLength];
+      compressedLengths = new int[originalLength / blockLength + 1];
       final int numBlocks = readCompressedLengths(in, originalLength, dictLength, blockLength);
 
-      buffer = ArrayUtil.growNoCopy(buffer, dictLength + blockLength);
       bytes.length = 0;
       // Read the dictionary
       if (LZ4.decompress(in, dictLength, buffer, 0) != dictLength) {
@@ -140,8 +139,8 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
       bytes.offset = offsetInBytesRef;
       bytes.length = length;
 
-      compressedLengths = new int[0];
-      buffer = new byte[0];
+      compressedLengths = null;
+      buffer = null;
       assert bytes.isValid();
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -139,6 +139,9 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
 
       bytes.offset = offsetInBytesRef;
       bytes.length = length;
+
+      compressedLengths = new int[0];
+      buffer = new byte[0];
       assert bytes.isValid();
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -63,11 +63,9 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
   private static final class LZ4WithPresetDictDecompressor extends Decompressor {
 
     private int[] compressedLengths;
-    private byte[] buffer;
 
     LZ4WithPresetDictDecompressor() {
       compressedLengths = new int[0];
-      buffer = new byte[0];
     }
 
     private int readCompressedLengths(
@@ -75,6 +73,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
       in.readVInt(); // compressed length of the dictionary, unused
       int totalLength = dictLength;
       int i = 0;
+      compressedLengths = ArrayUtil.growNoCopy(compressedLengths, originalLength / blockLength + 1);
       while (totalLength < originalLength) {
 
         compressedLengths[i++] = in.readVInt();
@@ -87,7 +86,6 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
     public void decompress(DataInput in, int originalLength, int offset, int length, BytesRef bytes)
         throws IOException {
       assert offset + length <= originalLength;
-
       if (length == 0) {
         bytes.length = 0;
         return;
@@ -95,21 +93,19 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
 
       final int dictLength = in.readVInt();
       final int blockLength = in.readVInt();
-      buffer = new byte[dictLength + blockLength];
-      compressedLengths = new int[originalLength / blockLength + 1];
+
       final int numBlocks = readCompressedLengths(in, originalLength, dictLength, blockLength);
 
+      bytes.buffer = ArrayUtil.growNoCopy(bytes.buffer, dictLength + blockLength);
       bytes.length = 0;
       // Read the dictionary
-      if (LZ4.decompress(in, dictLength, buffer, 0) != dictLength) {
+      if (LZ4.decompress(in, dictLength, bytes.buffer, 0) != dictLength) {
         throw new CorruptIndexException("Illegal dict length", in);
       }
-
       int offsetInBlock = dictLength;
       int offsetInBytesRef = offset;
       if (offset >= dictLength) {
         offsetInBytesRef -= dictLength;
-
         // Skip unneeded blocks
         int numBytesToSkip = 0;
         for (int i = 0; i < numBlocks && offsetInBlock + blockLength < offset; ++i) {
@@ -122,25 +118,21 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
       } else {
         // The dictionary contains some bytes we need, copy its content to the BytesRef
         bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, dictLength);
-        System.arraycopy(buffer, 0, bytes.bytes, 0, dictLength);
+        System.arraycopy(bytes.buffer, 0, bytes.bytes, 0, dictLength);
         bytes.length = dictLength;
       }
-
       // Read blocks that intersect with the interval we need
       while (offsetInBlock < offset + length) {
         final int bytesToDecompress = Math.min(blockLength, offset + length - offsetInBlock);
-        LZ4.decompress(in, bytesToDecompress, buffer, dictLength);
+        LZ4.decompress(in, bytesToDecompress, bytes.buffer, dictLength);
         bytes.bytes = ArrayUtil.grow(bytes.bytes, bytes.length + bytesToDecompress);
-        System.arraycopy(buffer, dictLength, bytes.bytes, bytes.length, bytesToDecompress);
+        System.arraycopy(bytes.buffer, dictLength, bytes.bytes, bytes.length, bytesToDecompress);
         bytes.length += bytesToDecompress;
         offsetInBlock += blockLength;
       }
 
       bytes.offset = offsetInBytesRef;
       bytes.length = length;
-
-      compressedLengths = null;
-      buffer = null;
       assert bytes.isValid();
     }
 

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRef.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRef.java
@@ -39,6 +39,9 @@ public final class BytesRef implements Comparable<BytesRef>, Cloneable {
   /** The contents of the BytesRef. Should never be {@code null}. */
   public byte[] bytes;
 
+  /** The Buffer for copy bytes and holds the buffer's lifecycle */
+  public byte[] buffer;
+
   /** Offset of first valid byte. */
   public int offset;
 
@@ -53,6 +56,7 @@ public final class BytesRef implements Comparable<BytesRef>, Cloneable {
   /** This instance will directly reference bytes w/o making a copy. bytes should not be null. */
   public BytesRef(byte[] bytes, int offset, int length) {
     this.bytes = bytes;
+    this.buffer = EMPTY_BYTES;
     this.offset = offset;
     this.length = length;
     assert isValid();


### PR DESCRIPTION
### Description
we have a es cluster(31G heap, 96G Mem, 30 instance nodes), with many shards per node(4000 per nodes), when nodes do many bulk and search requests concurrently, we can see the jvm going high memory usage, and can not release the memory even with the frequently GC and stop all write/search requests. we have to restart the node for recovery the heap, like the following GC metrics shows 
![image](https://user-images.githubusercontent.com/12760367/204531778-0c8e24ce-a927-492c-a173-cb2905a43c41.png)

we dumped the heap shows, `CompressingStoredFieldsReader` oncupied 70% heap: 
![image](https://user-images.githubusercontent.com/12760367/204548626-3cfe59b0-f007-4695-802e-0ed542f8f4a5.png)

all this reader path2GC roots shows with following(maybe in search or write thread):
![image](https://user-images.githubusercontent.com/12760367/204550346-21a7b219-2051-4333-910d-27138def8f3b.png)

### Root cause
i think the root cause that these threadlocal holds the referent, because `SegmentReader#getFieldsReader` calling following code, and Elasticsearch always using fixed thread_pool and never __calling `CloseableThreadLocal#purge`__

```
In `lucene/core/src/java/org/apache/lucene/index/SegmentCoreReaders.java` defined fieldsReaderLocal
  final CloseableThreadLocal<StoredFieldsReader> fieldsReaderLocal =
      new CloseableThreadLocal<StoredFieldsReader>() {
        @Override
        protected StoredFieldsReader initialValue() {
          return fieldsReaderOrig.clone();
        }
      };
```

we have searched some issues like [LUCENE-9959 ](https://issues.apache.org/jira/browse/LUCENE-9959),  and [LUCENE-10419](https://issues.apache.org/jira/browse/LUCENE-10519), there is no answer for this problem

---
i compare between different jvm heap, and different LUCENE versions, i think the  root cause is `LZ4WithPresetDictDecompressor`  would allocate a buffer in the class and init 
```
    LZ4WithPresetDictDecompressor() {
      compressedLengths = new int[0];
      buffer = new byte[0];
    }
```

when the elasticsearch instance doing `Stored-Fields-Read` operations, it will reallocate the JVM heap. but without release, because es `currentEngineReference` will keep the reference
![image](https://user-images.githubusercontent.com/12760367/204552928-9e8f2b5f-ce61-4cbb-93eb-bc1fee4a597a.png)

### Proposal
i think we can releasee this buffer memory when the decompress is done. it shows that jvm can holds more segment readers in the heap.
when these buffer memory can release, the heap metrics shows as following:
![image](https://user-images.githubusercontent.com/12760367/204555346-fd6be181-eb8b-4014-9cd1-1e17aee4282e.png)
