### PR TITLE
Better PostingsEnum reuse in MultiTermQueryConstantScoreBlendedWrapper

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -151,6 +151,8 @@ Optimizations
 
 * GITHUB#12139: Faster indexing of string fields. (Adrien Grand)
 
+* GITHUB#xxx: Better PostingsEnum reuse in MultiTermQueryConstantScoreBlendedWrapper. (Greg Miller)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -151,7 +151,7 @@ Optimizations
 
 * GITHUB#12139: Faster indexing of string fields. (Adrien Grand)
 
-* GITHUB#xxx: Better PostingsEnum reuse in MultiTermQueryConstantScoreBlendedWrapper. (Greg Miller)
+* GITHUB#12179: Better PostingsEnum reuse in MultiTermQueryConstantScoreBlendedWrapper. (Greg Miller)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreBlendedWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQueryConstantScoreBlendedWrapper.java
@@ -64,21 +64,22 @@ final class MultiTermQueryConstantScoreBlendedWrapper<Q extends MultiTermQuery>
             };
 
         // Handle the already-collected terms:
+        PostingsEnum reuse = null;
         if (collectedTerms.isEmpty() == false) {
           TermsEnum termsEnum2 = terms.iterator();
           for (TermAndState t : collectedTerms) {
             termsEnum2.seekExact(t.term, t.state);
-            PostingsEnum postings = termsEnum2.postings(null, PostingsEnum.NONE);
+            reuse = termsEnum2.postings(reuse, PostingsEnum.NONE);
             if (t.docFreq <= POSTINGS_PRE_PROCESS_THRESHOLD) {
-              otherTerms.add(postings);
+              otherTerms.add(reuse);
             } else {
-              highFrequencyTerms.add(postings);
+              highFrequencyTerms.add(reuse);
+              reuse = null; // can't reuse since we haven't processed the postings
             }
           }
         }
 
         // Then collect remaining terms:
-        PostingsEnum reuse = null;
         do {
           reuse = termsEnum.postings(reuse, PostingsEnum.NONE);
           // If a term contains all docs with a value for the specified field, we can discard the


### PR DESCRIPTION
### Description

We can be a bit better about PostingsEnum reuse when backfilling collected terms (i.e., reuse the same postings if we consume them into the bitset).