### PR TITLE
Allow VectorUtilProvider tests to be executed although hardware may not fully support vectorization or if C2 is not enabled

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -20,8 +20,7 @@ package org.apache.lucene.util;
 /** Utilities for computations with numeric arrays */
 public final class VectorUtil {
 
-  // visible for testing
-  static final VectorUtilProvider PROVIDER = VectorUtilProvider.lookup();
+  private static final VectorUtilProvider PROVIDER = VectorUtilProvider.lookup(false);
 
   private VectorUtil() {}
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtilProviders.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtilProviders.java
@@ -27,7 +27,7 @@ public class TestVectorUtilProviders extends LuceneTestCase {
 
   private static final double DELTA = 1e-3;
   private static final VectorUtilProvider LUCENE_PROVIDER = new VectorUtilDefaultProvider();
-  private static final VectorUtilProvider JDK_PROVIDER = VectorUtil.PROVIDER;
+  private static final VectorUtilProvider JDK_PROVIDER = VectorUtilProvider.lookup(true);
 
   private static final int[] VECTOR_SIZES = {
     1, 4, 6, 8, 13, 16, 25, 32, 64, 100, 128, 207, 256, 300, 512, 702, 1024


### PR DESCRIPTION
This PR allows us to better test the new Panama Vector Support, although the hardware may not fully support it. Currently when developers are running tests, C2 is disabled, so the provider never enables itsself. Also CPUs only with AVX1 are disabled.

To actually test the correctness of the provider with unsupported hardware, at the moment developers have to pass `export CI=true` or similar to enable C2 which slows down tests.

This PR adds a boolean to `lookupProvider()` called `testMode` which enforces its usage for tests (which directly test provider interface). The code is only used during tests, actually *only* in TestVectorUtilProviders, e.g. see here (the second test prints "test mode" while loading):

```
$ gradlew :lucene:core:test --tests 'TestVectorUtil*' -Ptests.verbose=true
> Task :lucene:core:test
WARNING: Using incubator modules: jdk.incubator.vector
WARNING: A command line option has enabled the Security Manager
WARNING: The Security Manager is deprecated and will be removed in a future release
  2> Juni 15, 2023 5:58:12 PM org.apache.lucene.store.MemorySegmentIndexInputProvider <init>
  2> INFORMATION: Using MemorySegmentIndexInput with Java 20; to disable start with -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false
  1> filesystem: ExtrasFS(HandleLimitFS(LeakFS(ShuffleFS(DisableFsyncFS(VerboseFS(sun.nio.fs.WindowsFileSystemProvider@76caf9d5))))))
  1> FS 0 [2023-06-15T15:58:13.110199200Z; SUITE-TestVectorUtil-seed#[B8B8B3EB0F1123E8]-worker]: createDirectory: ..\tests-tmp (FAILED: java.nio.file.FileAlreadyExistsException: C:\Users\Uwe Schindler\Projects\lucene\lucene\lucene\core\build\tmp\tests-tmp)
  1> Loaded codecs: [MinimalCodec, MinimalCompoundCodec, Lucene95, Asserting, CheapBastard, DeflateWithPresetCompressingStoredFieldsData, FastCompressingStoredFieldsData, FastDecompressionCompressingStoredFieldsData, HighCompressionCompressingStoredFieldsData, LZ4WithPresetCompressingStoredFieldsData, DummyCompressingStoredFieldsData, ConfigurableMCodec, SimpleText]
  1> Loaded postingsFormats: [Lucene90, MockRandom, RAMOnly, LuceneFixedGap, LuceneVarGapFixedInterval, LuceneVarGapDocFreqInterval, TestBloomFilteredLucenePostings, Asserting, UniformSplitRot13, STUniformSplitRot13, BlockTreeOrds, BloomFilter, Direct, FST50, UniformSplit, SharedTermsUniformSplit]
  2> ┼¢uw 15, 2023 3:58:13 ALUULA org.apache.lucene.util.VectorUtilProvider lookup
  2> WARNING: C2 compiler is disabled; Java vector incubator API can't be enabled
  2> NOTE: test params are: codec=Asserting(Lucene95), sim=Asserting(RandomSimilarity(queryNorm=true): {}), locale=khq-Latn-ML, timezone=Etc/GMT0
  2> NOTE: Windows 10 10.0 amd64/Oracle Corporation 20 (64-bit)/cpus=1,threads=1,free=220378024,total=257425408
  2> NOTE: All tests run in this JVM: [TestVectorUtil]
  2> Juni 15, 2023 5:58:14 PM org.apache.lucene.util.VectorUtilPanamaProvider <init>
  2> INFORMATION: Java vector incubator API enabled (test mode); uses preferredBitSize=256
  1> filesystem: ExtrasFS(HandleLimitFS(LeakFS(ShuffleFS(DisableFsyncFS(VerboseFS(sun.nio.fs.WindowsFileSystemProvider@76caf9d5))))))
  1> FS 1 [2023-06-15T15:58:14.169918700Z; SUITE-TestVectorUtilProviders-seed#[B8B8B3EB0F1123E8]-worker]: createDirectory: ..\tests-tmp (FAILED: java.nio.file.FileAlreadyExistsException: C:\Users\Uwe Schindler\Projects\lucene\lucene\lucene\core\build\tmp\tests-tmp)
  1> Loaded codecs: [MinimalCodec, MinimalCompoundCodec, Lucene95, Asserting, CheapBastard, DeflateWithPresetCompressingStoredFieldsData, FastCompressingStoredFieldsData, FastDecompressionCompressingStoredFieldsData, HighCompressionCompressingStoredFieldsData, LZ4WithPresetCompressingStoredFieldsData, DummyCompressingStoredFieldsData, ConfigurableMCodec, SimpleText]
  1> Loaded postingsFormats: [Lucene90, MockRandom, RAMOnly, LuceneFixedGap, LuceneVarGapFixedInterval, LuceneVarGapDocFreqInterval, TestBloomFilteredLucenePostings, Asserting, UniformSplitRot13, STUniformSplitRot13, BlockTreeOrds, BloomFilter, Direct, FST50, UniformSplit, SharedTermsUniformSplit]
  2> NOTE: test params are: codec=Asserting(Lucene95): {}, docValues:{}, maxPointsInLeafNode=2013, maxMBSortInHeap=5.179808517789641, sim=Asserting(RandomSimilarity(queryNorm=false): {}), locale=nyn-UG, timezone=America/Indiana/Petersburg
  2> NOTE: Windows 10 10.0 amd64/Oracle Corporation 20 (64-bit)/cpus=1,threads=1,free=277798920,total=324534272
  2> NOTE: All tests run in this JVM: [TestVectorUtil, TestVectorUtilProviders]
:lucene:core:test (SUCCESS): 57 test(s)
The slowest suites (exceeding 1s) during this run:
   1.85s TestVectorUtil (:lucene:core)
   1.03s TestVectorUtilProviders (:lucene:core)
```