### PR TITLE
use HashMap instead of TreeMap for OnHeapHnswGraph neighbors

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsWriter.java
@@ -25,6 +25,7 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import org.apache.lucene.codecs.BufferingKnnVectorsWriter;
 import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsWriter;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FieldInfo;
@@ -36,7 +37,6 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.hnsw.HnswGraph.NodesIterator;
 import org.apache.lucene.util.hnsw.RandomAccessVectorValues;
 
 /**
@@ -227,11 +227,10 @@ public final class Lucene91HnswVectorsWriter extends BufferingKnnVectorsWriter {
     } else {
       meta.writeInt(graph.numLevels());
       for (int level = 0; level < graph.numLevels(); level++) {
-        NodesIterator nodesOnLevel = graph.getNodesOnLevel(level);
-        meta.writeInt(nodesOnLevel.size()); // number of nodes on a level
+        int[] sortedNodes = Lucene95HnswVectorsWriter.getSortedNodes(graph.getNodesOnLevel(level));
+        meta.writeInt(sortedNodes.length); // number of nodes on a level
         if (level > 0) {
-          while (nodesOnLevel.hasNext()) {
-            int node = nodesOnLevel.nextInt();
+          for (int node : sortedNodes) {
             meta.writeInt(node); // list of nodes on a level
           }
         }
@@ -257,9 +256,8 @@ public final class Lucene91HnswVectorsWriter extends BufferingKnnVectorsWriter {
     // write vectors' neighbours on each level into the vectorIndex file
     int countOnLevel0 = graph.size();
     for (int level = 0; level < graph.numLevels(); level++) {
-      NodesIterator nodesOnLevel = graph.getNodesOnLevel(level);
-      while (nodesOnLevel.hasNext()) {
-        int node = nodesOnLevel.nextInt();
+      int[] sortedNodes = Lucene95HnswVectorsWriter.getSortedNodes(graph.getNodesOnLevel(level));
+      for (int node : sortedNodes) {
         Lucene91NeighborArray neighbors = graph.getNeighbors(level, node);
         int size = neighbors.size();
         vectorIndex.writeInt(size);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -676,16 +676,10 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     int countOnLevel0 = graph.size();
     int[][] offsets = new int[graph.numLevels()][];
     for (int level = 0; level < graph.numLevels(); level++) {
-      NodesIterator nodesOnLevel = graph.getNodesOnLevel(level);
-      int[] sortedNodes = new int[nodesOnLevel.size()];
-      for (int n = 0; nodesOnLevel.hasNext(); n++) {
-        sortedNodes[n] = nodesOnLevel.nextInt();
-      }
-      Arrays.sort(sortedNodes);
-      offsets[level] = new int[nodesOnLevel.size()];
+      int[] sortedNodes = getSortedNodes(graph.getNodesOnLevel(level));
+      offsets[level] = new int[sortedNodes.length];
       int nodeOffsetId = 0;
-      for (int n = 0; n < sortedNodes.length; n++) {
-        int node = sortedNodes[n];
+      for (int node : sortedNodes) {
         NeighborArray neighbors = graph.getNeighbors(level, node);
         int size = neighbors.size();
         // Write size in VInt as the neighbors list is typically small
@@ -708,6 +702,15 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
       }
     }
     return offsets;
+  }
+
+  public static int[] getSortedNodes(NodesIterator nodesOnLevel) {
+    int[] sortedNodes = new int[nodesOnLevel.size()];
+    for (int n = 0; nodesOnLevel.hasNext(); n++) {
+      sortedNodes[n] = nodesOnLevel.nextInt();
+    }
+    Arrays.sort(sortedNodes);
+    return sortedNodes;
   }
 
   private void writeMeta(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -315,9 +315,8 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     for (int level = 1; level < graph.numLevels(); level++) {
       NodesIterator nodesOnLevel = graph.getNodesOnLevel(level);
       int[] newNodes = new int[nodesOnLevel.size()];
-      int n = 0;
-      while (nodesOnLevel.hasNext()) {
-        newNodes[n++] = oldToNewMap[nodesOnLevel.nextInt()];
+      for (int n = 0; nodesOnLevel.hasNext(); n++) {
+        newNodes[n] = oldToNewMap[nodesOnLevel.nextInt()];
       }
       Arrays.sort(newNodes);
       nodesByLevel.add(newNodes);
@@ -679,14 +678,13 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     for (int level = 0; level < graph.numLevels(); level++) {
       NodesIterator nodesOnLevel = graph.getNodesOnLevel(level);
       int[] sortedNodes = new int[nodesOnLevel.size()];
-      int n = 0;
-      while (nodesOnLevel.hasNext()) {
-        sortedNodes[n++] = nodesOnLevel.nextInt();
+      for (int n = 0; nodesOnLevel.hasNext(); n++) {
+        sortedNodes[n] = nodesOnLevel.nextInt();
       }
       Arrays.sort(sortedNodes);
       offsets[level] = new int[nodesOnLevel.size()];
       int nodeOffsetId = 0;
-      for (n = 0; n < sortedNodes.length; n++) {
+      for (int n = 0; n < sortedNodes.length; n++) {
         int node = sortedNodes[n];
         NeighborArray neighbors = graph.getNeighbors(level, node);
         int size = neighbors.size();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -678,10 +678,16 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     int[][] offsets = new int[graph.numLevels()][];
     for (int level = 0; level < graph.numLevels(); level++) {
       NodesIterator nodesOnLevel = graph.getNodesOnLevel(level);
+      int[] sortedNodes = new int[nodesOnLevel.size()];
+      int n = 0;
+      while (nodesOnLevel.hasNext()) {
+        sortedNodes[n++] = nodesOnLevel.nextInt();
+      }
+      Arrays.sort(sortedNodes);
       offsets[level] = new int[nodesOnLevel.size()];
       int nodeOffsetId = 0;
-      while (nodesOnLevel.hasNext()) {
-        int node = nodesOnLevel.nextInt();
+      for (n = 0; n < sortedNodes.length; n++) {
+        int node = sortedNodes[n];
         NeighborArray neighbors = graph.getNeighbors(level, node);
         int size = neighbors.size();
         // Write size in VInt as the neighbors list is typically small
@@ -779,6 +785,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
         if (level > 0) {
           int[] nol = new int[nodesOnLevel.size()];
           int numberConsumed = nodesOnLevel.consume(nol);
+          Arrays.sort(nol);
           assert numberConsumed == nodesOnLevel.size();
           meta.writeVInt(nol.length); // number of nodes on a level
           for (int i = nodesOnLevel.size() - 1; i > 0; --i) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -81,7 +81,8 @@ public abstract class HnswGraph {
   public abstract int entryNode() throws IOException;
 
   /**
-   * Get all nodes on a given level as node 0th ordinals
+   * Get all nodes on a given level as node 0th ordinals.  The nodes are NOT
+   * guaranteed to be presented in any particular order.
    *
    * @param level level for which to get all nodes
    * @return an iterator over nodes where {@code nextInt} returns a next node on the level
@@ -123,7 +124,8 @@ public abstract class HnswGraph {
 
   /**
    * Iterator over the graph nodes on a certain level, Iterator also provides the size – the total
-   * number of nodes to be iterated over.
+   * number of nodes to be iterated over.  The nodes are NOT guaranteed to be presented
+   * in any particular order.
    */
   public abstract static class NodesIterator implements PrimitiveIterator.OfInt {
     protected final int size;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -242,34 +242,4 @@ public abstract class HnswGraph {
       return nodes.hasNext();
     }
   }
