### PR TITLE
FilterLeafReader$FilterTerms#intersect now delegates to wrapped Terms

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -119,7 +119,10 @@ New Features
 Improvements
 ---------------------
 
-GITHUB#12245: Add support for Score Mode to `ToParentBlockJoinQuery` explain. (Marcus Eagan via Mikhail Khludnev)
+* GITHUB#12245: Add support for Score Mode to `ToParentBlockJoinQuery` explain. (Marcus Eagan via Mikhail Khludnev)
+
+* GITHUB#xxx: FilterLeafReader$FilterTerms#intersect now delegates to wrapped Terms#intersect instead of masking it
+  with a default implementation. (Greg Miller)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Unwrappable;
+import org.apache.lucene.util.automaton.CompiledAutomaton;
 
 /**
  * A <code>FilterLeafReader</code> contains another LeafReader, which it uses as its basic source of
@@ -106,6 +107,11 @@ public abstract class FilterLeafReader extends LeafReader {
         throw new NullPointerException("incoming Terms must not be null");
       }
       this.in = in;
+    }
+
+    @Override
+    public TermsEnum intersect(CompiledAutomaton compiled, BytesRef startTerm) throws IOException {
+      return in.intersect(compiled, startTerm);
     }
 
     @Override


### PR DESCRIPTION
### Description

Right now, `FilterTerms#intersect` is picking up the default implementation from `Terms`, which hides any custom implementation provided by the wrapped `Terms` instance. This is unfortunate since some `Terms` implementations provide optimized intersection logic (e.g., BlockTree's `FieldReader#intersect`). We should instead delegate to the wrapped `Terms` instance.
