### PR TITLE
Remove VectorUtil#toBytesRef

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -270,23 +270,4 @@ public final class VectorUtil {
     float denom = (float) (a.length * (1 << 15));
     return 0.5f + dotProduct(a, b) / denom;
   }
-
-  /**
-   * Convert a floating point vector to an array of bytes using casting; the vector values should be
-   * in [-128,127]
-   *
-   * @param vector a vector
-   * @return a new BytesRef containing the vector's values cast to byte.
-   */
-  public static BytesRef toBytesRef(float[] vector) {
-    BytesRef b = new BytesRef(new byte[vector.length]);
-    for (int i = 0; i < vector.length; i++) {
-      if (vector[i] < -128 || vector[i] > 127) {
-        throw new IllegalArgumentException(
-            "Vector value at " + i + " is out of range [-128.127]: " + vector[i]);
-      }
-      b.bytes[i] = (byte) vector[i];
-    }
-    return b;
-  }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -262,16 +262,4 @@ public class TestVectorUtil extends LuceneTestCase {
     u[1] = -v[0];
     assertEquals(0, VectorUtil.cosine(u, v), DELTA);
   }
-
-  public void testToBytesRef() {
-    assertEquals(
-        new BytesRef(new byte[] {-128, 0, 127}),
-        VectorUtil.toBytesRef(new float[] {-128f, 0, 127f}));
-    assertEquals(
-        new BytesRef(new byte[] {-19, 0, 33}),
-        VectorUtil.toBytesRef(new float[] {-19.9f, 0.5f, 33.7f}));
-    expectThrows(
-        IllegalArgumentException.class, () -> VectorUtil.toBytesRef(new float[] {-128.1f}));
-    expectThrows(IllegalArgumentException.class, () -> VectorUtil.toBytesRef(new float[] {127.1f}));
-  }
 }


### PR DESCRIPTION
The method is currently only used in its corresponding test method.
