### PR TITLE
Skip the TokenStream overhead when indexing simple keywords.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -135,6 +135,8 @@ Optimizations
 
 * GITHUB#12050: Reuse HNSW graph for intialization during merge (Jack Mazanec)
 
+* GITHUB#12139: Faster indexing of string fields. (Adrien Grand)
+
 Bug Fixes
 ---------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/document/Field.java
+++ b/lucene/core/src/java/org/apache/lucene/document/Field.java
@@ -456,6 +456,11 @@ public class Field implements IndexableField {
   }
 
   @Override
+  public InvertableType invertableType() {
+    return InvertableType.TOKEN_STREAM;
+  }
+
+  @Override
   public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse) {
     if (fieldType().indexOptions() == IndexOptions.NONE) {
       // Not indexed

--- a/lucene/core/src/java/org/apache/lucene/document/InvertableType.java
+++ b/lucene/core/src/java/org/apache/lucene/document/InvertableType.java
@@ -16,14 +16,18 @@
  */
 package org.apache.lucene.document;
 
+import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexableField;
 
 /** Describes how an {@link IndexableField} should be inverted for indexing terms and postings. */
 public enum InvertableType {
 
   /**
-   * The field should be inverted through its {@link IndexableField#binaryValue()}, with a frequency
-   * of 1.
+   * The field should be treated as a single value whose binary content is returned by {@link
+   * IndexableField#binaryValue()}. The term frequency is assumed to be one. If you need to index
+   * multiple values, you should pass multiple {@link IndexableField} instances to the {@link
+   * IndexWriter}. If the same value is provided multiple times, the term frequency will be equal to
+   * the number of times that this value occurred in the same document.
    */
   BINARY,
 

--- a/lucene/core/src/java/org/apache/lucene/document/InvertableType.java
+++ b/lucene/core/src/java/org/apache/lucene/document/InvertableType.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.document;
+
+import org.apache.lucene.index.IndexableField;
+
+/** Describes how an {@link IndexableField} should be inverted for indexing terms and postings. */
+public enum InvertableType {
+
+  /**
+   * The field should be inverted through its {@link IndexableField#binaryValue()}, with a frequency
+   * of 1.
+   */
+  TERM,
+
+  /**
+   * The field should be inverted through its {@link
+   * IndexableField#tokenStream(org.apache.lucene.analysis.Analyzer,
+   * org.apache.lucene.analysis.TokenStream)}.
+   */
+  TOKEN_STREAM;
+}

--- a/lucene/core/src/java/org/apache/lucene/document/InvertableType.java
+++ b/lucene/core/src/java/org/apache/lucene/document/InvertableType.java
@@ -25,7 +25,7 @@ public enum InvertableType {
    * The field should be inverted through its {@link IndexableField#binaryValue()}, with a frequency
    * of 1.
    */
-  TERM,
+  BINARY,
 
   /**
    * The field should be inverted through its {@link

--- a/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
@@ -109,7 +109,7 @@ public class KeywordField extends Field {
 
   @Override
   public InvertableType invertableType() {
-    return InvertableType.TERM;
+    return InvertableType.BINARY;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
@@ -17,8 +17,6 @@
 package org.apache.lucene.document;
 
 import java.util.Objects;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
@@ -110,10 +108,8 @@ public class KeywordField extends Field {
   }
 
   @Override
-  public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse) {
-    // Return null so that the field gets indexed directly through its #binaryValue() and saves the
-    // TokenStream overhead.
-    return null;
+  public InvertableType invertableType() {
+    return InvertableType.TERM;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/document/StringField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/StringField.java
@@ -88,7 +88,7 @@ public final class StringField extends Field {
 
   @Override
   public InvertableType invertableType() {
-    return InvertableType.TERM;
+    return InvertableType.BINARY;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/document/StringField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/StringField.java
@@ -16,8 +16,6 @@
  */
 package org.apache.lucene.document;
 
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.util.BytesRef;
 
@@ -88,18 +86,9 @@ public final class StringField extends Field {
     }
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @deprecated Pulling a tokenStream directly on a {@link StringField} is deprecated, it should
-   *     only be called via IndexingChain.
-   */
-  @Deprecated
   @Override
-  public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse) {
-    // Return null so that the indexing chain indexes the field directly through the
-    // #binaryValue() and saves the TokenStream overhead.
-    return null;
+  public InvertableType invertableType() {
+    return InvertableType.TERM;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/document/StringField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/StringField.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.document;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.util.BytesRef;
 
@@ -81,6 +83,16 @@ public final class StringField extends Field {
     } else {
       storedValue = null;
     }
+  }
+
+  @Override
+  public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse) {
+    if (binaryValue() != null) {
+      // Return null so that the indexing chain indexes the field directly through the
+      // #binaryValue() and saves the TokenStream overhead.
+      return null;
+    }
+    return super.tokenStream(analyzer, reuse);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/document/StringField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/StringField.java
@@ -47,6 +47,7 @@ public final class StringField extends Field {
     TYPE_STORED.freeze();
   }
 
+  private BytesRef binaryValue;
   private final StoredValue storedValue;
 
   /**
@@ -59,6 +60,7 @@ public final class StringField extends Field {
    */
   public StringField(String name, String value, Store stored) {
     super(name, value, stored == Store.YES ? TYPE_STORED : TYPE_NOT_STORED);
+    binaryValue = new BytesRef(value);
     if (stored == Store.YES) {
       storedValue = new StoredValue(value);
     } else {
@@ -78,6 +80,7 @@ public final class StringField extends Field {
    */
   public StringField(String name, BytesRef value, Store stored) {
     super(name, value, stored == Store.YES ? TYPE_STORED : TYPE_NOT_STORED);
+    binaryValue = value;
     if (stored == Store.YES) {
       storedValue = new StoredValue(value);
     } else {
@@ -85,19 +88,29 @@ public final class StringField extends Field {
     }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * @deprecated Pulling a tokenStream directly on a {@link StringField} is deprecated, it should
+   *     only be called via IndexingChain.
+   */
+  @Deprecated
   @Override
   public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse) {
-    if (binaryValue() != null) {
-      // Return null so that the indexing chain indexes the field directly through the
-      // #binaryValue() and saves the TokenStream overhead.
-      return null;
-    }
-    return super.tokenStream(analyzer, reuse);
+    // Return null so that the indexing chain indexes the field directly through the
+    // #binaryValue() and saves the TokenStream overhead.
+    return null;
+  }
+
+  @Override
+  public BytesRef binaryValue() {
+    return binaryValue;
   }
 
   @Override
   public void setStringValue(String value) {
     super.setStringValue(value);
+    binaryValue = new BytesRef(value);
     if (storedValue != null) {
       storedValue.setStringValue(value);
     }
@@ -106,6 +119,7 @@ public final class StringField extends Field {
   @Override
   public void setBytesValue(BytesRef value) {
     super.setBytesValue(value);
+    binaryValue = value;
     if (storedValue != null) {
       storedValue.setBinaryValue(value);
     }

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInvertState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInvertState.java
@@ -96,11 +96,19 @@ public final class FieldInvertState {
   void setAttributeSource(AttributeSource attributeSource) {
     if (this.attributeSource != attributeSource) {
       this.attributeSource = attributeSource;
-      termAttribute = attributeSource.getAttribute(TermToBytesRefAttribute.class);
-      termFreqAttribute = attributeSource.addAttribute(TermFrequencyAttribute.class);
-      posIncrAttribute = attributeSource.addAttribute(PositionIncrementAttribute.class);
-      offsetAttribute = attributeSource.addAttribute(OffsetAttribute.class);
-      payloadAttribute = attributeSource.getAttribute(PayloadAttribute.class);
+      if (attributeSource == null) {
+        termAttribute = null;
+        termFreqAttribute = null;
+        posIncrAttribute = null;
+        offsetAttribute = null;
+        payloadAttribute = null;
+      } else {
+        termAttribute = attributeSource.getAttribute(TermToBytesRefAttribute.class);
+        termFreqAttribute = attributeSource.addAttribute(TermFrequencyAttribute.class);
+        posIncrAttribute = attributeSource.addAttribute(PositionIncrementAttribute.class);
+        offsetAttribute = attributeSource.addAttribute(OffsetAttribute.class);
+        payloadAttribute = attributeSource.getAttribute(PayloadAttribute.class);
+      }
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriterPerField.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriterPerField.java
@@ -144,7 +144,7 @@ final class FreqProxTermsWriterPerField extends TermsHashPerField {
 
     if (!hasFreq) {
       assert postings.termFreqs == null;
-      if (termFreqAtt.getTermFrequency() != 1) {
+      if (termFreqAtt != null && termFreqAtt.getTermFrequency() != 1) {
         throw new IllegalStateException(
             "field \""
                 + getFieldName()
@@ -203,7 +203,7 @@ final class FreqProxTermsWriterPerField extends TermsHashPerField {
   }
 
   private int getTermFreq() {
-    int freq = termFreqAtt.getTermFrequency();
+    int freq = termFreqAtt == null ? 1 : termFreqAtt.getTermFrequency();
     if (freq != 1) {
       if (hasProx) {
         throw new IllegalStateException(

--- a/lucene/core/src/java/org/apache/lucene/index/IndexableField.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexableField.java
@@ -19,6 +19,7 @@ package org.apache.lucene.index;
 import java.io.Reader;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.document.InvertableType;
 import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.util.BytesRef;
 
@@ -75,4 +76,10 @@ public interface IndexableField {
    * if the field stored.
    */
   public StoredValue storedValue();
+
+  /**
+   * Describes how this field should be inverted. This must return a non-null value if the field
+   * indexes terms and postings.
+   */
+  public InvertableType invertableType();
 }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -1113,7 +1113,7 @@ final class IndexingChain implements Accountable {
       }
 
       switch (field.invertableType()) {
-        case TERM:
+        case BINARY:
           invertTerm(docID, field, first);
           break;
         case TOKEN_STREAM:

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -1105,11 +1105,24 @@ final class IndexingChain implements Accountable {
      * this field name in this document.
      */
     public void invert(int docID, IndexableField field, boolean first) throws IOException {
+      assert field.fieldType().indexOptions().compareTo(IndexOptions.DOCS) >= 0;
+
       if (first) {
         // First time we're seeing this field (indexed) in this document
         invertState.reset();
       }
 
+      if (invertTokenStream(docID, field, first) == false
+          && invertKeyword(docID, field, first) == false) {
+        throw new IllegalArgumentException(
+            "Indexed fields must produce a TokenStream or a binary value, but "
+                + field.name()
+                + " did not");
+      }
+    }
+
+    private boolean invertTokenStream(int docID, IndexableField field, boolean first)
+        throws IOException {
       final boolean analyzed = field.fieldType().tokenized() && analyzer != null;
       /*
        * To assist people in tracking down problems in analysis components, we wish to write the field name to the infostream
@@ -1118,6 +1131,10 @@ final class IndexingChain implements Accountable {
        */
       boolean succeededInProcessingField = false;
       try (TokenStream stream = tokenStream = field.tokenStream(analyzer, tokenStream)) {
+        if (stream == null) {
+          succeededInProcessingField = true; // nothing to do
+          return false;
+        }
         // reset the TokenStream to the first token
         stream.reset();
         invertState.setAttributeSource(stream);
@@ -1251,6 +1268,50 @@ final class IndexingChain implements Accountable {
         invertState.position += analyzer.getPositionIncrementGap(fieldInfo.name);
         invertState.offset += analyzer.getOffsetGap(fieldInfo.name);
       }
+      return true;
+    }
+
+    private boolean invertKeyword(int docID, IndexableField field, boolean first)
+        throws IOException {
+      BytesRef binaryValue = field.binaryValue();
+      if (binaryValue == null) {
+        return false;
+      }
+      final IndexableFieldType fieldType = field.fieldType();
+      if (fieldType.tokenized()
+          || fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) > 0
+          || fieldType.storeTermVectorPositions()
+          || fieldType.storeTermVectorOffsets()
+          || fieldType.storeTermVectorPayloads()) {
+        throw new IllegalArgumentException(
+            "Fields that are tokenized or index proximity data must produce a non-null TokenStream, but "
+                + field.name()
+                + " did not");
+      }
+      invertState.setAttributeSource(null);
+      invertState.position++;
+      invertState.length++;
+      termsHashPerField.start(field, first);
+      invertState.length = Math.addExact(invertState.length, 1);
+      try {
+        termsHashPerField.add(binaryValue, docID);
+      } catch (MaxBytesLengthExceededException e) {
+        byte[] prefix = new byte[30];
+        System.arraycopy(binaryValue.bytes, binaryValue.offset, prefix, 0, 30);
+        String msg =
+            "Document contains at least one immense term in field=\""
+                + fieldInfo.name
+                + "\" (whose length is longer than the max length "
+                + IndexWriter.MAX_TERM_LENGTH
+                + "), all of which were skipped. The prefix of the first immense term is: '"
+                + Arrays.toString(prefix)
+                + "...'";
+        if (infoStream.isEnabled("IW")) {
+          infoStream.message("IW", "ERROR: " + msg);
+        }
+        throw new IllegalArgumentException(msg, e);
+      }
+      return true;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/TermVectorsConsumerPerField.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermVectorsConsumerPerField.java
@@ -284,6 +284,9 @@ final class TermVectorsConsumerPerField extends TermsHashPerField {
   }
 
   private int getTermFreq() {
+    if (termFreqAtt == null) {
+      return 1;
+    }
     int freq = termFreqAtt.getTermFrequency();
     if (freq != 1) {
       if (doVectorPositions) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentWriter.java
@@ -34,6 +34,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.InvertableType;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
@@ -437,6 +438,11 @@ public class TestDocumentWriter extends LuceneTestCase {
     @Override
     public StoredValue storedValue() {
       return null;
+    }
+
+    @Override
+    public InvertableType invertableType() {
+      return InvertableType.TERM;
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentWriter.java
@@ -17,6 +17,9 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenFilter;
@@ -37,8 +40,10 @@ import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
@@ -65,10 +70,6 @@ public class TestDocumentWriter extends LuceneTestCase {
   public void tearDown() throws Exception {
     dir.close();
     super.tearDown();
-  }
-
-  public void test() {
-    assertTrue(dir != null);
   }
 
   public void testAddDocument() throws Exception {
@@ -384,5 +385,218 @@ public class TestDocumentWriter extends LuceneTestCase {
         field ->
             new KnnFloatVectorField(
                 field, new float[] {1, 2, 3, 4}, VectorSimilarityFunction.EUCLIDEAN));
+  }
+
+  private static class MockIndexableField implements IndexableField {
+
+    private final String field;
+    private final BytesRef value;
+    private final IndexableFieldType fieldType;
+
+    MockIndexableField(String field, BytesRef value, IndexableFieldType fieldType) {
+      this.field = field;
+      this.value = value;
+      this.fieldType = fieldType;
+    }
+
+    @Override
+    public String name() {
+      return field;
+    }
+
+    @Override
+    public IndexableFieldType fieldType() {
+      return fieldType;
+    }
+
+    @Override
+    public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse) {
+      return null;
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+      return value;
+    }
+
+    @Override
+    public String stringValue() {
+      return null;
+    }
+
+    @Override
+    public Reader readerValue() {
+      return null;
+    }
+
+    @Override
+    public Number numericValue() {
+      return null;
+    }
+
+    @Override
+    public StoredValue storedValue() {
+      return null;
+    }
+  }
+
+  public void testIndexBinaryValueWithoutTokenStream() throws IOException {
+    List<FieldType> illegalFieldTypes = new ArrayList<>();
+    {
+      FieldType illegalFT = new FieldType();
+      // cannot index a tokenized binary field
+      illegalFT.setTokenized(true);
+      illegalFT.setIndexOptions(IndexOptions.DOCS);
+      illegalFT.freeze();
+      illegalFieldTypes.add(illegalFT);
+    }
+    {
+      FieldType illegalFT = new FieldType();
+      illegalFT.setTokenized(false);
+      // cannot index positions on a binary field
+      illegalFT.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+      illegalFT.freeze();
+      illegalFieldTypes.add(illegalFT);
+    }
+    {
+      FieldType illegalFT = new FieldType();
+      illegalFT.setTokenized(false);
+      illegalFT.setIndexOptions(IndexOptions.DOCS);
+      illegalFT.setStoreTermVectors(true);
+      // cannot index term vector positions
+      illegalFT.setStoreTermVectorPositions(true);
+      illegalFT.freeze();
+      illegalFieldTypes.add(illegalFT);
+    }
+    {
+      FieldType illegalFT = new FieldType();
+      illegalFT.setTokenized(false);
+      illegalFT.setIndexOptions(IndexOptions.DOCS);
+      illegalFT.setStoreTermVectors(true);
+      // cannot index term vector offsets
+      illegalFT.setStoreTermVectorOffsets(true);
+      illegalFT.freeze();
+      illegalFieldTypes.add(illegalFT);
+    }
+
+    for (FieldType ft : illegalFieldTypes) {
+      try (IndexWriter w =
+          new IndexWriter(dir, newIndexWriterConfig().setOpenMode(OpenMode.CREATE))) {
+        MockIndexableField field = new MockIndexableField("field", new BytesRef("a"), ft);
+        Document doc = new Document();
+        doc.add(field);
+        expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
+      }
+    }
+
+    try (IndexWriter w =
+        new IndexWriter(dir, newIndexWriterConfig().setOpenMode(OpenMode.CREATE))) {
+      // Field that has both a null token stream and a null binary value
+      MockIndexableField field = new MockIndexableField("field", null, StringField.TYPE_NOT_STORED);
+      Document doc = new Document();
+      doc.add(field);
+      expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
+    }
+
+    List<FieldType> legalFieldTypes = new ArrayList<>();
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS);
+      ft.setOmitNorms(false);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+      ft.setOmitNorms(false);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS);
+      ft.setOmitNorms(true);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+      ft.setOmitNorms(true);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS);
+      ft.setStoreTermVectors(true);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+      ft.setStoreTermVectors(true);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+
+    for (FieldType ft : legalFieldTypes) {
+      try (IndexWriter w =
+          new IndexWriter(dir, newIndexWriterConfig().setOpenMode(OpenMode.CREATE))) {
+        MockIndexableField field = new MockIndexableField("field", new BytesRef("a"), ft);
+        Document doc = new Document();
+        doc.add(field);
+        doc.add(field);
+        w.addDocument(doc);
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        LeafReader leafReader = getOnlyLeafReader(reader);
+
+        {
+          Terms terms = leafReader.terms("field");
+          assertEquals(1, terms.getSumDocFreq());
+          if (ft.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) >= 0) {
+            assertEquals(2, terms.getSumTotalTermFreq());
+          } else {
+            assertEquals(1, terms.getSumTotalTermFreq());
+          }
+          TermsEnum termsEnum = terms.iterator();
+          assertTrue(termsEnum.seekExact(new BytesRef("a")));
+          PostingsEnum pe = termsEnum.postings(null, PostingsEnum.ALL);
+          assertEquals(0, pe.nextDoc());
+          if (ft.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) >= 0) {
+            assertEquals(2, pe.freq());
+          } else {
+            assertEquals(1, pe.freq());
+          }
+          assertEquals(-1, pe.nextPosition());
+          assertEquals(DocIdSetIterator.NO_MORE_DOCS, pe.nextDoc());
+        }
+
+        if (ft.storeTermVectors()) {
+          Terms tvTerms = leafReader.termVectors().get(0).terms("field");
+          assertEquals(1, tvTerms.getSumDocFreq());
+          assertEquals(2, tvTerms.getSumTotalTermFreq());
+          TermsEnum tvTermsEnum = tvTerms.iterator();
+          assertTrue(tvTermsEnum.seekExact(new BytesRef("a")));
+          PostingsEnum pe = tvTermsEnum.postings(null, PostingsEnum.ALL);
+          assertEquals(0, pe.nextDoc());
+          assertEquals(2, pe.freq());
+          assertEquals(-1, pe.nextPosition());
+          assertEquals(DocIdSetIterator.NO_MORE_DOCS, pe.nextDoc());
+        } else {
+          assertNull(leafReader.termVectors().get(0));
+        }
+      }
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentWriter.java
@@ -442,7 +442,7 @@ public class TestDocumentWriter extends LuceneTestCase {
 
     @Override
     public InvertableType invertableType() {
-      return InvertableType.TERM;
+      return InvertableType.BINARY;
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldReuse.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldReuse.java
@@ -34,20 +34,20 @@ import org.apache.lucene.util.BytesRef;
 public class TestFieldReuse extends BaseTokenStreamTestCase {
 
   public void testStringField() throws IOException {
-    StringField stringField = new StringField("foo", "bar", Field.Store.NO);
+    Field stringField = new Field("foo", "bar", StringField.TYPE_NOT_STORED);
 
     // passing null
     TokenStream ts = stringField.tokenStream(null, null);
     assertTokenStreamContents(ts, new String[] {"bar"}, new int[] {0}, new int[] {3});
 
     // now reuse previous stream
-    stringField = new StringField("foo", "baz", Field.Store.NO);
+    stringField = new Field("foo", "baz", StringField.TYPE_NOT_STORED);
     TokenStream ts2 = stringField.tokenStream(null, ts);
     assertSame(ts, ts2);
     assertTokenStreamContents(ts, new String[] {"baz"}, new int[] {0}, new int[] {3});
 
     // pass a bogus stream and ensure it's still ok
-    stringField = new StringField("foo", "beer", Field.Store.NO);
+    stringField = new Field("foo", "beer", StringField.TYPE_NOT_STORED);
     TokenStream bogus = new CannedTokenStream();
     ts = stringField.tokenStream(null, bogus);
     assertNotSame(ts, bogus);

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldReuse.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldReuse.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.InvertableType;
 import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.store.Directory;
@@ -97,6 +98,11 @@ public class TestFieldReuse extends BaseTokenStreamTestCase {
     @Override
     public StoredValue storedValue() {
       return null;
+    }
+
+    @Override
+    public InvertableType invertableType() {
+      return InvertableType.TOKEN_STREAM;
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexableField.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexableField.java
@@ -26,6 +26,7 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.InvertableType;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.search.BooleanClause;
@@ -197,6 +198,11 @@ public class TestIndexableField extends LuceneTestCase {
       } else {
         return null;
       }
+    }
+
+    @Override
+    public InvertableType invertableType() {
+      return InvertableType.TOKEN_STREAM;
     }
   }
 
@@ -404,6 +410,11 @@ public class TestIndexableField extends LuceneTestCase {
     @Override
     public StoredValue storedValue() {
       return null;
+    }
+
+    @Override
+    public InvertableType invertableType() {
+      return InvertableType.TOKEN_STREAM;
     }
   }
 

--- a/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
+++ b/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.StringContains.containsString;
 
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,6 +32,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.BinaryPoint;
@@ -48,6 +50,7 @@ import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.BinaryDocValues;
@@ -56,6 +59,7 @@ import org.apache.lucene.index.FieldInvertState;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.PostingsEnum;
@@ -63,6 +67,7 @@ import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.CollectionStatistics;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -840,5 +845,143 @@ public class TestMemoryIndex extends LuceneTestCase {
     assertTrue(sndv.advanceExact(0));
     assertEquals(1, sndv.docValueCount());
     assertEquals(50, sndv.nextValue());
+  }
+
+  private static class MockIndexableField implements IndexableField {
+
+    private final String field;
+    private final BytesRef value;
+    private final IndexableFieldType fieldType;
+
+    MockIndexableField(String field, BytesRef value, IndexableFieldType fieldType) {
+      this.field = field;
+      this.value = value;
+      this.fieldType = fieldType;
+    }
+
+    @Override
+    public String name() {
+      return field;
+    }
+
+    @Override
+    public IndexableFieldType fieldType() {
+      return fieldType;
+    }
+
+    @Override
+    public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse) {
+      return null;
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+      return value;
+    }
+
+    @Override
+    public String stringValue() {
+      return null;
+    }
+
+    @Override
+    public Reader readerValue() {
+      return null;
+    }
+
+    @Override
+    public Number numericValue() {
+      return null;
+    }
+
+    @Override
+    public StoredValue storedValue() {
+      return null;
+    }
+  }
+
+  public void testKeywordWithoutTokenStream() throws IOException {
+    List<FieldType> legalFieldTypes = new ArrayList<>();
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS);
+      ft.setOmitNorms(false);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+      ft.setOmitNorms(false);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS);
+      ft.setOmitNorms(true);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+      ft.setOmitNorms(true);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS);
+      ft.setStoreTermVectors(true);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+    {
+      FieldType ft = new FieldType();
+      ft.setTokenized(false);
+      ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+      ft.setStoreTermVectors(true);
+      ft.freeze();
+      legalFieldTypes.add(ft);
+    }
+
+    for (FieldType ft : legalFieldTypes) {
+      MockIndexableField field = new MockIndexableField("field", new BytesRef("a"), ft);
+      MemoryIndex index = MemoryIndex.fromDocument(Arrays.asList(field, field), null);
+      LeafReader leafReader = index.createSearcher().getIndexReader().leaves().get(0).reader();
+      {
+        Terms terms = leafReader.terms("field");
+        assertEquals(1, terms.getSumDocFreq());
+        assertEquals(2, terms.getSumTotalTermFreq());
+        TermsEnum termsEnum = terms.iterator();
+        assertTrue(termsEnum.seekExact(new BytesRef("a")));
+        PostingsEnum pe = termsEnum.postings(null, PostingsEnum.ALL);
+        assertEquals(0, pe.nextDoc());
+        assertEquals(2, pe.freq());
+        assertEquals(0, pe.nextPosition());
+        assertEquals(1, pe.nextPosition());
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, pe.nextDoc());
+      }
+
+      if (ft.storeTermVectors()) {
+        Terms tvTerms = leafReader.termVectors().get(0).terms("field");
+        assertEquals(1, tvTerms.getSumDocFreq());
+        assertEquals(2, tvTerms.getSumTotalTermFreq());
+        TermsEnum tvTermsEnum = tvTerms.iterator();
+        assertTrue(tvTermsEnum.seekExact(new BytesRef("a")));
+        PostingsEnum pe = tvTermsEnum.postings(null, PostingsEnum.ALL);
+        assertEquals(0, pe.nextDoc());
+        assertEquals(2, pe.freq());
+        assertEquals(0, pe.nextPosition());
+        assertEquals(1, pe.nextPosition());
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, pe.nextDoc());
+      }
+    }
   }
 }

--- a/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
+++ b/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
@@ -902,7 +902,7 @@ public class TestMemoryIndex extends LuceneTestCase {
 
     @Override
     public InvertableType invertableType() {
-      return InvertableType.TERM;
+      return InvertableType.BINARY;
     }
   }
 

--- a/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
+++ b/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
@@ -44,6 +44,7 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.InvertableType;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
@@ -897,6 +898,11 @@ public class TestMemoryIndex extends LuceneTestCase {
     @Override
     public StoredValue storedValue() {
       return null;
+    }
+
+    @Override
+    public InvertableType invertableType() {
+      return InvertableType.TERM;
     }
   }
 

--- a/lucene/misc/src/java/org/apache/lucene/misc/document/LazyDocument.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/document/LazyDocument.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.InvertableType;
 import org.apache.lucene.document.StoredValue;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexReader;
@@ -193,7 +194,12 @@ public class LazyDocument {
 
     @Override
     public StoredValue storedValue() {
-      return null;
+      return getRealValue().storedValue();
+    }
+
+    @Override
+    public InvertableType invertableType() {
+      return getRealValue().invertableType();
     }
   }
 }


### PR DESCRIPTION
Indexing simple keywords through a `TokenStream` abstraction introduces a bit of overhead due to attribute management. Not much, but indexing keywords boils down to adding to a hash map and appending to a postings list, which is quite cheap too so even some low overhead can significantly impact indexing speed.

The way that this change works is by making `IndexingChain` check `binaryValue()` when a field is indexed but `tokenStream()` returns `null`. Then `KeywordField` only has to return `null` in `tokenStream()` to take advantage of this optimization. I hesitated doing the same with `StringField` but wondered if this could be breaking to some users who might pull a `TokenStream` themselves.
