### PR TITLE
Modify TermInSetQuery to "self optimize" if doc values are available

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -120,8 +120,11 @@ Optimizations
 * GITHUB#11900: BloomFilteringPostingsFormat now uses multiple hash functions
   in order to achieve the same false positive probability with less memory.
   (Jean-François Boeuf)
-  
+
 * GITHUB#12118 Optimize FeatureQuery to TermQuery & weight when scoring is not required (Ben Trent, Robert Muir)
+
+* GITHUB#12089: TermInSetQuery will choose between using postings and doc values (if doc values are indexed) to more
+  optimally execute the query. (Greg Miller)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/DisiWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisiWrapper.java
@@ -57,4 +57,14 @@ public class DisiWrapper {
       matchCost = 0f;
     }
   }
+
+  public DisiWrapper(DocIdSetIterator iterator) {
+    this.scorer = null;
+    this.iterator = iterator;
+    this.approximation = iterator;
+    this.cost = iterator.cost();
+    this.doc = -1;
+    this.twoPhaseView = null;
+    this.matchCost = 0f;
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -21,12 +21,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.SortedSet;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
@@ -36,17 +35,16 @@ import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermState;
+import org.apache.lucene.index.TermStates;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.LongBitSet;
-import org.apache.lucene.util.PriorityQueue;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
@@ -82,13 +80,6 @@ public class TermInSetQuery extends Query implements Accountable {
       RamUsageEstimator.shallowSizeOfInstance(TermInSetQuery.class);
   // Same threshold as MultiTermQueryConstantScoreWrapper
   static final int BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD = 16;
-  // number of terms we'll "pre-seek" to validate; limits heap if there are many terms
-  private static final int PRE_SEEK_TERM_LIMIT = 16;
-  // postings lists under this threshold will always be "pre-processed" into a bitset
-  private static final int POSTINGS_PRE_PROCESS_THRESHOLD = 512;
-  // max number of clauses we'll manage/check during scoring (these remain "unprocessed")
-  private static final int MAX_UNPROCESSED_POSTINGS =
-      Math.min(IndexSearcher.getMaxClauseCount(), 16);
 
   private final String field;
   private final PrefixCodedTerms termData;
@@ -126,16 +117,6 @@ public class TermInSetQuery extends Query implements Accountable {
 
   @Override
   public Query rewrite(IndexSearcher indexSearcher) throws IOException {
-    if (termData.size() == 0) {
-      return new MatchNoDocsQuery();
-    }
-    if (termData.size() == 1) {
-      Term term = new Term(field, termData.iterator().next());
-      return new ConstantScoreQuery(new TermQuery(term));
-    }
-    // TODO: Rewriting means we'll always use a postings-based approach, which can be worse than
-    // a doc values approach if the terms are expensive in aggregate compared to the lead cost.
-    // May be worth not rewriting or using a lower threshold.
     final int threshold =
         Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
     if (termData.size() <= threshold) {
@@ -226,6 +207,48 @@ public class TermInSetQuery extends Query implements Accountable {
     return Collections.emptyList();
   }
 
+  private static class TermAndState {
+    final String field;
+    final TermsEnum termsEnum;
+    final BytesRef term;
+    final TermState state;
+    final int docFreq;
+    final long totalTermFreq;
+
+    TermAndState(String field, TermsEnum termsEnum) throws IOException {
+      this.field = field;
+      this.termsEnum = termsEnum;
+      this.term = BytesRef.deepCopyOf(termsEnum.term());
+      this.state = termsEnum.termState();
+      this.docFreq = termsEnum.docFreq();
+      this.totalTermFreq = termsEnum.totalTermFreq();
+    }
+  }
+
+  private static class WeightOrDocIdSet {
+    final Weight weight;
+    final DocIdSet set;
+    final Scorer scorer;
+
+    WeightOrDocIdSet(Weight weight) {
+      this.weight = Objects.requireNonNull(weight);
+      this.set = null;
+      this.scorer = null;
+    }
+
+    WeightOrDocIdSet(DocIdSet bitset) {
+      this.set = bitset;
+      this.weight = null;
+      this.scorer = null;
+    }
+
+    WeightOrDocIdSet(Scorer scorer) {
+      this.set = null;
+      this.weight = null;
+      this.scorer = scorer;
+    }
+  }
+
   @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
       throws IOException {
@@ -244,69 +267,202 @@ public class TermInSetQuery extends Query implements Accountable {
                     context, doc, getQuery(), field, termData.iterator()));
       }
 
+      /**
+       * On the given leaf context, try to either rewrite to a disjunction if there are few matching
+       * terms, or build a bitset containing matching docs.
+       */
+      private WeightOrDocIdSet rewrite(
+          LeafReaderContext context, long leadCost, boolean isPrimaryKeyField, DocValuesType dvType)
+          throws IOException {
+        final LeafReader reader = context.reader();
+
+        Terms terms = reader.terms(field);
+        if (terms == null) {
+          return null;
+        }
+
+        long costThreshold = Long.MAX_VALUE;
+        if (dvType == DocValuesType.SORTED || dvType == DocValuesType.SORTED_SET) {
+          // Establish a threshold for switching to doc values. Give postings a significant
+          // advantage for the primary-key case, since many of the primary-key terms may not
+          // actually be in this segment. The 8x factor is arbitrary, based on IndexOrDVQuery,
+          // but has performed well in benchmarks:
+          costThreshold = isPrimaryKeyField ? leadCost << 3 : leadCost;
+
+          if (termData.size() > costThreshold) {
+            // If the number of terms is > the number of candidates, DV should perform better.
+            // TODO: This assumes all terms are present in the segment. If the actual number of
+            // found terms in the segment is significantly smaller, this can be the wrong
+            // decision. Maybe we can do better? Possible bloom filter application? This is
+            // why we special-case primary-key cases above.
+            return new WeightOrDocIdSet(docValuesScorer(reader));
+          }
+
+          // For a primary-key field, at this point, it's highly likely that a postings-based
+          // approach is the right solution as docIDs will be pulsed. Go straight to a postings-
+          // solution:
+          if (isPrimaryKeyField) {
+            costThreshold = Long.MAX_VALUE;
+          }
+        }
+
+        final int fieldDocCount = terms.getDocCount();
+        TermsEnum termsEnum = terms.iterator();
+        PostingsEnum docs = null;
+        TermIterator iterator = termData.iterator();
+
+        // We will first try to collect up to 'threshold' terms into 'matchingTerms'
+        // if there are too many terms, we will fall back to building the 'builder'
+        final int threshold =
+            Math.min(BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD, IndexSearcher.getMaxClauseCount());
+        assert termData.size() > threshold : "Query should have been rewritten";
+        List<TermAndState> matchingTerms = new ArrayList<>(threshold);
+        DocIdSetBuilder builder = null;
+
+        long expectedAdvances = 0;
+
+        for (BytesRef term = iterator.next(); term != null; term = iterator.next()) {
+          assert field.equals(iterator.field());
+          if (termsEnum.seekExact(term)) {
+            // If a term contains all docs with a value for the specified field (likely rare),
+            // we can discard the other terms and just use the dense term's postings:
+            int docFreq = termsEnum.docFreq();
+            if (fieldDocCount == docFreq) {
+              TermStates termStates = new TermStates(searcher.getTopReaderContext());
+              termStates.register(
+                  termsEnum.termState(), context.ord, docFreq, termsEnum.totalTermFreq());
+              Query q =
+                  new ConstantScoreQuery(
+                      new TermQuery(new Term(field, termsEnum.term()), termStates));
+              Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
+              return new WeightOrDocIdSet(weight);
+            }
+
+            if (matchingTerms == null) {
+              docs = termsEnum.postings(docs, PostingsEnum.NONE);
+              builder.add(docs);
+            } else if (matchingTerms.size() < threshold) {
+              expectedAdvances += Math.min(docFreq, leadCost);
+              if (expectedAdvances > costThreshold) {
+                return new WeightOrDocIdSet(docValuesScorer(reader));
+              }
+              matchingTerms.add(new TermAndState(field, termsEnum));
+            } else {
+              assert matchingTerms.size() == threshold;
+              builder = new DocIdSetBuilder(reader.maxDoc(), terms);
+              docs = termsEnum.postings(docs, PostingsEnum.NONE);
+              builder.add(docs);
+              for (TermAndState t : matchingTerms) {
+                t.termsEnum.seekExact(t.term, t.state);
+                docs = t.termsEnum.postings(docs, PostingsEnum.NONE);
+                builder.add(docs);
+              }
+              matchingTerms = null;
+            }
+          }
+        }
+
+        if (matchingTerms != null) {
+          assert builder == null;
+          BooleanQuery.Builder bq = new BooleanQuery.Builder();
+          for (TermAndState t : matchingTerms) {
+            final TermStates termStates = new TermStates(searcher.getTopReaderContext());
+            termStates.register(t.state, context.ord, t.docFreq, t.totalTermFreq);
+            bq.add(new TermQuery(new Term(t.field, t.term), termStates), Occur.SHOULD);
+          }
+          Query q = new ConstantScoreQuery(bq.build());
+          final Weight weight = searcher.rewrite(q).createWeight(searcher, scoreMode, score());
+          return new WeightOrDocIdSet(weight);
+        } else {
+          assert builder != null;
+          return new WeightOrDocIdSet(builder.build());
+        }
+      }
+
+      private Scorer scorer(DocIdSet set) throws IOException {
+        if (set == null) {
+          return null;
+        }
+        final DocIdSetIterator disi = set.iterator();
+        if (disi == null) {
+          return null;
+        }
+        return new ConstantScoreScorer(this, score(), scoreMode, disi);
+      }
+
       @Override
       public BulkScorer bulkScorer(LeafReaderContext context) throws IOException {
-        // Implement term-at-a-time scoring for top-level scoring as it is likely more efficient
-        // than doc-at-a-time:
-        final LeafReader reader = context.reader();
-        final Terms t = Terms.getTerms(reader, field);
-        final TermsEnum termsEnum = t.iterator();
-        int fieldDocCount = t.getDocCount();
-        PostingsEnum singleton = null;
-        PostingsEnum reuse = null;
-        DocIdSetBuilder builder = null;
-        TermIterator termIterator = termData.iterator();
-        for (BytesRef term = termIterator.next(); term != null; term = termIterator.next()) {
-          if (termsEnum.seekExact(term) == false) {
-            continue;
-          }
-
-          // If we find a "completely dense" postings list, we can use it directly:
-          int termDocFreq = termsEnum.docFreq();
-          if (fieldDocCount == termDocFreq) {
-            singleton = termsEnum.postings(reuse, PostingsEnum.NONE);
-            break;
-          }
-
-          reuse = termsEnum.postings(reuse, PostingsEnum.NONE);
-          if (builder == null) {
-            builder = new DocIdSetBuilder(reader.maxDoc());
-          }
-          builder.add(reuse);
-        }
-
-        final DocIdSetIterator it;
-        if (singleton != null) {
-          it = singleton;
-        } else if (builder == null) {
-          // No terms found:
+        final WeightOrDocIdSet weightOrBitSet =
+            rewrite(context, Long.MAX_VALUE, false, DocValuesType.NONE);
+        if (weightOrBitSet == null) {
           return null;
+        } else if (weightOrBitSet.scorer != null) {
+          return new DefaultBulkScorer(weightOrBitSet.scorer);
+        } else if (weightOrBitSet.weight != null) {
+          return weightOrBitSet.weight.bulkScorer(context);
         } else {
-          it = builder.build().iterator();
+          final Scorer scorer = scorer(weightOrBitSet.set);
+          if (scorer == null) {
+            return null;
+          }
+          return new DefaultBulkScorer(scorer);
         }
-        final long cost = it.cost();
+      }
 
-        return new BulkScorer() {
+      @Override
+      public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+        LeafReader reader = context.reader();
+        Terms indexTerms = reader.terms(field);
+        if (indexTerms == null) {
+          return null;
+        }
+
+        // Cost estimation reasoning is:
+        //  1. Assume every query term matches at least one document (queryTermsCount).
+        //  2. Determine the total number of docs beyond the first one for each term.
+        //     That count provides a ceiling on the number of extra docs that could match beyond
+        //     that first one. (We omit the first since it's already been counted in #1).
+        // This approach still provides correct worst-case cost in general, but provides tighter
+        // estimates for primary-key-like fields. See: LUCENE-10207
+
+        // TODO: This cost estimation may grossly overestimate since we have no index statistics
+        // for the specific query terms. While it's nice to avoid the cost of intersecting the
+        // query terms with the index, it could be beneficial to do that work and get better
+        // cost estimates.
+        final long cost;
+        final long queryTermsCount = termData.size();
+        final long sumDocFreq = indexTerms.getSumDocFreq();
+        long potentialExtraCost = sumDocFreq;
+        final long indexedTermCount = indexTerms.size();
+        if (indexedTermCount != -1) {
+          potentialExtraCost -= indexedTermCount;
+        }
+        cost = queryTermsCount + potentialExtraCost;
+
+        final boolean isPrimaryKeyField = indexedTermCount != -1 && sumDocFreq == indexedTermCount;
+        final DocValuesType dvType = reader.getFieldInfos().fieldInfo(field).getDocValuesType();
+
+        final Weight weight = this;
+        return new ScorerSupplier() {
           @Override
-          public int score(LeafCollector collector, Bits acceptDocs, int min, int max)
-              throws IOException {
-            final DummyScorable dummy = new DummyScorable(boost);
-            collector.setScorer(dummy);
-
-            int doc = it.docID();
-            if (doc < min) {
-              doc = it.advance(min);
+          public Scorer get(long leadCost) throws IOException {
+            WeightOrDocIdSet weightOrDocIdSet =
+                rewrite(context, leadCost, isPrimaryKeyField, dvType);
+            final Scorer scorer;
+            if (weightOrDocIdSet == null) {
+              scorer = null;
+            } else if (weightOrDocIdSet.scorer != null) {
+              scorer = weightOrDocIdSet.scorer;
+            } else if (weightOrDocIdSet.weight != null) {
+              scorer = weightOrDocIdSet.weight.scorer(context);
+            } else {
+              scorer = scorer(weightOrDocIdSet.set);
             }
 
-            while (doc < max) {
-              if (acceptDocs == null || acceptDocs.get(doc)) {
-                dummy.docID = doc;
-                collector.collect(doc);
-              }
-              doc = it.nextDoc();
-            }
-
-            return doc;
+            return Objects.requireNonNullElseGet(
+                scorer,
+                () ->
+                    new ConstantScoreScorer(weight, score(), scoreMode, DocIdSetIterator.empty()));
           }
 
           @Override
@@ -318,329 +474,11 @@ public class TermInSetQuery extends Query implements Accountable {
 
       @Override
       public Scorer scorer(LeafReaderContext context) throws IOException {
-        ScorerSupplier supplier = scorerSupplier(context);
+        final ScorerSupplier supplier = scorerSupplier(context);
         if (supplier == null) {
           return null;
-        } else {
-          return supplier.get(Long.MAX_VALUE);
         }
-      }
-
-      @Override
-      public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
-        assert termData.size() > BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD;
-
-        final LeafReader reader = context.reader();
-        final FieldInfo fi = reader.getFieldInfos().fieldInfo(field);
-        if (fi == null) {
-          // Field not in segment:
-          return null;
-        }
-        final DocValuesType dvType = fi.getDocValuesType();
-
-        final Terms t = Terms.getTerms(reader, field);
-
-        // Cost estimation reasoning is:
-        //  1. Assume every query term matches at least one document (queryTermsCount).
-        //  2. Determine the total number of docs beyond the first one for each term.
-        //     That count provides a ceiling on the number of extra docs that could match beyond
-        //     that first one. (We omit the first since it's already been counted in #1).
-        // This approach still provides correct worst-case cost in general, but provides tighter
-        // estimates for primary-key-like fields. See: LUCENE-10207
-        final long queryTermsCount = termData.size();
-        final long sumDocFreq = t.getSumDocFreq();
-        final long indexedTermCount = t.size();
-        long potentialExtraCost = sumDocFreq;
-        if (indexedTermCount != -1) {
-          potentialExtraCost -= indexedTermCount;
-        }
-        final long cost = queryTermsCount + potentialExtraCost;
-
-        final boolean isPrimaryKeyField = indexedTermCount != -1 && sumDocFreq == indexedTermCount;
-
-        return new ScorerSupplier() {
-
-          @Override
-          public Scorer get(long leadCost) throws IOException {
-            assert termData.size() > 1;
-
-            // If there are no doc values indexed, we have to use a postings-based approach:
-            if (dvType != DocValuesType.SORTED && dvType != DocValuesType.SORTED_SET) {
-              return postingsScorer(reader, t.getDocCount(), t.iterator(), null);
-            }
-
-            // Establish a threshold for switching to doc values. Give postings a significant
-            // advantage for the primary-key case, since many of the primary-key terms may not
-            // actually be in this segment. The 8x factor is arbitrary, based on IndexOrDVQuery,
-            // but has performed well in benchmarks:
-            long candidateSizeThreshold = isPrimaryKeyField ? leadCost << 3 : leadCost;
-
-            if (termData.size() > candidateSizeThreshold) {
-              // If the number of terms is > the number of candidates, DV should perform better.
-              // TODO: This assumes all terms are present in the segment. If the actual number of
-              // found terms in the segment is significantly smaller, this can be the wrong
-              // decision. Maybe we can do better? Possible bloom filter application? This is
-              // why we special-case primary-key cases above.
-              return docValuesScorer(reader);
-            }
-
-            // For a primary-key field, at this point, it's highly likely that a postings-based
-            // approach is the right solution as docIDs will be pulsed. Go straight to a postings-
-            // solution:
-            if (isPrimaryKeyField) {
-              return postingsScorer(reader, t.getDocCount(), t.iterator(), null);
-            }
-
-            // Begin estimating the postings-approach cost term-by-term, with a limit on the
-            // total number of terms we check. If we reach the limit and a postings-approach
-            // still seems cheaper than a DV approach, we'll use it. The term limit both
-            // ensures we don't do too much wasted term seeking work if we end up using DVs,
-            // and also limits our heap usage since we keep track of term states for all the
-            // terms:
-            long expectedAdvances = 0;
-            int visitedTermCount = 0;
-            int foundTermCount = 0;
-            int fieldDocCount = t.getDocCount();
-            TermsEnum termsEnum = t.iterator();
-            // Note: We can safely cast termData.size() to an int here since all the terms
-            // originally came into the ctor in a Collection:
-            List<TermState> termStates =
-                new ArrayList<>(Math.min(PRE_SEEK_TERM_LIMIT, Math.toIntExact(termData.size())));
-            TermState lastTermState = null;
-            BytesRefBuilder lastTerm = null;
-            TermIterator termIterator = termData.iterator();
-            for (BytesRef term = termIterator.next();
-                term != null && visitedTermCount < PRE_SEEK_TERM_LIMIT;
-                term = termIterator.next(), visitedTermCount++) {
-              if (termsEnum.seekExact(term) == false) {
-                // Keep track that the term wasn't found:
-                termStates.add(null);
-                continue;
-              }
-
-              // If we find a "completely dense" postings list, we can use it directly:
-              int termDocFreq = termsEnum.docFreq();
-              if (fieldDocCount == termDocFreq) {
-                PostingsEnum postings = termsEnum.postings(null, PostingsEnum.NONE);
-                return scorerFor(postings);
-              }
-
-              // As expectedAdvances grows, it becomes more-and-more likely a doc-values approach
-              // will be more cost-effective. Since the cost of a doc-values approach is bound
-              // by candidateSize, we chose to use it if expectedAdvances grows beyond a certain
-              // point:
-              expectedAdvances += Math.min(termDocFreq, leadCost);
-              if (expectedAdvances > candidateSizeThreshold) {
-                return docValuesScorer(reader);
-              }
-
-              foundTermCount++;
-              lastTermState = termsEnum.termState();
-              if (lastTerm == null) {
-                lastTerm = new BytesRefBuilder();
-              }
-              lastTerm.copyBytes(term);
-              termStates.add(lastTermState);
-            }
-
-            if (visitedTermCount == termData.size()) {
-              // If we visited all the terms, we do one more check for some special-cases:
-              if (foundTermCount == 0) {
-                return emptyScorer();
-              } else if (foundTermCount == 1) {
-                termsEnum.seekExact(lastTerm.get(), lastTermState);
-                PostingsEnum postings = termsEnum.postings(null, PostingsEnum.NONE);
-                return scorerFor(postings);
-              }
-            }
-
-            // If we reach this point, it's likely a postings-based approach will prove more
-            // cost-effective:
-            return postingsScorer(
-                context.reader(), fieldDocCount, termsEnum, termStates.iterator());
-          }
-
-          @Override
-          public long cost() {
-            return cost;
-          }
-        };
-      }
-
-      private Scorer emptyScorer() {
-        return new ConstantScoreScorer(this, score(), scoreMode, DocIdSetIterator.empty());
-      }
-
-      private Scorer scorerFor(DocIdSetIterator it) {
-        return new ConstantScoreScorer(this, score(), scoreMode, it);
-      }
-
-      private Scorer scorerFor(TwoPhaseIterator it) {
-        return new ConstantScoreScorer(this, score(), scoreMode, it);
-      }
-
-      private Scorer postingsScorer(
-          LeafReader reader, int fieldDocCount, TermsEnum termsEnum, Iterator<TermState> termStates)
-          throws IOException {
-        List<DisiWrapper> unprocessed = null;
-        PriorityQueue<DisiWrapper> unprocessedPq = null;
-        DocIdSetBuilder processedPostings = null;
-        PostingsEnum reuse = null;
-        TermIterator termIterator = termData.iterator();
-        for (BytesRef term = termIterator.next(); term != null; term = termIterator.next()) {
-          // Use any term states we have:
-          if (termStates != null && termStates.hasNext()) {
-            TermState termState = termStates.next();
-            if (termState == null) {
-              // Term wasn't found in the segment; move on:
-              continue;
-            }
-            termsEnum.seekExact(term, termState);
-          } else {
-            if (termsEnum.seekExact(term) == false) {
-              continue;
-            }
-
-            // If we find a "completely dense" postings list, we can use it directly:
-            if (fieldDocCount == termsEnum.docFreq()) {
-              reuse = termsEnum.postings(reuse, PostingsEnum.NONE);
-              return scorerFor(reuse);
-            }
-          }
-
-          if (termsEnum.docFreq() < POSTINGS_PRE_PROCESS_THRESHOLD) {
-            // For small postings lists, we pre-process them directly into a bitset since they
-            // are unlikely to benefit from skipping:
-            if (processedPostings == null) {
-              processedPostings = new DocIdSetBuilder(reader.maxDoc());
-            }
-            reuse = termsEnum.postings(reuse, PostingsEnum.NONE);
-            processedPostings.add(reuse);
-          } else {
-            DisiWrapper w = new DisiWrapper(termsEnum.postings(null, PostingsEnum.NONE));
-            if (unprocessedPq != null) {
-              // We've hit our unprocessed postings limit, so use our PQ:
-              DisiWrapper evicted = unprocessedPq.insertWithOverflow(w);
-              processedPostings.add(evicted.iterator);
-            } else {
-              if (unprocessed == null) {
-                unprocessed = new ArrayList<>(MAX_UNPROCESSED_POSTINGS);
-              }
-              if (unprocessed.size() < MAX_UNPROCESSED_POSTINGS) {
-                unprocessed.add(w);
-              } else {
-                // Hit our unprocessed postings limit; switch to PQ:
-                unprocessedPq =
-                    new PriorityQueue<>(MAX_UNPROCESSED_POSTINGS) {
-                      @Override
-                      protected boolean lessThan(DisiWrapper a, DisiWrapper b) {
-                        return a.cost < b.cost;
-                      }
-                    };
-                unprocessedPq.addAll(unprocessed);
-                unprocessed = null;
-
-                DisiWrapper evicted = unprocessedPq.insertWithOverflow(w);
-                if (processedPostings == null) {
-                  processedPostings = new DocIdSetBuilder(reader.maxDoc());
-                }
-                processedPostings.add(evicted.iterator);
-              }
-            }
-          }
-        }
-
-        // No terms found:
-        if (processedPostings == null && unprocessed == null) {
-          assert unprocessedPq == null;
-          return emptyScorer();
-        }
-
-        // Single term found and _not_ pre-built into the bitset:
-        if (processedPostings == null && unprocessed.size() == 1) {
-          assert unprocessedPq == null;
-          return scorerFor(unprocessed.get(0).iterator);
-        }
-
-        // All postings built into the bitset:
-        if (processedPostings != null && unprocessed == null && unprocessedPq == null) {
-          return scorerFor(processedPostings.build().iterator());
-        }
-
-        DisiPriorityQueue pq;
-        final long cost;
-        if (unprocessed != null) {
-          assert unprocessedPq == null;
-          if (processedPostings != null) {
-            unprocessed.add(new DisiWrapper(processedPostings.build().iterator()));
-          }
-          pq = new DisiPriorityQueue(unprocessed.size());
-          pq.addAll(unprocessed.toArray(new DisiWrapper[0]), 0, unprocessed.size());
-          cost = unprocessed.stream().mapToLong(w -> w.cost).sum();
-        } else {
-          assert unprocessedPq != null && processedPostings != null;
-          assert unprocessedPq.size() == MAX_UNPROCESSED_POSTINGS;
-          DisiWrapper[] postings = new DisiWrapper[MAX_UNPROCESSED_POSTINGS + 1];
-          int i = 0;
-          long c = 0;
-          for (DisiWrapper w : unprocessedPq) {
-            c += w.cost;
-            postings[i] = w;
-            i++;
-          }
-          DisiWrapper w = new DisiWrapper(processedPostings.build().iterator());
-          cost = c + w.cost;
-          postings[i] = w;
-          pq = new DisiPriorityQueue(postings.length);
-          pq.addAll(postings, 0, postings.length);
-        }
-
-        // This iterator is slightly different from a standard disjunction iterator in that it
-        // short-circuits whenever it finds a target doc (instead of ensuring all sub-iterators
-        // are positioned on the same doc). This can be done since we're not using it to score,
-        // only filter, and there are no second-phase checks:
-        DocIdSetIterator it =
-            new DocIdSetIterator() {
-              private int docID = -1;
-
-              @Override
-              public int docID() {
-                return docID;
-              }
-
-              @Override
-              public int nextDoc() throws IOException {
-                return doNext(docID + 1);
-              }
-
-              @Override
-              public int advance(int target) throws IOException {
-                return doNext(target);
-              }
-
-              private int doNext(int target) throws IOException {
-                DisiWrapper top = pq.top();
-                do {
-                  top.doc = top.approximation.advance(target);
-                  if (top.doc == target) {
-                    pq.updateTop();
-                    docID = target;
-                    return docID;
-                  }
-                  top = pq.updateTop();
-                } while (top.doc < target);
-
-                docID = top.doc;
-                return docID;
-              }
-
-              @Override
-              public long cost() {
-                return cost;
-              }
-            };
-
-        return scorerFor(it);
+        return supplier.get(Long.MAX_VALUE);
       }
 
       private Scorer docValuesScorer(LeafReader reader) throws IOException {
@@ -660,7 +498,7 @@ public class TermInSetQuery extends Query implements Accountable {
         }
 
         if (hasAtLeastOneTerm == false) {
-          return emptyScorer();
+          return new ConstantScoreScorer(this, score(), scoreMode, DocIdSetIterator.empty());
         }
 
         TwoPhaseIterator it;
@@ -698,7 +536,7 @@ public class TermInSetQuery extends Query implements Accountable {
               };
         }
 
-        return scorerFor(it);
+        return new ConstantScoreScorer(this, score(), scoreMode, it);
       }
 
       @Override
@@ -709,24 +547,5 @@ public class TermInSetQuery extends Query implements Accountable {
         return ramBytesUsed() <= RamUsageEstimator.QUERY_DEFAULT_RAM_BYTES_USED;
       }
     };
-  }
-
-  private static final class DummyScorable extends Scorable {
-    private final float score;
-    int docID = -1;
-
-    DummyScorable(float score) {
-      this.score = score;
-    }
-
-    @Override
-    public float score() throws IOException {
-      return score;
-    }
-
-    @Override
-    public int docID() {
-      return docID;
-    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -647,6 +647,8 @@ public class TermInSetQuery extends Query implements Accountable {
         SortedSetDocValues dv = DocValues.getSortedSet(reader, field);
 
         boolean hasAtLeastOneTerm = false;
+        // TODO: Consider LongHashSet instead. Benchmarks hinted that this might increase latency
+        // by as much as 20%, but we should revisit.
         LongBitSet ords = new LongBitSet(dv.getValueCount());
         PrefixCodedTerms.TermIterator termIterator = termData.iterator();
         for (BytesRef term = termIterator.next(); term != null; term = termIterator.next()) {


### PR DESCRIPTION
### Description

This change alters `TermInSetQuery` to "self-optimize" if there is a parallel doc value field present. The idea is to build on the new `KeywordField` being proposed in #12054, which indexes both postings and DV data. It takes a bit of a different approach though as compared to `IndexOrDocValuesQuery` by "internally" deciding whether to use postings vs. doc values (at the segment granularity). The idea is to actually start seeking through some of the terms to get a better postings-based cost estimate, which is something we can't easily expose through the typical `ScoreSupplier#cost()` mechanism since we want to short-circuit with a DV approach if we "accumulate" enough estimated cost.


I've run various task benchmarks using geonames data to convince myself that this approach is generally more performant than trying to use `IndexOrDocValuesQuery` on top of the existing `TermInSetQuery` + `DocValuesTermsQuery`, as well as to show that we shouldn't expect any significant regressions for existing users of `TermInSetQuery`: [TiSBenchResults.md.txt](https://github.com/apache/lucene/files/10608800/TiSBenchResults.md.txt). Benchmarks were run with a modified version of @rmuir's benchmarking tool used in #12087, and is available here: [TiSBench.java.txt](https://github.com/apache/lucene/files/10608804/TiSBench.java.txt).
