### PR TITLE
Remove remaining sources of contention on indexing.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -165,7 +165,8 @@ Optimizations
 
 * GITHUB#12179: Better PostingsEnum reuse in MultiTermQueryConstantScoreBlendedWrapper. (Greg Miller)
 
-* GITHUB#12198, GITHUB#12199: Reduced contention when indexing with many threads. (Adrien Grand)
+* GITHUB#12198, GITHUB#12199, GITHUB#12205: Reduced contention when indexing with many threads.
+  (Adrien Grand)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
@@ -168,7 +168,9 @@ final class DocumentsWriter implements Closeable, Accountable {
   private boolean applyAllDeletes() throws IOException {
     final DocumentsWriterDeleteQueue deleteQueue = this.deleteQueue;
 
-    if (flushControl.isFullFlush() == false
+    // Check getApplyAllDeletes first: it doesn't require taking a lock and is usually false.
+    if (flushControl.getApplyAllDeletes()
+        && flushControl.isFullFlush() == false
         // never apply deletes during full flush this breaks happens before relationship
         && deleteQueue.isOpen()
         // if it's closed then it's already fully applied and we have a new delete queue

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -449,7 +449,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
       final DocumentsWriterPerThread poll;
       assert numQueued == flushQueue.size() : "flush queue size: " + flushQueue.size() + ", cache size: " + numQueued;
       if ((poll = flushQueue.poll()) != null) {
-        numQueued = flushQueue.size();
+        numQueued--; // write acces synced
         updateStallState();
         return poll;
       }
@@ -622,7 +622,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
       assert assertBlockedFlushes(documentsWriter.deleteQueue);
       assert numQueued == flushQueue.size() : "flush queue size: " + flushQueue.size() + ", cache size: " + numQueued;
       flushQueue.addAll(fullFlushBuffer);
-      numQueued = flushQueue.size();
+      numQueued += fullFlushBuffer.size(); // write acces synced
       updateStallState();
       fullFlushMarkDone =
           true; // at this point we must have collected all DWPTs that belong to the old delete
@@ -654,7 +654,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
         // don't decr pending here - it's already done when DWPT is blocked
         assert numQueued == flushQueue.size() : "flush queue size: " + flushQueue.size() + ", cache size: " + numQueued;
         flushQueue.add(blockedFlush);
-        numQueued = flushQueue.size();
+        numQueued++; // write acces synced
       }
     }
   }
@@ -721,7 +721,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
       }
     } finally {
       flushQueue.clear();
-      numQueued = 0;
+      numQueued = 0; // write acces synced
       blockedFlushes.clear();
       updateStallState();
     }

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -44,7 +44,6 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
   private long activeBytes = 0;
   private volatile long flushBytes = 0;
   private volatile int numPending = 0;
-  private volatile int numQueued = 0;
   private int numDocsSinceStalled = 0; // only with assert
   private final AtomicBoolean flushDeletes = new AtomicBoolean(false);
   private boolean fullFlush = false;
@@ -438,8 +437,10 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
   }
 
   DocumentsWriterPerThread nextPendingFlush() {
-    if (numQueued == 0 && numPending == 0) {
-      // Common case, avoid taking a lock.
+    if (numPending == 0) {
+      // Nothing to do. This short circuit helps avoid taking the lock, which can otherwise cause
+      // contention. Note that pending flushes include queued flushes, so flushQueue is also empty
+      // here.
       return null;
     }
 
@@ -447,9 +448,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     boolean fullFlush;
     synchronized (this) {
       final DocumentsWriterPerThread poll;
-      assert numQueued == flushQueue.size() : "flush queue size: " + flushQueue.size() + ", cache size: " + numQueued;
       if ((poll = flushQueue.poll()) != null) {
-        numQueued = flushQueue.size();
         updateStallState();
         return poll;
       }
@@ -620,9 +619,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
        * blocking indexing.*/
       pruneBlockedQueue(flushingQueue);
       assert assertBlockedFlushes(documentsWriter.deleteQueue);
-      assert numQueued == flushQueue.size() : "flush queue size: " + flushQueue.size() + ", cache size: " + numQueued;
       flushQueue.addAll(fullFlushBuffer);
-      numQueued = flushQueue.size();
       updateStallState();
       fullFlushMarkDone =
           true; // at this point we must have collected all DWPTs that belong to the old delete
@@ -652,9 +649,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
         iterator.remove();
         addFlushingDWPT(blockedFlush);
         // don't decr pending here - it's already done when DWPT is blocked
-        assert numQueued == flushQueue.size() : "flush queue size: " + flushQueue.size() + ", cache size: " + numQueued;
         flushQueue.add(blockedFlush);
-        numQueued = flushQueue.size();
       }
     }
   }
