### PR TITLE
[Draft] #12236 Lazily compute similarity score

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ByteVectorScoringFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ByteVectorScoringFunction.java
@@ -1,0 +1,18 @@
+package org.apache.lucene.util.hnsw;
+
+import org.apache.lucene.index.VectorSimilarityFunction;
+
+
+public class ByteVectorScoringFunction extends ScoringFunction{
+    private final byte[] _vector;
+    private final byte[] _neighborVector;
+    public ByteVectorScoringFunction(byte[] vector, byte[] neighborVector, VectorSimilarityFunction similarityFunction) {
+        super(similarityFunction);
+        _vector = vector;
+        _neighborVector = neighborVector;
+    }
+
+    public float calculateScore() {
+        return _similarityFunction.compare(_vector, _neighborVector);
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/FloatVectorScoringFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/FloatVectorScoringFunction.java
@@ -1,0 +1,17 @@
+package org.apache.lucene.util.hnsw;
+
+import org.apache.lucene.index.VectorSimilarityFunction;
+
+
+public class FloatVectorScoringFunction extends ScoringFunction{
+    private final float[] _vector;
+    private final float[] _neighborVector;
+    public FloatVectorScoringFunction(float[] vector, float[] neighborVector, VectorSimilarityFunction similarityFunction) {
+        super(similarityFunction);
+        _vector = vector;
+        _neighborVector = neighborVector;
+    }
+    public float calculateScore() {
+        return _similarityFunction.compare(_vector, _neighborVector);
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ScoringFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ScoringFunction.java
@@ -1,0 +1,16 @@
+package org.apache.lucene.util.hnsw;
+import org.apache.lucene.index.VectorSimilarityFunction;
+
+/**
+ * Stores a VectorSimilarityFunction that evaluates the score between a vector and a neighborVector
+ * at a later time.
+ */
+public abstract class ScoringFunction {
+    protected final VectorSimilarityFunction _similarityFunction;
+
+    public ScoringFunction(VectorSimilarityFunction similarityFunction) {
+        _similarityFunction = similarityFunction;
+    }
+
+    public abstract float calculateScore();
+}


### PR DESCRIPTION
### Description
Per @zhaih suggestion in #12236, this PR moves the computation of the similarity score from `initalizedFromGraph` to a later time, when the `NeighborArray` needs to be sorted and pop out the worst non-diverse node. A new abstract class `ScoringFunction` is created to hold the necessary context to compute the similarity score, and is passed into the `addOutofOrder` function. Let me know if this solution works, as it puts extra strain on memory usage. 

I will work on writing unit tests, but the changes in this PR pass the current unit tests in hnsw test directory. 
