### PR TITLE
Don't generate stacktrace in CollectionTerminatedException

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -72,6 +72,8 @@ Optimizations
 
 * GITHUB#12160: Concurrent rewrite for AbstractKnnVectorQuery. (Kaival Parikh)
 
+* GITHUB#12270 Don't generate stacktrace in CollectionTerminatedException. (Armin Braun)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/CollectionTerminatedException.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CollectionTerminatedException.java
@@ -31,4 +31,10 @@ public final class CollectionTerminatedException extends RuntimeException {
   public CollectionTerminatedException() {
     super();
   }
+
+  @Override
+  public Throwable fillInStackTrace() {
+    // never re-thrown so we can save the expensive stacktrace
+    return this;
+  }
 }


### PR DESCRIPTION
Seems this exception is always ignored so there's no point in filling in a stack-trace for it.