-
-  public String prettyPrint() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(this);
-    sb.append("\n");
-
-    try {
-      for (int level = 0; level < numLevels(); level++) {
-        sb.append("# Level ").append(level).append("\n");
-        var it = getNodesOnLevel(level);
-        while (it.hasNext()) {
-          int node = it.nextInt();
-          sb.append("  ").append(node).append(" -> ");
-          seek(level, node);
-          while (true) {
-            int neighbor = nextNeighbor();
-            if (neighbor == NO_MORE_DOCS) {
-              break;
-            }
-            sb.append(" ").append(neighbor);
-          }
-          sb.append("\n");
-        }
-      }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-
-    return sb.toString();
-  }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -81,8 +81,8 @@ public abstract class HnswGraph {
   public abstract int entryNode() throws IOException;
 
   /**
-   * Get all nodes on a given level as node 0th ordinals.  The nodes are NOT
-   * guaranteed to be presented in any particular order.
+   * Get all nodes on a given level as node 0th ordinals. The nodes are NOT guaranteed to be
+   * presented in any particular order.
    *
    * @param level level for which to get all nodes
    * @return an iterator over nodes where {@code nextInt} returns a next node on the level
@@ -124,8 +124,8 @@ public abstract class HnswGraph {
 
   /**
    * Iterator over the graph nodes on a certain level, Iterator also provides the size – the total
-   * number of nodes to be iterated over.  The nodes are NOT guaranteed to be presented
-   * in any particular order.
+   * number of nodes to be iterated over. The nodes are NOT guaranteed to be presented in any
+   * particular order.
    */
   public abstract static class NodesIterator implements PrimitiveIterator.OfInt {
     protected final int size;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -242,4 +242,34 @@ public abstract class HnswGraph {
       return nodes.hasNext();
     }
   }
+
+  public String prettyPrint() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(this);
+    sb.append("\n");
+
+    try {
+      for (int level = 0; level < numLevels(); level++) {
+        sb.append("# Level ").append(level).append("\n");
+        var it = getNodesOnLevel(level);
+        while (it.hasNext()) {
+          int node = it.nextInt();
+          sb.append("  ").append(node).append(" -> ");
+          seek(level, node);
+          while (true) {
+            int neighbor = nextNeighbor();
+            if (neighbor == NO_MORE_DOCS) {
+              break;
+            }
+            sb.append(" ").append(neighbor);
+          }
+          sb.append("\n");
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return sb.toString();
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -205,4 +205,10 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
     }
     return total;
   }
+
+  @Override
+  public String toString() {
+    return "OnHeapHnswGraph(size=%d, numLevels=%d, entryNode=%d)"
+        .formatted(size(), numLevels, entryNode);
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -77,7 +77,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
     if (level == 0) {
       return graphLevel0.get(node);
     }
-    var levelMap = graphUpperLevels.get(level);
+    Map<Integer, NeighborArray> levelMap = graphUpperLevels.get(level);
     assert levelMap.containsKey(node);
     return levelMap.get(node);
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -20,8 +20,9 @@ package org.apache.lucene.util.hnsw;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.TreeMap;
+import java.util.Map;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 
@@ -40,12 +41,12 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
   // added to HnswBuilder, and the node values are the ordinals of those vectors.
   // Thus, on all levels, neighbors expressed as the level 0's nodes' ordinals.
   private final List<NeighborArray> graphLevel0;
-  // Represents levels 1-N. Each level is represented with a TreeMap that maps a levels level 0
+  // Represents levels 1-N. Each level is represented with a Map that maps a levels level 0
   // ordinal to its neighbors on that level. All nodes are in level 0, so we do not need to maintain
   // it in this list. However, to avoid changing list indexing, we always will make the first
   // element
   // null.
-  private final List<TreeMap<Integer, NeighborArray>> graphUpperLevels;
+  private final List<Map<Integer, NeighborArray>> graphUpperLevels;
   private final int nsize;
   private final int nsize0;
 
@@ -76,7 +77,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
     if (level == 0) {
       return graphLevel0.get(node);
     }
-    TreeMap<Integer, NeighborArray> levelMap = graphUpperLevels.get(level);
+    var levelMap = graphUpperLevels.get(level);
     assert levelMap.containsKey(node);
     return levelMap.get(node);
   }
@@ -103,7 +104,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
       // and make this node the graph's new entry point
       if (level >= numLevels) {
         for (int i = numLevels; i <= level; i++) {
-          graphUpperLevels.add(new TreeMap<>());
+          graphUpperLevels.add(new HashMap<>());
         }
         numLevels = level + 1;
         entryNode = node;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -208,7 +208,6 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
 
   @Override
   public String toString() {
-    return "OnHeapHnswGraph(size=%d, numLevels=%d, entryNode=%d)"
-        .formatted(size(), numLevels, entryNode);
+    return "OnHeapHnswGraph(size=" + size() + ", numLevels=" + numLevels + ", entryNode=" + entryNode + ")";
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -281,11 +281,11 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     String prettyG = prettyPrint(g);
     String prettyH = prettyPrint(h);
     assertEquals(
-        "the number of levels in the graphs are different:%n%s%n%s".formatted(prettyG, prettyH),
+        "the number of levels in the graphs are different:%n" + prettyG + "%n" + prettyH,
         g.numLevels(),
         h.numLevels());
     assertEquals(
-        "the number of nodes in the graphs are different:%n%s%n%s".formatted(prettyG, prettyH),
+        "the number of nodes in the graphs are different:%n" + prettyG + "%n" + prettyH,
         g.size(),
         h.size());
 
@@ -294,10 +294,9 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
       List<Integer> hNodes = sortedNodesOnLevel(h, level);
       List<Integer> gNodes = sortedNodesOnLevel(g, level);
       assertEquals(
-          "nodes in the graphs are different on level %d:%n%s%n%s"
-              .formatted(level, prettyG, prettyH),
-          gNodes,
-          hNodes);
+              "nodes in the graphs are different on level " + level + ":%n" + prettyG + "%n" + prettyH,
+              getNeighborNodes(g),
+              getNeighborNodes(h));
     }
 
     // assert equal nodes' neighbours on each level
@@ -308,7 +307,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
         g.seek(level, node);
         h.seek(level, node);
         assertEquals(
-            "arcs differ for node %d on level %d:%n%s%n%s".formatted(node, level, prettyG, prettyH),
+            "arcs differ for node " + node + " on level " + level + ":%n" + prettyG + "%n" + prettyH,
             getNeighborNodes(g),
             getNeighborNodes(h));
       }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -271,21 +271,24 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     // construct these up front since they call seek which will mess up our test loop
     String prettyG = prettyPrint(g);
     String prettyH = prettyPrint(h);
-    String m1 =
-        "the number of levels in the graphs are different:%n%s%n%s".formatted(prettyG, prettyH);
-    assertEquals(m1, g.numLevels(), h.numLevels());
-    String m2 =
-        "the number of nodes in the graphs are different:%n%s%n%s".formatted(prettyG, prettyH);
-    assertEquals(m2, g.size(), h.size());
+    assertEquals(
+        "the number of levels in the graphs are different:%n%s%n%s".formatted(prettyG, prettyH),
+        g.numLevels(),
+        h.numLevels());
+    assertEquals(
+        "the number of nodes in the graphs are different:%n%s%n%s".formatted(prettyG, prettyH),
+        g.size(),
+        h.size());
 
     // assert equal nodes on each level
     for (int level = 0; level < g.numLevels(); level++) {
       List<Integer> hNodes = sortedNodesOnLevel(h, level);
       List<Integer> gNodes = sortedNodesOnLevel(g, level);
-      String m3 =
+      assertEquals(
           "nodes in the graphs are different on level %d:%n%s%n%s"
-              .formatted(level, prettyG, prettyH);
-      assertEquals(m3, gNodes, hNodes);
+              .formatted(level, prettyG, prettyH),
+          gNodes,
+          hNodes);
     }
 
     // assert equal nodes' neighbours on each level
@@ -295,9 +298,10 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
         int node = nodesOnLevel.nextInt();
         g.seek(level, node);
         h.seek(level, node);
-        String m4 =
-            "arcs differ for node %d on level %d:%n%s%n%s".formatted(node, level, prettyG, prettyH);
-        assertEquals(m4, getNeighborNodes(g), getNeighborNodes(h));
+        assertEquals(
+            "arcs differ for node %d on level %d:%n%s%n%s".formatted(node, level, prettyG, prettyH),
+            getNeighborNodes(g),
+            getNeighborNodes(h));
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -22,9 +22,6 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.apache.lucene.tests.util.RamUsageTester.ramUsed;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
-import java.io.IOException;
-import java.util.*;
-import java.util.stream.Collectors;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.lucene95.Lucene95Codec;
 import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsFormat;
@@ -61,6 +58,18 @@ import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.HnswGraph.NodesIterator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Tests HNSW KNN graphs */
 abstract class HnswGraphTestCase<T> extends LuceneTestCase {

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -33,6 +33,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.lucene95.Lucene95Codec;
 import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsFormat;
@@ -495,11 +497,13 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     }
 
     for (int currLevel = 1; currLevel < numLevels; currLevel++) {
-      NodesIterator nodesIterator = bottomUpExpectedHnsw.getNodesOnLevel(currLevel);
+      var nodesIterator = bottomUpExpectedHnsw.getNodesOnLevel(currLevel);
       List<Integer> expectedNodesOnLevel = nodesPerLevel.get(currLevel);
       assertEquals(expectedNodesOnLevel.size(), nodesIterator.size());
+      var sortedNodes = IntStream.iterate(0, i -> nodesIterator.hasNext(), i -> nodesIterator.next())
+              .sorted().iterator();
       for (Integer expectedNode : expectedNodesOnLevel) {
-        int currentNode = nodesIterator.nextInt();
+        int currentNode = sortedNodes.nextInt();
         assertEquals(expectedNode.intValue(), currentNode);
         assertEquals(0, bottomUpExpectedHnsw.getNeighbors(currLevel, currentNode).size());
       }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -267,8 +267,14 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
   }
 
   void assertGraphEqual(HnswGraph g, HnswGraph h) throws IOException {
-    assertEquals("the number of levels in the graphs are different!", g.numLevels(), h.numLevels());
-    assertEquals("the number of nodes in the graphs are different!", g.size(), h.size());
+    var m1 =
+        "the number of levels in the graphs are different:%n%s%n%s"
+            .formatted(g.prettyPrint(), h.prettyPrint());
+    assertEquals(m1, g.numLevels(), h.numLevels());
+    var m2 =
+        "the number of nodes in the graphs are different:%n%s%n%s"
+            .formatted(g.prettyPrint(), h.prettyPrint());
+    assertEquals(m2, g.size(), h.size());
 
     // assert equal nodes on each level
     for (int level = 0; level < g.numLevels(); level++) {
@@ -277,7 +283,10 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
       while (nodesOnLevel.hasNext() && nodesOnLevel2.hasNext()) {
         int node = nodesOnLevel.nextInt();
         int node2 = nodesOnLevel2.nextInt();
-        assertEquals("nodes in the graphs are different", node, node2);
+        var m3 =
+            "nodes in the graphs are different on level %d:%n%s%n%s"
+                .formatted(level, g.prettyPrint(), h.prettyPrint());
+        assertEquals(m3, node, node2);
       }
     }
 
@@ -288,7 +297,10 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
         int node = nodesOnLevel.nextInt();
         g.seek(level, node);
         h.seek(level, node);
-        assertEquals("arcs differ for node " + node, getNeighborNodes(g), getNeighborNodes(h));
+        var m4 =
+            "arcs differ for node %d on level %d:%n%s%n%s"
+                .formatted(node, level, g.prettyPrint(), h.prettyPrint());
+        assertEquals(m4, getNeighborNodes(g), getNeighborNodes(h));
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -34,7 +34,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.lucene95.Lucene95Codec;
 import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsFormat;
@@ -500,8 +499,10 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
       var nodesIterator = bottomUpExpectedHnsw.getNodesOnLevel(currLevel);
       List<Integer> expectedNodesOnLevel = nodesPerLevel.get(currLevel);
       assertEquals(expectedNodesOnLevel.size(), nodesIterator.size());
-      var sortedNodes = IntStream.iterate(0, i -> nodesIterator.hasNext(), i -> nodesIterator.next())
-              .sorted().iterator();
+      var sortedNodes =
+          IntStream.iterate(0, i -> nodesIterator.hasNext(), i -> nodesIterator.next())
+              .sorted()
+              .iterator();
       for (Integer expectedNode : expectedNodesOnLevel) {
         int currentNode = sortedNodes.nextInt();
         assertEquals(expectedNode.intValue(), currentNode);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -612,13 +612,9 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
     // assert the nodes from the previous graph are successfully to levels > 0 in the new graph
     for (int level = 1; level < g.numLevels(); level++) {
-      NodesIterator nodesOnLevel = g.getNodesOnLevel(level);
-      NodesIterator nodesOnLevel2 = h.getNodesOnLevel(level);
-      while (nodesOnLevel.hasNext() && nodesOnLevel2.hasNext()) {
-        int node = nodesOnLevel.nextInt();
-        int node2 = oldToNewOrdMap.get(nodesOnLevel2.nextInt());
-        assertEquals("nodes in the graphs are different", node, node2);
-      }
+      var nodesOnLevel = sortedNodesOnLevel(g, level);
+      var nodesOnLevel2 = sortedNodesOnLevel(h, level).stream().map(oldToNewOrdMap::get).toList();
+      assertEquals(nodesOnLevel, nodesOnLevel2);
     }
 
     // assert that the neighbors from the old graph are successfully transferred to the new graph

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -269,19 +269,20 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
   void assertGraphEqual(HnswGraph g, HnswGraph h) throws IOException {
     // construct these up front since they call seek which will mess up our test loop
-    var prettyG = prettyPrint(g);
-    var prettyH = prettyPrint(h);
-    var m1 =
+    String prettyG = prettyPrint(g);
+    String prettyH = prettyPrint(h);
+    String m1 =
         "the number of levels in the graphs are different:%n%s%n%s".formatted(prettyG, prettyH);
     assertEquals(m1, g.numLevels(), h.numLevels());
-    var m2 = "the number of nodes in the graphs are different:%n%s%n%s".formatted(prettyG, prettyH);
+    String m2 =
+        "the number of nodes in the graphs are different:%n%s%n%s".formatted(prettyG, prettyH);
     assertEquals(m2, g.size(), h.size());
 
     // assert equal nodes on each level
     for (int level = 0; level < g.numLevels(); level++) {
-      var hNodes = sortedNodesOnLevel(h, level);
-      var gNodes = sortedNodesOnLevel(g, level);
-      var m3 =
+      List<Integer> hNodes = sortedNodesOnLevel(h, level);
+      List<Integer> gNodes = sortedNodesOnLevel(g, level);
+      String m3 =
           "nodes in the graphs are different on level %d:%n%s%n%s"
               .formatted(level, prettyG, prettyH);
       assertEquals(m3, gNodes, hNodes);
@@ -294,7 +295,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
         int node = nodesOnLevel.nextInt();
         g.seek(level, node);
         h.seek(level, node);
-        var m4 =
+        String m4 =
             "arcs differ for node %d on level %d:%n%s%n%s".formatted(node, level, prettyG, prettyH);
         assertEquals(m4, getNeighborNodes(g), getNeighborNodes(h));
       }
@@ -505,7 +506,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
     for (int currLevel = 1; currLevel < numLevels; currLevel++) {
       List<Integer> expectedNodesOnLevel = nodesPerLevel.get(currLevel);
-      var sortedNodes = sortedNodesOnLevel(bottomUpExpectedHnsw, currLevel);
+      List<Integer> sortedNodes = sortedNodesOnLevel(bottomUpExpectedHnsw, currLevel);
       assertEquals(
           "Nodes on level %d do not match".formatted(currLevel), expectedNodesOnLevel, sortedNodes);
     }
@@ -612,8 +613,9 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
     // assert the nodes from the previous graph are successfully to levels > 0 in the new graph
     for (int level = 1; level < g.numLevels(); level++) {
-      var nodesOnLevel = sortedNodesOnLevel(g, level);
-      var nodesOnLevel2 = sortedNodesOnLevel(h, level).stream().map(oldToNewOrdMap::get).toList();
+      List<Integer> nodesOnLevel = sortedNodesOnLevel(g, level);
+      List<Integer> nodesOnLevel2 =
+          sortedNodesOnLevel(h, level).stream().map(oldToNewOrdMap::get).toList();
       assertEquals(nodesOnLevel, nodesOnLevel2);
     }
 
@@ -1206,7 +1208,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     try {
       for (int level = 0; level < hnsw.numLevels(); level++) {
         sb.append("# Level ").append(level).append("\n");
-        var it = hnsw.getNodesOnLevel(level);
+        NodesIterator it = hnsw.getNodesOnLevel(level);
         while (it.hasNext()) {
           int node = it.nextInt();
           sb.append("  ").append(node).append(" -> ");


### PR DESCRIPTION
Switches OnHeapHnswGraph from representing a single node's neighbors as a TreeMap, to a HashMap, and updates its callers to no longer assume that NodeIterator results are ordered by ordinal.

This means that looking up neighbors goes from an O(log N) operation to an O(1) operation for all upper levels.  Only callers that need ordered neighbors need to pay the cost of sorting.

On my machine, building the graph and running the queries from the SIFT dataset at http://corpus-texmex.irisa.fr/ sees about a 4% speedup.  These are dimension 128 vectors; the relative importance of looking up neighbors vs computing similarities will vary inversely with dimensionality.

(First I did three runs for each codebase, but there was enough variance that I then ran five more.)

[TreeMap]
Run 0 took 708.876145328 seconds
Run 1 took 754.700354185 seconds
Run 2 took 710.236167725 seconds
Run 0 took 717.61476478 seconds
Run 1 took 742.494343683 seconds
Run 2 took 736.983143255 seconds
Run 3 took 719.305541186 seconds
Run 4 took 722.831859596 seconds

[HashMap]
Run 0 took 724.875610053 seconds
Run 1 took 682.65666933 seconds
Run 2 took 682.655977613 seconds
Run 0 took 716.165341298 seconds
Run 1 took 684.314657618 seconds
Run 2 took 686.456432263 seconds
Run 3 took 717.067567184 seconds
Run 4 took 702.009706983 seconds

The timing harness is here: https://github.com/jbellis/hnswdemo/tree/lucene-bench