### PR TITLE
Add sanity checks before using MemorySegment API

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/store/TestMmapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMmapDirectory.java
@@ -46,9 +46,13 @@ public class TestMmapDirectory extends BaseDirectoryTestCase {
         "MemorySegmentIndexInputProvider", MMapDirectory.PROVIDER.getClass().getSimpleName());
   }
 
+  private static boolean hasMemorySegmentAPI() {
+    return Class.forName(Object.class.getModule(), "java.lang.foreign.MemorySegment") != null;
+  }
+
   public void testCorrectImplementation() {
     final int runtimeVersion = Runtime.version().feature();
-    if (runtimeVersion == 19) {
+    if (runtimeVersion == 19 && hasMemorySegmentAPI()) {
       assertTrue(
           "on Java 19 we should use MemorySegmentIndexInputProvider to create mmap IndexInputs",
           isMemorySegmentImpl());

--- a/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
+++ b/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
@@ -210,12 +210,6 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
                       loader.getResource(
                           "META-INF/versions/19/org/apache/lucene/store/MemorySegmentIndexInput.class"))
                   .isNotNull();
-
-              if (Runtime.version().feature() == 19) {
-                Assertions.assertThat(
-                        loader.loadClass("org.apache.lucene.store.MemorySegmentIndexInput"))
-                    .isNotNull();
-              }
             });
   }
 


### PR DESCRIPTION
Followup on #12033:
- do sanity checks before enabling MemorySegment usage in Lucene
- remove useless distribution test