### PR TITLE
Speed up DocValuesRewriteMethod by making use of sortedness

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -135,6 +135,8 @@ Optimizations
 
 * GITHUB#12050: Reuse HNSW graph for intialization during merge (Jack Mazanec)
 
+* GITHUB#12155: Speed up DocValuesRewriteMethod by making use of sortedness. (Greg Miller)
+
 Bug Fixes
 ---------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesRewriteMethod.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesRewriteMethod.java
@@ -172,15 +172,25 @@ public final class DocValuesRewriteMethod extends MultiTermQuery.RewriteMethod {
               // query that are actually present in the doc values field). Cannot use FixedBitSet
               // because we require long index (ord):
               final LongBitSet termSet = new LongBitSet(values.getValueCount());
+              long maxOrd = -1;
               do {
                 long ord = termsEnum.ord();
                 if (ord >= 0) {
+                  assert ord > maxOrd;
+                  maxOrd = ord;
                   termSet.set(ord);
                 }
               } while (termsEnum.next() != null);
 
+              // no terms matched in this segment
+              if (maxOrd < 0) {
+                return new ConstantScoreScorer(
+                    weight, score(), scoreMode, DocIdSetIterator.empty());
+              }
+
               final SortedDocValues singleton = DocValues.unwrapSingleton(values);
               final TwoPhaseIterator iterator;
+              final long max = maxOrd;
               if (singleton != null) {
                 iterator =
                     new TwoPhaseIterator(singleton) {
@@ -200,7 +210,10 @@ public final class DocValuesRewriteMethod extends MultiTermQuery.RewriteMethod {
                       @Override
                       public boolean matches() throws IOException {
                         for (int i = 0; i < values.docValueCount(); i++) {
-                          if (termSet.get(values.nextOrd())) {
+                          long value = values.nextOrd();
+                          if (value > max) {
+                            return false; // values are sorted, terminate
+                          } else if (termSet.get(value)) {
                             return true;
                           }
                         }


### PR DESCRIPTION
### Description

This brings over the recent "max ord" optimization in `SortedSetDocValuesSetQuery` (#12129) to `DocValuesRewriteMethod`. 