### PR TITLE
Honor after value for skipping documents even if queue is not full for PagingFieldCollector

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -91,8 +91,8 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     // if skipping functionality should be enabled on this segment
     private final boolean enableSkipping;
     private final int maxDoc;
-    private final byte[] minValueAsBytes;
-    private final byte[] maxValueAsBytes;
+    private byte[] minValueAsBytes;
+    private byte[] maxValueAsBytes;
 
     private DocIdSetIterator competitiveIterator;
     private long iteratorCost = -1;
@@ -128,16 +128,10 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
         }
         this.enableSkipping = true; // skipping is enabled when points are available
         this.maxDoc = context.reader().maxDoc();
-        this.maxValueAsBytes =
-            reverse == false ? new byte[bytesCount] : topValueSet ? new byte[bytesCount] : null;
-        this.minValueAsBytes =
-            reverse ? new byte[bytesCount] : topValueSet ? new byte[bytesCount] : null;
         this.competitiveIterator = DocIdSetIterator.all(maxDoc);
       } else {
         this.enableSkipping = false;
         this.maxDoc = 0;
-        this.maxValueAsBytes = null;
-        this.minValueAsBytes = null;
       }
     }
 
@@ -191,7 +185,9 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     // update its iterator to include possibly only docs that are "stronger" than the current bottom
     // entry
     private void updateCompetitiveIterator() throws IOException {
-      if (enableSkipping == false || hitsThresholdReached == false || queueFull == false) return;
+      if (enableSkipping == false
+          || hitsThresholdReached == false
+          || (queueFull == false && topValueSet == false)) return;
       // if some documents have missing points, check that missing values prohibits optimization
       if ((pointValues.getDocCount() < maxDoc) && isMissingValueCompetitive()) {
         return; // we can't filter out documents, as documents with missing values are competitive
@@ -204,13 +200,21 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
         return;
       }
       if (reverse == false) {
-        encodeBottom(maxValueAsBytes);
+        if (queueFull) { // bottom is avilable only when queue is full
+          maxValueAsBytes = maxValueAsBytes == null ? new byte[bytesCount] : maxValueAsBytes;
+          encodeBottom(maxValueAsBytes);
+        }
         if (topValueSet) {
+          minValueAsBytes = minValueAsBytes == null ? new byte[bytesCount] : minValueAsBytes;
           encodeTop(minValueAsBytes);
         }
       } else {
-        encodeBottom(minValueAsBytes);
+        if (queueFull) { // bottom is avilable only when queue is full
+          minValueAsBytes = minValueAsBytes == null ? new byte[bytesCount] : minValueAsBytes;
+          encodeBottom(minValueAsBytes);
+        }
         if (topValueSet) {
+          maxValueAsBytes = maxValueAsBytes == null ? new byte[bytesCount] : maxValueAsBytes;
           encodeTop(maxValueAsBytes);
         }
       }


### PR DESCRIPTION
### Description
As mentioned in issue #12333, if ```after``` value is out of range for a field in a segment, ```PagingFieldCollector``` is not able to put any item in the ```FieldhitQueue```.  Due to which ```queueFull``` always stays ```false``` and it wont ever update PointValues based ```competitiveIterator``` to skip non-competitive hits. 

I think, it makes sense to update ```competitiveIterator``` even if queue is not full and the query is ```after``` query because we have at least ```topValue``` in ```after``` query always. That itself should be capable enough to skip non-competitive hits. 
It does not only help when after is out of range, also when after is within the range but filtering only based on the after value significantly reduces the number of hits to evaluate.
