### PR TITLE
Enable LongDoubleConversion error-prone check

### DIFF
--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -378,7 +378,7 @@ allprojects { prj ->
             // '-Xep:LiteProtoToString:OFF', // we don't use protobuf
             // '-Xep:LockNotBeforeTry:OFF', // TODO: there are problems
             '-Xep:LogicalAssignment:WARN',
-            // '-Xep:LongDoubleConversion:OFF', // TODO: there are problems
+            '-Xep:LongDoubleConversion:WARN',
             '-Xep:LongFloatConversion:WARN',
             '-Xep:LoopOverCharArray:WARN',
             '-Xep:MalformedInlineTag:WARN',

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene60/TestLucene60PointsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene60/TestLucene60PointsFormat.java
@@ -53,7 +53,8 @@ public class TestLucene60PointsFormat extends BasePointsFormatTestCase {
     return codec;
   }
 
-  @SuppressWarnings("NarrowCalculation")
+  // TODO: clean up the math/estimation here rather than suppress so many warnings
+  @SuppressWarnings({"NarrowCalculation", "LongDoubleConversion"})
   public void testEstimatePointCount() throws IOException {
     Directory dir = newDirectory();
     IndexWriterConfig iwc = newIndexWriterConfig();
@@ -179,7 +180,8 @@ public class TestLucene60PointsFormat extends BasePointsFormatTestCase {
 
   // The tree is always balanced in the N dims case, and leaves are
   // not all full so things are a bit different
-  @SuppressWarnings("NarrowCalculation")
+  // TODO: clean up the math/estimation here rather than suppress so many warnings
+  @SuppressWarnings({"NarrowCalculation", "LongDoubleConversion"})
   public void testEstimatePointCount2Dims() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene86/TestLucene86PointsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene86/TestLucene86PointsFormat.java
@@ -101,7 +101,8 @@ public class TestLucene86PointsFormat extends BasePointsFormatTestCase {
     super.testMergeStability();
   }
 
-  @SuppressWarnings("NarrowCalculation")
+  // TODO: clean up the math/estimation here rather than suppress so many warnings
+  @SuppressWarnings({"NarrowCalculation", "LongDoubleConversion"})
   public void testEstimatePointCount() throws IOException {
     Directory dir = newDirectory();
     IndexWriterConfig iwc = newIndexWriterConfig();
@@ -227,7 +228,8 @@ public class TestLucene86PointsFormat extends BasePointsFormatTestCase {
 
   // The tree is always balanced in the N dims case, and leaves are
   // not all full so things are a bit different
-  @SuppressWarnings("NarrowCalculation")
+  // TODO: clean up the math/estimation here rather than suppress so many warnings
+  @SuppressWarnings({"NarrowCalculation", "LongDoubleConversion"})
   public void testEstimatePointCount2Dims() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());

--- a/lucene/classification/src/java/org/apache/lucene/classification/BooleanPerceptronClassifier.java
+++ b/lucene/classification/src/java/org/apache/lucene/classification/BooleanPerceptronClassifier.java
@@ -147,8 +147,8 @@ public class BooleanPerceptronClassifier implements Classifier<Boolean> {
         Boolean assignedClass = classificationResult.getAssignedClass();
 
         Boolean correctClass = Boolean.valueOf(classField.stringValue());
-        long modifier = correctClass.compareTo(assignedClass);
-        if (modifier != 0) {
+        double modifier = Math.signum(correctClass.compareTo(assignedClass));
+        if (modifier != 0D) {
           updateWeights(
               indexReader,
               scoreDoc.doc,

--- a/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
@@ -267,8 +267,8 @@ final class LongDistanceFeatureQuery extends Query {
       return doc;
     }
 
-    private float score(double distance) {
-      return (float) (boost * (pivotDistance / (pivotDistance + distance)));
+    private float score(long distance) {
+      return (float) (boost * (pivotDistance / (pivotDistance + (double) distance)));
     }
 
     /**

--- a/lucene/core/src/java/org/apache/lucene/index/LogMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LogMergePolicy.java
@@ -494,7 +494,7 @@ public abstract class LogMergePolicy extends MergePolicy {
       }
 
       final SegmentInfoAndLevel infoLevel =
-          new SegmentInfoAndLevel(info, (float) Math.log(size) / norm);
+          new SegmentInfoAndLevel(info, (float) Math.log((double) size) / norm);
       levels.add(infoLevel);
 
       if (verbose(mergeContext)) {
@@ -517,7 +517,7 @@ public abstract class LogMergePolicy extends MergePolicy {
 
     final float levelFloor;
     if (minMergeSize <= 0) levelFloor = (float) 0.0;
-    else levelFloor = (float) (Math.log(minMergeSize) / norm);
+    else levelFloor = (float) (Math.log((double) minMergeSize) / norm);
 
     // Now, we quantize the log values into levels.  The
     // first level is any segment whose log size is within

--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -693,7 +693,7 @@ public class TieredMergePolicy extends MergePolicy {
     // don't want to make this exponent too large else we
     // can end up doing poor merges of small segments in
     // order to avoid the large merges:
-    mergeScore *= Math.pow(totAfterMergeBytes, 0.05);
+    mergeScore *= Math.pow((double) totAfterMergeBytes, 0.05);
 
     // Strongly favor merges that reclaim deletes:
     final double nonDelRatio = ((double) totAfterMergeBytes) / totBeforeMergeBytes;

--- a/lucene/core/src/java/org/apache/lucene/search/similarities/BasicModelIne.java
+++ b/lucene/core/src/java/org/apache/lucene/search/similarities/BasicModelIne.java
@@ -34,7 +34,7 @@ public class BasicModelIne extends BasicModel {
   public final double score(BasicStats stats, double tfn, double aeTimes1pTfn) {
     long N = stats.getNumberOfDocuments();
     long F = stats.getTotalTermFreq();
-    double ne = N * (1 - Math.pow((N - 1) / (double) N, F));
+    double ne = N * (1 - Math.pow((N - 1) / (double) N, (double) F));
     double A = log2((N + 1) / (ne + 0.5));
 
     // basic model I(ne) should return A * tfn

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90PointsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90PointsFormat.java
@@ -98,7 +98,8 @@ public class TestLucene90PointsFormat extends BasePointsFormatTestCase {
     super.testMergeStability();
   }
 
-  @SuppressWarnings("NarrowCalculation")
+  // TODO: clean up the math/estimation here rather than suppress so many warnings
+  @SuppressWarnings({"NarrowCalculation", "LongDoubleConversion"})
   public void testEstimatePointCount() throws IOException {
     Directory dir = newDirectory();
     IndexWriterConfig iwc = newIndexWriterConfig();
@@ -224,7 +225,8 @@ public class TestLucene90PointsFormat extends BasePointsFormatTestCase {
 
   // The tree is always balanced in the N dims case, and leaves are
   // not all full so things are a bit different
-  @SuppressWarnings("NarrowCalculation")
+  // TODO: clean up the math/estimation here rather than suppress so many warnings
+  @SuppressWarnings({"NarrowCalculation", "LongDoubleConversion"})
   public void testEstimatePointCount2Dims() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -541,7 +541,10 @@ public class TestLRUQueryCache extends LuceneTestCase {
     final long actualRamBytesUsed = RamUsageTester.ramUsed(queryCache, acc);
     final long expectedRamBytesUsed = queryCache.ramBytesUsed();
     // error < 30%
-    assertEquals(actualRamBytesUsed, expectedRamBytesUsed, 30.d * actualRamBytesUsed / 100.d);
+    assertEquals(
+        (double) actualRamBytesUsed,
+        (double) expectedRamBytesUsed,
+        30.d * actualRamBytesUsed / 100.d);
 
     reader.close();
     w.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
@@ -238,7 +238,8 @@ public class TestTermInSetQuery extends LuceneTestCase {
     final long actualRamBytesUsed = RamUsageTester.ramUsed(query);
     final long expectedRamBytesUsed = query.ramBytesUsed();
     // error margin within 5%
-    assertEquals(expectedRamBytesUsed, actualRamBytesUsed, actualRamBytesUsed / 20.d);
+    assertEquals(
+        (double) expectedRamBytesUsed, (double) actualRamBytesUsed, actualRamBytesUsed / 20.d);
   }
 
   private static class TermsCountingDirectoryReaderWrapper extends FilterDirectoryReader {

--- a/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
@@ -703,7 +703,7 @@ public class TestPackedInts extends LuceneTestCase {
     }
 
     // test ramBytesUsed
-    assertEquals(RamUsageTester.ramUsed(writer), writer.ramBytesUsed(), 8.d);
+    assertEquals((double) RamUsageTester.ramUsed(writer), (double) writer.ramBytesUsed(), 8.d);
 
     // test copy
     PagedGrowableWriter copy =

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -594,7 +594,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
     DoubleDocValuesField field = new DoubleDocValuesField("field", 0.0);
     doc.add(field);
     for (long l = 0; l < 100; l++) {
-      field.setDoubleValue(l);
+      field.setDoubleValue((double) l);
       w.addDocument(doc);
     }
 
@@ -632,8 +632,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     doc.add(field1);
     doc.add(field2);
     for (long l = 0; l < 100; l++) {
-      field1.setLongValue(NumericUtils.doubleToSortableLong(l));
-      field2.setLongValue(NumericUtils.doubleToSortableLong(l));
+      field1.setLongValue(NumericUtils.doubleToSortableLong((double) l));
+      field2.setLongValue(NumericUtils.doubleToSortableLong((double) l));
       w.addDocument(doc);
     }
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -593,8 +593,8 @@ public class TestRangeFacetCounts extends FacetTestCase {
     Document doc = new Document();
     DoubleDocValuesField field = new DoubleDocValuesField("field", 0.0);
     doc.add(field);
-    for (long l = 0; l < 100; l++) {
-      field.setDoubleValue((double) l);
+    for (int i = 0; i < 100; i++) {
+      field.setDoubleValue(i);
       w.addDocument(doc);
     }
 
@@ -631,9 +631,9 @@ public class TestRangeFacetCounts extends FacetTestCase {
     SortedNumericDocValuesField field2 = new SortedNumericDocValuesField("field", 0);
     doc.add(field1);
     doc.add(field2);
-    for (long l = 0; l < 100; l++) {
-      field1.setLongValue(NumericUtils.doubleToSortableLong((double) l));
-      field2.setLongValue(NumericUtils.doubleToSortableLong((double) l));
+    for (int i = 0; i < 100; i++) {
+      field1.setLongValue(NumericUtils.doubleToSortableLong(i));
+      field2.setLongValue(NumericUtils.doubleToSortableLong(i));
       w.addDocument(doc);
     }
 

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
@@ -1943,7 +1943,7 @@ public class TestJoinUtil extends LuceneTestCase {
       document.add(new SortedNumericDocValuesField(fieldName + "LONG", linkLong));
       document.add(
           new SortedNumericDocValuesField(
-              fieldName + "DOUBLE", Double.doubleToRawLongBits(linkLong)));
+              fieldName + "DOUBLE", Double.doubleToRawLongBits((double) linkLong)));
     } else {
       document.add(new SortedDocValuesField(fieldName, new BytesRef(linkValue)));
       document.add(new NumericDocValuesField(fieldName + "INT", linkInt));

--- a/lucene/misc/src/test/org/apache/lucene/misc/search/TestDocValuesStatsCollector.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/search/TestDocValuesStatsCollector.java
@@ -301,8 +301,8 @@ public class TestDocValuesStatsCollector extends LuceneTestCase {
         if (stats.count() > 0) {
           DoubleSummaryStatistics sumStats =
               filterAndFlatValues(docValues, (v) -> v != null).summaryStatistics();
-          assertEquals(sumStats.getMax(), (double) stats.max().longValue(), 0.00001);
-          assertEquals(sumStats.getMin(), (double) stats.min().longValue(), 0.00001);
+          assertEquals(sumStats.getMax(), stats.max(), 0.00001);
+          assertEquals(sumStats.getMin(), stats.min(), 0.00001);
           assertEquals(sumStats.getAverage(), stats.mean(), 0.00001);
           assertEquals(sumStats.getSum(), stats.sum().doubleValue(), 0.00001);
           assertEquals(sumStats.getCount(), stats.valuesCount());

--- a/lucene/misc/src/test/org/apache/lucene/misc/search/TestDocValuesStatsCollector.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/search/TestDocValuesStatsCollector.java
@@ -301,8 +301,8 @@ public class TestDocValuesStatsCollector extends LuceneTestCase {
         if (stats.count() > 0) {
           DoubleSummaryStatistics sumStats =
               filterAndFlatValues(docValues, (v) -> v != null).summaryStatistics();
-          assertEquals(sumStats.getMax(), stats.max().longValue(), 0.00001);
-          assertEquals(sumStats.getMin(), stats.min().longValue(), 0.00001);
+          assertEquals(sumStats.getMax(), (double) stats.max().longValue(), 0.00001);
+          assertEquals(sumStats.getMin(), (double) stats.min().longValue(), 0.00001);
           assertEquals(sumStats.getAverage(), stats.mean(), 0.00001);
           assertEquals(sumStats.getSum(), stats.sum().doubleValue(), 0.00001);
           assertEquals(sumStats.getCount(), stats.valuesCount());

--- a/lucene/misc/src/test/org/apache/lucene/misc/store/TestByteWritesTrackingDirectoryWrapper.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/store/TestByteWritesTrackingDirectoryWrapper.java
@@ -31,8 +31,8 @@ public class TestByteWritesTrackingDirectoryWrapper extends BaseDirectoryTestCas
   public void testEmptyDir() throws Exception {
     ByteWritesTrackingDirectoryWrapper dir =
         new ByteWritesTrackingDirectoryWrapper(new ByteBuffersDirectory());
-    assertEquals(0.0, dir.getFlushedBytes(), 0.0);
-    assertEquals(0.0, dir.getMergedBytes(), 0.0);
+    assertEquals(0, dir.getFlushedBytes());
+    assertEquals(0, dir.getMergedBytes());
   }
 
   public void testRandomOutput() throws Exception {
@@ -49,8 +49,8 @@ public class TestByteWritesTrackingDirectoryWrapper extends BaseDirectoryTestCas
       flushBytesArr[i] = (byte) random().nextInt(127);
     }
     output.writeBytes(flushBytesArr, flushBytesArr.length);
-    assertEquals(0.0, dir.getFlushedBytes(), 0.0);
-    assertEquals(0.0, dir.getMergedBytes(), 0.0);
+    assertEquals(0, dir.getFlushedBytes());
+    assertEquals(0, dir.getMergedBytes());
     output.close();
 
     // now merge bytes
@@ -61,12 +61,12 @@ public class TestByteWritesTrackingDirectoryWrapper extends BaseDirectoryTestCas
       mergeBytesArr[i] = (byte) random().nextInt(127);
     }
     output.writeBytes(mergeBytesArr, mergeBytesArr.length);
-    assertEquals(expectedFlushBytes, dir.getFlushedBytes(), 0.0);
-    assertEquals(0.0, dir.getMergedBytes(), 0.0);
+    assertEquals(expectedFlushBytes, dir.getFlushedBytes());
+    assertEquals(0, dir.getMergedBytes());
     output.close();
 
-    assertEquals(expectedFlushBytes, dir.getFlushedBytes(), 0.0);
-    assertEquals(expectedMergeBytes, dir.getMergedBytes(), 0.0);
+    assertEquals(expectedFlushBytes, dir.getFlushedBytes());
+    assertEquals(expectedMergeBytes, dir.getMergedBytes());
   }
 
   public void testRandomTempOutput() throws Exception {
@@ -83,8 +83,8 @@ public class TestByteWritesTrackingDirectoryWrapper extends BaseDirectoryTestCas
       flushBytesArr[i] = (byte) random().nextInt(127);
     }
     output.writeBytes(flushBytesArr, flushBytesArr.length);
-    assertEquals(0.0, dir.getFlushedBytes(), 0.0);
-    assertEquals(0.0, dir.getMergedBytes(), 0.0);
+    assertEquals(0, dir.getFlushedBytes());
+    assertEquals(0, dir.getMergedBytes());
     output.close();
 
     // now merge bytes
@@ -96,12 +96,12 @@ public class TestByteWritesTrackingDirectoryWrapper extends BaseDirectoryTestCas
       mergeBytesArr[i] = (byte) random().nextInt(127);
     }
     output.writeBytes(mergeBytesArr, mergeBytesArr.length);
-    assertEquals(expectedFlushBytes, dir.getFlushedBytes(), 0.0);
-    assertEquals(0.0, dir.getMergedBytes(), 0.0);
+    assertEquals(expectedFlushBytes, dir.getFlushedBytes());
+    assertEquals(0, dir.getMergedBytes());
     output.close();
 
-    assertEquals(expectedFlushBytes, dir.getFlushedBytes(), 0.0);
-    assertEquals(expectedMergeBytes, dir.getMergedBytes(), 0.0);
+    assertEquals(expectedFlushBytes, dir.getFlushedBytes());
+    assertEquals(expectedMergeBytes, dir.getMergedBytes());
   }
 
   @Override


### PR DESCRIPTION
See https://errorprone.info/bugpattern/LongDoubleConversion

After seeing #12008 (Calling isNaN on long arguments), looked into this check and it finds a few other things.

In general, we don't have many long-double conversions so the check is not particularly annoying or noisy, and as a library it is better not to play it fast and loose with floating point, even though java allows implicit cast of `long` to a `double`

It finds two bugs:
* BooleanPerceptron classifier was missing a call to `signum`, it passed the result of `Boolean.compareTo` directly to a scoring function, but the exact return values here are not guaranteed (only 0, negative, positive)
* TestBytesWritesTrackingDirectoryWrapper was inadvertently using `assertEquals(double, double, double)` to compare two long values: no need to bring floating point into this test. If it fails it will be a lot less confusing.

Otherwise I added explicit casts, with the exception of that pesky TestLucenePointsFormat.testEstimatePointCount which needs help around its math in general (I added TODOs, since it ends out getting duplicated about 6 times in the codebase right now due to backwards codecs) 

Closes #12009
