### PR TITLE
Optimize DocIdsWriter for BKD in reverse case with index sorting

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -322,6 +322,10 @@ public final class FixedBitSet extends BitSet {
       checkUnpositioned(iter);
       DocBaseBitSetIterator baseIter = (DocBaseBitSetIterator) iter;
       or(baseIter.getDocBase() >> 6, baseIter.getBitSet());
+    } else if (iter instanceof ReverseDocBaseBitSetIterator) {
+      // not checkUnpositioned for ReverseDocBaseBitSetIterator
+      ReverseDocBaseBitSetIterator baseIter = (ReverseDocBaseBitSetIterator) iter;
+      or(baseIter.getDocBase() >> 6, baseIter.getBitSet());
     } else {
       super.or(iter);
     }
@@ -409,6 +413,10 @@ public final class FixedBitSet extends BitSet {
     } else if (iter instanceof DocBaseBitSetIterator) {
       checkUnpositioned(iter);
       DocBaseBitSetIterator baseIter = (DocBaseBitSetIterator) iter;
+      andNot(baseIter.getDocBase() >> 6, baseIter.getBitSet());
+    } else if (iter instanceof ReverseDocBaseBitSetIterator) {
+      // not checkUnpositioned for ReverseDocBaseBitSetIterator
+      ReverseDocBaseBitSetIterator baseIter = (ReverseDocBaseBitSetIterator) iter;
       andNot(baseIter.getDocBase() >> 6, baseIter.getBitSet());
     } else {
       checkUnpositioned(iter);

--- a/lucene/core/src/java/org/apache/lucene/util/ReverseDocBaseBitSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ReverseDocBaseBitSetIterator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util;
+
+import org.apache.lucene.search.DocIdSetIterator;
+
+/**
+ * A {@link DocIdSetIterator} like {@link DocBaseBitSetIterator} but iterate over the documents in
+ * reverse order.
+ */
+public class ReverseDocBaseBitSetIterator extends DocIdSetIterator {
+
+  private final FixedBitSet bits;
+  private final int length;
+  private final long cost;
+  private final int docBase;
+  private int doc;
+
+  public ReverseDocBaseBitSetIterator(FixedBitSet bits, int cost, int docBase) {
+    if (cost < 0) {
+      throw new IllegalArgumentException("cost must be >= 0, got " + cost);
+    }
+    if ((docBase & 63) != 0) {
+      throw new IllegalArgumentException("docBase need to be a multiple of 64, got " + docBase);
+    }
+    this.bits = bits;
+    this.length = bits.length() + docBase;
+    this.cost = cost;
+    this.doc = length;
+    this.docBase = docBase;
+  }
+
+  /**
+   * Get the {@link FixedBitSet}. A docId will exist in this {@link DocIdSetIterator} if the bitset
+   * contains the (docId - {@link #getDocBase})
+   *
+   * @return the offset docId bitset
+   */
+  public FixedBitSet getBitSet() {
+    return bits;
+  }
+
+  @Override
+  public int docID() {
+    return doc;
+  }
+
+  /**
+   * Get the docBase. It is guaranteed that docBase is a multiple of 64.
+   *
+   * @return the docBase
+   */
+  public int getDocBase() {
+    return docBase;
+  }
+
+  @Override
+  public int nextDoc() {
+    return advance(doc - 1);
+  }
+
+  @Override
+  public int advance(int target) {
+    if (target - docBase < 0) {
+      return doc = NO_MORE_DOCS;
+    }
+    int next = bits.prevSetBit(target - docBase);
+    if (next == -1) {
+      return doc = NO_MORE_DOCS;
+    } else {
+      return doc = next + docBase;
+    }
+  }
+
+  @Override
+  public long cost() {
+    return cost;
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
@@ -502,6 +502,17 @@ public class TestFixedBitSet extends BaseBitSetTestCase<FixedBitSet> {
     }
 
     {
+      // test ReverseDocBaseBitSetIterator
+      FixedBitSet fixedBitSet2 = makeFixedBitSet(bits2, numBits2);
+      int[] offsetBits = Arrays.stream(bits1).map(i -> i - offset1).toArray();
+      DocIdSetIterator disi =
+          new ReverseDocBaseBitSetIterator(
+              makeFixedBitSet(offsetBits, numBits1 - offset1), count1, offset1);
+      fixedBitSet2.andNot(disi);
+      doGet(bitSet2, fixedBitSet2);
+    }
+
+    {
       // test other
       FixedBitSet fixedBitSet2 = makeFixedBitSet(bits2, numBits2);
       int[] sorted = new int[bits1.length + 1];

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -18,6 +18,7 @@ package org.apache.lucene.util.bkd;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Set;
 import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;
@@ -85,7 +86,12 @@ public class TestDocIdsWriter extends LuceneTestCase {
         while (set.size() < size) {
           set.add(small + random().nextInt(size * 16));
         }
-        int[] docIDs = set.stream().mapToInt(t -> t).sorted().toArray();
+        int[] docIDs;
+        if (random().nextBoolean()) {
+          docIDs = set.stream().sorted(Comparator.reverseOrder()).mapToInt(t -> t).toArray();
+        } else {
+          docIDs = set.stream().mapToInt(t -> t).sorted().toArray();
+        }
         test(dir, docIDs);
       }
     }
@@ -99,7 +105,11 @@ public class TestDocIdsWriter extends LuceneTestCase {
         int[] docIDs = new int[size];
         int start = random().nextInt(1000000);
         for (int i = 0; i < docIDs.length; i++) {
-          docIDs[i] = start + i;
+          if (random().nextBoolean()) {
+            docIDs[i] = start + i;
+          } else {
+            docIDs[i] = start + docIDs.length - i;
+          }
         }
         test(dir, docIDs);
       }


### PR DESCRIPTION
### Description

In https://github.com/apache/lucene/pull/438 , https://github.com/apache/lucene/pull/510, we optimized the doc ids more efficiently for store and decode, this pr allows these optimizations to be applied in reverse case.

for bitset store type, will write the bitset in same data format as asc order, and when reading the bitset, it have a same FixedBitset as asc order, just iterate over the bitset in reverse