### PR TITLE
Seal `IndexReader` and `IndexReaderContext`

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -47,6 +47,10 @@ API Changes
 * GITHUB#12107: Remove deprecated KnnVectorField, KnnVectorQuery, VectorValues and
   LeafReader#getVectorValues. (Luca Cavanna)
 
+* GITHUB#12296: Make IndexReader and IndexReaderContext classes explicitly sealed.
+  They have already been runtime-checked to only be implemented by the specific classes
+  so this is effectively a non-breaking change.
+
 New Features
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/CompositeReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CompositeReader.java
@@ -44,7 +44,7 @@ import org.apache.lucene.store.Directory;
  * synchronization, you should <b>not</b> synchronize on the <code>IndexReader</code> instance; use
  * your own (non-Lucene) objects instead.
  */
-public abstract class CompositeReader extends IndexReader {
+public abstract non-sealed class CompositeReader extends IndexReader {
 
   private volatile CompositeReaderContext readerContext = null; // lazy init
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexReader.java
@@ -63,17 +63,13 @@ import org.apache.lucene.store.AlreadyClosedException;
  * synchronization, you should <b>not</b> synchronize on the <code>IndexReader</code> instance; use
  * your own (non-Lucene) objects instead.
  */
-public abstract class IndexReader implements Closeable {
+public abstract sealed class IndexReader implements Closeable permits CompositeReader, LeafReader {
 
   private boolean closed = false;
   private boolean closedByChild = false;
   private final AtomicInteger refCount = new AtomicInteger(1);
 
-  IndexReader() {
-    if (!(this instanceof CompositeReader || this instanceof LeafReader))
-      throw new Error(
-          "IndexReader should never be directly extended, subclass LeafReader or CompositeReader instead.");
-  }
+  IndexReader() {}
 
   /**
    * A utility class that gives hooks in order to help build a cache based on the data that is

--- a/lucene/core/src/java/org/apache/lucene/index/IndexReaderContext.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexReaderContext.java
@@ -26,8 +26,8 @@ public abstract sealed class IndexReaderContext permits CompositeReaderContext, 
   /** The reader context for this reader's immediate parent, or null if none */
   public final CompositeReaderContext parent;
   /**
-   * {@code true} if this context struct represents the top level reader within the
-   * hierarchical context
+   * {@code true} if this context struct represents the top level reader within the hierarchical
+   * context
    */
   public final boolean isTopLevel;
   /** the doc base for this reader in the parent, {@code 0} if parent is null */
@@ -38,9 +38,10 @@ public abstract sealed class IndexReaderContext permits CompositeReaderContext, 
   // An object that uniquely identifies this context without referencing
   // segments. The goal is to make it fine to have references to this
   // identity object, even after the index reader has been closed
-  protected final Object identity = new Object();
+  final Object identity = new Object();
 
-  protected IndexReaderContext(CompositeReaderContext parent, int ordInParent, int docBaseInParent) {
+  protected IndexReaderContext(
+      CompositeReaderContext parent, int ordInParent, int docBaseInParent) {
     this.parent = parent;
     this.docBaseInParent = docBaseInParent;
     this.ordInParent = ordInParent;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexReaderContext.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexReaderContext.java
@@ -22,27 +22,25 @@ import java.util.List;
  * A struct like class that represents a hierarchical relationship between {@link IndexReader}
  * instances.
  */
-public abstract class IndexReaderContext {
+public abstract sealed class IndexReaderContext permits CompositeReaderContext, LeafReaderContext {
   /** The reader context for this reader's immediate parent, or null if none */
   public final CompositeReaderContext parent;
   /**
-   * <code>true</code> if this context struct represents the top level reader within the
+   * {@code true} if this context struct represents the top level reader within the
    * hierarchical context
    */
   public final boolean isTopLevel;
-  /** the doc base for this reader in the parent, <code>0</code> if parent is null */
+  /** the doc base for this reader in the parent, {@code 0} if parent is null */
   public final int docBaseInParent;
-  /** the ord for this reader in the parent, <code>0</code> if parent is null */
+  /** the ord for this reader in the parent, {@code 0} if parent is null */
   public final int ordInParent;
 
   // An object that uniquely identifies this context without referencing
   // segments. The goal is to make it fine to have references to this
   // identity object, even after the index reader has been closed
-  final Object identity = new Object();
+  protected final Object identity = new Object();
 
-  IndexReaderContext(CompositeReaderContext parent, int ordInParent, int docBaseInParent) {
-    if (!(this instanceof CompositeReaderContext || this instanceof LeafReaderContext))
-      throw new Error("This class should never be extended by custom code!");
+  protected IndexReaderContext(CompositeReaderContext parent, int ordInParent, int docBaseInParent) {
     this.parent = parent;
     this.docBaseInParent = docBaseInParent;
     this.ordInParent = ordInParent;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexReaderContext.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexReaderContext.java
@@ -40,8 +40,7 @@ public abstract sealed class IndexReaderContext permits CompositeReaderContext, 
   // identity object, even after the index reader has been closed
   final Object identity = new Object();
 
-  protected IndexReaderContext(
-      CompositeReaderContext parent, int ordInParent, int docBaseInParent) {
+  IndexReaderContext(CompositeReaderContext parent, int ordInParent, int docBaseInParent) {
     this.parent = parent;
     this.docBaseInParent = docBaseInParent;
     this.ordInParent = ordInParent;

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -41,7 +41,7 @@ import org.apache.lucene.util.Bits;
  * synchronization, you should <b>not</b> synchronize on the <code>IndexReader</code> instance; use
  * your own (non-Lucene) objects instead.
  */
-public abstract class LeafReader extends IndexReader {
+public abstract non-sealed class LeafReader extends IndexReader {
 
   private final LeafReaderContext readerContext = new LeafReaderContext(this);
 


### PR DESCRIPTION
### Description

`IndexReaderContext` is already effectively sealed since it's constructor does type check throwing `Error` if `this` is neither instance of `CompositeReaderContext` nor `LeafReaderContext`.

This PR simply makes this restriction explicit (codewise) turning attempts to extend this class from a runtime error into a compile time one.

I'v also replaced package-provate access modifiers to `protected` in order to make visibility more in-hand with this classes sealed'ness (effectively changing nothing) and updated deprecated `<code>`-blocks to `@code` in Javadocs.