### PR TITLE
Better skipping for multi-term queries with a FILTER rewrite.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -128,7 +128,7 @@ Optimizations
 * GITHUB#11900: BloomFilteringPostingsFormat now uses multiple hash functions
   in order to achieve the same false positive probability with less memory.
   (Jean-François Boeuf)
-  
+
 * GITHUB#12118: Optimize FeatureQuery to TermQuery & weight when scoring is not required. (Ben Trent, Robert Muir)
 
 * GITHUB#12128, GITHUB#12133: Speed up docvalues set query by making use of sortedness. (Robert Muir, Uwe Schindler)
@@ -276,6 +276,9 @@ Improvements
 
 * GITHUB#12070: Compound file creation is no longer subject to merge throttling.
   (Adrien Grand)
+
+* GITHUB#12055: Better skipping support for multi-term queries that have a
+  FILTER rewrite. (Adrien Grand)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -278,7 +278,7 @@ Improvements
   (Adrien Grand)
 
 * GITHUB#12055: Better skipping support for multi-term queries that have a
-  FILTER rewrite, as well as TermInSetQuery. (Adrien Grand, Greg Miller)
+  FILTER rewrite. (Adrien Grand, Greg Miller)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -278,7 +278,7 @@ Improvements
   (Adrien Grand)
 
 * GITHUB#12055: Better skipping support for multi-term queries that have a
-  FILTER rewrite. (Adrien Grand)
+  FILTER rewrite, as well as TermInSetQuery. (Adrien Grand, Greg Miller)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -120,7 +120,10 @@ New Features
 
 Improvements
 ---------------------
-(No changes)
+
+* GITHUB#12055: MultiTermQuery#CONSTANT_SCORE_BLENDED_REWRITE rewrite method introduced and used as the new default
+  for multi-term queries with a FILTER rewrite (PrefixQuery, WildcardQuery, TermRangeQuery). This introduces better
+  skipping support for common use-cases. (Adrien Grand, Greg Miller)
 
 Optimizations
 ---------------------
@@ -276,9 +279,6 @@ Improvements
 
 * GITHUB#12070: Compound file creation is no longer subject to merge throttling.
   (Adrien Grand)
