### PR TITLE
Make SliceExecutor extensible and include method to computeSlices. This will allow different custom implementation to be plugged in with IndexSearcher to compute and execute slices on provided executor

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -110,18 +110,18 @@ abstract class AbstractKnnVectorQuery extends Query {
   }
 
   private TopDocs[] parallelSearch(
-      IndexSearcher.LeafSlice[] slices, Weight filterWeight, SliceExecutor sliceExecutor) {
+      LeafSlice[] slices, Weight filterWeight, SliceExecutor sliceExecutor) {
 
     List<FutureTask<TopDocs[]>> tasks = new ArrayList<>(slices.length);
     int segmentsCount = 0;
-    for (IndexSearcher.LeafSlice slice : slices) {
-      segmentsCount += slice.leaves.length;
+    for (LeafSlice slice : slices) {
+      segmentsCount += slice.getLeaves().length;
       tasks.add(
           new FutureTask<>(
               () -> {
-                TopDocs[] results = new TopDocs[slice.leaves.length];
+                TopDocs[] results = new TopDocs[slice.getLeaves().length];
                 int i = 0;
-                for (LeafReaderContext context : slice.leaves) {
+                for (LeafReaderContext context : slice.getLeaves()) {
                   results[i++] = searchLeaf(context, filterWeight);
                 }
                 return results;

--- a/lucene/core/src/java/org/apache/lucene/search/LeafSlice.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafSlice.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import org.apache.lucene.index.LeafReaderContext;
+
+/**
+ * A class holding a subset of the {@link IndexSearcher}s leaf contexts to be executed within a
+ * single thread.
+ *
+ * @lucene.experimental
+ */
+public class LeafSlice {
+  /**
+   * The leaves that make up this slice.
+   *
+   * @lucene.experimental
+   */
+  private final LeafReaderContext[] leaves;
+
+  public LeafSlice(List<LeafReaderContext> leavesList) {
+    Collections.sort(leavesList, Comparator.comparingInt(l -> l.docBase));
+    this.leaves = leavesList.toArray(new LeafReaderContext[0]);
+  }
+
+  public LeafReaderContext[] getLeaves() {
+    return leaves;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/SliceExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SliceExecutor.java
@@ -18,22 +18,41 @@
 package org.apache.lucene.search;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
+import org.apache.lucene.index.LeafReaderContext;
 
 /**
  * Executor which is responsible for execution of slices based on the current status of the system
  * and current system load
  */
-class SliceExecutor {
+public class SliceExecutor {
+
+  /** Thresholds for index slice allocation logic */
+  private static final int MAX_DOCS_PER_SLICE = 250_000;
+
+  private static final int MAX_SEGMENTS_PER_SLICE = 5;
+
   private final Executor executor;
 
-  SliceExecutor(Executor executor) {
+  public SliceExecutor(Executor executor) {
     this.executor = Objects.requireNonNull(executor, "Executor is null");
   }
 
-  final void invokeAll(Collection<? extends Runnable> tasks) {
+  /**
+   * method to segregate LeafReaderContexts amongst multiple slices using the default
+   * MAX_SEGMENTS_PER_SLICE and MAX_DOCUMENTS_PER_SLICE
+   *
+   * @param leaves LeafReaderContexts for this index
+   * @return computed slices
+   */
+  public LeafSlice[] computeSlices(List<LeafReaderContext> leaves) {
+    return IndexSearcher.slices(leaves, MAX_DOCS_PER_SLICE, MAX_SEGMENTS_PER_SLICE);
+  }
+
+  public void invokeAll(Collection<? extends Runnable> tasks) {
     int i = 0;
     for (Runnable task : tasks) {
       if (shouldExecuteOnCallerThread(i, tasks.size())) {
@@ -54,5 +73,9 @@ class SliceExecutor {
   boolean shouldExecuteOnCallerThread(int index, int numTasks) {
     // Execute last task on caller thread
     return index == numTasks - 1;
+  }
+
+  public Executor getExecutor() {
+    return executor;
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -155,9 +155,11 @@ import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LRUQueryCache;
+import org.apache.lucene.search.LeafSlice;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryCache;
 import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.search.SliceExecutor;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
@@ -1996,8 +1998,14 @@ public abstract class LuceneTestCase extends Assert {
               }
             };
       } else {
-        ret =
-            random.nextBoolean() ? new IndexSearcher(r, ex) : new IndexSearcher(r.getContext(), ex);
+        if (random.nextBoolean()) {
+          ret = new IndexSearcher(r, ex);
+        } else {
+          ret =
+              (random.nextBoolean() || ex == null)
+                  ? new IndexSearcher(r.getContext(), ex)
+                  : new IndexSearcher(r.getContext(), ex, new SliceExecutor(ex));
+        }
       }
       ret.setSimilarity(classEnvRule.similarity);
       ret.setQueryCachingPolicy(MAYBE_CACHE_POLICY);


### PR DESCRIPTION
### Description

As mentioned in the issue https://github.com/apache/lucene/issues/12347, this PR is allowing to extend `SliceExecutor` and move the `slice` computation in it. This will allow the extensions of `IndexSearcher` to provide custom `SliceExecutor` and also custom logic to compute and execute the slices for an index.
