### PR TITLE
Avoid redundant copies of BytesRef when constructing new Term

### DIFF
--- a/lucene/classification/src/java/org/apache/lucene/classification/utils/NearestFuzzyQuery.java
+++ b/lucene/classification/src/java/org/apache/lucene/classification/utils/NearestFuzzyQuery.java
@@ -159,10 +159,7 @@ public class NearestFuzzyQuery extends Query {
             float score = fe.getBoost();
             if (variantsQ.size() < MAX_VARIANTS_PER_TERM || score > minScore) {
               ScoreTerm st =
-                  new ScoreTerm(
-                      new Term(startTerm.field(), BytesRef.deepCopyOf(possibleMatch)),
-                      score,
-                      startTerm);
+                  new ScoreTerm(new Term(startTerm.field(), possibleMatch), score, startTerm);
               variantsQ.insertWithOverflow(st);
               minScore = variantsQ.top().score; // maintain minScore
             }

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
@@ -186,7 +186,7 @@ public class TermFilteredPresearcher extends Presearcher {
                 + field
                 + ":"
                 + Term.toString(term));
-      bq.add(new TermQuery(new Term(field, BytesRef.deepCopyOf(term))), BooleanClause.Occur.SHOULD);
+      bq.add(new TermQuery(new Term(field, term)), BooleanClause.Occur.SHOULD);
     }
 
     BooleanQuery built = bq.build();

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/SpanOrTermsBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/SpanOrTermsBuilder.java
@@ -28,7 +28,6 @@ import org.apache.lucene.queries.spans.SpanQuery;
 import org.apache.lucene.queries.spans.SpanTermQuery;
 import org.apache.lucene.queryparser.xml.DOMUtils;
 import org.apache.lucene.queryparser.xml.ParserException;
-import org.apache.lucene.util.BytesRef;
 import org.w3c.dom.Element;
 
 /** Builder that analyzes the text into a {@link SpanOrQuery} */
@@ -51,8 +50,7 @@ public class SpanOrTermsBuilder extends SpanBuilderBase {
       TermToBytesRefAttribute termAtt = ts.addAttribute(TermToBytesRefAttribute.class);
       ts.reset();
       while (ts.incrementToken()) {
-        SpanTermQuery stq =
-            new SpanTermQuery(new Term(fieldName, BytesRef.deepCopyOf(termAtt.getBytesRef())));
+        SpanTermQuery stq = new SpanTermQuery(new Term(fieldName, termAtt.getBytesRef()));
         clausesList.add(stq);
       }
       ts.end();

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/TermsQueryBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/TermsQueryBuilder.java
@@ -29,7 +29,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.util.BytesRef;
 import org.w3c.dom.Element;
 
 /**
@@ -55,7 +54,7 @@ public class TermsQueryBuilder implements QueryBuilder {
       Term term = null;
       ts.reset();
       while (ts.incrementToken()) {
-        term = new Term(fieldName, BytesRef.deepCopyOf(termAtt.getBytesRef()));
+        term = new Term(fieldName, termAtt.getBytesRef());
         bq.add(new BooleanClause(new TermQuery(term), BooleanClause.Occur.SHOULD));
       }
       ts.end();

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/queries/FuzzyLikeThisQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/queries/FuzzyLikeThisQuery.java
@@ -224,10 +224,7 @@ public class FuzzyLikeThisQuery extends Query {
             float score = boostAtt.getBoost();
             if (variantsQ.size() < MAX_VARIANTS_PER_TERM || score > minScore) {
               ScoreTerm st =
-                  new ScoreTerm(
-                      new Term(startTerm.field(), BytesRef.deepCopyOf(possibleMatch)),
-                      score,
-                      startTerm);
+                  new ScoreTerm(new Term(startTerm.field(), possibleMatch), score, startTerm);
               variantsQ.insertWithOverflow(st);
               minScore = variantsQ.top().score; // maintain minScore
             }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/ThreadedIndexingAndSearchingTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/ThreadedIndexingAndSearchingTestCase.java
@@ -451,9 +451,7 @@ public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCas
                           // System.out.println(Thread.currentThread().getName() + " now search
                           // body:" + term.utf8ToString());
                           // }
-                          totHits.addAndGet(
-                              runQuery(
-                                  s, new TermQuery(new Term("body", BytesRef.deepCopyOf(term)))));
+                          totHits.addAndGet(runQuery(s, new TermQuery(new Term("body", term))));
                         }
                       }
                       // if (VERBOSE) {


### PR DESCRIPTION
### Description
Since the `Term(String, BytesRef)` constructor internally uses `BytesRef#deepCopyOf` to clone the buffer, there's no need to make another deep copy of the BytesRef prior to creating the new Term.