### PR TITLE
Fix TestRangeOnRaneFacetCounts dimention overflow error

### DIFF
--- a/lucene/facet/src/test/org/apache/lucene/facet/rangeonrange/TestRangeOnRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/rangeonrange/TestRangeOnRangeFacetCounts.java
@@ -16,14 +16,6 @@
  */
 package org.apache.lucene.facet.rangeonrange;
 
-import static org.apache.lucene.document.DoubleRange.verifyAndEncode;
-import static org.apache.lucene.document.LongRange.verifyAndEncode;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoubleRangeDocValuesField;
 import org.apache.lucene.document.LongRangeDocValuesField;
@@ -53,6 +45,15 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.lucene.document.DoubleRange.verifyAndEncode;
+import static org.apache.lucene.document.LongRange.verifyAndEncode;
 
 public class TestRangeOnRangeFacetCounts extends FacetTestCase {
 
@@ -1001,7 +1002,7 @@ public class TestRangeOnRangeFacetCounts extends FacetTestCase {
     RandomIndexWriter w = new RandomIndexWriter(random(), dir);
 
     int numDocs = atLeast(1000);
-    int dims = atLeast(2);
+    int dims = random().nextInt(2, 5);
     if (VERBOSE) {
       System.out.println("TEST: numDocs=" + numDocs);
     }
@@ -1318,7 +1319,7 @@ public class TestRangeOnRangeFacetCounts extends FacetTestCase {
     RandomIndexWriter w = new RandomIndexWriter(random(), dir);
 
     int numDocs = atLeast(1000);
-    int dims = atLeast(2);
+    int dims = random().nextInt(2, 5);
     if (VERBOSE) {
       System.out.println("TEST: numDocs=" + numDocs);
     }

--- a/lucene/facet/src/test/org/apache/lucene/facet/rangeonrange/TestRangeOnRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/rangeonrange/TestRangeOnRangeFacetCounts.java
@@ -16,6 +16,14 @@
  */
 package org.apache.lucene.facet.rangeonrange;
 
+import static org.apache.lucene.document.DoubleRange.verifyAndEncode;
+import static org.apache.lucene.document.LongRange.verifyAndEncode;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoubleRangeDocValuesField;
 import org.apache.lucene.document.LongRangeDocValuesField;
@@ -45,15 +53,6 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.apache.lucene.document.DoubleRange.verifyAndEncode;
-import static org.apache.lucene.document.LongRange.verifyAndEncode;
 
 public class TestRangeOnRangeFacetCounts extends FacetTestCase {
 


### PR DESCRIPTION
### Description

failing test: https://jenkins.thetaphi.de/job/Lucene-main-Linux/39124/testReport/junit/org.apache.lucene.facet.rangeonrange/TestRangeOnRangeFacetCounts/testRandomMultiDimLongs/ 

stack trace example:
```
org.apache.lucene.facet.rangeonrange.TestRangeOnRangeFacetCounts > testRandomMultiDimDoubles FAILED
    java.lang.IllegalArgumentException: DoubleRange does not support greater than 4 dimensions
        at __randomizedtesting.SeedInfo.seed([978417F05E30CBDA:D9132730633ABE7C]:0)
        at org.apache.lucene.core@10.0.0-SNAPSHOT/org.apache.lucene.document.DoubleRange.checkArgs(DoubleRange.java:117)
        at org.apache.lucene.core@10.0.0-SNAPSHOT/org.apache.lucene.document.DoubleRange.encode(DoubleRange.java:123)
        at org.apache.lucene.core@10.0.0-SNAPSHOT/org.apache.lucene.document.DoubleRangeDocValuesField.<init>(DoubleRangeDocValuesField.java:33)
        at org.apache.lucene.facet.rangeonrange.TestRangeOnRangeFacetCounts.testRandomMultiDimDoubles(TestRangeOnRangeFacetCounts.java:1340)
...
```