### PR TITLE
Fix detection of Hotspot in TestRamUsageEstimator so it works with OpenJ9 that has the bean, but without properties

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -217,6 +217,9 @@ Bug Fixes
 
 * GITHUB#12020: Fixes bug whereby very flat polygons can incorrectly contain intersecting geometries. (Craig Taverner)
 
+* GITHUB#12058: Fix detection of Hotspot in TestRamUsageEstimator so it works with OpenJ9.
+  (Uwe Schindler)
+
 Optimizations
 ---------------------
 * GITHUB#11738: Optimize MultiTermQueryConstantScoreWrapper when a term is present that matches all

--- a/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRamUsageEstimator.java
@@ -18,10 +18,8 @@ package org.apache.lucene.util;
 
 import static org.apache.lucene.tests.util.RamUsageTester.ramUsed;
 import static org.apache.lucene.util.RamUsageEstimator.COMPRESSED_REFS_ENABLED;
-import static org.apache.lucene.util.RamUsageEstimator.HOTSPOT_BEAN_CLASS;
 import static org.apache.lucene.util.RamUsageEstimator.JVM_IS_HOTSPOT_64BIT;
 import static org.apache.lucene.util.RamUsageEstimator.LONG_SIZE;
-import static org.apache.lucene.util.RamUsageEstimator.MANAGEMENT_FACTORY_CLASS;
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_ALIGNMENT;
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
@@ -30,11 +28,14 @@ import static org.apache.lucene.util.RamUsageEstimator.shallowSizeOf;
 import static org.apache.lucene.util.RamUsageEstimator.shallowSizeOfInstance;
 import static org.apache.lucene.util.RamUsageEstimator.sizeOf;
 
+import java.lang.management.CompilationMXBean;
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
@@ -204,18 +205,12 @@ public class TestRamUsageEstimator extends LuceneTestCase {
 
   public void testHotspotBean() {
     assumeTrue("testHotspotBean only works on 64bit JVMs.", Constants.JRE_IS_64BIT);
-    try {
-      Class.forName(MANAGEMENT_FACTORY_CLASS);
-    } catch (ClassNotFoundException e) {
-      assumeNoException("testHotspotBean does not work on Java 8+ compact profile.", e);
-    }
-    try {
-      Class.forName(HOTSPOT_BEAN_CLASS);
-    } catch (ClassNotFoundException e) {
-      assumeNoException(
-          "testHotspotBean only works on Hotspot (OpenJDK, Oracle) virtual machines.", e);
-    }
-
+    assumeTrue(
+        "testHotspotBean only works on Hotspot (OpenJDK, Oracle) virtual machines.",
+        Optional.ofNullable(ManagementFactory.getCompilationMXBean())
+            .map(CompilationMXBean::getName)
+            .orElse("Unknown")
+            .startsWith("HotSpot"));
     assertTrue(
         "We should have been able to detect Hotspot's internal settings from the management bean.",
         JVM_IS_HOTSPOT_64BIT);


### PR DESCRIPTION
This improves the test, which fails with OpenJ9 VMs, due to the following problem:
- OpenJ9 returns the HotspotMXBean, but it is empty and has no properties. So we can't detect compressed pointers. But the test requires it
- The assumption now uses the compilation bean to detect this in tests