### PR TITLE
Fix TestFeatureField#testBasicsNonScoringCase test

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/document/TestFeatureField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestFeatureField.java
@@ -84,7 +84,7 @@ public class TestFeatureField extends LuceneTestCase {
     writer.close();
 
     IndexSearcher searcher = LuceneTestCase.newSearcher(reader);
-    LeafReaderContext context = reader.leaves().get(0);
+    LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
 
     Query q = FeatureField.newLogQuery("features", "pagerank", 3f, 4.5f);
     Weight w = q.createWeight(searcher, ScoreMode.TOP_SCORES, 2);
@@ -408,7 +408,7 @@ public class TestFeatureField extends LuceneTestCase {
       }
 
       IndexSearcher searcher = LuceneTestCase.newSearcher(reader);
-      LeafReaderContext context = reader.leaves().get(0);
+      LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
 
       for (Query q :
           List.of(


### PR DESCRIPTION
Sometimes the random search lucene test searcher will wrap the reader. Consequently, we need to make sure to use the reader provided by the test `IndexSearcher` or the reader may be different between creating the weight with the searcher vs. accessing the leaf context for the scorer.