### PR TITLE
Add updateDocuments API which accept a query

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -130,6 +130,9 @@ API Changes
 * GITHUB#12268: Add BitSet.clear() without parameters for clearing the entire set
   (Jonathan Ellis)
 
+* GITHUB#12341: add new IndexWriter#updateDocuments(Query, Iterable<Document>) API
+  to update documents using a query. (Patrick Zhai)
+
 New Features
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterDeleteQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterDeleteQueue.java
@@ -142,6 +142,10 @@ final class DocumentsWriterDeleteQueue implements Accountable, Closeable {
     return new TermNode(term);
   }
 
+  static Node<Query> newNode(Query query) {
+    return new QueryNode(query);
+  }
+
   static Node<DocValuesUpdate[]> newNode(DocValuesUpdate... updates) {
     return new DocValuesUpdatesNode(updates);
   }
@@ -429,6 +433,23 @@ final class DocumentsWriterDeleteQueue implements Accountable, Closeable {
     @Override
     void apply(BufferedUpdates bufferedDeletes, int docIDUpto) {
       bufferedDeletes.addTerm(item, docIDUpto);
+    }
+
+    @Override
+    public String toString() {
+      return "del=" + item;
+    }
+  }
+
+  private static final class QueryNode extends Node<Query> {
+
+    QueryNode(Query query) {
+      super(query);
+    }
+
+    @Override
+    void apply(BufferedUpdates bufferedDeletes, int docIDUpto) {
+      bufferedDeletes.addQuery(item, docIDUpto);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1521,6 +1521,19 @@ public class IndexWriter
         delTerm == null ? null : DocumentsWriterDeleteQueue.newNode(delTerm), docs);
   }
 
+  /**
+   * Similar to {@link #updateDocuments(Term, Iterable)}, but take a query instead of a term to
+   * identify the documents to be updated
+   *
+   * @lucene.experimental
+   */
+  public long updateDocuments(
+      Query delQuery, Iterable<? extends Iterable<? extends IndexableField>> docs)
+      throws IOException {
+    return updateDocuments(
+        delQuery == null ? null : DocumentsWriterDeleteQueue.newNode(delQuery), docs);
+  }
+
   private long updateDocuments(
       final DocumentsWriterDeleteQueue.Node<?> delNode,
       Iterable<? extends Iterable<? extends IndexableField>> docs)

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -3476,7 +3476,12 @@ public class TestIndexWriter extends LuceneTestCase {
                       Document doc = new Document();
                       doc.add(new StringField("id", id, Field.Store.YES));
                       if (mixDeletes && random().nextBoolean()) {
-                        writer.updateDocuments(new Term("id", id), Arrays.asList(doc, doc));
+                        if (random().nextBoolean()) {
+                          writer.updateDocuments(new Term("id", id), Arrays.asList(doc, doc));
+                        } else {
+                          writer.updateDocuments(
+                              new TermQuery(new Term("id", id)), Arrays.asList(doc, doc));
+                        }
                       } else {
                         writer.softUpdateDocuments(
                             new Term("id", id),


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
Essentially just wire up `updateDocuments(Query, Iterable<Document>)` API, we could probably also add `updateDocument` for single document update, but I don't see a good reason to add that (except for completion) yet.