### PR TITLE
Update references to deprecated vector classes in comments and javadocs

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswGraphBuilder.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswGraphBuilder.java
@@ -60,7 +60,7 @@ public final class Lucene90HnswGraphBuilder {
   private final RandomAccessVectorValues<float[]> buildVectors;
 
   /**
-   * Reads all the vectors from a VectorValues, builds a graph connecting them by their dense
+   * Reads all the vectors from vector values, builds a graph connecting them by their dense
    * ordinals, using the given hyperparameter settings, and returns the resulting graph.
    *
    * @param vectors the vectors whose relations are represented by the graph - must provide a
@@ -96,8 +96,8 @@ public final class Lucene90HnswGraphBuilder {
   }
 
   /**
-   * Reads all the vectors from two copies of a random access VectorValues. Providing two copies
-   * enables efficient retrieval without extra data copying, while avoiding collision of the
+   * Reads all the vectors from two copies of a {@link RandomAccessVectorValues}. Providing two
+   * copies enables efficient retrieval without extra data copying, while avoiding collision of the
    * returned values.
    *
    * @param vectors the vectors for which to build a nearest neighbors graph. Must be an independet

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswGraphBuilder.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswGraphBuilder.java
@@ -67,7 +67,7 @@ public final class Lucene91HnswGraphBuilder {
   private RandomAccessVectorValues<float[]> buildVectors;
 
   /**
-   * Reads all the vectors from a VectorValues, builds a graph connecting them by their dense
+   * Reads all the vectors from vector values, builds a graph connecting them by their dense
    * ordinals, using the given hyperparameter settings, and returns the resulting graph.
    *
    * @param vectors the vectors whose relations are represented by the graph - must provide a
@@ -112,8 +112,8 @@ public final class Lucene91HnswGraphBuilder {
   }
 
   /**
-   * Reads all the vectors from two copies of a random access VectorValues. Providing two copies
-   * enables efficient retrieval without extra data copying, while avoiding collision of the
+   * Reads all the vectors from two copies of a {@link RandomAccessVectorValues}. Providing two
+   * copies enables efficient retrieval without extra data copying, while avoiding collision of the
    * returned values.
    *
    * @param vectors the vectors for which to build a nearest neighbors graph. Must be an independet

--- a/lucene/core/src/java/org/apache/lucene/codecs/BufferingKnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/BufferingKnnVectorsWriter.java
@@ -105,7 +105,7 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
     }
   }
 
-  /** Sorting VectorValues that iterate over documents in the order of the provided sortMap */
+  /** Sorting FloatVectorValues that iterate over documents in the order of the provided sortMap */
   private static class SortingVectorValues extends FloatVectorValues {
     private final BufferedVectorValues randomAccess;
     private final int[] docIdOffsets;

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -84,7 +84,7 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
       new KnnVectorsFormat("EMPTY") {
         @Override
         public KnnVectorsWriter fieldsWriter(SegmentWriteState state) {
-          throw new UnsupportedOperationException("Attempt to write EMPTY VectorValues");
+          throw new UnsupportedOperationException("Attempt to write EMPTY vector values");
         }
 
         @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -138,7 +138,7 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
     }
   }
 
-  /** View over multiple VectorValues supporting iterator-style access via DocIdMerger. */
+  /** View over multiple vector values supporting iterator-style access via DocIdMerger. */
   protected static final class MergedVectorValues {
     private MergedVectorValues() {}
 

--- a/lucene/core/src/java/org/apache/lucene/document/FieldType.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FieldType.java
@@ -380,7 +380,7 @@ public class FieldType implements IndexableFieldType {
     }
     if (numDimensions > FloatVectorValues.MAX_DIMENSIONS) {
       throw new IllegalArgumentException(
-          "vector numDimensions must be <= VectorValues.MAX_DIMENSIONS (="
+          "vector numDimensions must be <= FloatVectorValues.MAX_DIMENSIONS (="
               + FloatVectorValues.MAX_DIMENSIONS
               + "); got "
               + numDimensions);

--- a/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
@@ -30,9 +30,9 @@ import org.apache.lucene.util.VectorUtil;
  * an array (of type float[]) whose length is the vector dimension. Values can be retrieved using
  * {@link FloatVectorValues}, which is a forward-only docID-based iterator and also offers
  * random-access by dense ordinal (not docId). {@link VectorSimilarityFunction} may be used to
- * compare vectors at query time (for example as part of result ranking). A KnnVectorField may be
- * associated with a search similarity function defining the metric used for nearest-neighbor search
- * among vectors of that field.
+ * compare vectors at query time (for example as part of result ranking). A {@link
+ * KnnFloatVectorField} may be associated with a search similarity function defining the metric used
+ * for nearest-neighbor search among vectors of that field.
  *
  * @lucene.experimental
  */

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -377,7 +377,7 @@ public final class CheckIndex implements Closeable {
       public Throwable error;
     }
 
-    /** Status from testing VectorValues */
+    /** Status from testing vector values */
     public static final class VectorValuesStatus {
 
       VectorValuesStatus() {}
@@ -1015,7 +1015,7 @@ public final class CheckIndex implements Closeable {
         // Test PointValues
         segInfoStat.pointsStatus = testPoints(reader, infoStream, failFast);
 
-        // Test VectorValues
+        // Test FloatVectorValues and ByteVectorValues
         segInfoStat.vectorValuesStatus = testVectors(reader, infoStream, failFast);
 
         // Test Index Sort

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -454,11 +454,11 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
           throw new ExitingReaderException(
               "The request took too long to iterate over vector values. Timeout: "
                   + queryTimeout.toString()
-                  + ", VectorValues="
+                  + ", FloatVectorValues="
                   + in);
         } else if (Thread.interrupted()) {
           throw new ExitingReaderException(
-              "Interrupted while iterating over vector values. VectorValues=" + in);
+              "Interrupted while iterating over vector values. FloatVectorValues=" + in);
         }
       }
     }
@@ -521,11 +521,11 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
           throw new ExitingReaderException(
               "The request took too long to iterate over vector values. Timeout: "
                   + queryTimeout.toString()
-                  + ", VectorValues="
+                  + ", ByteVectorValues="
                   + in);
         } else if (Thread.interrupted()) {
           throw new ExitingReaderException(
-              "Interrupted while iterating over vector values. VectorValues=" + in);
+              "Interrupted while iterating over vector values. ByteVectorValues=" + in);
         }
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -270,7 +270,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
     return hasPointValues;
   }
 
