### PR TITLE
Reduce DeletesMerges time when softdelete enable

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -741,8 +741,16 @@ public abstract class MergePolicy {
    * non-deleted documents is set.
    */
   protected long size(SegmentCommitInfo info, MergeContext mergeContext) throws IOException {
-    long byteSize = info.sizeInBytes();
     int delCount = mergeContext.numDeletesToMerge(info);
+    return size(info, delCount);
+  }
+
+  /**
+   * Return the byte size of the provided {@link SegmentCommitInfo}, pro-rated by percentage of
+   * non-deleted documents is set.
+   */
+  protected final long size(SegmentCommitInfo info, int delCount) throws IOException {
+    long byteSize = info.sizeInBytes();
     assert assertDelCount(delCount, info);
     double delRatio =
         info.info.maxDoc() <= 0 ? 0d : (double) delCount / (double) info.info.maxDoc();


### PR DESCRIPTION
### Problem statement
we found when Lucene using in `frequently update` OR `update by query` scenarios. it will do many iteration in the following code:
https://github.com/apache/lucene/blob/0c293909c050e2f24ef5a6062d8da31e6595e8cd/lucene/core/src/java/org/apache/lucene/index/SoftDeletesRetentionMergePolicy.java#L166-L176

Because `SoftDeletesRetentionMergePolicy` need query with `retentionQuerySupplier` AND then filter the retention documents. it is time consuming to iterator docid in frequently updates scenarios

there is flame graph:
![](https://user-images.githubusercontent.com/30896830/241833749-d92303d3-1ebc-4a5d-8ae0-143bfb3d4660.png)

#### we tracing the stack:
![20230606-183434](https://github.com/apache/lucene/assets/12760367/35f2b509-a67d-4b05-a09c-6d048d958372)

it will be called from the stack in update documents:
https://github.com/apache/lucene/blob/0c293909c050e2f24ef5a6062d8da31e6595e8cd/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java#L5891-L5899

and will be called from the stack in merge:
https://github.com/apache/lucene/blob/0c293909c050e2f24ef5a6062d8da31e6595e8cd/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java#L2346-L2361

### Proposal
there is some optimize to reduce the number of calling `numDeletesToMerge`:
1. #12339 try to reduce in `getSortedBySegmentSize`
when me do merge before we call: `getSortedBySegmentSize`, and it will duplicate calculate `numDeletesToMerge`

2. this pr try to reduce in `findForcedDeletesMerges`
when we try to find delete size, it will duplicate calculate `numDeletesToMerge`

In our scenarios, `numDeletesToMerge` calling make the write latency strike increased,  because `updatePendingMerges` is a `synchronized` method. we can reduce duplicate calculation