### PR TITLE
Adjust DWPT pool concurrency to the number of cores.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentApproximatePriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentApproximatePriorityQueue.java
@@ -27,18 +27,12 @@ import java.util.function.Predicate;
  */
 final class ConcurrentApproximatePriorityQueue<T> {
 
-  /**
-   * Used for testing.
-   *
-   * @lucene.internal
-   */
-  static final String CONCURRENCY_OVERRIDE_PROPERTY = "lucene.dwptpool.concurrency_override";
+  static Integer CONCURRENCY_OVERRIDE;
 
   private static final int getConcurrency() {
-    String value = System.getProperty(CONCURRENCY_OVERRIDE_PROPERTY);
     int concurrency;
-    if (value != null) {
-      concurrency = Integer.parseInt(value);
+    if (CONCURRENCY_OVERRIDE != null) {
+      concurrency = CONCURRENCY_OVERRIDE;
     } else {
       int coreCount = Runtime.getRuntime().availableProcessors();
       // Aim for ~4 entries per slot when indexing with one thread per CPU core. The trade-off is

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentApproximatePriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentApproximatePriorityQueue.java
@@ -36,8 +36,8 @@ final class ConcurrentApproximatePriorityQueue<T> {
     // that if we set the concurrency too high then we'll completely lose the bias towards larger
     // DWPTs. And if we set it too low then we risk seeing contention.
     int concurrency = coreCount / 4;
-    concurrency = Math.max(1, concurrency);
-    concurrency = Math.min(256, concurrency);
+    concurrency = Math.max(MIN_CONCURRENCY, concurrency);
+    concurrency = Math.min(MAX_CONCURRENCY, concurrency);
     return concurrency;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentApproximatePriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentApproximatePriorityQueue.java
@@ -41,9 +41,9 @@ final class ConcurrentApproximatePriorityQueue<T> {
       concurrency = Integer.parseInt(value);
     } else {
       int coreCount = Runtime.getRuntime().availableProcessors();
-      // Aim for ~4 entries per slot when indexing with one thread per CPU core. The trade-off is that
-      // if we set the concurrency too high then we'll completely lose the bias towards larger DWPTs.
-      // And if we set it too low then we risk seeing contention.
+      // Aim for ~4 entries per slot when indexing with one thread per CPU core. The trade-off is
+      // that if we set the concurrency too high then we'll completely lose the bias towards larger
+      // DWPTs. And if we set it too low then we risk seeing contention.
       concurrency = coreCount / 4;
     }
     concurrency = Math.max(1, concurrency);

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentApproximatePriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentApproximatePriorityQueue.java
@@ -37,13 +37,7 @@ final class ConcurrentApproximatePriorityQueue<T> {
   private static final int getConcurrency() {
     String value = System.getProperty(CONCURRENCY_OVERRIDE_PROPERTY);
     if (value != null) {
-      try {
-        return Integer.parseInt(value);
-      } catch (
-          @SuppressWarnings("unused")
-          NumberFormatException e) {
-        // ignore
-      }
+      return Integer.parseInt(value);
     }
     int coreCount = Runtime.getRuntime().availableProcessors();
     // Aim for ~4 entries per slot when indexing with one thread per CPU core. The trade-off is that

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentApproximatePriorityQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentApproximatePriorityQueue.java
@@ -18,9 +18,25 @@ package org.apache.lucene.index;
 
 import java.util.concurrent.CountDownLatch;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ThreadInterruptedException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 public class TestConcurrentApproximatePriorityQueue extends LuceneTestCase {
+
+  @BeforeClass
+  public static void beforeClass() {
+    final int concurrency = TestUtil.nextInt(random(), 2, 8);
+    System.setProperty(
+        ConcurrentApproximatePriorityQueue.CONCURRENCY_OVERRIDE_PROPERTY,
+        Integer.toString(concurrency));
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    System.clearProperty(ConcurrentApproximatePriorityQueue.CONCURRENCY_OVERRIDE_PROPERTY);
+  }
 
   public void testPollFromSameThread() {
     ConcurrentApproximatePriorityQueue<Integer> pq = new ConcurrentApproximatePriorityQueue<>();

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentApproximatePriorityQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentApproximatePriorityQueue.java
@@ -20,23 +20,16 @@ import java.util.concurrent.CountDownLatch;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ThreadInterruptedException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 
 public class TestConcurrentApproximatePriorityQueue extends LuceneTestCase {
 
-  @BeforeClass
-  public static void beforeClass() {
-    ConcurrentApproximatePriorityQueue.CONCURRENCY_OVERRIDE = TestUtil.nextInt(random(), 2, 8);
-  }
-
-  @AfterClass
-  public static void afterClass() {
-    ConcurrentApproximatePriorityQueue.CONCURRENCY_OVERRIDE = null;
-  }
-
   public void testPollFromSameThread() {
-    ConcurrentApproximatePriorityQueue<Integer> pq = new ConcurrentApproximatePriorityQueue<>();
+    ConcurrentApproximatePriorityQueue<Integer> pq =
+        new ConcurrentApproximatePriorityQueue<>(
+            TestUtil.nextInt(
+                random(),
+                ConcurrentApproximatePriorityQueue.MIN_CONCURRENCY,
+                ConcurrentApproximatePriorityQueue.MAX_CONCURRENCY));
     pq.add(3, 3);
     pq.add(10, 10);
     pq.add(7, 7);
@@ -47,7 +40,12 @@ public class TestConcurrentApproximatePriorityQueue extends LuceneTestCase {
   }
 
   public void testPollFromDifferentThread() throws Exception {
-    ConcurrentApproximatePriorityQueue<Integer> pq = new ConcurrentApproximatePriorityQueue<>();
+    ConcurrentApproximatePriorityQueue<Integer> pq =
+        new ConcurrentApproximatePriorityQueue<>(
+            TestUtil.nextInt(
+                random(),
+                ConcurrentApproximatePriorityQueue.MIN_CONCURRENCY,
+                ConcurrentApproximatePriorityQueue.MAX_CONCURRENCY));
     pq.add(3, 3);
     pq.add(10, 10);
     pq.add(7, 7);
@@ -66,7 +64,10 @@ public class TestConcurrentApproximatePriorityQueue extends LuceneTestCase {
   }
 
   public void testCurrentLockIsBusy() throws Exception {
-    ConcurrentApproximatePriorityQueue<Integer> pq = new ConcurrentApproximatePriorityQueue<>();
+    // This test needs a concurrency of 2 or more.
+    ConcurrentApproximatePriorityQueue<Integer> pq =
+        new ConcurrentApproximatePriorityQueue<>(
+            TestUtil.nextInt(random(), 2, ConcurrentApproximatePriorityQueue.MAX_CONCURRENCY));
     pq.add(3, 3);
     CountDownLatch takeLock = new CountDownLatch(1);
     CountDownLatch releaseLock = new CountDownLatch(1);

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentApproximatePriorityQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentApproximatePriorityQueue.java
@@ -27,15 +27,12 @@ public class TestConcurrentApproximatePriorityQueue extends LuceneTestCase {
 
   @BeforeClass
   public static void beforeClass() {
-    final int concurrency = TestUtil.nextInt(random(), 2, 8);
-    System.setProperty(
-        ConcurrentApproximatePriorityQueue.CONCURRENCY_OVERRIDE_PROPERTY,
-        Integer.toString(concurrency));
+    ConcurrentApproximatePriorityQueue.CONCURRENCY_OVERRIDE = TestUtil.nextInt(random(), 2, 8);
   }
 
   @AfterClass
   public static void afterClass() {
-    System.clearProperty(ConcurrentApproximatePriorityQueue.CONCURRENCY_OVERRIDE_PROPERTY);
+    ConcurrentApproximatePriorityQueue.CONCURRENCY_OVERRIDE = null;
   }
 
   public void testPollFromSameThread() {


### PR DESCRIPTION
After upgrading Elasticsearch to a recent Lucene snapshot, we observed a few indexing slowdowns when indexing with low numbers of cores. This appears to be due to the fact that we lost too much of the bias towards larger DWPTs in apache/lucene#12199. This change tries to add back more ordering by adjusting the concurrency of `DWPTPool` to the number of cores that are available on the local node.
