### PR TITLE
Make MAX_DIMENSIONS configurable via a system property.

### DIFF
--- a/lucene/core/build.gradle
+++ b/lucene/core/build.gradle
@@ -23,3 +23,8 @@ dependencies {
   moduleTestImplementation project(':lucene:codecs')
   moduleTestImplementation project(':lucene:test-framework')
 }
+
+test {
+  // test higher dimensions than the default limit
+  systemProperty 'org.apache.lucene.hnsw.maxDimensions', '2048'
+}

--- a/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
@@ -28,8 +28,14 @@ import org.apache.lucene.search.DocIdSetIterator;
  */
 public abstract class FloatVectorValues extends DocIdSetIterator {
 
-  /** The maximum length of a vector */
-  public static final int MAX_DIMENSIONS = 1024;
+  /**
+   * The maximum length of a vector. Can be overridden via a system property
+   * "lucene.hnsw.maxDimensions".
+   *
+   * @deprecated Expected to move to a codec specific limit.
+   */
+  @Deprecated
+  public static final int MAX_DIMENSIONS = Integer.getInteger("lucene.hnsw.maxDimensions", 1024);
 
   /** Sole constructor */
   protected FloatVectorValues() {}

--- a/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
@@ -17,9 +17,12 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.logging.Logger;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.SuppressForbidden;
 
 /**
  * This class provides access to per-document floating point vector values indexed as {@link
@@ -36,7 +39,14 @@ public abstract class FloatVectorValues extends DocIdSetIterator {
    *
    * @deprecated Expected to move to a codec specific limit.
    */
-  @Deprecated public static final int MAX_DIMENSIONS = initMaxDim();
+  @Deprecated public static final int MAX_DIMENSIONS = doPrivileged(FloatVectorValues::initMaxDim);
+
+  // Extracted to a method to be able to apply the SuppressForbidden annotation
+  @SuppressWarnings("removal")
+  @SuppressForbidden(reason = "security manager")
+  private static <T> T doPrivileged(PrivilegedAction<T> action) {
+    return AccessController.doPrivileged(action);
+  }
 
   private static int initMaxDim() {
     final var PROP_NAME = "org.apache.lucene.hnsw.maxDimensions";

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene95/TestLucene95HnswVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene95/TestLucene95HnswVectorsFormat.java
@@ -18,6 +18,7 @@ package org.apache.lucene.codecs.lucene95;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 
@@ -47,5 +48,9 @@ public class TestLucene95HnswVectorsFormat extends BaseKnnVectorsFormatTestCase 
     expectThrows(IllegalArgumentException.class, () -> new Lucene95HnswVectorsFormat(20, -1));
     expectThrows(IllegalArgumentException.class, () -> new Lucene95HnswVectorsFormat(512 + 1, 20));
     expectThrows(IllegalArgumentException.class, () -> new Lucene95HnswVectorsFormat(20, 3201));
+  }
+
+  public void testTestedWithHighDimensionLimit() {
+    assertEquals(2048, FloatVectorValues.MAX_DIMENSIONS);
   }
 }


### PR DESCRIPTION
The principle objective of this PR is to make it easier for users to use Lucene with higher dimensions.  While it's [technically possible to circumvent the existing limit](https://lists.apache.org/thread/pc8280kn99s0lf2gjd50chk0nftzmzmt), it's a non-obvious awkward hack that either the user would need to figure out or would be baked into higher level search platforms.  It's so obscure that most Lucene committers didn't even know it was possible!  Thus the practical effect for users now is that it's not possible so they don't use Lucene.

The system property proposed here is "lucene.hnsw.maxDimensions".

I also deprecated the field in anticipation that it will move to a codec specific place.  Regardless of if/when that happens, I don't think we want to advertise this limit where it is now, which is at a surface level Lucene API with a present value based on the default codec that may not make sense for other vector codecs.  Moving that is out of scope of this PR.

AFAICT, this limit is merely an ergonomics kind of limit to help the user from shooting themselves in the foot.  The underlying codec we have can read/write an arbitrary number of dimensions.  CheckIndex validates the number of dimensions is greater than zero but doesn't enforce a maximum.