### PR TITLE
Add CachingLeafSlicesSupplier to compute the LeafSlices for concurrent segment search

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -126,7 +126,7 @@ New Features
 
 Improvements
 ---------------------
-(No changes)
+* GITHUB#12374: Add CachingLeafSlicesSupplier to compute the LeafSlices for concurrent segment search (Sorabh Hamirwasia)
 
 Optimizations
 ---------------------


### PR DESCRIPTION
### Description
Add a constructor which takes in the computed slices from extensions and uses that for running the search concurrently on provided executor. This is based on the discussion on the issue https://github.com/apache/lucene/issues/12347
