### PR TITLE
DRAFT: Vectorize ForUtil encoding for the 9.0 codec (same format)

### DIFF
--- a/gradle/generation/forUtil.gradle
+++ b/gradle/generation/forUtil.gradle
@@ -20,12 +20,12 @@
 configure(project(":lucene:core")) {
 
   task generateForUtilInternal() {
-    description "Regenerate gen_ForUtil.py"
+    description "Regenerate gen_DefaultForUtil90.py"
     group "generation"
 
-    def genDir = file("src/java/org/apache/lucene/codecs/lucene90")
-    def genScript = file("${genDir}/gen_ForUtil.py")
-    def genOutput = file("${genDir}/ForUtil.java")
+    def genDir = file("src/java/org/apache/lucene/internal/vectorization")
+    def genScript = file("${genDir}/gen_DefaultForUtil90.py")
+    def genOutput = file("${genDir}/DefaultForUtil90.java")
 
     inputs.file genScript
     outputs.file genOutput
@@ -40,6 +40,28 @@ configure(project(":lucene:core")) {
   }
 
   regenerate.dependsOn wrapWithPersistentChecksums(generateForUtilInternal, [ andThenTasks: ["spotlessJava", "spotlessJavaApply"] ])
+  
+  task generatePanamaForUtilInternal() {
+    description "Regenerate gen_PanamaForUtil.py"
+    group "generation"
+
+    def genDir = file("src/java20/org/apache/lucene/internal/vectorization")
+    def genScript = file("${genDir}/gen_PanamaForUtil90.py")
+    def genOutput = file("${genDir}/PanamaForUtil90.java")
+
+    inputs.file genScript
+    outputs.file genOutput
+
+    doLast {
+      quietExec {
+        workingDir genDir
+        executable project.externalTool("python3")
+        args = [ '-B', genScript ]
+      }
+    }
+  }
+
+  regenerate.dependsOn wrapWithPersistentChecksums(generatePanamaForUtilInternal, [ andThenTasks: ["spotlessJava", "spotlessJavaApply"] ])
 }
 
 configure(project(":lucene:backward-codecs")) {

--- a/lucene/core/src/generated/checksums/generateForUtil.json
+++ b/lucene/core/src/generated/checksums/generateForUtil.json
@@ -1,4 +1,4 @@
 {
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene90/ForUtil.java": "f2091e2b7284b70c740052a9b0ee389e67eb48a9",
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene90/gen_ForUtil.py": "7a137c58f88d68247be4368122780fa9cc8dce3e"
+    "lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultForUtil90.java": "8760243bd670376792b272f0a5cc54acb79c3ed6",
+    "lucene/core/src/java/org/apache/lucene/internal/vectorization/gen_DefaultForUtil90.py": "71cef263b135816680b29dd97a90961402aa005c"
 }

--- a/lucene/core/src/generated/checksums/generatePanamaForUtil.json
+++ b/lucene/core/src/generated/checksums/generatePanamaForUtil.json
@@ -1,0 +1,4 @@
+{
+    "lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaForUtil90.java": "5db61312b5f550c0feeade7a6cdff257ad7dbc8d",
+    "lucene/core/src/java20/org/apache/lucene/internal/vectorization/gen_PanamaForUtil90.py": "0d412b484d6ddb269bdb91f0203dad19cd998061"
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsFormat.java
@@ -31,6 +31,7 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.TermState;
+import org.apache.lucene.internal.vectorization.ForUtil90;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.packed.PackedInts;
@@ -356,7 +357,7 @@ public final class Lucene90PostingsFormat extends PostingsFormat {
   public static final String PAY_EXTENSION = "pay";
 
   /** Size of blocks. */
-  public static final int BLOCK_SIZE = ForUtil.BLOCK_SIZE;
+  public static final int BLOCK_SIZE = ForUtil90.BLOCK_SIZE;
 
   /**
    * Expert: The maximum number of skip levels. Smaller values result in slightly smaller indexes,
@@ -449,12 +450,12 @@ public final class Lucene90PostingsFormat extends PostingsFormat {
     public long payStartFP;
     /**
      * file offset for the start of the skip list, relative to docStartFP, if there are more than
-     * {@link ForUtil#BLOCK_SIZE} docs; otherwise -1
+     * {@link ForUtil90#BLOCK_SIZE} docs; otherwise -1
      */
     public long skipOffset;
     /**
      * file offset for the last position in the last block, if there are more than {@link
-     * ForUtil#BLOCK_SIZE} positions; otherwise -1
+     * ForUtil90#BLOCK_SIZE} positions; otherwise -1
      */
     public long lastPosBlockOffset;
     /**

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.codecs.lucene90;
 
-import static org.apache.lucene.codecs.lucene90.ForUtil.BLOCK_SIZE;
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.DOC_CODEC;
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.MAX_SKIP_LEVELS;
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.PAY_CODEC;
@@ -24,6 +23,7 @@ import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.POS_CODEC
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.TERMS_CODEC;
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.VERSION_CURRENT;
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.VERSION_START;
+import static org.apache.lucene.internal.vectorization.ForUtil90.BLOCK_SIZE;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -39,6 +39,7 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SlowImpactsEnum;
+import org.apache.lucene.internal.vectorization.ForUtil90;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.ArrayUtil;
@@ -306,7 +307,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
 
   final class BlockDocsEnum extends PostingsEnum {
 
-    final PForUtil pforUtil = new PForUtil(new ForUtil());
+    final PForUtil pforUtil = new PForUtil();
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];
     private final long[] freqBuffer = new long[BLOCK_SIZE];
@@ -394,7 +395,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
       this.needsFreq = PostingsEnum.featureRequested(flags, PostingsEnum.FREQS);
       this.isFreqsRead = true;
       if (indexHasFreq == false || needsFreq == false) {
-        for (int i = 0; i < ForUtil.BLOCK_SIZE; ++i) {
+        for (int i = 0; i < ForUtil90.BLOCK_SIZE; ++i) {
           freqBuffer[i] = 1;
         }
       }
@@ -563,7 +564,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
   // Also handles payloads + offsets
   final class EverythingEnum extends PostingsEnum {
 
-    final PForUtil pforUtil = new PForUtil(new ForUtil());
+    final PForUtil pforUtil = new PForUtil();
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];
     private final long[] freqBuffer = new long[BLOCK_SIZE + 1];
@@ -1047,7 +1048,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
 
   final class BlockImpactsDocsEnum extends ImpactsEnum {
 
-    final PForUtil pforUtil = new PForUtil(new ForUtil());
+    final PForUtil pforUtil = new PForUtil();
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];
     private final long[] freqBuffer = new long[BLOCK_SIZE];
@@ -1240,7 +1241,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
 
   final class BlockImpactsPostingsEnum extends ImpactsEnum {
 
-    final PForUtil pforUtil = new PForUtil(new ForUtil());
+    final PForUtil pforUtil = new PForUtil();
 
     private final long[] docBuffer = new long[BLOCK_SIZE];
     private final long[] freqBuffer = new long[BLOCK_SIZE];
@@ -1532,7 +1533,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
 
   final class BlockImpactsEverythingEnum extends ImpactsEnum {
 
-    final PForUtil pforUtil = new PForUtil(new ForUtil());
+    final PForUtil pforUtil = new PForUtil();
 
     private final long[] docBuffer = new long[BLOCK_SIZE];
     private final long[] freqBuffer = new long[BLOCK_SIZE];
@@ -1696,7 +1697,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
           docFreq);
 
       if (indexHasFreq == false) {
-        for (int i = 0; i < ForUtil.BLOCK_SIZE; ++i) {
+        for (int i = 0; i < ForUtil90.BLOCK_SIZE; ++i) {
           freqBuffer[i] = 1;
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsWriter.java
@@ -16,13 +16,13 @@
  */
 package org.apache.lucene.codecs.lucene90;
 
-import static org.apache.lucene.codecs.lucene90.ForUtil.BLOCK_SIZE;
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.DOC_CODEC;
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.MAX_SKIP_LEVELS;
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.PAY_CODEC;
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.POS_CODEC;
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.TERMS_CODEC;
 import static org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat.VERSION_CURRENT;
+import static org.apache.lucene.internal.vectorization.ForUtil90.BLOCK_SIZE;
 
 import java.io.IOException;
 import org.apache.lucene.codecs.BlockTermState;
@@ -110,7 +110,7 @@ public final class Lucene90PostingsWriter extends PushPostingsWriterBase {
     try {
       CodecUtil.writeIndexHeader(
           docOut, DOC_CODEC, VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
-      pforUtil = new PForUtil(new ForUtil());
+      pforUtil = new PForUtil();
       if (state.fieldInfos.hasProx()) {
         posDeltaBuffer = new long[BLOCK_SIZE];
         String posFileName =

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90SkipReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90SkipReader.java
@@ -19,6 +19,7 @@ package org.apache.lucene.codecs.lucene90;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.lucene.codecs.MultiLevelSkipListReader;
+import org.apache.lucene.internal.vectorization.ForUtil90;
 import org.apache.lucene.store.IndexInput;
 
 /**
@@ -67,7 +68,7 @@ class Lucene90SkipReader extends MultiLevelSkipListReader {
       boolean hasPos,
       boolean hasOffsets,
       boolean hasPayloads) {
-    super(skipStream, maxSkipLevels, ForUtil.BLOCK_SIZE, 8);
+    super(skipStream, maxSkipLevels, ForUtil90.BLOCK_SIZE, 8);
     docPointer = new long[maxSkipLevels];
     if (hasPos) {
       posPointer = new long[maxSkipLevels];
@@ -95,7 +96,7 @@ class Lucene90SkipReader extends MultiLevelSkipListReader {
    * the last block boundary 2. moving into the vInt block
    */
   protected int trim(int df) {
-    return df % ForUtil.BLOCK_SIZE == 0 ? df - 1 : df;
+    return df % ForUtil90.BLOCK_SIZE == 0 ? df - 1 : df;
   }
 
   public void init(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/PForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/PForUtil.java
@@ -18,6 +18,8 @@ package org.apache.lucene.codecs.lucene90;
 
 import java.io.IOException;
 import java.util.Arrays;
+import org.apache.lucene.internal.vectorization.ForUtil90;
+import org.apache.lucene.internal.vectorization.VectorizationProvider;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.LongHeap;
@@ -26,20 +28,22 @@ import org.apache.lucene.util.packed.PackedInts;
 /** Utility class to encode sequences of 128 small positive integers. */
 final class PForUtil {
 
+  private static final VectorizationProvider VPROVIDER = VectorizationProvider.getInstance();
+
   private static final int MAX_EXCEPTIONS = 7;
-  private static final int HALF_BLOCK_SIZE = ForUtil.BLOCK_SIZE / 2;
+  private static final int HALF_BLOCK_SIZE = ForUtil90.BLOCK_SIZE / 2;
 
   // IDENTITY_PLUS_ONE[i] == i + 1
-  private static final long[] IDENTITY_PLUS_ONE = new long[ForUtil.BLOCK_SIZE];
+  private static final long[] IDENTITY_PLUS_ONE = new long[ForUtil90.BLOCK_SIZE];
 
   static {
-    for (int i = 0; i < ForUtil.BLOCK_SIZE; ++i) {
+    for (int i = 0; i < ForUtil90.BLOCK_SIZE; ++i) {
       IDENTITY_PLUS_ONE[i] = i + 1;
     }
   }
 
   static boolean allEqual(long[] l) {
-    for (int i = 1; i < ForUtil.BLOCK_SIZE; ++i) {
+    for (int i = 1; i < ForUtil90.BLOCK_SIZE; ++i) {
       if (l[i] != l[0]) {
         return false;
       }
@@ -47,14 +51,15 @@ final class PForUtil {
     return true;
   }
 
-  private final ForUtil forUtil;
+  private final ForUtil90 forUtil;
   // buffer for reading exception data; each exception uses two bytes (pos + high-order bits of the
   // exception)
   private final byte[] exceptionBuff = new byte[MAX_EXCEPTIONS * 2];
 
-  PForUtil(ForUtil forUtil) {
-    assert ForUtil.BLOCK_SIZE <= 256 : "blocksize must fit in one byte. got " + ForUtil.BLOCK_SIZE;
-    this.forUtil = forUtil;
+  PForUtil() {
+    assert ForUtil90.BLOCK_SIZE <= 256
+        : "blocksize must fit in one byte. got " + ForUtil90.BLOCK_SIZE;
+    this.forUtil = VPROVIDER.newForUtil90();
   }
 
   /** Encode 128 integers from {@code longs} into {@code out}. */
@@ -65,7 +70,7 @@ final class PForUtil {
       top.push(longs[i]);
     }
     long topValue = top.top();
-    for (int i = MAX_EXCEPTIONS + 1; i < ForUtil.BLOCK_SIZE; ++i) {
+    for (int i = MAX_EXCEPTIONS + 1; i < ForUtil90.BLOCK_SIZE; ++i) {
       if (longs[i] > topValue) {
         topValue = top.updateTop(longs[i]);
       }
@@ -90,7 +95,7 @@ final class PForUtil {
     final byte[] exceptions = new byte[numExceptions * 2];
     if (numExceptions > 0) {
       int exceptionCount = 0;
-      for (int i = 0; i < ForUtil.BLOCK_SIZE; ++i) {
+      for (int i = 0; i < ForUtil90.BLOCK_SIZE; ++i) {
         if (longs[i] > maxUnpatchedValue) {
           exceptions[exceptionCount * 2] = (byte) i;
           exceptions[exceptionCount * 2 + 1] = (byte) (longs[i] >>> patchedBitsRequired);
@@ -122,7 +127,7 @@ final class PForUtil {
     final int bitsPerValue = token & 0x1f;
     final int numExceptions = token >>> 5;
     if (bitsPerValue == 0) {
-      Arrays.fill(longs, 0, ForUtil.BLOCK_SIZE, in.readVLong());
+      Arrays.fill(longs, 0, ForUtil90.BLOCK_SIZE, in.readVLong());
     } else {
       forUtil.decode(bitsPerValue, in, longs);
     }
@@ -184,9 +189,9 @@ final class PForUtil {
    * there are no exceptions to apply.
    */
   private static void prefixSumOfOnes(long[] longs, long base) {
-    System.arraycopy(IDENTITY_PLUS_ONE, 0, longs, 0, ForUtil.BLOCK_SIZE);
+    System.arraycopy(IDENTITY_PLUS_ONE, 0, longs, 0, ForUtil90.BLOCK_SIZE);
     // This loop gets auto-vectorized
-    for (int i = 0; i < ForUtil.BLOCK_SIZE; ++i) {
+    for (int i = 0; i < ForUtil90.BLOCK_SIZE; ++i) {
       longs[i] += base;
     }
   }
@@ -196,7 +201,7 @@ final class PForUtil {
    * this assumes there are no exceptions to apply.
    */
   private static void prefixSumOf(long[] longs, long base, long val) {
-    for (int i = 0; i < ForUtil.BLOCK_SIZE; i++) {
+    for (int i = 0; i < ForUtil90.BLOCK_SIZE; i++) {
       longs[i] = (i + 1) * val + base;
     }
   }
@@ -232,7 +237,7 @@ final class PForUtil {
     innerPrefixSum32(longs);
     expand32(longs);
     final long l = longs[HALF_BLOCK_SIZE - 1];
-    for (int i = HALF_BLOCK_SIZE; i < ForUtil.BLOCK_SIZE; ++i) {
+    for (int i = HALF_BLOCK_SIZE; i < ForUtil90.BLOCK_SIZE; ++i) {
       longs[i] += l;
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultForUtil90.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultForUtil90.java
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.lucene.codecs.lucene90;
+package org.apache.lucene.internal.vectorization;
 
 import java.io.IOException;
 import org.apache.lucene.store.DataInput;
@@ -27,10 +27,7 @@ import org.apache.lucene.store.DataOutput;
 // If bitsPerValue <= 8 then we pack 8 ints per long
 // else if bitsPerValue <= 16 we pack 4 ints per long
 // else we pack 2 ints per long
-final class ForUtil {
-
-  static final int BLOCK_SIZE = 128;
-  private static final int BLOCK_SIZE_LOG2 = 7;
+final class DefaultForUtil90 implements ForUtil90 {
 
   private static long expandMask32(long mask32) {
     return mask32 | (mask32 << 32);
@@ -135,7 +132,8 @@ final class ForUtil {
   private final long[] tmp = new long[BLOCK_SIZE / 2];
 
   /** Encode 128 integers from {@code longs} into {@code out}. */
-  void encode(long[] longs, int bitsPerValue, DataOutput out) throws IOException {
+  @Override
+  public void encode(long[] longs, int bitsPerValue, DataOutput out) throws IOException {
     final int nextPrimitive;
     final int numLongs;
     if (bitsPerValue <= 8) {
@@ -205,11 +203,6 @@ final class ForUtil {
     for (int i = 0; i < numLongsPerShift; ++i) {
       out.writeLong(tmp[i]);
     }
-  }
-
-  /** Number of bytes required to encode 128 integers of {@code bitsPerValue} bits per value. */
-  int numBytes(int bitsPerValue) {
-    return bitsPerValue << (BLOCK_SIZE_LOG2 - 3);
   }
 
   private static void decodeSlow(int bitsPerValue, DataInput in, long[] tmp, long[] longs)
@@ -317,7 +310,8 @@ final class ForUtil {
   private static final long MASK32_24 = MASKS32[24];
 
   /** Decode 128 integers into {@code longs}. */
-  void decode(int bitsPerValue, DataInput in, long[] longs) throws IOException {
+  @Override
+  public void decode(int bitsPerValue, DataInput in, long[] longs) throws IOException {
     switch (bitsPerValue) {
       case 1:
         decode1(in, tmp, longs);
@@ -428,7 +422,8 @@ final class ForUtil {
    * [0..63], and values [64..127] are encoded in the low-order bits of {@code longs} [0..63]. This
    * representation may allow subsequent operations to be performed on two values at a time.
    */
-  void decodeTo32(int bitsPerValue, DataInput in, long[] longs) throws IOException {
+  @Override
+  public void decodeTo32(int bitsPerValue, DataInput in, long[] longs) throws IOException {
     switch (bitsPerValue) {
       case 1:
         decode1(in, tmp, longs);

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorizationProvider.java
@@ -30,4 +30,9 @@ final class DefaultVectorizationProvider extends VectorizationProvider {
   public VectorUtilSupport getVectorUtilSupport() {
     return vectorUtilSupport;
   }
+
+  @Override
+  public ForUtil90 newForUtil90() {
+    return new DefaultForUtil90();
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/ForUtil90.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/ForUtil90.java
@@ -1,0 +1,50 @@
+// This file has been automatically generated, DO NOT EDIT
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.internal.vectorization;
+
+import java.io.IOException;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+
+/** TODO: add docs */
+public interface ForUtil90 {
+
+  static final int BLOCK_SIZE = 128;
+
+  static final int BLOCK_SIZE_LOG2 = 7;
+
+  /** Encode 128 integers from {@code longs} into {@code out}. */
+  void encode(long[] longs, int bitsPerValue, DataOutput out) throws IOException;
+
+  /** Number of bytes required to encode 128 integers of {@code bitsPerValue} bits per value. */
+  default int numBytes(int bitsPerValue) {
+    return bitsPerValue << (BLOCK_SIZE_LOG2 - 3);
+  }
+
+  /** Decode 128 integers into {@code longs}. */
+  void decode(int bitsPerValue, DataInput in, long[] longs) throws IOException;
+
+  /**
+   * Decodes 128 integers into 64 {@code longs} such that each long contains two values, each
+   * represented with 32 bits. Values [0..63] are encoded in the high-order bits of {@code longs}
+   * [0..63], and values [64..127] are encoded in the low-order bits of {@code longs} [0..63]. This
+   * representation may allow subsequent operations to be performed on two values at a time.
+   */
+  void decodeTo32(int bitsPerValue, DataInput in, long[] longs) throws IOException;
+}

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -25,8 +25,8 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.logging.Logger;
-import java.util.stream.Stream;
 import org.apache.lucene.util.SuppressForbidden;
 import org.apache.lucene.util.VectorUtil;
 
@@ -61,6 +61,9 @@ public abstract class VectorizationProvider {
    * VectorUtil}.
    */
   public abstract VectorUtilSupport getVectorUtilSupport();
+
+  /** Returns a new {@link ForUtil90} implementation to support SIMD usage in Lucene 9.0 codec. */
+  public abstract ForUtil90 newForUtil90();
 
   // *** Lookup mechanism: ***
 
@@ -162,11 +165,8 @@ public abstract class VectorizationProvider {
     }
   }
 
-  private static boolean isValidCaller(String cn) {
-    // add any class that is allowed to call getInstance()
-    // NOTE: the list here is lazy
-    return Stream.of(VectorUtil.class).map(Class::getName).anyMatch(cn::equals);
-  }
+  private static final Set<String> VALID_CALLERS =
+      Set.of("org.apache.lucene.util.VectorUtil", "org.apache.lucene.codecs.lucene90.PForUtil");
 
   private static void ensureCaller() {
     final boolean validCaller =
@@ -176,7 +176,7 @@ public abstract class VectorizationProvider {
                     s.skip(2)
                         .limit(1)
                         .map(StackFrame::getClassName)
-                        .allMatch(VectorizationProvider::isValidCaller));
+                        .allMatch(VALID_CALLERS::contains));
     if (!validCaller) {
       throw new UnsupportedOperationException(
           "VectorizationProvider is internal and can only be used by known Lucene classes.");

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/gen_DefaultForUtil90.py
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/gen_DefaultForUtil90.py
@@ -17,10 +17,10 @@
 
 from fractions import gcd
 
-"""Code generation for ForUtil.java"""
+"""Code generation for DefaultForUtil90.java"""
 
 MAX_SPECIALIZED_BITS_PER_VALUE = 24
-OUTPUT_FILE = "ForUtil.java"
+OUTPUT_FILE = "DefaultForUtil90.java"
 PRIMITIVE_SIZE = [8, 16, 32]
 HEADER = """// This file has been automatically generated, DO NOT EDIT
 
@@ -40,7 +40,7 @@ HEADER = """// This file has been automatically generated, DO NOT EDIT
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.lucene.codecs.lucene90;
+package org.apache.lucene.internal.vectorization;
 
 import java.io.IOException;
 import org.apache.lucene.store.DataInput;
@@ -51,10 +51,7 @@ import org.apache.lucene.store.DataOutput;
 // If bitsPerValue <= 8 then we pack 8 ints per long
 // else if bitsPerValue <= 16 we pack 4 ints per long
 // else we pack 2 ints per long
-final class ForUtil {
-
-  static final int BLOCK_SIZE = 128;
-  private static final int BLOCK_SIZE_LOG2 = 7;
+final class DefaultForUtil90 implements ForUtil90 {
 
   private static long expandMask32(long mask32) {
     return mask32 | (mask32 << 32);
@@ -159,7 +156,8 @@ final class ForUtil {
   private final long[] tmp = new long[BLOCK_SIZE / 2];
 
   /** Encode 128 integers from {@code longs} into {@code out}. */
-  void encode(long[] longs, int bitsPerValue, DataOutput out) throws IOException {
+  @Override
+  public void encode(long[] longs, int bitsPerValue, DataOutput out) throws IOException {
     final int nextPrimitive;
     final int numLongs;
     if (bitsPerValue <= 8) {
@@ -229,11 +227,6 @@ final class ForUtil {
     for (int i = 0; i < numLongsPerShift; ++i) {
       out.writeLong(tmp[i]);
     }
-  }
-
-  /** Number of bytes required to encode 128 integers of {@code bitsPerValue} bits per value. */
-  int numBytes(int bitsPerValue) {
-    return bitsPerValue << (BLOCK_SIZE_LOG2 - 3);
   }
 
   private static void decodeSlow(int bitsPerValue, DataInput in, long[] tmp, long[] longs)
@@ -383,7 +376,8 @@ if __name__ == '__main__':
 
   f.write("""
   /** Decode 128 integers into {@code longs}. */
-  void decode(int bitsPerValue, DataInput in, long[] longs) throws IOException {
+  @Override
+  public void decode(int bitsPerValue, DataInput in, long[] longs) throws IOException {
     switch (bitsPerValue) {
 """)
   for bpv in range(1, MAX_SPECIALIZED_BITS_PER_VALUE+1):
@@ -410,7 +404,8 @@ if __name__ == '__main__':
    * [0..63], and values [64..127] are encoded in the low-order bits of {@code longs} [0..63]. This
    * representation may allow subsequent operations to be performed on two values at a time.
    */
-  void decodeTo32(int bitsPerValue, DataInput in, long[] longs) throws IOException {
+  @Override
+  public void decodeTo32(int bitsPerValue, DataInput in, long[] longs) throws IOException {
     switch (bitsPerValue) {
 """)
   for bpv in range(1, MAX_SPECIALIZED_BITS_PER_VALUE+1):

--- a/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaForUtil90.java
+++ b/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaForUtil90.java
@@ -1,0 +1,6199 @@
+// This file has been automatically generated, DO NOT EDIT
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.internal.vectorization;
+
+import java.io.IOException;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+
+// Inspired from https://fulmicoton.com/posts/bitpacking/
+// Encodes multiple integers in a long to get SIMD-like speedups.
+// If bitsPerValue <= 8 then we pack 8 ints per long
+// else if bitsPerValue <= 16 we pack 4 ints per long
+// else we pack 2 ints per long
+final class PanamaForUtil90 implements ForUtil90 {
+
+  private static final VectorSpecies<Long> LANESIZE_2 = LongVector.SPECIES_128;
+
+  private static final VectorSpecies<Long> LANESIZE_4 = LongVector.SPECIES_256;
+
+  private static long expandMask32(long mask32) {
+    return mask32 | (mask32 << 32);
+  }
+
+  private static long expandMask16(long mask16) {
+    return expandMask32(mask16 | (mask16 << 16));
+  }
+
+  private static long expandMask8(long mask8) {
+    return expandMask16(mask8 | (mask8 << 8));
+  }
+
+  private static long mask32(int bitsPerValue) {
+    return expandMask32((1L << bitsPerValue) - 1);
+  }
+
+  private static long mask16(int bitsPerValue) {
+    return expandMask16((1L << bitsPerValue) - 1);
+  }
+
+  private static long mask8(int bitsPerValue) {
+    return expandMask8((1L << bitsPerValue) - 1);
+  }
+
+  private static void expand8(long[] arr) {
+    for (int i = 0; i < 16; ++i) {
+      long l = arr[i];
+      arr[i] = (l >>> 56) & 0xFFL;
+      arr[16 + i] = (l >>> 48) & 0xFFL;
+      arr[32 + i] = (l >>> 40) & 0xFFL;
+      arr[48 + i] = (l >>> 32) & 0xFFL;
+      arr[64 + i] = (l >>> 24) & 0xFFL;
+      arr[80 + i] = (l >>> 16) & 0xFFL;
+      arr[96 + i] = (l >>> 8) & 0xFFL;
+      arr[112 + i] = l & 0xFFL;
+    }
+  }
+
+  private static void expand8To32(long[] arr) {
+    for (int i = 0; i < 16; ++i) {
+      long l = arr[i];
+      arr[i] = (l >>> 24) & 0x000000FF000000FFL;
+      arr[16 + i] = (l >>> 16) & 0x000000FF000000FFL;
+      arr[32 + i] = (l >>> 8) & 0x000000FF000000FFL;
+      arr[48 + i] = l & 0x000000FF000000FFL;
+    }
+  }
+
+  private static void expand16(long[] arr) {
+    for (int i = 0; i < 32; ++i) {
+      long l = arr[i];
+      arr[i] = (l >>> 48) & 0xFFFFL;
+      arr[32 + i] = (l >>> 32) & 0xFFFFL;
+      arr[64 + i] = (l >>> 16) & 0xFFFFL;
+      arr[96 + i] = l & 0xFFFFL;
+    }
+  }
+
+  private static void expand16To32(long[] arr) {
+    for (int i = 0; i < 32; ++i) {
+      long l = arr[i];
+      arr[i] = (l >>> 16) & 0x0000FFFF0000FFFFL;
+      arr[32 + i] = l & 0x0000FFFF0000FFFFL;
+    }
+  }
+
+  private static void expand32(long[] arr) {
+    for (int i = 0; i < 64; ++i) {
+      long l = arr[i];
+      arr[i] = l >>> 32;
+      arr[64 + i] = l & 0xFFFFFFFFL;
+    }
+  }
+
+  private final long[] tmp = new long[BLOCK_SIZE / 2];
+
+  private static void encode1(long[] input, int bitsPerValue, long[] out) {
+    LongVector outputVector = LANESIZE_2.zero().reinterpretAsLongs();
+    long mask = (1L << 1) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_2, input, 0).and(mask);
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 63);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 2).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 62).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 4).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 61).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 6).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 60).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 8).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 59).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 10).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 58).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 12).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 57).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 14).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 56).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 16).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 55).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 18).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 54).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 20).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 53).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 22).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 52).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 24).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 51).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 26).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 50).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 28).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 49).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 30).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 48).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 32).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 47).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 34).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 46).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 36).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 45).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 38).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 44).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 40).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 43).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 42).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 42).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 44).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 41).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 46).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 40).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 48).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 39).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 50).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 38).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 52).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 37).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 54).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 36).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 56).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 35).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 58).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 34).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 60).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 33).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 62).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 32).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 64).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 31).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 66).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 30).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 68).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 29).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 70).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 28).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 72).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 27).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 74).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 26).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 76).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 25).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 78).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 24).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 80).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 23).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 82).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 22).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 84).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 21).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 86).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 20).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 88).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 19).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 90).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 18).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 92).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 17).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 94).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 16).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 96).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 15).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 98).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 14).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 100).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 13).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 102).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 12).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 104).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 11).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 106).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 10).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 108).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 9).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 110).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 8).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 112).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 7).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 114).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 6).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 116).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 5).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 118).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 4).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 120).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 3).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 122).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 2).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 124).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 1).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 126).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 0).or(outputVector);
+    outputVector.intoArray(out, 0);
+  }
+
+  @Override
+  public void encode(long[] longs, int bitsPerValue, DataOutput out) throws IOException {
+    switch (bitsPerValue) {
+      case 1 -> encode1(longs, bitsPerValue, tmp);
+      case 2 -> encode2(longs, bitsPerValue, tmp);
+      case 3 -> encode3(longs, bitsPerValue, tmp);
+      case 4 -> encode4(longs, bitsPerValue, tmp);
+      case 5 -> encode5(longs, bitsPerValue, tmp);
+      case 6 -> encode6(longs, bitsPerValue, tmp);
+      case 7 -> encode7(longs, bitsPerValue, tmp);
+      case 8 -> encode8(longs, bitsPerValue, tmp);
+      case 9 -> encode9(longs, bitsPerValue, tmp);
+      case 10 -> encode10(longs, bitsPerValue, tmp);
+      case 11 -> encode11(longs, bitsPerValue, tmp);
+      case 12 -> encode12(longs, bitsPerValue, tmp);
+      case 13 -> encode13(longs, bitsPerValue, tmp);
+      case 14 -> encode14(longs, bitsPerValue, tmp);
+      case 15 -> encode15(longs, bitsPerValue, tmp);
+      case 16 -> encode16(longs, bitsPerValue, tmp);
+      case 17 -> encode17(longs, bitsPerValue, tmp);
+      case 18 -> encode18(longs, bitsPerValue, tmp);
+      case 19 -> encode19(longs, bitsPerValue, tmp);
+      case 20 -> encode20(longs, bitsPerValue, tmp);
+      case 21 -> encode21(longs, bitsPerValue, tmp);
+      case 22 -> encode22(longs, bitsPerValue, tmp);
+      case 23 -> encode23(longs, bitsPerValue, tmp);
+      case 24 -> encode24(longs, bitsPerValue, tmp);
+      case 25 -> encode25(longs, bitsPerValue, tmp);
+      case 26 -> encode26(longs, bitsPerValue, tmp);
+      case 27 -> encode27(longs, bitsPerValue, tmp);
+      case 28 -> encode28(longs, bitsPerValue, tmp);
+      case 29 -> encode29(longs, bitsPerValue, tmp);
+      case 30 -> encode30(longs, bitsPerValue, tmp);
+      case 31 -> encode31(longs, bitsPerValue, tmp);
+      case 32 -> encode32(longs, bitsPerValue, tmp);
+    }
+
+    for (int i = 0; i < 2 * bitsPerValue; ++i) {
+      // Java longs are big endian and we want to read little endian longs, so we need to reverse
+      // bytes
+      long l = tmp[i];
+      out.writeLong(l);
+    }
+  }
+
+  private static void decodeSlow(int bitsPerValue, DataInput in, long[] tmp, long[] longs)
+      throws IOException {
+    final int numLongs = bitsPerValue << 1;
+    in.readLongs(tmp, 0, numLongs);
+    final long mask = MASKS32[bitsPerValue];
+    int longsIdx = 0;
+    int shift = 32 - bitsPerValue;
+    for (; shift >= 0; shift -= bitsPerValue) {
+      shiftLongs(tmp, numLongs, longs, longsIdx, shift, mask);
+      longsIdx += numLongs;
+    }
+    final int remainingBitsPerLong = shift + bitsPerValue;
+    final long mask32RemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+    int tmpIdx = 0;
+    int remainingBits = remainingBitsPerLong;
+    for (; longsIdx < BLOCK_SIZE / 2; ++longsIdx) {
+      int b = bitsPerValue - remainingBits;
+      long l = (tmp[tmpIdx++] & MASKS32[remainingBits]) << b;
+      while (b >= remainingBitsPerLong) {
+        b -= remainingBitsPerLong;
+        l |= (tmp[tmpIdx++] & mask32RemainingBitsPerLong) << b;
+      }
+      if (b > 0) {
+        l |= (tmp[tmpIdx] >>> (remainingBitsPerLong - b)) & MASKS32[b];
+        remainingBits = remainingBitsPerLong - b;
+      } else {
+        remainingBits = remainingBitsPerLong;
+      }
+      longs[longsIdx] = l;
+    }
+  }
+
+  /**
+   * The pattern that this shiftLongs method applies is recognized by the C2 compiler, which
+   * generates SIMD instructions for it in order to shift multiple longs at once.
+   */
+  private static void shiftLongs(long[] a, int count, long[] b, int bi, int shift, long mask) {
+    for (int i = 0; i < count; ++i) {
+      b[bi + i] = (a[i] >>> shift) & mask;
+    }
+  }
+
+  private static void encode2(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 2) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 62));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 60));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 58));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 56));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 54));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 52));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 46));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 30));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 28));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 26));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 24));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 22));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 20));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 14));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 0);
+  }
+
+  private static void encode3(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 3) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 61));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 6).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 58));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 53));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 22).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 45));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 38).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 54).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 29));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 70).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 26));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 21));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 86).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 13));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 102).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 118).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 0);
+
+    out[4] =
+        (input[4] << 61)
+            | (input[10] << 58)
+            | (input[20] << 53)
+            | (input[26] << 50)
+            | (input[36] << 45)
+            | (input[42] << 42)
+            | (input[52] << 37)
+            | (input[58] << 34)
+            | (input[68] << 29)
+            | (input[74] << 26)
+            | (input[84] << 21)
+            | (input[90] << 18)
+            | (input[100] << 13)
+            | (input[106] << 10)
+            | (input[116] << 5)
+            | (input[122] << 2);
+
+    out[5] =
+        (input[5] << 61)
+            | (input[11] << 58)
+            | (input[21] << 53)
+            | (input[27] << 50)
+            | (input[37] << 45)
+            | (input[43] << 42)
+            | (input[53] << 37)
+            | (input[59] << 34)
+            | (input[69] << 29)
+            | (input[75] << 26)
+            | (input[85] << 21)
+            | (input[91] << 18)
+            | (input[101] << 13)
+            | (input[107] << 10)
+            | (input[117] << 5)
+            | (input[123] << 2);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 56));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 24));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 12);
+    final int remainingBitsPerLong = 2;
+    final long maskRemainingBitsPerLong = MASKS8[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 12;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 16) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS8[remainingBitsPerValue];
+        mask2 = MASKS8[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode4(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 4) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 60));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 56));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 52));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 28));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 24));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 20));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 60));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 56));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 52));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 28));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 24));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 20));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 4);
+  }
+
+  private static void encode5(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 5) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 59));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 51));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 27));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 19));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 59));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 51));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 27));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 19));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 4);
+
+    out[8] =
+        (input[8] << 59)
+            | (input[24] << 51)
+            | (input[40] << 43)
+            | (input[56] << 35)
+            | (input[72] << 27)
+            | (input[88] << 19)
+            | (input[104] << 11)
+            | (input[120] << 3);
+
+    out[9] =
+        (input[9] << 59)
+            | (input[25] << 51)
+            | (input[41] << 43)
+            | (input[57] << 35)
+            | (input[73] << 27)
+            | (input[89] << 19)
+            | (input[105] << 11)
+            | (input[121] << 3);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 10).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 56));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 26).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 42).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 58).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 74).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 24));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 90).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 106).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 122).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 10);
+    out[14] =
+        (input[14] << 56)
+            | (input[30] << 48)
+            | (input[46] << 40)
+            | (input[62] << 32)
+            | (input[78] << 24)
+            | (input[94] << 16)
+            | (input[110] << 8)
+            | (input[126] << 0);
+
+    out[15] =
+        (input[15] << 56)
+            | (input[31] << 48)
+            | (input[47] << 40)
+            | (input[63] << 32)
+            | (input[79] << 24)
+            | (input[95] << 16)
+            | (input[111] << 8)
+            | (input[127] << 0);
+
+    final int remainingBitsPerLong = 3;
+    final long maskRemainingBitsPerLong = MASKS8[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 10;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 16) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS8[remainingBitsPerValue];
+        mask2 = MASKS8[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode6(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 6) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 58));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 26));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 58));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 26));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 58));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 26));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 56));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 24));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 12);
+    final int remainingBitsPerLong = 2;
+    final long maskRemainingBitsPerLong = MASKS8[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 12;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 16) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS8[remainingBitsPerValue];
+        mask2 = MASKS8[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode7(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 7) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 57));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 49));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 25));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 17));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 57));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 49));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 25));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 17));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 57));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 49));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 25));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 17));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 8);
+
+    out[12] =
+        (input[12] << 57)
+            | (input[28] << 49)
+            | (input[44] << 41)
+            | (input[60] << 33)
+            | (input[76] << 25)
+            | (input[92] << 17)
+            | (input[108] << 9)
+            | (input[124] << 1);
+
+    out[13] =
+        (input[13] << 57)
+            | (input[29] << 49)
+            | (input[45] << 41)
+            | (input[61] << 33)
+            | (input[77] << 25)
+            | (input[93] << 17)
+            | (input[109] << 9)
+            | (input[125] << 1);
+
+    out[14] =
+        (input[14] << 56)
+            | (input[30] << 48)
+            | (input[46] << 40)
+            | (input[62] << 32)
+            | (input[78] << 24)
+            | (input[94] << 16)
+            | (input[110] << 8)
+            | (input[126] << 0);
+
+    out[15] =
+        (input[15] << 56)
+            | (input[31] << 48)
+            | (input[47] << 40)
+            | (input[63] << 32)
+            | (input[79] << 24)
+            | (input[95] << 16)
+            | (input[111] << 8)
+            | (input[127] << 0);
+
+    final int remainingBitsPerLong = 1;
+    final long maskRemainingBitsPerLong = MASKS8[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 14;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 16) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS8[remainingBitsPerValue];
+        mask2 = MASKS8[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode8(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 8) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 56));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 24));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 56));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 24));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 56));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 24));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 56));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 24));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 12);
+  }
+
+  private static void encode9(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 9) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 55));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 23));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 55));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 23));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 55));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 23));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 55));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 23));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 12);
+
+    out[16] = (input[16] << 55) | (input[48] << 39) | (input[80] << 23) | (input[112] << 7);
+
+    out[17] = (input[17] << 55) | (input[49] << 39) | (input[81] << 23) | (input[113] << 7);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 18).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 50).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 82).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 114).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 18);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 22).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 54).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 86).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 118).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 22);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 26).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 58).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 90).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 122).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 26);
+    out[30] = (input[30] << 48) | (input[62] << 32) | (input[94] << 16) | (input[126] << 0);
+
+    out[31] = (input[31] << 48) | (input[63] << 32) | (input[95] << 16) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 7;
+    final long maskRemainingBitsPerLong = MASKS16[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 18;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 32) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS16[remainingBitsPerValue];
+        mask2 = MASKS16[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode10(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 10) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 54));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 22));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 54));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 22));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 54));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 22));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 54));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 22));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 54));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 22));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 20);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 24);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 28);
+    final int remainingBitsPerLong = 6;
+    final long maskRemainingBitsPerLong = MASKS16[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 20;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 32) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS16[remainingBitsPerValue];
+        mask2 = MASKS16[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode11(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 11) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 53));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 21));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 53));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 21));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 53));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 21));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 53));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 21));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 53));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 21));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 16);
+
+    out[20] = (input[20] << 53) | (input[52] << 37) | (input[84] << 21) | (input[116] << 5);
+
+    out[21] = (input[21] << 53) | (input[53] << 37) | (input[85] << 21) | (input[117] << 5);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 22).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 54).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 86).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 118).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 22);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 26).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 58).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 90).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 122).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 26);
+    out[30] = (input[30] << 48) | (input[62] << 32) | (input[94] << 16) | (input[126] << 0);
+
+    out[31] = (input[31] << 48) | (input[63] << 32) | (input[95] << 16) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 5;
+    final long maskRemainingBitsPerLong = MASKS16[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 22;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 32) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS16[remainingBitsPerValue];
+        mask2 = MASKS16[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode12(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 12) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 52));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 20));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 52));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 20));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 52));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 20));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 52));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 20));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 52));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 20));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 52));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 20));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 24);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 28);
+    final int remainingBitsPerLong = 4;
+    final long maskRemainingBitsPerLong = MASKS16[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 24;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 32) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS16[remainingBitsPerValue];
+        mask2 = MASKS16[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode13(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 13) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 51));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 19));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 51));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 19));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 51));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 19));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 51));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 19));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 51));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 19));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 51));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 19));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 20);
+
+    out[24] = (input[24] << 51) | (input[56] << 35) | (input[88] << 19) | (input[120] << 3);
+
+    out[25] = (input[25] << 51) | (input[57] << 35) | (input[89] << 19) | (input[121] << 3);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 26).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 58).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 90).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 122).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 26);
+    out[30] = (input[30] << 48) | (input[62] << 32) | (input[94] << 16) | (input[126] << 0);
+
+    out[31] = (input[31] << 48) | (input[63] << 32) | (input[95] << 16) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 3;
+    final long maskRemainingBitsPerLong = MASKS16[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 26;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 32) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS16[remainingBitsPerValue];
+        mask2 = MASKS16[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode14(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 14) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 50));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 18));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 28);
+    final int remainingBitsPerLong = 2;
+    final long maskRemainingBitsPerLong = MASKS16[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 28;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 32) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS16[remainingBitsPerValue];
+        mask2 = MASKS16[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode15(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 15) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 49));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 17));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 49));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 17));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 49));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 17));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 49));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 17));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 49));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 17));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 49));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 17));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 49));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 17));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 24);
+
+    out[28] = (input[28] << 49) | (input[60] << 33) | (input[92] << 17) | (input[124] << 1);
+
+    out[29] = (input[29] << 49) | (input[61] << 33) | (input[93] << 17) | (input[125] << 1);
+
+    out[30] = (input[30] << 48) | (input[62] << 32) | (input[94] << 16) | (input[126] << 0);
+
+    out[31] = (input[31] << 48) | (input[63] << 32) | (input[95] << 16) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 1;
+    final long maskRemainingBitsPerLong = MASKS16[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 30;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 32) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS16[remainingBitsPerValue];
+        mask2 = MASKS16[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode16(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 16) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 48));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 16));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 28);
+  }
+
+  private static void encode17(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 17) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 47));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 15));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 47));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 15));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 47));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 15));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 47));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 15));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 47));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 15));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 47));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 15));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 47));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 15));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 47));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 15));
+
+    outputVector.intoArray(out, 28);
+
+    out[32] = (input[32] << 47) | (input[96] << 15);
+
+    out[33] = (input[33] << 47) | (input[97] << 15);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 34).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 98).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 34);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 38).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 102).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 38);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 42).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 106).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 42);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 46).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 110).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 46);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 50).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 114).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 50);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 54).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 118).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 54);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 58).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 122).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 58);
+    out[62] = (input[62] << 32) | (input[126] << 0);
+
+    out[63] = (input[63] << 32) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 15;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 34;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode18(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 18) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 46));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 14));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 46));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 14));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 46));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 14));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 46));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 14));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 46));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 14));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 46));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 14));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 46));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 14));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 46));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 14));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 46));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 14));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 36);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 40);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 44);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 48);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 52);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 56);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 60);
+    final int remainingBitsPerLong = 14;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 36;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode19(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 19) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 45));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 13));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 45));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 13));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 45));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 13));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 45));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 13));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 45));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 13));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 45));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 13));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 45));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 13));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 45));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 13));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 45));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 13));
+
+    outputVector.intoArray(out, 32);
+
+    out[36] = (input[36] << 45) | (input[100] << 13);
+
+    out[37] = (input[37] << 45) | (input[101] << 13);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 38).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 102).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 38);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 42).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 106).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 42);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 46).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 110).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 46);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 50).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 114).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 50);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 54).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 118).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 54);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 58).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 122).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 58);
+    out[62] = (input[62] << 32) | (input[126] << 0);
+
+    out[63] = (input[63] << 32) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 13;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 38;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode20(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 20) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 44));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 12));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 40);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 44);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 48);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 52);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 56);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 60);
+    final int remainingBitsPerLong = 12;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 40;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode21(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 21) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 43));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 11));
+
+    outputVector.intoArray(out, 36);
+
+    out[40] = (input[40] << 43) | (input[104] << 11);
+
+    out[41] = (input[41] << 43) | (input[105] << 11);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 42).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 106).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 42);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 46).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 110).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 46);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 50).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 114).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 50);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 54).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 118).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 54);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 58).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 122).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 58);
+    out[62] = (input[62] << 32) | (input[126] << 0);
+
+    out[63] = (input[63] << 32) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 11;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 42;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode22(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 22) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 42));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 10));
+
+    outputVector.intoArray(out, 40);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 44);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 48);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 52);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 56);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 60);
+    final int remainingBitsPerLong = 10;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 44;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode23(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 23) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 41));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 9));
+
+    outputVector.intoArray(out, 40);
+
+    out[44] = (input[44] << 41) | (input[108] << 9);
+
+    out[45] = (input[45] << 41) | (input[109] << 9);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 46).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 110).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 46);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 50).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 114).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 50);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 54).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 118).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 54);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 58).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 122).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 58);
+    out[62] = (input[62] << 32) | (input[126] << 0);
+
+    out[63] = (input[63] << 32) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 9;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 46;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode24(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 24) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 40);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 40));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 8));
+
+    outputVector.intoArray(out, 44);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 48);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 52);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 56);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 60);
+    final int remainingBitsPerLong = 8;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 48;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode25(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 25) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 40);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 39));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 7));
+
+    outputVector.intoArray(out, 44);
+
+    out[48] = (input[48] << 39) | (input[112] << 7);
+
+    out[49] = (input[49] << 39) | (input[113] << 7);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 50).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 114).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 50);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 54).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 118).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 54);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 58).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 122).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 58);
+    out[62] = (input[62] << 32) | (input[126] << 0);
+
+    out[63] = (input[63] << 32) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 7;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 50;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode26(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 26) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 40);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 44);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 38));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 6));
+
+    outputVector.intoArray(out, 48);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 52);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 56);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 60);
+    final int remainingBitsPerLong = 6;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 52;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode27(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 27) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 40);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 44);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 37));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 5));
+
+    outputVector.intoArray(out, 48);
+
+    out[52] = (input[52] << 37) | (input[116] << 5);
+
+    out[53] = (input[53] << 37) | (input[117] << 5);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 54).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 118).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 54);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 58).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 122).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 58);
+    out[62] = (input[62] << 32) | (input[126] << 0);
+
+    out[63] = (input[63] << 32) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 5;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 54;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode28(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 28) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 40);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 44);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 48);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 36));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 4));
+
+    outputVector.intoArray(out, 52);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 56);
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 60);
+    final int remainingBitsPerLong = 4;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 56;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode29(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 29) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 40);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 44);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 48);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 35));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 3));
+
+    outputVector.intoArray(out, 52);
+
+    out[56] = (input[56] << 35) | (input[120] << 3);
+
+    out[57] = (input[57] << 35) | (input[121] << 3);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 58).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 122).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 58);
+    out[62] = (input[62] << 32) | (input[126] << 0);
+
+    out[63] = (input[63] << 32) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 3;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 58;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode30(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 30) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 40);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 44);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 48);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 52);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 34));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 2));
+
+    outputVector.intoArray(out, 56);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 60);
+    final int remainingBitsPerLong = 2;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 60;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode31(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 31) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 40);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 44);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 48);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 52);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 33));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 1));
+
+    outputVector.intoArray(out, 56);
+
+    out[60] = (input[60] << 33) | (input[124] << 1);
+
+    out[61] = (input[61] << 33) | (input[125] << 1);
+
+    out[62] = (input[62] << 32) | (input[126] << 0);
+
+    out[63] = (input[63] << 32) | (input[127] << 0);
+
+    final int remainingBitsPerLong = 1;
+    final long maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+
+    int tmpIdx = 0;
+    int idx = 62;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < 64) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS32[remainingBitsPerValue];
+        mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+  }
+
+  private static void encode32(long[] input, int bitsPerValue, long[] out) throws IOException {
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << 32) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, 0).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 64).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 0);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 4).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 68).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 4);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 8).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 72).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 8);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 12).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 76).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 12);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 16).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 80).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 16);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 20).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 84).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 20);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 24).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 88).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 24);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 28).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 92).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 28);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 32).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 96).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 32);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 36).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 100).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 36);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 40).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 104).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 40);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 44).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 108).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 44);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 48).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 112).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 48);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 52).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 116).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 52);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 56).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 120).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 56);
+
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 60).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 32));
+
+    inputVector = LongVector.fromArray(LANESIZE_4, input, 124).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, 0));
+
+    outputVector.intoArray(out, 60);
+  }
+
+  private static final long[] MASKS8 = new long[8];
+  private static final long[] MASKS16 = new long[16];
+  private static final long[] MASKS32 = new long[32];
+
+  static {
+    for (int i = 0; i < 8; ++i) {
+      MASKS8[i] = mask8(i);
+    }
+    for (int i = 0; i < 16; ++i) {
+      MASKS16[i] = mask16(i);
+    }
+    for (int i = 0; i < 32; ++i) {
+      MASKS32[i] = mask32(i);
+    }
+  }
+  // mark values in array as final longs to avoid the cost of reading array, arrays should only be
+  // used when the idx is a variable
+  private static final long MASK8_1 = MASKS8[1];
+  private static final long MASK8_2 = MASKS8[2];
+  private static final long MASK8_3 = MASKS8[3];
+  private static final long MASK8_4 = MASKS8[4];
+  private static final long MASK8_5 = MASKS8[5];
+  private static final long MASK8_6 = MASKS8[6];
+  private static final long MASK8_7 = MASKS8[7];
+  private static final long MASK16_1 = MASKS16[1];
+  private static final long MASK16_2 = MASKS16[2];
+  private static final long MASK16_3 = MASKS16[3];
+  private static final long MASK16_4 = MASKS16[4];
+  private static final long MASK16_5 = MASKS16[5];
+  private static final long MASK16_6 = MASKS16[6];
+  private static final long MASK16_7 = MASKS16[7];
+  private static final long MASK16_9 = MASKS16[9];
+  private static final long MASK16_10 = MASKS16[10];
+  private static final long MASK16_11 = MASKS16[11];
+  private static final long MASK16_12 = MASKS16[12];
+  private static final long MASK16_13 = MASKS16[13];
+  private static final long MASK16_14 = MASKS16[14];
+  private static final long MASK16_15 = MASKS16[15];
+  private static final long MASK32_1 = MASKS32[1];
+  private static final long MASK32_2 = MASKS32[2];
+  private static final long MASK32_3 = MASKS32[3];
+  private static final long MASK32_4 = MASKS32[4];
+  private static final long MASK32_5 = MASKS32[5];
+  private static final long MASK32_6 = MASKS32[6];
+  private static final long MASK32_7 = MASKS32[7];
+  private static final long MASK32_8 = MASKS32[8];
+  private static final long MASK32_9 = MASKS32[9];
+  private static final long MASK32_10 = MASKS32[10];
+  private static final long MASK32_11 = MASKS32[11];
+  private static final long MASK32_12 = MASKS32[12];
+  private static final long MASK32_13 = MASKS32[13];
+  private static final long MASK32_14 = MASKS32[14];
+  private static final long MASK32_15 = MASKS32[15];
+  private static final long MASK32_17 = MASKS32[17];
+  private static final long MASK32_18 = MASKS32[18];
+  private static final long MASK32_19 = MASKS32[19];
+  private static final long MASK32_20 = MASKS32[20];
+  private static final long MASK32_21 = MASKS32[21];
+  private static final long MASK32_22 = MASKS32[22];
+  private static final long MASK32_23 = MASKS32[23];
+  private static final long MASK32_24 = MASKS32[24];
+
+  /** Decode 128 integers into {@code longs}. */
+  @Override
+  public void decode(int bitsPerValue, DataInput in, long[] longs) throws IOException {
+    switch (bitsPerValue) {
+      case 1:
+        decode1(in, tmp, longs);
+        expand8(longs);
+        break;
+      case 2:
+        decode2(in, tmp, longs);
+        expand8(longs);
+        break;
+      case 3:
+        decode3(in, tmp, longs);
+        expand8(longs);
+        break;
+      case 4:
+        decode4(in, tmp, longs);
+        expand8(longs);
+        break;
+      case 5:
+        decode5(in, tmp, longs);
+        expand8(longs);
+        break;
+      case 6:
+        decode6(in, tmp, longs);
+        expand8(longs);
+        break;
+      case 7:
+        decode7(in, tmp, longs);
+        expand8(longs);
+        break;
+      case 8:
+        decode8(in, tmp, longs);
+        expand8(longs);
+        break;
+      case 9:
+        decode9(in, tmp, longs);
+        expand16(longs);
+        break;
+      case 10:
+        decode10(in, tmp, longs);
+        expand16(longs);
+        break;
+      case 11:
+        decode11(in, tmp, longs);
+        expand16(longs);
+        break;
+      case 12:
+        decode12(in, tmp, longs);
+        expand16(longs);
+        break;
+      case 13:
+        decode13(in, tmp, longs);
+        expand16(longs);
+        break;
+      case 14:
+        decode14(in, tmp, longs);
+        expand16(longs);
+        break;
+      case 15:
+        decode15(in, tmp, longs);
+        expand16(longs);
+        break;
+      case 16:
+        decode16(in, tmp, longs);
+        expand16(longs);
+        break;
+      case 17:
+        decode17(in, tmp, longs);
+        expand32(longs);
+        break;
+      case 18:
+        decode18(in, tmp, longs);
+        expand32(longs);
+        break;
+      case 19:
+        decode19(in, tmp, longs);
+        expand32(longs);
+        break;
+      case 20:
+        decode20(in, tmp, longs);
+        expand32(longs);
+        break;
+      case 21:
+        decode21(in, tmp, longs);
+        expand32(longs);
+        break;
+      case 22:
+        decode22(in, tmp, longs);
+        expand32(longs);
+        break;
+      case 23:
+        decode23(in, tmp, longs);
+        expand32(longs);
+        break;
+      case 24:
+        decode24(in, tmp, longs);
+        expand32(longs);
+        break;
+      default:
+        decodeSlow(bitsPerValue, in, tmp, longs);
+        expand32(longs);
+        break;
+    }
+  }
+
+  /**
+   * Decodes 128 integers into 64 {@code longs} such that each long contains two values, each
+   * represented with 32 bits. Values [0..63] are encoded in the high-order bits of {@code longs}
+   * [0..63], and values [64..127] are encoded in the low-order bits of {@code longs} [0..63]. This
+   * representation may allow subsequent operations to be performed on two values at a time.
+   */
+  @Override
+  public void decodeTo32(int bitsPerValue, DataInput in, long[] longs) throws IOException {
+    switch (bitsPerValue) {
+      case 1:
+        decode1(in, tmp, longs);
+        expand8To32(longs);
+        break;
+      case 2:
+        decode2(in, tmp, longs);
+        expand8To32(longs);
+        break;
+      case 3:
+        decode3(in, tmp, longs);
+        expand8To32(longs);
+        break;
+      case 4:
+        decode4(in, tmp, longs);
+        expand8To32(longs);
+        break;
+      case 5:
+        decode5(in, tmp, longs);
+        expand8To32(longs);
+        break;
+      case 6:
+        decode6(in, tmp, longs);
+        expand8To32(longs);
+        break;
+      case 7:
+        decode7(in, tmp, longs);
+        expand8To32(longs);
+        break;
+      case 8:
+        decode8(in, tmp, longs);
+        expand8To32(longs);
+        break;
+      case 9:
+        decode9(in, tmp, longs);
+        expand16To32(longs);
+        break;
+      case 10:
+        decode10(in, tmp, longs);
+        expand16To32(longs);
+        break;
+      case 11:
+        decode11(in, tmp, longs);
+        expand16To32(longs);
+        break;
+      case 12:
+        decode12(in, tmp, longs);
+        expand16To32(longs);
+        break;
+      case 13:
+        decode13(in, tmp, longs);
+        expand16To32(longs);
+        break;
+      case 14:
+        decode14(in, tmp, longs);
+        expand16To32(longs);
+        break;
+      case 15:
+        decode15(in, tmp, longs);
+        expand16To32(longs);
+        break;
+      case 16:
+        decode16(in, tmp, longs);
+        expand16To32(longs);
+        break;
+      case 17:
+        decode17(in, tmp, longs);
+        break;
+      case 18:
+        decode18(in, tmp, longs);
+        break;
+      case 19:
+        decode19(in, tmp, longs);
+        break;
+      case 20:
+        decode20(in, tmp, longs);
+        break;
+      case 21:
+        decode21(in, tmp, longs);
+        break;
+      case 22:
+        decode22(in, tmp, longs);
+        break;
+      case 23:
+        decode23(in, tmp, longs);
+        break;
+      case 24:
+        decode24(in, tmp, longs);
+        break;
+      default:
+        decodeSlow(bitsPerValue, in, tmp, longs);
+        break;
+    }
+  }
+
+  private static void decode1(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 2);
+    shiftLongs(tmp, 2, longs, 0, 7, MASK8_1);
+    shiftLongs(tmp, 2, longs, 2, 6, MASK8_1);
+    shiftLongs(tmp, 2, longs, 4, 5, MASK8_1);
+    shiftLongs(tmp, 2, longs, 6, 4, MASK8_1);
+    shiftLongs(tmp, 2, longs, 8, 3, MASK8_1);
+    shiftLongs(tmp, 2, longs, 10, 2, MASK8_1);
+    shiftLongs(tmp, 2, longs, 12, 1, MASK8_1);
+    shiftLongs(tmp, 2, longs, 14, 0, MASK8_1);
+  }
+
+  private static void decode2(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 4);
+    shiftLongs(tmp, 4, longs, 0, 6, MASK8_2);
+    shiftLongs(tmp, 4, longs, 4, 4, MASK8_2);
+    shiftLongs(tmp, 4, longs, 8, 2, MASK8_2);
+    shiftLongs(tmp, 4, longs, 12, 0, MASK8_2);
+  }
+
+  private static void decode3(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 6);
+    shiftLongs(tmp, 6, longs, 0, 5, MASK8_3);
+    shiftLongs(tmp, 6, longs, 6, 2, MASK8_3);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 12; iter < 2; ++iter, tmpIdx += 3, longsIdx += 2) {
+      long l0 = (tmp[tmpIdx + 0] & MASK8_2) << 1;
+      l0 |= (tmp[tmpIdx + 1] >>> 1) & MASK8_1;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK8_1) << 2;
+      l1 |= (tmp[tmpIdx + 2] & MASK8_2) << 0;
+      longs[longsIdx + 1] = l1;
+    }
+  }
+
+  private static void decode4(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 8);
+    shiftLongs(tmp, 8, longs, 0, 4, MASK8_4);
+    shiftLongs(tmp, 8, longs, 8, 0, MASK8_4);
+  }
+
+  private static void decode5(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 10);
+    shiftLongs(tmp, 10, longs, 0, 3, MASK8_5);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 10; iter < 2; ++iter, tmpIdx += 5, longsIdx += 3) {
+      long l0 = (tmp[tmpIdx + 0] & MASK8_3) << 2;
+      l0 |= (tmp[tmpIdx + 1] >>> 1) & MASK8_2;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK8_1) << 4;
+      l1 |= (tmp[tmpIdx + 2] & MASK8_3) << 1;
+      l1 |= (tmp[tmpIdx + 3] >>> 2) & MASK8_1;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 3] & MASK8_2) << 3;
+      l2 |= (tmp[tmpIdx + 4] & MASK8_3) << 0;
+      longs[longsIdx + 2] = l2;
+    }
+  }
+
+  private static void decode6(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 12);
+    shiftLongs(tmp, 12, longs, 0, 2, MASK8_6);
+    shiftLongs(tmp, 12, tmp, 0, 0, MASK8_2);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 12; iter < 4; ++iter, tmpIdx += 3, longsIdx += 1) {
+      long l0 = tmp[tmpIdx + 0] << 4;
+      l0 |= tmp[tmpIdx + 1] << 2;
+      l0 |= tmp[tmpIdx + 2] << 0;
+      longs[longsIdx + 0] = l0;
+    }
+  }
+
+  private static void decode7(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 14);
+    shiftLongs(tmp, 14, longs, 0, 1, MASK8_7);
+    shiftLongs(tmp, 14, tmp, 0, 0, MASK8_1);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 14; iter < 2; ++iter, tmpIdx += 7, longsIdx += 1) {
+      long l0 = tmp[tmpIdx + 0] << 6;
+      l0 |= tmp[tmpIdx + 1] << 5;
+      l0 |= tmp[tmpIdx + 2] << 4;
+      l0 |= tmp[tmpIdx + 3] << 3;
+      l0 |= tmp[tmpIdx + 4] << 2;
+      l0 |= tmp[tmpIdx + 5] << 1;
+      l0 |= tmp[tmpIdx + 6] << 0;
+      longs[longsIdx + 0] = l0;
+    }
+  }
+
+  private static void decode8(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(longs, 0, 16);
+  }
+
+  private static void decode9(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 18);
+    shiftLongs(tmp, 18, longs, 0, 7, MASK16_9);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 18; iter < 2; ++iter, tmpIdx += 9, longsIdx += 7) {
+      long l0 = (tmp[tmpIdx + 0] & MASK16_7) << 2;
+      l0 |= (tmp[tmpIdx + 1] >>> 5) & MASK16_2;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK16_5) << 4;
+      l1 |= (tmp[tmpIdx + 2] >>> 3) & MASK16_4;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 2] & MASK16_3) << 6;
+      l2 |= (tmp[tmpIdx + 3] >>> 1) & MASK16_6;
+      longs[longsIdx + 2] = l2;
+      long l3 = (tmp[tmpIdx + 3] & MASK16_1) << 8;
+      l3 |= (tmp[tmpIdx + 4] & MASK16_7) << 1;
+      l3 |= (tmp[tmpIdx + 5] >>> 6) & MASK16_1;
+      longs[longsIdx + 3] = l3;
+      long l4 = (tmp[tmpIdx + 5] & MASK16_6) << 3;
+      l4 |= (tmp[tmpIdx + 6] >>> 4) & MASK16_3;
+      longs[longsIdx + 4] = l4;
+      long l5 = (tmp[tmpIdx + 6] & MASK16_4) << 5;
+      l5 |= (tmp[tmpIdx + 7] >>> 2) & MASK16_5;
+      longs[longsIdx + 5] = l5;
+      long l6 = (tmp[tmpIdx + 7] & MASK16_2) << 7;
+      l6 |= (tmp[tmpIdx + 8] & MASK16_7) << 0;
+      longs[longsIdx + 6] = l6;
+    }
+  }
+
+  private static void decode10(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 20);
+    shiftLongs(tmp, 20, longs, 0, 6, MASK16_10);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 20; iter < 4; ++iter, tmpIdx += 5, longsIdx += 3) {
+      long l0 = (tmp[tmpIdx + 0] & MASK16_6) << 4;
+      l0 |= (tmp[tmpIdx + 1] >>> 2) & MASK16_4;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK16_2) << 8;
+      l1 |= (tmp[tmpIdx + 2] & MASK16_6) << 2;
+      l1 |= (tmp[tmpIdx + 3] >>> 4) & MASK16_2;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 3] & MASK16_4) << 6;
+      l2 |= (tmp[tmpIdx + 4] & MASK16_6) << 0;
+      longs[longsIdx + 2] = l2;
+    }
+  }
+
+  private static void decode11(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 22);
+    shiftLongs(tmp, 22, longs, 0, 5, MASK16_11);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 22; iter < 2; ++iter, tmpIdx += 11, longsIdx += 5) {
+      long l0 = (tmp[tmpIdx + 0] & MASK16_5) << 6;
+      l0 |= (tmp[tmpIdx + 1] & MASK16_5) << 1;
+      l0 |= (tmp[tmpIdx + 2] >>> 4) & MASK16_1;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 2] & MASK16_4) << 7;
+      l1 |= (tmp[tmpIdx + 3] & MASK16_5) << 2;
+      l1 |= (tmp[tmpIdx + 4] >>> 3) & MASK16_2;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 4] & MASK16_3) << 8;
+      l2 |= (tmp[tmpIdx + 5] & MASK16_5) << 3;
+      l2 |= (tmp[tmpIdx + 6] >>> 2) & MASK16_3;
+      longs[longsIdx + 2] = l2;
+      long l3 = (tmp[tmpIdx + 6] & MASK16_2) << 9;
+      l3 |= (tmp[tmpIdx + 7] & MASK16_5) << 4;
+      l3 |= (tmp[tmpIdx + 8] >>> 1) & MASK16_4;
+      longs[longsIdx + 3] = l3;
+      long l4 = (tmp[tmpIdx + 8] & MASK16_1) << 10;
+      l4 |= (tmp[tmpIdx + 9] & MASK16_5) << 5;
+      l4 |= (tmp[tmpIdx + 10] & MASK16_5) << 0;
+      longs[longsIdx + 4] = l4;
+    }
+  }
+
+  private static void decode12(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 24);
+    shiftLongs(tmp, 24, longs, 0, 4, MASK16_12);
+    shiftLongs(tmp, 24, tmp, 0, 0, MASK16_4);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 24; iter < 8; ++iter, tmpIdx += 3, longsIdx += 1) {
+      long l0 = tmp[tmpIdx + 0] << 8;
+      l0 |= tmp[tmpIdx + 1] << 4;
+      l0 |= tmp[tmpIdx + 2] << 0;
+      longs[longsIdx + 0] = l0;
+    }
+  }
+
+  private static void decode13(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 26);
+    shiftLongs(tmp, 26, longs, 0, 3, MASK16_13);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 26; iter < 2; ++iter, tmpIdx += 13, longsIdx += 3) {
+      long l0 = (tmp[tmpIdx + 0] & MASK16_3) << 10;
+      l0 |= (tmp[tmpIdx + 1] & MASK16_3) << 7;
+      l0 |= (tmp[tmpIdx + 2] & MASK16_3) << 4;
+      l0 |= (tmp[tmpIdx + 3] & MASK16_3) << 1;
+      l0 |= (tmp[tmpIdx + 4] >>> 2) & MASK16_1;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 4] & MASK16_2) << 11;
+      l1 |= (tmp[tmpIdx + 5] & MASK16_3) << 8;
+      l1 |= (tmp[tmpIdx + 6] & MASK16_3) << 5;
+      l1 |= (tmp[tmpIdx + 7] & MASK16_3) << 2;
+      l1 |= (tmp[tmpIdx + 8] >>> 1) & MASK16_2;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 8] & MASK16_1) << 12;
+      l2 |= (tmp[tmpIdx + 9] & MASK16_3) << 9;
+      l2 |= (tmp[tmpIdx + 10] & MASK16_3) << 6;
+      l2 |= (tmp[tmpIdx + 11] & MASK16_3) << 3;
+      l2 |= (tmp[tmpIdx + 12] & MASK16_3) << 0;
+      longs[longsIdx + 2] = l2;
+    }
+  }
+
+  private static void decode14(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 28);
+    shiftLongs(tmp, 28, longs, 0, 2, MASK16_14);
+    shiftLongs(tmp, 28, tmp, 0, 0, MASK16_2);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 28; iter < 4; ++iter, tmpIdx += 7, longsIdx += 1) {
+      long l0 = tmp[tmpIdx + 0] << 12;
+      l0 |= tmp[tmpIdx + 1] << 10;
+      l0 |= tmp[tmpIdx + 2] << 8;
+      l0 |= tmp[tmpIdx + 3] << 6;
+      l0 |= tmp[tmpIdx + 4] << 4;
+      l0 |= tmp[tmpIdx + 5] << 2;
+      l0 |= tmp[tmpIdx + 6] << 0;
+      longs[longsIdx + 0] = l0;
+    }
+  }
+
+  private static void decode15(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 30);
+    shiftLongs(tmp, 30, longs, 0, 1, MASK16_15);
+    shiftLongs(tmp, 30, tmp, 0, 0, MASK16_1);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 30; iter < 2; ++iter, tmpIdx += 15, longsIdx += 1) {
+      long l0 = tmp[tmpIdx + 0] << 14;
+      l0 |= tmp[tmpIdx + 1] << 13;
+      l0 |= tmp[tmpIdx + 2] << 12;
+      l0 |= tmp[tmpIdx + 3] << 11;
+      l0 |= tmp[tmpIdx + 4] << 10;
+      l0 |= tmp[tmpIdx + 5] << 9;
+      l0 |= tmp[tmpIdx + 6] << 8;
+      l0 |= tmp[tmpIdx + 7] << 7;
+      l0 |= tmp[tmpIdx + 8] << 6;
+      l0 |= tmp[tmpIdx + 9] << 5;
+      l0 |= tmp[tmpIdx + 10] << 4;
+      l0 |= tmp[tmpIdx + 11] << 3;
+      l0 |= tmp[tmpIdx + 12] << 2;
+      l0 |= tmp[tmpIdx + 13] << 1;
+      l0 |= tmp[tmpIdx + 14] << 0;
+      longs[longsIdx + 0] = l0;
+    }
+  }
+
+  private static void decode16(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(longs, 0, 32);
+  }
+
+  private static void decode17(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 34);
+    shiftLongs(tmp, 34, longs, 0, 15, MASK32_17);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 34; iter < 2; ++iter, tmpIdx += 17, longsIdx += 15) {
+      long l0 = (tmp[tmpIdx + 0] & MASK32_15) << 2;
+      l0 |= (tmp[tmpIdx + 1] >>> 13) & MASK32_2;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK32_13) << 4;
+      l1 |= (tmp[tmpIdx + 2] >>> 11) & MASK32_4;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 2] & MASK32_11) << 6;
+      l2 |= (tmp[tmpIdx + 3] >>> 9) & MASK32_6;
+      longs[longsIdx + 2] = l2;
+      long l3 = (tmp[tmpIdx + 3] & MASK32_9) << 8;
+      l3 |= (tmp[tmpIdx + 4] >>> 7) & MASK32_8;
+      longs[longsIdx + 3] = l3;
+      long l4 = (tmp[tmpIdx + 4] & MASK32_7) << 10;
+      l4 |= (tmp[tmpIdx + 5] >>> 5) & MASK32_10;
+      longs[longsIdx + 4] = l4;
+      long l5 = (tmp[tmpIdx + 5] & MASK32_5) << 12;
+      l5 |= (tmp[tmpIdx + 6] >>> 3) & MASK32_12;
+      longs[longsIdx + 5] = l5;
+      long l6 = (tmp[tmpIdx + 6] & MASK32_3) << 14;
+      l6 |= (tmp[tmpIdx + 7] >>> 1) & MASK32_14;
+      longs[longsIdx + 6] = l6;
+      long l7 = (tmp[tmpIdx + 7] & MASK32_1) << 16;
+      l7 |= (tmp[tmpIdx + 8] & MASK32_15) << 1;
+      l7 |= (tmp[tmpIdx + 9] >>> 14) & MASK32_1;
+      longs[longsIdx + 7] = l7;
+      long l8 = (tmp[tmpIdx + 9] & MASK32_14) << 3;
+      l8 |= (tmp[tmpIdx + 10] >>> 12) & MASK32_3;
+      longs[longsIdx + 8] = l8;
+      long l9 = (tmp[tmpIdx + 10] & MASK32_12) << 5;
+      l9 |= (tmp[tmpIdx + 11] >>> 10) & MASK32_5;
+      longs[longsIdx + 9] = l9;
+      long l10 = (tmp[tmpIdx + 11] & MASK32_10) << 7;
+      l10 |= (tmp[tmpIdx + 12] >>> 8) & MASK32_7;
+      longs[longsIdx + 10] = l10;
+      long l11 = (tmp[tmpIdx + 12] & MASK32_8) << 9;
+      l11 |= (tmp[tmpIdx + 13] >>> 6) & MASK32_9;
+      longs[longsIdx + 11] = l11;
+      long l12 = (tmp[tmpIdx + 13] & MASK32_6) << 11;
+      l12 |= (tmp[tmpIdx + 14] >>> 4) & MASK32_11;
+      longs[longsIdx + 12] = l12;
+      long l13 = (tmp[tmpIdx + 14] & MASK32_4) << 13;
+      l13 |= (tmp[tmpIdx + 15] >>> 2) & MASK32_13;
+      longs[longsIdx + 13] = l13;
+      long l14 = (tmp[tmpIdx + 15] & MASK32_2) << 15;
+      l14 |= (tmp[tmpIdx + 16] & MASK32_15) << 0;
+      longs[longsIdx + 14] = l14;
+    }
+  }
+
+  private static void decode18(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 36);
+    shiftLongs(tmp, 36, longs, 0, 14, MASK32_18);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 36; iter < 4; ++iter, tmpIdx += 9, longsIdx += 7) {
+      long l0 = (tmp[tmpIdx + 0] & MASK32_14) << 4;
+      l0 |= (tmp[tmpIdx + 1] >>> 10) & MASK32_4;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK32_10) << 8;
+      l1 |= (tmp[tmpIdx + 2] >>> 6) & MASK32_8;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 2] & MASK32_6) << 12;
+      l2 |= (tmp[tmpIdx + 3] >>> 2) & MASK32_12;
+      longs[longsIdx + 2] = l2;
+      long l3 = (tmp[tmpIdx + 3] & MASK32_2) << 16;
+      l3 |= (tmp[tmpIdx + 4] & MASK32_14) << 2;
+      l3 |= (tmp[tmpIdx + 5] >>> 12) & MASK32_2;
+      longs[longsIdx + 3] = l3;
+      long l4 = (tmp[tmpIdx + 5] & MASK32_12) << 6;
+      l4 |= (tmp[tmpIdx + 6] >>> 8) & MASK32_6;
+      longs[longsIdx + 4] = l4;
+      long l5 = (tmp[tmpIdx + 6] & MASK32_8) << 10;
+      l5 |= (tmp[tmpIdx + 7] >>> 4) & MASK32_10;
+      longs[longsIdx + 5] = l5;
+      long l6 = (tmp[tmpIdx + 7] & MASK32_4) << 14;
+      l6 |= (tmp[tmpIdx + 8] & MASK32_14) << 0;
+      longs[longsIdx + 6] = l6;
+    }
+  }
+
+  private static void decode19(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 38);
+    shiftLongs(tmp, 38, longs, 0, 13, MASK32_19);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 38; iter < 2; ++iter, tmpIdx += 19, longsIdx += 13) {
+      long l0 = (tmp[tmpIdx + 0] & MASK32_13) << 6;
+      l0 |= (tmp[tmpIdx + 1] >>> 7) & MASK32_6;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK32_7) << 12;
+      l1 |= (tmp[tmpIdx + 2] >>> 1) & MASK32_12;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 2] & MASK32_1) << 18;
+      l2 |= (tmp[tmpIdx + 3] & MASK32_13) << 5;
+      l2 |= (tmp[tmpIdx + 4] >>> 8) & MASK32_5;
+      longs[longsIdx + 2] = l2;
+      long l3 = (tmp[tmpIdx + 4] & MASK32_8) << 11;
+      l3 |= (tmp[tmpIdx + 5] >>> 2) & MASK32_11;
+      longs[longsIdx + 3] = l3;
+      long l4 = (tmp[tmpIdx + 5] & MASK32_2) << 17;
+      l4 |= (tmp[tmpIdx + 6] & MASK32_13) << 4;
+      l4 |= (tmp[tmpIdx + 7] >>> 9) & MASK32_4;
+      longs[longsIdx + 4] = l4;
+      long l5 = (tmp[tmpIdx + 7] & MASK32_9) << 10;
+      l5 |= (tmp[tmpIdx + 8] >>> 3) & MASK32_10;
+      longs[longsIdx + 5] = l5;
+      long l6 = (tmp[tmpIdx + 8] & MASK32_3) << 16;
+      l6 |= (tmp[tmpIdx + 9] & MASK32_13) << 3;
+      l6 |= (tmp[tmpIdx + 10] >>> 10) & MASK32_3;
+      longs[longsIdx + 6] = l6;
+      long l7 = (tmp[tmpIdx + 10] & MASK32_10) << 9;
+      l7 |= (tmp[tmpIdx + 11] >>> 4) & MASK32_9;
+      longs[longsIdx + 7] = l7;
+      long l8 = (tmp[tmpIdx + 11] & MASK32_4) << 15;
+      l8 |= (tmp[tmpIdx + 12] & MASK32_13) << 2;
+      l8 |= (tmp[tmpIdx + 13] >>> 11) & MASK32_2;
+      longs[longsIdx + 8] = l8;
+      long l9 = (tmp[tmpIdx + 13] & MASK32_11) << 8;
+      l9 |= (tmp[tmpIdx + 14] >>> 5) & MASK32_8;
+      longs[longsIdx + 9] = l9;
+      long l10 = (tmp[tmpIdx + 14] & MASK32_5) << 14;
+      l10 |= (tmp[tmpIdx + 15] & MASK32_13) << 1;
+      l10 |= (tmp[tmpIdx + 16] >>> 12) & MASK32_1;
+      longs[longsIdx + 10] = l10;
+      long l11 = (tmp[tmpIdx + 16] & MASK32_12) << 7;
+      l11 |= (tmp[tmpIdx + 17] >>> 6) & MASK32_7;
+      longs[longsIdx + 11] = l11;
+      long l12 = (tmp[tmpIdx + 17] & MASK32_6) << 13;
+      l12 |= (tmp[tmpIdx + 18] & MASK32_13) << 0;
+      longs[longsIdx + 12] = l12;
+    }
+  }
+
+  private static void decode20(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 40);
+    shiftLongs(tmp, 40, longs, 0, 12, MASK32_20);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 40; iter < 8; ++iter, tmpIdx += 5, longsIdx += 3) {
+      long l0 = (tmp[tmpIdx + 0] & MASK32_12) << 8;
+      l0 |= (tmp[tmpIdx + 1] >>> 4) & MASK32_8;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK32_4) << 16;
+      l1 |= (tmp[tmpIdx + 2] & MASK32_12) << 4;
+      l1 |= (tmp[tmpIdx + 3] >>> 8) & MASK32_4;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 3] & MASK32_8) << 12;
+      l2 |= (tmp[tmpIdx + 4] & MASK32_12) << 0;
+      longs[longsIdx + 2] = l2;
+    }
+  }
+
+  private static void decode21(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 42);
+    shiftLongs(tmp, 42, longs, 0, 11, MASK32_21);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 42; iter < 2; ++iter, tmpIdx += 21, longsIdx += 11) {
+      long l0 = (tmp[tmpIdx + 0] & MASK32_11) << 10;
+      l0 |= (tmp[tmpIdx + 1] >>> 1) & MASK32_10;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK32_1) << 20;
+      l1 |= (tmp[tmpIdx + 2] & MASK32_11) << 9;
+      l1 |= (tmp[tmpIdx + 3] >>> 2) & MASK32_9;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 3] & MASK32_2) << 19;
+      l2 |= (tmp[tmpIdx + 4] & MASK32_11) << 8;
+      l2 |= (tmp[tmpIdx + 5] >>> 3) & MASK32_8;
+      longs[longsIdx + 2] = l2;
+      long l3 = (tmp[tmpIdx + 5] & MASK32_3) << 18;
+      l3 |= (tmp[tmpIdx + 6] & MASK32_11) << 7;
+      l3 |= (tmp[tmpIdx + 7] >>> 4) & MASK32_7;
+      longs[longsIdx + 3] = l3;
+      long l4 = (tmp[tmpIdx + 7] & MASK32_4) << 17;
+      l4 |= (tmp[tmpIdx + 8] & MASK32_11) << 6;
+      l4 |= (tmp[tmpIdx + 9] >>> 5) & MASK32_6;
+      longs[longsIdx + 4] = l4;
+      long l5 = (tmp[tmpIdx + 9] & MASK32_5) << 16;
+      l5 |= (tmp[tmpIdx + 10] & MASK32_11) << 5;
+      l5 |= (tmp[tmpIdx + 11] >>> 6) & MASK32_5;
+      longs[longsIdx + 5] = l5;
+      long l6 = (tmp[tmpIdx + 11] & MASK32_6) << 15;
+      l6 |= (tmp[tmpIdx + 12] & MASK32_11) << 4;
+      l6 |= (tmp[tmpIdx + 13] >>> 7) & MASK32_4;
+      longs[longsIdx + 6] = l6;
+      long l7 = (tmp[tmpIdx + 13] & MASK32_7) << 14;
+      l7 |= (tmp[tmpIdx + 14] & MASK32_11) << 3;
+      l7 |= (tmp[tmpIdx + 15] >>> 8) & MASK32_3;
+      longs[longsIdx + 7] = l7;
+      long l8 = (tmp[tmpIdx + 15] & MASK32_8) << 13;
+      l8 |= (tmp[tmpIdx + 16] & MASK32_11) << 2;
+      l8 |= (tmp[tmpIdx + 17] >>> 9) & MASK32_2;
+      longs[longsIdx + 8] = l8;
+      long l9 = (tmp[tmpIdx + 17] & MASK32_9) << 12;
+      l9 |= (tmp[tmpIdx + 18] & MASK32_11) << 1;
+      l9 |= (tmp[tmpIdx + 19] >>> 10) & MASK32_1;
+      longs[longsIdx + 9] = l9;
+      long l10 = (tmp[tmpIdx + 19] & MASK32_10) << 11;
+      l10 |= (tmp[tmpIdx + 20] & MASK32_11) << 0;
+      longs[longsIdx + 10] = l10;
+    }
+  }
+
+  private static void decode22(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 44);
+    shiftLongs(tmp, 44, longs, 0, 10, MASK32_22);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 44; iter < 4; ++iter, tmpIdx += 11, longsIdx += 5) {
+      long l0 = (tmp[tmpIdx + 0] & MASK32_10) << 12;
+      l0 |= (tmp[tmpIdx + 1] & MASK32_10) << 2;
+      l0 |= (tmp[tmpIdx + 2] >>> 8) & MASK32_2;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 2] & MASK32_8) << 14;
+      l1 |= (tmp[tmpIdx + 3] & MASK32_10) << 4;
+      l1 |= (tmp[tmpIdx + 4] >>> 6) & MASK32_4;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 4] & MASK32_6) << 16;
+      l2 |= (tmp[tmpIdx + 5] & MASK32_10) << 6;
+      l2 |= (tmp[tmpIdx + 6] >>> 4) & MASK32_6;
+      longs[longsIdx + 2] = l2;
+      long l3 = (tmp[tmpIdx + 6] & MASK32_4) << 18;
+      l3 |= (tmp[tmpIdx + 7] & MASK32_10) << 8;
+      l3 |= (tmp[tmpIdx + 8] >>> 2) & MASK32_8;
+      longs[longsIdx + 3] = l3;
+      long l4 = (tmp[tmpIdx + 8] & MASK32_2) << 20;
+      l4 |= (tmp[tmpIdx + 9] & MASK32_10) << 10;
+      l4 |= (tmp[tmpIdx + 10] & MASK32_10) << 0;
+      longs[longsIdx + 4] = l4;
+    }
+  }
+
+  private static void decode23(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 46);
+    shiftLongs(tmp, 46, longs, 0, 9, MASK32_23);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 46; iter < 2; ++iter, tmpIdx += 23, longsIdx += 9) {
+      long l0 = (tmp[tmpIdx + 0] & MASK32_9) << 14;
+      l0 |= (tmp[tmpIdx + 1] & MASK32_9) << 5;
+      l0 |= (tmp[tmpIdx + 2] >>> 4) & MASK32_5;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 2] & MASK32_4) << 19;
+      l1 |= (tmp[tmpIdx + 3] & MASK32_9) << 10;
+      l1 |= (tmp[tmpIdx + 4] & MASK32_9) << 1;
+      l1 |= (tmp[tmpIdx + 5] >>> 8) & MASK32_1;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 5] & MASK32_8) << 15;
+      l2 |= (tmp[tmpIdx + 6] & MASK32_9) << 6;
+      l2 |= (tmp[tmpIdx + 7] >>> 3) & MASK32_6;
+      longs[longsIdx + 2] = l2;
+      long l3 = (tmp[tmpIdx + 7] & MASK32_3) << 20;
+      l3 |= (tmp[tmpIdx + 8] & MASK32_9) << 11;
+      l3 |= (tmp[tmpIdx + 9] & MASK32_9) << 2;
+      l3 |= (tmp[tmpIdx + 10] >>> 7) & MASK32_2;
+      longs[longsIdx + 3] = l3;
+      long l4 = (tmp[tmpIdx + 10] & MASK32_7) << 16;
+      l4 |= (tmp[tmpIdx + 11] & MASK32_9) << 7;
+      l4 |= (tmp[tmpIdx + 12] >>> 2) & MASK32_7;
+      longs[longsIdx + 4] = l4;
+      long l5 = (tmp[tmpIdx + 12] & MASK32_2) << 21;
+      l5 |= (tmp[tmpIdx + 13] & MASK32_9) << 12;
+      l5 |= (tmp[tmpIdx + 14] & MASK32_9) << 3;
+      l5 |= (tmp[tmpIdx + 15] >>> 6) & MASK32_3;
+      longs[longsIdx + 5] = l5;
+      long l6 = (tmp[tmpIdx + 15] & MASK32_6) << 17;
+      l6 |= (tmp[tmpIdx + 16] & MASK32_9) << 8;
+      l6 |= (tmp[tmpIdx + 17] >>> 1) & MASK32_8;
+      longs[longsIdx + 6] = l6;
+      long l7 = (tmp[tmpIdx + 17] & MASK32_1) << 22;
+      l7 |= (tmp[tmpIdx + 18] & MASK32_9) << 13;
+      l7 |= (tmp[tmpIdx + 19] & MASK32_9) << 4;
+      l7 |= (tmp[tmpIdx + 20] >>> 5) & MASK32_4;
+      longs[longsIdx + 7] = l7;
+      long l8 = (tmp[tmpIdx + 20] & MASK32_5) << 18;
+      l8 |= (tmp[tmpIdx + 21] & MASK32_9) << 9;
+      l8 |= (tmp[tmpIdx + 22] & MASK32_9) << 0;
+      longs[longsIdx + 8] = l8;
+    }
+  }
+
+  private static void decode24(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 48);
+    shiftLongs(tmp, 48, longs, 0, 8, MASK32_24);
+    shiftLongs(tmp, 48, tmp, 0, 0, MASK32_8);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 48; iter < 16; ++iter, tmpIdx += 3, longsIdx += 1) {
+      long l0 = tmp[tmpIdx + 0] << 16;
+      l0 |= tmp[tmpIdx + 1] << 8;
+      l0 |= tmp[tmpIdx + 2] << 0;
+      longs[longsIdx + 0] = l0;
+    }
+  }
+}

--- a/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
+++ b/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
@@ -82,4 +82,9 @@ final class PanamaVectorizationProvider extends VectorizationProvider {
   public VectorUtilSupport getVectorUtilSupport() {
     return vectorUtilSupport;
   }
+
+  @Override
+  public ForUtil90 newForUtil90() {
+    return new PanamaForUtil90();
+  }
 }

--- a/lucene/core/src/java20/org/apache/lucene/internal/vectorization/gen_PanamaForUtil90.py
+++ b/lucene/core/src/java20/org/apache/lucene/internal/vectorization/gen_PanamaForUtil90.py
@@ -1,0 +1,835 @@
+#! /usr/bin/env python
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Code generation for PanamaForUtil90.java"""
+
+MAX_SPECIALIZED_BITS_PER_VALUE = 24
+OUTPUT_FILE = "PanamaForUtil90.java"
+PRIMITIVE_SIZE = [8, 16, 32]
+HEADER = """// This file has been automatically generated, DO NOT EDIT
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.internal.vectorization;
+
+import java.io.IOException;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+
+// Inspired from https://fulmicoton.com/posts/bitpacking/
+// Encodes multiple integers in a long to get SIMD-like speedups.
+// If bitsPerValue <= 8 then we pack 8 ints per long
+// else if bitsPerValue <= 16 we pack 4 ints per long
+// else we pack 2 ints per long
+final class PanamaForUtil90 implements ForUtil90 {
+
+  private static final VectorSpecies<Long> LANESIZE_2 = LongVector.SPECIES_128;
+
+  private static final VectorSpecies<Long> LANESIZE_4 = LongVector.SPECIES_256;
+
+  private static long expandMask32(long mask32) {
+    return mask32 | (mask32 << 32);
+  }
+
+  private static long expandMask16(long mask16) {
+    return expandMask32(mask16 | (mask16 << 16));
+  }
+
+  private static long expandMask8(long mask8) {
+    return expandMask16(mask8 | (mask8 << 8));
+  }
+
+  private static long mask32(int bitsPerValue) {
+    return expandMask32((1L << bitsPerValue) - 1);
+  }
+
+  private static long mask16(int bitsPerValue) {
+    return expandMask16((1L << bitsPerValue) - 1);
+  }
+
+  private static long mask8(int bitsPerValue) {
+    return expandMask8((1L << bitsPerValue) - 1);
+  }
+
+  private static void expand8(long[] arr) {
+    for (int i = 0; i < 16; ++i) {
+      long l = arr[i];
+      arr[i] = (l >>> 56) & 0xFFL;
+      arr[16 + i] = (l >>> 48) & 0xFFL;
+      arr[32 + i] = (l >>> 40) & 0xFFL;
+      arr[48 + i] = (l >>> 32) & 0xFFL;
+      arr[64 + i] = (l >>> 24) & 0xFFL;
+      arr[80 + i] = (l >>> 16) & 0xFFL;
+      arr[96 + i] = (l >>> 8) & 0xFFL;
+      arr[112 + i] = l & 0xFFL;
+    }
+  }
+
+  private static void expand8To32(long[] arr) {
+    for (int i = 0; i < 16; ++i) {
+      long l = arr[i];
+      arr[i] = (l >>> 24) & 0x000000FF000000FFL;
+      arr[16 + i] = (l >>> 16) & 0x000000FF000000FFL;
+      arr[32 + i] = (l >>> 8) & 0x000000FF000000FFL;
+      arr[48 + i] = l & 0x000000FF000000FFL;
+    }
+  }
+
+  private static void expand16(long[] arr) {
+    for (int i = 0; i < 32; ++i) {
+      long l = arr[i];
+      arr[i] = (l >>> 48) & 0xFFFFL;
+      arr[32 + i] = (l >>> 32) & 0xFFFFL;
+      arr[64 + i] = (l >>> 16) & 0xFFFFL;
+      arr[96 + i] = l & 0xFFFFL;
+    }
+  }
+
+  private static void expand16To32(long[] arr) {
+    for (int i = 0; i < 32; ++i) {
+      long l = arr[i];
+      arr[i] = (l >>> 16) & 0x0000FFFF0000FFFFL;
+      arr[32 + i] = l & 0x0000FFFF0000FFFFL;
+    }
+  }
+
+  private static void expand32(long[] arr) {
+    for (int i = 0; i < 64; ++i) {
+      long l = arr[i];
+      arr[i] = l >>> 32;
+      arr[64 + i] = l & 0xFFFFFFFFL;
+    }
+  }
+
+  private final long[] tmp = new long[BLOCK_SIZE / 2];
+
+  private static void encode1(long[] input, int bitsPerValue, long[] out) {
+    LongVector outputVector = LANESIZE_2.zero().reinterpretAsLongs();
+    long mask = (1L << 1) - 1;
+
+    LongVector inputVector = LongVector.fromArray(LANESIZE_2, input, 0).and(mask);
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 63);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 2).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 62).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 4).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 61).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 6).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 60).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 8).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 59).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 10).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 58).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 12).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 57).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 14).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 56).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 16).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 55).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 18).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 54).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 20).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 53).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 22).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 52).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 24).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 51).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 26).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 50).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 28).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 49).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 30).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 48).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 32).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 47).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 34).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 46).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 36).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 45).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 38).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 44).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 40).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 43).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 42).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 42).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 44).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 41).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 46).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 40).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 48).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 39).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 50).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 38).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 52).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 37).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 54).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 36).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 56).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 35).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 58).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 34).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 60).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 33).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 62).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 32).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 64).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 31).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 66).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 30).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 68).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 29).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 70).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 28).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 72).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 27).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 74).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 26).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 76).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 25).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 78).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 24).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 80).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 23).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 82).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 22).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 84).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 21).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 86).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 20).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 88).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 19).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 90).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 18).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 92).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 17).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 94).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 16).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 96).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 15).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 98).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 14).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 100).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 13).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 102).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 12).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 104).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 11).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 106).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 10).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 108).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 9).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 110).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 8).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 112).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 7).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 114).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 6).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 116).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 5).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 118).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 4).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 120).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 3).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 122).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 2).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 124).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 1).or(outputVector);
+    inputVector = LongVector.fromArray(LANESIZE_2, input, 126).and(mask);
+
+    outputVector = inputVector.lanewise(VectorOperators.LSHL, 0).or(outputVector);
+    outputVector.intoArray(out, 0);
+  }
+
+   @Override
+   public void encode(long[] longs, int bitsPerValue, DataOutput out) throws IOException {
+    switch (bitsPerValue) {
+      case 1 -> encode1(longs, bitsPerValue, tmp);
+      case 2 -> encode2(longs, bitsPerValue, tmp);
+      case 3 -> encode3(longs, bitsPerValue, tmp);
+      case 4 -> encode4(longs, bitsPerValue, tmp);
+      case 5 -> encode5(longs, bitsPerValue, tmp);
+      case 6 -> encode6(longs, bitsPerValue, tmp);
+      case 7 -> encode7(longs, bitsPerValue, tmp);
+      case 8 -> encode8(longs, bitsPerValue, tmp);
+      case 9 -> encode9(longs, bitsPerValue, tmp);
+      case 10 -> encode10(longs, bitsPerValue, tmp);
+      case 11 -> encode11(longs, bitsPerValue, tmp);
+      case 12 -> encode12(longs, bitsPerValue, tmp);
+      case 13 -> encode13(longs, bitsPerValue, tmp);
+      case 14 -> encode14(longs, bitsPerValue, tmp);
+      case 15 -> encode15(longs, bitsPerValue, tmp);
+      case 16 -> encode16(longs, bitsPerValue, tmp);
+      case 17 -> encode17(longs, bitsPerValue, tmp);
+      case 18 -> encode18(longs, bitsPerValue, tmp);
+      case 19 -> encode19(longs, bitsPerValue, tmp);
+      case 20 -> encode20(longs, bitsPerValue, tmp);
+      case 21 -> encode21(longs, bitsPerValue, tmp);
+      case 22 -> encode22(longs, bitsPerValue, tmp);
+      case 23 -> encode23(longs, bitsPerValue, tmp);
+      case 24 -> encode24(longs, bitsPerValue, tmp);
+      case 25 -> encode25(longs, bitsPerValue, tmp);
+      case 26 -> encode26(longs, bitsPerValue, tmp);
+      case 27 -> encode27(longs, bitsPerValue, tmp);
+      case 28 -> encode28(longs, bitsPerValue, tmp);
+      case 29 -> encode29(longs, bitsPerValue, tmp);
+      case 30 -> encode30(longs, bitsPerValue, tmp);
+      case 31 -> encode31(longs, bitsPerValue, tmp);
+      case 32 -> encode32(longs, bitsPerValue, tmp);
+    }
+
+    for (int i = 0; i < 2 * bitsPerValue; ++i) {
+      // Java longs are big endian and we want to read little endian longs, so we need to reverse
+      // bytes
+      long l = tmp[i];
+      out.writeLong(l);
+    }
+  }
+
+  private static void decodeSlow(int bitsPerValue, DataInput in, long[] tmp, long[] longs)
+      throws IOException {
+    final int numLongs = bitsPerValue << 1;
+    in.readLongs(tmp, 0, numLongs);
+    final long mask = MASKS32[bitsPerValue];
+    int longsIdx = 0;
+    int shift = 32 - bitsPerValue;
+    for (; shift >= 0; shift -= bitsPerValue) {
+      shiftLongs(tmp, numLongs, longs, longsIdx, shift, mask);
+      longsIdx += numLongs;
+    }
+    final int remainingBitsPerLong = shift + bitsPerValue;
+    final long mask32RemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+    int tmpIdx = 0;
+    int remainingBits = remainingBitsPerLong;
+    for (; longsIdx < BLOCK_SIZE / 2; ++longsIdx) {
+      int b = bitsPerValue - remainingBits;
+      long l = (tmp[tmpIdx++] & MASKS32[remainingBits]) << b;
+      while (b >= remainingBitsPerLong) {
+        b -= remainingBitsPerLong;
+        l |= (tmp[tmpIdx++] & mask32RemainingBitsPerLong) << b;
+      }
+      if (b > 0) {
+        l |= (tmp[tmpIdx] >>> (remainingBitsPerLong - b)) & MASKS32[b];
+        remainingBits = remainingBitsPerLong - b;
+      } else {
+        remainingBits = remainingBitsPerLong;
+      }
+      longs[longsIdx] = l;
+    }
+  }
+
+  /**
+   * The pattern that this shiftLongs method applies is recognized by the C2 compiler, which
+   * generates SIMD instructions for it in order to shift multiple longs at once.
+   */
+  private static void shiftLongs(long[] a, int count, long[] b, int bi, int shift, long mask) {
+    for (int i = 0; i < count; ++i) {
+      b[bi + i] = (a[i] >>> shift) & mask;
+    }
+  }
+
+"""
+
+
+def writeRemainderWithSIMDOptimize(bpv, next_primitive, remaining_bits_per_long, o, num_values, f):
+    iteration = 1
+    num_longs = bpv * num_values / remaining_bits_per_long
+    while num_longs % 2 == 0 and num_values % 2 == 0:
+        num_longs /= 2
+        num_values /= 2
+        iteration *= 2
+
+    f.write('    shiftLongs(tmp, %d, tmp, 0, 0, MASK%d_%d);\n' %
+            (iteration * num_longs, next_primitive, remaining_bits_per_long))
+    f.write('    for (int iter = 0, tmpIdx = 0, longsIdx = %d; iter < %d; ++iter, tmpIdx += %d, longsIdx += %d) {\n' % (
+        o, iteration, num_longs, num_values))
+    tmp_idx = 0
+    b = bpv
+    b -= remaining_bits_per_long
+    f.write('      long l0 = tmp[tmpIdx + %d] << %d;\n' % (tmp_idx, b))
+    tmp_idx += 1
+    while b >= remaining_bits_per_long:
+        b -= remaining_bits_per_long
+        f.write('      l0 |= tmp[tmpIdx + %d] << %d;\n' % (tmp_idx, b))
+        tmp_idx += 1
+    f.write('      longs[longsIdx + 0] = l0;\n')
+    f.write('    }\n')
+
+
+def writeRemainder(bpv, next_primitive, remaining_bits_per_long, o, num_values, f):
+    iteration = 1
+    num_longs = bpv * num_values / remaining_bits_per_long
+    while num_longs % 2 == 0 and num_values % 2 == 0:
+        num_longs /= 2
+        num_values /= 2
+        iteration *= 2
+    f.write('    for (int iter = 0, tmpIdx = 0, longsIdx = %d; iter < %d; ++iter, tmpIdx += %d, longsIdx += %d) {\n' % (
+        o, iteration, num_longs, num_values))
+    i = 0
+    remaining_bits = 0
+    tmp_idx = 0
+    for i in range(int(num_values)):
+        b = bpv
+        if remaining_bits == 0:
+            b -= remaining_bits_per_long
+            f.write('      long l%d = (tmp[tmpIdx + %d] & MASK%d_%d) << %d;\n' % (
+                i, tmp_idx, next_primitive, remaining_bits_per_long, b))
+        else:
+            b -= remaining_bits
+            f.write('      long l%d = (tmp[tmpIdx + %d] & MASK%d_%d) << %d;\n' % (
+                i, tmp_idx, next_primitive, remaining_bits, b))
+        tmp_idx += 1
+        while b >= remaining_bits_per_long:
+            b -= remaining_bits_per_long
+            f.write('      l%d |= (tmp[tmpIdx + %d] & MASK%d_%d) << %d;\n' %
+                    (i, tmp_idx, next_primitive, remaining_bits_per_long, b))
+            tmp_idx += 1
+        if b > 0:
+            f.write('      l%d |= (tmp[tmpIdx + %d] >>> %d) & MASK%d_%d;\n' %
+                    (i, tmp_idx, remaining_bits_per_long-b, next_primitive, b))
+            remaining_bits = remaining_bits_per_long-b
+        f.write('      longs[longsIdx + %d] = l%d;\n' % (i, i))
+    f.write('    }\n')
+
+
+def writeDecode(bpv, f):
+    next_primitive = 32
+    if bpv <= 8:
+        next_primitive = 8
+    elif bpv <= 16:
+        next_primitive = 16
+    f.write(
+        '  private static void decode%d(DataInput in, long[] tmp, long[] longs) throws IOException {\n' % bpv)
+    num_values_per_long = 64 / next_primitive
+    if bpv == next_primitive:
+        f.write('    in.readLongs(longs, 0, %d);\n' % (bpv*2))
+    else:
+        f.write('    in.readLongs(tmp, 0, %d);\n' % (bpv*2))
+        shift = next_primitive - bpv
+        o = 0
+        while shift >= 0:
+            f.write('    shiftLongs(tmp, %d, longs, %d, %d, MASK%d_%d);\n' %
+                    (bpv*2, o, shift, next_primitive, bpv))
+            o += bpv*2
+            shift -= bpv
+        if shift + bpv > 0:
+            if bpv % (next_primitive % bpv) == 0:
+                writeRemainderWithSIMDOptimize(
+                    bpv, next_primitive, shift + bpv, o, 128/num_values_per_long - o, f)
+            else:
+                writeRemainder(bpv, next_primitive, shift + bpv,
+                               o, 128/num_values_per_long - o, f)
+    f.write('  }\n')
+
+
+def calculateCompressedFormat(bpv, next_primitive):
+    """
+    Calculate the compress format.
+    Currently it's a rough compress, we will compress it more later.
+    For example, if we have 128 values and bpv = 3, we could roughly compress it like:
+    0  16 ... ... 112
+    1  17 ... ...  .
+    2  18 ... ...  .
+    .  .   .   .   .
+    .  .   .   .   .
+    15 31 ... ... 127
+    """
+    # Initialize a list to store the compressed format
+    compressed_format = [[] for _ in range(2 * next_primitive)]
+    remaining = next_primitive
+
+    for num in range(128):
+        compressed_format[num % (2 * next_primitive)].append(num)
+
+    remaining -= bpv
+    return compressed_format, remaining
+
+
+def compactCompressedFormat(compressed_format, bpv, next_primitive, remaining):
+    """
+    Suppose we have bpv = 3 and 128 values.
+    We will use 8 bits to compress it, and 2 values could fit in 8 bits.
+    We have already used 3 bits before, so we still can use 5 bits to compress it.
+    So we will try to compress the next_line data into a line which is lower than compress_bound
+    until remaining < bpv or we have compressed all data.
+    """
+
+    # Initialize variables to compress the next line into compress_bound
+    next_line = 2 * bpv
+    line_num = 0
+
+    while next_line < 2 * next_primitive and remaining >= bpv:
+        pos = int((next_primitive - remaining) / bpv)
+        adjcent = pos + 1
+        for val in compressed_format[next_line]:
+            compressed_format[line_num % (2 * bpv)].insert(pos, val)
+            pos += adjcent
+        line_num += 1
+        next_line += 1
+        if line_num % (2 * bpv) == 0:
+            remaining -= bpv
+    return compressed_format, remaining, next_line
+
+
+def compressData(compressed_format, bpv, next_primitive, f):
+    # Define templates for initializing, resetting, and writing output vectors
+    init_template = """
+    LongVector outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+    long mask = (1L << %d) - 1;
+                                
+    LongVector inputVector = LongVector.fromArray(LANESIZE_4, input, %d).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, %d));\n"""
+
+    reset_template = """
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+                                
+    inputVector = LongVector.fromArray(LANESIZE_4, input, %d).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, %d));\n"""
+
+    program_template = """
+    inputVector = LongVector.fromArray(LANESIZE_4, input, %d).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, %d));\n"""
+
+    output_template = """
+    outputVector.intoArray(out, %d);\n"""
+
+    # Compress the data using the compressed format
+    first = True
+    for iter in range(0, 2 * bpv - 3, 4):
+        compress_line = compressed_format[iter]
+        block_remaining = next_primitive - bpv
+        times = 0
+
+        # Write the initialization or reset template to the file depending on whether this is the first iteration
+        if first:
+            f.write(init_template % (bpv, compress_line[0], 64 - bpv))
+            first = False
+        else:
+            f.write(reset_template % (compress_line[0], 64 - bpv))
+
+        # Write the program template to the file for each value in the compressed line
+        for i in range(1, len(compress_line)):
+            if block_remaining - bpv >= 0:
+                f.write(program_template % (
+                    compress_line[i], 64 - bpv - times * next_primitive - (next_primitive - block_remaining)))
+                block_remaining -= bpv
+            else:
+                times += 1
+                block_remaining = next_primitive - bpv
+                f.write(program_template %
+                        (compress_line[i], 64 - bpv - times * next_primitive))
+        f.write(output_template % (iter))
+
+
+def compressRemainingData(compressed_format, bpv, next_primitive, next_line, f):
+  # Define templates for initializing and writing output vectors
+    init_template = """
+    outputVector = LANESIZE_4.zero().reinterpretAsLongs();
+              
+    inputVector = LongVector.fromArray(LANESIZE_4, input, %d).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, %d));\n
+  """
+
+    program_template = """
+    inputVector = LongVector.fromArray(LANESIZE_4, input, %d).and(mask);
+    outputVector = outputVector.or(inputVector.lanewise(VectorOperators.LSHL, %d));
+  """
+
+    output_template = """
+    outputVector.intoArray(out, %d);"""
+
+    # Compress any remaining data that is not in the compress_bound
+    start_index = next_line
+    while start_index + 4 <= 2 * next_primitive:
+        compress_line = compressed_format[start_index]
+        f.write(init_template % (compress_line[0], 64 - next_primitive))
+        for i in range(1, len(compress_line)):
+            f.write(program_template %
+                    (compress_line[i], 64 - next_primitive * (i + 1)))
+        f.write(output_template % (start_index))
+        start_index += 4
+    return start_index
+
+
+def writeEncode(bpv, f):
+    # Write the method signature to the file
+    f.write(
+        '  private static void encode%d(long[] input, int bitsPerValue, long[] out) throws IOException {' % bpv)
+
+    # Determine the next power of 2 which is larger than or equal to bpv to compress the data
+    next_primitive = 32 if bpv > 16 else 16 if bpv > 8 else 8
+
+    compressed_format, remaining = calculateCompressedFormat(
+        bpv, next_primitive)
+
+    # Calculate the number of longs we need to compress 128 values
+    # compress_bound = 128 * bpv / 64 = 2 * bpv
+    compress_bound = 2 * bpv
+
+    compressed_format, remaining, next_line = compactCompressedFormat(
+        compressed_format, bpv, next_primitive, remaining)
+
+    # Compress any remaining data that is in the compress_bound
+    compressData(compressed_format, bpv, next_primitive, f)
+    compress_partial_data(bpv, compressed_format,
+                          next_primitive, f, bpv // 2 * 4, 2 * bpv)
+
+    # Compress all remaining data that is not in the compress_bound
+    start_index = compressRemainingData(
+        compressed_format, bpv, next_primitive, next_line, f)
+    compress_partial_data(next_primitive, compressed_format,
+                          next_primitive, f, start_index, 2 * next_primitive)
+
+    # Write the remaining code to the file
+    end = """
+    final int remainingBitsPerLong = %d;
+    final long maskRemainingBitsPerLong = MASKS%d[remainingBitsPerLong];
+            
+    int tmpIdx = 0;
+    int idx = %d;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < %d) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+
+        mask1 = MASKS%d[remainingBitsPerValue];
+        mask2 = MASKS%d[remainingBitsPerLong - remainingBitsPerValue];
+        out[tmpIdx] |= (out[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        out[tmpIdx++] |= (out[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+"""
+
+    # If we have data which is out of compress_bound, we need to compress them into compress_bound
+    # For example, if we have bpv = 3 and 128 values, we have already compressed 2 values into 1 byte,
+    # we still have 2 bits remaining, so we could use 2 lines to compress 1 value.
+    if next_line < 2 * next_primitive:
+        f.write(end % (next_primitive % bpv, next_primitive, next_line,
+                2 * next_primitive, next_primitive, next_primitive))
+
+    # Write the end of the method to the file
+    f.write("""  }\n\n""")
+
+
+def compress_partial_data(bpv, compressed_format, next_primitive, f, start, end, step=1):
+    """
+      Suppose we have bpv = 3 and 128 values 
+      we should compress it into 6 long, and we compressed it use simd
+      which means we will output 4 long each time
+      if the remaining line is lower than 4, we will use scalar code to compress it
+    """
+    init_template = """
+    out[%d] =
+        """
+
+    program_template = """(input[%d] << %d)"""
+
+    output_template = ";\n"
+
+    for i in range(start, end, step):
+        compress_line = compressed_format[i]
+        block_remaining = next_primitive
+        times = 0
+        f.write(init_template % (i))
+        for iter in range(0, len(compress_line)):
+            if block_remaining - bpv >= 0:
+                f.write(program_template % (
+                    compress_line[iter], 64 - bpv - times * next_primitive - (next_primitive - block_remaining)))
+                block_remaining -= bpv
+            else:
+                times += 1
+                block_remaining = next_primitive - bpv
+                f.write(program_template %
+                        (compress_line[iter], 64 - bpv - times * next_primitive))
+
+            if iter != len(compress_line) - 1:
+                f.write("""
+            | """)
+
+        f.write(output_template)
+
+
+if __name__ == '__main__':
+    f = open(OUTPUT_FILE, 'w')
+    f.write(HEADER)
+    for i in range(2, 33):
+        writeEncode(i, f)
+    for primitive_size in PRIMITIVE_SIZE:
+        f.write('  private static final long[] MASKS%d = new long[%d];\n' %
+                (primitive_size, primitive_size))
+    f.write('\n')
+    f.write('  static {\n')
+    for primitive_size in PRIMITIVE_SIZE:
+        f.write('    for (int i = 0; i < %d; ++i) {\n' % primitive_size)
+        f.write('      MASKS%d[i] = mask%d(i);\n' %
+                (primitive_size, primitive_size))
+        f.write('    }\n')
+    f.write('  }')
+    f.write("""
+  // mark values in array as final longs to avoid the cost of reading array, arrays should only be
+  // used when the idx is a variable
+""")
+    for primitive_size in PRIMITIVE_SIZE:
+        for bpv in range(1, min(MAX_SPECIALIZED_BITS_PER_VALUE + 1, primitive_size)):
+            if bpv * 2 != primitive_size or primitive_size == 8:
+                f.write('  private static final long MASK%d_%d = MASKS%d[%d];\n' % (
+                    primitive_size, bpv, primitive_size, bpv))
+
+    f.write("""
+  /** Decode 128 integers into {@code longs}. */
+  @Override
+  public void decode(int bitsPerValue, DataInput in, long[] longs) throws IOException {
+    switch (bitsPerValue) {
+""")
+    for bpv in range(1, MAX_SPECIALIZED_BITS_PER_VALUE+1):
+        next_primitive = 32
+        if bpv <= 8:
+            next_primitive = 8
+        elif bpv <= 16:
+            next_primitive = 16
+        f.write('      case %d:\n' % bpv)
+        f.write('        decode%d(in, tmp, longs);\n' % bpv)
+        f.write('        expand%d(longs);\n' % next_primitive)
+        f.write('        break;\n')
+    f.write('      default:\n')
+    f.write('        decodeSlow(bitsPerValue, in, tmp, longs);\n')
+    f.write('        expand32(longs);\n')
+    f.write('        break;\n')
+    f.write('    }\n')
+    f.write('  }\n')
+
+    f.write("""
+  /**
+   * Decodes 128 integers into 64 {@code longs} such that each long contains two values, each
+   * represented with 32 bits. Values [0..63] are encoded in the high-order bits of {@code longs}
+   * [0..63], and values [64..127] are encoded in the low-order bits of {@code longs} [0..63]. This
+   * representation may allow subsequent operations to be performed on two values at a time.
+   */
+  @Override
+  public void decodeTo32(int bitsPerValue, DataInput in, long[] longs) throws IOException {
+    switch (bitsPerValue) {
+""")
+    for bpv in range(1, MAX_SPECIALIZED_BITS_PER_VALUE+1):
+        next_primitive = 32
+        if bpv <= 8:
+            next_primitive = 8
+        elif bpv <= 16:
+            next_primitive = 16
+        f.write('      case %d:\n' % bpv)
+        f.write('        decode%d(in, tmp, longs);\n' % bpv)
+        if next_primitive <= 16:
+            f.write('        expand%dTo32(longs);\n' % next_primitive)
+        f.write('        break;\n')
+    f.write('      default:\n')
+    f.write('        decodeSlow(bitsPerValue, in, tmp, longs);\n')
+    f.write('        break;\n')
+    f.write('    }\n')
+    f.write('  }\n')
+
+    f.write('\n')
+    for i in range(1, MAX_SPECIALIZED_BITS_PER_VALUE+1):
+        writeDecode(i, f)
+        if i < MAX_SPECIALIZED_BITS_PER_VALUE:
+            f.write('\n')
+
+    f.write('}\n')

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestForUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestForUtil.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.lucene.codecs.lucene90;
+package org.apache.lucene.internal.vectorization;
 
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import java.io.IOException;
@@ -33,12 +33,12 @@ public class TestForUtil extends LuceneTestCase {
 
   public void testEncodeDecode() throws IOException {
     final int iterations = RandomNumbers.randomIntBetween(random(), 50, 1000);
-    final int[] values = new int[iterations * ForUtil.BLOCK_SIZE];
+    final int[] values = new int[iterations * ForUtil90.BLOCK_SIZE];
 
     for (int i = 0; i < iterations; ++i) {
       final int bpv = TestUtil.nextInt(random(), 1, 31);
-      for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
-        values[i * ForUtil.BLOCK_SIZE + j] =
+      for (int j = 0; j < ForUtil90.BLOCK_SIZE; ++j) {
+        values[i * ForUtil90.BLOCK_SIZE + j] =
             RandomNumbers.randomIntBetween(random(), 0, (int) PackedInts.maxValue(bpv));
       }
     }
@@ -49,13 +49,13 @@ public class TestForUtil extends LuceneTestCase {
     {
       // encode
       IndexOutput out = d.createOutput("test.bin", IOContext.DEFAULT);
-      final ForUtil forUtil = new ForUtil();
+      final ForUtil90 forUtil = new DefaultForUtil90();
 
       for (int i = 0; i < iterations; ++i) {
-        long[] source = new long[ForUtil.BLOCK_SIZE];
+        long[] source = new long[ForUtil90.BLOCK_SIZE];
         long or = 0;
-        for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
-          source[j] = values[i * ForUtil.BLOCK_SIZE + j];
+        for (int j = 0; j < ForUtil90.BLOCK_SIZE; ++j) {
+          source[j] = values[i * ForUtil90.BLOCK_SIZE + j];
           or |= source[j];
         }
         final int bpv = PackedInts.bitsRequired(or);
@@ -69,19 +69,20 @@ public class TestForUtil extends LuceneTestCase {
     {
       // decode
       IndexInput in = d.openInput("test.bin", IOContext.READONCE);
-      final ForUtil forUtil = new ForUtil();
+      final ForUtil90 forUtil = new DefaultForUtil90();
       for (int i = 0; i < iterations; ++i) {
         final int bitsPerValue = in.readByte();
         final long currentFilePointer = in.getFilePointer();
-        final long[] restored = new long[ForUtil.BLOCK_SIZE];
+        final long[] restored = new long[ForUtil90.BLOCK_SIZE];
         forUtil.decode(bitsPerValue, in, restored);
-        int[] ints = new int[ForUtil.BLOCK_SIZE];
-        for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
+        int[] ints = new int[ForUtil90.BLOCK_SIZE];
+        for (int j = 0; j < ForUtil90.BLOCK_SIZE; ++j) {
           ints[j] = Math.toIntExact(restored[j]);
         }
         assertArrayEquals(
             Arrays.toString(ints),
-            ArrayUtil.copyOfSubArray(values, i * ForUtil.BLOCK_SIZE, (i + 1) * ForUtil.BLOCK_SIZE),
+            ArrayUtil.copyOfSubArray(
+                values, i * ForUtil90.BLOCK_SIZE, (i + 1) * ForUtil90.BLOCK_SIZE),
             ints);
         assertEquals(forUtil.numBytes(bitsPerValue), in.getFilePointer() - currentFilePointer);
       }


### PR DESCRIPTION
DRAFT: This uses code from #12396 to vectorize ForUtil for the 9.0 codec (only encode!). It should show as example how it works, this is not ready for productions, although all tests pass.