### PR TITLE
Optimize disjunction counts.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -91,6 +91,8 @@ Optimizations
 * GITHUB#12408: Lazy initialization improvements for Facets implementations when there are segments with no hits
   to count. (Greg Miller)
 
+* GITHUB#12415: Optimized counts on disjunctive queries. (Adrien Grand)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
@@ -169,7 +169,6 @@ final class BooleanScorer extends BulkScorer {
       return count;
     }
   }
-  ;
 
   private final DocIdStreamView docIdStreamView = new DocIdStreamView();
 

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
@@ -234,35 +234,6 @@ final class BooleanScorer extends BulkScorer {
     return cost;
   }
 
-  private void scoreDocument(LeafCollector collector, int base, int i) throws IOException {
-    if (buckets != null) {
-      final Score score = this.score;
-      final Bucket bucket = buckets[i];
-      if (bucket.freq >= minShouldMatch) {
-        score.score = (float) bucket.score;
-        final int doc = base | i;
-        collector.collect(doc);
-      }
-      bucket.freq = 0;
-      bucket.score = 0;
-    } else {
-      collector.collect(base | i);
-    }
-  }
-
-  private void scoreMatches(LeafCollector collector, int base) throws IOException {
-    long[] matching = this.matching;
-    for (int idx = 0; idx < matching.length; idx++) {
-      long bits = matching[idx];
-      while (bits != 0L) {
-        int ntz = Long.numberOfTrailingZeros(bits);
-        int doc = idx << 6 | ntz;
-        scoreDocument(collector, base, doc);
-        bits ^= 1L << ntz;
-      }
-    }
-  }
-
   private void scoreWindowIntoBitSetAndReplay(
       LeafCollector collector,
       Bits acceptDocs,

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
@@ -155,19 +155,35 @@ final class BooleanScorer extends BulkScorer {
     @Override
     public void forEach(CheckedIntConsumer<IOException> consumer) throws IOException {
       long[] matching = BooleanScorer.this.matching;
+      Bucket[] buckets = BooleanScorer.this.buckets;
       int base = this.base;
       for (int idx = 0; idx < matching.length; idx++) {
         long bits = matching[idx];
         while (bits != 0L) {
           int ntz = Long.numberOfTrailingZeros(bits);
-          consumer.accept(base | (idx << 6) | ntz);
+          if (buckets != null) {
+            final int indexInWindow = (idx << 6) | ntz;
+            final Bucket bucket = buckets[indexInWindow];
+            if (bucket.freq >= minShouldMatch) {
+              score.score = (float) bucket.score;
+              consumer.accept(base | indexInWindow);
+            }
+            bucket.freq = 0;
+            bucket.score = 0;
+          } else {
+            consumer.accept(base | (idx << 6) | ntz);
+          }
           bits ^= 1L << ntz;
         }
       }
     }
 
     @Override
-    public int count() {
+    public int count() throws IOException {
+      if (minShouldMatch > 1) {
+        // We can't just count bits in that case
+        return super.count();
+      }
       int count = 0;
       for (long l : matching) {
         count += Long.bitCount(l);
@@ -218,31 +234,6 @@ final class BooleanScorer extends BulkScorer {
     return cost;
   }
 
-  private void scoreDocument(LeafCollector collector, int base, int i) throws IOException {
-    final Score score = this.score;
-    final Bucket bucket = buckets[i];
-    if (bucket.freq >= minShouldMatch) {
-      score.score = (float) bucket.score;
-      final int doc = base | i;
-      collector.collect(doc);
-    }
-    bucket.freq = 0;
-    bucket.score = 0;
-  }
-
-  private void scoreMatches(LeafCollector collector, int base) throws IOException {
-    long[] matching = this.matching;
-    for (int idx = 0; idx < matching.length; idx++) {
-      long bits = matching[idx];
-      while (bits != 0L) {
-        int ntz = Long.numberOfTrailingZeros(bits);
-        int doc = idx << 6 | ntz;
-        scoreDocument(collector, base, doc);
-        bits ^= 1L << ntz;
-      }
-    }
-  }
-
   private void scoreWindowIntoBitSetAndReplay(
       LeafCollector collector,
       Bits acceptDocs,
@@ -258,12 +249,9 @@ final class BooleanScorer extends BulkScorer {
       scorer.score(orCollector, acceptDocs, min, max);
     }
 
-    if (buckets != null) {
-      scoreMatches(collector, base);
-    } else {
-      docIdStreamView.base = base;
-      collector.collect(docIdStreamView);
-    }
+    docIdStreamView.base = base;
+    collector.collect(docIdStreamView);
+
     Arrays.fill(matching, 0L);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
@@ -147,21 +147,21 @@ final class BooleanScorer extends BulkScorer {
     int base;
 
     @Override
-    void forEach(CheckedIntConsumer<IOException> consumer) throws IOException {
+    public void forEach(CheckedIntConsumer<IOException> consumer) throws IOException {
       long[] matching = BooleanScorer.this.matching;
       int base = this.base;
       for (int idx = 0; idx < matching.length; idx++) {
         long bits = matching[idx];
         while (bits != 0L) {
           int ntz = Long.numberOfTrailingZeros(bits);
-          consumer.consume(base | (idx << 6) | ntz);
+          consumer.accept(base | (idx << 6) | ntz);
           bits ^= 1L << ntz;
         }
       }
     }
 
     @Override
-    int count() {
+    public int count() {
       int count = 0;
       for (long l : matching) {
         count += Long.bitCount(l);

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
@@ -109,7 +109,9 @@ final class BooleanScorer extends BulkScorer {
     }
   }
 
-  final Bucket[] buckets = new Bucket[SIZE];
+  // One bucket per doc ID in the window, non-null if scores are needed or if frequencies need to be
+  // counted
+  final Bucket[] buckets;
   // This is basically an inlined FixedBitSet... seems to help with bound checks
   final long[] matching = new long[SET_SIZE];
 
@@ -134,9 +136,13 @@ final class BooleanScorer extends BulkScorer {
       final int i = doc & MASK;
       final int idx = i >>> 6;
       matching[idx] |= 1L << i;
-      final Bucket bucket = buckets[i];
-      bucket.freq++;
-      bucket.score += scorer.score();
+      if (buckets != null) {
+        final Bucket bucket = buckets[i];
+        bucket.freq++;
+        if (needsScores) {
+          bucket.score += scorer.score();
+        }
+      }
     }
   }
 
@@ -185,8 +191,13 @@ final class BooleanScorer extends BulkScorer {
       throw new IllegalArgumentException(
           "This scorer can only be used with two scorers or more, got " + scorers.size());
     }
-    for (int i = 0; i < buckets.length; i++) {
-      buckets[i] = new Bucket();
+    if (needsScores || minShouldMatch > 1) {
+      buckets = new Bucket[SIZE];
+      for (int i = 0; i < buckets.length; i++) {
+        buckets[i] = new Bucket();
+      }
+    } else {
+      buckets = null;
     }
     this.leads = new BulkScorerAndDoc[scorers.size()];
     this.head = new HeadPriorityQueue(scorers.size() - minShouldMatch + 1);
@@ -194,11 +205,6 @@ final class BooleanScorer extends BulkScorer {
     this.minShouldMatch = minShouldMatch;
     this.needsScores = needsScores;
     for (BulkScorer scorer : scorers) {
-      if (needsScores == false) {
-        // OrCollector calls score() all the time so we have to explicitly
-        // disable scoring in order to avoid decoding useless norms
-        scorer = BooleanWeight.disableScoring(scorer);
-      }
       final BulkScorerAndDoc evicted = tail.insertWithOverflow(new BulkScorerAndDoc(scorer));
       if (evicted != null) {
         head.add(evicted);
@@ -252,7 +258,7 @@ final class BooleanScorer extends BulkScorer {
       scorer.score(orCollector, acceptDocs, min, max);
     }
 
-    if (minShouldMatch > 1 || needsScores) {
+    if (buckets != null) {
       scoreMatches(collector, base);
     } else {
       docIdStreamView.base = base;

--- a/lucene/core/src/java/org/apache/lucene/search/CheckedIntConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CheckedIntConsumer.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+@FunctionalInterface
+public interface CheckedIntConsumer<T extends Exception> {
+
+  void consume(int value) throws T;
+}

--- a/lucene/core/src/java/org/apache/lucene/search/CheckedIntConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CheckedIntConsumer.java
@@ -18,14 +18,13 @@ package org.apache.lucene.search;
 
 import java.util.function.IntConsumer;
 
-/**
- * Like {@link IntConsumer}, but may throw checked exceptions.
- */
+/** Like {@link IntConsumer}, but may throw checked exceptions. */
 @FunctionalInterface
 public interface CheckedIntConsumer<T extends Exception> {
 
   /**
    * Process the given value.
+   *
    * @see IntConsumer#accept(int)
    */
   void accept(int value) throws T;

--- a/lucene/core/src/java/org/apache/lucene/search/CheckedIntConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CheckedIntConsumer.java
@@ -19,5 +19,5 @@ package org.apache.lucene.search;
 @FunctionalInterface
 public interface CheckedIntConsumer<T extends Exception> {
 
-  void consume(int value) throws T;
+  void accept(int value) throws T;
 }

--- a/lucene/core/src/java/org/apache/lucene/search/CheckedIntConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CheckedIntConsumer.java
@@ -16,8 +16,17 @@
  */
 package org.apache.lucene.search;
 
+import java.util.function.IntConsumer;
+
+/**
+ * Like {@link IntConsumer}, but may throw checked exceptions.
+ */
 @FunctionalInterface
 public interface CheckedIntConsumer<T extends Exception> {
 
+  /**
+   * Process the given value.
+   * @see IntConsumer#accept(int)
+   */
   void accept(int value) throws T;
 }

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdStream.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdStream.java
@@ -18,12 +18,20 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 
+/**
+ * A stream of doc IDs. Most methods on {@link DocIdStream}s are terminal, meaning that the {@link DocIdStream} may not be further used.
+ * @see LeafCollector#collect(DocIdStream)
+ * @lucene.experimental
+ */
 public abstract class DocIdStream {
 
-  abstract void forEach(CheckedIntConsumer<IOException> consumer) throws IOException;
+  /**
+   * Iterate over doc IDs contained in this stream in order, calling the given {@link CheckedIntConsumer} on them. This is a terminal operation.
+   */
+  public abstract void forEach(CheckedIntConsumer<IOException> consumer) throws IOException;
 
   /** Count the number of entries in this stream. This is a terminal operation. */
-  int count() throws IOException {
+  public int count() throws IOException {
     int[] count = new int[1];
     forEach(doc -> count[0]++);
     return count[0];

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdStream.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdStream.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+
+public abstract class DocIdStream {
+
+  abstract void forEach(CheckedIntConsumer<IOException> consumer) throws IOException;
+
+  /** Count the number of entries in this stream. This is a terminal operation. */
+  int count() throws IOException {
+    int[] count = new int[1];
+    forEach(doc -> count[0]++);
+    return count[0];
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdStream.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdStream.java
@@ -19,14 +19,20 @@ package org.apache.lucene.search;
 import java.io.IOException;
 
 /**
- * A stream of doc IDs. Most methods on {@link DocIdStream}s are terminal, meaning that the {@link DocIdStream} may not be further used.
+ * A stream of doc IDs. Most methods on {@link DocIdStream}s are terminal, meaning that the {@link
+ * DocIdStream} may not be further used.
+ *
  * @see LeafCollector#collect(DocIdStream)
  * @lucene.experimental
  */
 public abstract class DocIdStream {
 
+  /** Sole constructor, for invocation by sub classes. */
+  protected DocIdStream() {}
+
   /**
-   * Iterate over doc IDs contained in this stream in order, calling the given {@link CheckedIntConsumer} on them. This is a terminal operation.
+   * Iterate over doc IDs contained in this stream in order, calling the given {@link
+   * CheckedIntConsumer} on them. This is a terminal operation.
    */
   public abstract void forEach(CheckedIntConsumer<IOException> consumer) throws IOException;
 

--- a/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
@@ -84,7 +84,23 @@ public interface LeafCollector {
   void collect(int doc) throws IOException;
 
   /**
-   * Bulk-collect doc IDs. The default implementation calls {@code stream.forEach(this::collect)}.
+   * Bulk-collect doc IDs.
+   *
+   * <p>Note: The provided {@link DocIdStream} may be reused across calls and should be consumed
+   * immediately.
+   *
+   * <p>Note: The provided {@link DocIdStream} typically only holds a small subset of query matches.
+   * This method may be called multiple times per segment.
+   *
+   * <p>Like {@link #collect(int)}, it is guaranteed that doc IDs get collected in order, ie. doc
+   * IDs are collected in order within a {@link DocIdStream}, and if called twice, all doc IDs from
+   * the second {@link DocIdStream} will be greater than all doc IDs from the first {@link
+   * DocIdStream}.
+   *
+   * <p>It is legal for callers to mix calls to {@link #collect(DocIdStream)} and {@link
+   * #collect(int)}.
+   *
+   * <p>The default implementation calls {@code stream.forEach(this::collect)}.
    */
   default void collect(DocIdStream stream) throws IOException {
     stream.forEach(this::collect);

--- a/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
@@ -83,7 +83,9 @@ public interface LeafCollector {
    */
   void collect(int doc) throws IOException;
 
-  /** Bulk-collect doc IDs. */
+  /**
+   * Bulk-collect doc IDs. The default implementation calls {@code stream.forEach(this::collect)}.
+   */
   default void collect(DocIdStream stream) throws IOException {
     stream.forEach(this::collect);
   }

--- a/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
@@ -83,6 +83,11 @@ public interface LeafCollector {
    */
   void collect(int doc) throws IOException;
 
+  /** Bulk-collect doc IDs. */
+  default void collect(DocIdStream stream) throws IOException {
+    stream.forEach(this::collect);
+  }
+
   /**
    * Optionally returns an iterator over competitive documents.
    *

--- a/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
@@ -211,6 +211,7 @@ public class MultiCollector implements Collector {
       }
     }
 
+    // NOTE: not propagating collect(DocIdStream) since DocIdStreams may only be consumed once.
     @Override
     public void collect(int doc) throws IOException {
       for (int i = 0; i < collectors.length; i++) {

--- a/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollector.java
@@ -59,6 +59,11 @@ public class TotalHitCountCollector implements Collector {
       public void collect(int doc) throws IOException {
         totalHits++;
       }
+
+      @Override
+      public void collect(DocIdStream stream) throws IOException {
+        totalHits += stream.count();
+      }
     };
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.tests.search;
 
 import java.io.IOException;
-
 import org.apache.lucene.search.CheckedIntConsumer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.DocIdStream;
@@ -72,29 +71,31 @@ class AssertingLeafCollector extends FilterLeafCollector {
   }
 
   private class AssertingDocIdStream extends DocIdStream {
-    
+
     private final DocIdStream stream;
     private boolean consumed;
-    
+
     AssertingDocIdStream(DocIdStream stream) {
       this.stream = stream;
     }
 
     @Override
     public void forEach(CheckedIntConsumer<IOException> consumer) throws IOException {
-      assert consumed == false;
-      stream.forEach(doc -> {
-        assert doc > lastCollected : "Out of order : " + lastCollected + " " + doc;
-        assert doc >= min : "Out of range: " + doc + " < " + min;
-        assert doc < max : "Out of range: " + doc + " >= " + max;
-        consumer.accept(doc);
-        lastCollected = doc;
-      });
+      assert consumed == false : "A terminal operation has already been called";
+      stream.forEach(
+          doc -> {
+            assert doc > lastCollected : "Out of order : " + lastCollected + " " + doc;
+            assert doc >= min : "Out of range: " + doc + " < " + min;
+            assert doc < max : "Out of range: " + doc + " >= " + max;
+            consumer.accept(doc);
+            lastCollected = doc;
+          });
       consumed = true;
     }
 
     @Override
     public int count() throws IOException {
+      assert consumed == false : "A terminal operation has already been called";
       int count = stream.count();
       consumed = true;
       return count;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
@@ -786,6 +786,10 @@ public class QueryUtils {
         continue;
       }
       scorer = weight.bulkScorer(context);
+      if (scorer == null) {
+        assertEquals(0, expectedCount[0]);
+        continue;
+      }
       int[] actualCount = {0};
       scorer.score(
           new LeafCollector() {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
@@ -759,6 +759,7 @@ public class QueryUtils {
           new LeafCollector() {
             @Override
             public void collect(DocIdStream stream) throws IOException {
+              // Don't use DocIdStream#count, we want to count the slow way here.
               docIdStream[0] = true;
               LeafCollector.super.collect(stream);
             }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
@@ -43,6 +43,7 @@ import org.apache.lucene.index.TermVectors;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.DocIdStream;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Query;
@@ -135,6 +136,7 @@ public class QueryUtils {
         checkFirstSkipTo(q1, s);
         checkSkipTo(q1, s);
         checkBulkScorerSkipTo(random, q1, s);
+        checkCount(q1, s);
         if (wrap) {
           check(random, q1, wrapUnderlyingReader(random, s, -1), false);
           check(random, q1, wrapUnderlyingReader(random, s, 0), false);
@@ -736,6 +738,68 @@ public class QueryUtils {
           break;
         }
       }
+    }
+  }
+
+  /**
+   * Check that counting hits through {@link DocIdStream#count()} yield the same result as counting
+   * naively.
+   */
+  public static void checkCount(Query query, final IndexSearcher searcher) throws IOException {
+    query = searcher.rewrite(query);
+    Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 1);
+    for (LeafReaderContext context : searcher.getIndexReader().leaves()) {
+      BulkScorer scorer = weight.bulkScorer(context);
+      if (scorer == null) {
+        continue;
+      }
+      int[] expectedCount = {0};
+      boolean[] docIdStream = {false};
+      scorer.score(
+          new LeafCollector() {
+            @Override
+            public void collect(DocIdStream stream) throws IOException {
+              docIdStream[0] = true;
+              LeafCollector.super.collect(stream);
+            }
+
+            @Override
+            public void collect(int doc) throws IOException {
+              expectedCount[0]++;
+            }
+
+            @Override
+            public void setScorer(Scorable scorer) throws IOException {}
+          },
+          context.reader().getLiveDocs(),
+          0,
+          DocIdSetIterator.NO_MORE_DOCS);
+      if (docIdStream[0] == false) {
+        // Don't spend cycles running the query one more time, it doesn't use the DocIdStream
+        // optimization.
+        continue;
+      }
+      scorer = weight.bulkScorer(context);
+      int[] actualCount = {0};
+      scorer.score(
+          new LeafCollector() {
+            @Override
+            public void collect(DocIdStream stream) throws IOException {
+              actualCount[0] += stream.count();
+            }
+
+            @Override
+            public void collect(int doc) throws IOException {
+              actualCount[0]++;
+            }
+
+            @Override
+            public void setScorer(Scorable scorer) throws IOException {}
+          },
+          context.reader().getLiveDocs(),
+          0,
+          DocIdSetIterator.NO_MORE_DOCS);
+      assertEquals(expectedCount[0], actualCount[0]);
     }
   }
 }


### PR DESCRIPTION
This introduces `LeafCollector#collect(DocIdStream)` to enable collectors to collect batches of doc IDs at once. `BooleanScorer` takes advantage of this by creating a `DocIdStream` whose `count()` method counts the number of bits that are set in the bit set of matches in the current window, instead of naively iterating over all matches.

On wikimedium10m, this yields a ~20% speedup when counting hits for the `title OR 12` query (2.9M hits).

Relates #12358