### PR TITLE
unify exception thrown by regexp & check repetition range

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -1095,14 +1095,33 @@ public class RegExp {
         int start = pos;
         while (peek("0123456789")) next();
         if (start == pos) throw new IllegalArgumentException("integer expected at position " + pos);
-        int n = Integer.parseInt(originalString.substring(start, pos));
         int m = -1;
-        if (match(',')) {
-          start = pos;
-          while (peek("0123456789")) next();
-          if (start != pos) m = Integer.parseInt(originalString.substring(start, pos));
-        } else m = n;
+        int n = -1;
+        try {
+          n = Integer.parseInt(originalString.substring(start, pos));
+          if (match(',')) {
+            start = pos;
+            while (peek("0123456789")) next();
+            if (start != pos) {
+              m = Integer.parseInt(originalString.substring(start, pos));
+            }
+          } else m = n;
+        } catch (NumberFormatException numberFormatException) {
+          throw new IllegalArgumentException(
+              "expected integer at position "
+                  + pos
+                  + " got "
+                  + originalString.substring(start, pos),
+              numberFormatException);
+        }
+        // n should never be -1, since if it could not be parsed, we would have thrown an exception
+        // before getting here
+        assert n != -1;
         if (!match('}')) throw new IllegalArgumentException("expected '}' at position " + pos);
+        if (n > m) {
+          throw new IllegalArgumentException(
+              "invalid repetition range(out of order): " + n + ".." + m);
+        }
         if (m == -1) e = makeRepeat(flags, e, n);
         else e = makeRepeat(flags, e, n, m);
       }

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -1095,28 +1095,13 @@ public class RegExp {
         int start = pos;
         while (peek("0123456789")) next();
         if (start == pos) throw new IllegalArgumentException("integer expected at position " + pos);
+        int n = Integer.parseInt(originalString.substring(start, pos));
         int m = -1;
-        int n = -1;
-        try {
-          n = Integer.parseInt(originalString.substring(start, pos));
-          if (match(',')) {
-            start = pos;
-            while (peek("0123456789")) next();
-            if (start != pos) {
-              m = Integer.parseInt(originalString.substring(start, pos));
-            }
-          } else m = n;
-        } catch (NumberFormatException numberFormatException) {
-          throw new IllegalArgumentException(
-              "expected integer at position "
-                  + pos
-                  + " got "
-                  + originalString.substring(start, pos),
-              numberFormatException);
-        }
-        // n should never be -1, since if it could not be parsed, we would have thrown an exception
-        // before getting here
-        assert n != -1;
+        if (match(',')) {
+          start = pos;
+          while (peek("0123456789")) next();
+          if (start != pos) m = Integer.parseInt(originalString.substring(start, pos));
+        } else m = n;
         if (!match('}')) throw new IllegalArgumentException("expected '}' at position " + pos);
         if (m != -1 && n > m) {
           throw new IllegalArgumentException(

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -1118,7 +1118,7 @@ public class RegExp {
         // before getting here
         assert n != -1;
         if (!match('}')) throw new IllegalArgumentException("expected '}' at position " + pos);
-        if (n > m) {
+        if (m != -1 && n > m) {
           throw new IllegalArgumentException(
               "invalid repetition range(out of order): " + n + ".." + m);
         }

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
@@ -86,6 +86,27 @@ public class TestRegExp extends LuceneTestCase {
     }
   }
 
+  public void testParseIllegalRepeatExp() {
+
+    // out of order
+    IllegalArgumentException expected =
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              new RegExp("a{99,11}");
+            });
+    assertTrue(expected.getMessage().contains("out of order"));
+
+    // overflow
+    expected =
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              new RegExp("a{13,9999999999999999999999999999999999999999999999}");
+            });
+    assertTrue(expected.getMessage().contains("expected integer at position"));
+  }
+
   static String randomDocValue(int minLength) {
     String charPalette = "AAAaaaBbbCccc123456 \t";
     StringBuilder sb = new StringBuilder();

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
@@ -87,7 +87,6 @@ public class TestRegExp extends LuceneTestCase {
   }
 
   public void testParseIllegalRepeatExp() {
-
     // out of order
     IllegalArgumentException expected =
         expectThrows(
@@ -96,15 +95,6 @@ public class TestRegExp extends LuceneTestCase {
               new RegExp("a{99,11}");
             });
     assertTrue(expected.getMessage().contains("out of order"));
-
-    // overflow
-    expected =
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              new RegExp("a{13,9999999999999999999999999999999999999999999999}");
-            });
-    assertTrue(expected.getMessage().contains("expected integer at position"));
   }
 
   static String randomDocValue(int minLength) {


### PR DESCRIPTION
### Description
ISSUE #12251 

This pull request addresses two issues in the [RegExp.java code](https://github.com/apache/lucene/blob/a39885fdab93c4cbbcab8f3112c9783a05ca15a9/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java#LL1088C3-L1111C4):

1. It unifies the exception handling by ensuring that IllegalArgumentException is thrown when Integer.parseInt fails, such as in cases of overflow, as per the method signature.
2. It adds a check for the correct order of the repetition range. Previously, the code would parse and accept invalid repetition ranges like "a{99,11}" that are not accepted by Java's Pattern. This update prevents such cases from being passed.

Original Code
````
  final RegExp parseRepeatExp() throws IllegalArgumentException {
    RegExp e = parseComplExp();
    while (peek("?*+{")) {
      if (match('?')) e = makeOptional(flags, e);
      else if (match('*')) e = makeRepeat(flags, e);
      else if (match('+')) e = makeRepeat(flags, e, 1);
      else if (match('{')) {
        int start = pos;
        while (peek("0123456789")) next();
        if (start == pos) throw new IllegalArgumentException("integer expected at position " + pos);
        int n = Integer.parseInt(originalString.substring(start, pos));
        int m = -1;
        if (match(',')) {
          start = pos;
          while (peek("0123456789")) next();
          if (start != pos) m = Integer.parseInt(originalString.substring(start, pos));
        } else m = n;
        if (!match('}')) throw new IllegalArgumentException("expected '}' at position " + pos);
        if (m == -1) e = makeRepeat(flags, e, n);
        else e = makeRepeat(flags, e, n, m);
      }
    }
    return e;
  }
  ````
  
