### PR TITLE
Wrap Query rewrite backwards layer with AccessController

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -8,8 +8,12 @@ http://s.apache.org/luceneversions
 API Changes
 ---------------------
 
-* GITHUB#11840: Query rewrite now takes an IndexSearcher instead of IndexReader to enable concurrent
-  rewriting. (Patrick Zhai, Ben Trent)
+* GITHUB#11840, GITHUB#12304: Query rewrite now takes an IndexSearcher instead of
+  IndexReader to enable concurrent rewriting. Please note: This is implemented in
+  a backwards compatible way. A query overriding any of both rewrite methods is
+  supported. To implement this backwards layer in Lucene 9.x the
+  RuntimePermission "accessDeclaredMembers" is needed in applications using
+  SecurityManager.  (Patrick Zhai, Ben Trent, Uwe Schindler)
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/Query.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Query.java
@@ -52,30 +52,12 @@ public abstract class Query {
       new VirtualMethod<>(Query.class, "rewrite", IndexReader.class);
   private static final VirtualMethod<Query> newMethod =
       new VirtualMethod<>(Query.class, "rewrite", IndexSearcher.class);
-  private final boolean isDeprecatedRewriteMethodOverridden;
-
-  /** Constructor for query classes. */
-  public Query() {
-    var clazz = this.getClass();
-    if (clazz.getName().startsWith("org.apache.lucene.")) {
-      // we know that all Lucene's own classes have been updated to use new API, so reflection is
-      // not needed
-      isDeprecatedRewriteMethodOverridden = false;
-    } else {
-      isDeprecatedRewriteMethodOverridden = detectDeprectatedRewriteMethodOverridden(clazz);
-    }
-  }
-
-  /** Test only method (used to test backwards layer) */
-  Query(Void forTestOnly) {
-    isDeprecatedRewriteMethodOverridden = detectDeprectatedRewriteMethodOverridden(this.getClass());
-  }
-
-  private static boolean detectDeprectatedRewriteMethodOverridden(Class<? extends Query> clazz) {
-    final PrivilegedAction<Boolean> action =
-        () -> VirtualMethod.compareImplementationDistance(clazz, oldMethod, newMethod) > 0;
-    return AccessController.doPrivileged(action);
-  }
+  private final boolean isDeprecatedRewriteMethodOverridden =
+      AccessController.doPrivileged(
+          (PrivilegedAction<Boolean>)
+              () ->
+                  VirtualMethod.compareImplementationDistance(this.getClass(), oldMethod, newMethod)
+                      > 0);
 
   /**
    * Prints a query to a string, with <code>field</code> assumed to be the default field and

--- a/lucene/core/src/java/org/apache/lucene/search/Query.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Query.java
@@ -52,12 +52,30 @@ public abstract class Query {
       new VirtualMethod<>(Query.class, "rewrite", IndexReader.class);
   private static final VirtualMethod<Query> newMethod =
       new VirtualMethod<>(Query.class, "rewrite", IndexSearcher.class);
-  private final boolean isDeprecatedRewriteMethodOverridden =
-      AccessController.doPrivileged(
-          (PrivilegedAction<Boolean>)
-              () ->
-                  VirtualMethod.compareImplementationDistance(this.getClass(), oldMethod, newMethod)
-                      > 0);
+  private final boolean isDeprecatedRewriteMethodOverridden;
+
+  /** Constructor for query classes. */
+  public Query() {
+    var clazz = this.getClass();
+    if (clazz.getName().startsWith("org.apache.lucene.")) {
+      // we know that all Lucene's own classes have been updated to use new API, so reflection is
+      // not needed
+      isDeprecatedRewriteMethodOverridden = false;
+    } else {
+      isDeprecatedRewriteMethodOverridden = detectDeprectatedRewriteMethodOverridden(clazz);
+    }
+  }
+
+  /** Test only method (used to test backwards layer) */
+  Query(Void forTestOnly) {
+    isDeprecatedRewriteMethodOverridden = detectDeprectatedRewriteMethodOverridden(this.getClass());
+  }
+
+  private static boolean detectDeprectatedRewriteMethodOverridden(Class<? extends Query> clazz) {
+    final PrivilegedAction<Boolean> action =
+        () -> VirtualMethod.compareImplementationDistance(clazz, oldMethod, newMethod) > 0;
+    return AccessController.doPrivileged(action);
+  }
 
   /**
    * Prints a query to a string, with <code>field</code> assumed to be the default field and

--- a/lucene/core/src/java/org/apache/lucene/search/Query.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Query.java
@@ -17,6 +17,8 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.util.VirtualMethod;
 
@@ -51,7 +53,11 @@ public abstract class Query {
   private static final VirtualMethod<Query> newMethod =
       new VirtualMethod<>(Query.class, "rewrite", IndexSearcher.class);
   private final boolean isDeprecatedRewriteMethodOverridden =
-      VirtualMethod.compareImplementationDistance(this.getClass(), oldMethod, newMethod) > 0;
+      AccessController.doPrivileged(
+          (PrivilegedAction<Boolean>)
+              () ->
+                  VirtualMethod.compareImplementationDistance(this.getClass(), oldMethod, newMethod)
+                      > 0);
 
   /**
    * Prints a query to a string, with <code>field</code> assumed to be the default field and

--- a/lucene/core/src/java/org/apache/lucene/util/VirtualMethod.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VirtualMethod.java
@@ -17,6 +17,8 @@
 package org.apache.lucene.util;
 
 import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -49,12 +51,19 @@ import java.util.Set;
  *
  * <pre class="prettyprint">
  *  final boolean isDeprecatedMethodOverridden =
- *   oldMethod.getImplementationDistance(this.getClass()) &gt; newMethod.getImplementationDistance(this.getClass());
+ *   AccessController.doPrivileged((PrivilegedAction&lt;Boolean&gt;) () -&gt;
+ *    (oldMethod.getImplementationDistance(this.getClass()) &gt; newMethod.getImplementationDistance(this.getClass())));
  *
  *  <em>// alternatively (more readable):</em>
  *  final boolean isDeprecatedMethodOverridden =
- *   VirtualMethod.compareImplementationDistance(this.getClass(), oldMethod, newMethod) &gt; 0
+ *   AccessController.doPrivileged((PrivilegedAction&lt;Boolean&gt;) () -&gt;
+ *    VirtualMethod.compareImplementationDistance(this.getClass(), oldMethod, newMethod) &gt; 0);
  * </pre>
+ *
+ * <p>It is important to use {@link AccessController#doPrivileged(PrivilegedAction)} for the actual
+ * call to get the implementation distance because the subclass may be in a different package. The
+ * static constructors do not need to use {@code AccessController} because it just initializes our
+ * own method reference. The caller should have access to all declared members in its own class.
  *
  * <p>{@link #getImplementationDistance} returns the distance of the subclass that overrides this
  * method. The one with the larger distance should be used preferable. This way also more

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
@@ -95,7 +95,7 @@ public class TestKnnFloatVectorQuery extends BaseKnnVectorQueryTestCase {
         assertEquals(1, reader.leaves().size());
         IndexSearcher searcher = new IndexSearcher(reader);
         AbstractKnnVectorQuery query = getKnnVectorQuery("field", new float[] {1, 0}, 2);
-        Query rewritten = query.rewrite(reader);
+        Query rewritten = query.rewrite(searcher);
         Weight weight = searcher.createWeight(rewritten, ScoreMode.COMPLETE, 1);
         Scorer scorer = weight.scorer(reader.leaves().get(0));
 
@@ -126,7 +126,7 @@ public class TestKnnFloatVectorQuery extends BaseKnnVectorQueryTestCase {
         IndexSearcher searcher = new IndexSearcher(reader);
         AbstractKnnVectorQuery query =
             getKnnVectorQuery("field", VectorUtil.l2normalize(new float[] {2, 3}), 3);
-        Query rewritten = query.rewrite(reader);
+        Query rewritten = query.rewrite(searcher);
         Weight weight = searcher.createWeight(rewritten, ScoreMode.COMPLETE, 1);
         Scorer scorer = weight.scorer(reader.leaves().get(0));
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestQueryRewriteBackwardsCompatibility.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestQueryRewriteBackwardsCompatibility.java
@@ -158,6 +158,10 @@ public class TestQueryRewriteBackwardsCompatibility extends LuceneTestCase {
   private abstract static class RewriteCountingQuery extends Query {
     int rewriteCount = 0;
 
+    RewriteCountingQuery() {
+      super(null); // enforce usage of backwards compatibility mode
+    }
+
     abstract RewriteCountingQuery getInnerQuery();
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestQueryRewriteBackwardsCompatibility.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestQueryRewriteBackwardsCompatibility.java
@@ -158,10 +158,6 @@ public class TestQueryRewriteBackwardsCompatibility extends LuceneTestCase {
   private abstract static class RewriteCountingQuery extends Query {
     int rewriteCount = 0;
 
-    RewriteCountingQuery() {
-      super(null); // enforce usage of backwards compatibility mode
-    }
-
     abstract RewriteCountingQuery getInnerQuery();
   }
 


### PR DESCRIPTION
This fixes #12304 for the Query class. The problem was introduced by #12197.

It also adds a note to changes and puts more documentation into `VirtualMethod`. The documentation changes will be forward-ported to main branch.