### PR TITLE
Increased the likelihood of leveraging inter-segment concurrency in tests

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -17,9 +17,7 @@
 
 package org.apache.lucene.tests.util;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.frequently;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
-import static com.carrotsearch.randomizedtesting.RandomizedTest.scaledRandomIntBetween;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.systemPropertyAsBoolean;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.systemPropertyAsInt;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1940,7 +1940,7 @@ public abstract class LuceneTestCase extends Assert {
     } else {
       int threads = 0;
       final ThreadPoolExecutor ex;
-      if (r.getReaderCacheHelper() == null || rarely()) {
+      if (r.getReaderCacheHelper() == null || random.nextBoolean()) {
         ex = null;
       } else {
         threads = TestUtil.nextInt(random, 1, 8);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1986,7 +1986,7 @@ public abstract class LuceneTestCase extends Assert {
                 }
               };
         }
-      } else if (frequently()) {
+      } else {
         ret =
             new IndexSearcher(r, ex) {
               @Override
@@ -1994,9 +1994,6 @@ public abstract class LuceneTestCase extends Assert {
                 return slices(leaves, maxDocPerSlice, maxSegmentsPerSlice);
               }
             };
-      } else {
-        ret =
-            random.nextBoolean() ? new IndexSearcher(r, ex) : new IndexSearcher(r.getContext(), ex);
       }
       ret.setSimilarity(classEnvRule.similarity);
       ret.setQueryCachingPolicy(MAYBE_CACHE_POLICY);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -19,6 +19,7 @@ package org.apache.lucene.tests.util;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.frequently;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.scaledRandomIntBetween;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.systemPropertyAsBoolean;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.systemPropertyAsInt;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
@@ -1941,7 +1942,7 @@ public abstract class LuceneTestCase extends Assert {
     } else {
       int threads = 0;
       final ThreadPoolExecutor ex;
-      if (r.getReaderCacheHelper() == null || random.nextBoolean()) {
+      if (r.getReaderCacheHelper() == null || rarely()) {
         ex = null;
       } else {
         threads = TestUtil.nextInt(random, 1, 8);
@@ -1965,9 +1966,9 @@ public abstract class LuceneTestCase extends Assert {
             .addClosedListener(cacheKey -> TestUtil.shutdownExecutorService(ex));
       }
       IndexSearcher ret;
+      int maxDocPerSlice = random.nextBoolean() ? 1 : 1 + random.nextInt(1000);
+      int maxSegmentsPerSlice = random.nextBoolean() ? 1 : 1 + random.nextInt(10);
       if (wrapWithAssertions) {
-        int maxDocPerSlice = 1 + random.nextInt(1000);
-        int maxSegmentsPerSlice = 1 + random.nextInt(10);
         if (random.nextBoolean()) {
           ret =
               new AssertingIndexSearcher(random, r, ex) {
@@ -1986,8 +1987,6 @@ public abstract class LuceneTestCase extends Assert {
               };
         }
       } else if (frequently()) {
-        int maxDocPerSlice = 1 + random.nextInt(1000);
-        int maxSegmentsPerSlice = 1 + random.nextInt(10);
         ret =
             new IndexSearcher(r, ex) {
               @Override


### PR DESCRIPTION
We have recently increased the likelihood of leveraging inter-segment search
concurrency in tests when `newSearcher` is used to create the index
searcher (see #959). When parallel execution is enabled though, it is
dependent on the number of documents and segments. That means
that out of 1000 test runs that use `RandomIndexWriter` to index a random
number of docs up to 100, we will effectively parallelize only a couple
of times.

This commit increases the likelihood of running concurrent searches by
randomly forcing 1 max segments per slice as well as 1 max doc per slice.