### PR TITLE
Ban use of Math.fma across the entire codebase

### DIFF
--- a/gradle/validation/forbidden-apis/defaults.all.txt
+++ b/gradle/validation/forbidden-apis/defaults.all.txt
@@ -66,3 +66,6 @@ javax.naming.spi.ContinuationDirContext
 javax.sql.rowset.spi.ProviderImpl
 javax.sql.rowset.spi.SyncFactory
 
+@defaultMessage Math.fma is insanely slow (2500x) in many environments (e.g. VMs). Use multiply/add and suffer the extra rounding
+java.lang.Math#fma(float,float,float)
+java.lang.Math#fma(double,double,double)


### PR DESCRIPTION
When FMA is not supported by the hardware, these methods fall back to `BigDecimal` usage [1] which causes them to be 2500x slower [2].

While most hardware in the last 10 years may have the support, out of box both VirtualBox and QEMU don't pass thru FMA support (for the latter at least you can tweak it with e.g. -cpu host or similar to fix this). 

This creates a terrible undocumented performance trap, see [3] for an example of a 30x slowdown of an entire application. In my experience, developers are often too far detached from the production reality, and that reality is: we're not deploying to macbook pros in production, instead we are almost all using virtualization: we can't afford such performance traps.

Practically it would be an issue too: e.g. Policeman jenkins instance that runs our tests currently uses virtualbox. It would be bad for vector-search tests to suddenly get 30x slower.

We can't safely use this method anywhere, as we don't have access to check CPUID or anything to see if it will be insanely slow or not. Let's ban it completely: I'm concerned it will sneak into our codebase otherwise... it almost happened before: #10718

[1] [Math.java source code](https://github.com/openjdk/jdk/blob/5d4ea9b9549b762b7c207e5c2ee65bc51591433b/src/java.base/share/classes/java/lang/Math.java#L2364-L2366)
[2] [Comment on JIRA issue for x86 intrinsic mentioning 2500x speedup](https://bugs.openjdk.org/browse/JDK-8154122?focusedCommentId=13995171&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13995171)
[3] [VirtualBox bug for lack of FMA support](https://www.virtualbox.org/ticket/15471)
