### PR TITLE
Fix HNSW graph visitation limit bug

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -153,6 +153,8 @@ Bug Fixes
 
 * GITHUB#12388: JoinUtil queries were ignoring boosts. (Alan Woodward)
 
+* GITHUB#12413: Fix HNSW graph search bug that potentially leaked unapproved docs (Ben Trent).
+
 Other
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -204,26 +204,26 @@ public class HnswGraphSearcher<T> {
     if (initialEp == -1) {
       return new NeighborQueue(1, true);
     }
-    NeighborQueue results;
-    results = new NeighborQueue(1, false);
-    int[] eps = new int[] {graph.entryNode()};
-    int numVisited = 0;
-    for (int level = graph.numLevels() - 1; level >= 1; level--) {
-      results.clear();
-      graphSearcher.searchLevel(results, query, 1, level, eps, vectors, graph, null, visitedLimit);
-
-      numVisited += results.visitedCount();
-      visitedLimit -= results.visitedCount();
-
-      if (results.incomplete()) {
-        results.setVisitedCount(numVisited);
-        return results;
-      }
-      eps[0] = results.pop();
+    int[] epAndVisited = graphSearcher.findBestEntryPoint(query, vectors, graph, visitedLimit);
+    int numVisited = epAndVisited[1];
+    int ep = epAndVisited[0];
+    if (ep == -1) {
+      NeighborQueue results = new NeighborQueue(1, false);
+      results.setVisitedCount(numVisited);
+      results.markIncomplete();
+      return results;
     }
-    results = new NeighborQueue(topK, false);
+    NeighborQueue results = new NeighborQueue(topK, false);
     graphSearcher.searchLevel(
-        results, query, topK, 0, eps, vectors, graph, acceptOrds, visitedLimit);
+        results,
+        query,
+        topK,
+        0,
+        new int[] {ep},
+        vectors,
+        graph,
+        acceptOrds,
+        visitedLimit - numVisited);
     results.setVisitedCount(results.visitedCount() + numVisited);
     return results;
   }
@@ -254,6 +254,56 @@ public class HnswGraphSearcher<T> {
     NeighborQueue results = new NeighborQueue(topK, false);
     searchLevel(results, query, topK, level, eps, vectors, graph, null, Integer.MAX_VALUE);
     return results;
+  }
+
+  /**
+   * Function to find the best entry point from which to search the zeroth graph layer.
+   *
+   * @param query vector query with which to search
+   * @param vectors random access vector values
+   * @param graph the HNSWGraph
+   * @param visitLimit How many vectors are allowed to be visited
+   * @return An integer array whose first element is the best entry point, and second is the number
+   *     of candidates visited. Entry point of `-1` indicates visitation limit exceed
+   * @throws IOException When accessing the vector fails
+   */
+  private int[] findBestEntryPoint(
+      T query, RandomAccessVectorValues<T> vectors, HnswGraph graph, int visitLimit)
+      throws IOException {
+    int currentEp = graph.entryNode();
+    float currentScore = compare(query, vectors, currentEp);
+    boolean betterEntryFound = true;
+    int size = graph.size();
+    int visitedCount = 1;
+    prepareScratchState(vectors.size());
+    visited.set(currentEp);
+    for (int level = graph.numLevels() - 1; level >= 1 && betterEntryFound; level--) {
+      while (betterEntryFound) {
+        betterEntryFound = false;
+        // get the best candidate (closest or best scoring)
+        graphSeek(graph, level, currentEp);
+        int friendOrd;
+        while ((friendOrd = graphNextNeighbor(graph)) != NO_MORE_DOCS) {
+          assert friendOrd < size : "friendOrd=" + friendOrd + "; size=" + size;
+          if (visited.getAndSet(friendOrd)) {
+            continue;
+          }
+          if (visitedCount >= visitLimit) {
+            return new int[] {-1, visitedCount};
+          }
+          visitedCount++;
+
+          float friendSimilarity = compare(query, vectors, friendOrd);
+          if (friendSimilarity > currentScore
+              || (friendSimilarity == currentScore && friendOrd < currentEp)) {
+            currentEp = friendOrd;
+            currentScore = friendSimilarity;
+            betterEntryFound = true;
+          }
+        }
+      }
+    }
+    return new int[] {currentEp, visitedCount};
   }
 
   /**


### PR DESCRIPTION
We have some weird behavior in HNSW searcher when finding the candidate entry point for the zeroth layer. 

While trying to find the best entry point to gather the full candidate set, we don't filter based on the acceptableOrds bitset. Consequently, if we exit the search early (before hitting the zeroth layer), the results that are returned may contain documents NOT within that bitset. 

Luckily since the results are marked as incomplete, the `*VectorQuery` logic switches back to an exact scan and throws away the results. 

However, if any user called the leaf searcher directly, bypassing the query, they could run into this bug.