### PR TITLE
Deduplicate ensureValidMerge check

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4761,7 +4761,11 @@ public class IndexWriter
                   + segString(info)
                   + " does not exist in live infos");
         }
-        return false;
+        throw new MergePolicy.MergeException(
+            "MergePolicy selected a segment ("
+                + info.info.name
+                + ") that is not in the current index "
+                + segString());
       }
       if (info.info.dir != directoryOrig) {
         isExternal = true;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4261,18 +4261,6 @@ public class IndexWriter
     return docWriter.getNumDocs();
   }
 
-  private synchronized void ensureValidMerge(MergePolicy.OneMerge merge) {
-    for (SegmentCommitInfo info : merge.segments) {
-      if (!segmentInfos.contains(info)) {
-        throw new MergePolicy.MergeException(
-            "MergePolicy selected a segment ("
-                + info.info.name
-                + ") that is not in the current index "
-                + segString());
-      }
-    }
-  }
-
   /**
    * Carefully merges deletes and updates for the segments we just merged. This is tricky because,
    * although merging will clear all deletes (compacts the documents) and compact all the updates,
@@ -4782,8 +4770,6 @@ public class IndexWriter
         merge.maxNumSegments = mergeMaxNumSegments;
       }
     }
-
-    ensureValidMerge(merge);
 
     pendingMerges.add(merge);
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
@@ -454,7 +454,7 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
             // return many merges.
             MergeSpecification spec = new MergeSpecification();
             List<SegmentCommitInfo> oneMerge = new ArrayList<>();
-            for (SegmentCommitInfo sci : segmentsToMerge.keySet()) {
+            for (SegmentCommitInfo sci : segmentInfos) {
               oneMerge.add(sci);
               if (oneMerge.size() >= 10) {
                 spec.add(new OneMerge(new ArrayList<>(oneMerge)));


### PR DESCRIPTION
when there is a call in IndexWrier#maybeMerge->updatePendingMerges->registerMerge

i think the `ensureValidMerge` is duplicated check  which do the same logic in the code:

https://github.com/apache/lucene/blob/bed07c6b0242646306470df9265469f6a811b5b2/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java#L4766-L4777

and when check error, it return false early.

