### PR TITLE
Avoid duplicate sorting in KeywordField#newSetQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -120,7 +120,9 @@ New Features
 
 Improvements
 ---------------------
-(No changes)
+
+* GITHUB#12135: KeywordField#newSetQuery avoids duplicate sorting/cloning of values across TermInSetQuery and
+  SortedSetDocValuesSetQuery. (Greg Miller)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
@@ -16,7 +16,10 @@
  */
 package org.apache.lucene.document;
 
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
@@ -168,8 +171,10 @@ public class KeywordField extends Field {
   public static Query newSetQuery(String field, BytesRef... values) {
     Objects.requireNonNull(field, "field must not be null");
     Objects.requireNonNull(values, "values must not be null");
+    SortedSet<BytesRef> sortedValues = new TreeSet<>(Arrays.asList(values));
     return new IndexOrDocValuesQuery(
-        new TermInSetQuery(field, values), new SortedSetDocValuesSetQuery(field, values));
+        new TermInSetQuery(field, sortedValues),
+        new SortedSetDocValuesSetQuery(field, sortedValues));
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/document/SortedDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedDocValuesField.java
@@ -98,6 +98,6 @@ public class SortedDocValuesField extends Field {
    * {@link BinaryPoint#newSetQuery}.
    */
   public static Query newSlowSetQuery(String field, BytesRef... values) {
-    return new SortedSetDocValuesSetQuery(field, values.clone());
+    return new SortedSetDocValuesSetQuery(field, values);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesField.java
@@ -102,6 +102,6 @@ public class SortedSetDocValuesField extends Field {
    * {@link BinaryPoint#newSetQuery}.
    */
   public static Query newSlowSetQuery(String field, BytesRef... values) {
-    return new SortedSetDocValuesSetQuery(field, values.clone());
+    return new SortedSetDocValuesSetQuery(field, values);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesSetQuery.java
@@ -17,6 +17,8 @@
 package org.apache.lucene.document;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Objects;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
@@ -37,7 +39,6 @@ import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.LongBitSet;
 import org.apache.lucene.util.RamUsageEstimator;
@@ -51,19 +52,13 @@ final class SortedSetDocValuesSetQuery extends Query implements Accountable {
   private final PrefixCodedTerms termData;
   private final int termDataHashCode; // cached hashcode of termData
 
-  SortedSetDocValuesSetQuery(String field, BytesRef terms[]) {
-    this.field = Objects.requireNonNull(field);
-    Objects.requireNonNull(terms);
-    ArrayUtil.timSort(terms);
-    PrefixCodedTerms.Builder builder = new PrefixCodedTerms.Builder();
-    BytesRef previous = null;
-    for (BytesRef term : terms) {
-      if (term.equals(previous) == false) {
-        builder.add(field, term);
-      }
-      previous = term;
-    }
-    termData = builder.finish();
+  SortedSetDocValuesSetQuery(String field, BytesRef[] terms) {
+    this(field, Arrays.asList(terms));
+  }
+
+  SortedSetDocValuesSetQuery(String field, Collection<BytesRef> terms) {
+    this.field = field;
+    termData = PrefixCodedTerms.ofFieldTerms(field, terms);
     termDataHashCode = termData.hashCode();
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestPrefixCodedTerms.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPrefixCodedTerms.java
@@ -16,12 +16,17 @@
  */
 package org.apache.lucene.index;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import org.apache.lucene.index.PrefixCodedTerms.TermIterator;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
 
 public class TestPrefixCodedTerms extends LuceneTestCase {
 
@@ -67,6 +72,29 @@ public class TestPrefixCodedTerms extends LuceneTestCase {
     while (iter.next() != null) {
       assertTrue(expected.hasNext());
       assertEquals(expected.next(), new Term(iter.field(), iter.bytes));
+    }
+
+    assertFalse(expected.hasNext());
+  }
+
+  public void testSingleField() {
+    Set<BytesRef> values = new HashSet<>();
+    String field = TestUtil.randomUnicodeString(random(), 8);
+    int nterms = atLeast(10000);
+    for (int i = 0; i < nterms; i++) {
+      values.add(new BytesRef(TestUtil.randomUnicodeString(random())));
+    }
+
+    PrefixCodedTerms codedTerms = PrefixCodedTerms.ofFieldTerms(field, values);
+
+    List<BytesRef> expectedValues = new ArrayList<>(values);
+    Collections.sort(expectedValues);
+    TermIterator iter = codedTerms.iterator();
+    Iterator<BytesRef> expected = expectedValues.iterator();
+    while (iter.next() != null) {
+      assertTrue(expected.hasNext());
+      assertEquals(expected.next(), iter.bytes);
+      assertEquals(field, iter.field);
     }
 
     assertFalse(expected.hasNext());


### PR DESCRIPTION
### Description

Term sorting can be a significant amount of work with a large number of terms. This change allows `KeywordField#newSetQuery` to do that work once, instead of `TermInSetQuery` and `SortedSetDocValuesSetQuery` duplicating the effort (and memory footprint as well).
