### PR TITLE
Lucene 9.x fails to merge 8.x segments with a field that changed IndexOptions NONE -> DOCS

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -43,6 +43,8 @@ Bug Fixes
 
 * GITHUB#12291: Skip blank lines from stopwords list. (Jerry Chin)
 
+* GITHUB#11350: Handle possible differences in FieldInfo when merging indices created with Lucene 8.x (Tomás Fernández Löbbe)
+
 Other
 ---------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
@@ -417,79 +417,107 @@ public final class FieldInfo {
     long newDvGen = this.dvGen;
 
     boolean fieldInfoChanges = false;
-    //System.out.println("FI.update field=" + name + " indexed=" + indexed + " omitNorms=" + omitNorms + " this.omitNorms=" + this.omitNorms);
+    // System.out.println("FI.update field=" + name + " indexed=" + indexed + " omitNorms=" +
+    // omitNorms + " this.omitNorms=" + this.omitNorms);
     if (this.indexOptions != otherFi.indexOptions) {
       if (this.indexOptions == IndexOptions.NONE) {
         newIndexOptions = otherFi.indexOptions;
         fieldInfoChanges = true;
       } else if (otherFi.indexOptions != IndexOptions.NONE) {
-        throw new IllegalArgumentException("cannot change field \"" + name + "\" from index options=" + this.indexOptions + " to inconsistent index options=" + otherFi.indexOptions);
+        throw new IllegalArgumentException(
+            "cannot change field \""
+                + name
+                + "\" from index options="
+                + this.indexOptions
+                + " to inconsistent index options="
+                + otherFi.indexOptions);
       }
     }
 
-    if (this.pointDimensionCount != otherFi.pointDimensionCount) {
+    if (this.pointDimensionCount != otherFi.pointDimensionCount
+        && otherFi.pointDimensionCount != 0) {
       if (this.pointDimensionCount == 0) {
         fieldInfoChanges = true;
         newPointDimensionCount = otherFi.pointDimensionCount;
       } else {
-        throw new IllegalArgumentException("cannot change field \"" + name + "\" from points dimensionCount=" + this.pointDimensionCount + " to inconsistent dimensionCount=" + otherFi.pointDimensionCount);
+        throw new IllegalArgumentException(
+            "cannot change field \""
+                + name
+                + "\" from points dimensionCount="
+                + this.pointDimensionCount
+                + " to inconsistent dimensionCount="
+                + otherFi.pointDimensionCount);
       }
     }
 
-    if (this.pointIndexDimensionCount != otherFi.pointIndexDimensionCount) {
+    if (this.pointIndexDimensionCount != otherFi.pointIndexDimensionCount
+        && otherFi.pointIndexDimensionCount != 0) {
       if (this.pointIndexDimensionCount == 0) {
         fieldInfoChanges = true;
         newPointIndexDimensionCount = otherFi.pointIndexDimensionCount;
       } else {
-        throw new IllegalArgumentException("cannot change field \"" + name + "\" from points indexDimensionCount=" + this.pointIndexDimensionCount + " to inconsistent indexDimensionCount=" + otherFi.pointIndexDimensionCount);
+        throw new IllegalArgumentException(
+            "cannot change field \""
+                + name
+                + "\" from points indexDimensionCount="
+                + this.pointIndexDimensionCount
+                + " to inconsistent indexDimensionCount="
+                + otherFi.pointIndexDimensionCount);
       }
     }
 
-    if (this.pointNumBytes != otherFi.pointNumBytes) {
+    if (this.pointNumBytes != otherFi.pointNumBytes && otherFi.pointNumBytes != 0) {
       if (this.pointNumBytes == 0) {
         fieldInfoChanges = true;
         newPointNumBytes = otherFi.pointNumBytes;
       } else {
-        throw new IllegalArgumentException("cannot change field \"" + name + "\" from points numBytes=" + this.pointNumBytes + " to inconsistent numBytes=" + otherFi.pointNumBytes);
+        throw new IllegalArgumentException(
+            "cannot change field \""
+                + name
+                + "\" from points numBytes="
+                + this.pointNumBytes
+                + " to inconsistent numBytes="
+                + otherFi.pointNumBytes);
       }
     }
 
-    if (newIndexOptions != IndexOptions.NONE) { // if updated field data is not for indexing, leave the updates out
-      if (this.storeTermVector != otherFi.storeTermVector) {
+    if (newIndexOptions
+        != IndexOptions.NONE) { // if updated field data is not for indexing, leave the updates out
+      if (this.storeTermVector != otherFi.storeTermVector && this.storeTermVector == false) {
         fieldInfoChanges = true;
-        this.storeTermVector |= otherFi.storeTermVector;                // once vector, always vector
+        newStoreTermVector = true; // once vector, always vector
       }
-      if (this.storePayloads != otherFi.storePayloads) {
+      if (this.storePayloads != otherFi.storePayloads
+          && this.storePayloads == false
+          && newIndexOptions.compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0) {
         fieldInfoChanges = true;
-        this.storePayloads |= otherFi.storePayloads;
+        newStorePayloads = true;
       }
 
       // Awkward: only drop norms if incoming update is indexed:
-      if (otherFi.indexOptions != IndexOptions.NONE && this.omitNorms != otherFi.omitNorms) {
+      if (otherFi.indexOptions != IndexOptions.NONE
+          && this.omitNorms != otherFi.omitNorms
+          && this.omitNorms == false) {
         fieldInfoChanges = true;
-        newOmitNorms = true;                // if one require omitNorms at least once, it remains off for life
+        newOmitNorms = true; // if one require omitNorms at least once, it remains off for life
       }
     }
-    if ((this.indexOptions == IndexOptions.NONE || this.indexOptions.compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) < 0) && this.storePayloads == true) {
-      fieldInfoChanges = true;
-      // cannot store payloads if we don't store positions:
-      newStorePayloads = false;
-    }
 
-    if (otherFi.docValuesType != DocValuesType.NONE && otherFi.docValuesType != this.docValuesType) {
+    if (otherFi.docValuesType != DocValuesType.NONE
+        && otherFi.docValuesType != this.docValuesType) {
       if (this.docValuesType == DocValuesType.NONE) {
         fieldInfoChanges = true;
         newDocValues = otherFi.docValuesType;
-        newDvGen = dvGen;
+        newDvGen = otherFi.dvGen;
       } else {
         throw new IllegalArgumentException(
-                "cannot change DocValues type from "
-                        + docValuesType
-                        + " to "
-                        + otherFi.docValuesType
-                        + " for field \""
-                        + name
-                        + "\"");
+            "cannot change DocValues type from "
+                + docValuesType
+                + " to "
+                + otherFi.docValuesType
+                + " for field \""
+                + name
+                + "\"");
       }
     }
 
@@ -497,22 +525,23 @@ public final class FieldInfo {
       return null;
     }
     return new FieldInfo(
-            this.name,
-            this.number,
-            newStoreTermVector,
-            newOmitNorms,
-            newStorePayloads,
-            newIndexOptions,
-            newDocValues,
-            newDvGen,
-            this.attributes, // attributes don't need to be handled here because they are handled for the non-legacy case in FieldInfos
-            newPointDimensionCount,
-            newPointIndexDimensionCount,
-            newPointNumBytes,
-            this.vectorDimension,
-            this.vectorEncoding,
-            this.vectorSimilarityFunction,
-            this.softDeletesField);
+        this.name,
+        this.number,
+        newStoreTermVector,
+        newOmitNorms,
+        newStorePayloads,
+        newIndexOptions,
+        newDocValues,
+        newDvGen,
+        this.attributes, // attributes don't need to be handled here because they are handled for
+        // the non-legacy case in FieldInfos
+        newPointDimensionCount,
+        newPointIndexDimensionCount,
+        newPointNumBytes,
+        this.vectorDimension,
+        this.vectorEncoding,
+        this.vectorSimilarityFunction,
+        this.softDeletesField);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -756,12 +756,15 @@ public class FieldInfos implements Iterable<FieldInfo> {
           // FieldInfo instances
           FieldInfo updatedFieldInfo = curFi.handleLegacySupportedUpdates(fi);
           if (updatedFieldInfo != null) {
-            if (fi.getDocValuesType() != DocValuesType.NONE
-                && curFi.getDocValuesType() == fi.getDocValuesType()) {
+            if (curFi.getDocValuesType() == DocValuesType.NONE
+                && updatedFieldInfo.getDocValuesType() != DocValuesType.NONE) {
               // Must also update docValuesType map so it's
               // aware of this field's DocValuesType.  This will throw IllegalArgumentException if
               // an illegal type change was attempted.
-              globalFieldNumbers.setDocValuesType(fi.number, fi.getName(), fi.getDocValuesType());
+              globalFieldNumbers.setDocValuesType(
+                  updatedFieldInfo.number,
+                  updatedFieldInfo.getName(),
+                  updatedFieldInfo.getDocValuesType());
             }
             // Since the FieldInfo changed, update in map
             byName.put(fi.getName(), updatedFieldInfo);

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -587,7 +587,6 @@ public class FieldInfos implements Iterable<FieldInfo> {
                   + "] must be doc values only field, but is also indexed with vectors.");
         }
       }
-
     }
 
     /**
@@ -636,14 +635,38 @@ public class FieldInfos implements Iterable<FieldInfo> {
 
     synchronized void verifyConsistent(Integer number, String name, DocValuesType dvType) {
       if (name.equals(numberToName.get(number)) == false) {
-        throw new IllegalArgumentException("field number " + number + " is already mapped to field name \"" + numberToName.get(number) + "\", not \"" + name + "\"");
+        throw new IllegalArgumentException(
+            "field number "
+                + number
+                + " is already mapped to field name \""
+                + numberToName.get(number)
+                + "\", not \""
+                + name
+                + "\"");
       }
       if (number.equals(nameToNumber.get(name)) == false) {
-        throw new IllegalArgumentException("field name \"" + name + "\" is already mapped to field number \"" + nameToNumber.get(name) + "\", not \"" + number + "\"");
+        throw new IllegalArgumentException(
+            "field name \""
+                + name
+                + "\" is already mapped to field number \""
+                + nameToNumber.get(name)
+                + "\", not \""
+                + number
+                + "\"");
       }
       DocValuesType currentDVType = docValuesType.get(name);
-      if (dvType != DocValuesType.NONE && currentDVType != null && currentDVType != DocValuesType.NONE && dvType != currentDVType) {
-        throw new IllegalArgumentException("cannot change DocValues type from " + currentDVType + " to " + dvType + " for field \"" + name + "\"");
+      if (dvType != DocValuesType.NONE
+          && currentDVType != null
+          && currentDVType != DocValuesType.NONE
+          && dvType != currentDVType) {
+        throw new IllegalArgumentException(
+            "cannot change DocValues type from "
+                + currentDVType
+                + " to "
+                + dvType
+                + " for field \""
+                + name
+                + "\"");
       }
     }
 
@@ -729,10 +752,12 @@ public class FieldInfos implements Iterable<FieldInfo> {
         curFi.verifySameSchema(fi, globalFieldNumbers.strictlyConsistent);
 
         if (!globalFieldNumbers.strictlyConsistent) {
-          // For the not strictly consistent case (legacy index), we may need to update merge the FieldInfo
+          // For the not strictly consistent case (legacy index), we may need to update merge the
+          // FieldInfo
           FieldInfo updatedFieldInfo = curFi.handleLegacySupportedUpdates(fi);
           if (updatedFieldInfo != null) {
-            if (fi.getDocValuesType() != DocValuesType.NONE && curFi.getDocValuesType() == fi.getDocValuesType()) {
+            if (fi.getDocValuesType() != DocValuesType.NONE
+                && curFi.getDocValuesType() == fi.getDocValuesType()) {
               // Must also update docValuesType map so it's
               // aware of this field's DocValuesType.  This will throw IllegalArgumentException if
               // an illegal type change was attempted.
@@ -746,7 +771,8 @@ public class FieldInfos implements Iterable<FieldInfo> {
           fi.attributes().forEach((k, v) -> curFi.putAttribute(k, v));
         }
         if (fi.hasPayloads()) {
-          //nocommit: How about the validation happening in handleLegacySupportedUpdates? not needed here?
+          // nocommit: How about the validation happening in handleLegacySupportedUpdates? not
+          // needed here?
           curFi.setStorePayloads();
         }
         return curFi;

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -752,8 +752,8 @@ public class FieldInfos implements Iterable<FieldInfo> {
         curFi.verifySameSchema(fi, globalFieldNumbers.strictlyConsistent);
 
         if (!globalFieldNumbers.strictlyConsistent) {
-          // For the not strictly consistent case (legacy index), we may need to update merge the
-          // FieldInfo
+          // For the not strictly consistent case (legacy index), we may need to merge the
+          // FieldInfo instances
           FieldInfo updatedFieldInfo = curFi.handleLegacySupportedUpdates(fi);
           if (updatedFieldInfo != null) {
             if (fi.getDocValuesType() != DocValuesType.NONE
@@ -771,8 +771,6 @@ public class FieldInfos implements Iterable<FieldInfo> {
           fi.attributes().forEach((k, v) -> curFi.putAttribute(k, v));
         }
         if (fi.hasPayloads()) {
-          // nocommit: How about the validation happening in handleLegacySupportedUpdates? not
-          // needed here?
           curFi.setStorePayloads();
         }
         return curFi;

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldInfo.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldInfo.java
@@ -1,0 +1,336 @@
+package org.apache.lucene.index;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestFieldInfo extends LuceneTestCase {
+
+  public void testHandleLegacySupportedUpdatesValidIndexInfoChange() {
+
+    FieldInfo fi1 = new FieldInfoTestBuilder().setIndexOptions(IndexOptions.NONE).get();
+    FieldInfo fi2 = new FieldInfoTestBuilder().setOmitNorms(true).setStoreTermVector(false).get();
+
+    FieldInfo updatedFi = fi1.handleLegacySupportedUpdates(fi2);
+    assertNotNull(updatedFi);
+    assertEquals(updatedFi.getIndexOptions(), IndexOptions.DOCS);
+    assertFalse(
+        updatedFi
+            .hasNorms()); // fi2 is set to omitNorms and fi1 was not indexed, it's OK that the final
+    // FieldInfo returns hasNorms == false
+    compareAttributes(fi1, fi2, Set.of("getIndexOptions", "hasNorms"));
+    compareAttributes(fi1, updatedFi, Set.of("getIndexOptions", "hasNorms"));
+    compareAttributes(fi2, updatedFi, Set.of());
+
+    // The reverse return null since fi2 wouldn't change
+    assertNull(fi2.handleLegacySupportedUpdates(fi1));
+  }
+
+  public void testHandleLegacySupportedUpdatesInvalidIndexInfoChange() {
+    FieldInfo fi1 = new FieldInfoTestBuilder().setIndexOptions(IndexOptions.DOCS).get();
+    FieldInfo fi2 =
+        new FieldInfoTestBuilder().setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS).get();
+    assertThrows(IllegalArgumentException.class, () -> fi1.handleLegacySupportedUpdates(fi2));
+    assertThrows(IllegalArgumentException.class, () -> fi2.handleLegacySupportedUpdates(fi1));
+  }
+
+  public void testHandleLegacySupportedUpdatesValidPointDimensionCount() {
+    FieldInfo fi1 = new FieldInfoTestBuilder().get();
+    FieldInfo fi2 = new FieldInfoTestBuilder().setPointDimensionCount(2).setPointNumBytes(2).get();
+    FieldInfo updatedFi = fi1.handleLegacySupportedUpdates(fi2);
+    assertNotNull(updatedFi);
+    assertEquals(2, updatedFi.getPointDimensionCount());
+    compareAttributes(fi1, fi2, Set.of("getPointDimensionCount", "getPointNumBytes"));
+    compareAttributes(fi1, updatedFi, Set.of("getPointDimensionCount", "getPointNumBytes"));
+    compareAttributes(fi2, updatedFi, Set.of());
+
+    // The reverse return null since fi2 wouldn't change
+    assertNull(fi2.handleLegacySupportedUpdates(fi1));
+  }
+
+  public void testHandleLegacySupportedUpdatesInvalidPointDimensionCount() {
+    FieldInfo fi1 = new FieldInfoTestBuilder().setPointDimensionCount(3).setPointNumBytes(2).get();
+    FieldInfo fi2 = new FieldInfoTestBuilder().setPointDimensionCount(2).setPointNumBytes(2).get();
+    FieldInfo fi3 = new FieldInfoTestBuilder().setPointDimensionCount(2).setPointNumBytes(3).get();
+    assertThrows(IllegalArgumentException.class, () -> fi1.handleLegacySupportedUpdates(fi2));
+    assertThrows(IllegalArgumentException.class, () -> fi2.handleLegacySupportedUpdates(fi1));
+
+    assertThrows(IllegalArgumentException.class, () -> fi1.handleLegacySupportedUpdates(fi3));
+    assertThrows(IllegalArgumentException.class, () -> fi3.handleLegacySupportedUpdates(fi1));
+
+    assertThrows(IllegalArgumentException.class, () -> fi2.handleLegacySupportedUpdates(fi3));
+    assertThrows(IllegalArgumentException.class, () -> fi3.handleLegacySupportedUpdates(fi2));
+  }
+
+  public void testHandleLegacySupportedUpdatesValidPointIndexDimensionCount() {
+    FieldInfo fi1 = new FieldInfoTestBuilder().get();
+    FieldInfo fi2 =
+        new FieldInfoTestBuilder()
+            .setPointIndexDimensionCount(2)
+            .setPointDimensionCount(2)
+            .setPointNumBytes(2)
+            .get();
+    FieldInfo updatedFi = fi1.handleLegacySupportedUpdates(fi2);
+    assertNotNull(updatedFi);
+    assertEquals(2, updatedFi.getPointDimensionCount());
+    compareAttributes(
+        fi1,
+        fi2,
+        Set.of("getPointDimensionCount", "getPointNumBytes", "getPointIndexDimensionCount"));
+    compareAttributes(
+        fi1,
+        updatedFi,
+        Set.of("getPointDimensionCount", "getPointNumBytes", "getPointIndexDimensionCount"));
+    compareAttributes(fi2, updatedFi, Set.of());
+
+    // The reverse return null since fi2 wouldn't change
+    assertNull(fi2.handleLegacySupportedUpdates(fi1));
+  }
+
+  public void testHandleLegacySupportedUpdatesInvalidPointIndexDimensionCount() {
+    FieldInfo fi1 =
+        new FieldInfoTestBuilder()
+            .setPointDimensionCount(2)
+            .setPointIndexDimensionCount(2)
+            .setPointNumBytes(2)
+            .get();
+    FieldInfo fi2 =
+        new FieldInfoTestBuilder()
+            .setPointDimensionCount(2)
+            .setPointIndexDimensionCount(3)
+            .setPointNumBytes(2)
+            .get();
+    assertThrows(IllegalArgumentException.class, () -> fi1.handleLegacySupportedUpdates(fi2));
+    assertThrows(IllegalArgumentException.class, () -> fi2.handleLegacySupportedUpdates(fi1));
+  }
+
+  public void testHandleLegacySupportedUpdatesValidStoreTermVectors() {
+    FieldInfo fi1 = new FieldInfoTestBuilder().setStoreTermVector(false).get();
+    FieldInfo fi2 = new FieldInfoTestBuilder().setStoreTermVector(true).get();
+    FieldInfo updatedFi = fi1.handleLegacySupportedUpdates(fi2);
+    assertNotNull(updatedFi);
+    assertTrue(updatedFi.hasVectors());
+    compareAttributes(fi1, fi2, Set.of("hasVectors"));
+    compareAttributes(fi1, updatedFi, Set.of("hasVectors"));
+    compareAttributes(fi2, updatedFi, Set.of());
+
+    // The reverse return null since fi2 wouldn't change
+    assertNull(fi2.handleLegacySupportedUpdates(fi1));
+  }
+
+  public void testHandleLegacySupportedUpdatesValidStorePayloads() {
+    FieldInfo fi1 =
+        new FieldInfoTestBuilder()
+            .setStorePayloads(false)
+            .setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS)
+            .get();
+    FieldInfo fi2 =
+        new FieldInfoTestBuilder()
+            .setStorePayloads(true)
+            .setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS)
+            .get();
+    FieldInfo updatedFi = fi1.handleLegacySupportedUpdates(fi2);
+    assertNotNull(updatedFi);
+    assertTrue(updatedFi.hasPayloads());
+    compareAttributes(fi1, fi2, Set.of("hasPayloads"));
+    compareAttributes(fi1, updatedFi, Set.of("hasPayloads"));
+    compareAttributes(fi2, updatedFi, Set.of());
+
+    // The reverse return null since fi2 wouldn't change
+    assertNull(fi2.handleLegacySupportedUpdates(fi1));
+  }
+
+  public void testHandleLegacySupportedUpdatesValidOmitNorms() {
+    FieldInfo fi1 =
+        new FieldInfoTestBuilder().setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS).get();
+    FieldInfo fi2 =
+        new FieldInfoTestBuilder()
+            .setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS)
+            .setOmitNorms(true)
+            .get();
+    FieldInfo updatedFi = fi1.handleLegacySupportedUpdates(fi2);
+    assertNotNull(updatedFi);
+    assertFalse(updatedFi.hasNorms()); // Once norms are omitted, they are always omitted
+    compareAttributes(fi1, fi2, Set.of("hasNorms"));
+    compareAttributes(fi1, updatedFi, Set.of("hasNorms"));
+    compareAttributes(fi2, updatedFi, Set.of());
+
+    // The reverse return null since fi2 wouldn't change
+    assertNull(fi2.handleLegacySupportedUpdates(fi1));
+  }
+
+  public void testHandleLegacySupportedUpdatesValidDocValuesType() {
+
+    FieldInfo fi1 = new FieldInfoTestBuilder().get();
+    FieldInfo fi2 = new FieldInfoTestBuilder().setDocValues(DocValuesType.SORTED).setDvGen(1).get();
+
+    FieldInfo updatedFi = fi1.handleLegacySupportedUpdates(fi2);
+    assertNotNull(updatedFi);
+    assertEquals(DocValuesType.SORTED, updatedFi.getDocValuesType());
+    assertEquals(1, updatedFi.getDocValuesGen());
+    compareAttributes(fi1, fi2, Set.of("getDocValuesType", "getDocValuesGen"));
+    compareAttributes(fi1, updatedFi, Set.of("getDocValuesType", "getDocValuesGen"));
+    compareAttributes(fi2, updatedFi, Set.of());
+
+    // The reverse return null since fi2 wouldn't change
+    assertNull(fi2.handleLegacySupportedUpdates(fi1));
+
+    FieldInfo fi3 = new FieldInfoTestBuilder().setDocValues(DocValuesType.SORTED).setDvGen(2).get();
+    // Changes in DocValues Generation only are ignored
+    assertNull(fi2.handleLegacySupportedUpdates(fi3));
+    assertNull(fi3.handleLegacySupportedUpdates(fi2));
+  }
+
+  public void testHandleLegacySupportedUpdatesInvalidDocValuesTypeChange() {
+    FieldInfo fi1 = new FieldInfoTestBuilder().setDocValues(DocValuesType.SORTED).get();
+    FieldInfo fi2 = new FieldInfoTestBuilder().setDocValues(DocValuesType.SORTED_SET).get();
+    assertThrows(IllegalArgumentException.class, () -> fi1.handleLegacySupportedUpdates(fi2));
+    assertThrows(IllegalArgumentException.class, () -> fi2.handleLegacySupportedUpdates(fi1));
+  }
+
+  private static class FieldInfoTestBuilder {
+    String name = "f1";
+    int number = 1;
+    boolean storeTermVector = true;
+    boolean omitNorms = false;
+    boolean storePayloads = false;
+    IndexOptions indexOptions = IndexOptions.DOCS;
+    DocValuesType docValues = DocValuesType.NONE;
+    long dvGen = -1;
+    Map<String, String> attributes = new HashMap<>();
+    int pointDimensionCount = 0;
+    int pointIndexDimensionCount = 0;
+    int pointNumBytes = 0;
+    int vectorDimension = 10;
+    VectorEncoding vectorEncoding = VectorEncoding.FLOAT32;
+    VectorSimilarityFunction vectorSimilarityFunction = VectorSimilarityFunction.EUCLIDEAN;
+    boolean softDeletesField = false;
+
+    FieldInfo get() {
+      return new FieldInfo(
+          name,
+          number,
+          storeTermVector,
+          omitNorms,
+          storePayloads,
+          indexOptions,
+          docValues,
+          dvGen,
+          attributes,
+          pointDimensionCount,
+          pointIndexDimensionCount,
+          pointNumBytes,
+          vectorDimension,
+          vectorEncoding,
+          vectorSimilarityFunction,
+          softDeletesField);
+    }
+
+    public FieldInfoTestBuilder setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setNumber(int number) {
+      this.number = number;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setStoreTermVector(boolean storeTermVector) {
+      this.storeTermVector = storeTermVector;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setOmitNorms(boolean omitNorms) {
+      this.omitNorms = omitNorms;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setStorePayloads(boolean storePayloads) {
+      this.storePayloads = storePayloads;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setIndexOptions(IndexOptions indexOptions) {
+      this.indexOptions = indexOptions;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setDocValues(DocValuesType docValues) {
+      this.docValues = docValues;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setDvGen(long dvGen) {
+      this.dvGen = dvGen;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setAttributes(Map<String, String> attributes) {
+      this.attributes = attributes;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setPointDimensionCount(int pointDimensionCount) {
+      this.pointDimensionCount = pointDimensionCount;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setPointIndexDimensionCount(int pointIndexDimensionCount) {
+      this.pointIndexDimensionCount = pointIndexDimensionCount;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setPointNumBytes(int pointNumBytes) {
+      this.pointNumBytes = pointNumBytes;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setVectorDimension(int vectorDimension) {
+      this.vectorDimension = vectorDimension;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setVectorEncoding(VectorEncoding vectorEncoding) {
+      this.vectorEncoding = vectorEncoding;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setVectorSimilarityFunction(
+        VectorSimilarityFunction vectorSimilarityFunction) {
+      this.vectorSimilarityFunction = vectorSimilarityFunction;
+      return this;
+    }
+
+    public FieldInfoTestBuilder setSoftDeletesField(boolean softDeletesField) {
+      this.softDeletesField = softDeletesField;
+      return this;
+    }
+  }
+
+  private void compareAttributes(FieldInfo fi1, FieldInfo fi2, Set<String> exclude) {
+    assertNotNull(fi1);
+    assertNotNull(fi2);
+    Arrays.stream(FieldInfo.class.getMethods())
+        .filter(
+            m ->
+                (m.getName().startsWith("get") || m.getName().startsWith("has"))
+                    && !m.getName().equals("hashCode")
+                    && !exclude.contains(m.getName())
+                    && m.getParameterCount() == 0)
+        .forEach(
+            m -> {
+              try {
+                assertEquals(
+                    "Unexpected difference in FieldInfo for method: " + m.getName(),
+                    m.invoke(fi1),
+                    m.invoke(fi2));
+              } catch (Exception e) {
+                e.printStackTrace();
+                fail(e.getMessage());
+              }
+            });
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldInfo.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.index;
 
 import java.util.Arrays;
@@ -228,16 +244,6 @@ public class TestFieldInfo extends LuceneTestCase {
           softDeletesField);
     }
 
-    public FieldInfoTestBuilder setName(String name) {
-      this.name = name;
-      return this;
-    }
-
-    public FieldInfoTestBuilder setNumber(int number) {
-      this.number = number;
-      return this;
-    }
-
     public FieldInfoTestBuilder setStoreTermVector(boolean storeTermVector) {
       this.storeTermVector = storeTermVector;
       return this;
@@ -268,11 +274,6 @@ public class TestFieldInfo extends LuceneTestCase {
       return this;
     }
 
-    public FieldInfoTestBuilder setAttributes(Map<String, String> attributes) {
-      this.attributes = attributes;
-      return this;
-    }
-
     public FieldInfoTestBuilder setPointDimensionCount(int pointDimensionCount) {
       this.pointDimensionCount = pointDimensionCount;
       return this;
@@ -285,27 +286,6 @@ public class TestFieldInfo extends LuceneTestCase {
 
     public FieldInfoTestBuilder setPointNumBytes(int pointNumBytes) {
       this.pointNumBytes = pointNumBytes;
-      return this;
-    }
-
-    public FieldInfoTestBuilder setVectorDimension(int vectorDimension) {
-      this.vectorDimension = vectorDimension;
-      return this;
-    }
-
-    public FieldInfoTestBuilder setVectorEncoding(VectorEncoding vectorEncoding) {
-      this.vectorEncoding = vectorEncoding;
-      return this;
-    }
-
-    public FieldInfoTestBuilder setVectorSimilarityFunction(
-        VectorSimilarityFunction vectorSimilarityFunction) {
-      this.vectorSimilarityFunction = vectorSimilarityFunction;
-      return this;
-    }
-
-    public FieldInfoTestBuilder setSoftDeletesField(boolean softDeletesField) {
-      this.softDeletesField = softDeletesField;
       return this;
     }
   }


### PR DESCRIPTION
This was reported in LUCENE-10314/#11350 and I'm surprised it didn't get more attention since it can get indices in a very bad state. 
This is my understanding, feel free to correct me if I'm wrong:
In Lucene 8, when a field was converted from having `IndexOptions.NONE` to `IndexOptions.DOCS`, the merging logic would make the new segment have `IndexOptions.DOCS` and things would continue to work.  Of course, docs that had been added before the change would not be searchable on this field, but it allowed the change to happen in-place for an existing index, users would probably want to re-submit all their docs to have the field be really searchable. Lucene 9 no longer supports this for various reasons, but it allows older indices to have this for backwards compatibility. However, the merging logic doesn't seem to handle this well. Instead of turning the `IndexOptions.NONE` into a `IndexOptions.DOCS` for the merged segment, it just takes the `IndexOptions` of whatever the first segment is which causes an invalid merge that fails, assertion error on tests, but an exception like this when running without assertions (using Solr 9.2.1 - Lucene 9.4.2):

```
java.lang.IllegalArgumentException: cannot write negative vLong (got: -368)
	at org.apache.lucene.store.DataOutput.writeVLong(DataOutput.java:238)
	at org.apache.lucene.codecs.lucene90.blocktree.Lucene90BlockTreeTermsWriter$StatsWriter.add(Lucene90BlockTreeTermsWriter.java:571)
	at org.apache.lucene.codecs.lucene90.blocktree.Lucene90BlockTreeTermsWriter$TermsWriter.writeBlock(Lucene90BlockTreeTermsWriter.java:832)
	at org.apache.lucene.codecs.lucene90.blocktree.Lucene90BlockTreeTermsWriter$TermsWriter.writeBlocks(Lucene90BlockTreeTermsWriter.java:709)
	at org.apache.lucene.codecs.lucene90.blocktree.Lucene90BlockTreeTermsWriter$TermsWriter.finish(Lucene90BlockTreeTermsWriter.java:1105)
	at org.apache.lucene.codecs.lucene90.blocktree.Lucene90BlockTreeTermsWriter.write(Lucene90BlockTreeTermsWriter.java:370)
	at org.apache.lucene.codecs.FieldsConsumer.merge(FieldsConsumer.java:95)
	at org.apache.lucene.codecs.perfield.PerFieldPostingsFormat$FieldsWriter.merge(PerFieldPostingsFormat.java:204)
	at org.apache.lucene.index.SegmentMerger.mergeTerms(SegmentMerger.java:208)
	at org.apache.lucene.index.SegmentMerger.mergeWithLogging(SegmentMerger.java:293)
	at org.apache.lucene.index.SegmentMerger.merge(SegmentMerger.java:136)
	at org.apache.lucene.index.IndexWriter.mergeMiddle(IndexWriter.java:5141)
	at org.apache.lucene.index.IndexWriter.merge(IndexWriter.java:4681)
	at org.apache.solr.update.SolrIndexWriter.merge(SolrIndexWriter.java:274)
	at org.apache.lucene.index.IndexWriter$IndexWriterMergeSource.merge(IndexWriter.java:6430)
	at org.apache.lucene.index.ConcurrentMergeScheduler.doMerge(ConcurrentMergeScheduler.java:638)
	at org.apache.lucene.index.ConcurrentMergeScheduler$MergeThread.run(ConcurrentMergeScheduler.java:699)

```

This makes upgrading pretty risky, because since it happens on merge, Lucene 9.x would be running fine until the merge policy decides to merge segments with different `IndexOptions` which could be weeks or more after the upgrade happened, and at that point, the index can't be rolled back (because it already has 9.x segments) and any backups would be very old. Even more, the outcome of the merge (successful or not) depends on the order in which the segments are selected.

I checked the [FieldInfos test](https://github.com/apache/lucene/pull/12326/files#diff-bca1c6738c6cc849a6b26880f6823b5e70e1df07f60887f2ea2b08423d04f9e9R365) and it passes in Lucene 8 without any changes, it fails in Lucene 9.x