### PR TITLE
buildAndPushRelease should optionally pause before assembleRelease

### DIFF
--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -91,7 +91,7 @@ def getGitRev():
   return os.popen('git rev-parse HEAD').read().strip()
 
 
-def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=False):
+def prepare(root, version, pause_before_sign, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=False):
   print()
   print('Prepare release...')
   if os.path.exists(LOG):
@@ -116,6 +116,9 @@ def prepare(root, version, gpg_key_id, gpg_password, gpg_home=None, sign_gradle=
     run('./gradlew --no-daemon clean check')
   else:
     print('  skipping precommit check due to dev-mode')
+
+  if pause_before_sign:
+    input("Tests complete! Please press ENTER to proceed to assembleRelease: ")
 
   print('  prepare-release')
   cmd = './gradlew --no-daemon assembleRelease' \
@@ -247,6 +250,8 @@ def parse_config():
                       help='Uses local KEYS file to validate presence of RM\'s gpg key')
   parser.add_argument('--push-local', metavar='PATH',
                       help='Push the release to the local path')
+  parser.add_argument('--pause-before-sign', default=False, action='store_true',
+                      help='Pause for user confirmation before the assembleRelease step (to prevent timeout on gpg pinentry')
   parser.add_argument('--sign', metavar='KEYID',
                       help='Sign the release with the given gpg key')
   parser.add_argument('--sign-method-gradle', dest='sign_method_gradle', default=False, action='store_true',
@@ -389,7 +394,7 @@ def main():
     c.key_password = None
 
   if c.prepare:
-    prepare(c.root, c.version, c.key_id, c.key_password, gpg_home=gpg_home, sign_gradle=c.sign_method_gradle)
+    prepare(c.root, c.version, c.pause_before_sign, c.key_id, c.key_password, gpg_home=gpg_home, sign_gradle=c.sign_method_gradle)
   else:
     os.chdir(c.root)
 


### PR DESCRIPTION
buildAndPushRelease currently proceeds directly from running tests to assembling the release (and signing jars). Since assembleRelease prompts for GPG key PIN, it can easily happen that the RM steps away while tests are running, and returns to find that tests have completed, but the script has failed due to timing out waiting for GPG pinentry in the `assembleRelease` step. To address this issue, this PR adds a (optional, non-default) pause for user confirmation before proceeding to the `assembleRelease` phase. 