### PR TITLE
Let hard link wrapper fallback to delegate.copyFrom

### DIFF
--- a/lucene/misc/src/java/org/apache/lucene/misc/store/HardlinkCopyDirectoryWrapper.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/HardlinkCopyDirectoryWrapper.java
@@ -92,7 +92,7 @@ public final class HardlinkCopyDirectoryWrapper extends FilterDirectory {
     }
     if (tryCopy) {
       try {
-        super.copyFrom(from, srcFile, destFile, context);
+        getDelegate().copyFrom(from, srcFile, destFile, context);
       } catch (Exception ex) {
         if (suppressedException != null) {
           ex.addSuppressed(suppressedException);


### PR DESCRIPTION
### Description

If `HardlinkCopyDirectoryWrapper` fails to create a hard link for a file, it falls back to `super.copyFrom` and not `delegate.copyFrom`, which means we cannot customize the behavior of `copyFrom` by overriding the method in the delegate.

One example usage is to let the delegate directory override `copyFrom` to count the number of times the fallback happened, and this is currently not possible.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
