### PR TITLE
Remove redundant code in Lucene search

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -346,12 +346,9 @@ public class IndexSearcher {
       } else {
         if (group == null) {
           group = new ArrayList<>();
-          group.add(ctx);
-
           groupedLeaves.add(group);
-        } else {
-          group.add(ctx);
         }
+        group.add(ctx);
 
         docSum += ctx.reader().maxDoc();
         if (group.size() >= maxSegmentsPerSlice || docSum > maxDocsPerSlice) {

--- a/lucene/core/src/java/org/apache/lucene/search/Weight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Weight.java
@@ -270,23 +270,13 @@ public abstract class Weight implements SegmentCacheable {
         int currentDoc,
         int end)
         throws IOException {
-      if (twoPhase == null) {
-        while (currentDoc < end) {
-          if (acceptDocs == null || acceptDocs.get(currentDoc)) {
-            collector.collect(currentDoc);
-          }
-          currentDoc = iterator.nextDoc();
+      while (currentDoc < end) {
+        if ((acceptDocs == null || acceptDocs.get(currentDoc)) && (twoPhase == null || twoPhase.matches())) {
+          collector.collect(currentDoc);
         }
-        return currentDoc;
-      } else {
-        while (currentDoc < end) {
-          if ((acceptDocs == null || acceptDocs.get(currentDoc)) && twoPhase.matches()) {
-            collector.collect(currentDoc);
-          }
-          currentDoc = iterator.nextDoc();
-        }
-        return currentDoc;
+        currentDoc = iterator.nextDoc();
       }
+      return currentDoc;
     }
 
     /**
@@ -299,23 +289,13 @@ public abstract class Weight implements SegmentCacheable {
         TwoPhaseIterator twoPhase,
         Bits acceptDocs)
         throws IOException {
-      if (twoPhase == null) {
-        for (int doc = iterator.nextDoc();
-            doc != DocIdSetIterator.NO_MORE_DOCS;
-            doc = iterator.nextDoc()) {
-          if (acceptDocs == null || acceptDocs.get(doc)) {
-            collector.collect(doc);
-          }
-        }
-      } else {
-        // The scorer has an approximation, so run the approximation first, then check acceptDocs,
-        // then confirm
-        for (int doc = iterator.nextDoc();
-            doc != DocIdSetIterator.NO_MORE_DOCS;
-            doc = iterator.nextDoc()) {
-          if ((acceptDocs == null || acceptDocs.get(doc)) && twoPhase.matches()) {
-            collector.collect(doc);
-          }
+      // The scorer has an approximation, so run the approximation first, then check acceptDocs,
+      // then confirm
+      for (int doc = iterator.nextDoc();
+          doc != DocIdSetIterator.NO_MORE_DOCS;
+          doc = iterator.nextDoc()) {
+        if ((acceptDocs == null || acceptDocs.get(doc)) && (twoPhase == null || twoPhase.matches())) {
+          collector.collect(doc);
         }
       }
     }


### PR DESCRIPTION
Weight: Move the twoPhase argument check in the loop, so the condition is true when twoPhase argument is null or, when not null, if matches() return true.

IndexSearcher: group is an ArrayList inserted by reference into groupedLeaves, so we can simply add to group outside of the if(group==null) check and keep it to initialize the group.