### PR TITLE
Fix boost missing in MultiFieldQueryParser

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -170,6 +170,8 @@ Bug Fixes
 
 * GITHUB#12196: Fix MultiFieldQueryParser to handle both query boost and phrase slop at the same time.  (Jasir KT)
 
+* GITHUB#12202: Fix MultiFieldQueryParser to apply boosts to regexp, wildcard, prefix, range, fuzzy queries.  (Jasir KT)
+
 Build
 ---------------------
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
@@ -132,6 +132,16 @@ public class MultiFieldQueryParser extends QueryParser {
     return q;
   }
 
+  private Query applyBoost(Query q, String field) {
+    if (boosts != null) {
+      Float boost = boosts.get(field);
+      if (boost != null) {
+        q = new BoostQuery(q, boost);
+      }
+    }
+    return q;
+  }
+
   @Override
   protected Query getFieldQuery(String field, String queryText, boolean quoted)
       throws ParseException {
@@ -205,7 +215,8 @@ public class MultiFieldQueryParser extends QueryParser {
       }
       return getMultiFieldQuery(clauses);
     }
-    return super.getFuzzyQuery(field, termStr, minSimilarity);
+    Query q = super.getFuzzyQuery(field, termStr, minSimilarity);
+    return applyBoost(q, field);
   }
 
   @Override
@@ -217,7 +228,8 @@ public class MultiFieldQueryParser extends QueryParser {
       }
       return getMultiFieldQuery(clauses);
     }
-    return super.getPrefixQuery(field, termStr);
+    Query q = super.getPrefixQuery(field, termStr);
+    return applyBoost(q, field);
   }
 
   @Override
@@ -229,7 +241,8 @@ public class MultiFieldQueryParser extends QueryParser {
       }
       return getMultiFieldQuery(clauses);
     }
-    return super.getWildcardQuery(field, termStr);
+    Query q = super.getWildcardQuery(field, termStr);
+    return applyBoost(q, field);
   }
 
   @Override
@@ -243,7 +256,8 @@ public class MultiFieldQueryParser extends QueryParser {
       }
       return getMultiFieldQuery(clauses);
     }
-    return super.getRangeQuery(field, part1, part2, startInclusive, endInclusive);
+    Query q = super.getRangeQuery(field, part1, part2, startInclusive, endInclusive);
+    return applyBoost(q, field);
   }
 
   @Override
@@ -255,7 +269,8 @@ public class MultiFieldQueryParser extends QueryParser {
       }
       return getMultiFieldQuery(clauses);
     }
-    return super.getRegexpQuery(field, termStr);
+    Query q = super.getRegexpQuery(field, termStr);
+    return applyBoost(q, field);
   }
 
   /** Creates a multifield query */

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParser.java
@@ -161,6 +161,26 @@ public class TestMultiFieldQueryParser extends LuceneTestCase {
     q = mfqp.parse("\"one two\"~2");
     assertEquals("(b:\"one two\"~2)^5.0 (t:\"one two\"~2)^10.0", q.toString());
 
+    // check boost with fuzzy
+    q = mfqp.parse("one~");
+    assertEquals("(b:one~2)^5.0 (t:one~2)^10.0", q.toString());
+
+    // check boost with prefix
+    q = mfqp.parse("one*");
+    assertEquals("(b:one*)^5.0 (t:one*)^10.0", q.toString());
+
+    // check boost with wildcard
+    q = mfqp.parse("o?n*e");
+    assertEquals("(b:o?n*e)^5.0 (t:o?n*e)^10.0", q.toString());
+
+    // check boost with regex
+    q = mfqp.parse("/[a-z][123]/");
+    assertEquals("(b:/[a-z][123]/)^5.0 (t:/[a-z][123]/)^10.0", q.toString());
+
+    // check boost with range
+    q = mfqp.parse("[one TO two]");
+    assertEquals("(b:[one TO two])^5.0 (t:[one TO two])^10.0", q.toString());
+
     q = mfqp.parse("one^3 AND two^4");
     assertEquals("+((b:one)^5.0 (t:one)^10.0)^3.0 +((b:two)^5.0 (t:two)^10.0)^4.0", q.toString());
   }


### PR DESCRIPTION
### Description

This fixes #8966.

When using boost along with any of fuzzy, wildcard, regexp, range or prefix queries, the boost is not applied.