### PR TITLE
Some minor code cleanup in IndexSortSortedNumericDocValuesRangeQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -157,6 +157,8 @@ Improvements
 * GITHUB#11860: Improve storage efficiency of connections in the HNSW graph that Lucene uses for
   vector search. (Ben Trent)
 
+* GITHUB#12003: Minor cleanup/improvements to IndexSortSortedNumericDocValuesRangeQuery. (Greg Miller)
+
 Bug Fixes
 ---------------------
 * GITHUB#11726: Indexing term vectors on large documents could fail due to

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -467,7 +467,7 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
     if (matchAll(points, queryLowerPoint, queryUpperPoint)) {
       int maxDoc = context.reader().maxDoc();
       if (points.getDocCount() == maxDoc) {
-        return delegate;
+        return DocIdSetIterator.all(maxDoc);
       } else {
         return new BoundedDocIdSetIterator(0, maxDoc, delegate);
       }


### PR DESCRIPTION
* Leverage DISI static factory methods more over custom DISI impl where possible
* Assert points field is a single-dim in a couple places
* Bound cost estimate by the cost of the doc values field (for sparse fields)

### Description
This PR contains some minor cleanup I thought might be useful after recently spending a little time looking at this code.
