### PR TITLE
Optimize flush of doc-value fields that are effectively single-valued when an index sort is configured.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesWriter.java
@@ -104,7 +104,7 @@ class NumericDocValuesWriter extends DocValuesWriter<NumericDocValues> {
     dvConsumer.addNumericField(
         fieldInfo,
         getDocValuesProducer(
-            NumericDocValuesWriter.this.fieldInfo, finalValues, docsWithField, sortMap));
+            fieldInfo, finalValues, docsWithField, sortMap));
   }
 
   static DocValuesProducer getDocValuesProducer(

--- a/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesWriter.java
@@ -102,9 +102,7 @@ class NumericDocValuesWriter extends DocValuesWriter<NumericDocValues> {
     }
 
     dvConsumer.addNumericField(
-        fieldInfo,
-        getDocValuesProducer(
-            fieldInfo, finalValues, docsWithField, sortMap));
+        fieldInfo, getDocValuesProducer(fieldInfo, finalValues, docsWithField, sortMap));
   }
 
   static DocValuesProducer getDocValuesProducer(

--- a/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesWriter.java
@@ -20,6 +20,7 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
 import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.Counter;
@@ -99,30 +100,40 @@ class NumericDocValuesWriter extends DocValuesWriter<NumericDocValues> {
     if (finalValues == null) {
       finalValues = pending.build();
     }
+
+    dvConsumer.addNumericField(
+        fieldInfo,
+        getDocValuesProducer(
+            NumericDocValuesWriter.this.fieldInfo, finalValues, docsWithField, sortMap));
+  }
+
+  static DocValuesProducer getDocValuesProducer(
+      FieldInfo writerFieldInfo,
+      PackedLongValues values,
+      DocsWithFieldSet docsWithField,
+      Sorter.DocMap sortMap)
+      throws IOException {
     final NumericDVs sorted;
     if (sortMap != null) {
-      NumericDocValues oldValues =
-          new BufferedNumericDocValues(finalValues, docsWithField.iterator());
-      sorted = sortDocValues(state.segmentInfo.maxDoc(), sortMap, oldValues);
+      NumericDocValues oldValues = new BufferedNumericDocValues(values, docsWithField.iterator());
+      sorted = sortDocValues(sortMap.size(), sortMap, oldValues);
     } else {
       sorted = null;
     }
 
-    dvConsumer.addNumericField(
-        fieldInfo,
-        new EmptyDocValuesProducer() {
-          @Override
-          public NumericDocValues getNumeric(FieldInfo fieldInfo) {
-            if (fieldInfo != NumericDocValuesWriter.this.fieldInfo) {
-              throw new IllegalArgumentException("wrong fieldInfo");
-            }
-            if (sorted == null) {
-              return new BufferedNumericDocValues(finalValues, docsWithField.iterator());
-            } else {
-              return new SortingNumericDocValues(sorted);
-            }
-          }
-        });
+    return new EmptyDocValuesProducer() {
+      @Override
+      public NumericDocValues getNumeric(FieldInfo fieldInfo) {
+        if (fieldInfo != writerFieldInfo) {
+          throw new IllegalArgumentException("wrong fieldInfo");
+        }
+        if (sorted == null) {
+          return new BufferedNumericDocValues(values, docsWithField.iterator());
+        } else {
+          return new SortingNumericDocValues(sorted);
+        }
+      }
+    };
   }
 
   // iterates over the values we have in ram

--- a/lucene/core/src/java/org/apache/lucene/index/SortedNumericDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortedNumericDocValuesWriter.java
@@ -21,6 +21,7 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.index.NumericDocValuesWriter.BufferedNumericDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.ArrayUtil;
@@ -171,6 +172,20 @@ class SortedNumericDocValuesWriter extends DocValuesWriter<SortedNumericDocValue
     } else {
       values = finalValues;
       valueCounts = finalValuesCount;
+    }
+
+    if (valueCounts == null) {
+      DocValuesProducer singleValueProducer =
+          NumericDocValuesWriter.getDocValuesProducer(fieldInfo, values, docsWithField, sortMap);
+      dvConsumer.addSortedNumericField(
+          fieldInfo,
+          new EmptyDocValuesProducer() {
+            @Override
+            public SortedNumericDocValues getSortedNumeric(FieldInfo fieldInfo) throws IOException {
+              return DocValues.singleton(singleValueProducer.getNumeric(fieldInfo));
+            }
+          });
+      return;
     }
 
     final LongValues sorted;

