### PR TITLE
Avoid redundant loop for compute min value in DirectMonotonicWriter

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -128,7 +128,7 @@ Improvements
 
 Optimizations
 ---------------------
-(No changes)
+* GITHUB#12377: Avoid redundant loop for compute min value in DirectMonotonicWriter. (Chao Zhang)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicWriter.java
@@ -79,13 +79,11 @@ public final class DirectMonotonicWriter {
 
     final float avgInc =
         (float) ((double) (buffer[bufferSize - 1] - buffer[0]) / Math.max(1, bufferSize - 1));
+
+    long min = Long.MAX_VALUE;
     for (int i = 0; i < bufferSize; ++i) {
       final long expected = (long) (avgInc * (long) i);
       buffer[i] -= expected;
-    }
-
-    long min = buffer[0];
-    for (int i = 1; i < bufferSize; ++i) {
       min = Math.min(buffer[i], min);
     }
 


### PR DESCRIPTION
### Description

This small change will reduce an unnecessary loop in DirectMonotonicWriter#flush