### PR TITLE
[Documentation] Remove statement that SSDV facets aren't hierarchical

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetCounts.java
@@ -43,8 +43,6 @@ import org.apache.lucene.util.LongValues;
  * Compute facets counts from previously indexed {@link SortedSetDocValuesFacetField}, without
  * require a separate taxonomy index. Faceting is a bit slower (~25%), and there is added cost on
  * every {@link IndexReader} open to create a new {@link SortedSetDocValuesReaderState}.
- * Furthermore, this does not support hierarchical facets; only flat (dimension + label) facets, but
- * it uses quite a bit less RAM to do so.
  *
  * <p><b>NOTE</b>: this class should be instantiated and then used from a single thread, because it
  * holds a thread-private instance of {@link SortedSetDocValues}.

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesReaderState.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesReaderState.java
@@ -28,11 +28,9 @@ import org.apache.lucene.util.FixedBitSet;
 
 /**
  * Wraps a {@link IndexReader} and resolves ords using existing {@link SortedSetDocValues} APIs
- * without a separate taxonomy index. This only supports flat facets (dimension + label), and it
- * makes faceting a bit slower, adds some cost at reopen time, but avoids managing the separate
- * taxonomy index. It also requires less RAM than the taxonomy index, as it manages the flat
- * (2-level) hierarchy more efficiently. In addition, the tie-break during faceting is now
- * meaningful (in label sorted order).
+ * without a separate taxonomy index. This makes faceting a bit slower, adds some cost at reopen
+ * time, but avoids managing the separate taxonomy index. In addition, the tie-break during faceting
+ * is now meaningful (in label sorted order).
  *
  * <p><b>NOTE</b>: creating an instance of this class is somewhat costly, as it computes per-segment
  * ordinal maps, so you should create it once and re-use that one instance for a given {@link


### PR DESCRIPTION
In #509, @mdmarshmallow added support for arbitrary length hierarchical SSDV facets.
This PR removes statements to the contrary from Javadoc.
