### PR TITLE
Upgrade forbiddenapis to version 3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
   id "base"
   id "com.palantir.consistent-versions" version "2.11.0"
   id "org.owasp.dependencycheck" version "7.2.0"
-  id 'de.thetaphi.forbiddenapis' version '3.4' apply false
+  id 'de.thetaphi.forbiddenapis' version '3.5' apply false
   id "de.undercouch.download" version "5.2.0" apply false
   id "net.ltgt.errorprone" version "3.0.1" apply false
   id 'com.diffplug.spotless' version "6.5.2" apply false

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -192,7 +192,7 @@ Build
   source tree. Those can be regenerated an demand with "gradlew :lucene:core:regenerate".
   (Uwe Schindler)
 
-* GITHUB#xxxx: Upgrade forbiddenapis to version 3.5.  This tones down some verbose warnings
+* GITHUB#12215: Upgrade forbiddenapis to version 3.5.  This tones down some verbose warnings
   printed while checking Java 19 and Java 20 sourcesets for the MR-JAR.  (Uwe Schindler)
 
 Other

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -192,6 +192,9 @@ Build
   source tree. Those can be regenerated an demand with "gradlew :lucene:core:regenerate".
   (Uwe Schindler)
 
+* GITHUB#xxxx: Upgrade forbiddenapis to version 3.5.  This tones down some verbose warnings
+  printed while checking Java 19 and Java 20 sourcesets for the MR-JAR.  (Uwe Schindler)
+
 Other
 ---------------------
 


### PR DESCRIPTION
This tones down some verbose warnings printed while checking Java 19 and Java 20 sourcesets for the MR-JAR.

```
$ gradlew forbiddenApis
Starting a Gradle Daemon (subsequent builds will be faster)

> Task :errorProneSkipped
WARNING: errorprone disabled (skipped on builds not running inside CI environments, pass -Pvalidation.errorprone=true to enable)

> Task :lucene:core:forbiddenApisMain19
While scanning classes to check, the following referenced classes were not found on classpath (this may miss some violations):
  java.lang.foreign.MemorySegment, java.lang.foreign.MemorySession, java.lang.foreign.ValueLayout,... (and 5 more).

> Task :lucene:core:forbiddenApisMain20
While scanning classes to check, the following referenced classes were not found on classpath (this may miss some violations):
  java.lang.foreign.Arena, java.lang.foreign.MemorySegment, java.lang.foreign.SegmentScope,... (and 6 more).

BUILD SUCCESSFUL in 35s
233 actionable tasks: 76 executed, 157 up-to-date
```