### PR TITLE
Speed up IndexedDISI Sparse #AdvanceExactWithinBlock for tiny step advance

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -131,6 +131,8 @@ Improvements
 Optimizations
 ---------------------
 
+* GITHUB#12324: Speed up Sparse block advanceExact with tiny step in IndexedDISI. (Guo Feng)
+
 * GITHUB#12270 Don't generate stacktrace in CollectionTerminatedException. (Armin Braun)
 
 * GITHUB#12286 Toposort use iterator to avoid stackoverflow. (Tang Donghai)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -131,7 +131,7 @@ Improvements
 Optimizations
 ---------------------
 
-* GITHUB#12324: Speed up Sparse block advanceExact with tiny step in IndexedDISI. (Guo Feng)
+* GITHUB#12324: Speed up sparse block advanceExact with tiny step in IndexedDISI. (Guo Feng)
 
 * GITHUB#12270 Don't generate stacktrace in CollectionTerminatedException. (Armin Braun)
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -110,12 +110,12 @@ public final class IndexedDISI extends DocIdSetIterator {
   private static void flush(
       int block, FixedBitSet buffer, int cardinality, byte denseRankPower, IndexOutput out)
       throws IOException {
-    assert block >= 0 && block < 65536;
+    assert block >= 0 && block < BLOCK_SIZE;
     out.writeShort((short) block);
-    assert cardinality > 0 && cardinality <= 65536;
+    assert cardinality > 0 && cardinality <= BLOCK_SIZE;
     out.writeShort((short) (cardinality - 1));
     if (cardinality > MAX_ARRAY_LENGTH) {
-      if (cardinality != 65536) { // all docs are set
+      if (cardinality != BLOCK_SIZE) { // all docs are set
         if (denseRankPower != -1) {
           final byte[] rank = createRank(buffer, denseRankPower);
           out.writeBytes(rank, rank.length);
@@ -497,7 +497,7 @@ public final class IndexedDISI extends DocIdSetIterator {
       method = Method.SPARSE;
       blockEnd = slice.getFilePointer() + (numValues << 1);
       nextExistDocInBlock = -1;
-    } else if (numValues == 65536) {
+    } else if (numValues == BLOCK_SIZE) {
       method = Method.ALL;
       blockEnd = slice.getFilePointer();
       gap = block - index - 1;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -556,7 +556,6 @@ public final class IndexedDISI extends DocIdSetIterator {
             return true;
           }
         }
-        disi.nextExistDocInBlock = Integer.MAX_VALUE;
         return false;
       }
 
@@ -579,14 +578,12 @@ public final class IndexedDISI extends DocIdSetIterator {
             if (doc != targetInBlock) {
               disi.index--;
               disi.slice.seek(disi.slice.getFilePointer() - Short.BYTES);
-              disi.exists = false;
-              return false;
+              break;
             }
             disi.exists = true;
             return true;
           }
         }
-        disi.nextExistDocInBlock = Integer.MAX_VALUE;
         disi.exists = false;
         return false;
       }


### PR DESCRIPTION
Today `Sparse#AdvanceExactWithinBlock` always need to read next doc and seek back if a doc not exists. This could do harm to performance in dense hit queries. 

For example, a field exists in doc 1, 5. When `advanceExact` 2,3,4 it always need to read next doc (5) and seek back.

I think caching the next existing doc in block can help dense hit queries without too much harm to other cases.

I ran a benchmark with `MatchAllDocsQuery` on some fields with different sparsity:

> sparsity=n means field only exists when `doc % n == 0`

<byte-sheet-html-origin data-id="1684739567508" data-version="4" data-is-embed="false" data-grid-line-hidden="false" data-importRangeRawData-spreadSource="https://bytedance.feishu.cn/sheets/YyZcs5ZLNh9tl2t2MvKcsU4jn6b" data-importRangeRawData-range="&#39;Sheet1&#39;!I1:L12">

sparsity | baseline(ms) | candidate(ms) | diff
-- | -- | -- | --
32 | 255 | 112 | -56.08%
64 | 260 | 95 | -63.46%
128 | 264 | 94 | -64.39%
256 | 262 | 93 | -64.50%
512 | 260 | 91 | -65.00%
1024 | 259 | 90 | -65.25%
2048 | 258 | 90 | -65.12%
4096 | 253 | 90 | -64.43%
8192 | 243 | 90 | -62.96%
16384 | 224 | 90 | -59.82%
32768 | 184 | 90 | -51.09%

</byte-sheet-html-origin>





