### PR TITLE
Don't generate stacktrace for TimeExceededException

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TimeLimitingBulkScorer.java
@@ -41,6 +41,12 @@ final class TimeLimitingBulkScorer extends BulkScorer {
     private TimeExceededException() {
       super("TimeLimit Exceeded");
     }
+
+    @Override
+    public Throwable fillInStackTrace() {
+      // never re-thrown so we can save the expensive stacktrace
+      return this;
+    }
   }
 
   private final BulkScorer in;


### PR DESCRIPTION
The exception is package private and never rethrown, we can avoid generating a stacktrace for it.
