### PR TITLE
Fix typo in CheckJoinIndex

### DIFF
--- a/lucene/join/src/java/org/apache/lucene/search/join/CheckJoinIndex.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/CheckJoinIndex.java
@@ -63,7 +63,7 @@ public class CheckJoinIndex {
           for (int child = prevParentDoc + 1; child != parentDoc; child++) {
             final boolean childIsLive = liveDocs.get(child);
             if (parentIsLive != childIsLive) {
-              if (childIsLive) {
+              if (parentIsLive) {
                 throw new IllegalStateException(
                     "Parent doc "
                         + parentDoc


### PR DESCRIPTION
Exception messages in the if/else block [here](https://github.com/apache/lucene/blob/main/lucene/join/src/java/org/apache/lucene/search/join/CheckJoinIndex.java#L66-L82) are inverted. Small PR to fix this.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
