### PR TITLE
Fix ordered intervals query and add test case

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -179,6 +179,8 @@ Bug Fixes
 
 * GITHUB#12202: Fix MultiFieldQueryParser to apply boosts to regexp, wildcard, prefix, range, fuzzy queries.  (Jasir KT)
 
+* GITHUB#12214: Fix ordered intervals query to avoid skipping some of the results over interleaved terms. (Hongyu Yan)
+
 Build
 ---------------------
 

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/OrderedIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/OrderedIntervalsSource.java
@@ -112,7 +112,7 @@ class OrderedIntervalsSource extends MinimizingConjunctionIntervalsSource {
 
   private static class OrderedIntervalIterator extends ConjunctionIntervalIterator {
 
-    int start = -1, end = -1, i;
+    int start = -1, end = -1, i = 1;
     int slop;
     final MatchCallback onMatch;
 
@@ -136,7 +136,6 @@ class OrderedIntervalsSource extends MinimizingConjunctionIntervalsSource {
       start = end = slop = IntervalIterator.NO_MORE_INTERVALS;
       int lastStart = Integer.MAX_VALUE;
       boolean minimizing = false;
-      i = 1;
       while (true) {
         while (true) {
           if (subIterators.get(i - 1).end() >= lastStart) {

--- a/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestIntervalQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestIntervalQuery.java
@@ -84,7 +84,8 @@ public class TestIntervalQuery extends LuceneTestCase {
     "greater new york",
     "x x x x x intend x x x message x x x message x x x addressed x x",
     "issue with intervals queries from search engine. So it's a big issue for us as we need to do ordered searches. Thank you to help us concerning that issue",
-    "場外好朋友"
+    "場外好朋友",
+    "alice bob alice alice carl alice bob alice carl"
   };
 
   private void checkHits(Query query, int[] results) throws IOException {
@@ -346,6 +347,17 @@ public class TestIntervalQuery extends LuceneTestCase {
                 Intervals.ordered(
                     Intervals.term("issue"), Intervals.term("search"), Intervals.term("ordered"))));
     checkHits(q, new int[] {});
+  }
+
+  public void testOrderedWithGaps2() throws IOException {
+    Query q =
+        new IntervalQuery(
+            field,
+            Intervals.maxgaps(
+                1,
+                Intervals.ordered(
+                    Intervals.term("alice"), Intervals.term("bob"), Intervals.term("carl"))));
+    checkHits(q, new int[] {12});
   }
 
   public void testNestedOrInContainedBy() throws IOException {


### PR DESCRIPTION
### Description
This PR aims to address issue #12213 Ordered intervals over interleaved terms.

A more detailed explanation of the issue and the reasoning behind the fix can be found in the report link above.
