### PR TITLE
Omit copying for creation of `Terms` from `CharSequence`s

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -156,6 +156,8 @@ Improvements
 * GITHUB#12333: NumericLeafComparator#competitiveIterator makes better use of a "search after" value when paginating.
   (Chaitanya Gohel)
 
+* GITHUB#12343 allow creation of `Term`s from `CharSequence`s
+
 Optimizations
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/Term.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Term.java
@@ -76,6 +76,16 @@ public final class Term implements Comparable<Term>, Accountable {
   }
 
   /**
+   * Constructs a Term with the given field and text.
+   *
+   * <p>Note that a null field or null text value results in undefined behavior for most Lucene APIs
+   * that accept a Term parameter.
+   */
+  public Term(String fld, CharSequence text) {
+    this(fld, new BytesRef(text));
+  }
+
+  /**
    * Constructs a Term with the given field and empty text. This serves two purposes: 1) reuse of a
    * Term with the same field. 2) pattern for a query.
    *


### PR DESCRIPTION
### Description

Currently constructors of `Term` require the internal `BytesRef` to be unmodifiable from the outside
and thus perform defensive copying in order to uphold this invariant.
In order to omit redundant copying there are constructor overloads which accept
`BytesRefBuilder` and `String` to create new `BytesRef`s from them.
The latter delegates to `BytesRef(CharSequence)` constructor internally.

Current approach does not however allow the creation of `Term`s from `CharSequence`s
which is a valid use-case (e.g. when creating `Term`s from `CharTermAttribute`s)
thus an overload delegating to `BytesRef(CharSequence)` is added in order to support such use-cases.
The previous `Term(String fld, String text)` constructor is preserved to maintain binary compatibility
and possibly allow futher `String`-specific optimizations.
