### PR TITLE
Fix failure in TestIndexSortSortedNumericDocValuesRangeQuery

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestIndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestIndexSortSortedNumericDocValuesRangeQuery.java
@@ -596,9 +596,11 @@ public class TestIndexSortSortedNumericDocValuesRangeQuery extends LuceneTestCas
         new IndexSortSortedNumericDocValuesRangeQuery(
             "field", lowerValue, upperValue, fallbackQuery);
     Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
+    int count = 0;
     for (LeafReaderContext context : searcher.getLeafContexts()) {
-      assertEquals(2, weight.count(context));
+      count += weight.count(context);
     }
+    assertEquals(2, count);
 
     writer.close();
     reader.close();


### PR DESCRIPTION
Fixes bug in `TestIndexSortSortedNumericDocValuesRangeQuery. testCountBoundary`. 
Addresses #12097 
