### PR TITLE
Set word2vec getSynonyms method thread-safe

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
@@ -27,10 +27,10 @@ import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.TermAndBoost;
-import org.apache.lucene.util.hnsw.HnswGraph;
 import org.apache.lucene.util.hnsw.HnswGraphBuilder;
 import org.apache.lucene.util.hnsw.HnswGraphSearcher;
 import org.apache.lucene.util.hnsw.NeighborQueue;
+import org.apache.lucene.util.hnsw.OnHeapHnswGraph;
 
 /**
  * The Word2VecSynonymProvider generates the list of sysnonyms of a term.
@@ -43,7 +43,7 @@ public class Word2VecSynonymProvider {
       VectorSimilarityFunction.DOT_PRODUCT;
   private static final VectorEncoding VECTOR_ENCODING = VectorEncoding.FLOAT32;
   private final Word2VecModel word2VecModel;
-  private final HnswGraph hnswGraph;
+  private final OnHeapHnswGraph hnswGraph;
 
   /**
    * Word2VecSynonymProvider constructor


### PR DESCRIPTION
### Description
This is a quick mitigation to avoid unexpected behavior if multiple queries are executed concurrently.

This commit wants to address some comments received in PR [12169](https://github.com/apache/lucene/pull/12169).

As @jimczi pointed out, the `OnHeapHnswGraph` is not thread-safe so we can avoid concurrent access to that object synchronizing the requests. Indeed, the graph has been reset by the searcher that calls the method `seek` [before each search](https://github.com/apache/lucene/blob/776149f0f6964bbc72ad2d292d1bfe770f82ba45/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java#L255).
Talking about performance, we will attach the result of some benchmarks we executed.

@zhaih noticed that the number of nodes that can be visited during the HnswGraph search was limited so I increased that limit to the max integer. 