### PR TITLE
Correct Javadocs using SimpleBindings

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/search/package-info.java
@@ -301,7 +301,7 @@
  *   // compile an expression:
  *   Expression expr = JavascriptCompiler.compile("_score * ln(popularity)");
  *
- *   // SimpleBindings just maps variables to SortField instances
+ *   // SimpleBindings just maps variables to DoubleValuesSource
  *   SimpleBindings bindings = new SimpleBindings();
  *   bindings.add("_score", DoubleValuesSource.SCORES);
  *   bindings.add("popularity", DoubleValuesSource.fromIntField("popularity"));

--- a/lucene/core/src/java/org/apache/lucene/search/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/search/package-info.java
@@ -301,7 +301,7 @@
  *   // compile an expression:
  *   Expression expr = JavascriptCompiler.compile("_score * ln(popularity)");
  *
- *   // SimpleBindings just maps variables to DoubleValuesSource
+ *   // SimpleBindings just maps variables to DoubleValuesSource instances
  *   SimpleBindings bindings = new SimpleBindings();
  *   bindings.add("_score", DoubleValuesSource.SCORES);
  *   bindings.add("popularity", DoubleValuesSource.fromIntField("popularity"));

--- a/lucene/core/src/java/org/apache/lucene/search/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/search/package-info.java
@@ -303,8 +303,8 @@
  *
  *   // SimpleBindings just maps variables to SortField instances
  *   SimpleBindings bindings = new SimpleBindings();
- *   bindings.add(new SortField("_score", SortField.Type.SCORE));
- *   bindings.add(new SortField("popularity", SortField.Type.INT));
+ *   bindings.add("_score", DoubleValuesSource.SCORES);
+ *   bindings.add("popularity", DoubleValuesSource.fromIntField("popularity"));
  *
  *   // create a query that matches based on 'originalQuery' but
  *   // scores using expr

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/Expression.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/Expression.java
@@ -33,8 +33,8 @@ import org.apache.lucene.search.SortField;
  *
  *   // SimpleBindings just maps variables to SortField instances
  *   SimpleBindings bindings = new SimpleBindings();
- *   bindings.add(new SortField("_score", SortField.Type.SCORE));
- *   bindings.add(new SortField("popularity", SortField.Type.INT));
+ *   bindings.add("_score", DoubleValuesSource.SCORES);
+ *   bindings.add("popularity", DoubleValuesSource.fromIntField("popularity"));
  *
  *   // create a sort field and sort by it (reverse order)
  *   Sort sort = new Sort(expr.getSortField(bindings, true));
@@ -50,8 +50,8 @@ import org.apache.lucene.search.SortField;
  *
  *   // SimpleBindings just maps variables to SortField instances
  *   SimpleBindings bindings = new SimpleBindings();
- *   bindings.add(new SortField("_score", SortField.Type.SCORE));
- *   bindings.add(new SortField("popularity", SortField.Type.INT));
+ *   bindings.add("_score", DoubleValuesSource.SCORES);
+ *   bindings.add("popularity", DoubleValuesSource.fromIntField("popularity"));
  *
  *   // create a query that matches based on body:contents but
  *   // scores using expr

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/Expression.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/Expression.java
@@ -31,7 +31,7 @@ import org.apache.lucene.search.SortField;
  *   // compile an expression:
  *   Expression expr = JavascriptCompiler.compile("sqrt(_score) + ln(popularity)");
  *
- *   // SimpleBindings just maps variables to SortField instances
+ *   // SimpleBindings just maps variables to DoubleValuesSource instances
  *   SimpleBindings bindings = new SimpleBindings();
  *   bindings.add("_score", DoubleValuesSource.SCORES);
  *   bindings.add("popularity", DoubleValuesSource.fromIntField("popularity"));
@@ -48,7 +48,7 @@ import org.apache.lucene.search.SortField;
  *   // compile an expression:
  *   Expression expr = JavascriptCompiler.compile("sqrt(_score) + ln(popularity)");
  *
- *   // SimpleBindings just maps variables to SortField instances
+ *   // SimpleBindings just maps variables to DoubleValuesSource instances
  *   SimpleBindings bindings = new SimpleBindings();
  *   bindings.add("_score", DoubleValuesSource.SCORES);
  *   bindings.add("popularity", DoubleValuesSource.fromIntField("popularity"));

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/TestDemoExpressions.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/TestDemoExpressions.java
@@ -92,7 +92,7 @@ public class TestDemoExpressions extends LuceneTestCase {
     // compile an expression:
     Expression expr = JavascriptCompiler.compile("sqrt(_score) + ln(popularity)");
 
-    // we use SimpleBindings: which just maps variables to SortField instances
+    // we use SimpleBindings: which just maps variables to DoubleValuesSource instances
     SimpleBindings bindings = new SimpleBindings();
     bindings.add("_score", DoubleValuesSource.SCORES);
     bindings.add("popularity", DoubleValuesSource.fromIntField("popularity"));

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/DocumentValueSourceDictionary.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/DocumentValueSourceDictionary.java
@@ -40,8 +40,8 @@ import org.apache.lucene.search.LongValuesSource;
  * addition of two fields: <code>
  *    Expression expression = JavascriptCompiler.compile("f1 + f2");
  *    SimpleBindings bindings = new SimpleBindings();
- *    bindings.add(new SortField("f1", SortField.Type.LONG));
- *    bindings.add(new SortField("f2", SortField.Type.LONG));
+ *    bindings.add("f1", DoubleValuesSource.fromLongField("f1"));
+ *    bindings.add("f2", DoubleValuesSource.fromLongField("f2"));
  *    LongValuesSource valueSource = expression.getDoubleValuesSource(bindings).toLongValuesSource();
  *  </code>
  */


### PR DESCRIPTION
### Description

Correct Javadocs still referring to removed API: SimpleBindings#add(SortField).
Relates to:
https://github.com/apache/lucene/commit/5eb117f561ab691f34409943ae1f85781735f8e0
https://github.com/apache/lucene/commit/f6462ee35056f92bcfeed5f251d5372506e66b57

/cc @romseygeek 

