### PR TITLE
Update to error-prone 2.17

### DIFF
--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -146,6 +146,7 @@ allprojects { prj ->
             '-Xep:IdentityHashMapBoxing:ERROR',
             // '-Xep:IgnoredPureGetter:OFF', // we don't use these annotations
             // '-Xep:Immutable:OFF', // we don't use this annotation
+            // '-Xep:ImpossibleNullComparison:OFF', // we don't use protobuf
             '-Xep:Incomparable:ERROR',
             // '-Xep:IncompatibleArgumentType:OFF', // we don't use this annotation
             // '-Xep:IncompatibleModifiers:OFF', // we don't use this annotation
@@ -173,6 +174,7 @@ allprojects { prj ->
             '-Xep:JUnitParameterMethodNotFound:ERROR',
             // '-Xep:JavaxInjectOnAbstractMethod:OFF', // we don't this annotation
             // '-Xep:JodaToSelf:OFF', // we don't use joda-time
+            // '-Xep:LenientFormatStringValidation:OFF' // we don't use these google libraries
             // '-Xep:LiteByteStringUtf8:OFF', // we don't use protobuf
             // '-Xep:LocalDateTemporalAmount:OFF', // we don't use LocalDate math
             '-Xep:LockOnBoxedPrimitive:ERROR',
@@ -255,6 +257,7 @@ allprojects { prj ->
 
             // On by Default : WARNING
 
+            // '-Xep:ASTHelpersSuggestions:OFF', // we don't use ASTHelpers
             // '-Xep:AlmostJavadoc:OFF', // noisy (e.g. commented-out code misinterpreted as javadocs)
             // '-Xep:AlreadyChecked:OFF', // TODO: there are problems
             // '-Xep:AmbiguousMethodReference:OFF',
@@ -315,6 +318,7 @@ allprojects { prj ->
             // '-Xep:ExtendingJUnitAssert:OFF', // noisy
             // '-Xep:ExtendsObject:OFF', // TODO: there are problems
             // '-Xep:FallThrough:OFF', // TODO: there are problems
+            // '-Xep:Finalize:OFF', // we use forbidden-apis for this (jdk-deprecated method)
             // '-Xep:Finally:OFF', // TODO: there are problems
             '-Xep:FloatCast:WARN',
             '-Xep:FloatingPointAssertionWithinEpsilon:WARN',
@@ -331,6 +335,7 @@ allprojects { prj ->
             // '-Xep:ImmutableEnumChecker:OFF', // noisy
             // '-Xep:InconsistentCapitalization:OFF', // TODO: there are problems
             // '-Xep:InconsistentHashCode:OFF', // noisy
+            // '-Xep:IgnoredPureGetter:OFF', // we don't use these google libraries
             '-Xep:IncorrectMainMethod:WARN',
             '-Xep:IncrementInForLoopAndHeader:WARN',
             '-Xep:InheritDoc:WARN',
@@ -382,7 +387,7 @@ allprojects { prj ->
             '-Xep:LongFloatConversion:WARN',
             '-Xep:LoopOverCharArray:WARN',
             '-Xep:MalformedInlineTag:WARN',
-            // '-Xep:MathAbsoluteRandom:OFF', // TODO: there are problems
+            // '-Xep:MathAbsoluteNegative:OFF', // TODO: there are problems
             // '-Xep:MemoizeConstantVisitorStateLookups:OFF', // we don't use this class
             // '-Xep:MissingCasesInEnumSwitch:OFF', // redundant with ECJ incompleteEnumSwitch/missingEnumCaseDespiteDefault
             // '-Xep:MissingFail:OFF', // TODO: there are problems
@@ -401,6 +406,7 @@ allprojects { prj ->
             // '-Xep:NarrowingCompoundAssignment:OFF', // noisy
             '-Xep:NegativeCharLiteral:WARN',
             '-Xep:NestedInstanceOfConditions:WARN',
+            // '-Xep:NewFileSystem:OFF', // we don't create new filesystems
             // '-Xep:NonAtomicVolatileUpdate:OFF', // TODO: there are problems
             // '-Xep:NonCanonicalType:OFF', // noisy
             '-Xep:NonOverridingEquals:WARN',
@@ -470,6 +476,7 @@ allprojects { prj ->
             // '-Xep:UnnecessaryMethodInvocationMatcher:OFF', // we don't use spring
             '-Xep:UnnecessaryMethodReference:WARN',
             // '-Xep:UnnecessaryParentheses:OFF', // noisy
+            // '-Xep:UnqualifiedYield:OFF', // javac takes care
             '-Xep:UnrecognisedJavadocTag:WARN',
             // '-Xep:UnsafeFinalization:OFF', // we don't use finalizers, deprecated for removal, fails build
             '-Xep:UnsafeReflectiveConstructionCast:WARN',

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletionBuilder.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletionBuilder.java
@@ -35,7 +35,7 @@ import org.apache.lucene.util.fst.Util;
  *
  * <h2>Implementation details</h2>
  *
- * <p>The construction step in {@link #finalize()} works as follows:
+ * <p>The construction step in {@link #build()} works as follows:
  *
  * <ul>
  *   <li>A set of input terms and their buckets is given.

--- a/versions.props
+++ b/versions.props
@@ -1,7 +1,7 @@
 com.carrotsearch.randomizedtesting:*=2.8.1
 com.carrotsearch:hppc=0.9.1
 com.carrotsearch:procfork=1.0.6
-com.google.errorprone:*=2.15.0
+com.google.errorprone:*=2.17.0
 com.ibm.icu:icu4j=70.1
 commons-codec:commons-codec=1.13
 io.sgr:s2-geometry-library-java=1.0.0


### PR DESCRIPTION
I investigated each of the new checks, nothing really interesting except an incorrect javadoc link (discovered manually) linking to Object.finalize()