### PR TITLE
Add Setter for vector Encoding in FieldType

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/FieldType.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FieldType.java
@@ -400,6 +400,17 @@ public class FieldType implements IndexableFieldType {
     return vectorEncoding;
   }
 
+  /**
+   * Set's the encoding for the field's vector value
+   *
+   * @param encoding The {@link VectorEncoding} of the field's vector value
+   * @throws IllegalStateException if this FieldType is frozen against future modifications.
+   */
+  public void setVectorEncoding(VectorEncoding encoding) {
+    checkIfFrozen();
+    this.vectorEncoding = Objects.requireNonNull(encoding);
+  }
+
   @Override
   public VectorSimilarityFunction vectorSimilarityFunction() {
     return vectorSimilarityFunction;


### PR DESCRIPTION
### Description
Add Setter method for vectorEncoding in FieldType to be able to set it with other vectorEncodings like `vectorEncoding.BYTE` instead of the default `vectorEncoding.FLOAT32`. Adding this method will help to avoid overriding `IndexableFieldType` for just to update the value of vectorEncoding.
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
