### PR TITLE
CompetitiveIterator should be null if sort field does not exist in TermOrdValComparator

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
@@ -244,7 +244,7 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
             throw new IllegalStateException("Field [" + field + "] cannot be found in field infos");
           }
           dense = false;
-          enableSkipping = true;
+          enableSkipping = false;
         } else if (fieldInfo.getIndexOptions() == IndexOptions.NONE) {
           // No terms index
           dense = false;


### PR DESCRIPTION
If sort field not in FieldInfo(eg. search sort field does not exist), it seems like we should disable Skipping, avoid intersecting termOrdValComparator's CompetitiveIterator