### PR TITLE
Remove useless abstractions in DocValues-based queries

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/NumericDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/NumericDocValuesField.java
@@ -16,12 +16,7 @@
  */
 package org.apache.lucene.document;
 
-import java.io.IOException;
-import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 
@@ -90,16 +85,7 @@ public class NumericDocValuesField extends Field {
    * @see DoubleField#newRangeQuery
    */
   public static Query newSlowRangeQuery(String field, long lowerValue, long upperValue) {
-    return new SortedNumericDocValuesRangeQuery(field, lowerValue, upperValue) {
-      @Override
-      SortedNumericDocValues getValues(LeafReader reader, String field) throws IOException {
-        NumericDocValues values = reader.getNumericDocValues(field);
-        if (values == null) {
-          return null;
-        }
-        return DocValues.singleton(values);
-      }
-    };
+    return new SortedNumericDocValuesRangeQuery(field, lowerValue, upperValue);
   }
 
   /**
@@ -116,16 +102,7 @@ public class NumericDocValuesField extends Field {
    * @see DoubleField#newSetQuery
    */
   public static Query newSlowSetQuery(String field, long... values) {
-    return new SortedNumericDocValuesSetQuery(field, values.clone()) {
-      @Override
-      SortedNumericDocValues getValues(LeafReader reader, String field) throws IOException {
-        NumericDocValues values = reader.getNumericDocValues(field);
-        if (values == null) {
-          return null;
-        }
-        return DocValues.singleton(values);
-      }
-    };
+    return new SortedNumericDocValuesSetQuery(field, values.clone());
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/document/SortedDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedDocValuesField.java
@@ -16,11 +16,7 @@
  */
 package org.apache.lucene.document;
 
-import java.io.IOException;
-import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
@@ -78,12 +74,7 @@ public class SortedDocValuesField extends Field {
       boolean lowerInclusive,
       boolean upperInclusive) {
     return new SortedSetDocValuesRangeQuery(
-        field, lowerValue, upperValue, lowerInclusive, upperInclusive) {
-      @Override
-      SortedSetDocValues getValues(LeafReader reader, String field) throws IOException {
-        return DocValues.singleton(DocValues.getSorted(reader, field));
-      }
-    };
+        field, lowerValue, upperValue, lowerInclusive, upperInclusive);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesField.java
@@ -16,12 +16,7 @@
  */
 package org.apache.lucene.document;
 
-import java.io.IOException;
-import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 
@@ -88,18 +83,7 @@ public class SortedNumericDocValuesField extends Field {
    * @see DoubleField#newRangeQuery
    */
   public static Query newSlowRangeQuery(String field, long lowerValue, long upperValue) {
-    return new SortedNumericDocValuesRangeQuery(field, lowerValue, upperValue) {
-      @Override
-      SortedNumericDocValues getValues(LeafReader reader, String field) throws IOException {
-        FieldInfo info = reader.getFieldInfos().fieldInfo(field);
-        if (info == null) {
-          // Queries have some optimizations when one sub scorer returns null rather
-          // than a scorer that does not match any documents
-          return null;
-        }
-        return DocValues.getSortedNumeric(reader, field);
-      }
-    };
+    return new SortedNumericDocValuesRangeQuery(field, lowerValue, upperValue);
   }
 
   /**
@@ -116,18 +100,7 @@ public class SortedNumericDocValuesField extends Field {
    * @see DoubleField#newSetQuery
    */
   public static Query newSlowSetQuery(String field, long... values) {
-    return new SortedNumericDocValuesSetQuery(field, values.clone()) {
-      @Override
-      SortedNumericDocValues getValues(LeafReader reader, String field) throws IOException {
-        FieldInfo info = reader.getFieldInfos().fieldInfo(field);
-        if (info == null) {
-          // Queries have some optimizations when one sub scorer returns null rather
-          // than a scorer that does not match any documents
-          return null;
-        }
-        return DocValues.getSortedNumeric(reader, field);
-      }
-    };
+    return new SortedNumericDocValuesSetQuery(field, values.clone());
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -19,7 +19,6 @@ package org.apache.lucene.document;
 import java.io.IOException;
 import java.util.Objects;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -34,7 +33,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 
-abstract class SortedNumericDocValuesRangeQuery extends Query {
+final class SortedNumericDocValuesRangeQuery extends Query {
 
   private final String field;
   private final long lowerValue;
@@ -59,11 +58,7 @@ abstract class SortedNumericDocValuesRangeQuery extends Query {
 
   @Override
   public int hashCode() {
-    int h = classHash();
-    h = 31 * h + field.hashCode();
-    h = 31 * h + Long.hashCode(lowerValue);
-    h = 31 * h + Long.hashCode(upperValue);
-    return h;
+    return Objects.hash(classHash(), field, lowerValue, upperValue);
   }
 
   @Override
@@ -95,8 +90,6 @@ abstract class SortedNumericDocValuesRangeQuery extends Query {
     return super.rewrite(indexSearcher);
   }
 
-  abstract SortedNumericDocValues getValues(LeafReader reader, String field) throws IOException;
-
   @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
       throws IOException {
@@ -109,10 +102,10 @@ abstract class SortedNumericDocValuesRangeQuery extends Query {
 
       @Override
       public Scorer scorer(LeafReaderContext context) throws IOException {
-        SortedNumericDocValues values = getValues(context.reader(), field);
-        if (values == null) {
+        if (context.reader().getFieldInfos().fieldInfo(field) == null) {
           return null;
         }
+        SortedNumericDocValues values = DocValues.getSortedNumeric(context.reader(), field);
         final NumericDocValues singleton = DocValues.unwrapSingleton(values);
         final TwoPhaseIterator iterator;
         if (singleton != null) {

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesField.java
@@ -16,11 +16,7 @@
  */
 package org.apache.lucene.document;
 
-import java.io.IOException;
-import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
@@ -78,12 +74,7 @@ public class SortedSetDocValuesField extends Field {
       boolean lowerInclusive,
       boolean upperInclusive) {
     return new SortedSetDocValuesRangeQuery(
-        field, lowerValue, upperValue, lowerInclusive, upperInclusive) {
-      @Override
-      SortedSetDocValues getValues(LeafReader reader, String field) throws IOException {
-        return DocValues.getSortedSet(reader, field);
-      }
-    };
+        field, lowerValue, upperValue, lowerInclusive, upperInclusive);
   }
 
   /**


### PR DESCRIPTION
There's no need to make things abstract: DocValues does the right thing Optimizing for where no docs for the field in the segment exist is easy, simple null check (replacing the existing one!)
