### PR TITLE
releaseWizard: allow explicitly setting MANIFEST.MF userid (e.g., to apache id)

### DIFF
--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -119,9 +119,9 @@ def prepare(root, version, mf_username, gpg_key_id, gpg_password, gpg_home=None,
 
   print('  prepare-release')
   cmd = './gradlew --no-daemon assembleRelease' \
-        ' -Dversion.release=%s' % version
+        ' -Pversion.release=%s' % version
   if mf_username is not None:
-    cmd += ' -Dmanifest.username=%s' % mf_username
+    cmd += ' -Pmanifest.username=%s' % mf_username
   if dev_mode:
     cmd += ' -Pvalidation.git.failOnModified=false'
   if gpg_key_id is not None:

--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -91,7 +91,7 @@ def getGitRev():
   return os.popen('git rev-parse HEAD').read().strip()
 
 
-def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=False):
+def prepare(root, version, mf_username, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=False):
   print()
   print('Prepare release...')
   if os.path.exists(LOG):
@@ -120,6 +120,8 @@ def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=
   print('  prepare-release')
   cmd = './gradlew --no-daemon assembleRelease' \
         ' -Dversion.release=%s' % version
+  if mf_username is not None:
+    cmd += ' -Dmanifest.username=%s' % mf_username
   if dev_mode:
     cmd += ' -Pvalidation.git.failOnModified=false'
   if gpg_key_id is not None:
@@ -247,6 +249,8 @@ def parse_config():
                       help='Uses local KEYS file to validate presence of RM\'s gpg key')
   parser.add_argument('--push-local', metavar='PATH',
                       help='Push the release to the local path')
+  parser.add_argument('--mf-username', metavar='ID',
+                      help='Use the specified username in the Implementation-Version for jar MANIFEST.MF files (e.g., Apache ID).')
   parser.add_argument('--sign', metavar='KEYID',
                       help='Sign the release with the given gpg key')
   parser.add_argument('--sign-method-gradle', dest='sign_method_gradle', default=False, action='store_true',
@@ -389,7 +393,7 @@ def main():
     c.key_password = None
 
   if c.prepare:
-    prepare(c.root, c.version, c.key_id, c.key_password, gpg_home=gpg_home, sign_gradle=c.sign_method_gradle)
+    prepare(c.root, c.version, c.mf_username, c.key_id, c.key_password, gpg_home=gpg_home, sign_gradle=c.sign_method_gradle)
   else:
     os.chdir(c.root)
 

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -679,7 +679,7 @@ groups:
         cmd: git pull --ff-only
         tee: true
       - !Command
-        cmd: python3 -u dev-tools/scripts/buildAndPushRelease.py {{ local_keys }}  --logfile {{ logfile }}  --push-local "{{ dist_file_path }}"  --rc-num {{ rc_number }}  --sign {{ gpg_key | default("<gpg_key_id>", True) }}{% if gpg.use_gradle %}  --sign-method-gradle{% endif %}{% if not gpg.prompt_pass %}  --gpg-pass-noprompt{% endif %}
+        cmd: python3 -u dev-tools/scripts/buildAndPushRelease.py {{ local_keys }}  --logfile {{ logfile }}  --push-local "{{ dist_file_path }}"  --rc-num {{ rc_number }} --mf-username {{ gpg.apache_id }} --sign {{ gpg_key | default("<gpg_key_id>", True) }}{% if gpg.use_gradle %}  --sign-method-gradle{% endif %}{% if not gpg.prompt_pass %}  --gpg-pass-noprompt{% endif %}
         comment: "Using {% if gpg.use_gradle %}gradle{% else %}gpg command{% endif %} for signing.{% if gpg.prompt_pass %} Remember to type your GPG pass-phrase at the prompt!{% endif %}"
         logfile: build_rc.log
         tee: true

--- a/gradle/java/jar-manifest.gradle
+++ b/gradle/java/jar-manifest.gradle
@@ -46,7 +46,9 @@ subprojects {
             if (snapshotBuild) {
               return "${project.version} ${gitRev} [snapshot build, details omitted]"
             } else {
-              return "${project.version} ${gitRev} - ${System.properties['user.name']} - ${buildDate} ${buildTime}"
+              def sysProps = System.properties
+              def manifestUsername = sysProps.getOrDefault('manifest.username', sysProps['user.name'])
+              return "${project.version} ${gitRev} - ${manifestUsername} - ${buildDate} ${buildTime}"
             }
           }
 

--- a/gradle/java/jar-manifest.gradle
+++ b/gradle/java/jar-manifest.gradle
@@ -46,8 +46,7 @@ subprojects {
             if (snapshotBuild) {
               return "${project.version} ${gitRev} [snapshot build, details omitted]"
             } else {
-              def sysProps = System.properties
-              def manifestUsername = sysProps.getOrDefault('manifest.username', sysProps['user.name'])
+              def manifestUsername = propertyOrDefault('manifest.username', System.properties['user.name'])
               return "${project.version} ${gitRev} - ${manifestUsername} - ${buildDate} ${buildTime}"
             }
           }


### PR DESCRIPTION
buildAndPushRelease (release script) currently sets the username portion of the `ImplementationVersion` property MANIFEST.MF entry for built jars according the local machine username of the active user. It is straightforward to support explicitly setting this value, allowing for official Apache release artifacts to consistently indicate the apache Id of the release manager.