### PR TITLE
Remove unnecessary NaN checks from LongRange#verifyAndEncode

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -157,6 +157,8 @@ Improvements
 * GITHUB#11860: Improve storage efficiency of connections in the HNSW graph that Lucene uses for
   vector search. (Ben Trent)
 
+* GITHUB#12008: Clean up LongRange#verifyAndEncode logic to remove unnecessary NaN checks. (Greg Miller)
+
 Bug Fixes
 ---------------------
 * GITHUB#11726: Indexing term vectors on large documents could fail due to

--- a/lucene/core/src/java/org/apache/lucene/document/LongRange.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LongRange.java
@@ -127,20 +127,12 @@ public class LongRange extends Field {
   }
 
   /**
-   * encode the ranges into a sortable byte array ({@code Double.NaN} not allowed)
+   * encode the ranges into a sortable byte array
    *
    * <p>example for 4 dimensions (8 bytes per dimension value): minD1 ... minD4 | maxD1 ... maxD4
    */
   static void verifyAndEncode(long[] min, long[] max, byte[] bytes) {
     for (int d = 0, i = 0, j = min.length * BYTES; d < min.length; ++d, i += BYTES, j += BYTES) {
-      if (Double.isNaN(min[d])) {
-        throw new IllegalArgumentException(
-            "invalid min value (" + Double.NaN + ")" + " in LongRange");
-      }
-      if (Double.isNaN(max[d])) {
-        throw new IllegalArgumentException(
-            "invalid max value (" + Double.NaN + ")" + " in LongRange");
-      }
       if (min[d] > max[d]) {
         throw new IllegalArgumentException(
             "min value (" + min[d] + ") is greater than max value (" + max[d] + ")");


### PR DESCRIPTION
### Description

Minor tweak to logic that appears to have been copy/pasted from `DoubleRange`.