### PR TITLE
Add checks in KNNVectorField / KNNVectorQuery to only allow non-null, non-empty and finite vectors

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -164,6 +164,8 @@ Improvements
 * GITHUB#12320: Add "direct to binary" option for DaciukMihovAutomatonBuilder and use it in TermInSetQuery#visit.
   (Greg Miller)
 
+* GITHUB#12281: Require indexed KNN float vectors and query vectors to be finite.  (Jonathan Ellis, Uwe Schindler)
+
 Optimizations
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
@@ -137,7 +137,12 @@ public class KnnByteVectorField extends Field {
               + " using byte[] but the field encoding is "
               + fieldType.vectorEncoding());
     }
-    fieldsData = Objects.requireNonNull(vector, "vector value must not be null");
+    Objects.requireNonNull(vector, "vector value must not be null");
+    if (vector.length != fieldType.vectorDimension()) {
+      throw new IllegalArgumentException(
+          "The number of vector dimensions does not match the field type");
+    }
+    fieldsData = vector;
   }
 
   /** Return the vector value of this field */

--- a/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
@@ -17,6 +17,7 @@
 
 package org.apache.lucene.document;
 
+import java.util.Objects;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
@@ -100,7 +101,7 @@ public class KnnByteVectorField extends Field {
   public KnnByteVectorField(
       String name, byte[] vector, VectorSimilarityFunction similarityFunction) {
     super(name, createType(vector, similarityFunction));
-    fieldsData = vector;
+    fieldsData = vector; // null-check done above
   }
 
   /**
@@ -136,7 +137,7 @@ public class KnnByteVectorField extends Field {
               + " using byte[] but the field encoding is "
               + fieldType.vectorEncoding());
     }
-    fieldsData = vector;
+    fieldsData = Objects.requireNonNull(vector, "vector value must not be null");
   }
 
   /** Return the vector value of this field */

--- a/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
@@ -138,8 +138,12 @@ public class KnnFloatVectorField extends Field {
               + " using float[] but the field encoding is "
               + fieldType.vectorEncoding());
     }
-    fieldsData =
-        VectorUtil.checkFinite(Objects.requireNonNull(vector, "vector value must not be null"));
+    Objects.requireNonNull(vector, "vector value must not be null");
+    if (vector.length != fieldType.vectorDimension()) {
+      throw new IllegalArgumentException(
+          "The number of vector dimensions does not match the field type");
+    }
+    fieldsData = VectorUtil.checkFinite(vector);
   }
 
   /** Return the vector value of this field */

--- a/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
@@ -17,6 +17,8 @@
 
 package org.apache.lucene.document;
 
+import static org.apache.lucene.util.VectorUtil.checkFinite;
+
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
@@ -50,6 +52,7 @@ public class KnnFloatVectorField extends Field {
       throw new IllegalArgumentException(
           "cannot index vectors with dimension greater than " + FloatVectorValues.MAX_DIMENSIONS);
     }
+    checkFinite(v);
     if (similarityFunction == null) {
       throw new IllegalArgumentException("similarity function must not be null");
     }

--- a/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
@@ -17,8 +17,7 @@
 
 package org.apache.lucene.document;
 
-import static org.apache.lucene.util.VectorUtil.checkFinite;
-
+import java.util.Objects;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
@@ -52,7 +51,6 @@ public class KnnFloatVectorField extends Field {
       throw new IllegalArgumentException(
           "cannot index vectors with dimension greater than " + FloatVectorValues.MAX_DIMENSIONS);
     }
-    checkFinite(v);
     if (similarityFunction == null) {
       throw new IllegalArgumentException("similarity function must not be null");
     }
