### PR TITLE
Optimize HNSW diversity calculation

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -72,8 +72,6 @@ Optimizations
 
 * GITHUB#12160: Concurrent rewrite for AbstractKnnVectorQuery. (Kaival Parikh)
 
-* GITHUB#12235: Optimize HNSW diversity calculation. (Patrick Zhai)
-
 Bug Fixes
 ---------------------
 
@@ -127,6 +125,8 @@ Optimizations
 ---------------------
 
 * GITHUB#12270 Don't generate stacktrace in CollectionTerminatedException. (Armin Braun)
+
+* GITHUB#12235: Optimize HNSW diversity calculation. (Patrick Zhai)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -72,6 +72,8 @@ Optimizations
 
 * GITHUB#12160: Concurrent rewrite for AbstractKnnVectorQuery. (Kaival Parikh)
 
+* GITHUB#12235: Optimize HNSW diversity calculation. (Patrick Zhai)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
@@ -85,7 +85,7 @@ public class Word2VecSynonymProvider {
               SIMILARITY_FUNCTION,
               hnswGraph,
               null,
-              word2VecModel.size());
+              Integer.MAX_VALUE);
 
       int size = synonyms.size();
       for (int i = 0; i < size; i++) {

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswGraphBuilder.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswGraphBuilder.java
@@ -183,10 +183,10 @@ public final class Lucene90HnswGraphBuilder {
     int size = neighbors.size();
     for (int i = 0; i < size; i++) {
       int nbr = neighbors.node()[i];
-      Lucene90NeighborArray nbrNbr = hnsw.getNeighbors(nbr);
-      nbrNbr.add(node, neighbors.score()[i]);
-      if (nbrNbr.size() > maxConn) {
-        diversityUpdate(nbrNbr);
+      Lucene90NeighborArray nbrsOfNbr = hnsw.getNeighbors(nbr);
+      nbrsOfNbr.add(node, neighbors.score()[i]);
+      if (nbrsOfNbr.size() > maxConn) {
+        diversityUpdate(nbrsOfNbr);
       }
     }
   }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswGraphBuilder.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswGraphBuilder.java
@@ -204,10 +204,10 @@ public final class Lucene91HnswGraphBuilder {
     int size = neighbors.size();
     for (int i = 0; i < size; i++) {
       int nbr = neighbors.node[i];
-      Lucene91NeighborArray nbrNbr = hnsw.getNeighbors(level, nbr);
-      nbrNbr.add(node, neighbors.score[i]);
-      if (nbrNbr.size() > maxConn) {
-        diversityUpdate(nbrNbr);
+      Lucene91NeighborArray nbrsOfNbr = hnsw.getNeighbors(level, nbr);
+      nbrsOfNbr.add(node, neighbors.score[i]);
+      if (nbrsOfNbr.size() > maxConn) {
+        diversityUpdate(nbrsOfNbr);
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -316,11 +316,11 @@ public final class HnswGraphBuilder<T> {
     int size = neighbors.size();
     for (int i = 0; i < size; i++) {
       int nbr = neighbors.node[i];
-      NeighborArray nbrNbr = hnsw.getNeighbors(level, nbr);
-      nbrNbr.addOutOfOrder(node, neighbors.score[i]);
-      if (nbrNbr.size() > maxConnOnLevel) {
-        int indexToRemove = findWorstNonDiverse(nbrNbr);
-        nbrNbr.removeIndex(indexToRemove);
+      NeighborArray nbrsOfNbr = hnsw.getNeighbors(level, nbr);
+      nbrsOfNbr.addOutOfOrder(node, neighbors.score[i]);
+      if (nbrsOfNbr.size() > maxConnOnLevel) {
+        int indexToRemove = findWorstNonDiverse(nbrsOfNbr);
+        nbrsOfNbr.removeIndex(indexToRemove);
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -218,7 +218,9 @@ public final class HnswGraphBuilder<T> {
                 case BYTE -> this.similarityFunction.compare(
                     binaryValue, (byte[]) vectorsCopy.vectorValue(newNeighbor));
               };
-          newNeighbors.insertSorted(newNeighbor, score);
+          // we are not sure whether the previous graph contains
+          // unchecked nodes, so we have to assume they're all unchecked
+          newNeighbors.insertSorted(newNeighbor, score, true);
         }
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -29,7 +29,7 @@ import org.apache.lucene.util.ArrayUtil;
  * @lucene.internal
  */
 public class NeighborArray {
-  private static final int UNCHECKED_NODE_INIT_SIZE = 4;
+  static final int UNCHECKED_NODE_INIT_SIZE = 4;
   private final boolean scoresDescOrder;
   private int size;
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -110,7 +110,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
         entryNode = node;
       }
 
-      graphUpperLevels.get(level).put(node, new NeighborArray(nsize, true));
+      graphUpperLevels.get(level).put(node, new NeighborArray(nsize, true, true));
     } else {
       // Add nodes all the way up to and including "node" in the new graph on level 0. This will
       // cause the size of the
@@ -118,7 +118,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
       // number of nodes
       // added will only be in sync once all nodes from 0...last_node are added into the graph.
       while (node >= graphLevel0.size()) {
-        graphLevel0.add(new NeighborArray(nsize0, true));
+        graphLevel0.add(new NeighborArray(nsize0, true, true));
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -18,7 +18,6 @@
 package org.apache.lucene.util.hnsw;
 
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
-import static org.apache.lucene.util.hnsw.NeighborArray.UNCHECKED_NODE_INIT_SIZE;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -111,7 +110,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
         entryNode = node;
       }
 
-      graphUpperLevels.get(level).put(node, new NeighborArray(nsize, true, true));
+      graphUpperLevels.get(level).put(node, new NeighborArray(nsize, true));
     } else {
       // Add nodes all the way up to and including "node" in the new graph on level 0. This will
       // cause the size of the
@@ -119,7 +118,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
       // number of nodes
       // added will only be in sync once all nodes from 0...last_node are added into the graph.
       while (node >= graphLevel0.size()) {
-        graphLevel0.add(new NeighborArray(nsize0, true, true));
+        graphLevel0.add(new NeighborArray(nsize0, true));
       }
     }
   }
@@ -170,24 +169,16 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
 
   @Override
   public long ramBytesUsed() {
-    // this is the lower bound estimation based on initial size
-    long uncheckedNeighborArrayBytes =
-        UNCHECKED_NODE_INIT_SIZE * (Integer.BYTES + Float.BYTES)
-            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2
-            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2
-            + Integer.BYTES * 2;
     long neighborArrayBytes0 =
         nsize0 * (Integer.BYTES + Float.BYTES)
-            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2
+            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
             + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2
-            + uncheckedNeighborArrayBytes
-            + Integer.BYTES * 2;
+            + Integer.BYTES * 3;
     long neighborArrayBytes =
         nsize * (Integer.BYTES + Float.BYTES)
-            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2
+            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
             + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2
-            + uncheckedNeighborArrayBytes
-            + Integer.BYTES * 2;
+            + Integer.BYTES * 3;
     long total = 0;
     for (int l = 0; l < numLevels; l++) {
       if (l == 0) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -17,14 +17,16 @@
 
 package org.apache.lucene.util.hnsw;
 
-import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.RamUsageEstimator;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.apache.lucene.util.hnsw.NeighborArray.UNCHECKED_NODE_INIT_SIZE;
 
 /**
  * An {@link HnswGraph} where all nodes and connections are held in memory. This class is used to
@@ -169,15 +171,23 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
 
   @Override
   public long ramBytesUsed() {
+    // this is the lower bound estimation based on initial size
+    long uncheckedNeighborArrayBytes =
+        UNCHECKED_NODE_INIT_SIZE * (Integer.BYTES + Float.BYTES)
+            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2
+            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2
+            + Integer.BYTES * 2;
     long neighborArrayBytes0 =
         nsize0 * (Integer.BYTES + Float.BYTES)
             + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2
-            + RamUsageEstimator.NUM_BYTES_OBJECT_REF
+            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2
+            + uncheckedNeighborArrayBytes
             + Integer.BYTES * 2;
     long neighborArrayBytes =
         nsize * (Integer.BYTES + Float.BYTES)
             + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2
-            + RamUsageEstimator.NUM_BYTES_OBJECT_REF
+            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2
+            + uncheckedNeighborArrayBytes
             + Integer.BYTES * 2;
     long total = 0;
     for (int l = 0; l < numLevels; l++) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -17,16 +17,15 @@
 
 package org.apache.lucene.util.hnsw;
 
-import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.RamUsageEstimator;
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.apache.lucene.util.hnsw.NeighborArray.UNCHECKED_NODE_INIT_SIZE;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
-import static org.apache.lucene.util.hnsw.NeighborArray.UNCHECKED_NODE_INIT_SIZE;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 
 /**
  * An {@link HnswGraph} where all nodes and connections are held in memory. This class is used to

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
@@ -23,100 +23,160 @@ public class TestNeighborArray extends LuceneTestCase {
 
   public void testScoresDescOrder() {
     NeighborArray neighbors = new NeighborArray(10, true);
-    neighbors.add(0, 1);
-    neighbors.add(1, 0.8f);
+    neighbors.addInOrder(0, 1);
+    neighbors.addInOrder(1, 0.8f);
 
-    AssertionError ex = expectThrows(AssertionError.class, () -> neighbors.add(2, 0.9f));
+    AssertionError ex = expectThrows(AssertionError.class, () -> neighbors.addInOrder(2, 0.9f));
     assertEquals("Nodes are added in the incorrect order!", ex.getMessage());
 
     neighbors.insertSorted(3, 0.9f);
     assertScoresEqual(new float[] {1, 0.9f, 0.8f}, neighbors);
-    asserNodesEqual(new int[] {0, 3, 1}, neighbors);
+    assertNodesEqual(new int[] {0, 3, 1}, neighbors);
 
     neighbors.insertSorted(4, 1f);
     assertScoresEqual(new float[] {1, 1, 0.9f, 0.8f}, neighbors);
-    asserNodesEqual(new int[] {0, 4, 3, 1}, neighbors);
+    assertNodesEqual(new int[] {0, 4, 3, 1}, neighbors);
 
     neighbors.insertSorted(5, 1.1f);
     assertScoresEqual(new float[] {1.1f, 1, 1, 0.9f, 0.8f}, neighbors);
-    asserNodesEqual(new int[] {5, 0, 4, 3, 1}, neighbors);
+    assertNodesEqual(new int[] {5, 0, 4, 3, 1}, neighbors);
 
     neighbors.insertSorted(6, 0.8f);
     assertScoresEqual(new float[] {1.1f, 1, 1, 0.9f, 0.8f, 0.8f}, neighbors);
-    asserNodesEqual(new int[] {5, 0, 4, 3, 1, 6}, neighbors);
+    assertNodesEqual(new int[] {5, 0, 4, 3, 1, 6}, neighbors);
 
     neighbors.insertSorted(7, 0.8f);
     assertScoresEqual(new float[] {1.1f, 1, 1, 0.9f, 0.8f, 0.8f, 0.8f}, neighbors);
-    asserNodesEqual(new int[] {5, 0, 4, 3, 1, 6, 7}, neighbors);
+    assertNodesEqual(new int[] {5, 0, 4, 3, 1, 6, 7}, neighbors);
 
     neighbors.removeIndex(2);
     assertScoresEqual(new float[] {1.1f, 1, 0.9f, 0.8f, 0.8f, 0.8f}, neighbors);
-    asserNodesEqual(new int[] {5, 0, 3, 1, 6, 7}, neighbors);
+    assertNodesEqual(new int[] {5, 0, 3, 1, 6, 7}, neighbors);
 
     neighbors.removeIndex(0);
     assertScoresEqual(new float[] {1, 0.9f, 0.8f, 0.8f, 0.8f}, neighbors);
-    asserNodesEqual(new int[] {0, 3, 1, 6, 7}, neighbors);
+    assertNodesEqual(new int[] {0, 3, 1, 6, 7}, neighbors);
 
     neighbors.removeIndex(4);
     assertScoresEqual(new float[] {1, 0.9f, 0.8f, 0.8f}, neighbors);
-    asserNodesEqual(new int[] {0, 3, 1, 6}, neighbors);
+    assertNodesEqual(new int[] {0, 3, 1, 6}, neighbors);
 
     neighbors.removeLast();
     assertScoresEqual(new float[] {1, 0.9f, 0.8f}, neighbors);
-    asserNodesEqual(new int[] {0, 3, 1}, neighbors);
+    assertNodesEqual(new int[] {0, 3, 1}, neighbors);
 
     neighbors.insertSorted(8, 0.9f);
     assertScoresEqual(new float[] {1, 0.9f, 0.9f, 0.8f}, neighbors);
-    asserNodesEqual(new int[] {0, 3, 8, 1}, neighbors);
+    assertNodesEqual(new int[] {0, 3, 8, 1}, neighbors);
   }
 
   public void testScoresAscOrder() {
     NeighborArray neighbors = new NeighborArray(10, false);
-    neighbors.add(0, 0.1f);
-    neighbors.add(1, 0.3f);
+    neighbors.addInOrder(0, 0.1f);
+    neighbors.addInOrder(1, 0.3f);
 
-    AssertionError ex = expectThrows(AssertionError.class, () -> neighbors.add(2, 0.15f));
+    AssertionError ex = expectThrows(AssertionError.class, () -> neighbors.addInOrder(2, 0.15f));
     assertEquals("Nodes are added in the incorrect order!", ex.getMessage());
 
     neighbors.insertSorted(3, 0.3f);
     assertScoresEqual(new float[] {0.1f, 0.3f, 0.3f}, neighbors);
-    asserNodesEqual(new int[] {0, 1, 3}, neighbors);
+    assertNodesEqual(new int[] {0, 1, 3}, neighbors);
 
     neighbors.insertSorted(4, 0.2f);
     assertScoresEqual(new float[] {0.1f, 0.2f, 0.3f, 0.3f}, neighbors);
-    asserNodesEqual(new int[] {0, 4, 1, 3}, neighbors);
+    assertNodesEqual(new int[] {0, 4, 1, 3}, neighbors);
 
     neighbors.insertSorted(5, 0.05f);
     assertScoresEqual(new float[] {0.05f, 0.1f, 0.2f, 0.3f, 0.3f}, neighbors);
-    asserNodesEqual(new int[] {5, 0, 4, 1, 3}, neighbors);
+    assertNodesEqual(new int[] {5, 0, 4, 1, 3}, neighbors);
 
     neighbors.insertSorted(6, 0.2f);
     assertScoresEqual(new float[] {0.05f, 0.1f, 0.2f, 0.2f, 0.3f, 0.3f}, neighbors);
-    asserNodesEqual(new int[] {5, 0, 4, 6, 1, 3}, neighbors);
+    assertNodesEqual(new int[] {5, 0, 4, 6, 1, 3}, neighbors);
 
     neighbors.insertSorted(7, 0.2f);
     assertScoresEqual(new float[] {0.05f, 0.1f, 0.2f, 0.2f, 0.2f, 0.3f, 0.3f}, neighbors);
-    asserNodesEqual(new int[] {5, 0, 4, 6, 7, 1, 3}, neighbors);
+    assertNodesEqual(new int[] {5, 0, 4, 6, 7, 1, 3}, neighbors);
 
     neighbors.removeIndex(2);
     assertScoresEqual(new float[] {0.05f, 0.1f, 0.2f, 0.2f, 0.3f, 0.3f}, neighbors);
-    asserNodesEqual(new int[] {5, 0, 6, 7, 1, 3}, neighbors);
+    assertNodesEqual(new int[] {5, 0, 6, 7, 1, 3}, neighbors);
 
     neighbors.removeIndex(0);
     assertScoresEqual(new float[] {0.1f, 0.2f, 0.2f, 0.3f, 0.3f}, neighbors);
-    asserNodesEqual(new int[] {0, 6, 7, 1, 3}, neighbors);
+    assertNodesEqual(new int[] {0, 6, 7, 1, 3}, neighbors);
 
     neighbors.removeIndex(4);
     assertScoresEqual(new float[] {0.1f, 0.2f, 0.2f, 0.3f}, neighbors);
-    asserNodesEqual(new int[] {0, 6, 7, 1}, neighbors);
+    assertNodesEqual(new int[] {0, 6, 7, 1}, neighbors);
 
     neighbors.removeLast();
     assertScoresEqual(new float[] {0.1f, 0.2f, 0.2f}, neighbors);
-    asserNodesEqual(new int[] {0, 6, 7}, neighbors);
+    assertNodesEqual(new int[] {0, 6, 7}, neighbors);
 
     neighbors.insertSorted(8, 0.01f);
     assertScoresEqual(new float[] {0.01f, 0.1f, 0.2f, 0.2f}, neighbors);
-    asserNodesEqual(new int[] {8, 0, 6, 7}, neighbors);
+    assertNodesEqual(new int[] {8, 0, 6, 7}, neighbors);
+  }
+
+  public void testSortAsc() {
+    NeighborArray neighbors = new NeighborArray(10, false);
+    neighbors.addOutOfOrder(1, 2);
+    // we disallow calling addInOrder after addOutOfOrder even if they're actual in order
+    expectThrows(AssertionError.class, () -> neighbors.addInOrder(1, 2));
+    neighbors.addOutOfOrder(2, 3);
+    neighbors.addOutOfOrder(5, 6);
+    neighbors.addOutOfOrder(3, 4);
+    neighbors.addOutOfOrder(7, 8);
+    neighbors.addOutOfOrder(6, 7);
+    neighbors.addOutOfOrder(4, 5);
+    int[] unchecked = neighbors.sort();
+    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
+    assertNodesEqual(new int[] {1, 2, 3, 4, 5, 6, 7}, neighbors);
+    assertScoresEqual(new float[] {2, 3, 4, 5, 6, 7, 8}, neighbors);
+
+    NeighborArray neighbors2 = new NeighborArray(10, false);
+    neighbors2.addInOrder(0, 1);
+    neighbors2.addInOrder(1, 2);
+    neighbors2.addInOrder(4, 5);
+    neighbors2.addOutOfOrder(2, 3);
+    neighbors2.addOutOfOrder(6, 7);
+    neighbors2.addOutOfOrder(5, 6);
+    neighbors2.addOutOfOrder(3, 4);
+    unchecked = neighbors2.sort();
+    assertArrayEquals(new int[] {2, 3, 5, 6}, unchecked);
+    assertNodesEqual(new int[] {0, 1, 2, 3, 4, 5, 6}, neighbors2);
+    assertScoresEqual(new float[] {1, 2, 3, 4, 5, 6, 7}, neighbors2);
+  }
+
+  public void testSortDesc() {
+    NeighborArray neighbors = new NeighborArray(10, true);
+    neighbors.addOutOfOrder(1, 7);
+    // we disallow calling addInOrder after addOutOfOrder even if they're actual in order
+    expectThrows(AssertionError.class, () -> neighbors.addInOrder(1, 2));
+    neighbors.addOutOfOrder(2, 6);
+    neighbors.addOutOfOrder(5, 3);
+    neighbors.addOutOfOrder(3, 5);
+    neighbors.addOutOfOrder(7, 1);
+    neighbors.addOutOfOrder(6, 2);
+    neighbors.addOutOfOrder(4, 4);
+    int[] unchecked = neighbors.sort();
+    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
+    assertNodesEqual(new int[] {1, 2, 3, 4, 5, 6, 7}, neighbors);
+    assertScoresEqual(new float[] {7, 6, 5, 4, 3, 2, 1}, neighbors);
+
+    NeighborArray neighbors2 = new NeighborArray(10, true);
+    neighbors2.addInOrder(1, 7);
+    neighbors2.addInOrder(2, 6);
+    neighbors2.addInOrder(5, 3);
+    neighbors2.addOutOfOrder(3, 5);
+    neighbors2.addOutOfOrder(7, 1);
+    neighbors2.addOutOfOrder(6, 2);
+    neighbors2.addOutOfOrder(4, 4);
+    unchecked = neighbors2.sort();
+    assertArrayEquals(new int[] {2, 3, 5, 6}, unchecked);
+    assertNodesEqual(new int[] {1, 2, 3, 4, 5, 6, 7}, neighbors2);
+    assertScoresEqual(new float[] {7, 6, 5, 4, 3, 2, 1}, neighbors2);
   }
 
   private void assertScoresEqual(float[] scores, NeighborArray neighbors) {
@@ -125,7 +185,7 @@ public class TestNeighborArray extends LuceneTestCase {
     }
   }
 
-  private void asserNodesEqual(int[] nodes, NeighborArray neighbors) {
+  private void assertNodesEqual(int[] nodes, NeighborArray neighbors) {
     for (int i = 0; i < nodes.length; i++) {
       assertEquals(nodes[i], neighbors.node[i]);
     }


### PR DESCRIPTION
### Description

Currently when we pop out the worst diverse node we go from the most distant node and calculate diversity one by one. But actually when we add the first batch of neighbours, we have already checked the diversity and rejected the non-diverse node. So the only nodes that are unchecked are only the ones that inserted by neighbours (using `insertSorted`), we should be able to only check those "unchecked" nodes but not every node.

I rely on current unit test to check the correctness but if that's not enough I'm pretty happy to write some test as well.

KNNGraphTester bench based on https://github.com/mikemccand/luceneutil/pull/218:
### This patch
```
recall	latency	nDoc	fanout	maxConn	beamWidth visited index ms
0.802	13.30	1000000	20	32	250	  120	  630614	1.00	post-filter
0.907	13.77	1000000	250	32	250	  350	  621157	1.00	post-filter
0.830	13.95	1000000	20	32	500	  120	  1242756	1.00	post-filter
0.926	14.33	1000000	250	32	500	  350	  1246090	1.00	post-filter
0.804	12.73	1000000	20	96	250	  120	  672480	1.00	post-filter
0.910	13.75	1000000	250	96	250	  350	  671602	1.00	post-filter
0.832	14.01	1000000	20	96	500	  120	  1376617	1.00	post-filter
0.928	14.36	1000000	250	96	500	  350	  1381215	1.00	post-filter
```
### Mainline
```
recall	latency	nDoc	fanout	maxConn	beamWidth visited index ms
0.802	12.82	1000000	20	32	250	  120	  686167	1.00	post-filter
0.907	13.58	1000000	250	32	250	  350	  633083	1.00	post-filter
0.831	13.73	1000000	20	32	500	  120	  1296331	1.00	post-filter
0.927	14.59	1000000	250	32	500	  350	  1275096	1.00	post-filter
0.804	12.79	1000000	20	96	250	  120	  672598	1.00	post-filter
0.910	13.27	1000000	250	96	250	  350	  670174	1.00	post-filter
0.832	13.76	1000000	20	96	500	  120	  1381401	1.00	post-filter
0.928	14.71	1000000	250	96	500	  350	  1393253	1.00	post-filter
```