### PR TITLE
Fix SynonymQuery equals implementation

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
@@ -146,7 +146,9 @@ public final class SynonymQuery extends Query {
 
   @Override
   public boolean equals(Object other) {
-    return sameClassAs(other) && field.equals(((SynonymQuery)other).field) && Arrays.equals(terms, ((SynonymQuery) other).terms);
+    return sameClassAs(other)
+        && field.equals(((SynonymQuery) other).field)
+        && Arrays.equals(terms, ((SynonymQuery) other).terms);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
@@ -113,7 +113,7 @@ public final class SynonymQuery extends Query {
    */
   private SynonymQuery(TermAndBoost[] terms, String field) {
     this.terms = Objects.requireNonNull(terms);
-    this.field = field;
+    this.field = Objects.requireNonNull(field);
   }
 
   public List<Term> getTerms() {
@@ -146,7 +146,7 @@ public final class SynonymQuery extends Query {
 
   @Override
   public boolean equals(Object other) {
-    return sameClassAs(other) && Arrays.equals(terms, ((SynonymQuery) other).terms);
+    return sameClassAs(other) && field.equals(((SynonymQuery)other).field) && Arrays.equals(terms, ((SynonymQuery) other).terms);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
@@ -73,6 +73,27 @@ public class TestSynonymQuery extends LuceneTestCase {
             .addTerm(new Term("field", "c"), 0.2f)
             .addTerm(new Term("field", "d"))
             .build());
+
+    QueryUtils.checkUnequal(new SynonymQuery.Builder("field")
+                    .addTerm(new Term("field", "a"), 0.4f)
+                    .build(),
+            new SynonymQuery.Builder("field")
+                    .addTerm(new Term("field", "b"), 0.4f)
+                    .build());
+
+    QueryUtils.checkUnequal(new SynonymQuery.Builder("field")
+                    .addTerm(new Term("field", "a"), 0.2f)
+                    .build(),
+            new SynonymQuery.Builder("field")
+                    .addTerm(new Term("field", "a"), 0.4f)
+                    .build());
+
+    QueryUtils.checkUnequal(new SynonymQuery.Builder("field1")
+                    .addTerm(new Term("field1", "b"), 0.4f)
+                    .build(),
+            new SynonymQuery.Builder("field2")
+                    .addTerm(new Term("field2", "b"), 0.4f)
+                    .build());
   }
 
   public void testBogusParams() {
@@ -127,6 +148,14 @@ public class TestSynonymQuery extends LuceneTestCase {
         () -> {
           new SynonymQuery.Builder("field1").addTerm(new Term("field1", "a"), -0f);
         });
+
+    expectThrows(
+            NullPointerException.class,
+            () -> new SynonymQuery.Builder(null).addTerm(new Term("field1", "a"), -0f));
+
+    expectThrows(
+            NullPointerException.class,
+            () -> new SynonymQuery.Builder(null).build());
   }
 
   public void testToString() {

--- a/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
@@ -74,26 +74,17 @@ public class TestSynonymQuery extends LuceneTestCase {
             .addTerm(new Term("field", "d"))
             .build());
 
-    QueryUtils.checkUnequal(new SynonymQuery.Builder("field")
-                    .addTerm(new Term("field", "a"), 0.4f)
-                    .build(),
-            new SynonymQuery.Builder("field")
-                    .addTerm(new Term("field", "b"), 0.4f)
-                    .build());
+    QueryUtils.checkUnequal(
+        new SynonymQuery.Builder("field").addTerm(new Term("field", "a"), 0.4f).build(),
+        new SynonymQuery.Builder("field").addTerm(new Term("field", "b"), 0.4f).build());
 
-    QueryUtils.checkUnequal(new SynonymQuery.Builder("field")
-                    .addTerm(new Term("field", "a"), 0.2f)
-                    .build(),
-            new SynonymQuery.Builder("field")
-                    .addTerm(new Term("field", "a"), 0.4f)
-                    .build());
+    QueryUtils.checkUnequal(
+        new SynonymQuery.Builder("field").addTerm(new Term("field", "a"), 0.2f).build(),
+        new SynonymQuery.Builder("field").addTerm(new Term("field", "a"), 0.4f).build());
 
-    QueryUtils.checkUnequal(new SynonymQuery.Builder("field1")
-                    .addTerm(new Term("field1", "b"), 0.4f)
-                    .build(),
-            new SynonymQuery.Builder("field2")
-                    .addTerm(new Term("field2", "b"), 0.4f)
-                    .build());
+    QueryUtils.checkUnequal(
+        new SynonymQuery.Builder("field1").addTerm(new Term("field1", "b"), 0.4f).build(),
+        new SynonymQuery.Builder("field2").addTerm(new Term("field2", "b"), 0.4f).build());
   }
 
   public void testBogusParams() {
@@ -150,12 +141,10 @@ public class TestSynonymQuery extends LuceneTestCase {
         });
 
     expectThrows(
-            NullPointerException.class,
-            () -> new SynonymQuery.Builder(null).addTerm(new Term("field1", "a"), -0f));
+        NullPointerException.class,
+        () -> new SynonymQuery.Builder(null).addTerm(new Term("field1", "a"), -0f));
 
-    expectThrows(
-            NullPointerException.class,
-            () -> new SynonymQuery.Builder(null).build());
+    expectThrows(NullPointerException.class, () -> new SynonymQuery.Builder(null).build());
   }
 
   public void testToString() {


### PR DESCRIPTION
The `term` member of `TermAndBoost` used to be a `Term` instance and became a `BytesRef` with #11941, which means its `equals` impl won't take the field name into account. The `SynonymQuery` equals impl needs to be updated accordingly to take the field into account as well, otherwise synonym queries with same term and boost across different fields are equal which is a bug.
