### PR TITLE
Adjust return type for VectorUtil methods

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
@@ -37,7 +37,7 @@ public enum VectorSimilarityFunction {
 
     @Override
     public float compare(byte[] v1, byte[] v2) {
-      return 1 / (float)(1 + squareDistance(v1, v2));
+      return 1 / (1f + squareDistance(v1, v2));
     }
   },
 

--- a/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
@@ -37,7 +37,7 @@ public enum VectorSimilarityFunction {
 
     @Override
     public float compare(byte[] v1, byte[] v2) {
-      return 1 / (1 + squareDistance(v1, v2));
+      return 1 / (float)(1 + squareDistance(v1, v2));
     }
   },
 

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -181,7 +181,7 @@ public final class VectorUtil {
   }
 
   /** Returns the sum of squared differences of the two vectors. */
-  public static float squareDistance(byte[] a, byte[] b) {
+  public static int squareDistance(byte[] a, byte[] b) {
     // Note: this will not overflow if dim < 2^18, since max(byte * byte) = 2^14.
     int squareSum = 0;
     for (int i = 0; i < a.length; i++) {
@@ -249,7 +249,7 @@ public final class VectorUtil {
    * @param b bytes containing another vector, of the same dimension
    * @return the value of the dot product of the two vectors
    */
-  public static float dotProduct(byte[] a, byte[] b) {
+  public static int dotProduct(byte[] a, byte[] b) {
     assert a.length == b.length;
     int total = 0;
     for (int i = 0; i < a.length; i++) {


### PR DESCRIPTION
Two of the methods (squareDistance and dotProduct) that take byte arrays return a float while the variable used to store the value is an int. They can just return an int.