### PR TITLE
Initialize facet counting data structures lazily

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -161,6 +161,9 @@ Optimizations
 
 * GITHUB#12453: Faster bulk numeric reads from BufferedIndexInput (Armin Braun)
 
+* GITHUB#12408: Lazy initialization improvements for Facets implementations when there are segments with no hits
+  to count. (Greg Miller)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
@@ -524,7 +524,6 @@ public class LongValueFacetCounts extends Facets {
 
     boolean countsAdded = false;
     for (int i = 0; i < upto; i++) {
-      // nocommit: shouldn't hash counts always follow the dense counts?
       if (countsAdded == false && hashValues[i] >= counts.length) {
         countsAdded = true;
         appendCounts(labelValues);

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/ConcurrentSortedSetDocValuesFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/ConcurrentSortedSetDocValuesFacetCounts.java
@@ -78,6 +78,13 @@ public class ConcurrentSortedSetDocValuesFacetCounts extends AbstractSortedSetDo
   }
 
   @Override
+  boolean hasCounts() {
+    // TODO: safe to always assume there are counts, but maybe it would be more optimal to
+    // actually track if we see a count?
+    return true;
+  }
+
+  @Override
   int getCount(int ord) {
     return counts.get(ord);
   }
@@ -99,6 +106,11 @@ public class ConcurrentSortedSetDocValuesFacetCounts extends AbstractSortedSetDo
 
     @Override
     public Void call() throws IOException {
+      // If we're counting collected hits but there were none, short-circuit:
+      if (hits != null && hits.totalHits == 0) {
+        return null;
+      }
+
       SortedSetDocValues multiValues = DocValues.getSortedSet(leafReader, field);
       if (multiValues == null) {
         // nothing to count here

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FastTaxonomyFacetCounts.java
@@ -71,11 +71,15 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
 
   private void count(List<MatchingDocs> matchingDocs) throws IOException {
     for (MatchingDocs hits : matchingDocs) {
+      if (hits.totalHits == 0) {
+        continue;
+      }
       SortedNumericDocValues multiValued =
           hits.context.reader().getSortedNumericDocValues(indexFieldName);
       if (multiValued == null) {
         continue;
       }
+      initializeValueCounters();
 
       NumericDocValues singleValued = DocValues.unwrapSingleton(multiValued);
 
@@ -114,13 +118,14 @@ public class FastTaxonomyFacetCounts extends IntTaxonomyFacets {
   }
 
   private void countAll(IndexReader reader) throws IOException {
-    assert values != null;
     for (LeafReaderContext context : reader.leaves()) {
       SortedNumericDocValues multiValued =
           context.reader().getSortedNumericDocValues(indexFieldName);
       if (multiValued == null) {
         continue;
       }
+      initializeValueCounters();
+      assert values != null;
 
       Bits liveDocs = context.reader().getLiveDocs();
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/FloatTaxonomyFacets.java
@@ -20,10 +20,12 @@ import com.carrotsearch.hppc.FloatArrayList;
 import com.carrotsearch.hppc.IntArrayList;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.lucene.facet.FacetResult;
+import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.FacetsConfig.DimConfig;
 import org.apache.lucene.facet.LabelAndValue;
@@ -39,22 +41,37 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
   final AssociationAggregationFunction aggregationFunction;
 
   /** Per-ordinal value. */
-  final float[] values;
+  float[] values;
 
   /** Sole constructor. */
   FloatTaxonomyFacets(
       String indexFieldName,
       TaxonomyReader taxoReader,
       AssociationAggregationFunction aggregationFunction,
-      FacetsConfig config)
+      FacetsConfig config,
+      FacetsCollector fc)
       throws IOException {
-    super(indexFieldName, taxoReader, config);
+    super(indexFieldName, taxoReader, config, fc);
     this.aggregationFunction = aggregationFunction;
-    values = new float[taxoReader.getSize()];
+  }
+
+  @Override
+  boolean hasValues() {
+    return values != null;
+  }
+
+  void initializeValueCounters() {
+    if (values == null) {
+      values = new float[taxoReader.getSize()];
+    }
   }
 
   /** Rolls up any single-valued hierarchical dimensions. */
   void rollup() throws IOException {
+    if (values == null) {
+      return;
+    }
+
     // Rollup any necessary dims:
     int[] children = getChildren();
     for (Map.Entry<String, DimConfig> ent : config.getDimConfigs().entrySet()) {
@@ -100,7 +117,7 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
     if (ord < 0) {
       return -1;
     }
-    return values[ord];
+    return values == null ? 0 : values[ord];
   }
 
   @Override
@@ -109,6 +126,10 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
     FacetLabel cp = new FacetLabel(dim, path);
     int dimOrd = taxoReader.getOrdinal(cp);
     if (dimOrd == -1) {
+      return null;
+    }
+
+    if (values == null) {
       return null;
     }
 
@@ -163,6 +184,10 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
     FacetLabel cp = new FacetLabel(dim, path);
     int dimOrd = taxoReader.getOrdinal(cp);
     if (dimOrd == -1) {
+      return null;
+    }
+
+    if (values == null) {
       return null;
     }
 
@@ -263,6 +288,10 @@ abstract class FloatTaxonomyFacets extends TaxonomyFacets {
   public List<FacetResult> getTopDims(int topNDims, int topNChildren) throws IOException {
     validateTopN(topNDims);
     validateTopN(topNChildren);
+
+    if (values == null) {
+      return Collections.emptyList();
+    }
 
     // get existing children and siblings ordinal array from TaxonomyFacets
     int[] children = getChildren();

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
@@ -21,6 +21,7 @@ import com.carrotsearch.hppc.IntIntHashMap;
 import com.carrotsearch.hppc.cursors.IntIntCursor;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,10 +41,13 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
   final AssociationAggregationFunction aggregationFunction;
 
   /** Dense ordinal values. */
-  final int[] values;
+  int[] values;
 
   /** Sparse ordinal values. */
-  final IntIntHashMap sparseValues;
+  IntIntHashMap sparseValues;
+
+  /** Have value counters been initialized. */
+  boolean initialized;
 
   /** Sole constructor. */
   IntTaxonomyFacets(
@@ -53,14 +57,24 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
       AssociationAggregationFunction aggregationFunction,
       FacetsCollector fc)
       throws IOException {
-    super(indexFieldName, taxoReader, config);
+    super(indexFieldName, taxoReader, config, fc);
     this.aggregationFunction = aggregationFunction;
+  }
 
+  @Override
+  boolean hasValues() {
+    return initialized;
+  }
+
+  void initializeValueCounters() {
+    if (initialized) {
+      return;
+    }
+    initialized = true;
+    assert sparseValues == null && values == null;
     if (useHashTable(fc, taxoReader)) {
       sparseValues = new IntIntHashMap();
-      values = null;
     } else {
-      sparseValues = null;
       values = new int[taxoReader.getSize()];
     }
   }
@@ -85,6 +99,10 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
 
   /** Rolls up any single-valued hierarchical dimensions. */
   void rollup() throws IOException {
+    if (initialized == false) {
+      return;
+    }
+
     // Rollup any necessary dims:
     int[] children = null;
     for (Map.Entry<String, DimConfig> ent : config.getDimConfigs().entrySet()) {
@@ -161,7 +179,7 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
     if (ord < 0) {
       return -1;
     }
-    return getValue(ord);
+    return initialized ? getValue(ord) : 0;
   }
 
   @Override
@@ -170,6 +188,10 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
     FacetLabel cp = new FacetLabel(dim, path);
     int dimOrd = taxoReader.getOrdinal(cp);
     if (dimOrd == -1) {
+      return null;
+    }
+
+    if (initialized == false) {
       return null;
     }
 
@@ -236,6 +258,10 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
     FacetLabel cp = new FacetLabel(dim, path);
     int dimOrd = taxoReader.getOrdinal(cp);
     if (dimOrd == -1) {
+      return null;
+    }
+
+    if (initialized == false) {
       return null;
     }
 
@@ -322,6 +348,10 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
   public List<FacetResult> getTopDims(int topNDims, int topNChildren) throws IOException {
     if (topNDims <= 0 || topNChildren <= 0) {
       throw new IllegalArgumentException("topN must be > 0");
+    }
+
+    if (initialized == false) {
+      return Collections.emptyList();
     }
 
     // get children and siblings ordinal array from TaxonomyFacets

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetFloatAssociations.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetFloatAssociations.java
@@ -88,7 +88,7 @@ public class TaxonomyFacetFloatAssociations extends FloatTaxonomyFacets {
       FacetsCollector fc,
       AssociationAggregationFunction aggregationFunction)
       throws IOException {
-    super(indexFieldName, taxoReader, aggregationFunction, config);
+    super(indexFieldName, taxoReader, aggregationFunction, config, fc);
     aggregateValues(aggregationFunction, fc.getMatchingDocs());
   }
 
@@ -104,7 +104,7 @@ public class TaxonomyFacetFloatAssociations extends FloatTaxonomyFacets {
       AssociationAggregationFunction aggregationFunction,
       DoubleValuesSource valuesSource)
       throws IOException {
-    super(indexFieldName, taxoReader, aggregationFunction, config);
+    super(indexFieldName, taxoReader, aggregationFunction, config, fc);
     aggregateValues(aggregationFunction, fc.getMatchingDocs(), fc.getKeepScores(), valuesSource);
   }
 
@@ -134,6 +134,11 @@ public class TaxonomyFacetFloatAssociations extends FloatTaxonomyFacets {
       DoubleValuesSource valueSource)
       throws IOException {
     for (MatchingDocs hits : matchingDocs) {
+      if (hits.totalHits == 0) {
+        continue;
+      }
+      initializeValueCounters();
+
       SortedNumericDocValues ordinalValues =
           DocValues.getSortedNumeric(hits.context.reader(), indexFieldName);
       DoubleValues scores = keepScores ? scores(hits) : null;
@@ -164,6 +169,11 @@ public class TaxonomyFacetFloatAssociations extends FloatTaxonomyFacets {
       throws IOException {
 
     for (MatchingDocs hits : matchingDocs) {
+      if (hits.totalHits == 0) {
+        continue;
+      }
+      initializeValueCounters();
+
       BinaryDocValues dv = DocValues.getBinary(hits.context.reader(), indexFieldName);
       DocIdSetIterator it =
           ConjunctionUtils.intersectIterators(Arrays.asList(hits.bits.iterator(), dv));

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetIntAssociations.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetIntAssociations.java
@@ -63,6 +63,11 @@ public class TaxonomyFacetIntAssociations extends IntTaxonomyFacets {
       AssociationAggregationFunction aggregationFunction, List<MatchingDocs> matchingDocs)
       throws IOException {
     for (MatchingDocs hits : matchingDocs) {
+      if (hits.totalHits == 0) {
+        continue;
+      }
+      initializeValueCounters();
+
       BinaryDocValues dv = DocValues.getBinary(hits.context.reader(), indexFieldName);
       DocIdSetIterator it = ConjunctionUtils.intersectIterators(List.of(hits.bits.iterator(), dv));
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -19,11 +19,13 @@ package org.apache.lucene.facet.taxonomy;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
+import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.FacetsConfig.DimConfig;
 
@@ -53,6 +55,9 @@ abstract class TaxonomyFacets extends Facets {
   /** {@code FacetsConfig} provided to the constructor. */
   final FacetsConfig config;
 
+  /** {@code FacetsCollector} provided to the constructor. */
+  final FacetsCollector fc;
+
   /** Maps parent ordinal to its child, or -1 if the parent is childless. */
   private int[] children;
 
@@ -63,11 +68,13 @@ abstract class TaxonomyFacets extends Facets {
   final int[] parents;
 
   /** Sole constructor. */
-  TaxonomyFacets(String indexFieldName, TaxonomyReader taxoReader, FacetsConfig config)
+  TaxonomyFacets(
+      String indexFieldName, TaxonomyReader taxoReader, FacetsConfig config, FacetsCollector fc)
       throws IOException {
     this.indexFieldName = indexFieldName;
     this.taxoReader = taxoReader;
     this.config = config;
+    this.fc = fc;
     parents = taxoReader.getParallelTaxonomyArrays().parents();
   }
 
@@ -138,6 +145,11 @@ abstract class TaxonomyFacets extends Facets {
   @Override
   public List<FacetResult> getAllDims(int topN) throws IOException {
     validateTopN(topN);
+
+    if (hasValues() == false) {
+      return Collections.emptyList();
+    }
+
     int[] children = getChildren();
     int[] siblings = getSiblings();
     int ord = children[TaxonomyReader.ROOT_ORDINAL];
@@ -158,4 +170,7 @@ abstract class TaxonomyFacets extends Facets {
     results.sort(BY_VALUE_THEN_DIM);
     return results;
   }
+
+  /** Were any values actually aggregated during counting? */
+  abstract boolean hasValues();
 }


### PR DESCRIPTION
This change proposes some faceting optimizations for situations where there are no hits to facet over. While this seems like an odd scenario, at Amazon product search we actually have some situations where this can become common (sparse queries that don't have results in some segments, or have no results altogether).

You could argue that the calling code should handle this optimization and avoid faceting altogether if there are no hits, but that only solves for the case of no results, not no results in some segments. I think it's also nice to move this optimization into the faceting module so that every user doesn't have to do this themselves.

Curious what people think of this idea. Happy to hear feedback, counterarguments, etc. :)

This change covers:
* Taxonomy faceting
  * FastTaxonomyFacetCounts
  * TaxonomyFacetIntAssociations
  * TaxonomyFacetFloatAssociations
* SSDV faceting
  * SortedSetDocValuesFacetCounts
  * ConcurrentSortedSetDocValuesFacetCounts
  * StringValueFacetCounts
* Range faceting:
  * LongRangeFacetCounts
  * DoubleRangeFacetCounts
* Long faceting:
  * LongValueFacetCounts

Left for a future iteration (I'll open a follow up issue if we move forward with this one):
* RangeOnRange faceting
* FacetSet faceting
