### PR TITLE
Cleanup NOTICE.txt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -6,7 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 Includes software from other Apache Software Foundation projects,
 including, but not limited to:
- - Apache Ant
  - Apache Jakarta Regexp
  - Apache Commons
  - Apache Xerces
@@ -37,9 +36,6 @@ under the 2-clause BSD license.
 
 The Google Code Prettify is Apache License 2.0.
 See http://code.google.com/p/google-code-prettify/
-
-JUnit (junit-4.10) is licensed under the Common Public License v. 1.0
-See http://junit.sourceforge.net/cpl-v10.html
 
 This product includes code (JaspellTernarySearchTrie) from Java Spelling Checkin
 g Package (jaspell): http://jaspell.sourceforge.net/
@@ -199,6 +195,3 @@ This software includes a binary and/or source version of data from
 which can be obtained from
 
   https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/mecab-ko-dic-2.1.1-20180720.tar.gz
-
-The floating point precision conversion in NumericUtils.Float16Converter is derived from work by
-Jeroen van der Zijp, granted for use under the Apache license.


### PR DESCRIPTION
Resolves #12226 

- Ant is no longer used as the build system for Lucene (Some classes are used in gradle tasks, but I'm not sure it needs to be called out still)
- JUnit is not packaged in a Lucene release
- The Float16Converter was removed before the PR it was used in was merged: https://github.com/apache/lucene-solr/pull/2108

The JUnit files are still in `lucene/licenses`, but that is true of other non-bundled dependencies as well.