### PR TITLE
Don't wrap readers when checking for term vector access in test

### DIFF
--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
@@ -28,14 +28,12 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
-import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.FilterDirectoryReader;
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.ParallelLeafReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermVectors;
 import org.apache.lucene.search.BooleanClause;
@@ -66,7 +64,7 @@ public class TestUnifiedHighlighterTermVec extends LuceneTestCase {
   private Directory dir;
 
   @Before
-  public void doBefore() throws IOException {
+  public void doBefore() {
     indexAnalyzer =
         new MockAnalyzer(
             random(), MockTokenizer.SIMPLE, true); // whitespace, punctuation, lowercase
@@ -107,7 +105,8 @@ public class TestUnifiedHighlighterTermVec extends LuceneTestCase {
     IndexReader ir = new AssertOnceTermVecDirectoryReader(originalReader);
     iw.close();
 
-    IndexSearcher searcher = newSearcher(ir);
+    IndexSearcher searcher =
+        newSearcher(ir, false); // wrapping the reader messes up our counting logic
     UnifiedHighlighter highlighter = UnifiedHighlighter.builder(searcher, indexAnalyzer).build();
     BooleanQuery.Builder queryBuilder = new BooleanQuery.Builder();
     for (String field : fields) {
@@ -134,7 +133,7 @@ public class TestUnifiedHighlighterTermVec extends LuceneTestCase {
           @Override
           public LeafReader wrap(LeafReader reader) {
             return new FilterLeafReader(reader) {
-              BitSet seenDocIDs = new BitSet();
+              final BitSet seenDocIDs = new BitSet();
 
               @Override
               public TermVectors termVectors() throws IOException {
@@ -142,16 +141,9 @@ public class TestUnifiedHighlighterTermVec extends LuceneTestCase {
                 return new TermVectors() {
                   @Override
                   public Fields get(int docID) throws IOException {
-                    // if we're invoked by ParallelLeafReader then we can't do our assertion. TODO
-                    // see
-                    // LUCENE-6868
-                    if (callStackContains(ParallelLeafReader.class) == false
-                        && callStackContains(CheckIndex.class) == false) {
-                      assertFalse(
-                          "Should not request TVs for doc more than once.", seenDocIDs.get(docID));
-                      seenDocIDs.set(docID);
-                    }
-
+                    assertFalse(
+                        "Should not request TVs for doc more than once.", seenDocIDs.get(docID));
+                    seenDocIDs.set(docID);
                     return orig.get(docID);
                   }
                 };


### PR DESCRIPTION
In TestUnifiedHighlighterTermVec, we have a special reader which counts the
number of times term vectors are accessed, so that we can assert that caching
works correctly here.  There is some special logic in place to skip the check
when the test framework wraps readers with CheckIndex or ParallelReader; 
however, this logic no longer works with ParallelReader in particular, because
term vectors are now accessed through an anonymous class.

A simpler solution here is to call `newSearcher(reader, false)`, which disables
wrapping, meaning that we can remove this extra logic entirely.

Fixes #12115 