--- a/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValuesWriter.java
@@ -22,6 +22,7 @@ import static org.apache.lucene.util.ByteBlockPool.BYTE_BLOCK_SIZE;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.index.SortedDocValuesWriter.BufferedSortedDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.ArrayUtil;
@@ -160,8 +161,7 @@ class SortedSetDocValuesWriter extends DocValuesWriter<SortedSetDocValues> {
     bytesUsed = newBytesUsed;
   }
 
-  @Override
-  SortedSetDocValues getDocValues() {
+  private void finish() {
     if (finalOrds == null) {
       assert finalOrdCounts == null && finalSortedValues == null && finalOrdMap == null;
       finishCurrentDoc();
@@ -170,10 +170,15 @@ class SortedSetDocValuesWriter extends DocValuesWriter<SortedSetDocValues> {
       finalOrdCounts = pendingCounts == null ? null : pendingCounts.build();
       finalSortedValues = hash.sort();
       finalOrdMap = new int[valueCount];
+      for (int ord = 0; ord < finalOrdMap.length; ord++) {
+        finalOrdMap[finalSortedValues[ord]] = ord;
+      }
     }
-    for (int ord = 0; ord < finalOrdMap.length; ord++) {
-      finalOrdMap[finalSortedValues[ord]] = ord;
-    }
+  }
+
+  @Override
+  SortedSetDocValues getDocValues() {
+    finish();
     return getValues(
         finalSortedValues, finalOrdMap, hash, finalOrds, finalOrdCounts, maxCount, docsWithField);
   }
@@ -198,27 +203,25 @@ class SortedSetDocValuesWriter extends DocValuesWriter<SortedSetDocValues> {
   @Override
   public void flush(SegmentWriteState state, Sorter.DocMap sortMap, DocValuesConsumer dvConsumer)
       throws IOException {
-    final int valueCount = hash.size();
-    final PackedLongValues ords;
-    final PackedLongValues ordCounts;
-    final int[] sortedValues;
-    final int[] ordMap;
+    finish();
+    final PackedLongValues ords = finalOrds;
+    final PackedLongValues ordCounts = finalOrdCounts;
+    final int[] sortedValues = finalSortedValues;
+    final int[] ordMap = finalOrdMap;
 
-    if (finalOrds == null) {
-      assert finalOrdCounts == null && finalSortedValues == null && finalOrdMap == null;
-      finishCurrentDoc();
-      ords = pending.build();
-      ordCounts = pendingCounts == null ? null : pendingCounts.build();
-      sortedValues = hash.sort();
-      ordMap = new int[valueCount];
-      for (int ord = 0; ord < valueCount; ord++) {
-        ordMap[sortedValues[ord]] = ord;
-      }
-    } else {
-      ords = finalOrds;
-      ordCounts = finalOrdCounts;
-      sortedValues = finalSortedValues;
-      ordMap = finalOrdMap;
+    if (ordCounts == null) {
+      DocValuesProducer singleValueProducer =
+          SortedDocValuesWriter.getDocValuesProducer(
+              fieldInfo, hash, ords, sortedValues, ordMap, docsWithField, sortMap);
+      dvConsumer.addSortedSetField(
+          fieldInfo,
+          new EmptyDocValuesProducer() {
+            @Override
+            public SortedSetDocValues getSortedSet(FieldInfo fieldInfo) throws IOException {
+              return DocValues.singleton(singleValueProducer.getSorted(fieldInfo));
+            }
+          });
+      return;
     }
 
     final DocOrds docOrds;


### PR DESCRIPTION
This iterates on #399 to also optimize the case when an index sort is configured. When cutting over the NYC taxis benchmark to the new numeric fields,
[flush times](http://people.apache.org/~mikemccand/lucenebench/sparseResults.html#flush_times) stayed mostly the same when index sorting is disabled and increased by 7-8% when index sorting is enabled. I expect this change to address this slowdown.