### PR TITLE
Implement VectorUtilProvider with Java 21 Project Panama Vector API

### DIFF
--- a/gradle/generation/extract-jdk-apis.gradle
+++ b/gradle/generation/extract-jdk-apis.gradle
@@ -20,7 +20,7 @@ def resources = scriptResources(buildscript)
 configure(rootProject) {
   ext {
     // also change this in extractor tool: ExtractForeignAPI
-    vectorIncubatorJavaVersions = [ JavaVersion.VERSION_20 ] as Set
+    vectorIncubatorJavaVersions = [ JavaVersion.VERSION_20, JavaVersion.VERSION_21 ] as Set
   }
 }
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -29,9 +29,9 @@ New Features
 
 * GITHUB#12257: Create OnHeapHnswGraphSearcher to let OnHeapHnswGraph to be searched in a thread-safety manner. (Patrick Zhai)
 
-* GITHUB#12302, GITHUB#12311: Add vectorized implementations of VectorUtil.dotProduct(),
-  squareDistance(), cosine() with Java 20 jdk.incubator.vector APIs. Applications started
-  with command line parameter "java --add-modules jdk.incubator.vector" on exactly Java 20
+* GITHUB#12302, GITHUB#12311, GITHUB#12363: Add vectorized implementations of VectorUtil.dotProduct(),
+  squareDistance(), cosine() with Java 20 or 21 jdk.incubator.vector APIs. Applications started
+  with command line parameter "java --add-modules jdk.incubator.vector" on exactly Java 20 or 21
   will automatically use the new vectorized implementations if running on a supported platform
   (x86 AVX2 or later, ARM NEON). This is an opt-in feature and requires explicit Java
   command line flag! When enabled, Lucene logs a notice using java.util.logging. Please test

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtilProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtilProvider.java
@@ -56,7 +56,7 @@ interface VectorUtilProvider {
 
   static VectorUtilProvider lookup() {
     final int runtimeVersion = Runtime.version().feature();
-    if (runtimeVersion == 20) {
+    if (runtimeVersion >= 20 && runtimeVersion <= 21) {
       // is locale sane (only buggy in Java 20)
       if (isAffectedByJDK8301190()) {
         LOG.warning(
@@ -98,9 +98,9 @@ interface VectorUtilProvider {
       } catch (ClassNotFoundException cnfe) {
         throw new LinkageError("VectorUtilPanamaProvider is missing in Lucene JAR file", cnfe);
       }
-    } else if (runtimeVersion >= 21) {
+    } else if (runtimeVersion >= 22) {
       LOG.warning(
-          "You are running with Java 21 or later. To make full use of the Vector API, please update Apache Lucene.");
+          "You are running with Java 22 or later. To make full use of the Vector API, please update Apache Lucene.");
     }
     return new VectorUtilDefaultProvider();
   }

--- a/lucene/core/src/java21/org/apache/lucene/util/VectorUtilPanamaProvider.txt
+++ b/lucene/core/src/java21/org/apache/lucene/util/VectorUtilPanamaProvider.txt
@@ -1,0 +1,2 @@
+The version of VectorUtilPanamaProvider for Java 21 is identical to that of Java 20.
+As such, there is no specific 21 version - the Java 20 version will be loaded from the MRJAR.


### PR DESCRIPTION
Backport of #12363 to 9x.

This commit enables the Panama Vector API for Java 21. The version of VectorUtilPanamaProvider for Java 21 is identical to that of Java 20. As such, there is no specific 21 version - the Java 20 version will be loaded from the MRJAR.

