### PR TITLE
Fix Slop Issue in MultiFieldQueryParser

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -162,6 +162,8 @@ Bug Fixes
 
 * GITHUB#12158: KeywordField#newSetQuery should clone input BytesRef[] to avoid modifying provided array. (Greg Miller)
 
+* GITHUB#12196: Fix MultiFieldQueryParser to handle both query boost and phrase slop at the same time.  (Jasir KT)
+
 Build
 ---------------------
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
@@ -124,6 +124,10 @@ public class MultiFieldQueryParser extends QueryParser {
       if (slop != mpq.getSlop()) {
         q = new MultiPhraseQuery.Builder(mpq).setSlop(slop).build();
       }
+    } else if (q instanceof BoostQuery boostQuery) {
+      Query subQuery = boostQuery.getQuery();
+      subQuery = applySlop(subQuery, slop);
+      q = new BoostQuery(subQuery, boostQuery.getBoost());
     }
     return q;
   }

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParser.java
@@ -159,7 +159,7 @@ public class TestMultiFieldQueryParser extends LuceneTestCase {
     // Check boost with slop
     // See https://github.com/apache/lucene/issues/12195
     q = mfqp.parse("\"one two\"~2");
-    assertEquals("(b:\"one two\"~2)^5.0 (t:\"one two\"~2)^10.0" , q.toString());
+    assertEquals("(b:\"one two\"~2)^5.0 (t:\"one two\"~2)^10.0", q.toString());
 
     q = mfqp.parse("one^3 AND two^4");
     assertEquals("+((b:one)^5.0 (t:one)^10.0)^3.0 +((b:two)^5.0 (t:two)^10.0)^4.0", q.toString());

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParser.java
@@ -156,6 +156,11 @@ public class TestMultiFieldQueryParser extends LuceneTestCase {
     q = mfqp.parse("one AND two AND foo:test");
     assertEquals("+((b:one)^5.0 (t:one)^10.0) +((b:two)^5.0 (t:two)^10.0) +foo:test", q.toString());
 
+    // Check boost with slop
+    // See https://github.com/apache/lucene/issues/12195
+    q = mfqp.parse("\"one two\"~2");
+    assertEquals("(b:\"one two\"~2)^5.0 (t:\"one two\"~2)^10.0" , q.toString());
+
     q = mfqp.parse("one^3 AND two^4");
     assertEquals("+((b:one)^5.0 (t:one)^10.0)^3.0 +((b:two)^5.0 (t:two)^10.0)^4.0", q.toString());
   }


### PR DESCRIPTION
### Description

This change fixes #12195.

In Lucene 5.4.0 [this commit](https://github.com/apache/lucene/commit/962313b83ba9c69379e1f84dffc881a361713ce9#diff-e10af886a9a7ba5221abfcfbe9dc057d2cee39d3b875e0eb2843085979ecdf5e) introduced some changes for immutability of queries. setBoost() function was replaced with new BoostQuery(), but BoostQuery is not handled in setSlop function. This pull request adds the handling of BoostQuery in setSlop() function
