### PR TITLE
Add "direct to binary" option for DaciukMihovAutomatonBuilder and use it in TermInSetQuery#visit

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -158,6 +158,9 @@ Improvements
 
 * GITHUB#12290: Make memory fence in ByteBufferGuard explicit using `VarHandle.fullFence()`
 
+* GITHUB#12320: Add "direct to binary" option for DaciukMihovAutomatonBuilder and use it in TermInSetQuery#visit.
+  (Greg Miller)
+
 Optimizations
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -34,9 +34,9 @@ import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
-import org.apache.lucene.util.automaton.StringsToAutomaton;
 
 /**
  * Specialization for a disjunction over many terms that, by default, behaves like a {@link
@@ -151,7 +151,7 @@ public class TermInSetQuery extends MultiTermQuery implements Accountable {
   // we won't have to do this (see GH#12176).
   private ByteRunAutomaton asByteRunAutomaton() {
     try {
-      Automaton a = StringsToAutomaton.build(termData.iterator(), true);
+      Automaton a = Automata.makeBinaryStringUnion(termData.iterator());
       return new ByteRunAutomaton(a, true);
     } catch (IOException e) {
       // Shouldn't happen since termData.iterator() provides an interator implementation that

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -17,11 +17,10 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.SortedSet;
 import org.apache.lucene.index.FilteredTermsEnum;
 import org.apache.lucene.index.PrefixCodedTerms;
@@ -35,11 +34,9 @@ import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
-import org.apache.lucene.util.automaton.CompiledAutomaton;
-import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.StringsToAutomaton;
 
 /**
  * Specialization for a disjunction over many terms that, by default, behaves like a {@link
@@ -150,17 +147,17 @@ public class TermInSetQuery extends MultiTermQuery implements Accountable {
     }
   }
 
-  // TODO: this is extremely slow. we should not be doing this.
+  // TODO: This is pretty heavy-weight. If we have TermInSetQuery directly extend AutomatonQuery
+  // we won't have to do this (see GH#12176).
   private ByteRunAutomaton asByteRunAutomaton() {
-    TermIterator iterator = termData.iterator();
-    List<Automaton> automata = new ArrayList<>();
-    for (BytesRef term = iterator.next(); term != null; term = iterator.next()) {
-      automata.add(Automata.makeBinary(term));
+    try {
+      Automaton a = StringsToAutomaton.build(termData.iterator(), true);
+      return new ByteRunAutomaton(a, true);
+    } catch (IOException e) {
+      // Shouldn't happen since termData.iterator() provides an interator implementation that
+      // never throws:
+      throw new UncheckedIOException(e);
     }
-    Automaton automaton =
-        Operations.determinize(
-            Operations.union(automata), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
-    return new CompiledAutomaton(automaton).runAutomaton;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
@@ -29,9 +29,11 @@
 
 package org.apache.lucene.util.automaton;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
 import org.apache.lucene.util.StringHelper;
 
 /**
@@ -578,7 +580,49 @@ public final class Automata {
     if (utf8Strings.isEmpty()) {
       return makeEmpty();
     } else {
-      return StringsToAutomaton.build(utf8Strings);
+      return StringsToAutomaton.build(utf8Strings, false);
     }
+  }
+
+  /**
+   * Returns a new (deterministic and minimal) automaton that accepts the union of the given
+   * collection of {@link BytesRef}s representing UTF-8 encoded strings. The resulting automaton
+   * will be built in a binary representation.
+   *
+   * @param utf8Strings The input strings, UTF-8 encoded. The collection must be in sorted order.
+   * @return An {@link Automaton} accepting all input strings. The resulting automaton is binary
+   *     based (UTF-8 encoded byte transition labels).
+   */
+  public static Automaton makeBinaryStringUnion(Collection<BytesRef> utf8Strings) {
+    if (utf8Strings.isEmpty()) {
+      return makeEmpty();
+    } else {
+      return StringsToAutomaton.build(utf8Strings, true);
+    }
+  }
+
+  /**
+   * Returns a new (deterministic and minimal) automaton that accepts the union of the given
+   * iterator of {@link BytesRef}s representing UTF-8 encoded strings.
+   *
+   * @param utf8Strings The input strings, UTF-8 encoded. The iterator must be in sorted order.
+   * @return An {@link Automaton} accepting all input strings. The resulting automaton is codepoint
+   *     based (full unicode codepoints on transitions).
+   */
+  public static Automaton makeStringUnion(BytesRefIterator utf8Strings) throws IOException {
+    return StringsToAutomaton.build(utf8Strings, false);
+  }
+
+  /**
+   * Returns a new (deterministic and minimal) automaton that accepts the union of the given
+   * iterator of {@link BytesRef}s representing UTF-8 encoded strings. The resulting automaton will
+   * be built in a binary representation.
+   *
+   * @param utf8Strings The input strings, UTF-8 encoded. The iterator must be in sorted order.
+   * @return An {@link Automaton} accepting all input strings. The resulting automaton is binary
+   *     based (UTF-8 encoded byte transition labels).
+   */
+  public static Automaton makeBinaryStringUnion(BytesRefIterator utf8Strings) throws IOException {
+    return StringsToAutomaton.build(utf8Strings, true);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/StringsToAutomaton.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/StringsToAutomaton.java
@@ -16,22 +16,27 @@
  */
 package org.apache.lucene.util.automaton;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.CharsRef;
-import org.apache.lucene.util.CharsRefBuilder;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.BytesRefIterator;
+import org.apache.lucene.util.UnicodeUtil;
 
 /**
  * Builds a minimal, deterministic {@link Automaton} that accepts a set of strings using the
  * algorithm described in <a href="https://aclanthology.org/J00-1002.pdf">Incremental Construction
  * of Minimal Acyclic Finite-State Automata by Daciuk, Mihov, Watson and Watson</a>. This requires
- * sorted input data, but is very fast (nearly linear with the input size).
+ * sorted input data, but is very fast (nearly linear with the input size). Also offers the ability
+ * to directly build a binary {@link Automaton} representation.
  *
+ * @see #build(Collection)
+ * @see #build(Collection, boolean)
+ * @see #build(BytesRefIterator, boolean)
  * @see Automata#makeStringUnion(Collection)
  */
 final class StringsToAutomaton {
@@ -176,64 +181,16 @@ final class StringsToAutomaton {
   /** Root automaton state. */
   private final State root = new State();
 
-  /** Previous sequence added to the automaton in {@link #add(CharsRef)}. */
-  private CharsRefBuilder previous;
+  /** Used for input order checking (only through assertions right now) */
+  private BytesRefBuilder previous;
 
-  /** A comparator used for enforcing sorted UTF8 order, used in assertions only. */
-  @SuppressWarnings("deprecation")
-  private static final Comparator<CharsRef> comparator = CharsRef.getUTF16SortedAsUTF8Comparator();
-
-  /**
-   * Add another character sequence to this automaton. The sequence must be lexicographically larger
-   * or equal compared to any previous sequences added to this automaton (the input must be sorted).
-   */
-  private void add(CharsRef current) {
-    if (current.length > Automata.MAX_STRING_UNION_TERM_LENGTH) {
-      throw new IllegalArgumentException(
-          "This builder doesn't allow terms that are larger than 1,000 characters, got " + current);
+  /** Copy <code>current</code> into an internal buffer. */
+  private boolean setPrevious(BytesRef current) {
+    if (previous == null) {
+      previous = new BytesRefBuilder();
     }
-    assert stateRegistry != null : "Automaton already built.";
-    assert previous == null || comparator.compare(previous.get(), current) <= 0
-        : "Input must be in sorted UTF-8 order: " + previous + " >= " + current;
-    assert setPrevious(current);
-
-    // Descend in the automaton (find matching prefix).
-    int pos = 0, max = current.length();
-    State state = root;
-    for (; ; ) {
-      assert pos <= max;
-      if (pos == max) {
-        break;
-      }
-
-      int codePoint = Character.codePointAt(current, pos);
-      State next = state.lastChild(codePoint);
-      if (next == null) {
-        break;
-      }
-
-      state = next;
-      pos += Character.charCount(codePoint);
-    }
-
-    if (state.hasChildren()) replaceOrRegister(state);
-
-    addSuffix(state, current, pos);
-  }
-
-  /**
-   * Finalize the automaton and return the root state. No more strings can be added to the builder
-   * after this call.
-   *
-   * @return Root automaton state.
-   */
-  private State complete() {
-    if (this.stateRegistry == null) throw new IllegalStateException();
-
-    if (root.hasChildren()) replaceOrRegister(root);
-
-    stateRegistry = null;
-    return root;
+    previous.copyBytes(current);
+    return true;
   }
 
   /** Internal recursive traversal for conversion. */
@@ -259,38 +216,126 @@ final class StringsToAutomaton {
   }
 
   /**
-   * Build a minimal, deterministic automaton from a sorted list of {@link BytesRef} representing
-   * strings in UTF-8. These strings must be binary-sorted.
+   * Called after adding all terms. Performs final minimization and converts to a standard {@link
+   * Automaton} instance.
    */
-  static Automaton build(Collection<BytesRef> input) {
-    final StringsToAutomaton builder = new StringsToAutomaton();
+  private Automaton completeAndConvert() {
+    // Final minimization:
+    if (this.stateRegistry == null) throw new IllegalStateException();
+    if (root.hasChildren()) replaceOrRegister(root);
+    stateRegistry = null;
 
-    CharsRefBuilder current = new CharsRefBuilder();
-    for (BytesRef b : input) {
-      current.copyUTF8Bytes(b);
-      builder.add(current.get());
-    }
-
+    // Convert:
     Automaton.Builder a = new Automaton.Builder();
-    convert(a, builder.complete(), new IdentityHashMap<>());
-
+    convert(a, root, new IdentityHashMap<>());
     return a.finish();
   }
 
-  /** Copy <code>current</code> into an internal buffer. */
-  private boolean setPrevious(CharsRef current) {
-    if (previous == null) {
-      previous = new CharsRefBuilder();
+  /**
+   * Build a minimal, deterministic automaton from a sorted list of {@link BytesRef} representing
+   * strings in UTF-8. These strings must be binary-sorted. Creates an {@link Automaton} with UTF-8
+   * codepoints as transition labels.
+   */
+  static Automaton build(Collection<BytesRef> input) {
+    return build(input, false);
+  }
+
+  /**
+   * Build a minimal, deterministic automaton from a sorted list of {@link BytesRef} representing
+   * strings in UTF-8. These strings must be binary-sorted. Creates an {@link Automaton} with either
+   * UTF-8 codepoints as transition labels or binary (compiled) transition labels based on {@code
+   * asBinary}.
+   */
+  static Automaton build(Collection<BytesRef> input, boolean asBinary) {
+    final StringsToAutomaton builder = new StringsToAutomaton();
+
+    for (BytesRef b : input) {
+      builder.add(b, asBinary);
     }
-    previous.copyChars(current);
-    return true;
+
+    return builder.completeAndConvert();
+  }
+
+  /**
+   * Build a minimal, deterministic automaton from a sorted list of {@link BytesRef} representing
+   * strings in UTF-8. These strings must be binary-sorted. Creates an {@link Automaton} with either
+   * UTF-8 codepoints as transition labels or binary (compiled) transition labels based on {@code
+   * asBinary}.
+   */
+  static Automaton build(BytesRefIterator input, boolean asBinary) throws IOException {
+    final StringsToAutomaton builder = new StringsToAutomaton();
+
+    for (BytesRef b = input.next(); b != null; b = input.next()) {
+      builder.add(b, asBinary);
+    }
+
+    return builder.completeAndConvert();
+  }
+
+  private void add(BytesRef current, boolean asBinary) {
+    if (current.length > Automata.MAX_STRING_UNION_TERM_LENGTH) {
+      throw new IllegalArgumentException(
+          "This builder doesn't allow terms that are larger than "
+              + Automata.MAX_STRING_UNION_TERM_LENGTH
+              + " characters, got "
+              + current);
+    }
+    assert stateRegistry != null : "Automaton already built.";
+    assert previous == null || previous.get().compareTo(current) <= 0
+        : "Input must be in sorted UTF-8 order: " + previous.get() + " >= " + current;
+    assert setPrevious(current);
+
+    // Reusable state information if we're building a non-binary based automaton
+    UnicodeUtil.UTF8CodePointState scratchState = null;
+    if (asBinary == false) {
+      scratchState = new UnicodeUtil.UTF8CodePointState();
+    }
+
+    // Descend in the automaton (find matching prefix).
+    int pos = 0, max = current.length;
+    State next, state = root;
+    if (asBinary) {
+      while (pos < max
+          && (next = state.lastChild(current.bytes[current.offset + pos] & 0xff)) != null) {
+        state = next;
+        pos++;
+      }
+    } else {
+      while (pos < max) {
+        UnicodeUtil.UTF8CodePointAt(current, pos, scratchState);
+        next = state.lastChild(scratchState.codePoint);
+        if (next == null) {
+          break;
+        }
+        state = next;
+        pos += scratchState.codePointBytes;
+      }
+    }
+
+    if (state.hasChildren()) replaceOrRegister(state);
+
+    // Add suffix
+    if (asBinary) {
+      while (pos < max) {
+        state = state.newState(current.bytes[current.offset + pos] & 0xff);
+        pos++;
+      }
+    } else {
+      while (pos < max) {
+        assert scratchState != null;
+        UnicodeUtil.UTF8CodePointAt(current, pos, scratchState);
+        state = state.newState(scratchState.codePoint);
+        pos += scratchState.codePointBytes;
+      }
+    }
+    state.is_final = true;
   }
 
   /**
    * Replace last child of <code>state</code> with an already registered state or stateRegistry the
    * last child state.
    */
-  private void replaceOrRegister(State state) {
+  protected void replaceOrRegister(State state) {
     final State child = state.lastChild();
 
     if (child.hasChildren()) replaceOrRegister(child);
@@ -301,19 +346,5 @@ final class StringsToAutomaton {
     } else {
       stateRegistry.put(child, child);
     }
-  }
-
-  /**
-   * Add a suffix of <code>current</code> starting at <code>fromIndex</code> (inclusive) to state
-   * <code>state</code>.
-   */
-  private void addSuffix(State state, CharSequence current, int fromIndex) {
-    final int len = current.length();
-    while (fromIndex < len) {
-      int cp = Character.codePointAt(current, fromIndex);
-      state = state.newState(cp);
-      fromIndex += Character.charCount(cp);
-    }
-    state.is_final = true;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/StringsToAutomaton.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/StringsToAutomaton.java
@@ -32,11 +32,9 @@ import org.apache.lucene.util.UnicodeUtil;
  * algorithm described in <a href="https://aclanthology.org/J00-1002.pdf">Incremental Construction
  * of Minimal Acyclic Finite-State Automata by Daciuk, Mihov, Watson and Watson</a>. This requires
  * sorted input data, but is very fast (nearly linear with the input size). Also offers the ability
- * to directly build a binary {@link Automaton} representation.
+ * to directly build a binary {@link Automaton} representation. Users should access this
+ * functionality through {@link Automata} static methods.
  *
- * @see #build(Collection)
- * @see #build(Collection, boolean)
- * @see #build(BytesRefIterator, boolean)
  * @see Automata#makeStringUnion(Collection)
  * @see Automata#makeBinaryStringUnion(Collection)
  * @see Automata#makeStringUnion(BytesRefIterator)
@@ -232,15 +230,6 @@ final class StringsToAutomaton {
     Automaton.Builder a = new Automaton.Builder();
     convert(a, root, new IdentityHashMap<>());
     return a.finish();
-  }
-
-  /**
-   * Build a minimal, deterministic automaton from a sorted list of {@link BytesRef} representing
-   * strings in UTF-8. These strings must be binary-sorted. Creates an {@link Automaton} with UTF-8
-   * codepoints as transition labels.
-   */
-  static Automaton build(Collection<BytesRef> input) {
-    return build(input, false);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/StringsToAutomaton.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/StringsToAutomaton.java
@@ -38,6 +38,9 @@ import org.apache.lucene.util.UnicodeUtil;
  * @see #build(Collection, boolean)
  * @see #build(BytesRefIterator, boolean)
  * @see Automata#makeStringUnion(Collection)
+ * @see Automata#makeBinaryStringUnion(Collection)
+ * @see Automata#makeStringUnion(BytesRefIterator)
+ * @see Automata#makeBinaryStringUnion(BytesRefIterator)
  */
 final class StringsToAutomaton {
 
@@ -335,7 +338,7 @@ final class StringsToAutomaton {
    * Replace last child of <code>state</code> with an already registered state or stateRegistry the
    * last child state.
    */
-  protected void replaceOrRegister(State state) {
+  private void replaceOrRegister(State state) {
     final State child = state.lastChild();
 
     if (child.hasChildren()) replaceOrRegister(child);

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/StringsToAutomaton.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/StringsToAutomaton.java
@@ -308,7 +308,7 @@ final class StringsToAutomaton {
           break;
         }
         state = next;
-        pos += codePoint.codePointBytes;
+        pos += codePoint.numBytes;
       }
     }
 
@@ -324,7 +324,7 @@ final class StringsToAutomaton {
       while (pos < max) {
         codePoint = UnicodeUtil.codePointAt(bytes, pos, codePoint);
         state = state.newState(codePoint.codePoint);
-        pos += codePoint.codePointBytes;
+        pos += codePoint.numBytes;
       }
     }
     state.is_final = true;

--- a/lucene/core/src/test/org/apache/lucene/util/TestUnicodeUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestUnicodeUtil.java
@@ -168,21 +168,20 @@ public class TestUnicodeUtil extends LuceneTestCase {
 
   public void testUTF8CodePointAt() {
     int num = atLeast(50000);
-    UnicodeUtil.UTF8CodePointState state = new UnicodeUtil.UTF8CodePointState();
+    UnicodeUtil.UTF8CodePoint reuse = null;
     for (int i = 0; i < num; i++) {
       final String s = TestUtil.randomUnicodeString(random());
       final byte[] utf8 = new byte[UnicodeUtil.maxUTF8Length(s.length())];
       final int utf8Len = UnicodeUtil.UTF16toUTF8(s, 0, s.length(), utf8);
-      final BytesRef utf8Ref = newBytesRef(utf8, 0, utf8Len);
 
       int[] expected = s.codePoints().toArray();
       int pos = 0;
       int expectedUpto = 0;
       while (pos < utf8Len) {
-        UnicodeUtil.UTF8CodePointAt(utf8Ref, pos, state);
-        assertEquals(expected[expectedUpto], state.codePoint);
+        reuse = UnicodeUtil.codePointAt(utf8, pos, reuse);
+        assertEquals(expected[expectedUpto], reuse.codePoint);
         expectedUpto++;
-        pos += state.codePointBytes;
+        pos += reuse.codePointBytes;
       }
       assertEquals(utf8Len, pos);
       assertEquals(expected.length, expectedUpto);

--- a/lucene/core/src/test/org/apache/lucene/util/TestUnicodeUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestUnicodeUtil.java
@@ -166,6 +166,29 @@ public class TestUnicodeUtil extends LuceneTestCase {
     }
   }
 
+  public void testUTF8CodePointAt() {
+    int num = atLeast(50000);
+    UnicodeUtil.UTF8CodePointState state = new UnicodeUtil.UTF8CodePointState();
+    for (int i = 0; i < num; i++) {
+      final String s = TestUtil.randomUnicodeString(random());
+      final byte[] utf8 = new byte[UnicodeUtil.maxUTF8Length(s.length())];
+      final int utf8Len = UnicodeUtil.UTF16toUTF8(s, 0, s.length(), utf8);
+      final BytesRef utf8Ref = newBytesRef(utf8, 0, utf8Len);
+
+      int[] expected = s.codePoints().toArray();
+      int pos = 0;
+      int expectedUpto = 0;
+      while (pos < utf8Len) {
+        UnicodeUtil.UTF8CodePointAt(utf8Ref, pos, state);
+        assertEquals(expected[expectedUpto], state.codePoint);
+        expectedUpto++;
+        pos += state.codePointBytes;
+      }
+      assertEquals(utf8Len, pos);
+      assertEquals(expected.length, expectedUpto);
+    }
+  }
+
   public void testNewString() {
     final int[] codePoints = {
       Character.toCodePoint(Character.MIN_HIGH_SURROGATE, Character.MAX_LOW_SURROGATE),

--- a/lucene/core/src/test/org/apache/lucene/util/TestUnicodeUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestUnicodeUtil.java
@@ -181,7 +181,7 @@ public class TestUnicodeUtil extends LuceneTestCase {
         reuse = UnicodeUtil.codePointAt(utf8, pos, reuse);
         assertEquals(expected[expectedUpto], reuse.codePoint);
         expectedUpto++;
-        pos += reuse.codePointBytes;
+        pos += reuse.numBytes;
       }
       assertEquals(utf8Len, pos);
       assertEquals(expected.length, expectedUpto);

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestStringsToAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestStringsToAutomaton.java
@@ -16,26 +16,138 @@
  */
 package org.apache.lucene.util.automaton;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.BytesRefIterator;
+import org.apache.lucene.util.IntsRef;
+import org.apache.lucene.util.fst.Util;
 
 public class TestStringsToAutomaton extends LuceneTestCase {
 
-  public void testLargeTerms() {
+  public void testBasic() throws Exception {
+    List<BytesRef> terms = basicTerms();
+    Collections.sort(terms);
+
+    Automaton a = build(terms, false);
+    checkAutomaton(terms, a, false);
+  }
+
+  public void testBasicBinary() throws Exception {
+    List<BytesRef> terms = basicTerms();
+    Collections.sort(terms);
+
+    Automaton a = build(terms, true);
+    checkAutomaton(terms, a, true);
+  }
+
+  public void testRandomUnicodeOnly() throws Exception {
+    testRandom(false);
+  }
+
+  public void testRandomBinary() throws Exception {
+    testRandom(true);
+  }
+
+  public void testLargeTerms() throws Exception {
     byte[] b10k = new byte[10_000];
     Arrays.fill(b10k, (byte) 'a');
     IllegalArgumentException e =
         expectThrows(
             IllegalArgumentException.class,
-            () -> StringsToAutomaton.build(Collections.singleton(new BytesRef(b10k))));
+            () -> build(Collections.singleton(new BytesRef(b10k)), false));
     assertTrue(
         e.getMessage()
-            .startsWith("This builder doesn't allow terms that are larger than 1,000 characters"));
+            .startsWith(
+                "This builder doesn't allow terms that are larger than "
+                    + StringsToAutomaton.MAX_TERM_LENGTH
+                    + " characters"));
 
     byte[] b1k = ArrayUtil.copyOfSubArray(b10k, 0, 1000);
-    StringsToAutomaton.build(Collections.singleton(new BytesRef(b1k))); // no exception
+    build(Collections.singleton(new BytesRef(b1k)), false); // no exception
+  }
+
+  private void testRandom(boolean allowBinary) throws Exception {
+    int iters = RandomizedTest.isNightly() ? 50 : 10;
+    for (int i = 0; i < iters; i++) {
+      int size = random().nextInt(500, 2_000);
+      Set<BytesRef> terms = new HashSet<>(size);
+      for (int j = 0; j < size; j++) {
+        if (allowBinary && random().nextInt(10) < 2) {
+          // Sometimes random bytes term that isn't necessarily valid unicode
+          terms.add(newBytesRef(TestUtil.randomBinaryTerm(random())));
+        } else {
+          terms.add(newBytesRef(TestUtil.randomRealisticUnicodeString(random())));
+        }
+      }
+
+      List<BytesRef> sorted = terms.stream().sorted().toList();
+      Automaton a = build(sorted, allowBinary);
+      checkAutomaton(sorted, a, allowBinary);
+    }
+  }
+
+  private void checkAutomaton(List<BytesRef> expected, Automaton a, boolean isBinary) {
+    CompiledAutomaton c = new CompiledAutomaton(a, true, false, isBinary);
+    ByteRunAutomaton runAutomaton = c.runAutomaton;
+
+    for (BytesRef t : expected) {
+      String readable = isBinary ? t.toString() : t.utf8ToString();
+      assertTrue(
+          readable + " should be found but wasn't", runAutomaton.run(t.bytes, t.offset, t.length));
+    }
+
+    BytesRefBuilder scratch = new BytesRefBuilder();
+    FiniteStringsIterator it = new FiniteStringsIterator(c.automaton);
+    for (IntsRef r = it.next(); r != null; r = it.next()) {
+      BytesRef t = Util.toBytesRef(r, scratch);
+      assertTrue(expected.contains(t));
+    }
+  }
+
+  private List<BytesRef> basicTerms() {
+    List<BytesRef> terms = new ArrayList<>();
+    terms.add(newBytesRef("dog"));
+    terms.add(newBytesRef("day"));
+    terms.add(newBytesRef("dad"));
+    terms.add(newBytesRef("cats"));
+    terms.add(newBytesRef("cat"));
+    return terms;
+  }
+
+  private Automaton build(Collection<BytesRef> terms, boolean asBinary) throws IOException {
+    if (random().nextBoolean()) {
+      return StringsToAutomaton.build(terms, asBinary);
+    } else {
+      return StringsToAutomaton.build(new TermIterator(terms), asBinary);
+    }
+  }
+
+  private static class TermIterator implements BytesRefIterator {
+    private final Iterator<BytesRef> it;
+
+    TermIterator(Collection<BytesRef> terms) {
+      this.it = terms.iterator();
+    }
+
+    @Override
+    public BytesRef next() throws IOException {
+      if (it.hasNext() == false) {
+        return null;
+      }
+      return it.next();
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestStringsToAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestStringsToAutomaton.java
@@ -103,12 +103,14 @@ public class TestStringsToAutomaton extends LuceneTestCase {
     CompiledAutomaton c = new CompiledAutomaton(a, true, false, isBinary);
     ByteRunAutomaton runAutomaton = c.runAutomaton;
 
+    // Make sure every expected term is accepted
     for (BytesRef t : expected) {
       String readable = isBinary ? t.toString() : t.utf8ToString();
       assertTrue(
           readable + " should be found but wasn't", runAutomaton.run(t.bytes, t.offset, t.length));
     }
 
+    // Make sure every term produced by the automaton is expected
     BytesRefBuilder scratch = new BytesRefBuilder();
     FiniteStringsIterator it = new FiniteStringsIterator(c.automaton);
     for (IntsRef r = it.next(); r != null; r = it.next()) {

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestStringsToAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestStringsToAutomaton.java
@@ -102,7 +102,7 @@ public class TestStringsToAutomaton extends LuceneTestCase {
         e.getMessage()
             .startsWith(
                 "This builder doesn't allow terms that are larger than "
-                    + StringsToAutomaton.MAX_TERM_LENGTH
+                    + Automata.MAX_STRING_UNION_TERM_LENGTH
                     + " characters"));
 
     byte[] b1k = ArrayUtil.copyOfSubArray(b10k, 0, 1000);


### PR DESCRIPTION
### Description

Adds the ability to directly build a binary automaton for a string union using the Daciuk-Mihov algorithm, and uses it to make the `TermInSetQuery#visit` implementation a little more optimal. I'm hoping we end up moving to an automaton approach in general for `TermInSetQuery` (see #12312), but I think this is a good iterative step for now, as suggested by @rmuir / @mikemccand in #12310.