### PR TITLE
Reduce contention in DocumentsWriterFlushControl.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -157,6 +157,8 @@ Optimizations
 
 * GITHUB#12179: Better PostingsEnum reuse in MultiTermQueryConstantScoreBlendedWrapper. (Greg Miller)
 
+* GITHUB#12198: Reduced contention when indexing with many threads. (Adrien Grand)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
@@ -435,8 +435,7 @@ final class DocumentsWriter implements Closeable, Accountable {
           flushControl.doOnAbort(dwpt);
         }
       }
-      final boolean isUpdate = delNode != null && delNode.isDelete();
-      flushingDWPT = flushControl.doAfterDocument(dwpt, isUpdate);
+      flushingDWPT = flushControl.doAfterDocument(dwpt);
     } finally {
       if (dwpt.isFlushPending() || dwpt.isAborted()) {
         dwpt.unlock();

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -185,8 +185,12 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     return true;
   }
 
-  DocumentsWriterPerThread doAfterDocument(DocumentsWriterPerThread perThread, boolean isUpdate) {
+  DocumentsWriterPerThread doAfterDocument(DocumentsWriterPerThread perThread) {
     final long delta = perThread.getCommitLastBytesUsedDelta();
+    if (flushPolicy.flushOnDocCount() == false && delta < flushPolicy.flushOnRAMGranularity()) {
+      // Skip accounting for now, we'll come back to it later when the delta is bigger
+      return null;
+    }
     synchronized (this) {
       // we need to commit this under lock but calculate it outside of the lock to minimize the time
       // this lock is held
@@ -208,11 +212,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
         } else {
           activeBytes += delta;
           assert updatePeaks(delta);
-          if (isUpdate) {
-            flushPolicy.onUpdate(this, perThread);
-          } else {
-            flushPolicy.onInsert(this, perThread);
-          }
+          flushPolicy.onChange(this, perThread);
           if (!perThread.isFlushPending() && perThread.ramBytesUsed() > hardMaxBytesPerDWPT) {
             // Safety check to prevent a single DWPT exceeding its RAM limit. This
             // is super important since we can not address more than 2048 MB per DWPT
@@ -462,7 +462,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
 
   synchronized void doOnDelete() {
     // pass null this is a global delete no update
-    flushPolicy.onDelete(this, null);
+    flushPolicy.onChange(this, null);
   }
 
   /**
@@ -724,7 +724,9 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
 
   synchronized DocumentsWriterPerThread findLargestNonPendingWriter() {
     DocumentsWriterPerThread maxRamUsingWriter = null;
-    long maxRamSoFar = 0;
+    // Note: should be initialized to -1 since some DWPTs might return 0 if their RAM usage has not
+    // been committed yet.
+    long maxRamSoFar = -1;
     int count = 0;
     for (DocumentsWriterPerThread next : perThreadPool) {
       if (next.isFlushPending() == false && next.getNumDocsInRAM() > 0) {

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -187,6 +187,8 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
 
   DocumentsWriterPerThread doAfterDocument(DocumentsWriterPerThread perThread) {
     final long delta = perThread.getCommitLastBytesUsedDelta();
+    // in order to prevent contention in the case of many threads indexing small documents 
+    // we skip ram accounting unless the DWPT accumulated enough ram to be worthwhile
     if (flushPolicy.flushOnDocCount() == false && delta < flushPolicy.flushOnRAMGranularity()) {
       // Skip accounting for now, we'll come back to it later when the delta is bigger
       return null;

--- a/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
@@ -89,23 +89,12 @@ class FlushByRamOrCountsPolicy extends FlushPolicy {
     }
   }
 
-  @Override
-  public boolean flushOnDocCount() {
+  /**
+   * Returns <code>true</code> if this {@link FlushPolicy} flushes on {@link
+   * IndexWriterConfig#getMaxBufferedDocs()}, otherwise <code>false</code>.
+   */
+  protected boolean flushOnDocCount() {
     return indexWriterConfig.getMaxBufferedDocs() != IndexWriterConfig.DISABLE_AUTO_FLUSH;
-  }
-
-  @Override
-  public long flushOnRAMGranularity() {
-    double ramBufferSizeMB = indexWriterConfig.getRAMBufferSizeMB();
-    if (ramBufferSizeMB == IndexWriterConfig.DISABLE_AUTO_FLUSH) {
-      ramBufferSizeMB = indexWriterConfig.getRAMPerThreadHardLimitMB();
-    }
-    // No more than ~0.1% of the RAM buffer size.
-    long granularity = (long) (ramBufferSizeMB * 1024.d);
-    // Or 16kB, so that with e.g. 64 active DWPTs, we'd never be missing more than 64*16kB = 1MB in
-    // the global RAM buffer accounting.
-    granularity = Math.min(granularity, 16 * 1024L);
-    return granularity;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
@@ -21,22 +21,8 @@ package org.apache.lucene.index;
  * document count depending on the IndexWriter's {@link IndexWriterConfig}. It also applies pending
  * deletes based on the number of buffered delete terms.
  *
- * <ul>
- *   <li>{@link #onDelete(DocumentsWriterFlushControl, DocumentsWriterPerThread)} - applies pending
- *       delete operations based on the global number of buffered delete terms if the consumed
- *       memory is greater than {@link IndexWriterConfig#getRAMBufferSizeMB()}.
- *   <li>{@link #onInsert(DocumentsWriterFlushControl, DocumentsWriterPerThread)} - flushes either
- *       on the number of documents per {@link DocumentsWriterPerThread} ( {@link
- *       DocumentsWriterPerThread#getNumDocsInRAM()}) or on the global active memory consumption in
- *       the current indexing session iff {@link IndexWriterConfig#getMaxBufferedDocs()} or {@link
- *       IndexWriterConfig#getRAMBufferSizeMB()} is enabled respectively
- *   <li>{@link #onUpdate(DocumentsWriterFlushControl, DocumentsWriterPerThread)} - calls {@link
- *       #onInsert(DocumentsWriterFlushControl, DocumentsWriterPerThread)} and {@link
- *       #onDelete(DocumentsWriterFlushControl, DocumentsWriterPerThread)} in order
- * </ul>
- *
- * All {@link IndexWriterConfig} settings are used to mark {@link DocumentsWriterPerThread} as flush
- * pending during indexing with respect to their live updates.
+ * <p>All {@link IndexWriterConfig} settings are used to mark {@link DocumentsWriterPerThread} as
+ * flush pending during indexing with respect to their live updates.
  *
  * <p>If {@link IndexWriterConfig#setRAMBufferSizeMB(double)} is enabled, the largest ram consuming
  * {@link DocumentsWriterPerThread} will be marked as pending iff the global active RAM consumption
@@ -45,44 +31,52 @@ package org.apache.lucene.index;
 class FlushByRamOrCountsPolicy extends FlushPolicy {
 
   @Override
-  public void onDelete(DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread) {
-    if ((flushOnRAM()
-        && control.getDeleteBytesUsed() > 1024 * 1024 * indexWriterConfig.getRAMBufferSizeMB())) {
-      control.setApplyAllDeletes();
-      if (infoStream.isEnabled("FP")) {
-        infoStream.message(
-            "FP",
-            "force apply deletes bytesUsed="
-                + control.getDeleteBytesUsed()
-                + " vs ramBufferMB="
-                + indexWriterConfig.getRAMBufferSizeMB());
-      }
-    }
-  }
-
-  @Override
-  public void onInsert(DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread) {
-    if (flushOnDocCount()
+  public void onChange(DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread) {
+    if (perThread != null
+        && flushOnDocCount()
         && perThread.getNumDocsInRAM() >= indexWriterConfig.getMaxBufferedDocs()) {
       // Flush this state by num docs
       control.setFlushPending(perThread);
     } else if (flushOnRAM()) { // flush by RAM
       final long limit = (long) (indexWriterConfig.getRAMBufferSizeMB() * 1024.d * 1024.d);
-      final long totalRam = control.activeBytes() + control.getDeleteBytesUsed();
-      if (totalRam >= limit) {
-        if (infoStream.isEnabled("FP")) {
-          infoStream.message(
-              "FP",
-              "trigger flush: activeBytes="
-                  + control.activeBytes()
-                  + " deleteBytes="
-                  + control.getDeleteBytesUsed()
-                  + " vs limit="
-                  + limit);
-        }
-        markLargestWriterPending(control, perThread);
+      final long activeRam = control.activeBytes();
+      final long deletesRam = control.getDeleteBytesUsed();
+      if (deletesRam >= limit && activeRam >= limit && perThread != null) {
+        flushDeletes(control);
+        flushActiveBytes(control, perThread);
+      } else if (deletesRam >= limit) {
+        flushDeletes(control);
+      } else if (activeRam + deletesRam >= limit && perThread != null) {
+        flushActiveBytes(control, perThread);
       }
     }
+  }
+
+  private void flushDeletes(DocumentsWriterFlushControl control) {
+    control.setApplyAllDeletes();
+    if (infoStream.isEnabled("FP")) {
+      infoStream.message(
+          "FP",
+          "force apply deletes bytesUsed="
+              + control.getDeleteBytesUsed()
+              + " vs ramBufferMB="
+              + indexWriterConfig.getRAMBufferSizeMB());
+    }
+  }
+
+  private void flushActiveBytes(
+      DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread) {
+    if (infoStream.isEnabled("FP")) {
+      infoStream.message(
+          "FP",
+          "trigger flush: activeBytes="
+              + control.activeBytes()
+              + " deleteBytes="
+              + control.getDeleteBytesUsed()
+              + " vs ramBufferMB="
+              + indexWriterConfig.getRAMBufferSizeMB());
+    }
+    markLargestWriterPending(control, perThread);
   }
 
   /** Marks the most ram consuming active {@link DocumentsWriterPerThread} flush pending */
@@ -95,12 +89,21 @@ class FlushByRamOrCountsPolicy extends FlushPolicy {
     }
   }
 
-  /**
-   * Returns <code>true</code> if this {@link FlushPolicy} flushes on {@link
-   * IndexWriterConfig#getMaxBufferedDocs()}, otherwise <code>false</code>.
-   */
-  protected boolean flushOnDocCount() {
+  @Override
+  public boolean flushOnDocCount() {
     return indexWriterConfig.getMaxBufferedDocs() != IndexWriterConfig.DISABLE_AUTO_FLUSH;
+  }
+
+  @Override
+  public long flushOnRAMGranularity() {
+    double ramBufferSizeMB = indexWriterConfig.getRAMBufferSizeMB();
+    if (ramBufferSizeMB == IndexWriterConfig.DISABLE_AUTO_FLUSH) {
+      ramBufferSizeMB = indexWriterConfig.getRAMPerThreadHardLimitMB();
+    }
+    // We use a granularity of RAMBufferSize/1024. This means that with 20 active DWPTs, we'd be
+    // missing at most 20/1024~=2% in the global RAM buffer accounting.
+    final long granularity = (long) (ramBufferSizeMB * 1024.d);
+    return granularity;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
@@ -100,9 +100,11 @@ class FlushByRamOrCountsPolicy extends FlushPolicy {
     if (ramBufferSizeMB == IndexWriterConfig.DISABLE_AUTO_FLUSH) {
       ramBufferSizeMB = indexWriterConfig.getRAMPerThreadHardLimitMB();
     }
-    // We use a granularity of RAMBufferSize/1024. This means that with 20 active DWPTs, we'd be
-    // missing at most 20/1024~=2% in the global RAM buffer accounting.
-    final long granularity = (long) (ramBufferSizeMB * 1024.d);
+    // No more than ~0.1% of the RAM buffer size.
+    long granularity = (long) (ramBufferSizeMB * 1024.d);
+    // Or 16kB, so that with e.g. 64 active DWPTs, we'd never be missing more than 64*16kB = 1MB in
+    // the global RAM buffer accounting.
+    granularity = Math.min(granularity, 16 * 1024L);
     return granularity;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FlushPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FlushPolicy.java
@@ -57,18 +57,6 @@ abstract class FlushPolicy {
   public abstract void onChange(
       DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread);
 
-  /**
-   * Returns {@code true} if this policy takes the document count as an input to decide whether to
-   * flush.
-   */
-  public abstract boolean flushOnDocCount();
-
-  /**
-   * Return the smallest number of bytes that we would like to make sure to not miss from the global
-   * RAM accounting.
-   */
-  public abstract long flushOnRAMGranularity();
-
   /** Called by DocumentsWriter to initialize the FlushPolicy */
   protected synchronized void init(LiveIndexWriterConfig indexWriterConfig) {
     this.indexWriterConfig = indexWriterConfig;

--- a/lucene/core/src/java/org/apache/lucene/index/FlushPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FlushPolicy.java
@@ -47,38 +47,27 @@ abstract class FlushPolicy {
   protected InfoStream infoStream;
 
   /**
-   * Called for each delete term. If this is a delete triggered due to an update the given {@link
-   * DocumentsWriterPerThread} is non-null.
+   * Called for each delete, insert or update. For pure deletes, the given {@link
+   * DocumentsWriterPerThread} may be {@code null}.
    *
    * <p>Note: This method is called synchronized on the given {@link DocumentsWriterFlushControl}
    * and it is guaranteed that the calling thread holds the lock on the given {@link
    * DocumentsWriterPerThread}
    */
-  public abstract void onDelete(
+  public abstract void onChange(
       DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread);
 
   /**
-   * Called for each document update on the given {@link DocumentsWriterPerThread}'s {@link
-   * DocumentsWriterPerThread}.
-   *
-   * <p>Note: This method is called synchronized on the given {@link DocumentsWriterFlushControl}
-   * and it is guaranteed that the calling thread holds the lock on the given {@link
-   * DocumentsWriterPerThread}
+   * Returns {@code true} if this policy takes the document count as an input to decide whether to
+   * flush.
    */
-  public void onUpdate(DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread) {
-    onInsert(control, perThread);
-    onDelete(control, perThread);
-  }
+  public abstract boolean flushOnDocCount();
 
   /**
-   * Called for each document addition on the given {@link DocumentsWriterPerThread}s {@link
-   * DocumentsWriterPerThread}.
-   *
-   * <p>Note: This method is synchronized by the given {@link DocumentsWriterFlushControl} and it is
-   * guaranteed that the calling thread holds the lock on the given {@link DocumentsWriterPerThread}
+   * Return the smallest number of bytes that we would like to make sure to not miss from the global
+   * RAM accounting.
    */
-  public abstract void onInsert(
-      DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread);
+  public abstract long flushOnRAMGranularity();
 
   /** Called by DocumentsWriter to initialize the FlushPolicy */
   protected synchronized void init(LiveIndexWriterConfig indexWriterConfig) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestFlushByRamOrCountsPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFlushByRamOrCountsPolicy.java
@@ -323,35 +323,7 @@ public class TestFlushByRamOrCountsPolicy extends LuceneTestCase {
     boolean hasMarkedPending = false;
 
     @Override
-    public void onDelete(DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread) {
-      final ArrayList<DocumentsWriterPerThread> pending = new ArrayList<>();
-      final ArrayList<DocumentsWriterPerThread> notPending = new ArrayList<>();
-      findPending(control, pending, notPending);
-      final boolean flushCurrent = perThread.isFlushPending();
-      final DocumentsWriterPerThread toFlush;
-      if (perThread.isFlushPending()) {
-        toFlush = perThread;
-      } else {
-        toFlush = null;
-      }
-      super.onDelete(control, perThread);
-      if (toFlush != null) {
-        if (flushCurrent) {
-          assertTrue(pending.remove(toFlush));
-        } else {
-          assertTrue(notPending.remove(toFlush));
-        }
-        assertTrue(toFlush.isFlushPending());
-        hasMarkedPending = true;
-      }
-
-      for (DocumentsWriterPerThread dwpt : notPending) {
-        assertFalse(dwpt.isFlushPending());
-      }
-    }
-
-    @Override
-    public void onInsert(DocumentsWriterFlushControl control, DocumentsWriterPerThread dwpt) {
+    public void onChange(DocumentsWriterFlushControl control, DocumentsWriterPerThread dwpt) {
       final ArrayList<DocumentsWriterPerThread> pending = new ArrayList<>();
       final ArrayList<DocumentsWriterPerThread> notPending = new ArrayList<>();
       findPending(control, pending, notPending);
@@ -370,7 +342,7 @@ public class TestFlushByRamOrCountsPolicy extends LuceneTestCase {
       } else {
         toFlush = null;
       }
-      super.onInsert(control, dwpt);
+      super.onChange(control, dwpt);
       if (toFlush != null) {
         if (flushCurrent) {
           assertTrue(pending.remove(toFlush));


### PR DESCRIPTION
lucene-util's `IndexGeoNames` benchmark is heavily contended when running with many indexing threads, 20 in my case. The main offender is `DocumentsWriterFlushControl#doAfterDocument`, which runs after every index operation to update doc and RAM accounting.

This change reduces contention by only updating RAM accounting if the amount of RAM consumption that has not been committed yet by a single DWPT is at least 0.1% of the total RAM buffer size or 16kB. This effectively batches updates to RAM accounting, similarly to what happens when using `IndexWriter#addDocuments` to index multiple documents at once. Since updates to RAM accounting may be batched, `FlushPolicy` can no longer distinguish between inserts, updates and deletes, so all 3 methods got merged into a single one.

With this change, `IndexGeoNames` goes from ~22s to ~19s and the main offender for contention is now `DocumentsWriterPerThreadPool#getAndLock`.
