### PR TITLE
Add tests for size() and contains() to LongHashSet

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/LongHashSet.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LongHashSet.java
@@ -52,10 +52,10 @@ final class LongHashSet implements Accountable {
     int size = 0;
     long previousValue = Long.MIN_VALUE; // for assert
     for (long value : values) {
-      if (value == MISSING || add(value)) {
-        if (value == MISSING) {
-          hasMissingValue = true;
-        }
+      if (value == MISSING) {
+        size += hasMissingValue ? 0 : 1;
+        hasMissingValue = true;
+      } else if (add(value)) {
         ++size;
       }
       assert value >= previousValue : "values must be provided in sorted order";

--- a/lucene/core/src/test/org/apache/lucene/document/TestLongHashSet.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLongHashSet.java
@@ -100,6 +100,20 @@ public class TestLongHashSet extends LuceneTestCase {
     assertEquals(set1, set2);
   }
 
+  public void testSameValue() {
+    LongHashSet set2 = new LongHashSet(new long[] {42L, 42L});
+    assertEquals(1, set2.size());
+    assertEquals(42L, set2.minValue);
+    assertEquals(42L, set2.maxValue);
+  }
+
+  public void testSameMissingPlaceholder() {
+    LongHashSet set2 = new LongHashSet(new long[] {Long.MIN_VALUE, Long.MIN_VALUE});
+    assertEquals(1, set2.size());
+    assertEquals(Long.MIN_VALUE, set2.minValue);
+    assertEquals(Long.MIN_VALUE, set2.maxValue);
+  }
+
   public void testRandom() {
     final int iters = atLeast(10);
     for (int iter = 0; iter < iters; ++iter) {

--- a/lucene/core/src/test/org/apache/lucene/document/TestLongHashSet.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLongHashSet.java
@@ -26,8 +26,9 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 public class TestLongHashSet extends LuceneTestCase {
 
   private void assertEquals(Set<Long> set1, LongHashSet longHashSet) {
-    Set<Long> set2 = longHashSet.stream().boxed().collect(Collectors.toSet());
+    assertEquals(set1.size(), longHashSet.size());
 
+    Set<Long> set2 = longHashSet.stream().boxed().collect(Collectors.toSet());
     LuceneTestCase.assertEquals(set1, set2);
 
     if (set1.isEmpty() == false) {
@@ -36,11 +37,14 @@ public class TestLongHashSet extends LuceneTestCase {
       while (true) {
         long next = random().nextLong();
         if (next != removed && set3.add(next)) {
+          assertFalse(longHashSet.contains(next));
           break;
         }
       }
       assertNotEquals(set3, longHashSet);
     }
+
+    assertTrue(set1.stream().allMatch(longHashSet::contains));
   }
 
   private void assertNotEquals(Set<Long> set1, LongHashSet longHashSet) {
@@ -51,11 +55,14 @@ public class TestLongHashSet extends LuceneTestCase {
     LongHashSet set3 = new LongHashSet(set1.stream().mapToLong(Long::longValue).sorted().toArray());
 
     LuceneTestCase.assertNotEquals(set2, set3.stream().boxed().collect(Collectors.toSet()));
+
+    assertFalse(set1.stream().allMatch(longHashSet::contains));
   }
 
   public void testEmpty() {
     Set<Long> set1 = new HashSet<>();
     LongHashSet set2 = new LongHashSet(new long[] {});
+    assertEquals(0, set2.size());
     assertEquals(Long.MAX_VALUE, set2.minValue);
     assertEquals(Long.MIN_VALUE, set2.maxValue);
     assertEquals(set1, set2);
@@ -64,12 +71,14 @@ public class TestLongHashSet extends LuceneTestCase {
   public void testOneValue() {
     Set<Long> set1 = new HashSet<>(Arrays.asList(42L));
     LongHashSet set2 = new LongHashSet(new long[] {42L});
+    assertEquals(1, set2.size());
     assertEquals(42L, set2.minValue);
     assertEquals(42L, set2.maxValue);
     assertEquals(set1, set2);
 
     set1 = new HashSet<>(Arrays.asList(Long.MIN_VALUE));
     set2 = new LongHashSet(new long[] {Long.MIN_VALUE});
+    assertEquals(1, set2.size());
     assertEquals(Long.MIN_VALUE, set2.minValue);
     assertEquals(Long.MIN_VALUE, set2.maxValue);
     assertEquals(set1, set2);
@@ -78,12 +87,14 @@ public class TestLongHashSet extends LuceneTestCase {
   public void testTwoValues() {
     Set<Long> set1 = new HashSet<>(Arrays.asList(42L, Long.MAX_VALUE));
     LongHashSet set2 = new LongHashSet(new long[] {42L, Long.MAX_VALUE});
+    assertEquals(2, set2.size());
     assertEquals(42, set2.minValue);
     assertEquals(Long.MAX_VALUE, set2.maxValue);
     assertEquals(set1, set2);
 
     set1 = new HashSet<>(Arrays.asList(Long.MIN_VALUE, 42L));
     set2 = new LongHashSet(new long[] {Long.MIN_VALUE, 42L});
+    assertEquals(2, set2.size());
     assertEquals(Long.MIN_VALUE, set2.minValue);
     assertEquals(42, set2.maxValue);
     assertEquals(set1, set2);


### PR DESCRIPTION
Another followup for #12128: Due to previously only testing the `java.util.Set` interface, the actual testing code never verified that `size()` and the actual call to `contains(long)` worked correctly.