### PR TITLE
Fix wrong assertion in TestBooleanQuery.testQueryMatchesCount

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -16,20 +16,8 @@
  */
 package org.apache.lucene.search;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
-
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
@@ -57,6 +45,19 @@ import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.NamedThreadFactory;
 import org.apache.lucene.util.automaton.Operations;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
 
 public class TestBooleanQuery extends LuceneTestCase {
 
@@ -771,9 +772,6 @@ public class TestBooleanQuery extends LuceneTestCase {
     Query builtQuery = q.build();
 
     assertEquals(searcher.count(builtQuery), numMatchingDocs);
-    final Weight weight = searcher.createWeight(builtQuery, ScoreMode.COMPLETE, 1);
-    // tests that the Weight#count API returns -1 instead of returning the total number of matches
-    assertEquals(weight.count(reader.leaves().get(0)), -1);
 
     IOUtils.close(reader, w, dir);
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -16,8 +16,20 @@
  */
 package org.apache.lucene.search;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
+
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
@@ -45,19 +57,6 @@ import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.NamedThreadFactory;
 import org.apache.lucene.util.automaton.Operations;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
 
 public class TestBooleanQuery extends LuceneTestCase {
 


### PR DESCRIPTION
### Description

An error discovered during checking in another commit lol.

Error stack trace:
```
org.apache.lucene.search.TestBooleanQuery > testQueryMatchesCount FAILED
    java.lang.AssertionError: expected:<5> but was:<-1>
        at __randomizedtesting.SeedInfo.seed([347B41327254C56F:C08C94809A6F6675]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:647)
        at org.junit.Assert.assertEquals(Assert.java:633)
        at org.apache.lucene.search.TestBooleanQuery.testQueryMatchesCount(TestBooleanQuery.java:776)
```

It turns out to be that after we have implemented some estimation method for BooleanQuery, this assertion is not always true anymore. Since the query is a pure disjunction query and when it contains `field:c`(The clause that retrieves all documents) the BooleanWeight will actually give a good answer.