-  /** Returns true if any fields have VectorValues */
+  /** Returns true if any fields have vector values */
   public boolean hasVectorValues() {
     return hasVectorValues;
   }

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -200,17 +200,6 @@ public abstract class LeafReader extends IndexReader {
   public abstract NumericDocValues getNormValues(String field) throws IOException;
 
   /**
-   * Returns {@link VectorValues} for this field, or null if no {@link VectorValues} were indexed.
-   * The returned instance should only be used by a single thread.
-   *
-   * @deprecated use {@link #getFloatVectorValues(String)} instead
-   */
-  @Deprecated
-  public VectorValues getVectorValues(String field) throws IOException {
-    return new FilterVectorValues(getFloatVectorValues(field)) {};
-  }
-
-  /**
    * Returns {@link FloatVectorValues} for this field, or null if no {@link FloatVectorValues} were
    * indexed. The returned instance should only be used by a single thread.
    *

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -212,7 +212,7 @@ public final class SortingCodecReader extends FilterCodecReader {
     }
   }
 
-  /** Sorting VectorValues that iterate over documents in the order of the provided sortMap */
+  /** Sorting FloatVectorValues that iterate over documents in the order of the provided sortMap */
   private static class SortingFloatVectorValues extends FloatVectorValues {
     final int size;
     final int dimension;

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -239,7 +239,7 @@ abstract class AbstractKnnVectorQuery extends Query {
   }
 
   /**
-   * @return the KnnVectorField where the KnnVector search happens.
+   * @return the knn vector field where the knn vector search happens.
    */
   public String getField() {
     return field;

--- a/lucene/core/src/java/org/apache/lucene/search/KnnVectorFieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnVectorFieldExistsQuery.java
@@ -18,8 +18,7 @@
 package org.apache.lucene.search;
 
 /**
- * A {@link Query} that matches documents that contain a {@link
- * org.apache.lucene.document.KnnVectorField}.
+ * A {@link Query} that matches documents that contain a vector field.
  *
  * @deprecated Use {@link org.apache.lucene.search.FieldExistsQuery} instead.
  */

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -76,7 +76,7 @@ public final class HnswGraphBuilder<T> {
   }
 
   /**
-   * Reads all the vectors from a VectorValues, builds a graph connecting them by their dense
+   * Reads all the vectors from vector values, builds a graph connecting them by their dense
    * ordinals, using the given hyperparameter settings, and returns the resulting graph.
    *
    * @param vectors the vectors whose relations are represented by the graph - must provide a
@@ -123,8 +123,8 @@ public final class HnswGraphBuilder<T> {
   }
 
   /**
-   * Reads all the vectors from two copies of a random access VectorValues. Providing two copies
-   * enables efficient retrieval without extra data copying, while avoiding collision of the
+   * Reads all the vectors from two copies of a {@link RandomAccessVectorValues}. Providing two
+   * copies enables efficient retrieval without extra data copying, while avoiding collision of the
    * returned values.
    *
    * @param vectorsToAdd the vectors for which to build a nearest neighbors graph. Must be an

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -342,7 +342,7 @@ public class TestKnnGraph extends LuceneTestCase {
          * approximate KNN search algorithm
          */
         assertGraphSearch(new int[] {0, 15, 3, 18, 5}, new float[] {0f, 0.1f}, dr);
-        // Tiebreaking by docid must be done after VectorValues.search.
+        // Tiebreaking by docid must be done after search.
         // assertGraphSearch(new int[]{11, 1, 8, 14, 21}, new float[]{2, 2}, dr);
         assertGraphSearch(new int[] {15, 18, 0, 3, 5}, new float[] {0.3f, 0.8f}, dr);
       }

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -48,7 +48,7 @@ import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 
-/** Test cases for KnnVectorQuery objects. */
+/** Test cases for AbstractKnnVectorQuery objects. */
 abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
 
   abstract AbstractKnnVectorQuery getKnnVectorQuery(

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
@@ -56,9 +56,8 @@ class MockVectorValues extends AbstractMockVectorValues<float[]> {
       return values[pos];
     } else {
       // Sometimes use the same scratch array repeatedly, mimicing what the codec will do.
-      // This should help us catch cases of aliasing where the same VectorValues source is used
-      // twice in a
-      // single computation.
+      // This should help us catch cases of aliasing where the same vector values source is used
+      // twice in a single computation.
       System.arraycopy(values[pos], 0, scratch, 0, dimension);
       return scratch;
     }


### PR DESCRIPTION
Follow-up of https://github.com/apache/lucene/pull/12105 to update references to the deprecated classes in comments and javadocs