### PR TITLE
Make TimeExceededException members final

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/TimeLimitingCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TimeLimitingCollector.java
@@ -33,9 +33,9 @@ public class TimeLimitingCollector implements Collector {
   /** Thrown when elapsed search time exceeds allowed search time. */
   @SuppressWarnings("serial")
   public static class TimeExceededException extends RuntimeException {
-    private long timeAllowed;
-    private long timeElapsed;
-    private int lastDocCollected;
+    private final long timeAllowed;
+    private final long timeElapsed;
+    private final int lastDocCollected;
 
     private TimeExceededException(long timeAllowed, long timeElapsed, int lastDocCollected) {
       super(


### PR DESCRIPTION
TimeExceededException has three members that are set within its constructor and never modified. They can be made final.