### PR TITLE
fix FragEnd bug in BaseFragmentsBuilder

### DIFF
--- a/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/BaseFragmentsBuilder.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/BaseFragmentsBuilder.java
@@ -369,7 +369,7 @@ public abstract class BaseFragmentsBuilder implements FragmentsBuilder {
           }
         }
         WeightedFragInfo weightedFragInfo =
-            new WeightedFragInfo(fragStart, fragEnd, subInfos, boost);
+            new WeightedFragInfo(fragStart, fragEnd - 1, subInfos, boost);
         fieldNameToFragInfos.get(field.name()).add(weightedFragInfo);
       }
     }

--- a/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestBaseFragmentsBuilder.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestBaseFragmentsBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search.vectorhighlight;
+
+public class TestBaseFragmentsBuilder extends AbstractTestCase {
+
+  public void testDiscreteMultiValueHighlightingWhenSecondFieldIsTheBestMatch() throws Exception {
+    makeIndexShortMV();
+
+    FieldQuery fq = new FieldQuery(tq("d"), true, true);
+    FieldTermStack stack = new FieldTermStack(reader, 0, F, fq);
+    FieldPhraseList fpl = new FieldPhraseList(stack, fq);
+    SingleFragListBuilder sflb = new SingleFragListBuilder();
+    FieldFragList ffl = sflb.createFieldFragList(fpl, Integer.MAX_VALUE);
+    ScoreOrderFragmentsBuilder sfb = new ScoreOrderFragmentsBuilder();
+    sfb.setDiscreteMultiValueHighlighting(true);
+    assertEquals("<b>d</b> e", sfb.createFragment(reader, 0, F, ffl));
+
+    make1dmfIndex("First text to highlight", "Second text to highlight in a text field");
+    fq = new FieldQuery(tq("text"), true, true);
+    stack = new FieldTermStack(reader, 0, F, fq);
+    fpl = new FieldPhraseList(stack, fq);
+    sflb = new SingleFragListBuilder();
+    ffl = sflb.createFieldFragList(fpl, Integer.MAX_VALUE);
+    String[] result = sfb.createFragments(reader, 0, F, ffl, 3);
+    assertEquals(2, result.length);
+    assertEquals("Second <b>text</b> to highlight in a <b>text</b> field", result[0]);
+    assertEquals("First <b>text</b> to highlight", result[1]);
+
+    fq = new FieldQuery(tq("highlight"), true, true);
+    stack = new FieldTermStack(reader, 0, F, fq);
+    fpl = new FieldPhraseList(stack, fq);
+    sflb = new SingleFragListBuilder();
+    ffl = sflb.createFieldFragList(fpl, Integer.MAX_VALUE);
+    result = sfb.createFragments(reader, 0, F, ffl, 3);
+    assertEquals(2, result.length);
+    assertEquals("First text to <b>highlight</b>", result[0]);
+    assertEquals("Second text to <b>highlight</b> in a text field", result[1]);
+  }
+
+}

--- a/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestBaseFragmentsBuilder.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestBaseFragmentsBuilder.java
@@ -51,5 +51,4 @@ public class TestBaseFragmentsBuilder extends AbstractTestCase {
     assertEquals("First text to <b>highlight</b>", result[0]);
     assertEquals("Second text to <b>highlight</b> in a text field", result[1]);
   }
-
 }

--- a/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestSimpleFragmentsBuilder.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestSimpleFragmentsBuilder.java
@@ -226,7 +226,7 @@ public class TestSimpleFragmentsBuilder extends AbstractTestCase {
     result = sfb.createFragments(reader, 0, F, ffl, 3);
     assertEquals(2, result.length);
     assertEquals("text to <b>highlight</b>", result[0]);
-    assertEquals("<b>highlight</b> other text", result[1]);
+    assertEquals("<b>highlight</b> other", result[1]);
   }
 
   public void testRandomDiscreteMultiValueHighlighting() throws Exception {


### PR DESCRIPTION
### Description

This is a fix to https://github.com/apache/lucene/issues/12221 .

FragEnd was the start of the next potential fragment, which will lead the boundary scanner to cover the first word in the next field when the fragment ends at current field's end.

Changed a text in `TestSimpleFragmentsBuilder.java`. The behavior change is expected (could be another bug): 
1. the newly created fragments [will stop at the original (fieldFragList.getFragInfos(); i.e. fragInfos without discreteMultiValueHighlighting set) fragment's end](https://github.com/waziqi89/lucene/blob/0c2f9a97af85c3839e0fe62fda90ba76925f8c31/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/BaseFragmentsBuilder.java#L313) even if the newly created fragment can be extended further as the new fragment could start later than the original one.
2. FragEnd used to be at "t" of the next word "text", so boundary scanner will cover the whole word. Now FragEnd stops before that character, so the "text" is excluded entirely
