### PR TITLE
Force merge into a single segment before getting the directory reader

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/document/TestFeatureField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestFeatureField.java
@@ -403,8 +403,8 @@ public class TestFeatureField extends LuceneTestCase {
         pageRankDoc.add(pagerank);
         writer.addDocument(pageRankDoc);
 
-        reader = writer.getReader();
         writer.forceMerge(1);
+        reader = writer.getReader();
       }
 
       IndexSearcher searcher = LuceneTestCase.newSearcher(reader);


### PR DESCRIPTION
The test assumes a single segment is created (because only one scorer is created from the leaf contexts).

But, force merging wasn't done before getting the reader. Forcemerge to a single segment before getting the reader.