### PR TITLE
No need to try packing for singleton merge

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -536,6 +536,7 @@ public class TieredMergePolicy extends MergePolicy {
               // singleton merges
               candidate.add(segSizeDocs.segInfo);
               bytesThisMerge += segBytes;
+              break;
             }
             // NOTE: we continue, so that we can try
             // "packing" smaller segments into this merge


### PR DESCRIPTION
### Description
For the singleton merge, we don't need to try packing additional small segments. 
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
