### PR TITLE
Update javadocs for QueryTimeout

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/QueryTimeout.java
+++ b/lucene/core/src/java/org/apache/lucene/index/QueryTimeout.java
@@ -17,14 +17,16 @@
 package org.apache.lucene.index;
 
 /**
- * Query timeout abstraction that controls whether a query should continue or be stopped.
- * Can be set to the searcher through {@link org.apache.lucene.search.IndexSearcher#setTimeout(QueryTimeout)}, in which case
- * bulk scoring will be time-bound. Can also be used in combination with {@link ExitableDirectoryReader}.
+ * Query timeout abstraction that controls whether a query should continue or be stopped. Can be set
+ * to the searcher through {@link org.apache.lucene.search.IndexSearcher#setTimeout(QueryTimeout)},
+ * in which case bulk scoring will be time-bound. Can also be used in combination with {@link
+ * ExitableDirectoryReader}.
  */
 public interface QueryTimeout {
 
   /**
    * Called to determine whether to stop processing a query
+   *
    * @return true if the query should stop, false otherwise
    */
   boolean shouldExit();

--- a/lucene/core/src/java/org/apache/lucene/index/QueryTimeout.java
+++ b/lucene/core/src/java/org/apache/lucene/index/QueryTimeout.java
@@ -17,14 +17,15 @@
 package org.apache.lucene.index;
 
 /**
- * Base for query timeout implementations, which will provide a {@code shouldExit()} method, used
- * with {@link ExitableDirectoryReader}.
+ * Query timeout abstraction that controls whether a query should continue or be stopped.
+ * Can be set to the searcher through {@link org.apache.lucene.search.IndexSearcher#setTimeout(QueryTimeout)}, in which case
+ * bulk scoring will be time-bound. Can also be used in combination with {@link ExitableDirectoryReader}.
  */
 public interface QueryTimeout {
 
   /**
-   * Called from {@link ExitableDirectoryReader.ExitableTermsEnum#next()} to determine whether to
-   * stop processing a query.
+   * Called to determine whether to stop processing a query
+   * @return true if the query should stop, false otherwise
    */
-  public abstract boolean shouldExit();
+  boolean shouldExit();
 }


### PR DESCRIPTION
QueryTimeout was introduced together with ExitableDirectoryReader but is now also optionally set to the IndexSearcher to wrap the bulk scorer with a TimeLimitingBulkScorer. Its javadocs needs updating

