### PR TITLE
Clone the BytesRef[] values in KeywordField#newSetQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -140,7 +140,7 @@ Optimizations
 Bug Fixes
 ---------------------
 
-* GITHUB#xxx: KeywordField#newSetQuery should clone input BytesRef[] to avoid modifying provided array. (Greg Miller)
+* GITHUB#12158: KeywordField#newSetQuery should clone input BytesRef[] to avoid modifying provided array. (Greg Miller)
 
 Build
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -139,7 +139,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+
+* GITHUB#xxx: KeywordField#newSetQuery should clone input BytesRef[] to avoid modifying provided array. (Greg Miller)
 
 Build
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
@@ -169,7 +169,7 @@ public class KeywordField extends Field {
     Objects.requireNonNull(field, "field must not be null");
     Objects.requireNonNull(values, "values must not be null");
     return new IndexOrDocValuesQuery(
-        new TermInSetQuery(field, values), new SortedSetDocValuesSetQuery(field, values));
+        new TermInSetQuery(field, values), new SortedSetDocValuesSetQuery(field, values.clone()));
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesSetQuery.java
@@ -51,6 +51,12 @@ final class SortedSetDocValuesSetQuery extends Query implements Accountable {
   private final PrefixCodedTerms termData;
   private final int termDataHashCode; // cached hashcode of termData
 
+  /**
+   * Sole constructor. Note that {@code terms} will be sorted in-place, so callers should clone the
+   * array prior to calling if they care to preserve original ordering. This decision was made since
+   * this is an internal implementation (pkg-private class) and not expected to be used directly by
+   * users.
+   */
   SortedSetDocValuesSetQuery(String field, BytesRef terms[]) {
     this.field = Objects.requireNonNull(field);
     Objects.requireNonNull(terms);

--- a/lucene/core/src/test/org/apache/lucene/document/TestKeywordField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestKeywordField.java
@@ -26,6 +26,7 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 
 public class TestKeywordField extends LuceneTestCase {
@@ -121,5 +122,18 @@ public class TestKeywordField extends LuceneTestCase {
     assertEquals("value", storedDoc.get("field"));
     reader.close();
     dir.close();
+  }
+
+  public void testValueClone() {
+    BytesRef[] values = new BytesRef[100];
+    for (int i = 0; i < 100; i++) {
+      String s = TestUtil.randomSimpleString(random(), 10, 20);
+      values[i] = new BytesRef(s);
+    }
+
+    // Make sure we don't modify the input values array.
+    BytesRef[] expected = values.clone();
+    KeywordField.newSetQuery("f", values);
+    assertArrayEquals(expected, values);
   }
 }


### PR DESCRIPTION
### Description

`SortedSetDocValuesSetQuery#new` sorts the provided terms `BytesRef[]` in place, so we should really clone the values provided to `KeywordField#newSetQuery` before initializing the query (we do this properly in the other locations where we invoke the ctor).