### PR TITLE
Expose iterator over query terms in TermInSetQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -110,7 +110,7 @@ Other
 
 API Changes
 ---------------------
-* GITHUB#xx: Expose iterator over query terms in TermInSetQuery (Greg Miller)
+* GITHUB#12280: Expose iterator over query terms in TermInSetQuery (Greg Miller)
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -110,7 +110,7 @@ Other
 
 API Changes
 ---------------------
-(No changes)
+* GITHUB#xx: Expose iterator over query terms in TermInSetQuery (Greg Miller)
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -34,6 +34,7 @@ import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.BytesRefIterator;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
@@ -135,6 +136,11 @@ public class TermInSetQuery extends MultiTermQuery implements Accountable {
   @Override
   public long getTermsCount() throws IOException {
     return termData.size();
+  }
+
+  /** Returns an iterator of the provided query terms */
+  public BytesRefIterator getQueryTerms() {
+    return termData.iterator();
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
@@ -46,6 +46,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.RamUsageTester;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 
@@ -402,5 +403,19 @@ public class TestTermInSetQuery extends LuceneTestCase {
             }
           }
         });
+  }
+
+  public void testQueryTermIteration() throws Exception {
+    Set<BytesRef> terms = new HashSet<>();
+    for (int i = 0; i < 100; i++) {
+      terms.add(new BytesRef(TestUtil.randomAnalysisString(random(), 10, true)));
+    }
+    List<BytesRef> expected = terms.stream().sorted().toList();
+    TermInSetQuery q = new TermInSetQuery("field", expected);
+    BytesRefIterator it = q.getQueryTerms();
+    for (BytesRef e : expected) {
+      assertEquals(e, it.next());
+    }
+    assertNull(it.next());
   }
 }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/PKTermInSetQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/PKTermInSetQuery.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.sandbox.search;
 
 import java.io.IOException;

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/PKTermInSetQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/PKTermInSetQuery.java
@@ -1,0 +1,117 @@
+package org.apache.lucene.sandbox.search;
+
+import java.io.IOException;
+import java.util.Collection;
+import org.apache.lucene.index.ImpactsEnum;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.TermState;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.TermInSetQuery;
+import org.apache.lucene.util.AttributeSource;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
+
+/**
+ * {@link TermInSetQuery} optimized for a primary key-like field.
+ *
+ * <p>Relies on {@link TermsEnum#seekExact(BytesRef)} instead of {@link
+ * TermsEnum#seekCeil(BytesRef)} to produce a terms iterator, which is compatible with {@code
+ * BloomFilteringPostingsFormat}.
+ */
+public class PKTermInSetQuery extends TermInSetQuery {
+  public PKTermInSetQuery(String field, Collection<BytesRef> terms) {
+    super(field, terms);
+  }
+
+  public PKTermInSetQuery(String field, BytesRef... terms) {
+    super(field, terms);
+  }
+
+  public PKTermInSetQuery(RewriteMethod rewriteMethod, String field, Collection<BytesRef> terms) {
+    super(rewriteMethod, field, terms);
+  }
+
+  public PKTermInSetQuery(RewriteMethod rewriteMethod, String field, BytesRef... terms) {
+    super(rewriteMethod, field, terms);
+  }
+
+  @Override
+  protected TermsEnum getTermsEnum(Terms terms, AttributeSource atts) throws IOException {
+    final TermsEnum tEnum = terms.iterator();
+    final BytesRefIterator queryTerms = getQueryTerms();
+
+    return new TermsEnum() {
+      @Override
+      public BytesRef next() throws IOException {
+        BytesRef nextTerm;
+        while ((nextTerm = queryTerms.next()) != null) {
+          if (tEnum.seekExact(nextTerm)) {
+            break;
+          }
+        }
+        return nextTerm;
+      }
+
+      @Override
+      public AttributeSource attributes() {
+        return tEnum.attributes();
+      }
+
+      @Override
+      public BytesRef term() throws IOException {
+        return tEnum.term();
+      }
+
+      @Override
+      public long ord() throws IOException {
+        return tEnum.ord();
+      }
+
+      @Override
+      public int docFreq() throws IOException {
+        return tEnum.docFreq();
+      }
+
+      @Override
+      public long totalTermFreq() throws IOException {
+        return tEnum.totalTermFreq();
+      }
+
+      @Override
+      public PostingsEnum postings(PostingsEnum reuse, int flags) throws IOException {
+        return tEnum.postings(reuse, flags);
+      }
+
+      @Override
+      public ImpactsEnum impacts(int flags) throws IOException {
+        return tEnum.impacts(flags);
+      }
+
+      @Override
+      public TermState termState() throws IOException {
+        return tEnum.termState();
+      }
+
+      @Override
+      public boolean seekExact(BytesRef text) throws IOException {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public SeekStatus seekCeil(BytesRef text) throws IOException {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void seekExact(long ord) throws IOException {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void seekExact(BytesRef term, TermState state) throws IOException {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+}


### PR DESCRIPTION
### Description
I'd like to propose we add an API to `TermInSetQuery` that exposes an iterator over the query terms. This is useful for extending `TermInSetQuery`. One concrete use-case for this is needing to change the way term intersection happens with the indexed terms dictionary to support bloom filters, as described in [this email thread](https://lists.apache.org/thread/ym2l3knqj4hgd0tcmnf9hwqlxk6hqw0b).

I don't think there's any harm in exposing this, but am interested in feedback of course! This abstraction decouples the current prefix-coding implementation details, so it seems clean.