### PR TITLE
Always generate a XYPolygon with no self intersections in test

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/document/BaseXYShapeTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/document/BaseXYShapeTestCase.java
@@ -226,7 +226,7 @@ public abstract class BaseXYShapeTestCase extends BaseSpatialTestCase {
         while (true) {
           XYPolygon p = ShapeTestUtil.nextPolygon();
           try {
-            Tessellator.tessellate(p, random().nextBoolean());
+            Tessellator.tessellate(p, true);
             return p;
           } catch (
               @SuppressWarnings("unused")


### PR DESCRIPTION
### Description

https://github.com/apache/lucene/issues/11829

`BaseXYShapeTestCase.ShapeType.POLYGON.nextShape()` can return polygons that can fail the self intersection check, which then cause failed test like `TestShapeDocValues.testXYPolygonCentroid`.
