### PR TITLE
Deprecate TermInSetQuery#getTermData

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -112,7 +112,7 @@ API Changes
 * GITHUB#12129: Move DocValuesTermsQuery from sandbox to SortedDocValuesField#newSlowSetQuery
   and SortedSetDocValuesField#newSlowSetQuery. (Robert Muir)
 
-* GITHUB#xxx: TermInSetQuery#getTermData has been deprecated. This exposes internal implementation details that we
+* GITHUB#12173: TermInSetQuery#getTermData has been deprecated. This exposes internal implementation details that we
   may want to change in the future, and users shouldn't rely on the encoding directly. (Greg Miller)
 
 New Features

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -112,6 +112,9 @@ API Changes
 * GITHUB#12129: Move DocValuesTermsQuery from sandbox to SortedDocValuesField#newSlowSetQuery
   and SortedSetDocValuesField#newSlowSetQuery. (Robert Muir)
 
+* GITHUB#xxx: TermInSetQuery#getTermData has been deprecated. This exposes internal implementation details that we
+  may want to change in the future, and users shouldn't rely on the encoding directly. (Greg Miller)
+
 New Features
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -168,7 +168,13 @@ public class TermInSetQuery extends Query implements Accountable {
     return 31 * classHash() + termDataHashCode;
   }
 
-  /** Returns the terms wrapped in a PrefixCodedTerms. */
+  /**
+   * Returns the terms wrapped in a PrefixCodedTerms.
+   *
+   * @deprecated the encoded terms will no longer be exposed in a future major version; this is an
+   *     implementation detail that could change at some point and shouldn't be relied on directly
+   */
+  @Deprecated
   public PrefixCodedTerms getTermData() {
     return termData;
   }


### PR DESCRIPTION
### Description

`TermInSetQuery#getTermData` is effectively leaking our internal encoding of the query terms, which will prevent us from changing this in the future if we want to. Nothing in our code relies on this right now, and I think we ought to remove it. If users really need to get the terms, they can keep track of them (they provide them in the first place) in whatever encoding they like. If there's really a need to go beyond this, we could expose some sort of `Iterator<BytesRef>` method. But let's stop exposing the `PrefixCodedTerms` instance directly.

**Note**: I will remove the method completely on `main` but mark deprecated on `9x` as this PR demonstrates.
