### PR TITLE
Set algorithm params during force merge in KnnGraphTester

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphTester.java
@@ -305,6 +305,13 @@ public class KnnGraphTester {
   @SuppressForbidden(reason = "Prints stuff")
   private void forceMerge() throws IOException {
     IndexWriterConfig iwc = new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.APPEND);
+    iwc.setCodec(
+        new Lucene95Codec() {
+          @Override
+          public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+            return new Lucene95HnswVectorsFormat(maxConn, beamWidth);
+          }
+        });
     iwc.setInfoStream(new PrintStreamInfoStream(System.out));
     System.out.println("Force merge index in " + indexPath);
     try (IndexWriter iw = new IndexWriter(FSDirectory.open(indexPath), iwc)) {


### PR DESCRIPTION
### Description

Sets index writer config codec for force merge operation in KnnGraphTester. Fixes issue where merged segments are built with different algorithm parameters than segments created from createIndex.