### PR TITLE
Remove unnecessary sort in writeFieldUpdates

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -555,8 +555,6 @@ final class ReadersAndUpdates {
     FieldInfos fieldInfos = null;
     boolean any = false;
     for (List<DocValuesFieldUpdates> updates : pendingDVUpdates.values()) {
-      // Sort by increasing delGen:
-      Collections.sort(updates, Comparator.comparingLong(a -> a.delGen));
       for (DocValuesFieldUpdates update : updates) {
         if (update.delGen <= maxDelGen && update.any()) {
           any = true;

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -18,8 +18,6 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;


### PR DESCRIPTION
We have many docValues field update scenarios especially enabled **softDeletes**. so we re check the logic in `ReadersAndUpdates`. i think the following sort logic is unnecessary

```
 Collections.sort(updates, Comparator.comparingLong(a -> a.delGen)); 
```

because sort need `O(n lg(n))` iterator, ant then scan List<DocValuesFieldUpdates>.  we can save this operation.


`pendingDVUpdates` all uses in 
https://github.com/apache/lucene/blob/a39885fdab93c4cbbcab8f3112c9783a05ca15a9/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java#L557-L566

AND

iterator all  `List<DocValuesFieldUpdates>` to  Prune the now-written DV updates:
https://github.com/apache/lucene/blob/a39885fdab93c4cbbcab8f3112c9783a05ca15a9/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java#L658-L666

it is unnecessary to sort with increasing delGen.
