### PR TITLE
TestHunspell: reduce the flakiness probability

### DIFF
--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspell.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspell.java
@@ -75,7 +75,7 @@ public class TestHunspell extends LuceneTestCase {
         };
 
     Hunspell hunspell = new Hunspell(dictionary, RETURN_PARTIAL_RESULT, checkCanceled);
-    // pass a long timeout so that slower CI servers are more predictable. 
+    // pass a long timeout so that slower CI servers are more predictable.
     assertEquals(expected, hunspell.suggest("apac", TimeUnit.DAYS.toMillis(1)));
 
     counter.set(0);

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspell.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspell.java
@@ -75,6 +75,7 @@ public class TestHunspell extends LuceneTestCase {
         };
 
     Hunspell hunspell = new Hunspell(dictionary, RETURN_PARTIAL_RESULT, checkCanceled);
+    // pass a long timeout so that slower CI servers are more predictable. 
     assertEquals(expected, hunspell.suggest("apac", TimeUnit.DAYS.toMillis(1)));
 
     counter.set(0);

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspell.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspell.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -74,7 +75,7 @@ public class TestHunspell extends LuceneTestCase {
         };
 
     Hunspell hunspell = new Hunspell(dictionary, RETURN_PARTIAL_RESULT, checkCanceled);
-    assertEquals(expected, hunspell.suggest("apac"));
+    assertEquals(expected, hunspell.suggest("apac", TimeUnit.DAYS.toMillis(1)));
 
     counter.set(0);
     var e =


### PR DESCRIPTION
We need to check how the timeout interacts with custom exception-throwing checkCanceled. The default timeout seems not enough for some CI agents, so let's increase it.