### PR TITLE
Restrict GraphTokenStreamFiniteStrings#articulationPointsRecurse recursion depth

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -86,6 +86,8 @@ Bug Fixes
 
 * GITHUB#12220: Hunspell: disallow hidden title-case entries from compound middle/end
 
+* LUCENE-10181: Restrict GraphTokenStreamFiniteStrings#articulationPointsRecurse recursion depth. (Chris Fournier)
+
 Other
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -86,8 +86,6 @@ Bug Fixes
 
 * GITHUB#12220: Hunspell: disallow hidden title-case entries from compound middle/end
 
-* LUCENE-10181: Restrict GraphTokenStreamFiniteStrings#articulationPointsRecurse recursion depth. (Chris Fournier)
-
 Other
 ---------------------
 
@@ -191,6 +189,8 @@ Bug Fixes
 
 * GITHUB#12352: [Tessellator] Improve the checks that validate the diagonal between two polygon nodes so
   the resulting polygons are valid counter clockwise polygons. (Ignacio Vera)
+
+* LUCENE-10181: Restrict GraphTokenStreamFiniteStrings#articulationPointsRecurse recursion depth. (Chris Fournier)
 
 Other
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
+++ b/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
@@ -18,6 +18,7 @@
 package org.apache.lucene.util.graph;
 
 import static org.apache.lucene.util.automaton.Operations.DEFAULT_DETERMINIZE_WORK_LIMIT;
