### PR TITLE
MemoryIndex should not fail integer fields that enable doc values.

### DIFF
--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -596,7 +596,7 @@ public class MemoryIndex {
                   + fieldName
                   + "]");
         }
-        info.numericProducer.dvLongValues = new long[] {(long) docValuesValue};
+        info.numericProducer.dvLongValues = new long[] {((Number) docValuesValue).longValue()};
         info.numericProducer.count++;
         break;
       case SORTED_NUMERIC:
@@ -605,7 +605,8 @@ public class MemoryIndex {
         }
         info.numericProducer.dvLongValues =
             ArrayUtil.grow(info.numericProducer.dvLongValues, info.numericProducer.count + 1);
-        info.numericProducer.dvLongValues[info.numericProducer.count++] = (long) docValuesValue;
+        info.numericProducer.dvLongValues[info.numericProducer.count++] =
+            ((Number) docValuesValue).longValue();
         break;
       case BINARY:
       case SORTED:

--- a/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
+++ b/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
@@ -39,6 +39,7 @@ import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -813,11 +814,13 @@ public class TestMemoryIndex extends LuceneTestCase {
     Field multiField =
         new Field("multi_field", multiFt) {
           {
-            fieldsData = 35;
+            fieldsData = 42;
           }
         };
 
-    MemoryIndex index = MemoryIndex.fromDocument(Arrays.asList(field, multiField), null);
+    Field intField = new IntField("int_field", 50);
+
+    MemoryIndex index = MemoryIndex.fromDocument(Arrays.asList(field, multiField, intField), null);
     IndexSearcher searcher = index.createSearcher();
 
     NumericDocValues ndv =
@@ -829,6 +832,12 @@ public class TestMemoryIndex extends LuceneTestCase {
         searcher.getIndexReader().leaves().get(0).reader().getSortedNumericDocValues("multi_field");
     assertTrue(sndv.advanceExact(0));
     assertEquals(1, sndv.docValueCount());
-    assertEquals(35, sndv.nextValue());
+    assertEquals(42, sndv.nextValue());
+
+    sndv =
+        searcher.getIndexReader().leaves().get(0).reader().getSortedNumericDocValues("int_field");
+    assertTrue(sndv.advanceExact(0));
+    assertEquals(1, sndv.docValueCount());
+    assertEquals(50, sndv.nextValue());
   }
 }


### PR DESCRIPTION
When a field indexes numeric doc values, `MemoryIndex` does an unchecked cast to `java.lang.Long`. However, the new `IntField` represents the value as a `java.lang.Integer` so this cast fails. This commit aligns `MemoryIndex` with `IndexingChain` by casting to `Number` and calling `Number#longValue` instead of casting to `Long`.