@@ -721,7 +716,6 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
       }
     } finally {
       flushQueue.clear();
-      numQueued = 0;
       blockedFlushes.clear();
       updateStallState();
     }
@@ -734,7 +728,17 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
 
   /** Returns the number of flushes that are already checked out but not yet actively flushing */
   int numQueuedFlushes() {
-    return numQueued;
+    if (numPending == 0) {
+      // Since queued flushed are a subset of pending flushes, a number of pending flushes equal to
+      // zero means that there are no queued flushes either. This short circuit helps avoid taking
+      // the lock on `this`, which introduces contention.
+      return 0;
+    }
+    synchronized (this) {
+      assert flushQueue.size() <= numPending
+          : "queued: " + flushQueue.size() + ", pending: " + numPending;
+      return flushQueue.size();
+    }
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -447,7 +447,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     boolean fullFlush;
     synchronized (this) {
       final DocumentsWriterPerThread poll;
-      assert numQueued == flushQueue.size();
+      assert numQueued == flushQueue.size() : "flush queue size: " + flushQueue.size() + ", cache size: " + numQueued;
       if ((poll = flushQueue.poll()) != null) {
         numQueued = flushQueue.size();
         updateStallState();
@@ -620,7 +620,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
        * blocking indexing.*/
       pruneBlockedQueue(flushingQueue);
       assert assertBlockedFlushes(documentsWriter.deleteQueue);
-      assert numQueued == flushQueue.size();
+      assert numQueued == flushQueue.size() : "flush queue size: " + flushQueue.size() + ", cache size: " + numQueued;
       flushQueue.addAll(fullFlushBuffer);
       numQueued = flushQueue.size();
       updateStallState();
@@ -652,7 +652,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
         iterator.remove();
         addFlushingDWPT(blockedFlush);
         // don't decr pending here - it's already done when DWPT is blocked
-        assert numQueued == flushQueue.size();
+        assert numQueued == flushQueue.size() : "flush queue size: " + flushQueue.size() + ", cache size: " + numQueued;
         flushQueue.add(blockedFlush);
         numQueued = flushQueue.size();
       }

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -43,6 +43,8 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
   private final long hardMaxBytesPerDWPT;
   private long activeBytes = 0;
   private volatile long flushBytes = 0;
+  // The number of DWPTs that are pending flush but aren't actively flushing. Note that this
+  // includes blocked and queued flushes.
   private volatile int numPending = 0;
   private int numDocsSinceStalled = 0; // only with assert
   private final AtomicBoolean flushDeletes = new AtomicBoolean(false);
@@ -89,6 +91,27 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     this.documentsWriter = documentsWriter;
   }
 
+  private synchronized boolean assertNumPending() {
+    int numBlocked = blockedFlushes.size();
+    int numQueued = flushQueue.size();
+    int numOtherPending = 0;
+    for (DocumentsWriterPerThread dwpt : perThreadPool) {
+      if (dwpt.isFlushPending()) {
+        numOtherPending++;
+      }
+    }
+    assert numPending == numBlocked + numQueued + numOtherPending
+        : "numPending="
+            + numPending
+            + ", numBlocked="
+            + numBlocked
+            + ", numQueued="
+            + numQueued
+            + ", numOtherPending="
+            + numOtherPending;
+    return true;
+  }
+
   public synchronized long activeBytes() {
     return activeBytes;
   }
@@ -124,7 +147,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
 
       // 2 * ramBufferBytes -> before we stall we need to cross the 2xRAM Buffer border this is
       // still a valid limit
-      // (numPending + numFlushingDWPT() + numBlockedFlushes()) * peakDelta) -> those are the total
+      // (numPending + numFlushingDWPT()) * peakDelta) -> those are the total
       // number of DWPT that are not active but not yet fully flushed
       // all of them could theoretically be taken out of the loop once they crossed the RAM buffer
       // and the last document was the peak delta
@@ -133,7 +156,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
       // peak document
       final long expected =
           (2 * ramBufferBytes)
-              + ((numPending + numFlushingDWPT() + numBlockedFlushes()) * peakDelta)
+              + ((numPending + numFlushingDWPT()) * peakDelta)
               + (numDocsSinceStalled * peakDelta);
       // the expected ram consumption is an upper bound at this point and not really the expected
       // consumption
@@ -398,10 +421,10 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     assert perThread.isHeldByCurrentThread();
     assert perThread.isFlushPending() : "can not block non-pending threadstate";
     assert fullFlush : "can not block if fullFlush == false";
-    numPending--; // write access synced
     blockedFlushes.add(perThread);
     boolean checkedOut = perThreadPool.checkout(perThread);
     assert checkedOut;
+    assert assertNumPending();
   }
 
   private synchronized DocumentsWriterPerThread checkOutForFlush(
@@ -415,6 +438,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
       numPending--; // write access synced
       boolean checkedOut = perThreadPool.checkout(perThread);
       assert checkedOut;
+      assert assertNumPending();
       return perThread;
     } finally {
       updateStallState();
@@ -437,6 +461,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
   }
 
   DocumentsWriterPerThread nextPendingFlush() {
+    assert assertNumPending();
     if (numPending == 0) {
       // Nothing to do. This short circuit helps avoid taking the lock, which can otherwise cause
       // contention. Note that pending flushes include queued flushes, so flushQueue is also empty
@@ -449,6 +474,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     synchronized (this) {
       final DocumentsWriterPerThread poll;
       if ((poll = flushQueue.poll()) != null) {
+        this.numPending--; // write access synced
         updateStallState();
         return poll;
       }
@@ -620,10 +646,12 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
       pruneBlockedQueue(flushingQueue);
       assert assertBlockedFlushes(documentsWriter.deleteQueue);
       flushQueue.addAll(fullFlushBuffer);
+      numPending += fullFlushBuffer.size(); // write access synced
       updateStallState();
       fullFlushMarkDone =
           true; // at this point we must have collected all DWPTs that belong to the old delete
       // queue
+      assert assertNumPending();
     }
     assert assertActiveDeleteQueue(documentsWriter.deleteQueue);
     assert flushingQueue.getLastSequenceNumber() <= flushingQueue.getMaxSeqNo();
@@ -652,6 +680,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
         flushQueue.add(blockedFlush);
       }
     }
+    assert assertNumPending();
   }
 
   synchronized void finishFullFlush() {
@@ -715,6 +744,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
         }
       }
     } finally {
+      numPending = numPending - flushQueue.size() - blockedFlushes.size(); // write access synced
       flushQueue.clear();
       blockedFlushes.clear();
       updateStallState();


### PR DESCRIPTION
With this change, running `IndexGeoNames` with 20 threads goes from 16-17 seconds to 15-16 seconds. If I disable the 3 text fields - which are the main bottleneck for indexing - out of 19 fields, then indexing geonames goes from 12-13 seconds to 9-10 seconds with this change.

After this change, running `IndexGeoNames` with 20 threads doesn't suffer from contention anymore. I'm only seeing a small bit of waiting due to stall control, which is expected.