+import static org.apache.lucene.util.automaton.Operations.MAX_RECURSION_LEVEL;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,7 +47,6 @@ import org.apache.lucene.util.automaton.Transition;
  */
 public final class GraphTokenStreamFiniteStrings {
 
-  private static final int MAX_RECURSION_DEPTH = 1024;
   private AttributeSource[] tokens = new AttributeSource[4];
   private final Automaton det;
   private final Transition transition = new Transition();
@@ -270,9 +270,13 @@ public final class GraphTokenStreamFiniteStrings {
     int numT = a.initTransition(state, t);
     for (int i = 0; i < numT; i++) {
       a.getNextTransition(t);
-      if (visited.get(t.dest) == false && d < MAX_RECURSION_DEPTH) {
+      if (visited.get(t.dest) == false) {
         parent[t.dest] = state;
-        articulationPointsRecurse(a, t.dest, d + 1, depth, low, parent, visited, points);
+        if (d < MAX_RECURSION_LEVEL) {
+          articulationPointsRecurse(a, t.dest, d + 1, depth, low, parent, visited, points);
+        } else {
+          continue;
+        }
         childCount++;
         if (low[t.dest] >= depth[state]) {
           isArticulation = true;

--- a/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
+++ b/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
@@ -275,7 +275,8 @@ public final class GraphTokenStreamFiniteStrings {
         if (d < MAX_RECURSION_LEVEL) {
           articulationPointsRecurse(a, t.dest, d + 1, depth, low, parent, visited, points);
         } else {
-          throw new IllegalArgumentException("Exceeded maximum recursion level during graph analysis");
+          throw new IllegalArgumentException(
+              "Exceeded maximum recursion level during graph analysis");
         }
         childCount++;
         if (low[t.dest] >= depth[state]) {

--- a/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
+++ b/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
@@ -46,7 +46,7 @@ import org.apache.lucene.util.automaton.Transition;
  */
 public final class GraphTokenStreamFiniteStrings {
   /** Maximum level of recursion allowed in recursive operations. */
-  public static final int MAX_RECURSION_LEVEL = 1000;
+  private static final int MAX_RECURSION_LEVEL = 1000;
 
   private AttributeSource[] tokens = new AttributeSource[4];
   private final Automaton det;

--- a/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
+++ b/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
@@ -275,7 +275,7 @@ public final class GraphTokenStreamFiniteStrings {
         if (d < MAX_RECURSION_LEVEL) {
           articulationPointsRecurse(a, t.dest, d + 1, depth, low, parent, visited, points);
         } else {
-          continue;
+          throw new IllegalArgumentException("Exceeded maximum recursion level during graph analysis");
         }
         childCount++;
         if (low[t.dest] >= depth[state]) {

--- a/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
+++ b/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
@@ -46,6 +46,7 @@ import org.apache.lucene.util.automaton.Transition;
  */
 public final class GraphTokenStreamFiniteStrings {
 
+  private static final int MAX_RECURSION_DEPTH = 1024;
   private AttributeSource[] tokens = new AttributeSource[4];
   private final Automaton det;
   private final Transition transition = new Transition();
@@ -269,7 +270,7 @@ public final class GraphTokenStreamFiniteStrings {
     int numT = a.initTransition(state, t);
     for (int i = 0; i < numT; i++) {
       a.getNextTransition(t);
-      if (visited.get(t.dest) == false) {
+      if (visited.get(t.dest) == false && d < MAX_RECURSION_DEPTH) {
         parent[t.dest] = state;
         articulationPointsRecurse(a, t.dest, d + 1, depth, low, parent, visited, points);
         childCount++;

--- a/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
+++ b/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
@@ -18,7 +18,6 @@
 package org.apache.lucene.util.graph;
 
 import static org.apache.lucene.util.automaton.Operations.DEFAULT_DETERMINIZE_WORK_LIMIT;
-import static org.apache.lucene.util.automaton.Operations.MAX_RECURSION_LEVEL;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,6 +45,8 @@ import org.apache.lucene.util.automaton.Transition;
  * different paths of the {@link Automaton}.
  */
 public final class GraphTokenStreamFiniteStrings {
+  /** Maximum level of recursion allowed in recursive operations. */
+  public static final int MAX_RECURSION_LEVEL = 1000;
 
   private AttributeSource[] tokens = new AttributeSource[4];
   private final Automaton det;

--- a/lucene/core/src/test/org/apache/lucene/util/graph/TestGraphTokenStreamFiniteStrings.java
+++ b/lucene/core/src/test/org/apache/lucene/util/graph/TestGraphTokenStreamFiniteStrings.java
@@ -684,32 +684,6 @@ public class TestGraphTokenStreamFiniteStrings extends LuceneTestCase {
     TokenStream ts = new CannedTokenStream(tokens.toArray(new Token[0]));
     GraphTokenStreamFiniteStrings graph = new GraphTokenStreamFiniteStrings(ts);
 
-    Iterator<TokenStream> it = graph.getFiniteStrings();
-    assertTrue(it.hasNext());
-    it.next();
-    assertTrue(it.hasNext());
-    it.next();
-    assertFalse(it.hasNext());
-
-    int[] points = graph.articulationPoints(); // This will cause a java.lang.StackOverflowError
-    assertEquals(points[0], 1);
-    assertEquals(points[1], 3);
-    assertEquals(points.length, MAX_RECURSION_LEVEL - 2);
-
-    assertFalse(graph.hasSidePath(0));
-    it = graph.getFiniteStrings(0, 1);
-    assertTrue(it.hasNext());
-    assertTokenStream(it.next(), new String[] {"fast"}, new int[] {1});
-    assertFalse(it.hasNext());
-    Term[] terms = graph.getTerms("field", 0);
-    assertArrayEquals(terms, new Term[] {new Term("field", "fast")});
-
-    assertTrue(graph.hasSidePath(1));
-    it = graph.getFiniteStrings(1, 3);
-    assertTrue(it.hasNext());
-    assertTokenStream(it.next(), new String[] {"wi", "fi"}, new int[] {1, 1});
-    assertTrue(it.hasNext());
-    assertTokenStream(it.next(), new String[] {"wifi"}, new int[] {1});
-    assertFalse(it.hasNext());
+    assertThrows(IllegalArgumentException.class, () -> graph.articulationPoints());
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/graph/TestGraphTokenStreamFiniteStrings.java
+++ b/lucene/core/src/test/org/apache/lucene/util/graph/TestGraphTokenStreamFiniteStrings.java
@@ -16,8 +16,6 @@
  */
 package org.apache.lucene.util.graph;
 
-import static org.apache.lucene.util.automaton.Operations.MAX_RECURSION_LEVEL;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import org.apache.lucene.analysis.TokenStream;
@@ -677,13 +675,13 @@ public class TestGraphTokenStreamFiniteStrings extends LuceneTestCase {
         };
 
     // Add in too many tokens to get a high depth graph
-    for (int i = 0; i < 1024 * 10; i++) {
+    for (int i = 0; i < 1024 + 1; i++) {
       tokens.add(token("network", 1, 1));
     }
 
     TokenStream ts = new CannedTokenStream(tokens.toArray(new Token[0]));
     GraphTokenStreamFiniteStrings graph = new GraphTokenStreamFiniteStrings(ts);
 
-    assertThrows(IllegalArgumentException.class, () -> graph.articulationPoints());
+    assertThrows(IllegalArgumentException.class, graph::articulationPoints);
   }
 }


### PR DESCRIPTION
### Description
This PR fixes https://github.com/apache/lucene/issues/11218 (or [LUCENE-10181](https://issues.apache.org/jira/browse/LUCENE-10181)), where `GraphTokenStreamFiniteStrings#articulationPointsRecurse` can result in a `StackOverflowError` for very long query strings. Errors are avoided by adding an arbitrary maximum recursion depth during `articulationPointsRecurse` and throwing an exception when this occurs.

### Testing
With only the first commit that adds a test, you can see the failure by running:
```
$ ./gradlew test --tests TestGraphTokenStreamFiniteStrings.testLongTokenStreamStackOverflowError
...
:lucene:core:test (FAILURE): 1 test(s), 1 failure(s)

1 test completed, 1 failed

ERROR: The following test(s) have failed:
  - org.apache.lucene.util.graph.TestGraphTokenStreamFiniteStrings.testLongTokenStreamStackOverflowError (:lucene:core)
    Test output: /Users/cfournie/src/github.com/lucene/lucene/core/build/test-results/test/outputs/OUTPUT-org.apache.lucene.util.graph.TestGraphTokenStreamFiniteStrings.txt
    Reproduce with: gradlew :lucene:core:test --tests "org.apache.lucene.util.graph.TestGraphTokenStreamFiniteStrings.testLongTokenStreamStackOverflowError" -Ptests.jvms=4 "-Ptests.jvmargs=-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1" -Ptests.seed=5AED26C08493DCF3 -Ptests.gui=false -Ptests.file.encoding=ISO-8859-1


FAILURE: Build failed with an exception.
```

After adding the subsequent commit the test then passes with the same command.