### PR TITLE
Parallelize knn query rewrite across slices rather than segments

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -82,6 +82,7 @@ abstract class AbstractKnnVectorQuery extends Query {
     }
 
     SliceExecutor sliceExecutor = indexSearcher.getSliceExecutor();
+    //in case of parallel execution, the leaf results are not ordered by leaf context's ordinal
     TopDocs[] perLeafResults =
         (sliceExecutor == null)
             ? sequentialSearch(reader.leaves(), filterWeight)

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -82,7 +82,7 @@ abstract class AbstractKnnVectorQuery extends Query {
     }
 
     SliceExecutor sliceExecutor = indexSearcher.getSliceExecutor();
-    //in case of parallel execution, the leaf results are not ordered by leaf context's ordinal
+    // in case of parallel execution, the leaf results are not ordered by leaf context's ordinal
     TopDocs[] perLeafResults =
         (sliceExecutor == null)
             ? sequentialSearch(reader.leaves(), filterWeight)

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -962,6 +962,10 @@ public class IndexSearcher {
     return executor;
   }
 
+  SliceExecutor getSliceExecutor() {
+    return sliceExecutor;
+  }
+
   /**
    * Thrown when an attempt is made to add more than {@link #getMaxClauseCount()} clauses. This
    * typically happens if a PrefixQuery, FuzzyQuery, WildcardQuery, or TermRangeQuery is expanded to


### PR DESCRIPTION
The concurrent query rewrite for knn vectory query introduced with #12160 requests one thread per segment to the executor. To align this with the IndexSearcher parallel behaviour, we should rather parallelize across slices. Also, we can reuse the same slice executor instance that the index searcher already holds, that way we are using a QueueSizeBasedExecutor when a thread pool executor is provided.

