### PR TITLE
SimpleText codec to support writing byte vectors (#12111)

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
@@ -405,7 +405,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
         case FLOAT32:
           docsWithField =
               writeVectorData(
-                  tempVectorData, MergedVectorValues.mergeVectorValues(fieldInfo, mergeState));
+                  tempVectorData, MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState));
           break;
         default:
           throw new IllegalArgumentException(
@@ -680,7 +680,6 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
       }
     }
 
-    @SuppressWarnings("unchecked")
     FieldWriter(FieldInfo fieldInfo, int M, int beamWidth, InfoStream infoStream)
         throws IOException {
       this.fieldInfo = fieldInfo;

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsWriter.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.lucene.codecs.BufferingKnnVectorsWriter;
-import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
@@ -73,23 +73,46 @@ public class SimpleTextKnnVectorsWriter extends BufferingKnnVectorsWriter {
   }
 
   @Override
-  public void writeField(FieldInfo fieldInfo, KnnVectorsReader knnVectorsReader, int maxDoc)
+  public void writeField(FieldInfo fieldInfo, FloatVectorValues floatVectorValues, int maxDoc)
       throws IOException {
-    FloatVectorValues vectors = knnVectorsReader.getFloatVectorValues(fieldInfo.name);
     long vectorDataOffset = vectorData.getFilePointer();
     List<Integer> docIds = new ArrayList<>();
-    int docV;
-    for (docV = vectors.nextDoc(); docV != NO_MORE_DOCS; docV = vectors.nextDoc()) {
-      writeVectorValue(vectors);
+    for (int docV = floatVectorValues.nextDoc();
+        docV != NO_MORE_DOCS;
+        docV = floatVectorValues.nextDoc()) {
+      writeFloatVectorValue(floatVectorValues);
       docIds.add(docV);
     }
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
     writeMeta(fieldInfo, vectorDataOffset, vectorDataLength, docIds);
   }
 
-  private void writeVectorValue(FloatVectorValues vectors) throws IOException {
+  private void writeFloatVectorValue(FloatVectorValues vectors) throws IOException {
     // write vector value
     float[] value = vectors.vectorValue();
+    assert value.length == vectors.dimension();
+    write(vectorData, Arrays.toString(value));
+    newline(vectorData);
+  }
+
+  @Override
+  public void writeField(FieldInfo fieldInfo, ByteVectorValues byteVectorValues, int maxDoc)
+      throws IOException {
+    long vectorDataOffset = vectorData.getFilePointer();
+    List<Integer> docIds = new ArrayList<>();
+    for (int docV = byteVectorValues.nextDoc();
+        docV != NO_MORE_DOCS;
+        docV = byteVectorValues.nextDoc()) {
+      writeByteVectorValue(byteVectorValues);
+      docIds.add(docV);
+    }
+    long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+    writeMeta(fieldInfo, vectorDataOffset, vectorDataLength, docIds);
+  }
+
+  private void writeByteVectorValue(ByteVectorValues vectors) throws IOException {
+    // write vector value
+    byte[] value = vectors.vectorValue();
     assert value.length == vectors.dimension();
     write(vectorData, Arrays.toString(value));
     newline(vectorData);

--- a/lucene/core/src/java/org/apache/lucene/codecs/BufferingKnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/BufferingKnnVectorsWriter.java
@@ -27,9 +27,7 @@ import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.Sorter;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.RamUsageEstimator;
 
 /**
@@ -39,79 +37,81 @@ import org.apache.lucene.util.RamUsageEstimator;
  * @lucene.experimental
  */
 public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
-  private final List<FieldWriter> fields = new ArrayList<>();
+  private final List<FieldWriter<?>> fields = new ArrayList<>();
 
   /** Sole constructor */
   protected BufferingKnnVectorsWriter() {}
 
   @Override
-  public KnnFieldVectorsWriter<float[]> addField(FieldInfo fieldInfo) throws IOException {
-    FieldWriter newField = new FieldWriter(fieldInfo);
+  public KnnFieldVectorsWriter<?> addField(FieldInfo fieldInfo) throws IOException {
+    FieldWriter<?> newField;
+    switch (fieldInfo.getVectorEncoding()) {
+      case FLOAT32:
+        newField =
+            new FieldWriter<float[]>(fieldInfo) {
+              @Override
+              public float[] copyValue(float[] vectorValue) {
+                return ArrayUtil.copyOfSubArray(vectorValue, 0, fieldInfo.getVectorDimension());
+              }
+            };
+        break;
+      case BYTE:
+        newField =
+            new FieldWriter<byte[]>(fieldInfo) {
+              @Override
+              public byte[] copyValue(byte[] vectorValue) {
+                return ArrayUtil.copyOfSubArray(vectorValue, 0, fieldInfo.getVectorDimension());
+              }
+            };
+        break;
+      default:
+        throw new UnsupportedOperationException();
+    }
     fields.add(newField);
     return newField;
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public void flush(int maxDoc, Sorter.DocMap sortMap) throws IOException {
-    for (FieldWriter fieldData : fields) {
-      KnnVectorsReader knnVectorsReader =
-          new KnnVectorsReader() {
-            @Override
-            public long ramBytesUsed() {
-              return 0;
-            }
-
-            @Override
-            public void close() {
-              throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void checkIntegrity() {
-              throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public FloatVectorValues getFloatVectorValues(String field) throws IOException {
-              BufferedVectorValues vectorValues =
-                  new BufferedVectorValues(
-                      fieldData.docsWithField,
-                      fieldData.vectors,
-                      fieldData.fieldInfo.getVectorDimension());
-              return sortMap != null
-                  ? new SortingVectorValues(vectorValues, sortMap)
-                  : vectorValues;
-            }
-
-            @Override
-            public ByteVectorValues getByteVectorValues(String field) throws IOException {
-              throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public TopDocs search(
-                String field, float[] target, int k, Bits acceptDocs, int visitedLimit) {
-              throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public TopDocs search(
-                String field, byte[] target, int k, Bits acceptDocs, int visitedLimit) {
-              throw new UnsupportedOperationException();
-            }
-          };
-
-      writeField(fieldData.fieldInfo, knnVectorsReader, maxDoc);
+    for (FieldWriter<?> fieldData : fields) {
+      switch (fieldData.fieldInfo.getVectorEncoding()) {
+        case FLOAT32:
+          BufferedFloatVectorValues bufferedFloatVectorValues =
+              new BufferedFloatVectorValues(
+                  fieldData.docsWithField,
+                  (List<float[]>) fieldData.vectors,
+                  fieldData.fieldInfo.getVectorDimension());
+          FloatVectorValues floatVectorValues =
+              sortMap != null
+                  ? new SortingFloatVectorValues(bufferedFloatVectorValues, sortMap)
+                  : bufferedFloatVectorValues;
+          writeField(fieldData.fieldInfo, floatVectorValues, maxDoc);
+          break;
+        case BYTE:
+          BufferedByteVectorValues bufferedByteVectorValues =
+              new BufferedByteVectorValues(
+                  fieldData.docsWithField,
+                  (List<byte[]>) fieldData.vectors,
+                  fieldData.fieldInfo.getVectorDimension());
+          ByteVectorValues byteVectorValues =
+              sortMap != null
+                  ? new SortingByteVectorValues(bufferedByteVectorValues, sortMap)
+                  : bufferedByteVectorValues;
+          writeField(fieldData.fieldInfo, byteVectorValues, maxDoc);
+          break;
+      }
     }
   }
 
   /** Sorting FloatVectorValues that iterate over documents in the order of the provided sortMap */
-  private static class SortingVectorValues extends FloatVectorValues {
-    private final BufferedVectorValues randomAccess;
+  private static class SortingFloatVectorValues extends FloatVectorValues {
+    private final BufferedFloatVectorValues randomAccess;
     private final int[] docIdOffsets;
     private int docId = -1;
 
-    SortingVectorValues(BufferedVectorValues delegate, Sorter.DocMap sortMap) throws IOException {
+    SortingFloatVectorValues(BufferedFloatVectorValues delegate, Sorter.DocMap sortMap)
+        throws IOException {
       this.randomAccess = delegate.copy();
       this.docIdOffsets = new int[sortMap.size()];
 
@@ -161,10 +161,67 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
     }
   }
 
+  /** Sorting FloatVectorValues that iterate over documents in the order of the provided sortMap */
+  private static class SortingByteVectorValues extends ByteVectorValues {
+    private final BufferedByteVectorValues randomAccess;
+    private final int[] docIdOffsets;
+    private int docId = -1;
+
+    SortingByteVectorValues(BufferedByteVectorValues delegate, Sorter.DocMap sortMap)
+        throws IOException {
+      this.randomAccess = delegate.copy();
+      this.docIdOffsets = new int[sortMap.size()];
+
+      int offset = 1; // 0 means no vector for this (field, document)
+      int docID;
+      while ((docID = delegate.nextDoc()) != NO_MORE_DOCS) {
+        int newDocID = sortMap.oldToNew(docID);
+        docIdOffsets[newDocID] = offset++;
+      }
+    }
+
+    @Override
+    public int docID() {
+      return docId;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      while (docId < docIdOffsets.length - 1) {
+        ++docId;
+        if (docIdOffsets[docId] != 0) {
+          return docId;
+        }
+      }
+      docId = NO_MORE_DOCS;
+      return docId;
+    }
+
+    @Override
+    public byte[] vectorValue() throws IOException {
+      return randomAccess.vectorValue(docIdOffsets[docId] - 1);
+    }
+
+    @Override
+    public int dimension() {
+      return randomAccess.dimension();
+    }
+
+    @Override
+    public int size() {
+      return randomAccess.size();
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+  }
+
   @Override
   public long ramBytesUsed() {
     long total = 0;
-    for (FieldWriter field : fields) {
+    for (FieldWriter<?> field : fields) {
       total += field.ramBytesUsed();
     }
     return total;
@@ -172,58 +229,37 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
 
   @Override
   public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
-    KnnVectorsReader knnVectorsReader =
-        new KnnVectorsReader() {
-
-          @Override
-          public long ramBytesUsed() {
-            return 0;
-          }
-
-          @Override
-          public void close() {}
-
-          @Override
-          public TopDocs search(
-              String field, float[] target, int k, Bits acceptDocs, int visitedLimit) {
-            throw new UnsupportedOperationException();
-          }
-
-          @Override
-          public TopDocs search(
-              String field, byte[] target, int k, Bits acceptDocs, int visitedLimit) {
-            throw new UnsupportedOperationException();
-          }
-
-          @Override
-          public FloatVectorValues getFloatVectorValues(String field) throws IOException {
-            return MergedVectorValues.mergeVectorValues(fieldInfo, mergeState);
-          }
-
-          @Override
-          public ByteVectorValues getByteVectorValues(String field) {
-            throw new UnsupportedOperationException();
-          }
-
-          @Override
-          public void checkIntegrity() {}
-        };
-    writeField(fieldInfo, knnVectorsReader, mergeState.segmentInfo.maxDoc());
+    switch (fieldInfo.getVectorEncoding()) {
+      case FLOAT32:
+        FloatVectorValues floatVectorValues =
+            MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
+        writeField(fieldInfo, floatVectorValues, mergeState.segmentInfo.maxDoc());
+        break;
+      case BYTE:
+        ByteVectorValues byteVectorValues =
+            MergedVectorValues.mergeByteVectorValues(fieldInfo, mergeState);
+        writeField(fieldInfo, byteVectorValues, mergeState.segmentInfo.maxDoc());
+        break;
+    }
   }
 
-  /** Write the provided field */
+  /** Write the provided float vector field */
   protected abstract void writeField(
-      FieldInfo fieldInfo, KnnVectorsReader knnVectorsReader, int maxDoc) throws IOException;
+      FieldInfo fieldInfo, FloatVectorValues floatVectorValues, int maxDoc) throws IOException;
 
-  private static class FieldWriter extends KnnFieldVectorsWriter<float[]> {
+  /** Write the provided byte vector field */
+  protected abstract void writeField(
+      FieldInfo fieldInfo, ByteVectorValues byteVectorValues, int maxDoc) throws IOException;
+
+  private abstract static class FieldWriter<T> extends KnnFieldVectorsWriter<T> {
     private final FieldInfo fieldInfo;
     private final int dim;
     private final DocsWithFieldSet docsWithField;
-    private final List<float[]> vectors;
+    private final List<T> vectors;
 
     private int lastDocID = -1;
 
-    public FieldWriter(FieldInfo fieldInfo) {
+    FieldWriter(FieldInfo fieldInfo) {
       this.fieldInfo = fieldInfo;
       this.dim = fieldInfo.getVectorDimension();
       this.docsWithField = new DocsWithFieldSet();
@@ -231,7 +267,7 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
     }
 
     @Override
-    public void addValue(int docID, float[] value) {
+    public final void addValue(int docID, T value) {
       if (docID == lastDocID) {
         throw new IllegalArgumentException(
             "VectorValuesField \""
@@ -245,12 +281,10 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
     }
 
     @Override
-    public float[] copyValue(float[] vectorValue) {
-      return ArrayUtil.copyOfSubArray(vectorValue, 0, dim);
-    }
+    public abstract T copyValue(T vectorValue);
 
     @Override
-    public long ramBytesUsed() {
+    public final long ramBytesUsed() {
       if (vectors.size() == 0) return 0;
       return docsWithField.ramBytesUsed()
           + vectors.size()
@@ -261,8 +295,7 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
     }
   }
 
-  private static class BufferedVectorValues extends FloatVectorValues {
-
+  private static class BufferedFloatVectorValues extends FloatVectorValues {
     final DocsWithFieldSet docsWithField;
 
     // These are always the vectors of a VectorValuesWriter, which are copied when added to it
@@ -272,15 +305,16 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
     DocIdSetIterator docsWithFieldIter;
     int ord = -1;
 
-    BufferedVectorValues(DocsWithFieldSet docsWithField, List<float[]> vectors, int dimension) {
+    BufferedFloatVectorValues(
+        DocsWithFieldSet docsWithField, List<float[]> vectors, int dimension) {
       this.docsWithField = docsWithField;
       this.vectors = vectors;
       this.dimension = dimension;
       docsWithFieldIter = docsWithField.iterator();
     }
 
-    public BufferedVectorValues copy() {
-      return new BufferedVectorValues(docsWithField, vectors, dimension);
+    public BufferedFloatVectorValues copy() {
+      return new BufferedFloatVectorValues(docsWithField, vectors, dimension);
     }
 
     @Override
@@ -298,7 +332,67 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
       return vectors.get(ord);
     }
 
-    public float[] vectorValue(int targetOrd) {
+    float[] vectorValue(int targetOrd) {
+      return vectors.get(targetOrd);
+    }
+
+    @Override
+    public int docID() {
+      return docsWithFieldIter.docID();
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      int docID = docsWithFieldIter.nextDoc();
+      if (docID != NO_MORE_DOCS) {
+        ++ord;
+      }
+      return docID;
+    }
+
+    @Override
+    public int advance(int target) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class BufferedByteVectorValues extends ByteVectorValues {
+    final DocsWithFieldSet docsWithField;
+
+    // These are always the vectors of a VectorValuesWriter, which are copied when added to it
+    final List<byte[]> vectors;
+    final int dimension;
+
+    DocIdSetIterator docsWithFieldIter;
+    int ord = -1;
+
+    BufferedByteVectorValues(DocsWithFieldSet docsWithField, List<byte[]> vectors, int dimension) {
+      this.docsWithField = docsWithField;
+      this.vectors = vectors;
+      this.dimension = dimension;
+      docsWithFieldIter = docsWithField.iterator();
+    }
+
+    public BufferedByteVectorValues copy() {
+      return new BufferedByteVectorValues(docsWithField, vectors, dimension);
+    }
+
+    @Override
+    public int dimension() {
+      return dimension;
+    }
+
+    @Override
+    public int size() {
+      return vectors.size();
+    }
+
+    @Override
+    public byte[] vectorValue() {
+      return vectors.get(ord);
+    }
+
+    byte[] vectorValue(int targetOrd) {
       return vectors.get(targetOrd);
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -62,7 +62,7 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
         KnnFieldVectorsWriter<float[]> floatWriter =
             (KnnFieldVectorsWriter<float[]>) addField(fieldInfo);
         FloatVectorValues mergedFloats =
-            MergedVectorValues.mergeVectorValues(fieldInfo, mergeState);
+            MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
         for (int doc = mergedFloats.nextDoc();
             doc != DocIdSetIterator.NO_MORE_DOCS;
             doc = mergedFloats.nextDoc()) {
@@ -143,8 +143,8 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
     private MergedVectorValues() {}
 
     /** Returns a merged view over all the segment's {@link FloatVectorValues}. */
-    public static FloatVectorValues mergeVectorValues(FieldInfo fieldInfo, MergeState mergeState)
-        throws IOException {
+    public static FloatVectorValues mergeFloatVectorValues(
+        FieldInfo fieldInfo, MergeState mergeState) throws IOException {
       assert fieldInfo != null && fieldInfo.hasVectorValues();
       if (fieldInfo.getVectorEncoding() != VectorEncoding.FLOAT32) {
         throw new UnsupportedOperationException(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -419,13 +419,12 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
         case FLOAT32:
           docsWithField =
               writeVectorData(
-                  tempVectorData, MergedVectorValues.mergeVectorValues(fieldInfo, mergeState));
+                  tempVectorData, MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState));
           break;
         default:
           throw new IllegalArgumentException(
               "unknown vector encoding=" + fieldInfo.getVectorEncoding());
       }
-      ;
       CodecUtil.writeFooter(tempVectorData);
       IOUtils.close(tempVectorData);
 


### PR DESCRIPTION
A recent test failure signaled that when the simple text codec was randomly selected, byte vectors could not be written. This commit addressed that by adding support for writing byte vectors to SimpleTextKnnVectorsWriter.

Note that while support is added to the BufferingKnnVectorsWriter base class, 90, 91 and 92 writers don't need to support byte vectors and will throw unsupported operation exception when attempting to do that.