### PR TITLE
add BitSet.clear()

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -47,9 +47,6 @@ API Changes
 * GITHUB#12107: Remove deprecated KnnVectorField, KnnVectorQuery, VectorValues and
   LeafReader#getVectorValues. (Luca Cavanna)
 
-* GITHUB#12268: Add BitSet.clear() without parameters for clearing the entire set
-  (Jonathan Ellis)
-
 New Features
 ---------------------
 
@@ -113,6 +110,10 @@ Other
 
 API Changes
 ---------------------
+
+* GITHUB#12268: Add BitSet.clear() without parameters for clearing the entire set
+  (Jonathan Ellis)
+
 (No changes)
 
 New Features

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -47,6 +47,9 @@ API Changes
 * GITHUB#12107: Remove deprecated KnnVectorField, KnnVectorQuery, VectorValues and
   LeafReader#getVectorValues. (Luca Cavanna)
 
+* GITHUB#12268: Add BitSet.clear() without parameters for clearing the entire set
+  (Jonathan Ellis)
+
 New Features
 ---------------------
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/TrigramAutomaton.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/TrigramAutomaton.java
@@ -79,7 +79,7 @@ class TrigramAutomaton {
   }
 
   int ngramScore(CharsRef s2) {
-    countedSubstrings.clear(0, countedSubstrings.length());
+    countedSubstrings.clear();
 
     int score1 = 0, score2 = 0, score3 = 0; // scores for substrings of length 1, 2 and 3
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/IndexedDISI.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/IndexedDISI.java
@@ -219,7 +219,7 @@ final class IndexedDISI extends DocIdSetIterator {
         // Flush block
         flush(prevBlock, buffer, blockCardinality, denseRankPower, out);
         // Reset for next block
-        buffer.clear(0, buffer.length());
+        buffer.clear();
         totalCardinality += blockCardinality;
         blockCardinality = 0;
       }
@@ -233,7 +233,7 @@ final class IndexedDISI extends DocIdSetIterator {
               jumps, out.getFilePointer() - origo, totalCardinality, jumpBlockIndex, prevBlock + 1);
       totalCardinality += blockCardinality;
       flush(prevBlock, buffer, blockCardinality, denseRankPower, out);
-      buffer.clear(0, buffer.length());
+      buffer.clear();
       prevBlock++;
     }
     final int lastBlock =

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -220,7 +220,7 @@ public final class IndexedDISI extends DocIdSetIterator {
         // Flush block
         flush(prevBlock, buffer, blockCardinality, denseRankPower, out);
         // Reset for next block
-        buffer.clear(0, buffer.length());
+        buffer.clear();
         totalCardinality += blockCardinality;
         blockCardinality = 0;
       }
@@ -234,7 +234,7 @@ public final class IndexedDISI extends DocIdSetIterator {
               jumps, out.getFilePointer() - origo, totalCardinality, jumpBlockIndex, prevBlock + 1);
       totalCardinality += blockCardinality;
       flush(prevBlock, buffer, blockCardinality, denseRankPower, out);
-      buffer.clear(0, buffer.length());
+      buffer.clear();
       prevBlock++;
     }
     final int lastBlock =

