### PR TITLE
Remove redundant code in Lucene geo

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/geo/GeoUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/GeoUtils.java
@@ -205,13 +205,7 @@ public final class GeoUtils {
   public static int orient(double ax, double ay, double bx, double by, double cx, double cy) {
     double v1 = (bx - ax) * (cy - ay);
     double v2 = (cx - ax) * (by - ay);
-    if (v1 > v2) {
-      return 1;
-    } else if (v1 < v2) {
-      return -1;
-    } else {
-      return 0;
-    }
+    return Double.compare(v1, v2);
   }
 
   /** uses orient method to compute whether two line segments cross */
@@ -262,11 +256,8 @@ public final class GeoUtils {
       double a2y,
       double b2x,
       double b2y) {
-    if (orient(a2x, a2y, b2x, b2y, a1x, a1y) * orient(a2x, a2y, b2x, b2y, b1x, b1y) <= 0
-        && orient(a1x, a1y, b1x, b1y, a2x, a2y) * orient(a1x, a1y, b1x, b1y, b2x, b2y) <= 0) {
-      return true;
-    }
-    return false;
+    return orient(a2x, a2y, b2x, b2y, a1x, a1y) * orient(a2x, a2y, b2x, b2y, b1x, b1y) <= 0
+        && orient(a1x, a1y, b1x, b1y, a2x, a2y) * orient(a1x, a1y, b1x, b1y, b2x, b2y) <= 0;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/geo/GeoUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/GeoUtils.java
@@ -205,7 +205,13 @@ public final class GeoUtils {
   public static int orient(double ax, double ay, double bx, double by, double cx, double cy) {
     double v1 = (bx - ax) * (cy - ay);
     double v2 = (cx - ax) * (by - ay);
-    return Double.compare(v1, v2);
+    if (v1 > v2) {
+      return 1;
+    } else if (v1 < v2) {
+      return -1;
+    } else {
+      return 0;
+    }
   }
 
   /** uses orient method to compute whether two line segments cross */

--- a/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
@@ -20,7 +20,6 @@ import static org.apache.lucene.geo.GeoEncodingUtils.encodeLatitude;
 import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
 import static org.apache.lucene.geo.GeoUtils.lineCrossesLine;
 import static org.apache.lucene.geo.GeoUtils.lineOverlapLine;
-import static org.apache.lucene.geo.GeoUtils.orient;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -674,24 +673,24 @@ public final class Tessellator {
   /** Check if there are other points inside the potential ear **/
   private static boolean pointsInsideEar(Node nodeToCheck, Node ear) {
     return nodeToCheck.idx != ear.previous.idx
-            && nodeToCheck.idx != ear.next.idx
-            && pointInEar(
-                nodeToCheck.getX(),
-                nodeToCheck.getY(),
-                ear.previous.getX(),
-                ear.previous.getY(),
-                ear.getX(),
-                ear.getY(),
-                ear.next.getX(),
-                ear.next.getY())
-            && area(
+        && nodeToCheck.idx != ear.next.idx
+        && pointInEar(
+            nodeToCheck.getX(),
+            nodeToCheck.getY(),
+            ear.previous.getX(),
+            ear.previous.getY(),
+            ear.getX(),
+            ear.getY(),
+            ear.next.getX(),
+            ear.next.getY())
+        && area(
                 nodeToCheck.previous.getX(),
                 nodeToCheck.previous.getY(),
                 nodeToCheck.getX(),
                 nodeToCheck.getY(),
                 nodeToCheck.next.getX(),
                 nodeToCheck.next.getY())
-               >= 0;
+            >= 0;
   }
 
   /** Iterate through all polygon nodes and remove small local self-intersections * */


### PR DESCRIPTION
Tessellator: Move boolean check repeated 4 times to its dedicated function.
Replace pointInTriangle implementation with the Component2D one, passing to it the calculated minX, minY, maxX, maxY.