### PR TITLE
Increase KnnByteVectorField limit on dimensions to 2048

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/FieldType.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FieldType.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.lucene.analysis.Analyzer; // javadocs
 import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.index.PointValues;
@@ -377,13 +376,6 @@ public class FieldType implements IndexableFieldType {
     checkIfFrozen();
     if (numDimensions <= 0) {
       throw new IllegalArgumentException("vector numDimensions must be > 0; got " + numDimensions);
-    }
-    if (numDimensions > FloatVectorValues.MAX_DIMENSIONS) {
-      throw new IllegalArgumentException(
-          "vector numDimensions must be <= FloatVectorValues.MAX_DIMENSIONS (="
-              + FloatVectorValues.MAX_DIMENSIONS
-              + "); got "
-              + numDimensions);
     }
     this.vectorDimension = numDimensions;
     this.vectorSimilarityFunction = Objects.requireNonNull(similarity);

--- a/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
@@ -45,6 +45,10 @@ public class KnnByteVectorField extends Field {
     if (dimension == 0) {
       throw new IllegalArgumentException("cannot index an empty vector");
     }
+    return createType(dimension, similarityFunction);
+  }
+
+  private static FieldType createType(int dimension, VectorSimilarityFunction similarityFunction) {
     if (dimension > ByteVectorValues.MAX_DIMENSIONS) {
       throw new IllegalArgumentException(
           "cannot index vectors with dimension greater than " + ByteVectorValues.MAX_DIMENSIONS);
@@ -79,10 +83,7 @@ public class KnnByteVectorField extends Field {
    */
   public static FieldType createFieldType(
       int dimension, VectorSimilarityFunction similarityFunction) {
-    FieldType type = new FieldType();
-    type.setVectorAttributes(dimension, VectorEncoding.BYTE, similarityFunction);
-    type.freeze();
-    return type;
+    return createType(dimension, similarityFunction);
   }
 
   /**
@@ -135,6 +136,10 @@ public class KnnByteVectorField extends Field {
               + name
               + " using byte[] but the field encoding is "
               + fieldType.vectorEncoding());
+    }
+    if (fieldType.vectorDimension() > ByteVectorValues.MAX_DIMENSIONS) {
+      throw new IllegalArgumentException(
+          "cannot index vectors with dimension greater than " + ByteVectorValues.MAX_DIMENSIONS);
     }
     fieldsData = vector;
   }

--- a/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
@@ -46,6 +46,10 @@ public class KnnFloatVectorField extends Field {
     if (dimension == 0) {
       throw new IllegalArgumentException("cannot index an empty vector");
     }
+    return createType(dimension, similarityFunction);
+  }
+
+  private static FieldType createType(int dimension, VectorSimilarityFunction similarityFunction) {
     if (dimension > FloatVectorValues.MAX_DIMENSIONS) {
       throw new IllegalArgumentException(
           "cannot index vectors with dimension greater than " + FloatVectorValues.MAX_DIMENSIONS);
@@ -68,10 +72,7 @@ public class KnnFloatVectorField extends Field {
    */
   public static FieldType createFieldType(
       int dimension, VectorSimilarityFunction similarityFunction) {
-    FieldType type = new FieldType();
-    type.setVectorAttributes(dimension, VectorEncoding.FLOAT32, similarityFunction);
-    type.freeze();
-    return type;
+    return createType(dimension, similarityFunction);
   }
 
   /**
@@ -136,6 +137,10 @@ public class KnnFloatVectorField extends Field {
               + name
               + " using float[] but the field encoding is "
               + fieldType.vectorEncoding());
+    }
+    if (fieldType.vectorDimension() > FloatVectorValues.MAX_DIMENSIONS) {
+      throw new IllegalArgumentException(
+          "cannot index vectors with dimension greater than " + FloatVectorValues.MAX_DIMENSIONS);
     }
     fieldsData = vector;
   }

--- a/lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java
@@ -29,7 +29,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 public abstract class ByteVectorValues extends DocIdSetIterator {
 
   /** The maximum length of a vector */
-  public static final int MAX_DIMENSIONS = 1024;
+  public static final int MAX_DIMENSIONS = 2048;
 
   /** Sole constructor */
   protected ByteVectorValues() {}

--- a/lucene/core/src/test/org/apache/lucene/document/TestField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestField.java
@@ -18,6 +18,7 @@ package org.apache.lucene.document;
 
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import org.apache.lucene.codecs.Codec;
@@ -687,6 +688,55 @@ public class TestField extends LuceneTestCase {
     r.close();
     w.close();
     dir.close();
+  }
+
+  public void testKnnVectorFieldLimits() {
+    if (Codec.getDefault().getName().equals("SimpleText")) {
+      return;
+    }
+    new KnnFloatVectorField(
+        RandomizedTest.randomAsciiLettersOfLength(10), new float[FloatVectorValues.MAX_DIMENSIONS]);
+    expectThrows(
+        IllegalArgumentException.class,
+        () ->
+            new KnnFloatVectorField(
+                "bogus",
+                new float
+                    [FloatVectorValues.MAX_DIMENSIONS
+                        + 1
+                        + random().nextInt(FloatVectorValues.MAX_DIMENSIONS)]));
+    expectThrows(
+        IllegalArgumentException.class,
+        () ->
+            new KnnFloatVectorField(
+                "bogus",
+                new float
+                    [FloatVectorValues.MAX_DIMENSIONS
+                        + 1
+                        + random().nextInt(FloatVectorValues.MAX_DIMENSIONS)],
+                RandomizedTest.randomFrom(VectorSimilarityFunction.values())));
+    // Should not throw
+    new KnnByteVectorField(
+        RandomizedTest.randomAsciiLettersOfLength(10), new byte[ByteVectorValues.MAX_DIMENSIONS]);
+    expectThrows(
+        IllegalArgumentException.class,
+        () ->
+            new KnnByteVectorField(
+                "bogus",
+                new byte
+                    [ByteVectorValues.MAX_DIMENSIONS
+                        + 1
+                        + random().nextInt(ByteVectorValues.MAX_DIMENSIONS)]));
+    expectThrows(
+        IllegalArgumentException.class,
+        () ->
+            new KnnByteVectorField(
+                "bogus",
+                new byte
+                    [ByteVectorValues.MAX_DIMENSIONS
+                        + 1
+                        + random().nextInt(ByteVectorValues.MAX_DIMENSIONS)],
+                RandomizedTest.randomFrom(VectorSimilarityFunction.values())));
   }
 
   public void testKnnVectorField() throws Exception {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
@@ -29,6 +29,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
@@ -352,10 +353,15 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     }
 
     if (r.nextBoolean()) {
-      int dimension = 1 + r.nextInt(FloatVectorValues.MAX_DIMENSIONS);
+      VectorEncoding encoding = RandomPicks.randomFrom(r, VectorEncoding.values());
+      int dimension =
+          1
+              + r.nextInt(
+                  encoding == VectorEncoding.BYTE
+                      ? ByteVectorValues.MAX_DIMENSIONS
+                      : FloatVectorValues.MAX_DIMENSIONS);
       VectorSimilarityFunction similarityFunction =
           RandomPicks.randomFrom(r, VectorSimilarityFunction.values());
-      VectorEncoding encoding = RandomPicks.randomFrom(r, VectorEncoding.values());
       type.setVectorAttributes(dimension, encoding, similarityFunction);
     }
 


### PR DESCRIPTION
This increases the vector size limit only for ByteVectors only.

Byte vectors use much less memory than float (less than half required to store float vectors). Additionally, dot-products between two byte vectors are faster than between two float vectors (about 1.5x faster).

Here are some micro-benchmark (the dot-product methods used were the same from the `VectorSimilarity` class):

```
VectorMultiplicationBenchmark.byteDotProducts                          64  avgt    7   119207.749 ±    87.092  ns/op
VectorMultiplicationBenchmark.byteDotProducts                        1024  avgt    7  1615737.126 ±   955.261  ns/op
VectorMultiplicationBenchmark.byteDotProducts                        2048  avgt    7  3283335.169 ±  1624.888  ns/op
VectorMultiplicationBenchmark.floatDotProductsUnwrapped                64  avgt    7   197209.288 ±   191.285  ns/op
VectorMultiplicationBenchmark.floatDotProductsUnwrapped              1024  avgt    7  2844926.617 ± 10232.337  ns/op
VectorMultiplicationBenchmark.floatDotProductsUnwrapped              2048  avgt    7  5544835.569 ±  2476.568  ns/op
```

Consequently, it makes sense to me to allow larger vectors for `byte` vectors, but still enforce the current limitation for float. Thus ensuring that callers with larger vectors will:

 - Have to quantize their input
 - Do dimensionality reduction
 - Some combination of both

At least until we can get hardware accelerated vector multiplication (on its 5th!!!!!! incubator at the time of this PR): https://openjdk.org/jeps/438

This PR is a continuation of various other previous work and discussion: 

 - https://github.com/apache/lucene/pull/874
 - https://github.com/apache/lucene/issues/11507