### PR TITLE
Reuse HNSW graph for intialization during merge

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -121,6 +121,8 @@ Optimizations
   in order to achieve the same false positive probability with less memory.
   (Jean-François Boeuf)
 
+* GITHUB#12050: Reuse HNSW graph for intialization during merge (Jack Mazanec)
+
 Bug Fixes
 ---------------------
 (No changes)

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
@@ -561,9 +561,9 @@ public final class Lucene91HnswVectorsReader extends KnnVectorsReader {
     @Override
     public NodesIterator getNodesOnLevel(int level) {
       if (level == 0) {
-        return new NodesIterator(size());
+        return new ArrayNodesIterator(size());
       } else {
-        return new NodesIterator(nodesByLevel[level], nodesByLevel[level].length);
+        return new ArrayNodesIterator(nodesByLevel[level], nodesByLevel[level].length);
       }
     }
   }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91OnHeapHnswGraph.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91OnHeapHnswGraph.java
@@ -163,9 +163,9 @@ public final class Lucene91OnHeapHnswGraph extends HnswGraph {
   @Override
   public NodesIterator getNodesOnLevel(int level) {
     if (level == 0) {
-      return new NodesIterator(size());
+      return new ArrayNodesIterator(size());
     } else {
-      return new NodesIterator(nodesByLevel.get(level), graph.get(level).size());
+      return new ArrayNodesIterator(nodesByLevel.get(level), graph.get(level).size());
     }
   }
 }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsReader.java
@@ -457,9 +457,9 @@ public final class Lucene92HnswVectorsReader extends KnnVectorsReader {
     @Override
     public NodesIterator getNodesOnLevel(int level) {
       if (level == 0) {
-        return new NodesIterator(size());
+        return new ArrayNodesIterator(size());
       } else {
-        return new NodesIterator(nodesByLevel[level], nodesByLevel[level].length);
+        return new ArrayNodesIterator(nodesByLevel[level], nodesByLevel[level].length);
       }
     }
   }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsReader.java
@@ -533,9 +533,9 @@ public final class Lucene94HnswVectorsReader extends KnnVectorsReader {
     @Override
     public NodesIterator getNodesOnLevel(int level) {
       if (level == 0) {
-        return new NodesIterator(size());
+        return new ArrayNodesIterator(size());
       } else {
-        return new NodesIterator(nodesByLevel[level], nodesByLevel[level].length);
+        return new ArrayNodesIterator(nodesByLevel[level], nodesByLevel[level].length);
       }
     }
   }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
@@ -345,7 +345,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
         if (level == 0) {
           return graph.getNodesOnLevel(0);
         } else {
-          return new NodesIterator(nodesByLevel.get(level), nodesByLevel.get(level).length);
+          return new ArrayNodesIterator(nodesByLevel.get(level), nodesByLevel.get(level).length);
         }
       }
     };

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
@@ -687,10 +687,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
       assert docID > lastDocID;
       docsWithField.add(docID);
       vectors.add(copyValue(vectorValue));
-      if (node > 0) {
-        // start at node 1! node 0 is added implicitly, in the constructor
-        hnswGraphBuilder.addGraphNode(node, vectorValue);
-      }
+      hnswGraphBuilder.addGraphNode(node, vectorValue);
       node++;
       lastDocID = docID;
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsReader.java
@@ -573,9 +573,9 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader {
     @Override
     public NodesIterator getNodesOnLevel(int level) {
       if (level == 0) {
-        return new NodesIterator(size());
+        return new ArrayNodesIterator(size());
       } else {
-        return new NodesIterator(nodesByLevel[level], nodesByLevel[level].length);
+        return new ArrayNodesIterator(nodesByLevel[level], nodesByLevel[level].length);
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -735,10 +735,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
       assert docID > lastDocID;
       docsWithField.add(docID);
       vectors.add(copyValue(vectorValue));
-      if (node > 0) {
-        // start at node 1! node 0 is added implicitly, in the constructor
-        hnswGraphBuilder.addGraphNode(node, vectorValue);
-      }
+      hnswGraphBuilder.addGraphNode(node, vectorValue);
       node++;
       lastDocID = docID;
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -440,8 +440,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                         vectorDataInput,
                         byteSize);
                 HnswGraphBuilder<byte[]> hnswGraphBuilder =
-                    createByteVectorHnswGraphBuilder(
-                        mergeState, fieldInfo, vectorValues, initializerIndex);
+                    createHnswGraphBuilder(mergeState, fieldInfo, vectorValues, initializerIndex);
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.copy());
               }
@@ -453,8 +452,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                         vectorDataInput,
                         byteSize);
                 HnswGraphBuilder<float[]> hnswGraphBuilder =
-                    createFloatVectorHnswGraphBuilder(
-                        mergeState, fieldInfo, vectorValues, initializerIndex);
+                    createHnswGraphBuilder(mergeState, fieldInfo, vectorValues, initializerIndex);
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.copy());
               }
@@ -485,10 +483,10 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     }
   }
 