@@ -104,7 +102,7 @@ public class KnnFloatVectorField extends Field {
   public KnnFloatVectorField(
       String name, float[] vector, VectorSimilarityFunction similarityFunction) {
     super(name, createType(vector, similarityFunction));
-    fieldsData = vector;
+    fieldsData = VectorUtil.checkFinite(vector); // null check done above
   }
 
   /**
@@ -140,7 +138,8 @@ public class KnnFloatVectorField extends Field {
               + " using float[] but the field encoding is "
               + fieldType.vectorEncoding());
     }
-    fieldsData = vector;
+    fieldsData =
+        VectorUtil.checkFinite(Objects.requireNonNull(vector, "vector value must not be null"));
   }
 
   /** Return the vector value of this field */

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -56,7 +56,7 @@ abstract class AbstractKnnVectorQuery extends Query {
   private final Query filter;
 
   public AbstractKnnVectorQuery(String field, int k, Query filter) {
-    this.field = field;
+    this.field = Objects.requireNonNull(field, "field");
     this.k = k;
     if (k < 1) {
       throw new IllegalArgumentException("k must be at least 1, got: " + k);

--- a/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
@@ -71,7 +71,7 @@ public class KnnByteVectorQuery extends AbstractKnnVectorQuery {
    */
   public KnnByteVectorQuery(String field, byte[] target, int k, Query filter) {
     super(field, k, filter);
-    this.target = target;
+    this.target = Objects.requireNonNull(target, "target");
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
@@ -18,6 +18,7 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.FieldInfo;
@@ -25,6 +26,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.VectorUtil;
 
 /**
  * Uses {@link KnnVectorsReader#search(String, float[], int, Bits, int)} to perform nearest
@@ -70,7 +72,7 @@ public class KnnFloatVectorQuery extends AbstractKnnVectorQuery {
    */
   public KnnFloatVectorQuery(String field, float[] target, int k, Query filter) {
     super(field, k, filter);
-    this.target = target;
+    this.target = VectorUtil.checkFinite(Objects.requireNonNull(target, "target"));
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -166,6 +166,7 @@ public final class VectorUtil {
    *
    * @param v bytes containing a vector
    * @return the vector for call-chaining
+   * @throws IllegalArgumentException if any component of vector is not finite
    */
   public static float[] checkFinite(float[] v) {
     for (int i = 0; i < v.length; i++) {

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -17,8 +17,6 @@
 
 package org.apache.lucene.util;
 
-import java.util.Arrays;
-
 /** Utilities for computations with numeric arrays */
 public final class VectorUtil {
 
@@ -37,7 +35,7 @@ public final class VectorUtil {
       throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
     }
     float r = PROVIDER.dotProduct(a, b);
-    checkFinite(r, a, b, "dot product");
+    assert Float.isFinite(r);
     return r;
   }
 
@@ -51,7 +49,7 @@ public final class VectorUtil {
       throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
     }
     float r = PROVIDER.cosine(a, b);
-    checkFinite(r, a, b, "dot product");
+    assert Float.isFinite(r);
     return r;
   }
 
@@ -73,7 +71,7 @@ public final class VectorUtil {
       throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
     }
     float r = PROVIDER.squareDistance(a, b);
-    checkFinite(r, a, b, "square distance");
+    assert Float.isFinite(r);
     return r;
   }
 
@@ -163,27 +161,18 @@ public final class VectorUtil {
     return 0.5f + dotProduct(a, b) / denom;
   }
 
-  private static void checkFinite(float r, float[] a, float[] b, String optype) {
-    if (!Float.isFinite(r)) {
-      checkFinite(a);
-      checkFinite(b);
-      throw new IllegalArgumentException(
-          "Non-finite ("
-              + r
-              + ") "
-              + optype
-              + " similarity from "
-              + Arrays.toString(a)
-              + " and "
-              + Arrays.toString(b));
-    }
-  }
-
-  public static void checkFinite(float[] a) {
-    for (int i = 0; i < a.length; i++) {
-      if (!Float.isFinite(a[i])) {
-        throw new IllegalArgumentException("non-finite value at vector[" + i + "]=" + a[i]);
+  /**
+   * Checks if a float vector only has finite components.
+   *
+   * @param v bytes containing a vector
+   * @return the vector for call-chaining
+   */
+  public static float[] checkFinite(float[] v) {
+    for (int i = 0; i < v.length; i++) {
+      if (!Float.isFinite(v[i])) {
+        throw new IllegalArgumentException("non-finite value at vector[" + i + "]=" + v[i]);
       }
     }
+    return v;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -17,6 +17,8 @@
 
 package org.apache.lucene.util;
 
+import java.util.Arrays;
+
 /** Utilities for computations with numeric arrays */
 public final class VectorUtil {
 
@@ -34,7 +36,9 @@ public final class VectorUtil {
     if (a.length != b.length) {
       throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
     }
-    return PROVIDER.dotProduct(a, b);
+    float r = PROVIDER.dotProduct(a, b);
+    checkFinite(r, a, b, "dot product");
+    return r;
   }
 
   /**
@@ -46,7 +50,9 @@ public final class VectorUtil {
     if (a.length != b.length) {
       throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
     }
-    return PROVIDER.cosine(a, b);
+    float r = PROVIDER.cosine(a, b);
+    checkFinite(r, a, b, "dot product");
+    return r;
   }
 
   /** Returns the cosine similarity between the two vectors. */
@@ -66,7 +72,9 @@ public final class VectorUtil {
     if (a.length != b.length) {
       throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
     }
-    return PROVIDER.squareDistance(a, b);
+    float r = PROVIDER.squareDistance(a, b);
+    checkFinite(r, a, b, "square distance");
+    return r;
   }
 
   /** Returns the sum of squared differences of the two vectors. */
@@ -153,5 +161,29 @@ public final class VectorUtil {
     // divide by 2 * 2^14 (maximum absolute value of product of 2 signed bytes) * len
     float denom = (float) (a.length * (1 << 15));
     return 0.5f + dotProduct(a, b) / denom;
+  }
+
+  private static void checkFinite(float r, float[] a, float[] b, String optype) {
+    if (!Float.isFinite(r)) {
+      checkFinite(a);
+      checkFinite(b);
+      throw new IllegalArgumentException(
+          "Non-finite ("
+              + r
+              + ") "
+              + optype
+              + " similarity from "
+              + Arrays.toString(a)
+              + " and "
+              + Arrays.toString(b));
+    }
+  }
+
+  public static void checkFinite(float[] a) {
+    for (int i = 0; i < a.length; i++) {
+      if (!Float.isFinite(a[i])) {
+        throw new IllegalArgumentException("non-finite value at vector[" + i + "]=" + a[i]);
+      }
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtilDefaultProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtilDefaultProvider.java
@@ -17,8 +17,6 @@
 
 package org.apache.lucene.util;
 
-import java.util.Arrays;
-
 /** The default VectorUtil provider implementation. */
 final class VectorUtilDefaultProvider implements VectorUtilProvider {
 
@@ -87,7 +85,6 @@ final class VectorUtilDefaultProvider implements VectorUtilProvider {
               + b[i + 6] * a[i + 6]
               + b[i + 7] * a[i + 7];
     }
-    checkFinite(res, a, b, "dot product");
     return res;
   }
 
@@ -105,9 +102,7 @@ final class VectorUtilDefaultProvider implements VectorUtilProvider {
       norm1 += elem1 * elem1;
       norm2 += elem2 * elem2;
     }
-    var r = (float) (sum / Math.sqrt(norm1 * norm2));
-    checkFinite(r, a, b, "cosine");
-    return r;
+    return (float) (sum / Math.sqrt(norm1 * norm2));
   }
 
   @Override
@@ -122,30 +117,7 @@ final class VectorUtilDefaultProvider implements VectorUtilProvider {
       float diff = a[i] - b[i];
       squareSum += diff * diff;
     }
-    checkFinite(squareSum, a, b, "square distance");
     return squareSum;
-  }
-
-  private static void checkFinite(float r, float[] a, float[] b, String optype) {
-    if (!Float.isFinite(r)) {
-      for (int i = 0; i < a.length; i++) {
-        if (!Float.isFinite(a[i])) {
-          throw new IllegalArgumentException("v1[" + i + "]=" + a[i]);
-        }
-        if (!Float.isFinite(b[i])) {
-          throw new IllegalArgumentException("v2[" + i + "]=" + b[i]);
-        }
-      }
-      throw new IllegalArgumentException(
-          "Non-finite ("
-              + r
-              + ") "
-              + optype
-              + " similarity from "
-              + Arrays.toString(a)
-              + " and "
-              + Arrays.toString(b));
-    }
   }
 
   private static float squareDistanceUnrolled(float[] v1, float[] v2, int index) {

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtilDefaultProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtilDefaultProvider.java
@@ -102,7 +102,7 @@ final class VectorUtilDefaultProvider implements VectorUtilProvider {
       norm1 += elem1 * elem1;
       norm2 += elem2 * elem2;
     }
-    return (float) (sum / Math.sqrt(norm1 * norm2));
+    return (float) (sum / Math.sqrt((double) norm1 * (double) norm2));
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtilDefaultProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtilDefaultProvider.java
@@ -17,6 +17,8 @@
 
 package org.apache.lucene.util;
 
+import java.util.Arrays;
+
 /** The default VectorUtil provider implementation. */
 final class VectorUtilDefaultProvider implements VectorUtilProvider {
 
@@ -85,6 +87,7 @@ final class VectorUtilDefaultProvider implements VectorUtilProvider {
               + b[i + 6] * a[i + 6]
               + b[i + 7] * a[i + 7];
     }
+    checkFinite(res, a, b, "dot product");
     return res;
   }
 
@@ -102,7 +105,9 @@ final class VectorUtilDefaultProvider implements VectorUtilProvider {
       norm1 += elem1 * elem1;
       norm2 += elem2 * elem2;
     }
-    return (float) (sum / Math.sqrt(norm1 * norm2));
+    var r = (float) (sum / Math.sqrt(norm1 * norm2));
+    checkFinite(r, a, b, "cosine");
+    return r;
   }
 
   @Override
@@ -117,7 +122,30 @@ final class VectorUtilDefaultProvider implements VectorUtilProvider {
       float diff = a[i] - b[i];
       squareSum += diff * diff;
     }
+    checkFinite(squareSum, a, b, "square distance");
     return squareSum;
+  }
+
+  private static void checkFinite(float r, float[] a, float[] b, String optype) {
+    if (!Float.isFinite(r)) {
+      for (int i = 0; i < a.length; i++) {
+        if (!Float.isFinite(a[i])) {
+          throw new IllegalArgumentException("v1[" + i + "]=" + a[i]);
+        }
+        if (!Float.isFinite(b[i])) {
+          throw new IllegalArgumentException("v2[" + i + "]=" + b[i]);
+        }
+      }
+      throw new IllegalArgumentException(
+          "Non-finite ("
+              + r
+              + ") "
+              + optype
+              + " similarity from "
+              + Arrays.toString(a)
+              + " and "
+              + Arrays.toString(b));
+    }
   }
 
   private static float squareDistanceUnrolled(float[] v1, float[] v2, int index) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -56,7 +56,10 @@ public class NeighborArray {
       float previousScore = score[size - 1];
       assert ((scoresDescOrder && (previousScore >= newScore))
               || (scoresDescOrder == false && (previousScore <= newScore)))
-          : "Nodes are added in the incorrect order!";
+          : "Nodes are added in the incorrect order! Comparing "
+              + newScore
+              + " to "
+              + Arrays.toString(ArrayUtil.copyOfSubArray(score, 0, size));
     }
     node[size] = newNode;
     score[size] = newScore;

--- a/lucene/core/src/java20/org/apache/lucene/util/VectorUtilPanamaProvider.java
+++ b/lucene/core/src/java20/org/apache/lucene/util/VectorUtilPanamaProvider.java
@@ -217,7 +217,7 @@ final class VectorUtilPanamaProvider implements VectorUtilProvider {
       norm1 += elem1 * elem1;
       norm2 += elem2 * elem2;
     }
-    return (float) (sum / Math.sqrt(norm1 * norm2));
+    return (float) (sum / Math.sqrt((double) norm1 * (double) norm2));
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -40,6 +40,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.TestVectorUtil;
 
 /**
  * Test that uses a default/lucene Implementation of {@link QueryTimeout} to exit out long running
@@ -463,13 +464,21 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
           ExitingReaderException.class,
           () ->
               leaf.searchNearestVectors(
-                  "vector", new float[dimension], 5, leaf.getLiveDocs(), Integer.MAX_VALUE));
+                  "vector",
+                  TestVectorUtil.randomVector(dimension),
+                  5,
+                  leaf.getLiveDocs(),
+                  Integer.MAX_VALUE));
     } else {
       DocIdSetIterator iter = leaf.getFloatVectorValues("vector");
       scanAndRetrieve(leaf, iter);
 
       leaf.searchNearestVectors(
-          "vector", new float[dimension], 5, leaf.getLiveDocs(), Integer.MAX_VALUE);
+          "vector",
+          TestVectorUtil.randomVector(dimension),
+          5,
+          leaf.getLiveDocs(),
+          Integer.MAX_VALUE);
     }
 
     reader.close();

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -103,6 +103,16 @@ public class TestVectorUtil extends LuceneTestCase {
     expectThrows(IllegalArgumentException.class, () -> VectorUtil.cosine(u, v));
   }
 
+  public void testCosineThrowsForNaN() {
+    float[] v = {1, 0, Float.NaN}, u = {0, 0, 0};
+    expectThrows(IllegalArgumentException.class, () -> VectorUtil.cosine(u, v));
+  }
+
+  public void testCosineThrowsForInfinity() {
+    float[] v = {1, 0, Float.NEGATIVE_INFINITY}, u = {0, 0, 0};
+    expectThrows(IllegalArgumentException.class, () -> VectorUtil.cosine(u, v));
+  }
+
   public void testNormalize() {
     float[] v = randomVector();
     v[random().nextInt(v.length)] = 1; // ensure vector is not all zeroes

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -103,16 +103,6 @@ public class TestVectorUtil extends LuceneTestCase {
     expectThrows(IllegalArgumentException.class, () -> VectorUtil.cosine(u, v));
   }
 
-  public void testCosineThrowsForNaN() {
-    float[] v = {1, 0, Float.NaN}, u = {0, 0, 0};
-    expectThrows(IllegalArgumentException.class, () -> VectorUtil.cosine(u, v));
-  }
-
-  public void testCosineThrowsForInfinity() {
-    float[] v = {1, 0, Float.NEGATIVE_INFINITY}, u = {0, 0, 0};
-    expectThrows(IllegalArgumentException.class, () -> VectorUtil.cosine(u, v));
-  }
-
   public void testNormalize() {
     float[] v = randomVector();
     v[random().nextInt(v.length)] = 1; // ensure vector is not all zeroes

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
@@ -27,7 +27,7 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addInOrder(1, 0.8f);
 
     AssertionError ex = expectThrows(AssertionError.class, () -> neighbors.addInOrder(2, 0.9f));
-    assertEquals("Nodes are added in the incorrect order!", ex.getMessage());
+    assert ex.getMessage().startsWith("Nodes are added in the incorrect order!") : ex.getMessage();
 
     neighbors.insertSorted(3, 0.9f);
     assertScoresEqual(new float[] {1, 0.9f, 0.8f}, neighbors);
@@ -76,7 +76,7 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addInOrder(1, 0.3f);
 
     AssertionError ex = expectThrows(AssertionError.class, () -> neighbors.addInOrder(2, 0.15f));
-    assertEquals("Nodes are added in the incorrect order!", ex.getMessage());
+    assert ex.getMessage().startsWith("Nodes are added in the incorrect order!") : ex.getMessage();
 
     neighbors.insertSorted(3, 0.3f);
     assertScoresEqual(new float[] {0.1f, 0.3f, 0.3f}, neighbors);


### PR DESCRIPTION
This PR adds argument checking to constructors of fields and query, so all vector values must be finite.