### PR TITLE
Ensure refreshed reader has the latest index commit generation

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -495,7 +495,8 @@ public class IndexWriter
    *     instance
    * @throws IOException If there is a low-level I/O error
    */
-  DirectoryReader getReader(boolean applyAllDeletes, boolean writeAllDeletes) throws IOException {
+  StandardDirectoryReader getReader(boolean applyAllDeletes, boolean writeAllDeletes)
+      throws IOException {
     ensureOpen();
 
     if (writeAllDeletes && applyAllDeletes == false) {
@@ -5661,7 +5662,8 @@ public class IndexWriter
   synchronized boolean nrtIsCurrent(SegmentInfos infos) {
     ensureOpen();
     boolean isCurrent =
-        infos.getVersion() == segmentInfos.getVersion()
+        infos.getGeneration() == segmentInfos.getGeneration()
+            && infos.getVersion() == segmentInfos.getVersion()
             && docWriter.anyChanges() == false
             && bufferedUpdatesStream.any() == false
             && readerPool.anyDocValuesChanges() == false;

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -378,10 +378,11 @@ public final class StandardDirectoryReader extends DirectoryReader {
       return null;
     }
 
-    DirectoryReader reader = writer.getReader(applyAllDeletes, writeAllDeletes);
+    StandardDirectoryReader reader = writer.getReader(applyAllDeletes, writeAllDeletes);
 
     // If in fact no changes took place, return null:
-    if (reader.getVersion() == segmentInfos.getVersion()) {
+    if (reader.segmentInfos.getVersion() == segmentInfos.getVersion()
+        && reader.segmentInfos.getGeneration() == segmentInfos.getGeneration()) {
       reader.decRef();
       return null;
     }


### PR DESCRIPTION
If a refresh occurs while a flush is in progress (after all DWPT instances are flushed), the generation of the reader can become stuck with the generation of the previous index commit. 