### PR TITLE
Remove null check in IndexReaderContext#leaves() usages

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -180,6 +180,8 @@ Improvements
 
 * GITHUB#12016: Upgrade lucene/expressions to use antlr 4.11.1 (Andriy Redko)
 
+* GITHUB#12034: Remove null check in IndexReaderContext#leaves() usages (Erik Pellizzon)
+
 Bug Fixes
 ---------------------
 * GITHUB#11726: Indexing term vectors on large documents could fail due to

--- a/lucene/core/src/java/org/apache/lucene/index/IndexReaderContext.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexReaderContext.java
@@ -64,7 +64,8 @@ public abstract class IndexReaderContext {
 
   /**
    * Returns the context's leaves if this context is a top-level context. For convenience, if this
-   * is an {@link LeafReaderContext} this returns itself as the only leaf.
+   * is an {@link LeafReaderContext} this returns itself as the only leaf, and it will never return
+   * a null value.
    *
    * <p>Note: this is convenience method since leaves can always be obtained by walking the context
    * tree using {@link #children()}.

--- a/lucene/core/src/java/org/apache/lucene/index/TermStates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermStates.java
@@ -49,13 +49,7 @@ public final class TermStates {
     topReaderContextIdentity = context.identity;
     docFreq = 0;
     totalTermFreq = 0;
-    final int len;
-    if (context.leaves() == null) {
-      len = 1;
-    } else {
-      len = context.leaves().size();
-    }
-    states = new TermState[len];
+    states = new TermState[context.leaves().size()];
     this.term = term;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/BlendedTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BlendedTermQuery.java
@@ -314,14 +314,8 @@ public final class BlendedTermQuery extends Query {
       IndexReaderContext readerContext, TermStates ctx, int artificialDf, long artificialTtf)
       throws IOException {
     List<LeafReaderContext> leaves = readerContext.leaves();
-    final int len;
-    if (leaves == null) {
-      len = 1;
-    } else {
-      len = leaves.size();
-    }
     TermStates newCtx = new TermStates(readerContext);
-    for (int i = 0; i < len; ++i) {
+    for (int i = 0; i < leaves.size(); ++i) {
       TermState termState = ctx.get(leaves.get(i));
       if (termState == null) {
         continue;


### PR DESCRIPTION
IndexReaderContext#leaves() never returns a null value, so we can safely remove the null checks from the method calls.
We should also update the method documentation to make that clear.