### PR TITLE
Don't throw UOE when highlighting FieldExistsQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -240,6 +240,9 @@ Bug Fixes
 * GITHUB#12072: Fix exponential runtime for nested BooleanQuery#rewrite when a
   BooleanClause is non-scoring. (Ben Trent)
 
+* GITHUB#12088: WeightedSpanTermExtractor should not throw UnsupportedOperationException
+  when it encounters a FieldExistsQuery. (Alan Woodward)
+
 Optimizations
 ---------------------
 * GITHUB#11738: Optimize MultiTermQueryConstantScoreWrapper when a term is present that matches all

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
@@ -53,6 +53,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MultiPhraseQuery;
@@ -231,6 +232,8 @@ public class WeightedSpanTermExtractor {
         }
       }
     } else if (query instanceof MatchAllDocsQuery) {
+      // nothing
+    } else if (query instanceof FieldExistsQuery) {
       // nothing
     } else if (query instanceof FunctionScoreQuery) {
       extract(((FunctionScoreQuery) query).getWrappedQuery(), boost, terms);

--- a/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
@@ -63,6 +63,7 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DoubleValuesSource;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MultiPhraseQuery;
@@ -1422,6 +1423,17 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
         3,
         new CannedTokenStream(new Token("aa", 0, 2), new Token("bb", 2, 4)),
         "foo"); // field "foo"
+  }
+
+  public void testFieldExistsQuery() throws IOException {
+    Query q =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("field", "term")), Occur.MUST)
+            .add(new FieldExistsQuery("field"), Occur.MUST)
+            .build();
+
+    WeightedSpanTermExtractor extractor = new WeightedSpanTermExtractor();
+    extractor.getWeightedSpanTerms(q, 1, new CannedTokenStream(new Token("term", 0, 4)), "field");
   }
 
   public void testGetBestSingleFragmentWithWeights() throws Exception {


### PR DESCRIPTION
WeightedSpanTermExtractor will try to rewrite queries that it doesn't
know about, to see if they end up as something it does know about and
that it can extract terms from.  To support field merging, it rewrites against
a delegating leaf reader that does not support `getFieldInfos()`.

FieldExistsQuery uses `getFieldInfos()` in its rewrite, which means that 
if one is passed to WeightedSpanTermExtractor, we get an
UnsupportedOperationException thrown.

This commit makes WeightedSpanTermExtractor aware of FieldExistsQuery,
so that it can just ignore it and avoid throwing an exception.