### PR TITLE
Fixup TestLongValueFacetCounts after GITHUB#11744.

### DIFF
--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -394,7 +394,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (random().nextBoolean()) {
         topN = docCount;
       } else {
-        topN = random().nextInt(docCount);
+        topN = random().nextInt(1, docCount);
       }
       if (VERBOSE) {
         System.out.println("  topN=" + topN);
@@ -486,7 +486,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (random().nextBoolean()) {
         topN = docCount;
       } else {
-        topN = random().nextInt(docCount);
+        topN = random().nextInt(1, docCount);
       }
       actual = facetCounts.getTopChildren(topN, "field");
       assertSame(
@@ -657,7 +657,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (random().nextBoolean()) {
         topN = docCount;
       } else {
-        topN = random().nextInt(docCount);
+        topN = random().nextInt(1, docCount);
       }
       if (VERBOSE) {
         System.out.println("  topN=" + topN);
@@ -727,7 +727,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (random().nextBoolean()) {
         topN = docCount;
       } else {
-        topN = random().nextInt(docCount);
+        topN = random().nextInt(1, docCount);
       }
       actual = facetCounts.getTopChildren(topN, "field");
       assertSame(


### PR DESCRIPTION
GH#11744 deprecated LongValueFacetCounts#getTopChildrenSortByCount in favor of the standard Facets#getTopChildren. The issue is that #getTopChildrenSortByCount didn't do any input validation and allowed for topN == 0, while #getTopChildren does input validation. Randomized testing could produce topN values of 0, which resulted in falied tests. This addresses the tests.
