### PR TITLE
Fix forUtil.gradle to actually execute python script and also fix type error in script

### DIFF
--- a/gradle/generation/forUtil.gradle
+++ b/gradle/generation/forUtil.gradle
@@ -34,7 +34,7 @@ configure(project(":lucene:core")) {
       quietExec {
         workingDir genDir
         executable project.externalTool("python3")
-        args = [ genScript ]
+        args = [ '-B', genScript ]
       }
     }
   }
@@ -59,7 +59,7 @@ configure(project(":lucene:backward-codecs")) {
       quietExec {
         workingDir genDir
         executable project.externalTool("python3")
-        args = [ genScript ]
+        args = [ '-B', genScript ]
       }
     }
   }

--- a/gradle/generation/forUtil.gradle
+++ b/gradle/generation/forUtil.gradle
@@ -34,7 +34,7 @@ configure(project(":lucene:core")) {
       quietExec {
         workingDir genDir
         executable project.externalTool("python3")
-        args = []
+        args = [ genScript ]
       }
     }
   }
@@ -59,7 +59,7 @@ configure(project(":lucene:backward-codecs")) {
       quietExec {
         workingDir genDir
         executable project.externalTool("python3")
-        args = []
+        args = [ genScript ]
       }
     }
   }

--- a/lucene/backward-codecs/src/generated/checksums/generateForUtil.json
+++ b/lucene/backward-codecs/src/generated/checksums/generateForUtil.json
@@ -1,4 +1,4 @@
 {
     "lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene84/ForUtil.java": "e91aafa414018b34a39c8f0947ff58c1f1dde78d",
-    "lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene84/gen_ForUtil.py": "285ed73b9763c541edaf40072667d68bd2537c56"
+    "lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene84/gen_ForUtil.py": "7be3f1e17c9055d68a8ad6b0d6321481dcc4d711"
 }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene84/gen_ForUtil.py
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene84/gen_ForUtil.py
@@ -414,7 +414,7 @@ def writeRemainder(bpv, next_primitive, remaining_bits_per_long, o, num_values, 
   i = 0
   remaining_bits = 0
   tmp_idx = 0
-  for i in range(num_values):
+  for i in range(int(num_values)):
     b = bpv
     if remaining_bits == 0:
       b -= remaining_bits_per_long

--- a/lucene/core/src/generated/checksums/generateForUtil.json
+++ b/lucene/core/src/generated/checksums/generateForUtil.json
@@ -1,4 +1,4 @@
 {
     "lucene/core/src/java/org/apache/lucene/codecs/lucene90/ForUtil.java": "f2091e2b7284b70c740052a9b0ee389e67eb48a9",
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene90/gen_ForUtil.py": "69b6fcb95fc127a5cd29a40e4454048f56570a26"
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene90/gen_ForUtil.py": "7a137c58f88d68247be4368122780fa9cc8dce3e"
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/gen_ForUtil.py
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/gen_ForUtil.py
@@ -227,10 +227,7 @@ final class ForUtil {
     }
 
     for (int i = 0; i < numLongsPerShift; ++i) {
-      // Java longs are big endian and we want to read little endian longs, so we need to reverse
-      // bytes
-      long l = tmp[i];
-      out.writeLong(l);
+      out.writeLong(tmp[i]);
     }
   }
 
@@ -317,7 +314,7 @@ def writeRemainder(bpv, next_primitive, remaining_bits_per_long, o, num_values, 
   i = 0
   remaining_bits = 0
   tmp_idx = 0
-  for i in range(num_values):
+  for i in range(int(num_values)):
     b = bpv
     if remaining_bits == 0:
       b -= remaining_bits_per_long


### PR DESCRIPTION
When we ported the build to gradle, the forUtil generator script was never executed, because the script name was missing as argument. Actually the script was also buggy, because it produced type error (with newer python versions)