### PR TITLE
Unrelated code in TestIndexSortSortedNumericDocValuesRangeQuery

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestIndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestIndexSortSortedNumericDocValuesRangeQuery.java
@@ -24,7 +24,6 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
@@ -37,7 +36,6 @@ import org.apache.lucene.tests.search.DummyTotalHitCountCollector;
 import org.apache.lucene.tests.search.QueryUtils;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.apache.lucene.util.BytesRef;
 
 @LuceneTestCase.SuppressCodecs(value = "SimpleText")
 public class TestIndexSortSortedNumericDocValuesRangeQuery extends LuceneTestCase {
@@ -122,25 +120,6 @@ public class TestIndexSortSortedNumericDocValuesRangeQuery extends LuceneTestCas
     assertEquals("foo:[3 TO 5]", q1.toString());
     assertEquals("[3 TO 5]", q1.toString("foo"));
     assertEquals("foo:[3 TO 5]", q1.toString("bar"));
-
-    Query q2 =
-        SortedSetDocValuesField.newSlowRangeQuery(
-            "foo", new BytesRef("bar"), new BytesRef("baz"), true, true);
-    assertEquals("foo:[[62 61 72] TO [62 61 7a]]", q2.toString());
-    q2 =
-        SortedSetDocValuesField.newSlowRangeQuery(
-            "foo", new BytesRef("bar"), new BytesRef("baz"), false, true);
-    assertEquals("foo:{[62 61 72] TO [62 61 7a]]", q2.toString());
-    q2 =
-        SortedSetDocValuesField.newSlowRangeQuery(
-            "foo", new BytesRef("bar"), new BytesRef("baz"), false, false);
-    assertEquals("foo:{[62 61 72] TO [62 61 7a]}", q2.toString());
-    q2 = SortedSetDocValuesField.newSlowRangeQuery("foo", new BytesRef("bar"), null, true, true);
-    assertEquals("foo:[[62 61 72] TO *}", q2.toString());
-    q2 = SortedSetDocValuesField.newSlowRangeQuery("foo", null, new BytesRef("baz"), true, true);
-    assertEquals("foo:{* TO [62 61 7a]]", q2.toString());
-    assertEquals("{* TO [62 61 7a]]", q2.toString("foo"));
-    assertEquals("foo:{* TO [62 61 7a]]", q2.toString("bar"));
   }
 
   public void testIndexSortDocValuesWithEvenLength() throws Exception {


### PR DESCRIPTION
`SortedSetDocValuesField.newSlowRangeQuery`  appeared in `TestIndexSortSortedNumericDocValuesRangeQuery#toString` seems no reason?

