### PR TITLE
NeighborQueue set incomplemete false when call clear

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -156,6 +156,7 @@ public class NeighborQueue {
   public void clear() {
     heap.clear();
     visitedCount = 0;
+    incomplete = false;
   }
 
   public int visitedCount() {

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborQueue.java
@@ -72,10 +72,12 @@ public class TestNeighborQueue extends LuceneTestCase {
     nn.add(1, 1.1f);
     nn.add(2, -2.2f);
     nn.setVisitedCount(42);
+    nn.markIncomplete();
     nn.clear();
 
     assertEquals(0, nn.size());
     assertEquals(0, nn.visitedCount());
+    assertFalse(nn.incomplete());
   }
 
   public void testMaxSizeQueue() {


### PR DESCRIPTION
### Description
solve the bug that @msokolov mentioned in [PR](https://github.com/apache/lucene/pull/12255#issuecomment-1553088549)
