### PR TITLE
Add LatLonField class to index both LatLonPoint and LatLonDocValues

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -112,6 +112,9 @@ API Changes
 * GITHUB#12129: Move DocValuesTermsQuery from sandbox to SortedDocValuesField#newSlowSetQuery
   and SortedSetDocValuesField#newSlowSetQuery. (Robert Muir)
 
+* GITHUB#12161: Introduce LatLonField which ndex both LatLonField and LatLonDDocValues.
+  (Ignacio Vera)
+
 New Features
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -112,7 +112,7 @@ API Changes
 * GITHUB#12129: Move DocValuesTermsQuery from sandbox to SortedDocValuesField#newSlowSetQuery
   and SortedSetDocValuesField#newSlowSetQuery. (Robert Muir)
 
-* GITHUB#12161: Introduce LatLonField which ndex both LatLonField and LatLonDDocValues.
+* GITHUB#12161: Introduce LatLonField which indexes both LatLonPoint and LatLonDocValuesField.
   (Ignacio Vera)
 
 New Features

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonDocValuesField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonDocValuesField.java
@@ -230,12 +230,26 @@ public class LatLonDocValuesField extends Field {
   }
 
   /**
-   * Create a query for matching one or more geometries against the provided {@link
-   * ShapeField.QueryRelation}. Line geometries are not supported for WITHIN relationship. This
-   * query is usually slow as it does not use an index structure and needs to verify documents
-   * one-by-one in order to know whether they match. It is best used wrapped in an {@link
-   * IndexOrDocValuesQuery} alongside a {@link LatLonPoint#newGeometryQuery(String,
-   * ShapeField.QueryRelation, LatLonGeometry...)}.
+   * Expert: Create a query for matching one or more geometries against the provided {@link
+   * ShapeField.QueryRelation}. This query is usually slow as it does not use an index structure and
+   * needs to verify documents one-by-one in order to know whether they match. It is best used
+   * wrapped in an {@link IndexOrDocValuesQuery} alongside a {@link
+   * LatLonPoint#newGeometryQuery(String, ShapeField.QueryRelation, LatLonGeometry...)}.
+   *
+   * <p>The following {@link ShapeField.QueryRelation} can be defined:
+   *
+   * <ol>
+   *   <li>{@link ShapeField.QueryRelation#INTERSECTS}: Matches a document if at least one point of
+   *       the field matches at least one of the provided {@link LatLonGeometry}.
+   *   <li>{@link ShapeField.QueryRelation#WITHIN}: Matches a document if all points of the field
+   *       matches one or more of the provided {@link LatLonGeometry}. Line geometries are not
+   *       supported for WITHIN relationship.
+   *   <li>{@link ShapeField.QueryRelation#DISJOINT}: Matches a document if none of the points of
+   *       the field matches any of the provided {@link LatLonGeometry}.
+   *   <li>{@link ShapeField.QueryRelation#CONTAINS}: Matches a documents if one or more points of
+   *       the field matches all the provided {@link LatLonGeometry}. It returns {@link
+   *       MatchNoDocsQuery} if any of the provided {@link LatLonGeometry} is not a {@link Point}.
+   * </ol>
    *
    * @param field field name. must not be null.
    * @param queryRelation The relation the points needs to satisfy with the provided geometries,

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonField.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.document;
+
+import static org.apache.lucene.geo.GeoEncodingUtils.decodeLatitude;
+import static org.apache.lucene.geo.GeoEncodingUtils.decodeLongitude;
+import static org.apache.lucene.geo.GeoEncodingUtils.encodeLatitude;
+import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
+
+import java.io.IOException;
+import org.apache.lucene.geo.LatLonGeometry;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * An indexed location field for querying and sorting. If you need more fine-grained control you can
+ * use {@link LatLonPoint} and {@link LatLonDocValuesField}.
+ *
+ * <p>Finding all documents within a range at search time is efficient. Multiple values for the same
+ * field in one document is allowed.
+ *
+ * <p>This field defines static factory methods for common operations:
+ *
+ * <ul>
+ *   <li>{@link #newGeometryQuery newGeometryQuery()} for matching points complying with a spatial
+ *       relationship with an arbitrary geometry.
+ *   <li>{@link #newDistanceFeatureQuery newDistanceFeatureQuery()} for returning points scored by
+ *       distance to a specified location.
+ *   <li>{@link #nearest nearest()} for returning the nearest points from a specified location.
+ *   <li>{@link #newDistanceSort newDistanceSort()} for ordering documents by distance from a
+ *       specified location.
+ * </ul>
+ *
+ * <p>If you also need to store the value, you should add a separate {@link StoredField} instance.
+ *
+ * <p><b>WARNING</b>: Values are indexed with some loss of precision from the original {@code
+ * double} values (4.190951585769653E-8 for the latitude component and 8.381903171539307E-8 for
+ * longitude).
+ *
+ * @see LatLonPoint
+ * @see LatLonDocValuesField
+ */
+public class LatLonField extends Field {
+  /** LatLonPoint is encoded as integer values so number of bytes is 4 */
+  public static final int BYTES = Integer.BYTES;
+  /**
+   * Type for an indexed LatLonPoint
+   *
+   * <p>Each point stores two dimensions with 4 bytes per dimension.
+   */
+  public static final FieldType TYPE = new FieldType();
+
+  static {
+    TYPE.setDimensions(2, Integer.BYTES);
+    TYPE.setDocValuesType(DocValuesType.SORTED_NUMERIC);
+    TYPE.freeze();
+  }
+
+  // holds the doc value value.
+  private long docValue;
+
+  /**
+   * Change the values of this field
+   *
+   * @param latitude latitude value: must be within standard +/-90 coordinate bounds.
+   * @param longitude longitude value: must be within standard +/-180 coordinate bounds.
+   * @throws IllegalArgumentException if latitude or longitude are out of bounds
+   */
+  public void setLocationValue(double latitude, double longitude) {
+    final byte[] bytes;
+
+    if (fieldsData == null) {
+      bytes = new byte[8];
+      fieldsData = new BytesRef(bytes);
+    } else {
+      bytes = ((BytesRef) fieldsData).bytes;
+    }
+
+    int latitudeEncoded = encodeLatitude(latitude);
+    int longitudeEncoded = encodeLongitude(longitude);
+    NumericUtils.intToSortableBytes(latitudeEncoded, bytes, 0);
+    NumericUtils.intToSortableBytes(longitudeEncoded, bytes, Integer.BYTES);
+    docValue = Long.valueOf((((long) latitudeEncoded) << 32) | (longitudeEncoded & 0xFFFFFFFFL));
+  }
+
+  @Override
+  public Number numericValue() {
+    return docValue;
+  }
+
+  /**
+   * Creates a new LatLonPoint with the specified latitude and longitude
+   *
+   * @param name field name
+   * @param latitude latitude value: must be within standard +/-90 coordinate bounds.
+   * @param longitude longitude value: must be within standard +/-180 coordinate bounds.
+   * @throws IllegalArgumentException if the field name is null or latitude or longitude are out of
+   *     bounds
+   */
+  public LatLonField(String name, double latitude, double longitude) {
+    super(name, TYPE);
+    setLocationValue(latitude, longitude);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder result = new StringBuilder();
+    result.append(getClass().getSimpleName());
+    result.append(" <");
+    result.append(name);
+    result.append(':');
+
+    byte[] bytes = ((BytesRef) fieldsData).bytes;
+    result.append(decodeLatitude(bytes, 0));
+    result.append(',');
+    result.append(decodeLongitude(bytes, Integer.BYTES));
+
+    result.append('>');
+    return result.toString();
+  }
+
+  // static methods for generating queries
+
+  /**
+   * Create a query for matching one or more geometries against the provided {@link
+   * ShapeField.QueryRelation}. Line geometries are not supported for WITHIN relationship.
+   *
+   * @param field field name. must not be null.
+   * @param queryRelation The relation the points needs to satisfy with the provided geometries,
+   *     must not be null.
+   * @param latLonGeometries array of LatLonGeometries. must not be null or empty.
+   * @return query matching points within at least one geometry.
+   * @throws IllegalArgumentException if {@code field} is null, {@code queryRelation} is null,
+   *     {@code latLonGeometries} is null, empty or contain a null.
+   * @see LatLonGeometry
+   */
+  public static Query newGeometryQuery(
+      String field, ShapeField.QueryRelation queryRelation, LatLonGeometry... latLonGeometries) {
+    return new IndexOrDocValuesQuery(
+        LatLonPoint.newGeometryQuery(field, queryRelation, latLonGeometries),
+        LatLonDocValuesField.newSlowGeometryQuery(field, queryRelation, latLonGeometries));
+  }
+
+  /**
+   * Given a field that indexes point values into a {@link LatLonField} and doc values into {@link
+   * LatLonDocValuesField}, this returns a query that scores documents based on their haversine
+   * distance in meters to {@code (originLat, originLon)}: {@code score = weight *
+   * pivotDistanceMeters / (pivotDistanceMeters + distance)}, ie. score is in the {@code [0,
+   * weight]} range, is equal to {@code weight} when the document's value is equal to {@code
+   * (originLat, originLon)} and is equal to {@code weight/2} when the document's value is distant
+   * of {@code pivotDistanceMeters} from {@code (originLat, originLon)}. In case of multi-valued
+   * fields, only the closest point to {@code (originLat, originLon)} will be considered. This query
+   * is typically useful to boost results based on distance by adding this query to a {@link
+   * Occur#SHOULD} clause of a {@link BooleanQuery}.
+   */
+  public static Query newDistanceFeatureQuery(
+      String field, float weight, double originLat, double originLon, double pivotDistanceMeters) {
+    return LatLonPoint.newDistanceFeatureQuery(
+        field, weight, originLat, originLon, pivotDistanceMeters);
+  }
+
+  /**
+   * Finds the {@code n} nearest indexed points to the provided point, according to Haversine
+   * distance.
+   *
+   * <p>This is functionally equivalent to running {@link MatchAllDocsQuery} with a {@link
+   * LatLonDocValuesField#newDistanceSort}, but is far more efficient since it takes advantage of
+   * properties the indexed BKD tree. Multi-valued fields are currently not de-duplicated, so if a
+   * document had multiple instances of the specified field that make it into the top n, that
+   * document will appear more than once.
+   *
+   * <p>Documents are ordered by ascending distance from the location. The value returned in {@link
+   * FieldDoc} for the hits contains a Double instance with the distance in meters.
+   *
+   * @param searcher IndexSearcher to find nearest points from.
+   * @param field field name. must not be null.
+   * @param latitude latitude at the center: must be within standard +/-90 coordinate bounds.
+   * @param longitude longitude at the center: must be within standard +/-180 coordinate bounds.
+   * @param n the number of nearest neighbors to retrieve.
+   * @return TopFieldDocs containing documents ordered by distance, where the field value for each
+   *     {@link FieldDoc} is the distance in meters
+   * @throws IllegalArgumentException if {@code field} or {@code searcher} is null, or if {@code
+   *     latitude}, {@code longitude} or {@code n} are out-of-bounds
+   * @throws IOException if an IOException occurs while finding the points.
+   */
+  // TODO: what about multi-valued documents? what happens?
+  public static TopFieldDocs nearest(
+      IndexSearcher searcher, String field, double latitude, double longitude, int n)
+      throws IOException {
+    return LatLonPoint.nearest(searcher, field, latitude, longitude, n);
+  }
+
+  /**
+   * Creates a SortField for sorting by distance from a location.
+   *
+   * <p>This sort orders documents by ascending distance from the location. The value returned in
+   * {@link FieldDoc} for the hits contains a Double instance with the distance in meters.
+   *
+   * <p>If a document is missing the field, then by default it is treated as having {@link
+   * Double#POSITIVE_INFINITY} distance (missing values sort last).
+   *
+   * <p>If a document contains multiple values for the field, the <i>closest</i> distance to the
+   * location is used.
+   *
+   * @param field field name. must not be null.
+   * @param latitude latitude at the center: must be within standard +/-90 coordinate bounds.
+   * @param longitude longitude at the center: must be within standard +/-180 coordinate bounds.
+   * @return SortField ordering documents by distance
+   * @throws IllegalArgumentException if {@code field} is null or location has invalid coordinates.
+   */
+  public static SortField newDistanceSort(String field, double latitude, double longitude) {
+    return new LatLonPointSortField(field, latitude, longitude);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonField.java
@@ -145,6 +145,19 @@ public class LatLonField extends Field {
   }
 
   // static methods for generating queries
+  /**
+   * Create a query for matching a bounding box.
+   *
+   * <p>The box may cross over the dateline.
+   *
+   * @param field field name. must not be null.
+   * @param minLatitude latitude lower bound: must be within standard +/-90 coordinate bounds.
+   * @param maxLatitude latitude upper bound: must be within standard +/-90 coordinate bounds.
+   * @param minLongitude longitude lower bound: must be within standard +/-180 coordinate bounds.
+   * @param maxLongitude longitude upper bound: must be within standard +/-180 coordinate bounds.
+   * @return query matching points within this box
+   * @throws IllegalArgumentException if {@code field} is null, or the box has invalid coordinates.
+   */
   public static Query newBoxQuery(
       String field,
       double minLatitude,

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonField.java
@@ -23,6 +23,7 @@ import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
 
 import java.io.IOException;
 import org.apache.lucene.geo.LatLonGeometry;
+import org.apache.lucene.geo.Point;
 import org.apache.lucene.geo.Polygon;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.search.BooleanClause.Occur;
@@ -31,6 +32,7 @@ import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopFieldDocs;
@@ -47,6 +49,10 @@ import org.apache.lucene.util.NumericUtils;
  * <p>This field defines static factory methods for common operations:
  *
  * <ul>
+ *   <li>{@link #newBoxQuery newBoxQuery()} for matching points within a bounding box.
+ *   <li>{@link #newDistanceQuery newDistanceQuery()} for matching points within a specified
+ *       distance.
+ *   <li>{@link #newPolygonQuery newPolygonQuery()} for matching points within an arbitrary polygon.
  *   <li>{@link #newGeometryQuery newGeometryQuery()} for matching points complying with a spatial
  *       relationship with an arbitrary geometry.
  *   <li>{@link #newDistanceFeatureQuery newDistanceFeatureQuery()} for returning points scored by
@@ -205,8 +211,23 @@ public class LatLonField extends Field {
   }
 
   /**
-   * Create a query for matching one or more geometries against the provided {@link
-   * ShapeField.QueryRelation}. Line geometries are not supported for WITHIN relationship.
+   * Expert: Create a query for matching one or more geometries against the provided {@link
+   * ShapeField.QueryRelation}.
+   *
+   * <p>The following {@link ShapeField.QueryRelation} can be defined:
+   *
+   * <ol>
+   *   <li>{@link ShapeField.QueryRelation#INTERSECTS}: Matches a document if at least one point of
+   *       the field matches at least one of the provided {@link LatLonGeometry}.
+   *   <li>{@link ShapeField.QueryRelation#WITHIN}: Matches a document if all points of the field
+   *       matches one or more of the provided {@link LatLonGeometry}. Line geometries are not
+   *       supported for WITHIN relationship.
+   *   <li>{@link ShapeField.QueryRelation#DISJOINT}: Matches a document if none of the points of
+   *       the field matches any of the provided {@link LatLonGeometry}.
+   *   <li>{@link ShapeField.QueryRelation#CONTAINS}: Matches a documents if one or more points of
+   *       the field matches all the provided {@link LatLonGeometry}. It returns {@link
+   *       MatchNoDocsQuery} if any of the provided {@link LatLonGeometry} is not a {@link Point}.
+   * </ol>
    *
    * @param field field name. must not be null.
    * @param queryRelation The relation the points needs to satisfy with the provided geometries,

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPoint.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPoint.java
@@ -310,8 +310,23 @@ public class LatLonPoint extends Field {
   }
 
   /**
-   * Create a query for matching one or more geometries against the provided {@link
-   * ShapeField.QueryRelation}. Line geometries are not supported for WITHIN relationship.
+   * Expert: Create a query for matching one or more geometries against the provided {@link
+   * ShapeField.QueryRelation}.
+   *
+   * <p>The following {@link ShapeField.QueryRelation} can be defined:
+   *
+   * <ol>
+   *   <li>{@link ShapeField.QueryRelation#INTERSECTS}: Matches a document if at least one point of
+   *       the field matches at least one of the provided {@link LatLonGeometry}.
+   *   <li>{@link ShapeField.QueryRelation#WITHIN}: Matches a document if all points of the field
+   *       matches one or more of the provided {@link LatLonGeometry}. Line geometries are not
+   *       supported for WITHIN relationship.
+   *   <li>{@link ShapeField.QueryRelation#DISJOINT}: Matches a document if none of the points of
+   *       the field matches any of the provided {@link LatLonGeometry}.
+   *   <li>{@link ShapeField.QueryRelation#CONTAINS}: Matches a documents if one or more points of
+   *       the field matches all the provided {@link LatLonGeometry}. It returns {@link
+   *       MatchNoDocsQuery} if any of the provided {@link LatLonGeometry} is not a {@link Point}.
+   * </ol>
    *
    * @param field field name. must not be null.
    * @param queryRelation The relation the points needs to satisfy with the provided geometries,

--- a/lucene/core/src/java/org/apache/lucene/geo/LatLonGeometry.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/LatLonGeometry.java
@@ -17,7 +17,23 @@
 
 package org.apache.lucene.geo;
 
-/** Lat/Lon Geometry object. */
+/**
+ * Represents a unified view of the supported geometries on the earth's surface. They can determine
+ * their spatial relationship against data indexed with {@link
+ * org.apache.lucene.document.LatLonField}, {@link org.apache.lucene.document.LatLonPoint} and
+ * {@link org.apache.lucene.document.LatLonDocValuesField}.
+ *
+ * <p>The supported geometries are:
+ *
+ * <ol>
+ *   <li>{@link Point}
+ *   <li>{@link Line}
+ *   <li>{@link Polygon}
+ *   <li>{@link Circle}
+ * </ol>
+ *
+ * @lucene.experimental
+ */
 public abstract class LatLonGeometry extends Geometry {
 
   /** Creates a Component2D from the provided LatLonGeometry array */

--- a/lucene/core/src/test/org/apache/lucene/document/BaseLatLonPointTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/document/BaseLatLonPointTestCase.java
@@ -20,6 +20,7 @@ import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import java.util.Arrays;
 import org.apache.lucene.document.ShapeField.QueryRelation;
 import org.apache.lucene.geo.Circle;
+import org.apache.lucene.geo.LatLonGeometry;
 import org.apache.lucene.geo.Line;
 import org.apache.lucene.geo.Point;
 import org.apache.lucene.geo.Polygon;
@@ -52,19 +53,17 @@ public abstract class BaseLatLonPointTestCase extends BaseLatLonSpatialTestCase 
 
   @Override
   protected Query newLineQuery(String field, QueryRelation queryRelation, Object... lines) {
-    return LatLonPoint.newGeometryQuery(
-        field, queryRelation, Arrays.stream(lines).toArray(Line[]::new));
+    return newGeometryQuery(field, queryRelation, Arrays.stream(lines).toArray(Line[]::new));
   }
 
   @Override
   protected Query newPolygonQuery(String field, QueryRelation queryRelation, Object... polygons) {
-    return LatLonPoint.newGeometryQuery(
-        field, queryRelation, Arrays.stream(polygons).toArray(Polygon[]::new));
+    return newGeometryQuery(field, queryRelation, Arrays.stream(polygons).toArray(Polygon[]::new));
   }
 
   @Override
   protected Query newDistanceQuery(String field, QueryRelation queryRelation, Object circle) {
-    return LatLonPoint.newGeometryQuery(field, queryRelation, (Circle) circle);
+    return newGeometryQuery(field, queryRelation, (Circle) circle);
   }
 
   @Override
@@ -74,8 +73,11 @@ public abstract class BaseLatLonPointTestCase extends BaseLatLonSpatialTestCase 
       double[] point = (double[]) points[i];
       pointsArray[i] = new Point(point[0], point[1]);
     }
-    return LatLonPoint.newGeometryQuery(field, queryRelation, pointsArray);
+    return newGeometryQuery(field, queryRelation, pointsArray);
   }
+
+  public abstract Query newGeometryQuery(
+      String field, QueryRelation queryRelation, LatLonGeometry... geometries);
 
   public void testBoundingBoxQueriesEquivalence() throws Exception {
     int numShapes = atLeast(20);

--- a/lucene/core/src/test/org/apache/lucene/document/TestLatLonField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLatLonField.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.document;
+
+import org.apache.lucene.geo.Rectangle;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+/** Simple tests for {@link LatLonPoint} TODO: move this lone test and remove class? */
+public class TestLatLonField extends LuceneTestCase {
+
+  public void testToString() throws Exception {
+    // looks crazy due to lossiness
+    assertEquals(
+        "LatLonField <field:18.313693958334625,-65.22744401358068>",
+        (new LatLonField("field", 18.313694, -65.227444)).toString());
+
+    Query query =
+        LatLonField.newGeometryQuery(
+            "field", ShapeField.QueryRelation.INTERSECTS, new Rectangle(18, 19, -66, -65));
+
+    assertTrue(query instanceof IndexOrDocValuesQuery);
+
+    IndexOrDocValuesQuery indexOrDocValuesQuery = (IndexOrDocValuesQuery) query;
+
+    // looks crazy due to lossiness
+    assertEquals(
+        "field:[18.000000016763806 TO 18.999999999068677],[-65.9999999217689 TO -65.00000006519258]",
+        indexOrDocValuesQuery.getIndexQuery().toString());
+    assertEquals(
+        "field:box(minLat=18.000000016763806, maxLat=18.999999999068677, minLon=-65.9999999217689, maxLon=-65.00000006519258)",
+        indexOrDocValuesQuery.getRandomAccessQuery().toString());
+
+    assertEquals(
+        "(LatLonPointDistanceFeatureQuery(field=,originLat=18.0,originLon=-66.0,pivotDistance=50.0))^2.0",
+        LatLonField.newDistanceFeatureQuery("field", 2.0f, 18, -66, 50).toString());
+
+    assertEquals(
+        "<distance:\"field\" latitude=2.0 longitude=18.0>",
+        LatLonField.newDistanceSort("field", 2.0f, 18).toString());
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/document/TestLatLonFieldMultiPointQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLatLonFieldMultiPointQueries.java
@@ -18,13 +18,15 @@ package org.apache.lucene.document;
 
 import org.apache.lucene.document.ShapeField.QueryRelation;
 import org.apache.lucene.geo.Component2D;
+import org.apache.lucene.geo.LatLonGeometry;
 import org.apache.lucene.geo.Point;
+import org.apache.lucene.search.Query;
 
 /**
  * random bounding box, line, and polygon query tests for random indexed arrays of {@code latitude,
  * longitude} points
  */
-public class TestLatLonMultiPointPointQueries extends BaseLatLonPointTestCase {
+public class TestLatLonFieldMultiPointQueries extends BaseLatLonPointTestCase {
 
   @Override
   protected ShapeType getShapeType() {
@@ -46,9 +48,15 @@ public class TestLatLonMultiPointPointQueries extends BaseLatLonPointTestCase {
     Point[] points = (Point[]) o;
     Field[] fields = new Field[points.length];
     for (int i = 0; i < points.length; i++) {
-      fields[i] = new LatLonPoint(FIELD_NAME, points[i].getLat(), points[i].getLon());
+      fields[i] = new LatLonField(FIELD_NAME, points[i].getLat(), points[i].getLon());
     }
     return fields;
+  }
+
+  @Override
+  public Query newGeometryQuery(
+      String field, QueryRelation queryRelation, LatLonGeometry... geometries) {
+    return LatLonField.newGeometryQuery(field, queryRelation, geometries);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/document/TestLatLonFieldPointQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLatLonFieldPointQueries.java
@@ -26,7 +26,7 @@ import org.apache.lucene.search.Query;
  * random bounding box, line, and polygon query tests for random indexed arrays of {@code latitude,
  * longitude} points
  */
-public class TestLatLonPointPointQueries extends BaseLatLonPointTestCase {
+public class TestLatLonFieldPointQueries extends BaseLatLonPointTestCase {
 
   @Override
   protected ShapeType getShapeType() {
@@ -41,13 +41,13 @@ public class TestLatLonPointPointQueries extends BaseLatLonPointTestCase {
   @Override
   protected Field[] createIndexableFields(String name, Object o) {
     Point point = (Point) o;
-    return new Field[] {new LatLonPoint(FIELD_NAME, point.getLat(), point.getLon())};
+    return new Field[] {new LatLonField(FIELD_NAME, point.getLat(), point.getLon())};
   }
 
   @Override
   public Query newGeometryQuery(
       String field, QueryRelation queryRelation, LatLonGeometry... geometries) {
-    return LatLonPoint.newGeometryQuery(field, queryRelation, geometries);
+    return LatLonField.newGeometryQuery(field, queryRelation, geometries);
   }
 
   protected static class PointValidator extends Validator {

--- a/lucene/core/src/test/org/apache/lucene/search/TestLatLonFieldNearest.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLatLonFieldNearest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LatLonField;
+
+public class TestLatLonFieldNearest extends BaseLatLonNearestTestCase {
+
+  @Override
+  protected Field getField(String name, double lat, double lon) {
+    return new LatLonField(name, lat, lon);
+  }
+
+  @Override
+  protected TopFieldDocs nearest(IndexSearcher searcher, String name, double lat, double lon, int n)
+      throws IOException {
+    return LatLonField.nearest(searcher, name, lat, lon, n);
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestLatLonFieldQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLatLonFieldQueries.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.LatLonField;
+import org.apache.lucene.document.ShapeField;
+import org.apache.lucene.geo.Circle;
+import org.apache.lucene.geo.GeoEncodingUtils;
+import org.apache.lucene.geo.LatLonGeometry;
+import org.apache.lucene.geo.Polygon;
+import org.apache.lucene.geo.Rectangle;
+import org.apache.lucene.tests.geo.BaseGeoPointTestCase;
+
+public class TestLatLonFieldQueries extends BaseGeoPointTestCase {
+
+  @Override
+  protected void addPointToDoc(String field, Document doc, double lat, double lon) {
+    doc.add(new LatLonField(field, lat, lon));
+  }
+
+  @Override
+  protected Query newRectQuery(
+      String field, double minLat, double maxLat, double minLon, double maxLon) {
+    return newGeometryQuery(field, new Rectangle(minLat, maxLat, minLon, maxLon));
+  }
+
+  @Override
+  protected Query newDistanceQuery(
+      String field, double centerLat, double centerLon, double radiusMeters) {
+    return newGeometryQuery(field, new Circle(centerLat, centerLon, radiusMeters));
+  }
+
+  @Override
+  protected Query newPolygonQuery(String field, Polygon... polygons) {
+    return newGeometryQuery(field, polygons);
+  }
+
+  @Override
+  protected Query newGeometryQuery(String field, LatLonGeometry... geometry) {
+    return LatLonField.newGeometryQuery(field, ShapeField.QueryRelation.INTERSECTS, geometry);
+  }
+
+  @Override
+  protected double quantizeLat(double latRaw) {
+    return GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(latRaw));
+  }
+
+  @Override
+  protected double quantizeLon(double lonRaw) {
+    return GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(lonRaw));
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestLatLonPointNearest.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLatLonPointNearest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LatLonPoint;
+
+public class TestLatLonPointNearest extends BaseLatLonNearestTestCase {
+
+  @Override
+  protected Field getField(String name, double lat, double lon) {
+    return new LatLonPoint(name, lat, lon);
+  }
+
+  @Override
+  protected TopFieldDocs nearest(IndexSearcher searcher, String name, double lat, double lon, int n)
+      throws IOException {
+    return LatLonPoint.nearest(searcher, name, lat, lon, n);
+  }
+}


### PR DESCRIPTION
Add new field that index both LatLonPoint and LatLonDocValues and provides factory methods for the operations that can be performed. Those are:

```
Query newGeometryQuery(String field, ShapeField.QueryRelation queryRelation, LatLonGeometry... latLonGeometries);

Query newDistanceFeatureQuery(String field, float weight, double originLat, double originLon, double pivotDistanceMeters) ;

TopFieldDocs nearest( IndexSearcher searcher, String field, double latitude, double longitude, int n);

SortField newDistanceSort(String field, double latitude, double longitude) ;
```


closes https://github.com/apache/lucene/issues/12161