### PR TITLE
Gradle optimizations

### DIFF
--- a/gradle/java/folder-layout.gradle
+++ b/gradle/java/folder-layout.gradle
@@ -25,13 +25,11 @@ allprojects {
       test.resources.srcDirs = ['src/test-files']
     }
 
-    task copyTestResources(type: Copy) {
+    tasks.named('processTestResources').configure {
       from('src/test') {
         exclude '**/*.java'
       }
-      into sourceSets.test.java.classesDirectory
     }
-    processTestResources.dependsOn copyTestResources
 
     // if 'src/tools' exists, add it as a separate sourceSet.
     if (file('src/tools/java').exists()) {

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -34,7 +34,7 @@ allprojects {
           // asserts, debug output.
           [propName: 'tests.verbose', value: false, description: "Enables verbose mode (emits full test outputs immediately)."],
           [propName: 'tests.workDir',
-           value: { -> file("${buildDir}/tmp/tests-tmp") },
+           value: { -> project.relativePath(file("${buildDir}/tmp/tests-tmp")) },
            description: "Working directory for forked test JVMs",
            includeInReproLine: false
           ],
@@ -124,7 +124,15 @@ allprojects {
       // (if the runner JVM does not support them, it will fail tests):
       jvmArgs '--add-modules', 'jdk.unsupported,jdk.management'
 
-      systemProperty 'java.util.logging.config.file', file("${resources}/logging.properties")
+      def loggingConfigFile = layout.projectDirectory.file("${resources}/logging.properties")
+      def tempDir = layout.projectDirectory.dir(testsTmpDir.toString())
+      jvmArgumentProviders.add(
+          new LoggingFileArgumentProvider(
+              loggingConfigFile: loggingConfigFile,
+              tempDir: tempDir
+          )
+      )
+
       systemProperty 'java.awt.headless', 'true'
       systemProperty 'jdk.map.althashing.threshold', '0'
 
@@ -145,7 +153,6 @@ allprojects {
 
       // Set up cwd and temp locations.
       systemProperty("java.io.tmpdir", testsTmpDir)
-      systemProperty("tempDir", testsTmpDir)
       doFirst {
         testsCwd.mkdirs()
         testsTmpDir.mkdirs()
@@ -187,5 +194,22 @@ allprojects {
         logger.info("Test folders for {}: cwd={}, tmp={}", project.path, testsCwd, testsTmpDir)
       }
     }
+  }
+}
+
+class LoggingFileArgumentProvider implements CommandLineArgumentProvider {
+  @InputFile
+  @PathSensitive(PathSensitivity.RELATIVE)
+  RegularFile loggingConfigFile
+
+  @Internal
+  Directory tempDir
+
+  @Override
+  Iterable<String> asArguments() {
+    [
+        "-Djava.util.logging.config.file=${loggingConfigFile.getAsFile()}",
+        "-DtempDir=${tempDir.getAsFile()}"
+    ]
   }
 }

--- a/gradle/testing/randomization.gradle
+++ b/gradle/testing/randomization.gradle
@@ -166,18 +166,18 @@ allprojects {
 
         // Enable security manager, if requested. We could move the selection of security manager and security policy
         // to each project's build/ configuration but it seems compact enough to keep it here for now.
+        def securityArgumentProvider = new SecurityArgumentProvider(commonDir: project(":lucene").layout.projectDirectory)
         if (Boolean.parseBoolean(testOptionsResolved["tests.useSecurityManager"])) {
           if (project.path.endsWith(".tests")) {
             // LUCENE-10301: for now, do not use the security manager for modular tests (test framework is not available).
           } else if (project.path == ":lucene:replicator") {
             systemProperty 'java.security.manager', "org.apache.lucene.tests.util.TestSecurityManager"
-            systemProperty 'java.security.policy', file("${resources}/policies/replicator-tests.policy")
+            securityArgumentProvider.javaSecurityPolicy = layout.projectDirectory.file("${resources}/policies/replicator-tests.policy")
           } else if (project.path.startsWith(":lucene")) {
             systemProperty 'java.security.manager', "org.apache.lucene.tests.util.TestSecurityManager"
-            systemProperty 'java.security.policy', file("${resources}/policies/tests.policy")
+            securityArgumentProvider.javaSecurityPolicy = layout.projectDirectory.file("${resources}/policies/tests.policy")
           }
-
-          systemProperty 'common.dir', commonDir
+          jvmArgumentProviders.add(securityArgumentProvider)
 
           def gradleUserHome = project.gradle.getGradleUserHomeDir()
           systemProperty 'gradle.lib.dir', Paths.get(project.class.location.toURI()).parent.toAbsolutePath().toString().replace('\\', '/')
@@ -224,5 +224,24 @@ allprojects {
         }
       }
     }
+  }
+}
+
+class SecurityArgumentProvider implements CommandLineArgumentProvider {
+  @Internal
+  Directory commonDir
+
+  @InputFile
+  @Optional
+  @PathSensitive(PathSensitivity.RELATIVE)
+  RegularFile javaSecurityPolicy
+
+  @Override
+  Iterable<String> asArguments() {
+    def args = ["-Dcommon.dir=${commonDir.getAsFile()}"]
+    if (javaSecurityPolicy) {
+      args.add("-Djava.security.policy=${javaSecurityPolicy.getAsFile()}")
+    }
+    return args
   }
 }

--- a/gradle/validation/jar-checks.gradle
+++ b/gradle/validation/jar-checks.gradle
@@ -181,10 +181,17 @@ subprojects {
   // where 'jar-or-prefix' can be any '-'-delimited prefix of the dependency JAR's name.
   // So for 'commons-io' it can be 'commons-io-LICENSE-foo.txt' or
   // 'commons-LICENSE.txt'
-  task validateJarLicenses() {
+  tasks.register('validateJarLicenses') {
     group = 'Dependency validation'
     description = "Validate license and notice files of dependencies"
     dependsOn collectJarInfos
+
+    def outputFileName = 'validateJarLicenses'
+    inputs.dir(file(project.rootDir.path + '/lucene/licenses'))
+        .withPropertyName('licenses')
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.file(layout.buildDirectory.file(outputFileName))
+        .withPropertyName('validateJarLicensesResult')
 
     doLast {
       def errors = []
@@ -231,7 +238,9 @@ subprojects {
           }
         }
       }
-
+      // Required to take advantage of incremental building and the build cache
+      def f = new File(project.buildDir.path + "/" + outputFileName)
+      f.write(errors.toString(), "UTF-8")
       if (errors) {
         def msg = "Certain license/ notice files are missing:\n  - " + errors.join("\n  - ")
         if (failOnError) {

--- a/gradle/validation/validate-source-patterns.gradle
+++ b/gradle/validation/validate-source-patterns.gradle
@@ -80,14 +80,11 @@ allprojects {
       // default excludes.
       exclude '**/build/**'
       exclude '**/.idea/**'
+      exclude '**/.gradle/**'
 
       if (project == rootProject) {
         // ourselves :-)
         exclude 'gradle/validation/validate-source-patterns.gradle'
-
-        // gradle and idea folders.
-        exclude '.gradle/**'
-        exclude '.idea/**'
       } else {
         // ignore txt files in source resources and tests.
         exclude 'src/**/*.txt'

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/custom/TestCustomAnalyzer.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/custom/TestCustomAnalyzer.java
@@ -266,7 +266,13 @@ public class TestCustomAnalyzer extends BaseTokenStreamTestCase {
         CustomAnalyzer.builder(this.getDataPath(""))
             .withTokenizer("whitespace")
             .addTokenFilter(
-                "stop", "ignoreCase", "true", "words", "teststop.txt", "format", "wordset")
+                "stop",
+                "ignoreCase",
+                "true",
+                "words",
+                this.getDataPath("teststop.txt").toString(),
+                "format",
+                "wordset")
             .build();
     assertAnalyzesTo(a, "foo Foo Bar", new String[0]);
     a.close();


### PR DESCRIPTION
## Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

Ported recent build improvements from Apache Solr ([#1319](https://github.com/apache/solr/pull/1319) and [#1345](https://github.com/apache/solr/pull/1345)) with some modifications.

In addition, the following build issues were addressed:
1. Task `validateSourcePatterns` was including the `.gradle` directory for both `buildSrc` and `dev-tools/missing-doclet` as inputs, causing this task to not be cacheable.
   * Resolved by excluding all `.gradle` directories as inputs to `validateSourcePatterns`, not just the `.gradle` directory for the root project.
2. With the changes to `copyTestResources`/`processTestResources`, the test `TestCustomAnalyzer.testStopWordsFromFile` was failing because `teststop.txt` was no longer at the root of the classes directory.
   * Resolved by following the convention set by other tests: providing the path to the file with `this.getDataPath("teststop.txt").toString()`

## Improvements

Improved overall build time:
  * [Build scan timeline summary before changes](https://scans.gradle.com/s/wyryx5onlnlls#timeline)
  * [Build scan timeline summary after changes](https://scans.gradle.com/s/qupifnuiysdfq#timeline)

Reduced number of executed cacheable tasks (cache misses):
  * [Build scan before changes](https://scans.gradle.com/s/wyryx5onlnlls/timeline?cacheability=cacheable&outcome=success,failed&sort=longest)
  * [Build scan after changes](https://scans.gradle.com/s/qupifnuiysdfq/timeline?cacheability=cacheable&outcome=success,failed)

Improved the number of cacheable tasks:
  * [Non-cacheable tasks before changes](https://scans.gradle.com/s/wyryx5onlnlls/timeline?cacheability=any-non-cacheable&outcome=success,failed&sort=longest)
  * [Non-cacheable tasks after changes](https://scans.gradle.com/s/qupifnuiysdfq/timeline?cacheability=any-non-cacheable&outcome=success,failed)

Reduced the number of eagerly created tasks:
  * [Eagerly created tasks before changes](https://scans.gradle.com/s/wyryx5onlnlls/performance/configuration#summary-task-created-immediately)
  * [Eagerly created tasks after changes](https://scans.gradle.com/s/qupifnuiysdfq/performance/configuration#summary-task-created-immediately)
