### PR TITLE
Change offset to start when data is all equals in StoredFieldsInts.java

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/StoredFieldsInts.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/StoredFieldsInts.java
@@ -38,7 +38,7 @@ class StoredFieldsInts {
     }
     if (allEqual) {
       out.writeByte((byte) 0);
-      out.writeVInt(values[0]);
+      out.writeVInt(values[start]);
     } else {
       long max = 0;
       for (int i = 0; i < count; ++i) {


### PR DESCRIPTION


### Description
This pull request addresses an issue in the StoredFieldsInts.java file, where the offset is hardcoded as 0 when data is all equal. Instead, it should be set to the value of start. Additionally, as the argument for start is always 0 when StoredFieldInts#writeInts is called by Lucene90CompressingStoredFieldsWriter.java, should we  remove the start argument?
https://github.com/apache/lucene/blob/3c163745bb07aed51b52878de0666f1405696147/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/StoredFieldsInts.java#L41 
https://github.com/apache/lucene/blob/3c163745bb07aed51b52878de0666f1405696147/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/StoredFieldsInts.java#L31

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
