### PR TITLE
Remove a test in TestDocumentsWriterDeleteQueue

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterDeleteQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterDeleteQueue.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.index;
 
-import java.lang.ref.WeakReference;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -30,31 +29,9 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.ThreadInterruptedException;
-import org.junit.Ignore;
 
 /** Unit test for {@link DocumentsWriterDeleteQueue} */
 public class TestDocumentsWriterDeleteQueue extends LuceneTestCase {
-
-  /* Ignored because System.gc() is not reliable */
-  @Ignore
-  public void testAdvanceReferencesOriginal() {
-    WeakAndNext weakAndNext = new WeakAndNext();
-    DocumentsWriterDeleteQueue next = weakAndNext.next;
-    assertNotNull(next);
-    System.gc();
-    assertNull(weakAndNext.weak.get());
-  }
-
-  class WeakAndNext {
-    final WeakReference<DocumentsWriterDeleteQueue> weak;
-    final DocumentsWriterDeleteQueue next;
-
-    WeakAndNext() {
-      DocumentsWriterDeleteQueue deleteQueue = new DocumentsWriterDeleteQueue(null);
-      weak = new WeakReference<>(deleteQueue);
-      next = deleteQueue.advanceQueue(2);
-    }
-  }
 
   public void testUpdateDeleteSlices() throws Exception {
     DocumentsWriterDeleteQueue queue = new DocumentsWriterDeleteQueue(null);

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterDeleteQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterDeleteQueue.java
@@ -30,10 +30,13 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.ThreadInterruptedException;
+import org.junit.Ignore;
 
 /** Unit test for {@link DocumentsWriterDeleteQueue} */
 public class TestDocumentsWriterDeleteQueue extends LuceneTestCase {
 
+  /* Ignored because System.gc() is not reliable */
+  @Ignore
   public void testAdvanceReferencesOriginal() {
     WeakAndNext weakAndNext = new WeakAndNext();
     DocumentsWriterDeleteQueue next = weakAndNext.next;
@@ -53,7 +56,7 @@ public class TestDocumentsWriterDeleteQueue extends LuceneTestCase {
     }
   }
 
-  public void testUpdateDelteSlices() throws Exception {
+  public void testUpdateDeleteSlices() throws Exception {
     DocumentsWriterDeleteQueue queue = new DocumentsWriterDeleteQueue(null);
     final int size = 200 + random().nextInt(500) * RANDOM_MULTIPLIER;
     Integer[] ids = new Integer[size];


### PR DESCRIPTION
### Description
The test is rely on `System.gc()` call and we know it is not very reliable, and since it is just testing the WeakReference itself I think we can safely ignore it.

Test failure: https://jenkins.thetaphi.de/job/Lucene-main-Linux/41045/