--- a/lucene/core/src/java/org/apache/lucene/util/BitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitSet.java
@@ -48,7 +48,10 @@ public abstract class BitSet implements Bits, Accountable {
    *
    * <p>Depending on the implementation, this may be significantly faster than clear(0, length).
    */
-  public abstract void clear();
+  public void clear() {
+    // default implementation for compatibility with possible out-of-tree code
+    clear(0, length());
+  }
 
   /** Set the bit at <code>i</code>. */
   public abstract void set(int i);

--- a/lucene/core/src/java/org/apache/lucene/util/BitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitSet.java
@@ -49,7 +49,7 @@ public abstract class BitSet implements Bits, Accountable {
    * <p>Depending on the implementation, this may be significantly faster than clear(0, length).
    */
   public void clear() {
-    // default implementation for compatibility with possible out-of-tree code
+    // default implementation for compatibility
     clear(0, length());
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/BitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitSet.java
@@ -43,6 +43,13 @@ public abstract class BitSet implements Bits, Accountable {
     return set;
   }
 
+  /**
+   * Clear all the bits of the set.
+   *
+   * <p>Depending on the implementation, this may be significantly faster than clear(0, length).
+   */
+  public abstract void clear();
+
   /** Set the bit at <code>i</code>. */
   public abstract void set(int i);
 

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -147,6 +147,11 @@ public final class FixedBitSet extends BitSet {
     assert verifyGhostBitsClear();
   }
 
+  @Override
+  public void clear() {
+    Arrays.fill(bits, 0L);
+  }
+
   /**
    * Checks if the bits past numBits are clear. Some methods rely on this implicit assumption:
    * search for "Depends on the ghost bits being clear!"

--- a/lucene/core/src/java/org/apache/lucene/util/SparseFixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/SparseFixedBitSet.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.util;
 
 import java.io.IOException;
+import java.util.Arrays;
 import org.apache.lucene.search.DocIdSetIterator;
 
 /**
@@ -67,6 +68,17 @@ public class SparseFixedBitSet extends BitSet {
     final int blockCount = blockCount(length);
     indices = new long[blockCount];
     bits = new long[blockCount][];
+    ramBytesUsed =
+        BASE_RAM_BYTES_USED
+            + RamUsageEstimator.sizeOf(indices)
+            + RamUsageEstimator.shallowSizeOf(bits);
+  }
+
+  @Override
+  public void clear() {
+    Arrays.fill(bits, null);
+    Arrays.fill(indices, 0L);
+    nonZeroLongCount = 0;
     ramBytesUsed =
         BASE_RAM_BYTES_USED
             + RamUsageEstimator.sizeOf(indices)

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
@@ -1097,7 +1097,7 @@ public final class Operations {
       FixedBitSet tmp = current;
       current = next;
       next = tmp;
-      next.clear(0, next.length());
+      next.clear();
     }
     return builder.toString();
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -296,6 +296,6 @@ public class HnswGraphSearcher<T> {
     if (visited.length() < capacity) {
       visited = FixedBitSet.ensureCapacity((FixedBitSet) visited, capacity);
     }
-    visited.clear(0, visited.length());
+    visited.clear();
   }
 }

--- a/lucene/facet/src/java/org/apache/lucene/facet/range/OverlappingLongRangeCounter.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/OverlappingLongRangeCounter.java
@@ -84,7 +84,7 @@ class OverlappingLongRangeCounter extends LongRangeCounter {
     if (multiValuedDocElementaryIntervalHits == null) {
       multiValuedDocElementaryIntervalHits = new FixedBitSet(boundaries.length);
     } else {
-      multiValuedDocElementaryIntervalHits.clear(0, multiValuedDocElementaryIntervalHits.length());
+      multiValuedDocElementaryIntervalHits.clear();
     }
   }
 
@@ -103,7 +103,7 @@ class OverlappingLongRangeCounter extends LongRangeCounter {
     if (multiValuedDocRangeHits == null) {
       multiValuedDocRangeHits = new FixedBitSet(rangeCount());
     } else {
-      multiValuedDocRangeHits.clear(0, multiValuedDocRangeHits.length());
+      multiValuedDocRangeHits.clear();
     }
     elementaryIntervalUpto = 0;
     rollupMultiValued(root);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/BaseBitSetTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/BaseBitSetTestCase.java
@@ -170,6 +170,22 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
     }
   }
 
+  /** Test the {@link BitSet#clear()} method. */
+  public void testClearAll() throws IOException {
+    Random random = random();
+    final int numBits = 1 + random.nextInt(100000);
+    for (float percentSet : new float[] {0, 0.01f, 0.1f, 0.5f, 0.9f, 0.99f, 1f}) {
+      BitSet set1 = new JavaUtilBitSet(randomSet(numBits, percentSet), numBits);
+      T set2 = copyOf(set1, numBits);
+      final int iters = atLeast(random, 10);
+      for (int i = 0; i < iters; ++i) {
+        set1.clear();
+        set2.clear();
+        assertEquals(set1, set2, numBits);
+      }
+    }
+  }
+
   private DocIdSet randomCopy(BitSet set, int numBits) throws IOException {
     switch (random().nextInt(5)) {
       case 0:
@@ -239,6 +255,11 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
     JavaUtilBitSet(java.util.BitSet bitSet, int numBits) {
       this.bitSet = bitSet;
       this.numBits = numBits;
+    }
+
+    @Override
+    public void clear() {
+      bitSet.clear();
     }
 
     @Override


### PR DESCRIPTION
Depending on the implementation, this may be significantly faster than clear(0, length).

In particular, SparseFixedBitSet can use a single Arrays.fill call instead of looping through the backing array.