### PR TITLE
Minor cleanup and improvements to DaciukMihovAutomatonBuilder

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -125,7 +125,7 @@ Improvements
 
 * GITHUB#12245: Add support for Score Mode to `ToParentBlockJoinQuery` explain. (Marcus Eagan via Mikhail Khludnev)
 
-* GITHUB#xx: Minor cleanup and improvements to DaciukMihovAutomatonBuilder. (Greg Miller)
+* GITHUB#12305: Minor cleanup and improvements to DaciukMihovAutomatonBuilder. (Greg Miller)
 
 Optimizations
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -123,7 +123,9 @@ New Features
 Improvements
 ---------------------
 
-GITHUB#12245: Add support for Score Mode to `ToParentBlockJoinQuery` explain. (Marcus Eagan via Mikhail Khludnev)
+* GITHUB#12245: Add support for Score Mode to `ToParentBlockJoinQuery` explain. (Marcus Eagan via Mikhail Khludnev)
+
+* GITHUB#xx: Minor cleanup and improvements to DaciukMihovAutomatonBuilder. (Greg Miller)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/DaciukMihovAutomatonBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/DaciukMihovAutomatonBuilder.java
@@ -204,7 +204,7 @@ public final class DaciukMihovAutomatonBuilder {
 
     // Descend in the automaton (find matching prefix).
     int pos = 0, max = current.length();
-    State next, state = root;
+    State state = root;
     for (; ; ) {
       assert pos <= max;
       if (pos == max) {
@@ -212,7 +212,7 @@ public final class DaciukMihovAutomatonBuilder {
       }
 
       int codePoint = Character.codePointAt(current, pos);
-      next = state.lastChild(codePoint);
+      State next = state.lastChild(codePoint);
       if (next == null) {
         break;
       }

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/DaciukMihovAutomatonBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/DaciukMihovAutomatonBuilder.java
@@ -16,16 +16,15 @@
  */
 package org.apache.lucene.util.automaton;
 
-import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.CharsRef;
-import org.apache.lucene.util.CharsRefBuilder;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.CharsRef;
+import org.apache.lucene.util.CharsRefBuilder;
 
 /**
  * Builds a minimal, deterministic {@link Automaton} that accepts a set of strings. The algorithm


### PR DESCRIPTION
### Description

This proposes some minor cleanup and improvements to `DaciukMihovAutomatonBuilder` I came across while starting to explore #12176 (exploring the idea of allowing this algorithm to directly build binary automata). I thought it would be good to independently ship these minor cleanups:
1. A few methods can be made `private` instead of `public`. Since the ctor is private, and there's no way to actually get an instance reference externally, there's no need for instance-level public methods.
2. We can be slightly more efficient when adding terms by "remembering" the code point for each character.
3. Make use of `CharsRefBuilder` to tidy up code a little bit and avoid unnecessary object creation with assertions enabled.