-  private HnswGraphBuilder<float[]> createFloatVectorHnswGraphBuilder(
+  private <T> HnswGraphBuilder<T> createHnswGraphBuilder(
       MergeState mergeState,
       FieldInfo fieldInfo,
-      RandomAccessVectorValues<float[]> floatVectorValues,
+      RandomAccessVectorValues<T> floatVectorValues,
       int initializerIndex)
       throws IOException {
     if (initializerIndex == -1) {
@@ -507,37 +505,6 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
         getOldToNewOrdinalMap(mergeState, fieldInfo, initializerIndex);
     return HnswGraphBuilder.create(
         floatVectorValues,
-        fieldInfo.getVectorEncoding(),
-        fieldInfo.getVectorSimilarityFunction(),
-        M,
-        beamWidth,
-        HnswGraphBuilder.randSeed,
-        initializerGraph,
-        ordinalMapper);
-  }
-
-  private HnswGraphBuilder<byte[]> createByteVectorHnswGraphBuilder(
-      MergeState mergeState,
-      FieldInfo fieldInfo,
-      RandomAccessVectorValues<byte[]> byteVectorValues,
-      int initializerIndex)
-      throws IOException {
-    if (initializerIndex == -1) {
-      return HnswGraphBuilder.create(
-          byteVectorValues,
-          fieldInfo.getVectorEncoding(),
-          fieldInfo.getVectorSimilarityFunction(),
-          M,
-          beamWidth,
-          HnswGraphBuilder.randSeed);
-    }
-
-    HnswGraph initializerGraph =
-        getHnswGraphFromReader(fieldInfo.name, mergeState.knnVectorsReaders[initializerIndex]);
-    Map<Integer, Integer> ordinalMapper =
-        getOldToNewOrdinalMap(mergeState, fieldInfo, initializerIndex);
-    return HnswGraphBuilder.create(
-        byteVectorValues,
         fieldInfo.getVectorEncoding(),
         fieldInfo.getVectorSimilarityFunction(),
         M,

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -20,10 +20,10 @@ package org.apache.lucene.util.hnsw;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.PrimitiveIterator;
-import java.util.Set;
 import org.apache.lucene.index.FloatVectorValues;
 
 /**
@@ -204,11 +204,11 @@ public abstract class HnswGraph {
   }
 
   /** Nodes iterator based on set representation of nodes. */
-  public static class SetNodesIterator extends NodesIterator {
+  public static class CollectionNodesIterator extends NodesIterator {
     Iterator<Integer> nodes;
 
-    /** Constructor for iterator based on set representing nodes */
-    public SetNodesIterator(Set<Integer> nodes) {
+    /** Constructor for iterator based on collection representing nodes */
+    public CollectionNodesIterator(Collection<Integer> nodes) {
       super(nodes.size());
       this.nodes = nodes.iterator();
     }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -20,8 +20,10 @@ package org.apache.lucene.util.hnsw;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.PrimitiveIterator;
+import java.util.Set;
 import org.apache.lucene.index.FloatVectorValues;
 
 /**
@@ -115,7 +117,7 @@ public abstract class HnswGraph {
 
         @Override
         public NodesIterator getNodesOnLevel(int level) {
-          return NodesIterator.EMPTY;
+          return ArrayNodesIterator.EMPTY;
         }
       };
 
@@ -123,25 +125,17 @@ public abstract class HnswGraph {
    * Iterator over the graph nodes on a certain level, Iterator also provides the size – the total
    * number of nodes to be iterated over.
    */
-  public static final class NodesIterator implements PrimitiveIterator.OfInt {
-    static NodesIterator EMPTY = new NodesIterator(0);
-
-    private final int[] nodes;
-    private final int size;
-    int cur = 0;
-
-    /** Constructor for iterator based on the nodes array up to the size */
-    public NodesIterator(int[] nodes, int size) {
-      assert nodes != null;
-      assert size <= nodes.length;
-      this.nodes = nodes;
-      this.size = size;
-    }
+  public abstract static class NodesIterator implements PrimitiveIterator.OfInt {
+    protected final int size;
 
     /** Constructor for iterator based on the size */
     public NodesIterator(int size) {
-      this.nodes = null;
       this.size = size;
+    }
+
+    /** The number of elements in this iterator * */
+    public int size() {
+      return size;
     }
 
     /**
@@ -150,6 +144,31 @@ public abstract class HnswGraph {
      * @param dest where to put the integers
      * @return The number of integers written to `dest`
      */
+    public abstract int consume(int[] dest);
+  }
+
+  /** NodesIterator that accepts nodes as an integer array. */
+  public static class ArrayNodesIterator extends NodesIterator {
+    static NodesIterator EMPTY = new ArrayNodesIterator(0);
+
+    private final int[] nodes;
+    private int cur = 0;
+
+    /** Constructor for iterator based on integer array representing nodes */
+    public ArrayNodesIterator(int[] nodes, int size) {
+      super(size);
+      assert nodes != null;
+      assert size <= nodes.length;
+      this.nodes = nodes;
+    }
+
+    /** Constructor for iterator based on the size */
+    public ArrayNodesIterator(int size) {
+      super(size);
+      this.nodes = null;
+    }
+
+    @Override
     public int consume(int[] dest) {
       if (hasNext() == false) {
         throw new NoSuchElementException();
@@ -182,10 +201,43 @@ public abstract class HnswGraph {
     public boolean hasNext() {
       return cur < size;
     }
+  }
 
-    /** The number of elements in this iterator * */
-    public int size() {
-      return size;
+  /** Nodes iterator based on set representation of nodes. */
+  public static class SetNodesIterator extends NodesIterator {
+    Iterator<Integer> nodes;
+
+    /** Constructor for iterator based on set representing nodes */
+    public SetNodesIterator(Set<Integer> nodes) {
+      super(nodes.size());
+      this.nodes = nodes.iterator();
+    }
+
+    @Override
+    public int consume(int[] dest) {
+      if (hasNext() == false) {
+        throw new NoSuchElementException();
+      }
+
+      int destIndex = 0;
+      while (hasNext() && destIndex < dest.length) {
+        dest[destIndex++] = nextInt();
+      }
+
+      return destIndex;
+    }
+
+    @Override
+    public int nextInt() {
+      if (hasNext() == false) {
+        throw new NoSuchElementException();
+      }
+      return nodes.next();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return nodes.hasNext();
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -166,7 +166,7 @@ public final class HnswGraphBuilder<T> {
     final int nodeLevel = getRandomGraphLevel(ml, random);
     int curMaxLevel = hnsw.numLevels() - 1;
 
-    // If entrynode is -1, then this should all fail with no neighbors
+    // If entrynode is -1, then this should finish without adding neighbors
     if (hnsw.entryNode() == -1) {
       for (int level = nodeLevel; level >= 0; level--) {
         hnsw.addNode(level, node);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -80,6 +80,22 @@ public final class HnswGraphBuilder<T> {
     return new HnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, M, beamWidth, seed);
   }
 
+  public static <T> HnswGraphBuilder<T> create(
+      RandomAccessVectorValues<T> vectors,
+      VectorEncoding vectorEncoding,
+      VectorSimilarityFunction similarityFunction,
+      int M,
+      int beamWidth,
+      long seed,
+      HnswGraph initializerGraph,
+      Map<Integer, Integer> oldToNewOrdinalMap)
+      throws IOException {
+    HnswGraphBuilder<T> hnswGraphBuilder =
+        new HnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, M, beamWidth, seed);
+    hnswGraphBuilder.initializeFromGraph(initializerGraph, oldToNewOrdinalMap);
+    return hnswGraphBuilder;
+  }
+
   /**
    * Reads all the vectors from vector values, builds a graph connecting them by their dense
    * ordinals, using the given hyperparameter settings, and returns the resulting graph.
@@ -157,7 +173,7 @@ public final class HnswGraphBuilder<T> {
    * @param oldToNewOrdinalMap map for converting from ordinals in the initializerGraph to this
    *     builder's graph
    */
-  public void initializeFromGraph(
+  private void initializeFromGraph(
       HnswGraph initializerGraph, Map<Integer, Integer> oldToNewOrdinalMap) throws IOException {
     assert hnsw.size() == 0;
     float[] vectorValue = null;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -101,7 +101,12 @@ public class HnswGraphSearcher<T> {
             new NeighborQueue(topK, true),
             new SparseFixedBitSet(vectors.size()));
     NeighborQueue results;
-    int[] eps = new int[] {graph.entryNode()};
+
+    int initialEp = graph.entryNode();
+    if (initialEp == -1) {
+      return NeighborQueue.EMPTY_MAX_HEAP_NEIGHBOR_QUEUE;
+    }
+    int[] eps = new int[] {initialEp};
     int numVisited = 0;
     for (int level = graph.numLevels() - 1; level >= 1; level--) {
       results = graphSearcher.searchLevel(query, 1, level, eps, vectors, graph, null, visitedLimit);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -104,7 +104,7 @@ public class HnswGraphSearcher<T> {
 
     int initialEp = graph.entryNode();
     if (initialEp == -1) {
-      return NeighborQueue.EMPTY_MAX_HEAP_NEIGHBOR_QUEUE;
+      return new NeighborQueue(1, true);
     }
     int[] eps = new int[] {initialEp};
     int numVisited = 0;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -56,8 +56,6 @@ public class NeighborQueue {
   // Whether the search stopped early because it reached the visited nodes limit
   private boolean incomplete;
 
-  public static final NeighborQueue EMPTY_MAX_HEAP_NEIGHBOR_QUEUE = new NeighborQueue(1, true);
-
   public NeighborQueue(int initialSize, boolean maxHeap) {
     this.heap = new LongHeap(initialSize);
     this.order = maxHeap ? Order.MAX_HEAP : Order.MIN_HEAP;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -56,6 +56,8 @@ public class NeighborQueue {
   // Whether the search stopped early because it reached the visited nodes limit
   private boolean incomplete;
 
+  public static final NeighborQueue EMPTY_MAX_HEAP_NEIGHBOR_QUEUE = new NeighborQueue(1, true);
+
   public NeighborQueue(int initialSize, boolean maxHeap) {
     this.heap = new LongHeap(initialSize);
     this.order = maxHeap ? Order.MAX_HEAP : Order.MIN_HEAP;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -20,11 +20,9 @@ package org.apache.lucene.util.hnsw;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.TreeMap;
 import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
 
 /**
@@ -36,40 +34,34 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
   private int numLevels; // the current number of levels in the graph
   private int entryNode; // the current graph entry node on the top level. -1 if not set
 
-  // Nodes by level expressed as the level 0's nodes' ordinals.
-  // As level 0 contains all nodes, nodesByLevel.get(0) is null.
-  private final List<int[]> nodesByLevel;
-
-  // graph is a list of graph levels.
-  // Each level is represented as List<NeighborArray> – nodes' connections on this level.
+  // Level 0 is represented as List<NeighborArray> – nodes' connections on level 0.
   // Each entry in the list has the top maxConn/maxConn0 neighbors of a node. The nodes correspond
   // to vectors
   // added to HnswBuilder, and the node values are the ordinals of those vectors.
   // Thus, on all levels, neighbors expressed as the level 0's nodes' ordinals.
-  private final List<List<NeighborArray>> graph;
+  private final List<NeighborArray> graphLevel0;
+  // Represents levels 1-N. Each level is represented with a TreeMap that maps a levels level 0
+  // ordinal to its
+  // neighbors on that level.
+  private final List<TreeMap<Integer, NeighborArray>> graphUpperLevels;
   private final int nsize;
   private final int nsize0;
 
   // KnnGraphValues iterator members
   private int upto;
   private NeighborArray cur;
-  // Keep track of the last added nodes in the graph for insertion optimization
-  private final List<Integer> lastAddedPosInLayer;
 
   OnHeapHnswGraph(int M) {
     this.numLevels = 1; // Implicitly start the graph with a single level
-    this.graph = new ArrayList<>(Collections.singleton(new ArrayList<>()));
+    this.graphLevel0 = new ArrayList<>();
     this.entryNode = -1; // Entry node should be negative until a node is added
     // Neighbours' size on upper levels (nsize) and level 0 (nsize0)
     // We allocate extra space for neighbours, but then prune them to keep allowed maximum
     this.nsize = M + 1;
     this.nsize0 = (M * 2 + 1);
 
-    this.nodesByLevel = new ArrayList<>(numLevels);
-    nodesByLevel.add(null); // we don't need this for 0th level, as it contains all nodes
-
-    this.lastAddedPosInLayer = new ArrayList<>(numLevels);
-    lastAddedPosInLayer.add(null);
+    this.graphUpperLevels = new ArrayList<>(numLevels);
+    graphUpperLevels.add(null); // we don't need this for 0th level, as it contains all nodes
   }
 
   /**
@@ -80,16 +72,16 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
    */
   public NeighborArray getNeighbors(int level, int node) {
     if (level == 0) {
-      return graph.get(level).get(node);
+      return graphLevel0.get(node);
     }
-    int nodeIndex = Arrays.binarySearch(nodesByLevel.get(level), 0, graph.get(level).size(), node);
-    assert nodeIndex >= 0;
-    return graph.get(level).get(nodeIndex);
+    TreeMap<Integer, NeighborArray> levelMap = graphUpperLevels.get(level);
+    assert levelMap.containsKey(node);
+    return levelMap.get(node);
   }
 
   @Override
   public int size() {
-    return graph.get(0).size(); // all nodes are located on the 0th level
+    return graphLevel0.size(); // all nodes are located on the 0th level
   }
 
   /**
@@ -108,66 +100,22 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
       // if the new node introduces a new level, add more levels to the graph,
       // and make this node the graph's new entry point
       if (level >= numLevels) {
-        for (int i = numLevels; i < level; i++) {
-          graph.add(new ArrayList<>());
-          nodesByLevel.add(new int[] {});
-          lastAddedPosInLayer.add(-1);
+        for (int i = numLevels; i <= level; i++) {
+          graphUpperLevels.add(new TreeMap<>());
         }
-        nodesByLevel.add(new int[] {node});
         numLevels = level + 1;
         entryNode = node;
-        lastAddedPosInLayer.add(0);
-        graph.add(new ArrayList<>(Collections.singleton(new NeighborArray(nsize, true))));
-      } else {
-        // Add this node id to this level's nodes
-        int[] nodes = nodesByLevel.get(level);
-        int idx = graph.get(level).size();
-        if (idx >= nodes.length) {
-          nodes = ArrayUtil.grow(nodes);
-          nodesByLevel.set(level, nodes);
-        }
-
-        // Find what position in the nodes array to insert the new node to ensure it stays sorted.
-        // In the worst case, we need to perform a binary search to find the position to insert the
-        // node.
-        // However, we can avoid binary search in 2 common cases:
-        // (1) When the node belongs at the end of the array
-        // (2) When the node belongs after the position of the last inserted node
-        int position;
-        int lastPositionInsertedInLevel = lastAddedPosInLayer.get(level);
-
-        if (lastPositionInsertedInLevel == -1) {
-          position = 0;
-        } else if (lastPositionInsertedInLevel == idx - 1 && node > nodes[idx - 1]) {
-          position = idx;
-        } else if (lastPositionInsertedInLevel < idx - 1
-            && node > nodes[lastPositionInsertedInLevel]
-            && node < nodes[lastPositionInsertedInLevel + 1]) {
-          position = lastPositionInsertedInLevel + 1;
-        } else {
-          position = Arrays.binarySearch(nodes, 0, idx, node);
-          assert position < 0;
-          position = -1 * position - 1;
-        }
-
-        if (position == idx) {
-          graph.get(level).add(new NeighborArray(nsize, true));
-        } else {
-          System.arraycopy(nodes, position, nodes, position + 1, (idx - position));
-          graph.get(level).add(position, new NeighborArray(nsize, true));
-        }
-        nodes[position] = node;
-        lastAddedPosInLayer.set(level, position);
       }
+
+      graphUpperLevels.get(level).put(node, new NeighborArray(nsize, true));
     } else {
       // Add nodes all the way up to and including "node" in the new graph on level 0. This will
       // cause the size of the
       // graph to differ from the number of nodes added to the graph. The size of the graph and the
       // number of nodes
       // added will only be in sync once all nodes from 0...last_node are added into the graph.
-      List<NeighborArray> level0Neighbors = graph.get(level);
-      while (node >= level0Neighbors.size()) {
-        level0Neighbors.add(new NeighborArray(nsize0, true));
+      while (node >= graphLevel0.size()) {
+        graphLevel0.add(new NeighborArray(nsize0, true));
       }
     }
   }
@@ -210,9 +158,9 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
   @Override
   public NodesIterator getNodesOnLevel(int level) {
     if (level == 0) {
-      return new NodesIterator(size());
+      return new ArrayNodesIterator(size());
     } else {
-      return new NodesIterator(nodesByLevel.get(level), graph.get(level).size());
+      return new SetNodesIterator(graphUpperLevels.get(level).keySet());
     }
   }
 
@@ -230,19 +178,26 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
             + Integer.BYTES * 2;
     long total = 0;
     for (int l = 0; l < numLevels; l++) {
-      int numNodesOnLevel = graph.get(l).size();
       if (l == 0) {
         total +=
-            numNodesOnLevel * neighborArrayBytes0
+            graphLevel0.size() * neighborArrayBytes0
                 + RamUsageEstimator.NUM_BYTES_OBJECT_REF; // for graph;
       } else {
+        long numNodesOnLevel = graphUpperLevels.get(l).size();
+
+        // For levels > 0, we represent the graph structure with a tree map.
+        // A single node in the tree contains 3 references (left root, right root, value) as well
+        // as an Integer for the key and 1 extra byte for the color of the node (this is actually 1
+        // bit, but
+        // because we do not have that granularity, we set to 1 byte). In addition, we include 1
+        // more reference for
+        // the tree map itself.
         total +=
-            nodesByLevel.get(l).length * Integer.BYTES
-                + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
-                + RamUsageEstimator.NUM_BYTES_OBJECT_REF; // for nodesByLevel
-        total +=
-            numNodesOnLevel * neighborArrayBytes
-                + RamUsageEstimator.NUM_BYTES_OBJECT_REF; // for graph;
+            numNodesOnLevel * (3L * RamUsageEstimator.NUM_BYTES_OBJECT_REF + Integer.BYTES + 1)
+                + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+
+        // Add the size neighbor of each node
+        total += numNodesOnLevel * neighborArrayBytes;
       }
     }
     return total;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -41,8 +41,10 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
   // Thus, on all levels, neighbors expressed as the level 0's nodes' ordinals.
   private final List<NeighborArray> graphLevel0;
   // Represents levels 1-N. Each level is represented with a TreeMap that maps a levels level 0
-  // ordinal to its
-  // neighbors on that level.
+  // ordinal to its neighbors on that level. All nodes are in level 0, so we do not need to maintain
+  // it in this list. However, to avoid changing list indexing, we always will make the first
+  // element
+  // null.
   private final List<TreeMap<Integer, NeighborArray>> graphUpperLevels;
   private final int nsize;
   private final int nsize0;
@@ -160,7 +162,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
     if (level == 0) {
       return new ArrayNodesIterator(size());
     } else {
-      return new SetNodesIterator(graphUpperLevels.get(level).keySet());
+      return new CollectionNodesIterator(graphUpperLevels.get(level).keySet());
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -531,8 +531,8 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
         HnswGraphBuilder.create(
             vectors, getVectorEncoding(), similarityFunction, 2, 10, random().nextInt());
     // node 0 is added by the builder constructor
-    // builder.addGraphNode(vectors.vectorValue(0));
     RandomAccessVectorValues<T> vectorsCopy = vectors.copy();
+    builder.addGraphNode(0, vectorsCopy);
     builder.addGraphNode(1, vectorsCopy);
     builder.addGraphNode(2, vectorsCopy);
     // now every node has tried to attach every other node as a neighbor, but
@@ -586,9 +586,8 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     HnswGraphBuilder<T> builder =
         HnswGraphBuilder.create(
             vectors, getVectorEncoding(), similarityFunction, 1, 10, random().nextInt());
-    // node 0 is added by the builder constructor
-    // builder.addGraphNode(vectors.vectorValue(0));
     RandomAccessVectorValues<T> vectorsCopy = vectors.copy();
+    builder.addGraphNode(0, vectorsCopy);
     builder.addGraphNode(1, vectorsCopy);
     builder.addGraphNode(2, vectorsCopy);
     assertLevel0Neighbors(builder.hnsw, 0, 1, 2);
@@ -619,9 +618,8 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     HnswGraphBuilder<T> builder =
         HnswGraphBuilder.create(
             vectors, getVectorEncoding(), similarityFunction, 1, 10, random().nextInt());
-    // node 0 is added by the builder constructor
-    // builder.addGraphNode(vectors.vectorValue(0));
     RandomAccessVectorValues<T> vectorsCopy = vectors.copy();
+    builder.addGraphNode(0, vectorsCopy);
     builder.addGraphNode(1, vectorsCopy);
     builder.addGraphNode(2, vectorsCopy);
     assertLevel0Neighbors(builder.hnsw, 0, 1, 2);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -26,10 +26,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.lucene95.Lucene95Codec;
 import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsFormat;
@@ -84,6 +87,12 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
   abstract AbstractMockVectorValues<T> vectorValues(LeafReader reader, String fieldName)
       throws IOException;
+
+  abstract AbstractMockVectorValues<T> vectorValues(
+      int size,
+      int dimension,
+      AbstractMockVectorValues<T> pregeneratedVectorValues,
+      int pregeneratedOffset);
 
   abstract Field knnVectorField(String name, T vector, VectorSimilarityFunction similarityFunction);
 
@@ -499,6 +508,155 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     assertGraphEqual(bottomUpExpectedHnsw, topDownOrderReversedHnsw);
     assertGraphEqual(bottomUpExpectedHnsw, bottomUpOrderReversedHnsw);
     assertGraphEqual(bottomUpExpectedHnsw, topDownOrderRandomHnsw);
+  }
+
+  public void testHnswGraphBuilderInitializationFromGraph_withOffsetZero() throws IOException {
+    int totalSize = atLeast(100);
+    int initializerSize = random().nextInt(5, totalSize);
+    int docIdOffset = 0;
+    int dim = atLeast(10);
+    long seed = random().nextLong();
+
+    AbstractMockVectorValues<T> initializerVectors = vectorValues(initializerSize, dim);
+    HnswGraphBuilder<T> initializerBuilder =
+        HnswGraphBuilder.create(
+            initializerVectors, getVectorEncoding(), similarityFunction, 10, 30, seed);
+
+    OnHeapHnswGraph initializerGraph = initializerBuilder.build(initializerVectors.copy());
+    AbstractMockVectorValues<T> finalVectorValues =
+        vectorValues(totalSize, dim, initializerVectors, docIdOffset);
+
+    Map<Integer, Integer> initializerOrdMap =
+        createOffsetOrdinalMap(initializerSize, finalVectorValues, docIdOffset);
+
+    HnswGraphBuilder<T> finalBuilder =
+        HnswGraphBuilder.create(
+            finalVectorValues, getVectorEncoding(), similarityFunction, 10, 30, seed);
+
+    finalBuilder.initializeFromGraph(initializerGraph, initializerOrdMap);
+
+    // When offset is 0, the graphs should be identical before vectors are added
+    assertGraphEqual(initializerGraph, finalBuilder.getGraph());
+
+    OnHeapHnswGraph finalGraph = finalBuilder.build(finalVectorValues.copy());
+    assertGraphContainsGraph(finalGraph, initializerGraph, initializerOrdMap);
+  }
+
+  public void testHnswGraphBuilderInitializationFromGraph_withNonZeroOffset() throws IOException {
+    int totalSize = atLeast(100);
+    int initializerSize = random().nextInt(5, totalSize);
+    int docIdOffset = random().nextInt(1, totalSize - initializerSize + 1);
+    int dim = atLeast(10);
+    long seed = random().nextLong();
+
+    AbstractMockVectorValues<T> initializerVectors = vectorValues(initializerSize, dim);
+    HnswGraphBuilder<T> initializerBuilder =
+        HnswGraphBuilder.create(
+            initializerVectors.copy(), getVectorEncoding(), similarityFunction, 10, 30, seed);
+    OnHeapHnswGraph initializerGraph = initializerBuilder.build(initializerVectors.copy());
+    AbstractMockVectorValues<T> finalVectorValues =
+        vectorValues(totalSize, dim, initializerVectors.copy(), docIdOffset);
+    Map<Integer, Integer> initializerOrdMap =
+        createOffsetOrdinalMap(initializerSize, finalVectorValues.copy(), docIdOffset);
+
+    HnswGraphBuilder<T> finalBuilder =
+        HnswGraphBuilder.create(
+            finalVectorValues, getVectorEncoding(), similarityFunction, 10, 30, seed);
+
+    finalBuilder.initializeFromGraph(initializerGraph, initializerOrdMap);
+
+    assertGraphInitializedFromGraph(finalBuilder.getGraph(), initializerGraph, initializerOrdMap);
+
+    // Confirm that the graph is appropriately constructed by checking that the nodes in the old
+    // graph are present in the levels of the new graph
+    OnHeapHnswGraph finalGraph = finalBuilder.build(finalVectorValues.copy());
+    assertGraphContainsGraph(finalGraph, initializerGraph, initializerOrdMap);
+  }
+
+  private void assertGraphContainsGraph(
+      HnswGraph g, HnswGraph h, Map<Integer, Integer> oldToNewOrdMap) throws IOException {
+    for (int i = 0; i < h.numLevels(); i++) {
+      int[] finalGraphNodesOnLevel = nodesIteratorToArray(g.getNodesOnLevel(i));
+      int[] initializerGraphNodesOnLevel =
+          mapArrayAndSort(nodesIteratorToArray(h.getNodesOnLevel(i)), oldToNewOrdMap);
+      int overlap = computeOverlap(finalGraphNodesOnLevel, initializerGraphNodesOnLevel);
+      assertEquals(initializerGraphNodesOnLevel.length, overlap);
+    }
+  }
+
+  private void assertGraphInitializedFromGraph(
+      HnswGraph g, HnswGraph h, Map<Integer, Integer> oldToNewOrdMap) throws IOException {
+    assertEquals("the number of levels in the graphs are different!", g.numLevels(), h.numLevels());
+    // Confirm that the size of the new graph includes all nodes up to an including the max new
+    // ordinal in the old to
+    // new ordinal mapping
+    assertEquals(
+        "the number of nodes in the graphs are different!",
+        g.size(),
+        Collections.max(oldToNewOrdMap.values()) + 1);
+
+    // assert the nodes from the previous graph are successfully to levels > 0 in the new graph
+    for (int level = 1; level < g.numLevels(); level++) {
+      NodesIterator nodesOnLevel = g.getNodesOnLevel(level);
+      NodesIterator nodesOnLevel2 = h.getNodesOnLevel(level);
+      while (nodesOnLevel.hasNext() && nodesOnLevel2.hasNext()) {
+        int node = nodesOnLevel.nextInt();
+        int node2 = oldToNewOrdMap.get(nodesOnLevel2.nextInt());
+        assertEquals("nodes in the graphs are different", node, node2);
+      }
+    }
+
+    // assert that the neighbors from the old graph are successfully transferred to the new graph
+    for (int level = 0; level < g.numLevels(); level++) {
+      NodesIterator nodesOnLevel = h.getNodesOnLevel(level);
+      while (nodesOnLevel.hasNext()) {
+        int node = nodesOnLevel.nextInt();
+        g.seek(level, oldToNewOrdMap.get(node));
+        h.seek(level, node);
+        assertEquals(
+            "arcs differ for node " + node,
+            getNeighborNodes(g),
+            getNeighborNodes(h).stream().map(oldToNewOrdMap::get).collect(Collectors.toSet()));
+      }
+    }
+  }
+
+  private Map<Integer, Integer> createOffsetOrdinalMap(
+      int docIdSize, AbstractMockVectorValues<T> totalVectorValues, int docIdOffset) {
+    // Compute the offset for the ordinal map to be the number of non-null vectors in the total
+    // vector values
+    // before the docIdOffset
+    int ordinalOffset = 0;
+    while (totalVectorValues.nextDoc() < docIdOffset) {
+      ordinalOffset++;
+    }
+
+    Map<Integer, Integer> offsetOrdinalMap = new HashMap<>();
+    for (int curr = 0;
+        totalVectorValues.docID() < docIdOffset + docIdSize;
+        totalVectorValues.nextDoc()) {
+      offsetOrdinalMap.put(curr, ordinalOffset + curr++);
+    }
+
+    return offsetOrdinalMap;
+  }
+
+  private int[] nodesIteratorToArray(NodesIterator nodesIterator) {
+    int[] arr = new int[nodesIterator.size()];
+    int i = 0;
+    while (nodesIterator.hasNext()) {
+      arr[i++] = nodesIterator.nextInt();
+    }
+    return arr;
+  }
+
+  private int[] mapArrayAndSort(int[] arr, Map<Integer, Integer> map) {
+    int[] mappedA = new int[arr.length];
+    for (int i = 0; i < arr.length; i++) {
+      mappedA[i] = map.get(arr[i]);
+    }
+    Arrays.sort(mappedA);
+    return mappedA;
   }
 
   @SuppressWarnings("unchecked")

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -531,9 +531,14 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
     HnswGraphBuilder<T> finalBuilder =
         HnswGraphBuilder.create(
-            finalVectorValues, getVectorEncoding(), similarityFunction, 10, 30, seed);
-
-    finalBuilder.initializeFromGraph(initializerGraph, initializerOrdMap);
+            finalVectorValues,
+            getVectorEncoding(),
+            similarityFunction,
+            10,
+            30,
+            seed,
+            initializerGraph,
+            initializerOrdMap);
 
     // When offset is 0, the graphs should be identical before vectors are added
     assertGraphEqual(initializerGraph, finalBuilder.getGraph());
@@ -561,9 +566,14 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
     HnswGraphBuilder<T> finalBuilder =
         HnswGraphBuilder.create(
-            finalVectorValues, getVectorEncoding(), similarityFunction, 10, 30, seed);
-
-    finalBuilder.initializeFromGraph(initializerGraph, initializerOrdMap);
+            finalVectorValues,
+            getVectorEncoding(),
+            similarityFunction,
+            10,
+            30,
+            seed,
+            initializerGraph,
+            initializerOrdMap);
 
     assertGraphInitializedFromGraph(finalBuilder.getGraph(), initializerGraph, initializerOrdMap);
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswByteVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswByteVectorGraph.java
@@ -86,6 +86,34 @@ public class TestHnswByteVectorGraph extends HnswGraphTestCase<byte[]> {
   }
 
   @Override
+  AbstractMockVectorValues<byte[]> vectorValues(
+      int size,
+      int dimension,
+      AbstractMockVectorValues<byte[]> pregeneratedVectorValues,
+      int pregeneratedOffset) {
+    byte[][] vectors = new byte[size][];
+    byte[][] randomVectors =
+        createRandomByteVectors(size - pregeneratedVectorValues.values.length, dimension, random());
+
+    for (int i = 0; i < pregeneratedOffset; i++) {
+      vectors[i] = randomVectors[i];
+    }
+
+    int currentDoc;
+    while ((currentDoc = pregeneratedVectorValues.nextDoc()) != NO_MORE_DOCS) {
+      vectors[pregeneratedOffset + currentDoc] = pregeneratedVectorValues.values[currentDoc];
+    }
+
+    for (int i = pregeneratedOffset + pregeneratedVectorValues.values.length;
+        i < vectors.length;
+        i++) {
+      vectors[i] = randomVectors[i - pregeneratedVectorValues.values.length];
+    }
+
+    return MockByteVectorValues.fromValues(vectors);
+  }
+
+  @Override
   AbstractMockVectorValues<byte[]> vectorValues(LeafReader reader, String fieldName)
       throws IOException {
     ByteVectorValues vectorValues = reader.getByteVectorValues(fieldName);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
@@ -80,6 +80,35 @@ public class TestHnswFloatVectorGraph extends HnswGraphTestCase<float[]> {
   }
 
   @Override
+  AbstractMockVectorValues<float[]> vectorValues(
+      int size,
+      int dimension,
+      AbstractMockVectorValues<float[]> pregeneratedVectorValues,
+      int pregeneratedOffset) {
+    float[][] vectors = new float[size][];
+    float[][] randomVectors =
+        createRandomFloatVectors(
+            size - pregeneratedVectorValues.values.length, dimension, random());
+
+    for (int i = 0; i < pregeneratedOffset; i++) {
+      vectors[i] = randomVectors[i];
+    }
+
+    int currentDoc;
+    while ((currentDoc = pregeneratedVectorValues.nextDoc()) != NO_MORE_DOCS) {
+      vectors[pregeneratedOffset + currentDoc] = pregeneratedVectorValues.values[currentDoc];
+    }
+
+    for (int i = pregeneratedOffset + pregeneratedVectorValues.values.length;
+        i < vectors.length;
+        i++) {
+      vectors[i] = randomVectors[i - pregeneratedVectorValues.values.length];
+    }
+
+    return MockVectorValues.fromValues(vectors);
+  }
+
+  @Override
   Field knnVectorField(String name, float[] vector, VectorSimilarityFunction similarityFunction) {
     return new KnnFloatVectorField(name, vector, similarityFunction);
   }


### PR DESCRIPTION
### Description

Related to #11354 (performance metrics can be found here). I also started a draft PR in #11719, but decided to refactor into a new PR.

This PR adds the functionality to initialize a merged segment's HNSW graph from the largest HNSW graph from the segments being merged. The graph selected must not contain any dead documents. If no suitable intiailizer graph is found, it will fall back to creating the graph from scratch.

To support this functionality, a couple of changes to current graph construction process needed to be made. OnHeapHnswGraph had to support out of order insertion. This is because the mapped ordinals of the nodes in the graph used for initialization are not necessarily the first X ordinals in the new graph.

I also removed the implicit addition of the first node into the graph. Implicitly adding the first node created a lot of complexity for initialization. In #11719, I got it to work without changing this but thought it was cleaner to switch to require the first node to be added explicitly.

In addition to this, graphs produced by merging two segments are no longer necessarily going to be equivalent to indexing one segment directly. This is caused by both differences in assigned random values as well as insertion order dictating which neighbors are selected for which nodes.
