### PR TITLE
Change the access modifier for the "expert" readLatestCommit API to public

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
@@ -2241,4 +2241,18 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
       }
     }
   }
+
+  @Nightly
+  public void testReadNMinusTwoSegmentInfos() throws IOException {
+    for (String name : binarySupportedNames) {
+      Path oldIndexDir = createTempDir(name);
+      TestUtil.unzip(getDataInputStream("unsupported." + name + ".zip"), oldIndexDir);
+      try (BaseDirectoryWrapper dir = newFSDirectory(oldIndexDir)) {
+        expectThrows(
+            IndexFormatTooOldException.class,
+            () -> SegmentInfos.readLatestCommit(dir, Version.MIN_SUPPORTED_MAJOR));
+        SegmentInfos.readLatestCommit(dir, MIN_BINARY_SUPPORTED_MAJOR);
+      }
+    }
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -517,8 +517,14 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
     return readLatestCommit(directory, Version.MIN_SUPPORTED_MAJOR);
   }
 
-  static final SegmentInfos readLatestCommit(Directory directory, int minSupportedMajorVersion)
-      throws IOException {
+  /**
+   * Find the latest commit ({@code segments_N file}) and load all {@link SegmentCommitInfo}s, as
+   * long as the commit's {@link SegmentInfos#getIndexCreatedVersionMajor()} is strictly greater
+   * than the provided minimum supported major version. If the commit's version is older, an {@link
+   * IndexFormatTooOldException} will be thrown.
+   */
+  public static final SegmentInfos readLatestCommit(
+      Directory directory, int minSupportedMajorVersion) throws IOException {
     return new FindSegmentsFile<SegmentInfos>(directory) {
       @Override
       protected SegmentInfos doBody(String segmentFileName) throws IOException {


### PR DESCRIPTION
### Description

The purpose of this change is to change the access modifier for the "expert" variant of the `readLatestCommit` API from package-private to public. This change also includes a unit test for the new public API. As per the contribution guidelines, `./gradlew tidy` was run and `./gradlew check` passes.

In https://github.com/apache/lucene-solr/pull/2212, a variant of the `readLatestCommit` API was added that allowed read-only access to older Lucene indices. However, the only public entrypoints to the feature relied on an `IndexCommit`. 

[OpenSearch](https://github.com/opensearch-project/OpenSearch) currently has an experimental feature to enable read-only, searchable access to [snapshots](https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/), and I'd like to leverage Lucene's "expert" API to enable access to older snapshots. However, the `Engine` implementations in OpenSearch track `SegmentInfos` objects rather than `IndexCommit` so the experimental implementation currently [uses a workaround](https://github.com/opensearch-project/OpenSearch/issues/7084). Removing the workaround would help us move this feature closer to GA.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