-
-* GITHUB#12055: Better skipping support for multi-term queries that have a
-  FILTER rewrite. (Adrien Grand, Greg Miller)
 
 Bug Fixes
 ---------------------

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/EnwikiQueryMaker.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/EnwikiQueryMaker.java
@@ -135,7 +135,7 @@ public class EnwikiQueryMaker extends AbstractQueryMaker {
         new WildcardQuery(
             new Term(field, "fo*"),
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
-            MultiTermQuery.CONSTANT_SCORE_REWRITE);
+            MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
     // be wary of unanalyzed text
     return new Query[] {
       new SpanFirstQuery(new SpanTermQuery(new Term(field, "ford")), 5),

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/EnwikiQueryMaker.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/EnwikiQueryMaker.java
@@ -135,7 +135,7 @@ public class EnwikiQueryMaker extends AbstractQueryMaker {
         new WildcardQuery(
             new Term(field, "fo*"),
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
-            MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
+            MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE);
     // be wary of unanalyzed text
     return new Query[] {
       new SpanFirstQuery(new SpanTermQuery(new Term(field, "ford")), 5),

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractMultiTermQueryConstantScoreWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractMultiTermQueryConstantScoreWrapper.java
@@ -1,0 +1,146 @@
+package org.apache.lucene.search;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.TermState;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Contains functionality common to both {@link MultiTermQueryConstantScoreBlendedWrapper} and
+ * {@link MultiTermQueryConstantScoreWrapper}. Internal implementation detail only. Not meant
+ * as an extension point for users.
+ *
+ * @lucene.internal
+ */
+abstract class AbstractMultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends Query
+    implements Accountable {
+  // mtq that matches 16 terms or less will be executed as a regular disjunction
+  private static final int BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD = 16;
+
+  protected final Q query;
+
+  AbstractMultiTermQueryConstantScoreWrapper(Q query) {
+    this.query = query;
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    if (query instanceof Accountable) {
+      return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
+          + RamUsageEstimator.NUM_BYTES_OBJECT_REF
+          + ((Accountable) query).ramBytesUsed();
+    }
+    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
+        + RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        + RamUsageEstimator.QUERY_DEFAULT_RAM_BYTES_USED;
+  }
+
+  @Override
+  public String toString(String field) {
+    // query.toString should be ok for the filter, too, if the query boost is 1.0f
+    return query.toString(field);
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    return sameClassAs(other)
+        && query.equals(((AbstractMultiTermQueryConstantScoreWrapper<?>) other).query);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * classHash() + query.hashCode();
+  }
+
+  /** Returns the encapsulated query */
+  public Q getQuery() {
+    return query;
+  }
+
+  /** Returns the field name for this query */
+  public String getField() {
+    return query.getField();
+  }
+
+  @Override
+  public void visit(QueryVisitor visitor) {
+    if (visitor.acceptField(getField())) {
+      query.visit(visitor.getSubVisitor(BooleanClause.Occur.FILTER, this));
+    }
+  }
+
+  protected static final class TermAndState {
+    final BytesRef term;
+    final TermState state;
+    final int docFreq;
+    final long totalTermFreq;
+
+    TermAndState(BytesRef term, TermState state, int docFreq, long totalTermFreq) {
+      this.term = term;
+      this.state = state;
+      this.docFreq = docFreq;
+      this.totalTermFreq = totalTermFreq;
+    }
+  }
+
+  protected static abstract class WrapperWeight extends ConstantScoreWeight {
+    private final MultiTermQuery q;
+    private final ScoreMode scoreMode;
+
+    WrapperWeight(MultiTermQuery q, float boost, ScoreMode scoreMode) {
+      super(q, boost);
+      this.q = q;
+      this.scoreMode = scoreMode;
+    }
+
+    protected boolean collectTerms(int fieldDocCount, TermsEnum termsEnum, List<TermAndState> terms)
+        throws IOException {
+      final int threshold =
+          Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
+      for (int i = 0; i < threshold; ++i) {
+        final BytesRef term = termsEnum.next();
+        if (term == null) {
+          return true;
+        }
+        TermState state = termsEnum.termState();
+        int docFreq = termsEnum.docFreq();
+        TermAndState termAndState =
+            new TermAndState(
+                BytesRef.deepCopyOf(term), state, docFreq, termsEnum.totalTermFreq());
+        if (fieldDocCount == docFreq) {
+          // If the term contains every document with a value for the field, we can ignore all
+          // other terms:
+          terms.clear();
+          terms.add(termAndState);
+          return true;
+        }
+        terms.add(termAndState);
+      }
+      return termsEnum.next() == null;
+    }
+
+    @Override
+    public Matches matches(LeafReaderContext context, int doc) throws IOException {
+      final Terms terms = context.reader().terms(q.field);
+      if (terms == null) {
+        return null;
+      }
+      return MatchesUtils.forField(
+          q.field,
+          () ->
+              DisjunctionMatchesIterator.fromTermsEnum(
+                  context, doc, q, q.field, q.getTermsEnum(terms)));
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return true;
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractMultiTermQueryConstantScoreWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractMultiTermQueryConstantScoreWrapper.java
@@ -1,20 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.search;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermState;
+import org.apache.lucene.index.TermStates;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 
-import java.io.IOException;
-import java.util.List;
-
 /**
  * Contains functionality common to both {@link MultiTermQueryConstantScoreBlendedWrapper} and
- * {@link MultiTermQueryConstantScoreWrapper}. Internal implementation detail only. Not meant
- * as an extension point for users.
+ * {@link MultiTermQueryConstantScoreWrapper}. Internal implementation detail only. Not meant as an
+ * extension point for users.
  *
  * @lucene.internal
  */
@@ -25,7 +44,7 @@ abstract class AbstractMultiTermQueryConstantScoreWrapper<Q extends MultiTermQue
 
   protected final Q query;
 
-  AbstractMultiTermQueryConstantScoreWrapper(Q query) {
+  protected AbstractMultiTermQueryConstantScoreWrapper(Q query) {
     this.query = query;
   }
 
@@ -89,21 +108,85 @@ abstract class AbstractMultiTermQueryConstantScoreWrapper<Q extends MultiTermQue
     }
   }
 
-  protected static abstract class WrapperWeight extends ConstantScoreWeight {
+  protected static final class WeightOrDocIdSetIterator {
+    final Weight weight;
+    final DocIdSetIterator iterator;
+
+    WeightOrDocIdSetIterator(Weight weight) {
+      this.weight = Objects.requireNonNull(weight);
+      this.iterator = null;
+    }
+
+    WeightOrDocIdSetIterator(DocIdSetIterator iterator) {
+      this.iterator = iterator;
+      this.weight = null;
+    }
+  }
+
+  protected abstract static class RewritingWeight extends ConstantScoreWeight {
     private final MultiTermQuery q;
     private final ScoreMode scoreMode;
+    private final IndexSearcher searcher;
 
-    WrapperWeight(MultiTermQuery q, float boost, ScoreMode scoreMode) {
+    protected RewritingWeight(
+        MultiTermQuery q, float boost, ScoreMode scoreMode, IndexSearcher searcher) {
       super(q, boost);
       this.q = q;
       this.scoreMode = scoreMode;
+      this.searcher = searcher;
     }
 
-    protected boolean collectTerms(int fieldDocCount, TermsEnum termsEnum, List<TermAndState> terms)
+    /**
+     * Rewrite the query as either a {@link Weight} or a {@link DocIdSetIterator} wrapped in a
+     * {@link WeightOrDocIdSetIterator}. Before this is called, the weight will attempt to "collect"
+     * found terms up to a threshold. If fewer terms than the threshold are found, the query will
+     * simply be rewritten into a {@link BooleanQuery} and this method will not be called. This will
+     * only be called if it is determined there are more found terms. At the point this method is
+     * invoked, {@code termsEnum} will be positioned on the next "uncollected" term. The terms that
+     * were already collected will be in {@code collectedTerms}.
+     */
+    protected abstract WeightOrDocIdSetIterator rewriteInner(
+        LeafReaderContext context,
+        int fieldDocCount,
+        Terms terms,
+        TermsEnum termsEnum,
+        List<TermAndState> collectedTerms)
+        throws IOException;
+
+    private WeightOrDocIdSetIterator rewrite(LeafReaderContext context) throws IOException {
+      final Terms terms = context.reader().terms(q.field);
+      if (terms == null) {
+        // field does not exist
+        return null;
+      }
+
+      final int fieldDocCount = terms.getDocCount();
+      final TermsEnum termsEnum = q.getTermsEnum(terms);
+      assert termsEnum != null;
+
+      final List<TermAndState> collectedTerms = new ArrayList<>();
+      if (collectTerms(fieldDocCount, termsEnum, collectedTerms)) {
+        // build a boolean query
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        for (TermAndState t : collectedTerms) {
+          final TermStates termStates = new TermStates(searcher.getTopReaderContext());
+          termStates.register(t.state, context.ord, t.docFreq, t.totalTermFreq);
+          bq.add(new TermQuery(new Term(q.field, t.term), termStates), BooleanClause.Occur.SHOULD);
+        }
+        Query q = new ConstantScoreQuery(bq.build());
+        final Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
+        return new WeightOrDocIdSetIterator(weight);
+      }
+
+      // Too many terms to rewrite as a simple bq. Invoke rewriteInner logic to handle rewriting:
+      return rewriteInner(context, fieldDocCount, terms, termsEnum, collectedTerms);
+    }
+
+    private boolean collectTerms(int fieldDocCount, TermsEnum termsEnum, List<TermAndState> terms)
         throws IOException {
       final int threshold =
           Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
-      for (int i = 0; i < threshold; ++i) {
+      for (int i = 0; i < threshold; i++) {
         final BytesRef term = termsEnum.next();
         if (term == null) {
           return true;
@@ -111,8 +194,7 @@ abstract class AbstractMultiTermQueryConstantScoreWrapper<Q extends MultiTermQue
         TermState state = termsEnum.termState();
         int docFreq = termsEnum.docFreq();
         TermAndState termAndState =
-            new TermAndState(
-                BytesRef.deepCopyOf(term), state, docFreq, termsEnum.totalTermFreq());
+            new TermAndState(BytesRef.deepCopyOf(term), state, docFreq, termsEnum.totalTermFreq());
         if (fieldDocCount == docFreq) {
           // If the term contains every document with a value for the field, we can ignore all
           // other terms:
@@ -123,6 +205,41 @@ abstract class AbstractMultiTermQueryConstantScoreWrapper<Q extends MultiTermQue
         terms.add(termAndState);
       }
       return termsEnum.next() == null;
+    }
+
+    private Scorer scorerForIterator(DocIdSetIterator iterator) {
+      if (iterator == null) {
+        return null;
+      }
+      return new ConstantScoreScorer(this, score(), scoreMode, iterator);
+    }
+
+    @Override
+    public BulkScorer bulkScorer(LeafReaderContext context) throws IOException {
+      final WeightOrDocIdSetIterator weightOrIterator = rewrite(context);
+      if (weightOrIterator == null) {
+        return null;
+      } else if (weightOrIterator.weight != null) {
+        return weightOrIterator.weight.bulkScorer(context);
+      } else {
+        final Scorer scorer = scorerForIterator(weightOrIterator.iterator);
+        if (scorer == null) {
+          return null;
+        }
+        return new DefaultBulkScorer(scorer);
+      }
+    }
+
+    @Override
+    public Scorer scorer(LeafReaderContext context) throws IOException {
+      final WeightOrDocIdSetIterator weightOrIterator = rewrite(context);
+      if (weightOrIterator == null) {
+        return null;
+      } else if (weightOrIterator.weight != null) {
+        return weightOrIterator.weight.scorer(context);
+      } else {
+        return scorerForIterator(weightOrIterator.iterator);
+      }
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/AutomatonQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AutomatonQuery.java
@@ -76,7 +76,7 @@ public class AutomatonQuery extends MultiTermQuery implements Accountable {
    *     UTF32ToUTF8 conversion
    */
   public AutomatonQuery(final Term term, Automaton automaton, boolean isBinary) {
-    this(term, automaton, isBinary, CONSTANT_SCORE_AUTO_REWRITE);
+    this(term, automaton, isBinary, CONSTANT_SCORE_BLENDED_REWRITE);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/AutomatonQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AutomatonQuery.java
@@ -76,7 +76,7 @@ public class AutomatonQuery extends MultiTermQuery implements Accountable {
    *     UTF32ToUTF8 conversion
    */
   public AutomatonQuery(final Term term, Automaton automaton, boolean isBinary) {
-    this(term, automaton, isBinary, CONSTANT_SCORE_REWRITE);
+    this(term, automaton, isBinary, CONSTANT_SCORE_AUTO_REWRITE);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/DisiWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisiWrapper.java
@@ -56,13 +56,4 @@ public class DisiWrapper {
       matchCost = 0f;
     }
   }
-
-  public DisiWrapper(DocIdSetIterator iterator) {
-    this.scorer = null;
-    this.iterator = iterator;
-    this.cost = iterator.cost();
-    this.twoPhaseView = null;
-    this.approximation = iterator;
-    this.matchCost = 0;
-  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/DisiWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisiWrapper.java
@@ -26,7 +26,7 @@ public class DisiWrapper {
   public final Scorer scorer;
   public final long cost;
   public final float matchCost; // the match cost for two-phase iterators, 0 otherwise
-  public int doc = -1; // the current doc, used for comparison
+  public int doc; // the current doc, used for comparison
   public DisiWrapper next; // reference to a next element, see #topList
 
   // An approximation of the iterator, or the iterator itself if it does not
@@ -46,6 +46,7 @@ public class DisiWrapper {
     this.scorer = scorer;
     this.iterator = scorer.iterator();
     this.cost = iterator.cost();
+    this.doc = -1;
     this.twoPhaseView = scorer.twoPhaseIterator();
 
     if (twoPhaseView != null) {

--- a/lucene/core/src/java/org/apache/lucene/search/DisiWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisiWrapper.java
@@ -26,7 +26,7 @@ public class DisiWrapper {
   public final Scorer scorer;
   public final long cost;
   public final float matchCost; // the match cost for two-phase iterators, 0 otherwise
-  public int doc; // the current doc, used for comparison
+  public int doc = -1; // the current doc, used for comparison
   public DisiWrapper next; // reference to a next element, see #topList
 
   // An approximation of the iterator, or the iterator itself if it does not
@@ -46,7 +46,6 @@ public class DisiWrapper {
     this.scorer = scorer;
     this.iterator = scorer.iterator();
     this.cost = iterator.cost();
-    this.doc = -1;
     this.twoPhaseView = scorer.twoPhaseIterator();
 
     if (twoPhaseView != null) {
@@ -56,5 +55,14 @@ public class DisiWrapper {
       approximation = iterator;
       matchCost = 0f;
     }
+  }
+
+  public DisiWrapper(DocIdSetIterator iterator) {
+    this.scorer = null;
+    this.iterator = iterator;
+    this.cost = iterator.cost();
+    this.twoPhaseView = null;
+    this.approximation = iterator;
+    this.matchCost = 0;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -39,10 +39,10 @@ import org.apache.lucene.util.AttributeSource;
  * {@link #SCORING_BOOLEAN_REWRITE}, you may encounter a {@link IndexSearcher.TooManyClauses}
  * exception during searching, which happens when the number of terms to be searched exceeds {@link
  * IndexSearcher#getMaxClauseCount()}. Setting {@link RewriteMethod} to {@link
- * #CONSTANT_SCORE_AUTO_REWRITE} or {@link #CONSTANT_SCORE_REWRITE} prevents this.
+ * #CONSTANT_SCORE_BLENDED_REWRITE} or {@link #CONSTANT_SCORE_REWRITE} prevents this.
  *
- * <p>The recommended rewrite method is {@link #CONSTANT_SCORE_AUTO_REWRITE}: it doesn't spend CPU
- * computing unhelpful scores, and is the most performant rewrite method given the query. If you
+ * <p>The recommended rewrite method is {@link #CONSTANT_SCORE_BLENDED_REWRITE}: it doesn't spend
+ * CPU computing unhelpful scores, and is the most performant rewrite method given the query. If you
  * need scoring (like {@link FuzzyQuery}, use {@link TopTermsScoringBooleanQueryRewrite} which uses
  * a priority queue to only collect competitive terms and not hit this limitation.
  *
@@ -82,11 +82,11 @@ public abstract class MultiTermQuery extends Query {
    * cost terms, {@link #CONSTANT_SCORE_REWRITE} may be more performant. While for some use-cases
    * with all high cost terms, {@link #CONSTANT_SCORE_BOOLEAN_REWRITE} may be better.
    */
-  public static final RewriteMethod CONSTANT_SCORE_AUTO_REWRITE =
+  public static final RewriteMethod CONSTANT_SCORE_BLENDED_REWRITE =
       new RewriteMethod() {
         @Override
         public Query rewrite(IndexSearcher indexSearcher, MultiTermQuery query) {
-          return new MultiTermQueryConstantScoreAutoWrapper<>(query);
+          return new MultiTermQueryConstantScoreBlendedWrapper<>(query);
         }
       };
 

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -78,7 +78,7 @@ public abstract class MultiTermQuery extends Query {
    * <p>This method aims to balance the benefits of both {@link #CONSTANT_SCORE_BOOLEAN_REWRITE} and
    * {@link #CONSTANT_SCORE_REWRITE} by enabling skipping and early termination over costly terms
    * while limiting the overhead of a BooleanQuery with many terms. It also ensures you cannot hit
-   * {@link org.apache.lucene.search.IndexSearcher.TooManyClauses}. For some uses-case with all low
+   * {@link org.apache.lucene.search.IndexSearcher.TooManyClauses}. For some use-cases with all low
    * cost terms, {@link #CONSTANT_SCORE_REWRITE} may be more performant. While for some use-cases
    * with all high cost terms, {@link #CONSTANT_SCORE_BOOLEAN_REWRITE} may be better.
    */

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -39,9 +39,9 @@ import org.apache.lucene.util.AttributeSource;
  * {@link #SCORING_BOOLEAN_REWRITE}, you may encounter a {@link IndexSearcher.TooManyClauses}
  * exception during searching, which happens when the number of terms to be searched exceeds {@link
  * IndexSearcher#getMaxClauseCount()}. Setting {@link RewriteMethod} to {@link
- * #CONSTANT_SCORE_REWRITE} prevents this.
+ * #CONSTANT_SCORE_AUTO_REWRITE} or {@link #CONSTANT_SCORE_REWRITE} prevents this.
  *
- * <p>The recommended rewrite method is {@link #CONSTANT_SCORE_REWRITE}: it doesn't spend CPU
+ * <p>The recommended rewrite method is {@link #CONSTANT_SCORE_AUTO_REWRITE}: it doesn't spend CPU
  * computing unhelpful scores, and is the most performant rewrite method given the query. If you
  * need scoring (like {@link FuzzyQuery}, use {@link TopTermsScoringBooleanQueryRewrite} which uses
  * a priority queue to only collect competitive terms and not hit this limitation.
@@ -68,6 +68,27 @@ public abstract class MultiTermQuery extends Query {
           terms, atts); // allow RewriteMethod subclasses to pull a TermsEnum from the MTQ
     }
   }
+
+  /**
+   * A rewrite method where documents are assigned a constant score equal to the query's boost.
+   * Maintains a boolean query-like implementation over the most costly terms while pre-processing
+   * the less costly terms into a filter bitset. Enforces an upper-limit on the number of terms
+   * allowed in the boolean query-like implementation.
+   *
+   * <p>This method aims to balance the benefits of both {@link #CONSTANT_SCORE_BOOLEAN_REWRITE} and
+   * {@link #CONSTANT_SCORE_REWRITE} by enabling skipping and early termination over costly terms
+   * while limiting the overhead of a BooleanQuery with many terms. It also ensures you cannot hit
+   * {@link org.apache.lucene.search.IndexSearcher.TooManyClauses}. For some uses-case with all low
+   * cost terms, {@link #CONSTANT_SCORE_REWRITE} may be more performant. While for some use-cases
+   * with all high cost terms, {@link #CONSTANT_SCORE_BOOLEAN_REWRITE} may be better.
+   */
+  public static final RewriteMethod CONSTANT_SCORE_AUTO_REWRITE =
+      new RewriteMethod() {
+        @Override
+        public Query rewrite(IndexSearcher indexSearcher, MultiTermQuery query) {
+          return new MultiTermQueryConstantScoreAutoWrapper<>(query);
+        }
+      };
 
   /**
    * A rewrite method that first creates a private Filter, by visiting each term in sequence and

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreBlendedWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreBlendedWrapper.java
@@ -35,11 +35,12 @@ import org.apache.lucene.util.PriorityQueue;
 import org.apache.lucene.util.RamUsageEstimator;
 
 /**
- * This class provides the functionality behind {@link MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE}.
- * It maintains a boolean query-like approach over the most costly terms with a limit of {@link
- * #BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD} while rewriting the remaining terms into a filter bitset.
+ * This class provides the functionality behind {@link
+ * MultiTermQuery#CONSTANT_SCORE_BLENDED_REWRITE}. It maintains a boolean query-like approach over
+ * the most costly terms with a limit of {@link #BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD} while
+ * rewriting the remaining terms into a filter bitset.
  */
-final class MultiTermQueryConstantScoreAutoWrapper<Q extends MultiTermQuery> extends Query
+final class MultiTermQueryConstantScoreBlendedWrapper<Q extends MultiTermQuery> extends Query
     implements Accountable {
 
   // mtq that matches 16 terms or less will be executed as a regular disjunction
@@ -91,7 +92,7 @@ final class MultiTermQueryConstantScoreAutoWrapper<Q extends MultiTermQuery> ext
   private final Q query;
 
   /** Wrap a {@link MultiTermQuery} as a Filter. */
-  MultiTermQueryConstantScoreAutoWrapper(Q query) {
+  MultiTermQueryConstantScoreBlendedWrapper(Q query) {
     this.query = query;
   }
 
@@ -104,7 +105,7 @@ final class MultiTermQueryConstantScoreAutoWrapper<Q extends MultiTermQuery> ext
   @Override
   public boolean equals(final Object other) {
     return sameClassAs(other)
-        && query.equals(((MultiTermQueryConstantScoreAutoWrapper<?>) other).query);
+        && query.equals(((MultiTermQueryConstantScoreBlendedWrapper<?>) other).query);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
@@ -16,59 +16,26 @@
  */
 package org.apache.lucene.search;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.index.TermState;
 import org.apache.lucene.index.TermStates;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.DocIdSetBuilder;
-import org.apache.lucene.util.RamUsageEstimator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * This class also provides the functionality behind {@link MultiTermQuery#CONSTANT_SCORE_REWRITE}.
  * It tries to rewrite per-segment as a boolean query that returns a constant score and otherwise
  * fills a bit set with matches and builds a Scorer on top of this bit set.
  */
-final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends Query
-    implements Accountable {
-
-  // mtq that matches 16 terms or less will be executed as a regular disjunction
-  private static final int BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD = 16;
-
-  @Override
-  public long ramBytesUsed() {
-    if (query instanceof Accountable) {
-      return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
-          + RamUsageEstimator.NUM_BYTES_OBJECT_REF
-          + ((Accountable) query).ramBytesUsed();
-    }
-    return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
-        + RamUsageEstimator.NUM_BYTES_OBJECT_REF
-        + RamUsageEstimator.QUERY_DEFAULT_RAM_BYTES_USED;
-  }
-
-  private static class TermAndState {
-    final BytesRef term;
-    final TermState state;
-    final int docFreq;
-    final long totalTermFreq;
-
-    TermAndState(BytesRef term, TermState state, int docFreq, long totalTermFreq) {
-      this.term = term;
-      this.state = state;
-      this.docFreq = docFreq;
-      this.totalTermFreq = totalTermFreq;
-    }
-  }
+final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends AbstractMultiTermQueryConstantScoreWrapper<Q> {
 
   private static class WeightOrDocIdSet {
     final Weight weight;
@@ -85,76 +52,14 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
     }
   }
 
-  protected final Q query;
-
-  /** Wrap a {@link MultiTermQuery} as a Filter. */
-  protected MultiTermQueryConstantScoreWrapper(Q query) {
-    this.query = query;
-  }
-
-  @Override
-  public String toString(String field) {
-    // query.toString should be ok for the filter, too, if the query boost is 1.0f
-    return query.toString(field);
-  }
-
-  @Override
-  public final boolean equals(final Object other) {
-    return sameClassAs(other)
-        && query.equals(((MultiTermQueryConstantScoreWrapper<?>) other).query);
-  }
-
-  @Override
-  public final int hashCode() {
-    return 31 * classHash() + query.hashCode();
-  }
-
-  /** Returns the encapsulated query */
-  public Q getQuery() {
-    return query;
-  }
-
-  /** Returns the field name for this query */
-  public final String getField() {
-    return query.getField();
+  MultiTermQueryConstantScoreWrapper(Q query) {
+    super(query);
   }
 
   @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
       throws IOException {
-    return new ConstantScoreWeight(this, boost) {
-
-      /**
-       * Try to collect terms from the given terms enum and return true if all terms could be
-       * collected or if one of the iterated terms contains all docs for the field. If {@code false}
-       * is returned, the enum is left positioned on the next term.
-       */
-      private boolean collectTerms(int fieldDocCount, TermsEnum termsEnum, List<TermAndState> terms)
-          throws IOException {
-        final int threshold =
-            Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
-        for (int i = 0; i < threshold; ++i) {
-          final BytesRef term = termsEnum.next();
-          if (term == null) {
-            return true;
-          }
-          TermState state = termsEnum.termState();
-          int docFreq = termsEnum.docFreq();
-          TermAndState termAndState =
-              new TermAndState(
-                  BytesRef.deepCopyOf(term), state, docFreq, termsEnum.totalTermFreq());
-          if (fieldDocCount == docFreq) {
-            // If the term contains every document with a value for the field, we can ignore all
-            // other terms:
-            terms.clear();
-            terms.add(termAndState);
-            return true;
-          }
-          terms.add(termAndState);
-        }
-        return termsEnum.next() == null;
-      }
-
+    return new WrapperWeight(query, boost, scoreMode) {
       /**
        * On the given leaf context, try to either rewrite to a disjunction if there are few terms,
        * or build a bitset containing matching docs.
@@ -245,19 +150,6 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
       }
 
       @Override
-      public Matches matches(LeafReaderContext context, int doc) throws IOException {
-        final Terms terms = context.reader().terms(query.field);
-        if (terms == null) {
-          return null;
-        }
-        return MatchesUtils.forField(
-            query.field,
-            () ->
-                DisjunctionMatchesIterator.fromTermsEnum(
-                    context, doc, query, query.field, query.getTermsEnum(terms)));
-      }
-
-      @Override
       public Scorer scorer(LeafReaderContext context) throws IOException {
         final WeightOrDocIdSet weightOrBitSet = rewrite(context);
         if (weightOrBitSet.weight != null) {
@@ -266,18 +158,6 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
           return scorer(weightOrBitSet.set);
         }
       }
-
-      @Override
-      public boolean isCacheable(LeafReaderContext ctx) {
-        return true;
-      }
     };
-  }
-
-  @Override
-  public void visit(QueryVisitor visitor) {
-    if (visitor.acceptField(getField())) {
-      query.visit(visitor.getSubVisitor(Occur.FILTER, this));
-    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreWrapper.java
@@ -16,41 +16,23 @@
  */
 package org.apache.lucene.search;
 
+import java.io.IOException;
+import java.util.List;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermStates;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.util.DocIdSetBuilder;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 /**
- * This class also provides the functionality behind {@link MultiTermQuery#CONSTANT_SCORE_REWRITE}.
- * It tries to rewrite per-segment as a boolean query that returns a constant score and otherwise
- * fills a bit set with matches and builds a Scorer on top of this bit set.
+ * This class provides the functionality behind {@link MultiTermQuery#CONSTANT_SCORE_REWRITE}. It
+ * tries to rewrite per-segment as a boolean query that returns a constant score and otherwise fills
+ * a bit set with matches and builds a Scorer on top of this bit set.
  */
-final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends AbstractMultiTermQueryConstantScoreWrapper<Q> {
-
-  private static class WeightOrDocIdSet {
-    final Weight weight;
-    final DocIdSet set;
-
-    WeightOrDocIdSet(Weight weight) {
-      this.weight = Objects.requireNonNull(weight);
-      this.set = null;
-    }
-
-    WeightOrDocIdSet(DocIdSet bitset) {
-      this.set = bitset;
-      this.weight = null;
-    }
-  }
+final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery>
+    extends AbstractMultiTermQueryConstantScoreWrapper<Q> {
 
   MultiTermQueryConstantScoreWrapper(Q query) {
     super(query);
@@ -59,40 +41,20 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
   @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
       throws IOException {
-    return new WrapperWeight(query, boost, scoreMode) {
-      /**
-       * On the given leaf context, try to either rewrite to a disjunction if there are few terms,
-       * or build a bitset containing matching docs.
-       */
-      private WeightOrDocIdSet rewrite(LeafReaderContext context) throws IOException {
-        final Terms terms = context.reader().terms(query.field);
-        if (terms == null) {
-          // field does not exist
-          return new WeightOrDocIdSet((DocIdSet) null);
-        }
+    return new RewritingWeight(query, boost, scoreMode, searcher) {
 
-        final int fieldDocCount = terms.getDocCount();
-        final TermsEnum termsEnum = query.getTermsEnum(terms);
-        assert termsEnum != null;
-
+      @Override
+      protected WeightOrDocIdSetIterator rewriteInner(
+          LeafReaderContext context,
+          int fieldDocCount,
+          Terms terms,
+          TermsEnum termsEnum,
+          List<TermAndState> collectedTerms)
+          throws IOException {
+        DocIdSetBuilder builder = new DocIdSetBuilder(context.reader().maxDoc(), terms);
         PostingsEnum docs = null;
 
-        final List<TermAndState> collectedTerms = new ArrayList<>();
-        if (collectTerms(fieldDocCount, termsEnum, collectedTerms)) {
-          // build a boolean query
-          BooleanQuery.Builder bq = new BooleanQuery.Builder();
-          for (TermAndState t : collectedTerms) {
-            final TermStates termStates = new TermStates(searcher.getTopReaderContext());
-            termStates.register(t.state, context.ord, t.docFreq, t.totalTermFreq);
-            bq.add(new TermQuery(new Term(query.field, t.term), termStates), Occur.SHOULD);
-          }
-          Query q = new ConstantScoreQuery(bq.build());
-          final Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
-          return new WeightOrDocIdSet(weight);
-        }
-
-        // Too many terms: go back to the terms we already collected and start building the bit set
-        DocIdSetBuilder builder = new DocIdSetBuilder(context.reader().maxDoc(), terms);
+        // Handle the already-collected terms:
         if (collectedTerms.isEmpty() == false) {
           TermsEnum termsEnum2 = terms.iterator();
           for (TermAndState t : collectedTerms) {
@@ -102,7 +64,7 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
           }
         }
 
-        // Then keep filling the bit set with remaining terms
+        // Then keep filling the bit set with remaining terms:
         do {
           docs = termsEnum.postings(docs, PostingsEnum.NONE);
           // If a term contains all docs with a value for the specified field, we can discard the
@@ -116,47 +78,12 @@ final class MultiTermQueryConstantScoreWrapper<Q extends MultiTermQuery> extends
                 new ConstantScoreQuery(
                     new TermQuery(new Term(query.field, termsEnum.term()), termStates));
             Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
-            return new WeightOrDocIdSet(weight);
+            return new WeightOrDocIdSetIterator(weight);
           }
           builder.add(docs);
         } while (termsEnum.next() != null);
 
-        return new WeightOrDocIdSet(builder.build());
-      }
-
-      private Scorer scorer(DocIdSet set) throws IOException {
-        if (set == null) {
-          return null;
-        }
-        final DocIdSetIterator disi = set.iterator();
-        if (disi == null) {
-          return null;
-        }
-        return new ConstantScoreScorer(this, score(), scoreMode, disi);
-      }
-
-      @Override
-      public BulkScorer bulkScorer(LeafReaderContext context) throws IOException {
-        final WeightOrDocIdSet weightOrBitSet = rewrite(context);
-        if (weightOrBitSet.weight != null) {
-          return weightOrBitSet.weight.bulkScorer(context);
-        } else {
-          final Scorer scorer = scorer(weightOrBitSet.set);
-          if (scorer == null) {
-            return null;
-          }
-          return new DefaultBulkScorer(scorer);
-        }
-      }
-
-      @Override
-      public Scorer scorer(LeafReaderContext context) throws IOException {
-        final WeightOrDocIdSet weightOrBitSet = rewrite(context);
-        if (weightOrBitSet.weight != null) {
-          return weightOrBitSet.weight.scorer(context);
-        } else {
-          return scorer(weightOrBitSet.set);
-        }
+        return new WeightOrDocIdSetIterator(builder.build().iterator());
       }
     };
   }

--- a/lucene/core/src/java/org/apache/lucene/search/PrefixQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PrefixQuery.java
@@ -24,13 +24,13 @@ import org.apache.lucene.util.automaton.Automaton;
  * A Query that matches documents containing terms with a specified prefix. A PrefixQuery is built
  * by QueryParser for input like <code>app*</code>.
  *
- * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE} rewrite method.
+ * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_BLENDED_REWRITE} rewrite method.
  */
 public class PrefixQuery extends AutomatonQuery {
 
   /** Constructs a query for terms starting with <code>prefix</code>. */
   public PrefixQuery(Term prefix) {
-    this(prefix, CONSTANT_SCORE_AUTO_REWRITE);
+    this(prefix, CONSTANT_SCORE_BLENDED_REWRITE);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/PrefixQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PrefixQuery.java
@@ -24,13 +24,13 @@ import org.apache.lucene.util.automaton.Automaton;
  * A Query that matches documents containing terms with a specified prefix. A PrefixQuery is built
  * by QueryParser for input like <code>app*</code>.
  *
- * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_REWRITE} rewrite method.
+ * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE} rewrite method.
  */
 public class PrefixQuery extends AutomatonQuery {
 
   /** Constructs a query for terms starting with <code>prefix</code>. */
   public PrefixQuery(Term prefix) {
-    this(prefix, CONSTANT_SCORE_REWRITE);
+    this(prefix, CONSTANT_SCORE_AUTO_REWRITE);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
@@ -100,7 +100,7 @@ public class RegexpQuery extends AutomatonQuery {
         match_flags,
         DEFAULT_PROVIDER,
         determinizeWorkLimit,
-        CONSTANT_SCORE_REWRITE);
+        CONSTANT_SCORE_AUTO_REWRITE);
   }
 
   /**
@@ -116,7 +116,7 @@ public class RegexpQuery extends AutomatonQuery {
    */
   public RegexpQuery(
       Term term, int syntax_flags, AutomatonProvider provider, int determinizeWorkLimit) {
-    this(term, syntax_flags, 0, provider, determinizeWorkLimit, CONSTANT_SCORE_REWRITE);
+    this(term, syntax_flags, 0, provider, determinizeWorkLimit, CONSTANT_SCORE_AUTO_REWRITE);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
@@ -100,7 +100,7 @@ public class RegexpQuery extends AutomatonQuery {
         match_flags,
         DEFAULT_PROVIDER,
         determinizeWorkLimit,
-        CONSTANT_SCORE_AUTO_REWRITE);
+        CONSTANT_SCORE_BLENDED_REWRITE);
   }
 
   /**
@@ -116,7 +116,7 @@ public class RegexpQuery extends AutomatonQuery {
    */
   public RegexpQuery(
       Term term, int syntax_flags, AutomatonProvider provider, int determinizeWorkLimit) {
-    this(term, syntax_flags, 0, provider, determinizeWorkLimit, CONSTANT_SCORE_AUTO_REWRITE);
+    this(term, syntax_flags, 0, provider, determinizeWorkLimit, CONSTANT_SCORE_BLENDED_REWRITE);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/ScoringRewrite.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScoringRewrite.java
@@ -42,7 +42,8 @@ public abstract class ScoringRewrite<B> extends TermCollectingRewrite<B> {
    * A rewrite method that first translates each term into {@link BooleanClause.Occur#SHOULD} clause
    * in a BooleanQuery, and keeps the scores as computed by the query. Note that typically such
    * scores are meaningless to the user, and require non-trivial CPU to compute, so it's almost
-   * always better to use {@link MultiTermQuery#CONSTANT_SCORE_REWRITE} instead.
+   * always better to use {@link MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE} or {@link
+   * MultiTermQuery#CONSTANT_SCORE_REWRITE} instead.
    *
    * <p><b>NOTE</b>: This rewrite method will hit {@link IndexSearcher.TooManyClauses} if the number
    * of terms exceeds {@link IndexSearcher#getMaxClauseCount}.

--- a/lucene/core/src/java/org/apache/lucene/search/ScoringRewrite.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScoringRewrite.java
@@ -42,7 +42,7 @@ public abstract class ScoringRewrite<B> extends TermCollectingRewrite<B> {
    * A rewrite method that first translates each term into {@link BooleanClause.Occur#SHOULD} clause
    * in a BooleanQuery, and keeps the scores as computed by the query. Note that typically such
    * scores are meaningless to the user, and require non-trivial CPU to compute, so it's almost
-   * always better to use {@link MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE} or {@link
+   * always better to use {@link MultiTermQuery#CONSTANT_SCORE_BLENDED_REWRITE} or {@link
    * MultiTermQuery#CONSTANT_SCORE_REWRITE} instead.
    *
    * <p><b>NOTE</b>: This rewrite method will hit {@link IndexSearcher.TooManyClauses} if the number

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.SortedSet;
@@ -31,6 +30,7 @@ import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.PrefixCodedTerms;
 import org.apache.lucene.index.PrefixCodedTerms.TermIterator;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermState;
 import org.apache.lucene.index.TermStates;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
@@ -40,7 +40,6 @@ import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.DocIdSetBuilder;
-import org.apache.lucene.util.PriorityQueue;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
@@ -77,8 +76,6 @@ public class TermInSetQuery extends Query implements Accountable {
       RamUsageEstimator.shallowSizeOfInstance(TermInSetQuery.class);
   // Same threshold as MultiTermQueryConstantScoreWrapper
   static final int BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD = 16;
-  // postings lists under this threshold will always be "pre-processed" into a bitset
-  private static final int POSTINGS_PRE_PROCESS_THRESHOLD = 512;
 
   private final String field;
   private final PrefixCodedTerms termData;
@@ -206,17 +203,35 @@ public class TermInSetQuery extends Query implements Accountable {
     return Collections.emptyList();
   }
 
-  private static class WeightOrDocIdSetIterator {
-    final Weight weight;
-    final DocIdSetIterator iterator;
+  private static class TermAndState {
+    final String field;
+    final TermsEnum termsEnum;
+    final BytesRef term;
+    final TermState state;
+    final int docFreq;
+    final long totalTermFreq;
 
-    WeightOrDocIdSetIterator(Weight weight) {
+    TermAndState(String field, TermsEnum termsEnum) throws IOException {
+      this.field = field;
+      this.termsEnum = termsEnum;
+      this.term = BytesRef.deepCopyOf(termsEnum.term());
+      this.state = termsEnum.termState();
+      this.docFreq = termsEnum.docFreq();
+      this.totalTermFreq = termsEnum.totalTermFreq();
+    }
+  }
+
+  private static class WeightOrDocIdSet {
+    final Weight weight;
+    final DocIdSet set;
+
+    WeightOrDocIdSet(Weight weight) {
       this.weight = Objects.requireNonNull(weight);
-      this.iterator = null;
+      this.set = null;
     }
 
-    WeightOrDocIdSetIterator(DocIdSetIterator iterator) {
-      this.iterator = iterator;
+    WeightOrDocIdSet(DocIdSet bitset) {
+      this.set = bitset;
       this.weight = null;
     }
   }
@@ -243,122 +258,85 @@ public class TermInSetQuery extends Query implements Accountable {
        * On the given leaf context, try to either rewrite to a disjunction if there are few matching
        * terms, or build a bitset containing matching docs.
        */
-      private WeightOrDocIdSetIterator rewrite(LeafReaderContext context) throws IOException {
+      private WeightOrDocIdSet rewrite(LeafReaderContext context) throws IOException {
         final LeafReader reader = context.reader();
 
         Terms terms = reader.terms(field);
         if (terms == null) {
           return null;
         }
-
         final int fieldDocCount = terms.getDocCount();
         TermsEnum termsEnum = terms.iterator();
-        PostingsEnum reuse = null;
+        PostingsEnum docs = null;
         TermIterator iterator = termData.iterator();
 
-        // We will first try to collect up to 'threshold' terms into 'unprocessed'
-        // if there are too many terms, we will fall back to building the 'processedPostings'
+        // We will first try to collect up to 'threshold' terms into 'matchingTerms'
+        // if there are too many terms, we will fall back to building the 'builder'
         final int threshold =
             Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
         assert termData.size() > threshold : "Query should have been rewritten";
-        List<PostingsEnum> unprocessed = new ArrayList<>(threshold);
-        PriorityQueue<PostingsEnum> unprocessedPq = null;
-        DocIdSetBuilder processedPostings = null;
+        List<TermAndState> matchingTerms = new ArrayList<>(threshold);
+        DocIdSetBuilder builder = null;
 
         for (BytesRef term = iterator.next(); term != null; term = iterator.next()) {
           assert field.equals(iterator.field());
-          if (termsEnum.seekExact(term) == false) {
-            continue;
-          }
-
-          // If a term contains all docs with a value for the specified field (likely rare),
-          // we can discard the other terms and just use the dense term's postings:
-          int docFreq = termsEnum.docFreq();
-          if (fieldDocCount == docFreq) {
-            TermStates termStates = new TermStates(searcher.getTopReaderContext());
-            termStates.register(
-                termsEnum.termState(), context.ord, docFreq, termsEnum.totalTermFreq());
-            Query q =
-                new ConstantScoreQuery(
-                    new TermQuery(new Term(field, termsEnum.term()), termStates));
-            Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
-            return new WeightOrDocIdSetIterator(weight);
-          }
-
-          // All small postings get immediately processed into our bitset:
-          if (docFreq <= POSTINGS_PRE_PROCESS_THRESHOLD) {
-            if (processedPostings == null) {
-              processedPostings = new DocIdSetBuilder(reader.maxDoc(), terms);
+          if (termsEnum.seekExact(term)) {
+            // If a term contains all docs with a value for the specified field (likely rare),
+            // we can discard the other terms and just use the dense term's postings:
+            int docFreq = termsEnum.docFreq();
+            if (fieldDocCount == docFreq) {
+              TermStates termStates = new TermStates(searcher.getTopReaderContext());
+              termStates.register(
+                  termsEnum.termState(), context.ord, docFreq, termsEnum.totalTermFreq());
+              Query q =
+                  new ConstantScoreQuery(
+                      new TermQuery(new Term(field, termsEnum.term()), termStates));
+              Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
+              return new WeightOrDocIdSet(weight);
             }
-            reuse = termsEnum.postings(reuse, PostingsEnum.NONE);
-            processedPostings.add(reuse);
-            continue;
-          }
 
-          PostingsEnum p = termsEnum.postings(null, PostingsEnum.NONE);
-          if (unprocessedPq != null) {
-            // We've already switched to using a PQ, so find the next smallest postings of
-            // all the remaining unprocessed ones and process it into our bitset:
-            PostingsEnum evicted = unprocessedPq.insertWithOverflow(p);
-            assert evicted != null;
-            processedPostings.add(evicted);
-          } else if (unprocessed.size() < threshold) {
-            // We haven't hit our "unprocessed" limit yet, so just add to our list:
-            unprocessed.add(p);
-          } else {
-            // We're at our "unprocessed" limit, so we'll switch to a PQ in order to always
-            // lazily process the next shortest postings into our bitset:
-            assert unprocessed.size() == threshold;
-            unprocessedPq =
-                new PriorityQueue<>(threshold) {
-                  @Override
-                  protected boolean lessThan(PostingsEnum a, PostingsEnum b) {
-                    // Note: No tie-breaker for equal cost means that "larger" terms tied for lowest
-                    // cost will get immediately processed, avoiding churn. The PQ logic requires an
-                    // insertWithOverflow candidate to be strictly less than the smallest entry to
-                    // be
-                    // added to the queue:
-                    return a.cost() < b.cost();
-                  }
-                };
-            unprocessedPq.addAll(unprocessed);
-            unprocessed = null;
-            PostingsEnum evicted = unprocessedPq.insertWithOverflow(p);
-            assert evicted != null;
-            if (processedPostings == null) {
-              processedPostings = new DocIdSetBuilder(reader.maxDoc(), terms);
+            if (matchingTerms == null) {
+              docs = termsEnum.postings(docs, PostingsEnum.NONE);
+              builder.add(docs);
+            } else if (matchingTerms.size() < threshold) {
+              matchingTerms.add(new TermAndState(field, termsEnum));
+            } else {
+              assert matchingTerms.size() == threshold;
+              builder = new DocIdSetBuilder(reader.maxDoc(), terms);
+              docs = termsEnum.postings(docs, PostingsEnum.NONE);
+              builder.add(docs);
+              for (TermAndState t : matchingTerms) {
+                t.termsEnum.seekExact(t.term, t.state);
+                docs = t.termsEnum.postings(docs, PostingsEnum.NONE);
+                builder.add(docs);
+              }
+              matchingTerms = null;
             }
-            processedPostings.add(evicted);
           }
         }
 
-        int iteratorCount = processedPostings != null ? 1 : 0;
-        Iterator<PostingsEnum> unprocessedIt;
-        if (unprocessed != null) {
-          iteratorCount += unprocessed.size();
-          unprocessedIt = unprocessed.iterator();
+        if (matchingTerms != null) {
+          assert builder == null;
+          BooleanQuery.Builder bq = new BooleanQuery.Builder();
+          for (TermAndState t : matchingTerms) {
+            final TermStates termStates = new TermStates(searcher.getTopReaderContext());
+            termStates.register(t.state, context.ord, t.docFreq, t.totalTermFreq);
+            bq.add(new TermQuery(new Term(t.field, t.term), termStates), Occur.SHOULD);
+          }
+          Query q = new ConstantScoreQuery(bq.build());
+          final Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
+          return new WeightOrDocIdSet(weight);
         } else {
-          iteratorCount += unprocessedPq.size();
-          unprocessedIt = unprocessedPq.iterator();
+          assert builder != null;
+          return new WeightOrDocIdSet(builder.build());
         }
-
-        if (iteratorCount == 0) {
-          return null;
-        }
-
-        DisiPriorityQueue disiPq = new DisiPriorityQueue(iteratorCount);
-        while (unprocessedIt.hasNext()) {
-          disiPq.add(new DisiWrapper(unprocessedIt.next()));
-        }
-
-        if (processedPostings != null) {
-          disiPq.add(new DisiWrapper(processedPostings.build().iterator()));
-        }
-
-        return new WeightOrDocIdSetIterator(new DisjunctionDISIApproximation(disiPq));
       }
 
-      private Scorer scorer(DocIdSetIterator disi) throws IOException {
+      private Scorer scorer(DocIdSet set) throws IOException {
+        if (set == null) {
+          return null;
+        }
+        final DocIdSetIterator disi = set.iterator();
         if (disi == null) {
           return null;
         }
@@ -367,13 +345,13 @@ public class TermInSetQuery extends Query implements Accountable {
 
       @Override
       public BulkScorer bulkScorer(LeafReaderContext context) throws IOException {
-        final WeightOrDocIdSetIterator weightOrBitSet = rewrite(context);
+        final WeightOrDocIdSet weightOrBitSet = rewrite(context);
         if (weightOrBitSet == null) {
           return null;
         } else if (weightOrBitSet.weight != null) {
           return weightOrBitSet.weight.bulkScorer(context);
         } else {
-          final Scorer scorer = scorer(weightOrBitSet.iterator);
+          final Scorer scorer = scorer(weightOrBitSet.set);
           if (scorer == null) {
             return null;
           }
@@ -413,14 +391,14 @@ public class TermInSetQuery extends Query implements Accountable {
         return new ScorerSupplier() {
           @Override
           public Scorer get(long leadCost) throws IOException {
-            WeightOrDocIdSetIterator weightOrDocIdSetIterator = rewrite(context);
+            WeightOrDocIdSet weightOrDocIdSet = rewrite(context);
             final Scorer scorer;
-            if (weightOrDocIdSetIterator == null) {
+            if (weightOrDocIdSet == null) {
               scorer = null;
-            } else if (weightOrDocIdSetIterator.weight != null) {
-              scorer = weightOrDocIdSetIterator.weight.scorer(context);
+            } else if (weightOrDocIdSet.weight != null) {
+              scorer = weightOrDocIdSet.weight.scorer(context);
             } else {
-              scorer = scorer(weightOrDocIdSetIterator.iterator);
+              scorer = scorer(weightOrDocIdSet.set);
             }
 
             return Objects.requireNonNullElseGet(

--- a/lucene/core/src/java/org/apache/lucene/search/TermRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermRangeQuery.java
@@ -30,7 +30,7 @@ import org.apache.lucene.util.automaton.Automaton;
  * <p><b>NOTE</b>: {@link TermRangeQuery} performs significantly slower than {@link PointRangeQuery
  * point-based ranges} as it needs to visit all terms that match the range and merges their matches.
  *
- * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_REWRITE} rewrite method.
+ * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE} rewrite method.
  *
  * @since 2.9
  */
@@ -60,7 +60,7 @@ public class TermRangeQuery extends AutomatonQuery {
       BytesRef upperTerm,
       boolean includeLower,
       boolean includeUpper) {
-    this(field, lowerTerm, upperTerm, includeLower, includeUpper, CONSTANT_SCORE_REWRITE);
+    this(field, lowerTerm, upperTerm, includeLower, includeUpper, CONSTANT_SCORE_AUTO_REWRITE);
   }
 
   /**
@@ -120,7 +120,7 @@ public class TermRangeQuery extends AutomatonQuery {
       boolean includeLower,
       boolean includeUpper) {
     return newStringRange(
-        field, lowerTerm, upperTerm, includeLower, includeUpper, CONSTANT_SCORE_REWRITE);
+        field, lowerTerm, upperTerm, includeLower, includeUpper, CONSTANT_SCORE_AUTO_REWRITE);
   }
 
   /** Factory that creates a new TermRangeQuery using Strings for term text. */

--- a/lucene/core/src/java/org/apache/lucene/search/TermRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermRangeQuery.java
@@ -30,7 +30,7 @@ import org.apache.lucene.util.automaton.Automaton;
  * <p><b>NOTE</b>: {@link TermRangeQuery} performs significantly slower than {@link PointRangeQuery
  * point-based ranges} as it needs to visit all terms that match the range and merges their matches.
  *
- * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE} rewrite method.
+ * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_BLENDED_REWRITE} rewrite method.
  *
  * @since 2.9
  */
@@ -60,7 +60,7 @@ public class TermRangeQuery extends AutomatonQuery {
       BytesRef upperTerm,
       boolean includeLower,
       boolean includeUpper) {
-    this(field, lowerTerm, upperTerm, includeLower, includeUpper, CONSTANT_SCORE_AUTO_REWRITE);
+    this(field, lowerTerm, upperTerm, includeLower, includeUpper, CONSTANT_SCORE_BLENDED_REWRITE);
   }
 
   /**
@@ -120,7 +120,7 @@ public class TermRangeQuery extends AutomatonQuery {
       boolean includeLower,
       boolean includeUpper) {
     return newStringRange(
-        field, lowerTerm, upperTerm, includeLower, includeUpper, CONSTANT_SCORE_AUTO_REWRITE);
+        field, lowerTerm, upperTerm, includeLower, includeUpper, CONSTANT_SCORE_BLENDED_REWRITE);
   }
 
   /** Factory that creates a new TermRangeQuery using Strings for term text. */

--- a/lucene/core/src/java/org/apache/lucene/search/UsageTrackingQueryCachingPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/search/UsageTrackingQueryCachingPolicy.java
@@ -47,7 +47,7 @@ public class UsageTrackingQueryCachingPolicy implements QueryCachingPolicy {
     // already have the DocIdSetIterator#cost API) but the cost to build the
     // DocIdSet in the first place
     return query instanceof MultiTermQuery
-        || query instanceof MultiTermQueryConstantScoreAutoWrapper
+        || query instanceof MultiTermQueryConstantScoreBlendedWrapper
         || query instanceof MultiTermQueryConstantScoreWrapper
         || query instanceof TermInSetQuery
         || isPointQuery(query);

--- a/lucene/core/src/java/org/apache/lucene/search/UsageTrackingQueryCachingPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/search/UsageTrackingQueryCachingPolicy.java
@@ -47,6 +47,7 @@ public class UsageTrackingQueryCachingPolicy implements QueryCachingPolicy {
     // already have the DocIdSetIterator#cost API) but the cost to build the
     // DocIdSet in the first place
     return query instanceof MultiTermQuery
+        || query instanceof MultiTermQueryConstantScoreAutoWrapper
         || query instanceof MultiTermQueryConstantScoreWrapper
         || query instanceof TermInSetQuery
         || isPointQuery(query);

--- a/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
@@ -31,7 +31,7 @@ import org.apache.lucene.util.automaton.Operations;
  * <p>Note this query can be slow, as it needs to iterate over many terms. In order to prevent
  * extremely slow WildcardQueries, a Wildcard term should not start with the wildcard <code>*</code>
  *
- * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_REWRITE} rewrite method.
+ * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE} rewrite method.
  *
  * @see AutomatonQuery
  */
@@ -59,7 +59,7 @@ public class WildcardQuery extends AutomatonQuery {
    *     otherwise know what to specify.
    */
   public WildcardQuery(Term term, int determinizeWorkLimit) {
-    this(term, determinizeWorkLimit, CONSTANT_SCORE_REWRITE);
+    this(term, determinizeWorkLimit, CONSTANT_SCORE_AUTO_REWRITE);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
@@ -31,7 +31,7 @@ import org.apache.lucene.util.automaton.Operations;
  * <p>Note this query can be slow, as it needs to iterate over many terms. In order to prevent
  * extremely slow WildcardQueries, a Wildcard term should not start with the wildcard <code>*</code>
  *
- * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE} rewrite method.
+ * <p>This query uses the {@link MultiTermQuery#CONSTANT_SCORE_BLENDED_REWRITE} rewrite method.
  *
  * @see AutomatonQuery
  */
@@ -59,7 +59,7 @@ public class WildcardQuery extends AutomatonQuery {
    *     otherwise know what to specify.
    */
   public WildcardQuery(Term term, int determinizeWorkLimit) {
-    this(term, determinizeWorkLimit, CONSTANT_SCORE_AUTO_REWRITE);
+    this(term, determinizeWorkLimit, CONSTANT_SCORE_BLENDED_REWRITE);
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQuery.java
@@ -105,7 +105,10 @@ public class TestAutomatonQuery extends LuceneTestCase {
         expected,
         automatonQueryNrHits(
             new AutomatonQuery(
-                newTerm("bogus"), automaton, false, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE)));
+                newTerm("bogus"),
+                automaton,
+                false,
+                MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE)));
     assertEquals(
         expected,
         automatonQueryNrHits(

--- a/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQuery.java
@@ -105,6 +105,11 @@ public class TestAutomatonQuery extends LuceneTestCase {
         expected,
         automatonQueryNrHits(
             new AutomatonQuery(
+                newTerm("bogus"), automaton, false, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE)));
+    assertEquals(
+        expected,
+        automatonQueryNrHits(
+            new AutomatonQuery(
                 newTerm("bogus"),
                 automaton,
                 false,

--- a/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQueryUnicode.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQueryUnicode.java
@@ -111,6 +111,11 @@ public class TestAutomatonQueryUnicode extends LuceneTestCase {
         expected,
         automatonQueryNrHits(
             new AutomatonQuery(
+                newTerm("bogus"), automaton, false, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE)));
+    assertEquals(
+        expected,
+        automatonQueryNrHits(
+            new AutomatonQuery(
                 newTerm("bogus"),
                 automaton,
                 false,

--- a/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQueryUnicode.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQueryUnicode.java
@@ -111,7 +111,10 @@ public class TestAutomatonQueryUnicode extends LuceneTestCase {
         expected,
         automatonQueryNrHits(
             new AutomatonQuery(
-                newTerm("bogus"), automaton, false, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE)));
+                newTerm("bogus"),
+                automaton,
+                false,
+                MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE)));
     assertEquals(
         expected,
         automatonQueryNrHits(

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldCacheRewriteMethod.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldCacheRewriteMethod.java
@@ -54,7 +54,7 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
             0,
             name -> null,
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
-            MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
+            MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE);
 
     TopDocs fieldCacheDocs = searcher1.search(fieldCache, 25);
     TopDocs filterDocs = searcher2.search(filter, 25);

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldCacheRewriteMethod.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldCacheRewriteMethod.java
@@ -47,10 +47,21 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
             MultiTermQuery.CONSTANT_SCORE_REWRITE);
 
+    RegexpQuery filter2 =
+        new RegexpQuery(
+            new Term(fieldName, regexp),
+            RegExp.NONE,
+            0,
+            name -> null,
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
+
     TopDocs fieldCacheDocs = searcher1.search(fieldCache, 25);
     TopDocs filterDocs = searcher2.search(filter, 25);
+    TopDocs filter2Docs = searcher2.search(filter2, 25);
 
     CheckHits.checkEqual(fieldCache, fieldCacheDocs.scoreDocs, filterDocs.scoreDocs);
+    CheckHits.checkEqual(fieldCache, fieldCacheDocs.scoreDocs, filter2Docs.scoreDocs);
   }
 
   public void testEquals() throws Exception {

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
@@ -97,15 +97,22 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
     small = null;
   }
 
-  /** macro for readability */
+  /**
+   * macro for readability
+   *
+   * @deprecated please use {@link #cspq(Term, MultiTermQuery.RewriteMethod)} instead
+   */
+  @Deprecated
   public static Query csrq(String f, String l, String h, boolean il, boolean ih) {
-    TermRangeQuery query = TermRangeQuery.newStringRange(f, l, h, il, ih);
+    TermRangeQuery query =
+        TermRangeQuery.newStringRange(f, l, h, il, ih, MultiTermQuery.CONSTANT_SCORE_REWRITE);
     if (VERBOSE) {
       System.out.println("TEST: query=" + query);
     }
     return query;
   }
 
+  /** macro for readability */
   public static Query csrq(
       String f, String l, String h, boolean il, boolean ih, MultiTermQuery.RewriteMethod method) {
     TermRangeQuery query = TermRangeQuery.newStringRange(f, l, h, il, ih, method);
@@ -115,20 +122,33 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
     return query;
   }
 
-  /** macro for readability */
+  /**
+   * macro for readability
+   *
+   * @deprecated please use {@link #cspq(Term, MultiTermQuery.RewriteMethod)} instead
+   */
+  @Deprecated
   public static Query cspq(Term prefix) {
-    return new PrefixQuery(prefix);
+    return new PrefixQuery(prefix, MultiTermQuery.CONSTANT_SCORE_REWRITE);
   }
 
+  /** macro for readability */
   public static Query cspq(Term prefix, MultiTermQuery.RewriteMethod method) {
     return new PrefixQuery(prefix, method);
   }
 
-  /** macro for readability */
+  /**
+   * macro for readability
+   *
+   * @deprecated please use {@link #cswcq(Term, MultiTermQuery.RewriteMethod)} instead
+   */
+  @Deprecated
   public static Query cswcq(Term wild) {
-    return new WildcardQuery(wild, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+    return new WildcardQuery(
+        wild, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.CONSTANT_SCORE_REWRITE);
   }
 
+  /** macro for readability */
   public static Query cswcq(Term wild, MultiTermQuery.RewriteMethod method) {
     return new WildcardQuery(wild, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, method);
   }
@@ -160,7 +180,10 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
     // some hits match more terms then others, score should be the same
 
-    result = search.search(csrq("data", "1", "6", T, T), 1000).scoreDocs;
+    result =
+        search.search(
+                csrq("data", "1", "6", T, T, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE), 1000)
+            .scoreDocs;
     int numHits = result.length;
     assertEquals("wrong number of results", 6, numHits);
     float score = result[0].score;
@@ -204,7 +227,9 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
     BooleanQuery.Builder bq = new BooleanQuery.Builder();
     bq.add(dummyTerm, BooleanClause.Occur.SHOULD); // hits one doc
-    bq.add(csrq("data", "#", "#", T, T), BooleanClause.Occur.SHOULD); // hits no docs
+    bq.add(
+        csrq("data", "#", "#", T, T, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE),
+        BooleanClause.Occur.SHOULD); // hits no docs
     result = search.search(bq.build(), 1000).scoreDocs;
     int numHits = result.length;
     assertEquals("wrong number of results", 1, numHits);

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
@@ -41,7 +41,7 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
   public static final float SCORE_COMP_THRESH = 1e-6f;
 
   public static final Set<MultiTermQuery.RewriteMethod> CONSTANT_SCORE_REWRITES =
-      Set.of(MultiTermQuery.CONSTANT_SCORE_REWRITE, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
+      Set.of(MultiTermQuery.CONSTANT_SCORE_REWRITE, MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE);
 
   static Directory small;
   static IndexReader reader;
@@ -182,7 +182,7 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
     result =
         search.search(
-                csrq("data", "1", "6", T, T, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE), 1000)
+                csrq("data", "1", "6", T, T, MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE), 1000)
             .scoreDocs;
     int numHits = result.length;
     assertEquals("wrong number of results", 6, numHits);
@@ -228,7 +228,7 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
     BooleanQuery.Builder bq = new BooleanQuery.Builder();
     bq.add(dummyTerm, BooleanClause.Occur.SHOULD); // hits one doc
     bq.add(
-        csrq("data", "#", "#", T, T, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE),
+        csrq("data", "#", "#", T, T, MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE),
         BooleanClause.Occur.SHOULD); // hits no docs
     result = search.search(bq.build(), 1000).scoreDocs;
     int numHits = result.length;

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
+import java.util.Set;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -38,6 +39,9 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
   /** threshold for comparing floats */
   public static final float SCORE_COMP_THRESH = 1e-6f;
+
+  public static final Set<MultiTermQuery.RewriteMethod> CONSTANT_SCORE_REWRITES =
+      Set.of(MultiTermQuery.CONSTANT_SCORE_REWRITE, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
 
   static Directory small;
   static IndexReader reader;
@@ -95,8 +99,7 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
   /** macro for readability */
   public static Query csrq(String f, String l, String h, boolean il, boolean ih) {
-    TermRangeQuery query =
-        TermRangeQuery.newStringRange(f, l, h, il, ih, MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    TermRangeQuery query = TermRangeQuery.newStringRange(f, l, h, il, ih);
     if (VERBOSE) {
       System.out.println("TEST: query=" + query);
     }
@@ -114,26 +117,37 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
   /** macro for readability */
   public static Query cspq(Term prefix) {
-    return new PrefixQuery(prefix, MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    return new PrefixQuery(prefix);
+  }
+
+  public static Query cspq(Term prefix, MultiTermQuery.RewriteMethod method) {
+    return new PrefixQuery(prefix, method);
   }
 
   /** macro for readability */
   public static Query cswcq(Term wild) {
-    return new WildcardQuery(
-        wild, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    return new WildcardQuery(wild, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+  }
+
+  public static Query cswcq(Term wild, MultiTermQuery.RewriteMethod method) {
+    return new WildcardQuery(wild, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, method);
   }
 
   @Test
   public void testBasics() throws IOException {
-    QueryUtils.check(csrq("data", "1", "6", T, T));
-    QueryUtils.check(csrq("data", "A", "Z", T, T));
-    QueryUtils.checkUnequal(csrq("data", "1", "6", T, T), csrq("data", "A", "Z", T, T));
+    for (MultiTermQuery.RewriteMethod rw : CONSTANT_SCORE_REWRITES) {
+      QueryUtils.check(csrq("data", "1", "6", T, T, rw));
+      QueryUtils.check(csrq("data", "A", "Z", T, T, rw));
+      QueryUtils.checkUnequal(csrq("data", "1", "6", T, T, rw), csrq("data", "A", "Z", T, T, rw));
 
-    QueryUtils.check(cspq(new Term("data", "p*u?")));
-    QueryUtils.checkUnequal(cspq(new Term("data", "pre*")), cspq(new Term("data", "pres*")));
+      QueryUtils.check(cspq(new Term("data", "p*u?"), rw));
+      QueryUtils.checkUnequal(
+          cspq(new Term("data", "pre*"), rw), cspq(new Term("data", "pres*"), rw));
 
-    QueryUtils.check(cswcq(new Term("data", "p")));
-    QueryUtils.checkUnequal(cswcq(new Term("data", "pre*n?t")), cswcq(new Term("data", "pr*t?j")));
+      QueryUtils.check(cswcq(new Term("data", "p"), rw));
+      QueryUtils.checkUnequal(
+          cswcq(new Term("data", "pre*n?t"), rw), cswcq(new Term("data", "pr*t?j"), rw));
+    }
   }
 
   @Test
@@ -233,26 +247,29 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
     IndexSearcher search = newSearcher(reader);
 
-    // first do a regular TermRangeQuery which uses term expansion so
-    // docs with more terms in range get higher scores
+    for (MultiTermQuery.RewriteMethod rw : CONSTANT_SCORE_REWRITES) {
 
-    Query rq = TermRangeQuery.newStringRange("data", "1", "4", T, T);
+      // first do a regular TermRangeQuery which uses term expansion so
+      // docs with more terms in range get higher scores
 
-    ScoreDoc[] expected = search.search(rq, 1000).scoreDocs;
-    int numHits = expected.length;
+      Query rq = TermRangeQuery.newStringRange("data", "1", "4", T, T, rw);
 
-    // now do a boolean where which also contains a
-    // ConstantScoreRangeQuery and make sure hte order is the same
+      ScoreDoc[] expected = search.search(rq, 1000).scoreDocs;
+      int numHits = expected.length;
 
-    BooleanQuery.Builder q = new BooleanQuery.Builder();
-    q.add(rq, BooleanClause.Occur.MUST); // T, F);
-    q.add(csrq("data", "1", "6", T, T), BooleanClause.Occur.MUST); // T, F);
+      // now do a boolean where which also contains a
+      // ConstantScoreRangeQuery and make sure the order is the same
 
-    ScoreDoc[] actual = search.search(q.build(), 1000).scoreDocs;
+      BooleanQuery.Builder q = new BooleanQuery.Builder();
+      q.add(rq, BooleanClause.Occur.MUST); // T, F);
+      q.add(csrq("data", "1", "6", T, T, rw), BooleanClause.Occur.MUST); // T, F);
 
-    assertEquals("wrong numebr of hits", numHits, actual.length);
-    for (int i = 0; i < numHits; i++) {
-      assertEquals("mismatch in docid for hit#" + i, expected[i].doc, actual[i].doc);
+      ScoreDoc[] actual = search.search(q.build(), 1000).scoreDocs;
+
+      assertEquals("wrong number of hits", numHits, actual.length);
+      for (int i = 0; i < numHits; i++) {
+        assertEquals("mismatch in docid for hit#" + i, expected[i].doc, actual[i].doc);
+      }
     }
   }
 
@@ -279,153 +296,74 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
     ScoreDoc[] result;
 
-    // test id, bounded on both ends
+    for (MultiTermQuery.RewriteMethod rw : CONSTANT_SCORE_REWRITES) {
 
-    result = search.search(csrq("id", minIP, maxIP, T, T), numDocs).scoreDocs;
-    assertEquals("find all", numDocs, result.length);
+      // test id, bounded on both ends
 
-    result =
-        search.search(
-                csrq("id", minIP, maxIP, T, T, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("find all", numDocs, result.length);
+      result = search.search(csrq("id", minIP, maxIP, T, T, rw), numDocs).scoreDocs;
+      assertEquals("find all", numDocs, result.length);
 
-    result = search.search(csrq("id", minIP, maxIP, T, F), numDocs).scoreDocs;
-    assertEquals("all but last", numDocs - 1, result.length);
+      result = search.search(csrq("id", minIP, maxIP, T, F, rw), numDocs).scoreDocs;
+      assertEquals("all but last", numDocs - 1, result.length);
 
-    result =
-        search.search(
-                csrq("id", minIP, maxIP, T, F, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("all but last", numDocs - 1, result.length);
+      result = search.search(csrq("id", minIP, maxIP, F, T, rw), numDocs).scoreDocs;
+      assertEquals("all but first", numDocs - 1, result.length);
 
-    result = search.search(csrq("id", minIP, maxIP, F, T), numDocs).scoreDocs;
-    assertEquals("all but first", numDocs - 1, result.length);
+      result = search.search(csrq("id", minIP, maxIP, F, F, rw), numDocs).scoreDocs;
+      assertEquals("all but ends", numDocs - 2, result.length);
 
-    result =
-        search.search(
-                csrq("id", minIP, maxIP, F, T, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("all but first", numDocs - 1, result.length);
+      result = search.search(csrq("id", medIP, maxIP, T, T, rw), numDocs).scoreDocs;
+      assertEquals("med and up", 1 + maxId - medId, result.length);
 
-    result = search.search(csrq("id", minIP, maxIP, F, F), numDocs).scoreDocs;
-    assertEquals("all but ends", numDocs - 2, result.length);
+      result = search.search(csrq("id", minIP, medIP, T, T, rw), numDocs).scoreDocs;
+      assertEquals("up to med", 1 + medId - minId, result.length);
 
-    result =
-        search.search(
-                csrq("id", minIP, maxIP, F, F, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("all but ends", numDocs - 2, result.length);
+      // unbounded id
 
-    result = search.search(csrq("id", medIP, maxIP, T, T), numDocs).scoreDocs;
-    assertEquals("med and up", 1 + maxId - medId, result.length);
+      result = search.search(csrq("id", minIP, null, T, F, rw), numDocs).scoreDocs;
+      assertEquals("min and up", numDocs, result.length);
 
-    result =
-        search.search(
-                csrq("id", medIP, maxIP, T, T, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("med and up", 1 + maxId - medId, result.length);
+      result = search.search(csrq("id", null, maxIP, F, T, rw), numDocs).scoreDocs;
+      assertEquals("max and down", numDocs, result.length);
 
-    result = search.search(csrq("id", minIP, medIP, T, T), numDocs).scoreDocs;
-    assertEquals("up to med", 1 + medId - minId, result.length);
+      result = search.search(csrq("id", minIP, null, F, F, rw), numDocs).scoreDocs;
+      assertEquals("not min, but up", numDocs - 1, result.length);
 
-    result =
-        search.search(
-                csrq("id", minIP, medIP, T, T, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("up to med", 1 + medId - minId, result.length);
+      result = search.search(csrq("id", null, maxIP, F, F, rw), numDocs).scoreDocs;
+      assertEquals("not max, but down", numDocs - 1, result.length);
 
-    // unbounded id
+      result = search.search(csrq("id", medIP, maxIP, T, F, rw), numDocs).scoreDocs;
+      assertEquals("med and up, not max", maxId - medId, result.length);
 
-    result = search.search(csrq("id", minIP, null, T, F), numDocs).scoreDocs;
-    assertEquals("min and up", numDocs, result.length);
+      result = search.search(csrq("id", minIP, medIP, F, T, rw), numDocs).scoreDocs;
+      assertEquals("not min, up to med", medId - minId, result.length);
 
-    result = search.search(csrq("id", null, maxIP, F, T), numDocs).scoreDocs;
-    assertEquals("max and down", numDocs, result.length);
+      // very small sets
 
-    result = search.search(csrq("id", minIP, null, F, F), numDocs).scoreDocs;
-    assertEquals("not min, but up", numDocs - 1, result.length);
+      result = search.search(csrq("id", minIP, minIP, F, F, rw), numDocs).scoreDocs;
+      assertEquals("min,min,F,F", 0, result.length);
 
-    result = search.search(csrq("id", null, maxIP, F, F), numDocs).scoreDocs;
-    assertEquals("not max, but down", numDocs - 1, result.length);
+      result = search.search(csrq("id", medIP, medIP, F, F, rw), numDocs).scoreDocs;
+      assertEquals("med,med,F,F", 0, result.length);
 
-    result = search.search(csrq("id", medIP, maxIP, T, F), numDocs).scoreDocs;
-    assertEquals("med and up, not max", maxId - medId, result.length);
+      result = search.search(csrq("id", maxIP, maxIP, F, F, rw), numDocs).scoreDocs;
+      assertEquals("max,max,F,F", 0, result.length);
 
-    result = search.search(csrq("id", minIP, medIP, F, T), numDocs).scoreDocs;
-    assertEquals("not min, up to med", medId - minId, result.length);
+      result = search.search(csrq("id", minIP, minIP, T, T, rw), numDocs).scoreDocs;
+      assertEquals("min,min,T,T", 1, result.length);
 
-    // very small sets
+      result = search.search(csrq("id", null, minIP, F, T, rw), numDocs).scoreDocs;
+      assertEquals("nul,min,F,T", 1, result.length);
 
-    result = search.search(csrq("id", minIP, minIP, F, F), numDocs).scoreDocs;
-    assertEquals("min,min,F,F", 0, result.length);
+      result = search.search(csrq("id", maxIP, maxIP, T, T, rw), numDocs).scoreDocs;
+      assertEquals("max,max,T,T", 1, result.length);
 
-    result =
-        search.search(
-                csrq("id", minIP, minIP, F, F, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("min,min,F,F", 0, result.length);
+      result = search.search(csrq("id", maxIP, null, T, F, rw), numDocs).scoreDocs;
+      assertEquals("max,nul,T,T", 1, result.length);
 
-    result = search.search(csrq("id", medIP, medIP, F, F), numDocs).scoreDocs;
-    assertEquals("med,med,F,F", 0, result.length);
-
-    result =
-        search.search(
-                csrq("id", medIP, medIP, F, F, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("med,med,F,F", 0, result.length);
-
-    result = search.search(csrq("id", maxIP, maxIP, F, F), numDocs).scoreDocs;
-    assertEquals("max,max,F,F", 0, result.length);
-
-    result =
-        search.search(
-                csrq("id", maxIP, maxIP, F, F, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("max,max,F,F", 0, result.length);
-
-    result = search.search(csrq("id", minIP, minIP, T, T), numDocs).scoreDocs;
-    assertEquals("min,min,T,T", 1, result.length);
-
-    result =
-        search.search(
-                csrq("id", minIP, minIP, T, T, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("min,min,T,T", 1, result.length);
-
-    result = search.search(csrq("id", null, minIP, F, T), numDocs).scoreDocs;
-    assertEquals("nul,min,F,T", 1, result.length);
-
-    result =
-        search.search(csrq("id", null, minIP, F, T, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("nul,min,F,T", 1, result.length);
-
-    result = search.search(csrq("id", maxIP, maxIP, T, T), numDocs).scoreDocs;
-    assertEquals("max,max,T,T", 1, result.length);
-
-    result =
-        search.search(
-                csrq("id", maxIP, maxIP, T, T, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("max,max,T,T", 1, result.length);
-
-    result = search.search(csrq("id", maxIP, null, T, F), numDocs).scoreDocs;
-    assertEquals("max,nul,T,T", 1, result.length);
-
-    result =
-        search.search(csrq("id", maxIP, null, T, F, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("max,nul,T,T", 1, result.length);
-
-    result = search.search(csrq("id", medIP, medIP, T, T), numDocs).scoreDocs;
-    assertEquals("med,med,T,T", 1, result.length);
-
-    result =
-        search.search(
-                csrq("id", medIP, medIP, T, T, MultiTermQuery.CONSTANT_SCORE_REWRITE), numDocs)
-            .scoreDocs;
-    assertEquals("med,med,T,T", 1, result.length);
+      result = search.search(csrq("id", medIP, medIP, T, T, rw), numDocs).scoreDocs;
+      assertEquals("med,med,T,T", 1, result.length);
+    }
   }
 
   @Test
@@ -444,49 +382,52 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
     ScoreDoc[] result;
 
-    // test extremes, bounded on both ends
+    for (MultiTermQuery.RewriteMethod rw : CONSTANT_SCORE_REWRITES) {
 
-    result = search.search(csrq("rand", minRP, maxRP, T, T), numDocs).scoreDocs;
-    assertEquals("find all", numDocs, result.length);
+      // test extremes, bounded on both ends
 
-    result = search.search(csrq("rand", minRP, maxRP, T, F), numDocs).scoreDocs;
-    assertEquals("all but biggest", numDocs - 1, result.length);
+      result = search.search(csrq("rand", minRP, maxRP, T, T, rw), numDocs).scoreDocs;
+      assertEquals("find all", numDocs, result.length);
 
-    result = search.search(csrq("rand", minRP, maxRP, F, T), numDocs).scoreDocs;
-    assertEquals("all but smallest", numDocs - 1, result.length);
+      result = search.search(csrq("rand", minRP, maxRP, T, F, rw), numDocs).scoreDocs;
+      assertEquals("all but biggest", numDocs - 1, result.length);
 
-    result = search.search(csrq("rand", minRP, maxRP, F, F), numDocs).scoreDocs;
-    assertEquals("all but extremes", numDocs - 2, result.length);
+      result = search.search(csrq("rand", minRP, maxRP, F, T, rw), numDocs).scoreDocs;
+      assertEquals("all but smallest", numDocs - 1, result.length);
 
-    // unbounded
+      result = search.search(csrq("rand", minRP, maxRP, F, F, rw), numDocs).scoreDocs;
+      assertEquals("all but extremes", numDocs - 2, result.length);
 
-    result = search.search(csrq("rand", minRP, null, T, F), numDocs).scoreDocs;
-    assertEquals("smallest and up", numDocs, result.length);
+      // unbounded
 
-    result = search.search(csrq("rand", null, maxRP, F, T), numDocs).scoreDocs;
-    assertEquals("biggest and down", numDocs, result.length);
+      result = search.search(csrq("rand", minRP, null, T, F, rw), numDocs).scoreDocs;
+      assertEquals("smallest and up", numDocs, result.length);
 
-    result = search.search(csrq("rand", minRP, null, F, F), numDocs).scoreDocs;
-    assertEquals("not smallest, but up", numDocs - 1, result.length);
+      result = search.search(csrq("rand", null, maxRP, F, T, rw), numDocs).scoreDocs;
+      assertEquals("biggest and down", numDocs, result.length);
 
-    result = search.search(csrq("rand", null, maxRP, F, F), numDocs).scoreDocs;
-    assertEquals("not biggest, but down", numDocs - 1, result.length);
+      result = search.search(csrq("rand", minRP, null, F, F, rw), numDocs).scoreDocs;
+      assertEquals("not smallest, but up", numDocs - 1, result.length);
 
-    // very small sets
+      result = search.search(csrq("rand", null, maxRP, F, F, rw), numDocs).scoreDocs;
+      assertEquals("not biggest, but down", numDocs - 1, result.length);
 
-    result = search.search(csrq("rand", minRP, minRP, F, F), numDocs).scoreDocs;
-    assertEquals("min,min,F,F", 0, result.length);
-    result = search.search(csrq("rand", maxRP, maxRP, F, F), numDocs).scoreDocs;
-    assertEquals("max,max,F,F", 0, result.length);
+      // very small sets
 
-    result = search.search(csrq("rand", minRP, minRP, T, T), numDocs).scoreDocs;
-    assertEquals("min,min,T,T", 1, result.length);
-    result = search.search(csrq("rand", null, minRP, F, T), numDocs).scoreDocs;
-    assertEquals("nul,min,F,T", 1, result.length);
+      result = search.search(csrq("rand", minRP, minRP, F, F, rw), numDocs).scoreDocs;
+      assertEquals("min,min,F,F", 0, result.length);
+      result = search.search(csrq("rand", maxRP, maxRP, F, F, rw), numDocs).scoreDocs;
+      assertEquals("max,max,F,F", 0, result.length);
 
-    result = search.search(csrq("rand", maxRP, maxRP, T, T), numDocs).scoreDocs;
-    assertEquals("max,max,T,T", 1, result.length);
-    result = search.search(csrq("rand", maxRP, null, T, F), numDocs).scoreDocs;
-    assertEquals("max,nul,T,T", 1, result.length);
+      result = search.search(csrq("rand", minRP, minRP, T, T, rw), numDocs).scoreDocs;
+      assertEquals("min,min,T,T", 1, result.length);
+      result = search.search(csrq("rand", null, minRP, F, T, rw), numDocs).scoreDocs;
+      assertEquals("nul,min,F,T", 1, result.length);
+
+      result = search.search(csrq("rand", maxRP, maxRP, T, T, rw), numDocs).scoreDocs;
+      assertEquals("max,max,T,T", 1, result.length);
+      result = search.search(csrq("rand", maxRP, null, T, F, rw), numDocs).scoreDocs;
+      assertEquals("max,nul,T,T", 1, result.length);
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiTermQueryRewrites.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiTermQueryRewrites.java
@@ -266,7 +266,7 @@ public class TestMultiTermQueryRewrites extends LuceneTestCase {
     checkMaxClauseLimitation(MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE);
 
     checkNoMaxClauseLimitation(MultiTermQuery.CONSTANT_SCORE_REWRITE);
-    checkNoMaxClauseLimitation(MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
+    checkNoMaxClauseLimitation(MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE);
     checkNoMaxClauseLimitation(new MultiTermQuery.TopTermsScoringBooleanQueryRewrite(1024));
     checkNoMaxClauseLimitation(new MultiTermQuery.TopTermsBoostOnlyBooleanQueryRewrite(1024));
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiTermQueryRewrites.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiTermQueryRewrites.java
@@ -266,6 +266,7 @@ public class TestMultiTermQueryRewrites extends LuceneTestCase {
     checkMaxClauseLimitation(MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE);
 
     checkNoMaxClauseLimitation(MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    checkNoMaxClauseLimitation(MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
     checkNoMaxClauseLimitation(new MultiTermQuery.TopTermsScoringBooleanQueryRewrite(1024));
     checkNoMaxClauseLimitation(new MultiTermQuery.TopTermsBoostOnlyBooleanQueryRewrite(1024));
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestPrefixRandom.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPrefixRandom.java
@@ -81,7 +81,7 @@ public class TestPrefixRandom extends LuceneTestCase {
     private final BytesRef prefix;
 
     DumbPrefixQuery(Term term) {
-      super(term.field(), CONSTANT_SCORE_AUTO_REWRITE);
+      super(term.field(), CONSTANT_SCORE_BLENDED_REWRITE);
       prefix = term.bytes();
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestPrefixRandom.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPrefixRandom.java
@@ -81,7 +81,7 @@ public class TestPrefixRandom extends LuceneTestCase {
     private final BytesRef prefix;
 
     DumbPrefixQuery(Term term) {
-      super(term.field(), CONSTANT_SCORE_REWRITE);
+      super(term.field(), CONSTANT_SCORE_AUTO_REWRITE);
       prefix = term.bytes();
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestRegexpRandom2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRegexpRandom2.java
@@ -110,7 +110,7 @@ public class TestRegexpRandom2 extends LuceneTestCase {
     private final Automaton automaton;
 
     DumbRegexpQuery(Term term, int flags) {
-      super(term.field(), MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
+      super(term.field(), MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE);
       RegExp re = new RegExp(term.text(), flags);
       automaton =
           Operations.determinize(re.toAutomaton(), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);

--- a/lucene/core/src/test/org/apache/lucene/search/TestRegexpRandom2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRegexpRandom2.java
@@ -110,7 +110,7 @@ public class TestRegexpRandom2 extends LuceneTestCase {
     private final Automaton automaton;
 
     DumbRegexpQuery(Term term, int flags) {
-      super(term.field(), MultiTermQuery.CONSTANT_SCORE_REWRITE);
+      super(term.field(), MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
       RegExp re = new RegExp(term.text(), flags);
       automaton =
           Operations.determinize(re.toAutomaton(), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);

--- a/lucene/core/src/test/org/apache/lucene/search/TestWildcard.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestWildcard.java
@@ -88,6 +88,14 @@ public class TestWildcard extends LuceneTestCase {
             new WildcardQuery(
                 new Term("field", "nowildcard"),
                 Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+                MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE));
+    assertTrue(q instanceof MultiTermQueryConstantScoreAutoWrapper);
+
+    q =
+        searcher.rewrite(
+            new WildcardQuery(
+                new Term("field", "nowildcard"),
+                Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
                 MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE));
     assertTrue(q instanceof ConstantScoreQuery);
     reader.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestWildcard.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestWildcard.java
@@ -88,8 +88,8 @@ public class TestWildcard extends LuceneTestCase {
             new WildcardQuery(
                 new Term("field", "nowildcard"),
                 Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
-                MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE));
-    assertTrue(q instanceof MultiTermQueryConstantScoreAutoWrapper);
+                MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE));
+    assertTrue(q instanceof MultiTermQueryConstantScoreBlendedWrapper);
 
     q =
         searcher.rewrite(

--- a/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
@@ -1094,7 +1094,7 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
         new WildcardQuery(
             new Term(FIELD_NAME, "ken*"),
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
-            MultiTermQuery.CONSTANT_SCORE_REWRITE);
+            MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
     searcher = newSearcher(reader);
     // can't rewrite ConstantScore if you want to highlight it -
     // it rewrites to ConstantScoreQuery which cannot be highlighted

--- a/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
@@ -1094,7 +1094,7 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
         new WildcardQuery(
             new Term(FIELD_NAME, "ken*"),
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
-            MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
+            MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE);
     searcher = newSearcher(reader);
     // can't rewrite ConstantScore if you want to highlight it -
     // it rewrites to ConstantScoreQuery which cannot be highlighted

--- a/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
@@ -63,7 +63,7 @@ class TermsQuery extends MultiTermQuery implements Accountable {
       String fromField,
       Query fromQuery,
       Object indexReaderContextId) {
-    super(toField, CONSTANT_SCORE_AUTO_REWRITE);
+    super(toField, CONSTANT_SCORE_BLENDED_REWRITE);
     this.terms = terms;
     ords = terms.sort();
     this.fromField = fromField;

--- a/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
@@ -63,7 +63,7 @@ class TermsQuery extends MultiTermQuery implements Accountable {
       String fromField,
       Query fromQuery,
       Object indexReaderContextId) {
-    super(toField, CONSTANT_SCORE_REWRITE);
+    super(toField, CONSTANT_SCORE_AUTO_REWRITE);
     this.terms = terms;
     ords = terms.sort();
     this.fromField = fromField;

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
@@ -82,7 +82,8 @@ public abstract class QueryParserBase extends QueryBuilder
   /** The actual operator that parser uses to combine query terms */
   Operator operator = OR_OPERATOR;
 
-  MultiTermQuery.RewriteMethod multiTermRewriteMethod = MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE;
+  MultiTermQuery.RewriteMethod multiTermRewriteMethod =
+      MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE;
   boolean allowLeadingWildcard = false;
 
   protected String field;

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
@@ -82,7 +82,7 @@ public abstract class QueryParserBase extends QueryBuilder
   /** The actual operator that parser uses to combine query terms */
   Operator operator = OR_OPERATOR;
 
-  MultiTermQuery.RewriteMethod multiTermRewriteMethod = MultiTermQuery.CONSTANT_SCORE_REWRITE;
+  MultiTermQuery.RewriteMethod multiTermRewriteMethod = MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE;
   boolean allowLeadingWildcard = false;
 
   protected String field;
@@ -256,15 +256,6 @@ public abstract class QueryParserBase extends QueryBuilder
     return operator;
   }
 
-  /**
-   * By default QueryParser uses {@link
-   * org.apache.lucene.search.MultiTermQuery#CONSTANT_SCORE_REWRITE} when creating a {@link
-   * PrefixQuery}, {@link WildcardQuery} or {@link TermRangeQuery}. This implementation is generally
-   * preferable because it a) Runs faster b) Does not have the scarcity of terms unduly influence
-   * score c) avoids any {@link TooManyClauses} exception. However, if your application really needs
-   * to use the old-fashioned {@link BooleanQuery} expansion rewriting and the above points are not
-   * relevant then use this to change the rewrite method.
-   */
   @Override
   public void setMultiTermRewriteMethod(MultiTermQuery.RewriteMethod method) {
     multiTermRewriteMethod = method;

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/CommonQueryParserConfiguration.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/CommonQueryParserConfiguration.java
@@ -65,7 +65,10 @@ public interface CommonQueryParserConfiguration {
    * score c) avoids any {@link org.apache.lucene.search.IndexSearcher.TooManyClauses} exception.
    * However, if your application really needs to use the old-fashioned {@link BooleanQuery}
    * expansion rewriting and the above points are not relevant then use this to change the rewrite
-   * method.
+   * method. As another alternative, if you prefer all terms to be rewritten as a filter up-front,
+   * you can use {@link org.apache.lucene.search.MultiTermQuery#CONSTANT_SCORE_REWRITE}. For more
+   * information on the different rewrite methods available, see {@link
+   * org.apache.lucene.search.MultiTermQuery} documentation.
    */
   public void setMultiTermRewriteMethod(MultiTermQuery.RewriteMethod method);
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/CommonQueryParserConfiguration.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/CommonQueryParserConfiguration.java
@@ -59,7 +59,7 @@ public interface CommonQueryParserConfiguration {
 
   /**
    * By default QueryParser uses {@link
-   * org.apache.lucene.search.MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE} when creating a {@link
+   * org.apache.lucene.search.MultiTermQuery#CONSTANT_SCORE_BLENDED_REWRITE} when creating a {@link
    * PrefixQuery}, {@link WildcardQuery} or {@link TermRangeQuery}. This implementation is generally
    * preferable because it a) Runs faster b) Does not have the scarcity of terms unduly influence
    * score c) avoids any {@link org.apache.lucene.search.IndexSearcher.TooManyClauses} exception.

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/CommonQueryParserConfiguration.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/CommonQueryParserConfiguration.java
@@ -18,12 +18,15 @@ package org.apache.lucene.queryparser.flexible.standard;
 
 import java.util.Locale;
 import java.util.TimeZone;
-import java.util.TooManyListenersException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.DateTools;
 import org.apache.lucene.document.DateTools.Resolution;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.PrefixQuery;
+import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.search.WildcardQuery;
 
 /** Configuration options common across queryparser implementations. */
 public interface CommonQueryParserConfiguration {
@@ -55,12 +58,14 @@ public interface CommonQueryParserConfiguration {
   public boolean getEnablePositionIncrements();
 
   /**
-   * By default, it uses {@link MultiTermQuery#CONSTANT_SCORE_REWRITE} when creating a prefix,
-   * wildcard and range queries. This implementation is generally preferable because it a) Runs
-   * faster b) Does not have the scarcity of terms unduly influence score c) avoids any {@link
-   * TooManyListenersException} exception. However, if your application really needs to use the
-   * old-fashioned boolean queries expansion rewriting and the above points are not relevant then
-   * use this change the rewrite method.
+   * By default QueryParser uses {@link
+   * org.apache.lucene.search.MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE} when creating a {@link
+   * PrefixQuery}, {@link WildcardQuery} or {@link TermRangeQuery}. This implementation is generally
+   * preferable because it a) Runs faster b) Does not have the scarcity of terms unduly influence
+   * score c) avoids any {@link org.apache.lucene.search.IndexSearcher.TooManyClauses} exception.
+   * However, if your application really needs to use the old-fashioned {@link BooleanQuery}
+   * expansion rewriting and the above points are not relevant then use this to change the rewrite
+   * method.
    */
   public void setMultiTermRewriteMethod(MultiTermQuery.RewriteMethod method);
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/StandardQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/StandardQueryParser.java
@@ -19,7 +19,6 @@ package org.apache.lucene.queryparser.flexible.standard;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.TooManyListenersException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.DateTools;
 import org.apache.lucene.document.DateTools.Resolution;
@@ -342,14 +341,6 @@ public class StandardQueryParser extends QueryParserHelper
     }
   }
 
-  /**
-   * By default, it uses {@link MultiTermQuery#CONSTANT_SCORE_REWRITE} when creating a prefix,
-   * wildcard and range queries. This implementation is generally preferable because it a) Runs
-   * faster b) Does not have the scarcity of terms unduly influence score c) avoids any {@link
-   * TooManyListenersException} exception. However, if your application really needs to use the
-   * old-fashioned boolean queries expansion rewriting and the above points are not relevant then
-   * use this change the rewrite method.
-   */
   @Override
   public void setMultiTermRewriteMethod(MultiTermQuery.RewriteMethod method) {
     getQueryConfigHandler().set(ConfigurationKeys.MULTI_TERM_REWRITE_METHOD, method);

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/PrefixWildcardQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/PrefixWildcardQueryNodeBuilder.java
@@ -39,7 +39,7 @@ public class PrefixWildcardQueryNodeBuilder implements StandardQueryBuilder {
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
     if (method == null) {
-      method = MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE;
+      method = MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE;
     }
 
     String text =

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/PrefixWildcardQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/PrefixWildcardQueryNodeBuilder.java
@@ -39,7 +39,7 @@ public class PrefixWildcardQueryNodeBuilder implements StandardQueryBuilder {
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
     if (method == null) {
-      method = MultiTermQuery.CONSTANT_SCORE_REWRITE;
+      method = MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE;
     }
 
     String text =

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/RegexpQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/RegexpQueryNodeBuilder.java
@@ -40,7 +40,7 @@ public class RegexpQueryNodeBuilder implements StandardQueryBuilder {
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
     if (method == null) {
-      method = MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE;
+      method = MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE;
     }
 
     // TODO: make the maxStates configurable w/ a reasonable default (QueryParserBase uses 10000)

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/RegexpQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/RegexpQueryNodeBuilder.java
@@ -40,7 +40,7 @@ public class RegexpQueryNodeBuilder implements StandardQueryBuilder {
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
     if (method == null) {
-      method = MultiTermQuery.CONSTANT_SCORE_REWRITE;
+      method = MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE;
     }
 
     // TODO: make the maxStates configurable w/ a reasonable default (QueryParserBase uses 10000)

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/TermRangeQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/TermRangeQueryNodeBuilder.java
@@ -53,7 +53,7 @@ public class TermRangeQueryNodeBuilder implements StandardQueryBuilder {
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
     if (method == null) {
-      method = MultiTermQuery.CONSTANT_SCORE_REWRITE;
+      method = MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE;
     }
 
     return TermRangeQuery.newStringRange(

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/TermRangeQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/TermRangeQueryNodeBuilder.java
@@ -53,7 +53,7 @@ public class TermRangeQueryNodeBuilder implements StandardQueryBuilder {
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
     if (method == null) {
-      method = MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE;
+      method = MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE;
     }
 
     return TermRangeQuery.newStringRange(

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/WildcardQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/WildcardQueryNodeBuilder.java
@@ -39,7 +39,7 @@ public class WildcardQueryNodeBuilder implements StandardQueryBuilder {
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
     if (method == null) {
-      method = MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE;
+      method = MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE;
     }
 
     return new WildcardQuery(

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/WildcardQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/WildcardQueryNodeBuilder.java
@@ -39,7 +39,7 @@ public class WildcardQueryNodeBuilder implements StandardQueryBuilder {
     MultiTermQuery.RewriteMethod method =
         (MultiTermQuery.RewriteMethod) queryNode.getTag(MultiTermRewriteMethodProcessor.TAG_ID);
     if (method == null) {
-      method = MultiTermQuery.CONSTANT_SCORE_REWRITE;
+      method = MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE;
     }
 
     return new WildcardQuery(

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/config/StandardQueryConfigHandler.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/config/StandardQueryConfigHandler.java
@@ -203,7 +203,7 @@ public class StandardQueryConfigHandler extends QueryConfigHandler {
     set(ConfigurationKeys.FIELD_BOOST_MAP, new LinkedHashMap<String, Float>());
     set(ConfigurationKeys.FUZZY_CONFIG, new FuzzyConfig());
     set(ConfigurationKeys.LOCALE, Locale.getDefault());
-    set(ConfigurationKeys.MULTI_TERM_REWRITE_METHOD, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
+    set(ConfigurationKeys.MULTI_TERM_REWRITE_METHOD, MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE);
     set(
         ConfigurationKeys.FIELD_DATE_RESOLUTION_MAP,
         new HashMap<CharSequence, DateTools.Resolution>());

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/config/StandardQueryConfigHandler.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/config/StandardQueryConfigHandler.java
@@ -203,7 +203,7 @@ public class StandardQueryConfigHandler extends QueryConfigHandler {
     set(ConfigurationKeys.FIELD_BOOST_MAP, new LinkedHashMap<String, Float>());
     set(ConfigurationKeys.FUZZY_CONFIG, new FuzzyConfig());
     set(ConfigurationKeys.LOCALE, Locale.getDefault());
-    set(ConfigurationKeys.MULTI_TERM_REWRITE_METHOD, MultiTermQuery.CONSTANT_SCORE_REWRITE);
+    set(ConfigurationKeys.MULTI_TERM_REWRITE_METHOD, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE);
     set(
         ConfigurationKeys.FIELD_DATE_RESOLUTION_MAP,
         new HashMap<CharSequence, DateTools.Resolution>());

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/MultiTermRewriteMethodProcessor.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/MultiTermRewriteMethodProcessor.java
@@ -28,7 +28,7 @@ import org.apache.lucene.search.MultiTermQuery;
 /**
  * This processor instates the default {@link
  * org.apache.lucene.search.MultiTermQuery.RewriteMethod}, {@link
- * MultiTermQuery#CONSTANT_SCORE_REWRITE}, for multi-term query nodes.
+ * MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE}, for multi-term query nodes.
  */
 public class MultiTermRewriteMethodProcessor extends QueryNodeProcessorImpl {
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/MultiTermRewriteMethodProcessor.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/MultiTermRewriteMethodProcessor.java
@@ -28,7 +28,7 @@ import org.apache.lucene.search.MultiTermQuery;
 /**
  * This processor instates the default {@link
  * org.apache.lucene.search.MultiTermQuery.RewriteMethod}, {@link
- * MultiTermQuery#CONSTANT_SCORE_AUTO_REWRITE}, for multi-term query nodes.
+ * MultiTermQuery#CONSTANT_SCORE_BLENDED_REWRITE}, for multi-term query nodes.
  */
 public class MultiTermRewriteMethodProcessor extends QueryNodeProcessorImpl {
 

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestQPHelper.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestQPHelper.java
@@ -309,17 +309,17 @@ public class TestQPHelper extends LuceneTestCase {
     Query q = qp.parse("foo*bar", "field");
     assertTrue(q instanceof WildcardQuery);
     assertEquals(
-        MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
+        MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
 
     q = qp.parse("foo*", "field");
     assertTrue(q instanceof PrefixQuery);
     assertEquals(
-        MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
+        MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
 
     q = qp.parse("[a TO z]", "field");
     assertTrue(q instanceof TermRangeQuery);
     assertEquals(
-        MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
+        MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
   }
 
   public void testCJK() throws Exception {
@@ -649,7 +649,7 @@ public class TestQPHelper extends LuceneTestCase {
   public void testRange() throws Exception {
     assertQueryEquals("[ a TO z]", null, "[a TO z]");
     assertEquals(
-        MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE,
+        MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE,
         ((TermRangeQuery) getQuery("[ a TO z]", null)).getRewriteMethod());
 
     StandardQueryParser qp = new StandardQueryParser();

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestQPHelper.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestQPHelper.java
@@ -308,15 +308,18 @@ public class TestQPHelper extends LuceneTestCase {
         new StandardQueryParser(new MockAnalyzer(random(), MockTokenizer.WHITESPACE, false));
     Query q = qp.parse("foo*bar", "field");
     assertTrue(q instanceof WildcardQuery);
-    assertEquals(MultiTermQuery.CONSTANT_SCORE_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
+    assertEquals(
+        MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
 
     q = qp.parse("foo*", "field");
     assertTrue(q instanceof PrefixQuery);
-    assertEquals(MultiTermQuery.CONSTANT_SCORE_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
+    assertEquals(
+        MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
 
     q = qp.parse("[a TO z]", "field");
     assertTrue(q instanceof TermRangeQuery);
-    assertEquals(MultiTermQuery.CONSTANT_SCORE_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
+    assertEquals(
+        MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE, ((MultiTermQuery) q).getRewriteMethod());
   }
 
   public void testCJK() throws Exception {
@@ -646,7 +649,7 @@ public class TestQPHelper extends LuceneTestCase {
   public void testRange() throws Exception {
     assertQueryEquals("[ a TO z]", null, "[a TO z]");
     assertEquals(
-        MultiTermQuery.CONSTANT_SCORE_REWRITE,
+        MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE,
         ((TermRangeQuery) getQuery("[ a TO z]", null)).getRewriteMethod());
 
     StandardQueryParser qp = new StandardQueryParser();
@@ -1205,7 +1208,6 @@ public class TestQPHelper extends LuceneTestCase {
         MultiTermQuery.SCORING_BOOLEAN_REWRITE,
         ((RegexpQuery) (((BoostQuery) qp.parse("/[A-Z][123]/^0.5", df)).getQuery()))
             .getRewriteMethod());
-    qp.setMultiTermRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
   }
 
   public void testStopwords() throws Exception {

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
@@ -561,7 +561,7 @@ public abstract class QueryParserTestBase extends LuceneTestCase {
     assertQueryEquals("{ a TO z]", null, "{a TO z]");
 
     assertEquals(
-        MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE,
+        MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE,
         ((TermRangeQuery) getQuery("[ a TO z]")).getRewriteMethod());
 
     CommonQueryParserConfiguration qp =

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
@@ -561,7 +561,7 @@ public abstract class QueryParserTestBase extends LuceneTestCase {
     assertQueryEquals("{ a TO z]", null, "{a TO z]");
 
     assertEquals(
-        MultiTermQuery.CONSTANT_SCORE_REWRITE,
+        MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE,
         ((TermRangeQuery) getQuery("[ a TO z]")).getRewriteMethod());
 
     CommonQueryParserConfiguration qp =


### PR DESCRIPTION
Currently multi-term queries with a filter rewrite internally rewrite to a disjunction if 16 terms or less match the query. Otherwise postings lists of matching terms are collected into a `DocIdSetBuilder`. This change replaces the latter with a mixed approach where a disjunction is created between the 16 terms that have the highest document frequency and an iterator produced from the `DocIdSetBuilder` that collects all other terms. On fields that have a zipfian distribution, it's quite likely that no high-frequency terms make it to the `DocIdSetBuilder`. This provides two main benefits:
 - Queries are less likely to allocate a FixedBitSet of size `maxDoc`.
 - Queries are better at skipping or early terminating. On the other hand, queries that need to consume most or all matching documents may get a slowdown.

The slowdown is unfortunate, but my gut feeling is that this change still has more pros than cons.
