### PR TITLE
 Avoid duplicate sorting in KeywordField#newSetQuery (alternative approach)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
@@ -16,7 +16,9 @@
  */
 package org.apache.lucene.document;
 
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.TreeSet;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
@@ -168,8 +170,10 @@ public class KeywordField extends Field {
   public static Query newSetQuery(String field, BytesRef... values) {
     Objects.requireNonNull(field, "field must not be null");
     Objects.requireNonNull(values, "values must not be null");
+    final var sortedValues = new TreeSet<>(Arrays.asList(values));
     return new IndexOrDocValuesQuery(
-        new TermInSetQuery(field, values), new SortedSetDocValuesSetQuery(field, values));
+        new TermInSetQuery(field, sortedValues),
+        new SortedSetDocValuesSetQuery(field, sortedValues));
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/document/SortedDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedDocValuesField.java
@@ -98,6 +98,6 @@ public class SortedDocValuesField extends Field {
    * {@link BinaryPoint#newSetQuery}.
    */
   public static Query newSlowSetQuery(String field, BytesRef... values) {
-    return new SortedSetDocValuesSetQuery(field, values.clone());
+    return new SortedSetDocValuesSetQuery(field, values);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesField.java
@@ -102,6 +102,6 @@ public class SortedSetDocValuesField extends Field {
    * {@link BinaryPoint#newSetQuery}.
    */
   public static Query newSlowSetQuery(String field, BytesRef... values) {
-    return new SortedSetDocValuesSetQuery(field, values.clone());
+    return new SortedSetDocValuesSetQuery(field, values);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/PrefixCodedTerms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PrefixCodedTerms.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collector;
 import org.apache.lucene.store.ByteBuffersDataInput;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.util.Accountable;
@@ -102,6 +103,16 @@ public class PrefixCodedTerms implements Accountable {
     public PrefixCodedTerms finish() {
       return new PrefixCodedTerms(output.toBufferList(), size);
     }
+  }
+
+  public static Collector<BytesRef, Builder, PrefixCodedTerms> collector(String field) {
+    return Collector.of(
+        Builder::new,
+        (builder, bytes) -> builder.add(field, bytes),
+        (b1, b2) -> {
+          throw new IllegalStateException("concurrent collection is not possible");
+        },
+        Builder::finish);
   }
 
   /** An iterator over the list of terms stored in a {@link PrefixCodedTerms}. */

--- a/lucene/core/src/java/org/apache/lucene/index/PrefixCodedTerms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PrefixCodedTerms.java
@@ -105,7 +105,7 @@ public class PrefixCodedTerms implements Accountable {
     }
   }
 
-  public static Collector<BytesRef, Builder, PrefixCodedTerms> collector(String field) {
+  public static Collector<BytesRef, ?, PrefixCodedTerms> collector(String field) {
     return Collector.of(
         Builder::new,
         (builder, bytes) -> builder.add(field, bytes),

--- a/lucene/core/src/java/org/apache/lucene/index/PrefixCodedTerms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PrefixCodedTerms.java
@@ -105,6 +105,10 @@ public class PrefixCodedTerms implements Accountable {
     }
   }
 
+  /**
+   * A stream {@link Collector} to process a stream of {@link BytesRef} instances and build instance
+   * of {@code PrefixCodedTerms}.
+   */
   public static Collector<BytesRef, ?, PrefixCodedTerms> collector(String field) {
     return Collector.of(
         Builder::new,


### PR DESCRIPTION
This is an alternative approach for #12135

Like in @gsmiller's code, the removal of "clone()" is ok here, as the query only consumes the terms array, but does not modify it or saves it anywhere.