### PR TITLE
Ensure caching all leaves from the upper tier (#12147)

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestUsageTrackingFilterCachingPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestUsageTrackingFilterCachingPolicy.java
@@ -75,11 +75,7 @@ public class TestUsageTrackingFilterCachingPolicy extends LuceneTestCase {
     IndexSearcher searcher = new IndexSearcher(reader);
     UsageTrackingQueryCachingPolicy policy = new UsageTrackingQueryCachingPolicy();
     LRUQueryCache cache =
-        new LRUQueryCache(
-            10,
-            Long.MAX_VALUE,
-            new LRUQueryCache.MinSegmentSizePredicate(1, 0f),
-            Float.POSITIVE_INFINITY);
+        new LRUQueryCache(10, Long.MAX_VALUE, ctx -> true, Float.POSITIVE_INFINITY);
     searcher.setQueryCache(cache);
     searcher.setQueryCachingPolicy(policy);
 


### PR DESCRIPTION
Backport of #12147 to 9_5

This change adjusts the cache policy to ensure that all segments in the  max tier to be cached. Before, we cache segments that have more than 3% of the total documents in the index; now cache segments have more than half of the average documents per leave of the index.

Closes #12140
