### PR TITLE
Fully reuse postings enums when flushing sorted indexes.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
@@ -408,6 +408,7 @@ final class FreqProxTermsWriter extends TermsHash {
       startOffset = -1;
       endOffset = -1;
 
+      buffer.reset();
       int doc;
       int i = 0;
       while ((doc = in.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {


### PR DESCRIPTION
Currently we're only half reusing postings enums when flushing sorted indexes as we still create new wrapper instances every time, which can be costly with fields that have many terms.