### PR TITLE
Clear thread local values on UTF8TaxonomyWriterCache.close()

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/writercache/UTF8TaxonomyWriterCache.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/writercache/UTF8TaxonomyWriterCache.java
@@ -24,14 +24,15 @@ import org.apache.lucene.util.ByteBlockPool.DirectTrackingAllocator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.BytesRefHash;
+import org.apache.lucene.util.CloseableThreadLocal;
 import org.apache.lucene.util.Counter;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.UnicodeUtil;
 
 /** A "cache" that never frees memory, and stores labels in a BytesRefHash (utf-8 encoding). */
 public final class UTF8TaxonomyWriterCache implements TaxonomyWriterCache, Accountable {
-  private final ThreadLocal<BytesRefBuilder> bytes =
-      new ThreadLocal<BytesRefBuilder>() {
+  private final CloseableThreadLocal<BytesRefBuilder> bytes =
+      new CloseableThreadLocal<>() {
         @Override
         protected BytesRefBuilder initialValue() {
           return new BytesRefBuilder();
@@ -153,7 +154,10 @@ public final class UTF8TaxonomyWriterCache implements TaxonomyWriterCache, Accou
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    map.clear();
+    this.bytes.close();
+  }
 
   private static final byte DELIM_CHAR = (byte) 0x1F;
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/writercache/TestUTF8TaxonomyWriterCache.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/writercache/TestUTF8TaxonomyWriterCache.java
@@ -108,6 +108,16 @@ public class TestUTF8TaxonomyWriterCache extends FacetTestCase {
     }
   }
 
+  public void testCacheClose() {
+    UTF8TaxonomyWriterCache cache = new UTF8TaxonomyWriterCache();
+    FacetLabel testLabel = new FacetLabel("test/label");
+    int testOrd = 7;
+    cache.put(testLabel, testOrd);
+    assertEquals(testOrd, cache.get(testLabel));
+    cache.close();
+    assertThrows(NullPointerException.class, () -> cache.get(testLabel));
+  }
+
   private static class LabelToOrdinalMap extends LabelToOrdinal {
     private Map<FacetLabel, Integer> map = new HashMap<>();
 


### PR DESCRIPTION
`UTF8TaxonomyWriterCache` keeps a ThreadLocal `BytesRefBuilder`, the bytes for which, are not removed on thread close. This leads to memory leaks. 

The change uses `CloseableThreadLocal` instead, and closes out the object on cache.close() 
Addresses #12000 