### PR TITLE
Remove LogMergePolicy's boundary at the floor level.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/LogMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LogMergePolicy.java
@@ -554,11 +554,6 @@ public abstract class LogMergePolicy extends MergePolicy {
         // With a merge factor of 10, this means that the biggest segment and the smallest segment
         // that take part of a merge have a size difference of at most 5.6x.
         levelBottom = (float) (maxLevel - LEVEL_LOG_SPAN);
-
-        // Force a boundary at the level floor
-        if (levelBottom < levelFloor && maxLevel >= levelFloor) {
-          levelBottom = levelFloor;
-        }
       } else {
         // For segments below the floor size, we allow more unbalanced merges, but still somewhat
         // balanced to avoid running into O(n^2) merging.


### PR DESCRIPTION
`LogMergePolicy` has this boundary at the floor level that prevents merging segments above the minimum segment size with segments below this size. I cannot see a benefit from doing this, and no tests fail if I remove it, while this boundary has the downside of not running merges that seem legit to me. Should we remove this boundary check?
