### PR TITLE
Concurrent hnsw graph and builder, take two

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91OnHeapHnswGraph.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91OnHeapHnswGraph.java
@@ -97,7 +97,6 @@ public final class Lucene91OnHeapHnswGraph extends HnswGraph {
    * @param level level to add a node on
    * @param node the node to add, represented as an ordinal on the level 0.
    */
-  @Override
   public void addNode(int level, int node) {
     if (level > 0) {
       // if the new node introduces a new level, add more levels to the graph,

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91OnHeapHnswGraph.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91OnHeapHnswGraph.java
@@ -97,6 +97,7 @@ public final class Lucene91OnHeapHnswGraph extends HnswGraph {
    * @param level level to add a node on
    * @param node the node to add, represented as an ordinal on the level 0.
    */
+  @Override
   public void addNode(int level, int node) {
     if (level > 0) {
       // if the new node introduces a new level, add more levels to the graph,

--- a/lucene/core/build.gradle
+++ b/lucene/core/build.gradle
@@ -23,3 +23,12 @@ dependencies {
   moduleTestImplementation project(':lucene:codecs')
   moduleTestImplementation project(':lucene:test-framework')
 }
+
+test {
+  // open jdk classes for inspection by ram usage estimator
+  jvmArgs(
+          '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+          '--add-opens', 'java.base/java.util.concurrent.atomic=ALL-UNNAMED',
+          '--add-opens', 'java.base/java.util.concurrent.locks=ALL-UNNAMED'
+  )
+}

--- a/lucene/core/src/java/org/apache/lucene/util/GrowableBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/GrowableBitSet.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.apache.lucene.search.DocIdSetIterator;
+
+/**
+ * A {@link BitSet} implementation that grows as needed to accommodate set(index) calls. When it
+ * does so, it will grow its internal storage multiplicatively, assuming that more growth will be
+ * needed in the future. This is the important difference from FixedBitSet + FBS.ensureCapacity,
+ * which grows the minimum necessary each time.
+ */
+public class GrowableBitSet extends BitSet {
+
+  private final java.util.BitSet bitSet;
+
+  public GrowableBitSet(java.util.BitSet bitSet) {
+    this.bitSet = bitSet;
+  }
+
+  public GrowableBitSet(int initialBits) {
+    this.bitSet = new java.util.BitSet(initialBits);
+  }
+
+  @Override
+  public void clear(int index) {
+    bitSet.clear(index);
+  }
+
+  @Override
+  public void clear() {
+    bitSet.clear();
+  }
+
+  @Override
+  public boolean get(int index) {
+    return bitSet.get(index);
+  }
+
+  @Override
+  public boolean getAndSet(int index) {
+    boolean v = get(index);
+    set(index);
+    return v;
+  }
+
+  @Override
+  public int length() {
+    return bitSet.length();
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return -1;
+  }
+
+  @Override
+  public Collection<Accountable> getChildResources() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void set(int i) {
+    bitSet.set(i);
+  }
+
+  @Override
+  public void clear(int startIndex, int endIndex) {
+    if (startIndex == 0 && endIndex == bitSet.length()) {
+      bitSet.clear();
+      return;
+    } else if (startIndex >= endIndex) {
+      return;
+    }
+    bitSet.clear(startIndex, endIndex);
+  }
+
+  @Override
+  public int cardinality() {
+    return bitSet.cardinality();
+  }
+
+  @Override
+  public int approximateCardinality() {
+    return bitSet.cardinality();
+  }
+
+  @Override
+  public int prevSetBit(int index) {
+    return bitSet.previousSetBit(index);
+  }
+
+  @Override
+  public int nextSetBit(int i) {
+    int next = bitSet.nextSetBit(i);
+    if (next == -1) {
+      next = DocIdSetIterator.NO_MORE_DOCS;
+    }
+    return next;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
@@ -191,7 +191,8 @@ public class ConcurrentHnswGraphBuilder<T> {
     Set<Integer> inFlight = ConcurrentHashMap.newKeySet();
     AtomicReference<Throwable> asyncException = new AtomicReference<>(null);
 
-    ExplicitThreadLocal<RandomAccessVectorValues<T>> threadSafeVectors = createThreadSafeVectors(vectorsToAdd);
+    ExplicitThreadLocal<RandomAccessVectorValues<T>> threadSafeVectors =
+        createThreadSafeVectors(vectorsToAdd);
 
     for (int i = 0; i < vectorsToAdd.size(); i++) {
       final int node = i; // copy for closure
@@ -232,14 +233,16 @@ public class ConcurrentHnswGraphBuilder<T> {
         });
   }
 
-  private static <T> ExplicitThreadLocal<RandomAccessVectorValues<T>> createThreadSafeVectors(RandomAccessVectorValues<T> vectorValues) {
-    return ExplicitThreadLocal.withInitial(() -> {
-      try {
-        return vectorValues.copy();
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
-    });
+  private static <T> ExplicitThreadLocal<RandomAccessVectorValues<T>> createThreadSafeVectors(
+      RandomAccessVectorValues<T> vectorValues) {
+    return ExplicitThreadLocal.withInitial(
+        () -> {
+          try {
+            return vectorValues.copy();
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
   }
 
   /**
@@ -300,7 +303,15 @@ public class ConcurrentHnswGraphBuilder<T> {
       for (int level = entry.level; level > nodeLevel; level--) {
         candidates.clear();
         gs.searchLevel(
-            candidates, value, 1, level, eps, vectors.get(), consistentView, null, Integer.MAX_VALUE);
+            candidates,
+            value,
+            1,
+            level,
+            eps,
+            vectors.get(),
+            consistentView,
+            null,
+            Integer.MAX_VALUE);
         eps = new int[] {candidates.pop()};
       }
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
@@ -137,7 +137,7 @@ public class ConcurrentHnswGraphBuilder<T> {
           }
 
           @Override
-          public Function<Integer, Float> scoreProvider(int node1) {
+          public ScoreFunction scoreProvider(int node1) {
             T v1;
             try {
               v1 = vectors.get().vectorValue(node1);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
@@ -39,7 +39,6 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.GrowableBitSet;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.ThreadInterruptedException;
-import org.apache.lucene.util.hnsw.ConcurrentNeighborSet.NeighborSimilarity;
 import org.apache.lucene.util.hnsw.ConcurrentOnHeapHnswGraph.NodeAtLevel;
 
 /**

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
@@ -224,7 +224,7 @@ public class ConcurrentHnswGraphBuilder<T> {
     ExplicitThreadLocal<RandomAccessVectorValues<T>> threadSafeVectors =
         createThreadSafeVectors(vectorsToAdd);
 
-    for (int i = 0; i < vectorsToAdd.size(); i++) {
+    for (int i = 0; i < vectorsToAdd.size() && asyncException.get() == null; i++) {
       final int node = i; // copy for closure
       try {
         semaphore.acquire();

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswGraphBuilder.java
@@ -1,0 +1,465 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import static java.lang.Math.log;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.GrowableBitSet;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.NamedThreadFactory;
+import org.apache.lucene.util.ThreadInterruptedException;
+import org.apache.lucene.util.hnsw.ConcurrentOnHeapHnswGraph.NodeAtLevel;
+
+/**
+ * Builder for Concurrent HNSW graph. See {@link HnswGraph} for a high level overview, and the
+ * comments to `addGraphNode` for details on the concurrent building approach.
+ *
+ * @param <T> the type of vector
+ */
+public class ConcurrentHnswGraphBuilder<T> {
+
+  /** Default number of maximum connections per node */
+  public static final int DEFAULT_MAX_CONN = 16;
+
+  /**
+   * Default number of the size of the queue maintained while searching during a graph construction.
+   */
+  public static final int DEFAULT_BEAM_WIDTH = 100;
+
+  /** A name for the HNSW component for the info-stream */
+  public static final String HNSW_COMPONENT = "HNSW";
+
+  private final int beamWidth;
+  private final double ml;
+  private final ExplicitThreadLocal<NeighborArray> scratchNeighbors;
+
+  private final VectorSimilarityFunction similarityFunction;
+  private final VectorEncoding vectorEncoding;
+  private final RandomAccessVectorValues<T> vectors;
+  private final ExplicitThreadLocal<HnswGraphSearcher<T>> graphSearcher;
+  private final ExplicitThreadLocal<NeighborQueue> beamCandidates;
+
+  final ConcurrentOnHeapHnswGraph hnsw;
+  private final ConcurrentSkipListSet<NodeAtLevel> insertionsInProgress =
+      new ConcurrentSkipListSet<>();
+
+  private InfoStream infoStream = InfoStream.getDefault();
+
+  // we need two sources of vectors in order to perform diversity check comparisons without
+  // colliding
+  private final RandomAccessVectorValues<T> vectorsCopy;
+
+  /** This is the "native" factory for ConcurrentHnswGraphBuilder. */
+  public static <T> ConcurrentHnswGraphBuilder<T> create(
+      RandomAccessVectorValues<T> vectors,
+      VectorEncoding vectorEncoding,
+      VectorSimilarityFunction similarityFunction,
+      int M,
+      int beamWidth)
+      throws IOException {
+    return new ConcurrentHnswGraphBuilder<>(
+        vectors, vectorEncoding, similarityFunction, M, beamWidth);
+  }
+
+  /**
+   * Reads all the vectors from vector values, builds a graph connecting them by their dense
+   * ordinals, using the given hyperparameter settings, and returns the resulting graph.
+   *
+   * @param vectors the vectors whose relations are represented by the graph - must provide a
+   *     different view over those vectors than the one used to add via addGraphNode.
+   * @param M – graph fanout parameter used to calculate the maximum number of connections a node
+   *     can have – M on upper layers, and M * 2 on the lowest level.
+   * @param beamWidth the size of the beam search to use when finding nearest neighbors.
+   */
+  public ConcurrentHnswGraphBuilder(
+      RandomAccessVectorValues<T> vectors,
+      VectorEncoding vectorEncoding,
+      VectorSimilarityFunction similarityFunction,
+      int M,
+      int beamWidth)
+      throws IOException {
+    this.vectors = vectors;
+    this.vectorsCopy = vectors.copy();
+    this.vectorEncoding = Objects.requireNonNull(vectorEncoding);
+    this.similarityFunction = Objects.requireNonNull(similarityFunction);
+    if (M <= 0) {
+      throw new IllegalArgumentException("maxConn must be positive");
+    }
+    if (beamWidth <= 0) {
+      throw new IllegalArgumentException("beamWidth must be positive");
+    }
+    this.beamWidth = beamWidth;
+    // normalization factor for level generation; currently not configurable
+    this.ml = M == 1 ? 1 : 1 / Math.log(1.0 * M);
+    this.hnsw = new ConcurrentOnHeapHnswGraph(M);
+    this.graphSearcher =
+        ExplicitThreadLocal.withInitial(
+            () -> {
+              return new HnswGraphSearcher<>(
+                  vectorEncoding,
+                  similarityFunction,
+                  new NeighborQueue(beamWidth, true),
+                  new GrowableBitSet(this.vectors.size()));
+            });
+    // in scratch we store candidates in reverse order: worse candidates are first
+    this.scratchNeighbors =
+        ExplicitThreadLocal.withInitial(() -> new NeighborArray(Math.max(beamWidth, M + 1), false));
+    this.beamCandidates =
+        ExplicitThreadLocal.withInitial(() -> new NeighborQueue(beamWidth, false));
+  }
+
+  private abstract static class ExplicitThreadLocal<U> {
+    private final ConcurrentHashMap<Long, U> map = new ConcurrentHashMap<>();
+
+    public U get() {
+      return map.computeIfAbsent(Thread.currentThread().getId(), k -> initialValue());
+    }
+
+    protected abstract U initialValue();
+
+    public static <U> ExplicitThreadLocal<U> withInitial(Supplier<U> initialValue) {
+      return new ExplicitThreadLocal<U>() {
+        @Override
+        protected U initialValue() {
+          return initialValue.get();
+        }
+      };
+    }
+  }
+
+  /**
+   * Reads all the vectors from two copies of a {@link RandomAccessVectorValues}. Providing two
+   * copies enables efficient retrieval without extra data copying, while avoiding collision of the
+   * returned values.
+   *
+   * @param vectorsToAdd the vectors for which to build a nearest neighbors graph. Must be an
+   *     independent accessor for the vectors
+   * @param autoParallel if true, the builder will allocate one thread per core to building the
+   *     graph; if false, it will use a single thread. For more fine-grained control, use the
+   *     ExecutorService (ThreadPoolExecutor) overload.
+   */
+  public ConcurrentOnHeapHnswGraph build(
+      RandomAccessVectorValues<T> vectorsToAdd, boolean autoParallel) throws IOException {
+    ExecutorService es;
+    int threadCount;
+    if (autoParallel) {
+      threadCount = Runtime.getRuntime().availableProcessors();
+      es =
+          Executors.newFixedThreadPool(
+              threadCount, new NamedThreadFactory("Concurrent HNSW builder"));
+    } else {
+      threadCount = 1;
+      es = Executors.newSingleThreadExecutor(new NamedThreadFactory("Concurrent HNSW builder"));
+    }
+
+    Future<ConcurrentOnHeapHnswGraph> f = buildAsync(vectorsToAdd, es, threadCount);
+    try {
+      return f.get();
+    } catch (InterruptedException e) {
+      throw new ThreadInterruptedException(e);
+    } catch (ExecutionException e) {
+      throw new IOException(e);
+    } finally {
+      es.shutdown();
+    }
+  }
+
+  public ConcurrentOnHeapHnswGraph build(RandomAccessVectorValues<T> vectorsToAdd)
+      throws IOException {
+    return build(vectorsToAdd, true);
+  }
+
+  /**
+   * Bring-your-own ExecutorService graph builder.
+   *
+   * <p>Reads all the vectors from two copies of a {@link RandomAccessVectorValues}. Providing two
+   * copies enables efficient retrieval without extra data copying, while avoiding collision of the
+   * returned values.
+   *
+   * @param vectorsToAdd the vectors for which to build a nearest neighbors graph. Must be an
+   *     independent accessor for the vectors
+   * @param pool The ExecutorService to use. Must be an instance of ThreadPoolExecutor.
+   * @param concurrentTasks the number of tasks to submit in parallel.
+   */
+  public Future<ConcurrentOnHeapHnswGraph> buildAsync(
+      RandomAccessVectorValues<T> vectorsToAdd, ExecutorService pool, int concurrentTasks) {
+    if (vectorsToAdd == this.vectors) {
+      throw new IllegalArgumentException(
+          "Vectors to build must be independent of the source of vectors provided to HnswGraphBuilder()");
+    }
+    if (infoStream.isEnabled(HNSW_COMPONENT)) {
+      infoStream.message(HNSW_COMPONENT, "build graph from " + vectorsToAdd.size() + " vectors");
+    }
+    return addVectors(vectorsToAdd, pool, concurrentTasks);
+  }
+
+  // the goal here is to keep all the ExecutorService threads busy, but not to create potentially
+  // millions of futures by naively throwing everything at submit at once.  So, we use
+  // a semaphore to wait until a thread is free before adding a new task.
+  private Future<ConcurrentOnHeapHnswGraph> addVectors(
+      RandomAccessVectorValues<T> vectorsToAdd, ExecutorService pool, int concurrentTasks) {
+    Semaphore semaphore = new Semaphore(concurrentTasks);
+    Set<Integer> inFlight = ConcurrentHashMap.newKeySet();
+    AtomicReference<Throwable> asyncException = new AtomicReference<>(null);
+
+    for (int i = 0; i < vectorsToAdd.size(); i++) {
+      final int node = i; // copy for closure
+      try {
+        semaphore.acquire();
+        inFlight.add(node);
+        pool.submit(
+            () -> {
+              try {
+                addGraphNode(node, vectorsToAdd);
+              } catch (Throwable e) {
+                asyncException.set(e);
+              } finally {
+                semaphore.release();
+                inFlight.remove(node);
+              }
+            });
+      } catch (InterruptedException e) {
+        throw new ThreadInterruptedException(e);
+      }
+    }
+
+    // return a future that will complete when the inflight set is empty
+    return CompletableFuture.supplyAsync(
+        () -> {
+          while (!inFlight.isEmpty()) {
+            try {
+              TimeUnit.MILLISECONDS.sleep(10);
+            } catch (InterruptedException e) {
+              throw new ThreadInterruptedException(e);
+            }
+          }
+          if (asyncException.get() != null) {
+            throw new CompletionException(asyncException.get());
+          }
+          hnsw.validateEntryNode();
+          return hnsw;
+        });
+  }
+
+  /**
+   * Adds a node to the graph, with the vector at the same ordinal in the given provider.
+   *
+   * <p>See {@link #addGraphNode(int, Object)} for more details.
+   */
+  public long addGraphNode(int node, RandomAccessVectorValues<T> values) throws IOException {
+    return addGraphNode(node, values.vectorValue(node));
+  }
+
+  /** Set info-stream to output debugging information * */
+  public void setInfoStream(InfoStream infoStream) {
+    this.infoStream = infoStream;
+  }
+
+  public ConcurrentOnHeapHnswGraph getGraph() {
+    return hnsw;
+  }
+
+  /** Number of inserts in progress, across all threads. */
+  public int insertsInProgress() {
+    return insertionsInProgress.size();
+  }
+
+  /**
+   * Inserts a doc with vector value to the graph.
+   *
+   * <p>To allow correctness under concurrency, we track in-progress updates in a
+   * ConcurrentSkipListSet. After adding ourselves, we take a snapshot of this set, and consider all
+   * other in-progress updates as neighbor candidates (subject to normal level constraints).
+   *
+   * @param node the node ID to add
+   * @param value the vector value to add
+   * @return an estimate of the number of extra bytes used by the graph after adding the given node
+   */
+  public long addGraphNode(int node, T value) throws IOException {
+    // do this before adding to in-progress, so a concurrent writer checking
+    // the in-progress set doesn't have to worry about uninitialized neighbor sets
+    final int nodeLevel = getRandomGraphLevel(ml);
+    for (int level = nodeLevel; level >= 0; level--) {
+      hnsw.addNode(level, node);
+    }
+
+    HnswGraph consistentView = hnsw.getView();
+    NodeAtLevel progressMarker = new NodeAtLevel(nodeLevel, node);
+    insertionsInProgress.add(progressMarker);
+    ConcurrentSkipListSet<NodeAtLevel> inProgressBefore = insertionsInProgress.clone();
+    try {
+      // find ANN of the new node by searching the graph
+      NodeAtLevel entry = hnsw.entry();
+      int ep = entry.node;
+      int[] eps = ep >= 0 ? new int[] {ep} : new int[0];
+      var gs = graphSearcher.get();
+
+      // for levels > nodeLevel search with topk = 1
+      NeighborQueue candidates = new NeighborQueue(1, false);
+      for (int level = entry.level; level > nodeLevel; level--) {
+        candidates.clear();
+        gs.searchLevel(
+            candidates, value, 1, level, eps, vectors, consistentView, null, Integer.MAX_VALUE);
+        eps = new int[] {candidates.pop()};
+      }
+
+      // for levels <= nodeLevel search with topk = beamWidth, and add connections
+      candidates = beamCandidates.get();
+      for (int level = Math.min(nodeLevel, entry.level); level >= 0; level--) {
+        candidates.clear();
+        // find best "natural" candidates at this level with a beam search
+        gs.searchLevel(
+            candidates,
+            value,
+            beamWidth,
+            level,
+            eps,
+            vectors,
+            consistentView,
+            null,
+            Integer.MAX_VALUE);
+        eps = candidates.nodes();
+
+        // Update entry points and neighbors with these candidates.
+        //
+        // Note: We don't want to over-prune the neighbors, which can
+        // happen if we group the concurrent candidates and the natural candidates together.
+        //
+        // Consider the following graph with "circular" test vectors:
+        //
+        // 0 -> 1
+        // 1 <- 0
+        // At this point we insert nodes 2 and 3 concurrently, denoted T1 and T2 for threads 1 and 2
+        //   T1  T2
+        //       insert 2 to L1 [2 is marked "in progress"]
+        //   insert 3 to L1
+        //   3 considers as neighbors 0, 1, 2; 0 and 1 are not diverse wrt 2
+        // 3 -> 2 is added to graph
+        //   3 is marked entry node
+        //        2 follows 3 to L0, where 3 only has 2 as a neighbor
+        // 2 -> 3 is added to graph
+        // all further nodes will only be added to the 2/3 subgraph; 0/1 are partitioned forever
+        //
+        // Considering concurrent inserts separately from natural candidates solves this problem;
+        // both 1 and 2 will be added as neighbors to 3, avoiding the partition, and 2 will then
+        // pick up the connection to 1 that it's supposed to have as well.
+        addForwardLinks(level, node, candidates); // natural candidates
+        addForwardLinks(level, node, inProgressBefore, progressMarker); // concurrent candidates
+        // Backlinking is the same for both natural and concurrent candidates.
+        addBackLinks(level, node);
+      }
+
+      // If we're being added in a new level above the entry point, consider concurrent insertions
+      // for inclusion as neighbors at that level. There are no natural neighbors yet.
+      for (int level = entry.level + 1; level <= nodeLevel; level++) {
+        addForwardLinks(level, node, inProgressBefore, progressMarker);
+        addBackLinks(level, node);
+      }
+
+      hnsw.markComplete(nodeLevel, node);
+    } finally {
+      insertionsInProgress.remove(progressMarker);
+    }
+
+    return hnsw.ramBytesUsedOneNode(nodeLevel);
+  }
+
+  private void addForwardLinks(int level, int newNode, NeighborQueue candidates)
+      throws IOException {
+    NeighborArray scratch = popToScratch(candidates); // worst are first
+    ConcurrentNeighborSet neighbors = hnsw.getNeighbors(level, newNode);
+    neighbors.insertDiverse(scratch, this::scoreBetween);
+  }
+
+  private void addForwardLinks(
+      int level, int newNode, Set<NodeAtLevel> inProgress, NodeAtLevel progressMarker)
+      throws IOException {
+    NeighborQueue candidates = new NeighborQueue(inProgress.size(), false);
+    for (NodeAtLevel n : inProgress) {
+      if (n.level >= level && n != progressMarker) {
+        candidates.add(n.node, scoreBetween(n.node, newNode));
+      }
+    }
+    ConcurrentNeighborSet neighbors = hnsw.getNeighbors(level, newNode);
+    NeighborArray scratch = popToScratch(candidates); // worst are first
+    neighbors.insertDiverse(scratch, this::scoreBetween);
+  }
+
+  private void addBackLinks(int level, int newNode) throws IOException {
+    ConcurrentNeighborSet neighbors = hnsw.getNeighbors(level, newNode);
+    neighbors.backlink(i -> hnsw.getNeighbors(level, i), this::scoreBetween);
+  }
+
+  private float scoreBetween(int i, int j) {
+    try {
+      T v1 = vectorsCopy.vectorValue(i);
+      T v2 = vectorsCopy.vectorValue(j);
+      return scoreBetween(v1, v2);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e); // called from closures
+    }
+  }
+
+  protected float scoreBetween(T v1, T v2) {
+    return switch (vectorEncoding) {
+      case BYTE -> similarityFunction.compare((byte[]) v1, (byte[]) v2);
+      case FLOAT32 -> similarityFunction.compare((float[]) v1, (float[]) v2);
+    };
+  }
+
+  private NeighborArray popToScratch(NeighborQueue candidates) {
+    NeighborArray scratch = this.scratchNeighbors.get();
+    scratch.clear();
+    int candidateCount = candidates.size();
+    // extract all the Neighbors from the queue into an array; these will now be
+    // sorted from worst to best
+    for (int i = 0; i < candidateCount; i++) {
+      float maxSimilarity = candidates.topScore();
+      scratch.addInOrder(candidates.pop(), maxSimilarity);
+    }
+    return scratch;
+  }
+
+  int getRandomGraphLevel(double ml) {
+    double randDouble;
+    do {
+      randDouble =
+          ThreadLocalRandom.current().nextDouble(); // avoid 0 value, as log(0) is undefined
+    } while (randDouble == 0.0);
+    return ((int) (-log(randDouble) * ml));
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentNeighborSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentNeighborSet.java
@@ -227,6 +227,9 @@ public class ConcurrentNeighborSet {
      */
     ScoreFunction scoreProvider(int node1);
 
+    /**
+     * A Function&lt;Integer, Float&gt; without the boxing
+     */
     @FunctionalInterface
     public interface ScoreFunction {
       float apply(int node);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentNeighborSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentNeighborSet.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.PrimitiveIterator;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.FixedBitSet;
+
+/** A concurrent set of neighbors. */
+public class ConcurrentNeighborSet {
+  /** the node id whose neighbors we are storing */
+  private final int nodeId;
+
+  /**
+   * We use a copy-on-write NeighborArray to store the neighbors. Even though updating this is
+   * expensive, it is still faster than using a concurrent Collection because "iterate through a
+   * node's neighbors" is a hot loop in adding to the graph, and NeighborArray can do that much
+   * faster: no boxing/unboxing, all the data is stored sequentially instead of having to follow
+   * references, and no fancy encoding necessary for node/score.
+   */
+  private final AtomicReference<ConcurrentNeighborArray> neighborsRef;
+
+  /** the maximum number of neighbors we can store */
+  private final int maxConnections;
+
+  public ConcurrentNeighborSet(int nodeId, int maxConnections) {
+    this.nodeId = nodeId;
+    this.maxConnections = maxConnections;
+    neighborsRef = new AtomicReference<>(new ConcurrentNeighborArray(maxConnections, true));
+  }
+
+  public PrimitiveIterator.OfInt nodeIterator() {
+    // don't use a stream here. stream's implementation of iterator buffers
+    // very aggressively, which is a big waste for a lot of searches.
+    return new NeighborIterator(neighborsRef.get());
+  }
+
+  public void backlink(
+      Function<Integer, ConcurrentNeighborSet> neighborhoodOf, NeighborSimilarity scoreBetween)
+      throws IOException {
+    NeighborArray neighbors = neighborsRef.get();
+    for (int i = 0; i < neighbors.size(); i++) {
+      int nbr = neighbors.node[i];
+      float nbrScore = neighbors.score[i];
+      ConcurrentNeighborSet nbrNbr = neighborhoodOf.apply(nbr);
+      nbrNbr.insert(nodeId, nbrScore, scoreBetween);
+    }
+  }
+
+  private static class NeighborIterator implements PrimitiveIterator.OfInt {
+    private final NeighborArray neighbors;
+    private int i;
+
+    private NeighborIterator(NeighborArray neighbors) {
+      this.neighbors = neighbors;
+      i = 0;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return i < neighbors.size();
+    }
+
+    @Override
+    public int nextInt() {
+      return neighbors.node[i++];
+    }
+  }
+
+  public int size() {
+    return neighborsRef.get().size();
+  }
+
+  public int arrayLength() {
+    return neighborsRef.get().node.length;
+  }
+
+  /**
+   * For each candidate (going from best to worst), select it only if it is closer to target than it
+   * is to any of the already-selected candidates. This is maintained whether those other neighbors
+   * were selected by this method, or were added as a "backlink" to a node inserted concurrently
+   * that chose this one as a neighbor.
+   */
+  public void insertDiverse(NeighborArray candidates, NeighborSimilarity scoreBetween) {
+    BitSet selected = new FixedBitSet(candidates.size());
+    for (int i = candidates.size() - 1; i >= 0; i--) {
+      int cNode = candidates.node[i];
+      float cScore = candidates.score[i];
+      if (isDiverse(cNode, cScore, candidates, selected, scoreBetween)) {
+        selected.set(i);
+      }
+    }
+    insertMultiple(candidates, selected, scoreBetween);
+    // This leaves the paper's keepPrunedConnection option out; we might want to add that
+    // as an option in the future.
+  }
+
+  private void insertMultiple(
+      NeighborArray others, BitSet selected, NeighborSimilarity scoreBetween) {
+    neighborsRef.getAndUpdate(
+        current -> {
+          ConcurrentNeighborArray next = current.copy();
+          for (int i = others.size() - 1; i >= 0; i--) {
+            if (!selected.get(i)) {
+              continue;
+            }
+            int node = others.node[i];
+            float score = others.score[i];
+            next.insertSorted(node, score);
+          }
+          enforceMaxConnLimit(next, scoreBetween);
+          return next;
+        });
+  }
+
+  /**
+   * Insert a new neighbor, maintaining our size cap by removing the least diverse neighbor if
+   * necessary.
+   */
+  public void insert(int neighborId, float score, NeighborSimilarity scoreBetween)
+      throws IOException {
+    assert neighborId != nodeId : "can't add self as neighbor at node " + nodeId;
+    neighborsRef.getAndUpdate(
+        current -> {
+          ConcurrentNeighborArray next = current.copy();
+          next.insertSorted(neighborId, score);
+          enforceMaxConnLimit(next, scoreBetween);
+          return next;
+        });
+  }
+
+  // is the candidate node with the given score closer to the base node than it is to any of the
+  // existing neighbors
+  private boolean isDiverse(
+      int node,
+      float score,
+      NeighborArray others,
+      BitSet selected,
+      NeighborSimilarity scoreBetween) {
+    for (int i = others.size() - 1; i >= 0; i--) {
+      if (!selected.get(i)) {
+        continue;
+      }
+      int candidateNode = others.node[i];
+      if (node == candidateNode) {
+        break;
+      }
+      if (scoreBetween.score(candidateNode, node) > score) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void enforceMaxConnLimit(NeighborArray neighbors, NeighborSimilarity scoreBetween) {
+    while (neighbors.size() > maxConnections) {
+      try {
+        removeLeastDiverse(neighbors, scoreBetween);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e); // called from closures
+      }
+    }
+  }
+
+  /**
+   * For each node e1 starting with the last neighbor (i.e. least similar to the base node), look at
+   * all nodes e2 that are closer to the base node than e1 is. If any e2 is closer to e1 than e1 is
+   * to the base node, remove e1.
+   */
+  private void removeLeastDiverse(NeighborArray neighbors, NeighborSimilarity scoreBetween)
+      throws IOException {
+    for (int i = neighbors.size() - 1; i >= 1; i--) {
+      int e1Id = neighbors.node[i];
+      float baseScore = neighbors.score[i];
+      for (int j = i - 1; j >= 0; j--) {
+        int n2Id = neighbors.node[j];
+        float n1n2Score = scoreBetween.score(e1Id, n2Id);
+        if (n1n2Score > baseScore) {
+          neighbors.removeIndex(i);
+          return;
+        }
+      }
+    }
+    // couldn't find any "non-diverse" neighbors, so remove the one farthest from the base node
+    neighbors.removeIndex(neighbors.size() - 1);
+  }
+
+  /** Only for testing; this is a linear search */
+  boolean contains(int i) {
+    var it = this.nodeIterator();
+    while (it.hasNext()) {
+      if (it.nextInt() == i) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @FunctionalInterface
+  interface NeighborSimilarity {
+    float score(int node1, int node2);
+  }
+
+  /** A NeighborArray that knows how to copy itself and that checks for duplicate entries */
+  private static class ConcurrentNeighborArray extends NeighborArray {
+    public ConcurrentNeighborArray(int maxSize, boolean descOrder) {
+      super(maxSize, descOrder);
+    }
+
+    // two nodes may attempt to add each other in the Concurrent classes,
+    // so we need to check if the node is already present.  this means that we can't use
+    // the parent approach of "append it, and then move it into place"
+    @Override
+    public void insertSorted(int newNode, float newScore) {
+      if (size == node.length) {
+        growArrays();
+      }
+      int insertionPoint =
+          scoresDescOrder
+              ? descSortFindRightMostInsertionPoint(newScore, size)
+              : ascSortFindRightMostInsertionPoint(newScore, size);
+      if (insertionPoint == size || node[insertionPoint] != newNode) {
+        System.arraycopy(node, insertionPoint, node, insertionPoint + 1, size - insertionPoint);
+        System.arraycopy(score, insertionPoint, score, insertionPoint + 1, size - insertionPoint);
+        node[insertionPoint] = newNode;
+        score[insertionPoint] = newScore;
+        ++size;
+      }
+    }
+
+    public ConcurrentNeighborArray copy() {
+      ConcurrentNeighborArray copy = new ConcurrentNeighborArray(node.length, scoresDescOrder);
+      copy.size = size;
+      System.arraycopy(node, 0, copy.node, 0, size);
+      System.arraycopy(score, 0, copy.score, 0, size);
+      return copy;
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentNeighborSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentNeighborSet.java
@@ -216,26 +216,6 @@ public class ConcurrentNeighborSet {
     return false;
   }
 
-  /** Encapsulates comparing node distances for diversity checks. */
-  public interface NeighborSimilarity {
-    /** for one-off comparisons between nodes */
-    float score(int node1, int node2);
-
-    /**
-     * For when we're going to compare node1 with multiple other nodes. This allows us to skip
-     * loading node1's vector (potentially from disk) redundantly for each comparison.
-     */
-    ScoreFunction scoreProvider(int node1);
-
-    /**
-     * A Function&lt;Integer, Float&gt; without the boxing
-     */
-    @FunctionalInterface
-    public interface ScoreFunction {
-      float apply(int node);
-    }
-  }
-
   /** A NeighborArray that knows how to copy itself and that checks for duplicate entries */
   static class ConcurrentNeighborArray extends NeighborArray {
     public ConcurrentNeighborArray(int maxSize, boolean descOrder) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentNeighborSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentNeighborSet.java
@@ -154,7 +154,7 @@ public class ConcurrentNeighborSet {
       return true;
     }
 
-    Function<Integer, Float> scoreProvider = similarity.scoreProvider(node);
+    NeighborSimilarity.ScoreFunction scoreProvider = similarity.scoreProvider(node);
     for (int i = others.size() - 1; i >= 0; i--) {
       if (!selected.get(i)) {
         continue;
@@ -189,7 +189,7 @@ public class ConcurrentNeighborSet {
     for (int i = neighbors.size() - 1; i >= 1; i--) {
       int e1Id = neighbors.node[i];
       float baseScore = neighbors.score[i];
-      Function<Integer, Float> scoreProvider = similarity.scoreProvider(e1Id);
+      NeighborSimilarity.ScoreFunction scoreProvider = similarity.scoreProvider(e1Id);
 
       for (int j = i - 1; j >= 0; j--) {
         int n2Id = neighbors.node[j];
@@ -225,7 +225,12 @@ public class ConcurrentNeighborSet {
      * For when we're going to compare node1 with multiple other nodes. This allows us to skip
      * loading node1's vector (potentially from disk) redundantly for each comparison.
      */
-    Function<Integer, Float> scoreProvider(int node1);
+    ScoreFunction scoreProvider(int node1);
+
+    @FunctionalInterface
+    public interface ScoreFunction {
+      float apply(int node);
+    }
   }
 
   /** A NeighborArray that knows how to copy itself and that checks for duplicate entries */

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentNeighborSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentNeighborSet.java
@@ -229,7 +229,7 @@ public class ConcurrentNeighborSet {
   }
 
   /** A NeighborArray that knows how to copy itself and that checks for duplicate entries */
-  private static class ConcurrentNeighborArray extends NeighborArray {
+  static class ConcurrentNeighborArray extends NeighborArray {
     public ConcurrentNeighborArray(int maxSize, boolean descOrder) {
       super(maxSize, descOrder);
     }
@@ -246,13 +246,31 @@ public class ConcurrentNeighborSet {
           scoresDescOrder
               ? descSortFindRightMostInsertionPoint(newScore, size)
               : ascSortFindRightMostInsertionPoint(newScore, size);
-      if (insertionPoint == size || node[insertionPoint] != newNode) {
+      if (!duplicateExistsNear(insertionPoint, newNode, newScore)) {
         System.arraycopy(node, insertionPoint, node, insertionPoint + 1, size - insertionPoint);
         System.arraycopy(score, insertionPoint, score, insertionPoint + 1, size - insertionPoint);
         node[insertionPoint] = newNode;
         score[insertionPoint] = newScore;
         ++size;
       }
+    }
+
+    private boolean duplicateExistsNear(int insertionPoint, int newNode, float newScore) {
+      // Check to the left
+      for (int i = insertionPoint - 1; i >= 0 && score[i] == newScore; i--) {
+        if (node[i] == newNode) {
+          return true;
+        }
+      }
+
+      // Check to the right
+      for (int i = insertionPoint; i < size && score[i] == newScore; i++) {
+        if (node[i] == newNode) {
+          return true;
+        }
+      }
+
+      return false;
     }
 
     public ConcurrentNeighborArray copy() {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentOnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentOnHeapHnswGraph.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.StampedLock;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.apache.lucene.util.hnsw.ConcurrentNeighborSet.NeighborSimilarity;
 
 /**
  * An {@link HnswGraph} that offers concurrent access; for typical graphs you will get significant

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentOnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentOnHeapHnswGraph.java
@@ -82,7 +82,20 @@ public final class ConcurrentOnHeapHnswGraph extends HnswGraph implements Accoun
     return levelZero == null ? 0 : levelZero.size(); // all nodes are located on the 0th level
   }
 
-  @Override
+  /**
+   * Add node on the given level with an empty set of neighbors.
+   *
+   * <p>Nodes can be inserted out of order, but it requires that the nodes preceded by the node
+   * inserted out of order are eventually added.
+   *
+   * <p>Actually populating the neighbors, and establishing bidirectional links, is the
+   * responsibility of the caller.
+   *
+   * <p>It is also the responsibility of the caller to ensure that each node is only added once.
+   *
+   * @param level level to add a node on
+   * @param node the node to add, represented as an ordinal on the level 0.
+   */
   public void addNode(int level, int node) {
     if (level >= graphLevels.size()) {
       for (int i = graphLevels.size(); i <= level; i++) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentOnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentOnHeapHnswGraph.java
@@ -1,0 +1,436 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.PrimitiveIterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.StampedLock;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+
+/**
+ * An {@link HnswGraph} that offers concurrent access; for typical graphs you will get significant
+ * speedups in construction and searching as you add threads.
+ *
+ * <p>To search this graph, you should use a View obtained from {@link #getView()} to perform `seek`
+ * and `nextNeighbor` operations.
+ */
+public final class ConcurrentOnHeapHnswGraph extends HnswGraph implements Accountable {
+  private final AtomicReference<NodeAtLevel>
+      entryPoint; // the current graph entry node on the top level. -1 if not set
+
+  // Unlike OnHeapHnswGraph (OHHG), we use the same data structure for Level 0 and higher node
+  // lists, a ConcurrentHashMap.  While the ArrayList used for L0 in OHHG is faster for
+  // single-threaded workloads, it imposes an unacceptable contention burden for concurrent
+  // graph building.
+  private final Map<Integer, Map<Integer, ConcurrentNeighborSet>> graphLevels;
+  private final CompletionTracker completions;
+
+  // Neighbours' size on upper levels (nsize) and level 0 (nsize0)
+  private final int nsize;
+  private final int nsize0;
+
+  ConcurrentOnHeapHnswGraph(int M) {
+    this.entryPoint =
+        new AtomicReference<>(
+            new NodeAtLevel(0, -1)); // Entry node should be negative until a node is added
+    this.nsize = M;
+    this.nsize0 = 2 * M;
+
+    this.graphLevels = new ConcurrentHashMap<>();
+    this.completions = new CompletionTracker(nsize0);
+  }
+
+  /**
+   * Returns the neighbors connected to the given node.
+   *
+   * @param level level of the graph
+   * @param node the node whose neighbors are returned, represented as an ordinal on the level 0.
+   */
+  public ConcurrentNeighborSet getNeighbors(int level, int node) {
+    return graphLevels.get(level).get(node);
+  }
+
+  @Override
+  public int size() {
+    Map<Integer, ConcurrentNeighborSet> levelZero = graphLevels.get(0);
+    return levelZero == null ? 0 : levelZero.size(); // all nodes are located on the 0th level
+  }
+
+  @Override
+  public void addNode(int level, int node) {
+    if (level >= graphLevels.size()) {
+      for (int i = graphLevels.size(); i <= level; i++) {
+        graphLevels.putIfAbsent(i, new ConcurrentHashMap<>());
+      }
+    }
+
+    graphLevels.get(level).put(node, new ConcurrentNeighborSet(node, connectionsOnLevel(level)));
+  }
+
+  /** must be called after addNode once neighbors are linked in all levels. */
+  void markComplete(int level, int node) {
+    entryPoint.accumulateAndGet(
+        new NodeAtLevel(level, node),
+        (oldEntry, newEntry) -> {
+          if (oldEntry.node >= 0 && oldEntry.level >= level) {
+            return oldEntry;
+          } else {
+            return newEntry;
+          }
+        });
+    completions.markComplete(node);
+  }
+
+  private int connectionsOnLevel(int level) {
+    return level == 0 ? nsize0 : nsize;
+  }
+
+  @Override
+  public void seek(int level, int target) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int nextNeighbor() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @return the current number of levels in the graph where nodes have been added and we have a
+   *     valid entry point.
+   */
+  @Override
+  public int numLevels() {
+    return entryPoint.get().level + 1;
+  }
+
+  /**
+   * Returns the graph's current entry node on the top level shown as ordinals of the nodes on 0th
+   * level
+   *
+   * @return the graph's current entry node on the top level
+   */
+  @Override
+  public int entryNode() {
+    return entryPoint.get().node;
+  }
+
+  NodeAtLevel entry() {
+    return entryPoint.get();
+  }
+
+  @Override
+  public NodesIterator getNodesOnLevel(int level) {
+    // We avoid the temptation to optimize L0 by using ArrayNodesIterator.
+    // This is because, while L0 will contain sequential ordinals once the graph is complete,
+    // and internally Lucene only calls getNodesOnLevel at that point, this is a public
+    // method so we cannot assume that that is the only time it will be called by third parties.
+    return new CollectionNodesIterator(graphLevels.get(level).keySet());
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    // the main graph structure
+    long total = concurrentHashMapRamUsed(graphLevels.size());
+    for (int l = 0; l <= entryPoint.get().level; l++) {
+      Map<Integer, ConcurrentNeighborSet> level = graphLevels.get(l);
+      if (level == null) {
+        continue;
+      }
+
+      int numNodesOnLevel = graphLevels.get(l).size();
+      long chmSize = concurrentHashMapRamUsed(numNodesOnLevel);
+      long neighborSize = neighborsRamUsed(connectionsOnLevel(l)) * numNodesOnLevel;
+
+      total += chmSize + neighborSize;
+    }
+
+    // logical clocks
+    total += completions.ramBytesUsed();
+
+    return total;
+  }
+
+  public long ramBytesUsedOneNode(int nodeLevel) {
+    int entryCount = (int) (nodeLevel / CHM_LOAD_FACTOR);
+    var graphBytesUsed =
+        chmEntriesRamUsed(entryCount)
+            + neighborsRamUsed(connectionsOnLevel(0))
+            + nodeLevel * neighborsRamUsed(connectionsOnLevel(1));
+    var clockBytesUsed = Integer.BYTES;
+    return graphBytesUsed + clockBytesUsed;
+  }
+
+  private static long neighborsRamUsed(int count) {
+    long REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+    long AH_BYTES = RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+    long neighborSetBytes =
+        REF_BYTES // atomicreference
+            + Integer.BYTES
+            + Integer.BYTES
+            + REF_BYTES // NeighborArray
+            + AH_BYTES * 2 // NeighborArray internals
+            + REF_BYTES * 2
+            + Integer.BYTES
+            + 1;
+    return neighborSetBytes + (long) count * (Integer.BYTES + Float.BYTES);
+  }
+
+  private static final float CHM_LOAD_FACTOR = 0.75f; // this is hardcoded inside ConcurrentHashMap
+
+  /**
+   * caller's responsibility to divide number of entries by load factor to get internal node count
+   */
+  private static long chmEntriesRamUsed(int internalEntryCount) {
+    long REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+    long chmNodeBytes =
+        REF_BYTES // node itself in Node[]
+            + 3L * REF_BYTES
+            + Integer.BYTES; // node internals
+
+    return internalEntryCount * chmNodeBytes;
+  }
+
+  private static long concurrentHashMapRamUsed(int externalSize) {
+    long REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+    long AH_BYTES = RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+    long CORES = Runtime.getRuntime().availableProcessors();
+
+    // CHM has a striped counter Cell implementation, we expect at most one per core
+    long chmCounters = AH_BYTES + CORES * (REF_BYTES + Long.BYTES);
+
+    int nodeCount = (int) (externalSize / CHM_LOAD_FACTOR);
+
+    long chmSize =
+        chmEntriesRamUsed(nodeCount) // nodes
+            + nodeCount * REF_BYTES
+            + AH_BYTES // nodes array
+            + Long.BYTES
+            + 3 * Integer.BYTES
+            + 3 * REF_BYTES // extra internal fields
+            + chmCounters
+            + REF_BYTES; // the Map reference itself
+    return chmSize;
+  }
+
+  @Override
+  public String toString() {
+    return "ConcurrentOnHeapHnswGraph(size=" + size() + ", entryPoint=" + entryPoint.get();
+  }
+
+  /**
+   * Returns a view of the graph that is safe to use concurrently with updates performed on the
+   * underlying graph.
+   *
+   * <p>Multiple Views may be searched concurrently.
+   */
+  public HnswGraph getView() {
+    return new ConcurrentHnswGraphView();
+  }
+
+  void validateEntryNode() {
+    if (size() == 0) {
+      return;
+    }
+    var en = entryPoint.get();
+    if (!(en.level >= 0 && en.node >= 0 && graphLevels.get(en.level).containsKey(en.node))) {
+      throw new IllegalStateException("Entry node was incompletely added! " + en);
+    }
+  }
+
+  /**
+   * A concurrent View of the graph that is safe to search concurrently with updates and with other
+   * searches. The View provides a limited kind of snapshot isolation: only nodes completely added
+   * to the graph at the time the View was created will be visible (but the connections between them
+   * are allowed to change, so you could potentially get different top K results from the same query
+   * if concurrent updates are in progress.)
+   */
+  private class ConcurrentHnswGraphView extends HnswGraph {
+    // It is tempting, but incorrect, to try to provide "adequate" isolation by
+    // (1) keeping a bitset of complete nodes and giving that to the searcher as nodes to
+    // accept -- but we need to keep incomplete nodes out of the search path entirely,
+    // not just out of the result set, or
+    // (2) keeping a bitset of complete nodes and restricting the View to those nodes
+    // -- but we needs to consider neighbor diversity separately for concurrent
+    // inserts and completed nodes; this allows us to keep the former out of the latter,
+    // but not the latter out of the former (when a node completes while we are working,
+    // that was in-progress when we started.)
+    // The only really foolproof solution is to implement snapshot isolation as
+    // we have done here.
+    private final int timestamp;
+    private PrimitiveIterator.OfInt remainingNeighbors;
+
+    public ConcurrentHnswGraphView() {
+      this.timestamp = completions.clock();
+    }
+
+    @Override
+    public int size() {
+      return ConcurrentOnHeapHnswGraph.this.size();
+    }
+
+    @Override
+    public int numLevels() {
+      return ConcurrentOnHeapHnswGraph.this.numLevels();
+    }
+
+    @Override
+    public int entryNode() {
+      return ConcurrentOnHeapHnswGraph.this.entryNode();
+    }
+
+    @Override
+    public NodesIterator getNodesOnLevel(int level) {
+      return ConcurrentOnHeapHnswGraph.this.getNodesOnLevel(level);
+    }
+
+    @Override
+    public void seek(int level, int targetNode) {
+      remainingNeighbors = getNeighbors(level, targetNode).nodeIterator();
+    }
+
+    @Override
+    public int nextNeighbor() {
+      while (remainingNeighbors.hasNext()) {
+        int next = remainingNeighbors.nextInt();
+        if (completions.completedAt(next) < timestamp) {
+          return next;
+        }
+      }
+      return NO_MORE_DOCS;
+    }
+
+    @Override
+    public String toString() {
+      return "ConcurrentOnHeapHnswGraphView(size=" + size() + ", entryPoint=" + entryPoint.get();
+    }
+  }
+
+  static final class NodeAtLevel implements Comparable<NodeAtLevel> {
+    public final int level;
+    public final int node;
+
+    public NodeAtLevel(int level, int node) {
+      this.level = level;
+      this.node = node;
+    }
+
+    @Override
+    public int compareTo(NodeAtLevel o) {
+      int cmp = Integer.compare(level, o.level);
+      if (cmp == 0) {
+        cmp = Integer.compare(node, o.node);
+      }
+      return cmp;
+    }
+
+    @Override
+    public String toString() {
+      return "NodeAtLevel(level=" + level + ", node=" + node + ")";
+    }
+  }
+
+  /** Class to provide snapshot isolation for nodes in the progress of being added. */
+  static final class CompletionTracker implements Accountable {
+    private final AtomicInteger logicalClock = new AtomicInteger();
+    private volatile AtomicIntegerArray completionTimes;
+    private final StampedLock sl = new StampedLock();
+
+    public CompletionTracker(int initialSize) {
+      completionTimes = new AtomicIntegerArray(initialSize);
+      for (int i = 0; i < initialSize; i++) {
+        completionTimes.set(i, Integer.MAX_VALUE);
+      }
+    }
+
+    /**
+     * @param node ordinal
+     */
+    void markComplete(int node) {
+      int completionClock = logicalClock.getAndIncrement();
+      ensureCapacity(node);
+      long stamp;
+      do {
+        stamp = sl.tryOptimisticRead();
+        completionTimes.set(node, completionClock);
+      } while (!sl.validate(stamp));
+    }
+
+    /**
+     * @return the current logical timestamp; can be compared with completedAt values
+     */
+    int clock() {
+      return logicalClock.get();
+    }
+
+    /**
+     * @param node ordinal
+     * @return the logical clock completion time of the node, or Integer.MAX_VALUE if the node has
+     *     not yet been completed.
+     */
+    public int completedAt(int node) {
+      AtomicIntegerArray ct = completionTimes;
+      if (node >= ct.length()) {
+        return Integer.MAX_VALUE;
+      }
+      return ct.get(node);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+      int REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+      return REF_BYTES
+          + Integer.BYTES // logicalClock
+          + REF_BYTES
+          + (long) Integer.BYTES * completionTimes.length();
+    }
+
+    private void ensureCapacity(int node) {
+      if (node < completionTimes.length()) {
+        return;
+      }
+
+      long stamp = sl.writeLock();
+      try {
+        AtomicIntegerArray oldArray = completionTimes;
+        if (node >= oldArray.length()) {
+          int newSize = (node + 1) * 2;
+          AtomicIntegerArray newArray = new AtomicIntegerArray(newSize);
+          for (int i = 0; i < newSize; i++) {
+            if (i < oldArray.length()) {
+              newArray.set(i, oldArray.get(i));
+            } else {
+              newArray.set(i, Integer.MAX_VALUE);
+            }
+          }
+          completionTimes = newArray;
+        }
+      } finally {
+        sl.unlockWrite(stamp);
+      }
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -44,9 +44,10 @@ import org.apache.lucene.index.FloatVectorValues;
  *       many of the <code>efConst</code> neighbors are connected to the new node
  * </ul>
  *
- * <p>Note: The graph may be searched by multiple threads concurrently, but updates are not
- * thread-safe. The search method optionally takes a set of "accepted nodes", which can be used to
+ * <p>Note: The search method optionally takes a set of "accepted nodes", which can be used to
  * exclude deleted documents.
+ *
+ * <p>Thread safety of inserts and searches depends on the implementation.
  */
 public abstract class HnswGraph {
 
@@ -121,6 +122,24 @@ public abstract class HnswGraph {
           return ArrayNodesIterator.EMPTY;
         }
       };
+
+  /**
+   * Add node on the given level with an empty set of neighbors.
+   *
+   * <p>Nodes can be inserted out of order, but it requires that the nodes preceded by the node
+   * inserted out of order are eventually added.
+   *
+   * <p>Actually populating the neighbors, and establishing bidirectional links, is the
+   * responsibility of the caller.
+   *
+   * <p>It is also the responsibility of the caller to ensure that each node is only added once.
+   *
+   * @param level level to add a node on
+   * @param node the node to add, represented as an ordinal on the level 0.
+   */
+  public void addNode(int level, int node) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Iterator over the graph nodes on a certain level, Iterator also provides the size – the total

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -124,24 +124,6 @@ public abstract class HnswGraph {
       };
 
   /**
-   * Add node on the given level with an empty set of neighbors.
-   *
-   * <p>Nodes can be inserted out of order, but it requires that the nodes preceded by the node
-   * inserted out of order are eventually added.
-   *
-   * <p>Actually populating the neighbors, and establishing bidirectional links, is the
-   * responsibility of the caller.
-   *
-   * <p>It is also the responsibility of the caller to ensure that each node is only added once.
-   *
-   * @param level level to add a node on
-   * @param node the node to add, represented as an ordinal on the level 0.
-   */
-  public void addNode(int level, int node) {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
    * Iterator over the graph nodes on a certain level, Iterator also provides the size – the total
    * number of nodes to be iterated over. The nodes are NOT guaranteed to be presented in any
    * particular order.

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -78,6 +78,7 @@ public final class HnswGraphBuilder<T> {
   // we need two sources of vectors in order to perform diversity check comparisons without
   // colliding
   private final RandomAccessVectorValues<T> vectorsCopy;
+  // tracks nodes that were already added when initializing from another graph
   private final Set<Integer> initializedNodes;
 
   public static <T> HnswGraphBuilder<T> create(

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -120,7 +120,7 @@ public class HnswGraphSearcher<T> {
       RandomAccessVectorValues<float[]> vectors,
       VectorEncoding vectorEncoding,
       VectorSimilarityFunction similarityFunction,
-      HnswGraph graph,
+      ConcurrentOnHeapHnswGraph graph,
       Bits acceptOrds,
       int visitedLimit)
       throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -29,8 +29,8 @@ import org.apache.lucene.util.ArrayUtil;
  * @lucene.internal
  */
 public class NeighborArray {
-  private final boolean scoresDescOrder;
-  private int size;
+  protected final boolean scoresDescOrder;
+  protected int size;
 
   float[] score;
   int[] node;
@@ -49,8 +49,7 @@ public class NeighborArray {
   public void addInOrder(int newNode, float newScore) {
     assert size == sortedNodeSize : "cannot call addInOrder after addOutOfOrder";
     if (size == node.length) {
-      node = ArrayUtil.grow(node);
-      score = ArrayUtil.growExact(score, node.length);
+      growArrays();
     }
     if (size > 0) {
       float previousScore = score[size - 1];
@@ -70,8 +69,7 @@ public class NeighborArray {
   /** Add node and score but do not insert as sorted */
   public void addOutOfOrder(int newNode, float newScore) {
     if (size == node.length) {
-      node = ArrayUtil.grow(node);
-      score = ArrayUtil.growExact(score, node.length);
+      growArrays();
     }
     node[size] = newNode;
     score[size] = newScore;
@@ -126,10 +124,14 @@ public class NeighborArray {
     return insertionPoint;
   }
 
-  /** This method is for test only. */
-  void insertSorted(int newNode, float newScore) {
+  protected void insertSorted(int newNode, float newScore) {
     addOutOfOrder(newNode, newScore);
     insertSortedInternal();
+  }
+
+  protected void growArrays() {
+    node = ArrayUtil.grow(node);
+    score = ArrayUtil.growExact(score, node.length);
   }
 
   public int size() {
@@ -173,7 +175,7 @@ public class NeighborArray {
     return "NeighborArray[" + size + "]";
   }
 
-  private int ascSortFindRightMostInsertionPoint(float newScore, int bound) {
+  protected int ascSortFindRightMostInsertionPoint(float newScore, int bound) {
     int insertionPoint = Arrays.binarySearch(score, 0, bound, newScore);
     if (insertionPoint >= 0) {
       // find the right most position with the same score
@@ -187,7 +189,7 @@ public class NeighborArray {
     return insertionPoint;
   }
 
-  private int descSortFindRightMostInsertionPoint(float newScore, int bound) {
+  protected int descSortFindRightMostInsertionPoint(float newScore, int bound) {
     int start = 0;
     int end = bound - 1;
     while (start <= end) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -129,7 +129,7 @@ public class NeighborArray {
     insertSortedInternal();
   }
 
-  protected void growArrays() {
+  protected final void growArrays() {
     node = ArrayUtil.grow(node);
     score = ArrayUtil.growExact(score, node.length);
   }
@@ -175,7 +175,7 @@ public class NeighborArray {
     return "NeighborArray[" + size + "]";
   }
 
-  protected int ascSortFindRightMostInsertionPoint(float newScore, int bound) {
+  protected final int ascSortFindRightMostInsertionPoint(float newScore, int bound) {
     int insertionPoint = Arrays.binarySearch(score, 0, bound, newScore);
     if (insertionPoint >= 0) {
       // find the right most position with the same score
@@ -189,7 +189,7 @@ public class NeighborArray {
     return insertionPoint;
   }
 
-  protected int descSortFindRightMostInsertionPoint(float newScore, int bound) {
+  protected final int descSortFindRightMostInsertionPoint(float newScore, int bound) {
     int start = 0;
     int end = bound - 1;
     while (start <= end) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -131,6 +131,9 @@ public class NeighborQueue {
     return decodeNodeId(heap.pop());
   }
 
+  /**
+   * Returns a copy of the internal nodes array.  Not sorted by score!
+   */
   public int[] nodes() {
     int size = size();
     int[] nodes = new int[size];

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -131,9 +131,7 @@ public class NeighborQueue {
     return decodeNodeId(heap.pop());
   }
 
-  /**
-   * Returns a copy of the internal nodes array.  Not sorted by score!
-   */
+  /** Returns a copy of the internal nodes array. Not sorted by score! */
   public int[] nodes() {
     int size = size();
     int[] nodes = new int[size];

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborSimilarity.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborSimilarity.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+/**
+ * Encapsulates comparing node distances for diversity checks.
+ */
+public interface NeighborSimilarity {
+  /**
+   * for one-off comparisons between nodes
+   */
+  float score(int node1, int node2);
+
+  /**
+   * For when we're going to compare node1 with multiple other nodes. This allows us to skip
+   * loading node1's vector (potentially from disk) redundantly for each comparison.
+   */
+  ScoreFunction scoreProvider(int node1);
+
+  /**
+   * A Function&lt;Integer, Float&gt; without the boxing
+   */
+  @FunctionalInterface
+  interface ScoreFunction {
+    float apply(int node);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborSimilarity.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborSimilarity.java
@@ -17,24 +17,18 @@
 
 package org.apache.lucene.util.hnsw;
 
-/**
- * Encapsulates comparing node distances for diversity checks.
- */
+/** Encapsulates comparing node distances for diversity checks. */
 public interface NeighborSimilarity {
-  /**
-   * for one-off comparisons between nodes
-   */
+  /** for one-off comparisons between nodes */
   float score(int node1, int node2);
 
   /**
-   * For when we're going to compare node1 with multiple other nodes. This allows us to skip
-   * loading node1's vector (potentially from disk) redundantly for each comparison.
+   * For when we're going to compare node1 with multiple other nodes. This allows us to skip loading
+   * node1's vector (potentially from disk) redundantly for each comparison.
    */
   ScoreFunction scoreProvider(int node1);
 
-  /**
-   * A Function&lt;Integer, Float&gt; without the boxing
-   */
+  /** A Function&lt;Integer, Float&gt; without the boxing */
   @FunctionalInterface
   interface ScoreFunction {
     float apply(int node);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -92,7 +92,20 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
     return graphLevel0.size(); // all nodes are located on the 0th level
   }
 
-  @Override
+  /**
+   * Add node on the given level with an empty set of neighbors.
+   *
+   * <p>Nodes can be inserted out of order, but it requires that the nodes preceded by the node
+   * inserted out of order are eventually added.
+   *
+   * <p>Actually populating the neighbors, and establishing bidirectional links, is the
+   * responsibility of the caller.
+   *
+   * <p>It is also the responsibility of the caller to ensure that each node is only added once.
+   *
+   * @param level level to add a node on
+   * @param node the node to add, represented as an ordinal on the level 0.
+   */
   public void addNode(int level, int node) {
     if (entryNode == -1) {
       entryNode = node;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -188,15 +188,17 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
     long REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
 
     long neighborArrayBytes0 =
-        (long) nsize0 * (Integer.BYTES + Float.BYTES)
+        (long) nsize0 * (Integer.BYTES + Float.BYTES) // int[] and float[] array contents
+            + AH_BYTES * 2 // int[] and float[] array contents
+            + REF_BYTES // the object reference
+            + Integer.BYTES * 2 // size and sortedNodeSize
+            + 1; // boolean scoresDescOrder
+    long neighborArrayBytes = // same as level 0 but with nsize instead of nsize0
+        (long) nsize * (Integer.BYTES + Float.BYTES)
             + AH_BYTES * 2
             + REF_BYTES
-            + Integer.BYTES * 2;
-    long neighborArrayBytes =
-        (long) nsize * (Integer.BYTES + Float.BYTES)
-            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
-            + REF_BYTES * 2
-            + Integer.BYTES * 3;
+            + Integer.BYTES * 2
+            + 1;
     long total = 0;
 
     // a hashmap Node contains an int hash and a Node reference, as well as K and V references.

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomAccessVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomAccessVectorValues.java
@@ -35,6 +35,10 @@ public interface RandomAccessVectorValues<T> {
 
   /**
    * Return the vector value indexed at the given ordinal.
+   * <p>
+   * For performance, implementations will usually re-use the same object across invocations,
+   * that is, you will get back the same float[] reference (for instance) for every requested
+   * ordinal.  If you want to use those values across calls, you should make a copy.
    *
    * @param targetOrd a valid ordinal, &ge; 0 and &lt; {@link #size()}.
    */

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomAccessVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomAccessVectorValues.java
@@ -35,10 +35,10 @@ public interface RandomAccessVectorValues<T> {
 
   /**
    * Return the vector value indexed at the given ordinal.
-   * <p>
-   * For performance, implementations will usually re-use the same object across invocations,
+   *
+   * <p>For performance, implementations will usually re-use the same object across invocations,
    * that is, you will get back the same float[] reference (for instance) for every requested
-   * ordinal.  If you want to use those values across calls, you should make a copy.
+   * ordinal. If you want to use those values across calls, you should make a copy.
    *
    * @param targetOrd a valid ordinal, &ge; 0 and &lt; {@link #size()}.
    */

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/AbstractMockVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/AbstractMockVectorValues.java
@@ -30,6 +30,7 @@ abstract class AbstractMockVectorValues<T> implements RandomAccessVectorValues<T
   protected final int numVectors;
   protected final BytesRef binaryValue;
 
+  private long callingThreadID = -1;
   protected int pos = -1;
 
   AbstractMockVectorValues(T[] values, int dimension, T[] denseValues, int numVectors) {
@@ -54,6 +55,13 @@ abstract class AbstractMockVectorValues<T> implements RandomAccessVectorValues<T
 
   @Override
   public T vectorValue(int targetOrd) {
+    if (callingThreadID < 0) {
+      callingThreadID = Thread.currentThread().getId();
+    }
+    if (callingThreadID != Thread.currentThread().getId()) {
+      throw new RuntimeException("RandomAccessVectorValues is not thread safe, but multiple calling threads detected");
+    }
+
     return denseValues[targetOrd];
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/AbstractMockVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/AbstractMockVectorValues.java
@@ -59,7 +59,8 @@ abstract class AbstractMockVectorValues<T> implements RandomAccessVectorValues<T
       callingThreadID = Thread.currentThread().getId();
     }
     if (callingThreadID != Thread.currentThread().getId()) {
-      throw new RuntimeException("RandomAccessVectorValues is not thread safe, but multiple calling threads detected");
+      throw new RuntimeException(
+          "RandomAccessVectorValues is not thread safe, but multiple calling threads detected");
     }
 
     return denseValues[targetOrd];

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/ConcurrentHnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/ConcurrentHnswGraphTestCase.java
@@ -523,8 +523,8 @@ abstract class ConcurrentHnswGraphTestCase<T> extends LuceneTestCase {
       }
     }
 
-    ConcurrentNeighborSet.NeighborSimilarity mockSimilarity =
-        new ConcurrentNeighborSet.NeighborSimilarity() {
+    NeighborSimilarity mockSimilarity =
+        new NeighborSimilarity() {
           @Override
           public float score(int a, int b) {
             throw new UnsupportedOperationException();

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/ConcurrentHnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/ConcurrentHnswGraphTestCase.java
@@ -1,0 +1,1297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween;
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.apache.lucene.tests.util.RamUsageTester.ramUsed;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.lucene95.Lucene95Codec;
+import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsFormat;
+import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsReader;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.ThreadInterruptedException;
+import org.apache.lucene.util.VectorUtil;
+import org.apache.lucene.util.hnsw.HnswGraph.NodesIterator;
+
+/** Tests HNSW KNN graphs */
+abstract class ConcurrentHnswGraphTestCase<T> extends LuceneTestCase {
+
+  VectorSimilarityFunction similarityFunction;
+
+  abstract VectorEncoding getVectorEncoding();
+
+  abstract Query knnQuery(String field, T vector, int k);
+
+  abstract T randomVector(int dim);
+
+  abstract AbstractMockVectorValues<T> vectorValues(int size, int dimension);
+
+  abstract AbstractMockVectorValues<T> vectorValues(float[][] values);
+
+  abstract AbstractMockVectorValues<T> vectorValues(LeafReader reader, String fieldName)
+      throws IOException;
+
+  abstract AbstractMockVectorValues<T> vectorValues(
+      int size,
+      int dimension,
+      AbstractMockVectorValues<T> pregeneratedVectorValues,
+      int pregeneratedOffset);
+
+  abstract Field knnVectorField(String name, T vector, VectorSimilarityFunction similarityFunction);
+
+  abstract RandomAccessVectorValues<T> circularVectorValues(int nDoc);
+
+  abstract T getTargetVector();
+
+  // test writing out and reading in a graph gives the expected graph
+  public void testReadWrite() throws IOException {
+    int dim = random().nextInt(100) + 1;
+    int nDoc = random().nextInt(100) + 1;
+    int M = random().nextInt(4) + 2;
+    int beamWidth = random().nextInt(10) + 5;
+    long seed = random().nextLong();
+    AbstractMockVectorValues<T> vectors = vectorValues(nDoc, dim);
+    AbstractMockVectorValues<T> v2 = vectors.copy(), v3 = vectors.copy();
+    HnswGraphBuilder<T> builder =
+        HnswGraphBuilder.create(
+            vectors, getVectorEncoding(), similarityFunction, M, beamWidth, seed);
+    HnswGraph hnsw = builder.build(vectors.copy());
+
+    // Recreate the graph while indexing with the same random seed and write it out
+    HnswGraphBuilder.randSeed = seed;
+    try (Directory dir = newDirectory()) {
+      int nVec = 0, indexedDoc = 0;
+      // Don't merge randomly, create a single segment because we rely on the docid ordering for
+      // this test
+      IndexWriterConfig iwc =
+          new IndexWriterConfig()
+              .setCodec(
+                  new Lucene95Codec() {
+                    @Override
+                    public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                      return new Lucene95HnswVectorsFormat(M, beamWidth);
+                    }
+                  });
+      try (IndexWriter iw = new IndexWriter(dir, iwc)) {
+        while (v2.nextDoc() != NO_MORE_DOCS) {
+          while (indexedDoc < v2.docID()) {
+            // increment docId in the index by adding empty documents
+            iw.addDocument(new Document());
+            indexedDoc++;
+          }
+          Document doc = new Document();
+          doc.add(knnVectorField("field", v2.vectorValue(), similarityFunction));
+          doc.add(new StoredField("id", v2.docID()));
+          iw.addDocument(doc);
+          nVec++;
+          indexedDoc++;
+        }
+      }
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        for (LeafReaderContext ctx : reader.leaves()) {
+          AbstractMockVectorValues<T> values = vectorValues(ctx.reader(), "field");
+          assertEquals(dim, values.dimension());
+          assertEquals(nVec, values.size());
+          assertEquals(indexedDoc, ctx.reader().maxDoc());
+          assertEquals(indexedDoc, ctx.reader().numDocs());
+          assertVectorsEqual(v3, values);
+          HnswGraph graphValues =
+              ((Lucene95HnswVectorsReader)
+                      ((PerFieldKnnVectorsFormat.FieldsReader)
+                              ((CodecReader) ctx.reader()).getVectorReader())
+                          .getFieldReader("field"))
+                  .getGraph("field");
+          assertGraphEqual(hnsw, graphValues);
+        }
+      }
+    }
+  }
+
+  // test that sorted index returns the same search results are unsorted
+  public void testSortedAndUnsortedIndicesReturnSameResults() throws IOException {
+    int dim = random().nextInt(10) + 3;
+    int nDoc = random().nextInt(200) + 100;
+    AbstractMockVectorValues<T> vectors = vectorValues(nDoc, dim);
+
+    int M = random().nextInt(10) + 5;
+    int beamWidth = random().nextInt(10) + 5;
+    VectorSimilarityFunction similarityFunction =
+        RandomizedTest.randomFrom(VectorSimilarityFunction.values());
+    IndexWriterConfig iwc =
+        new IndexWriterConfig()
+            .setCodec(
+                new Lucene95Codec() {
+                  @Override
+                  public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                    return new Lucene95HnswVectorsFormat(M, beamWidth);
+                  }
+                });
+    IndexWriterConfig iwc2 =
+        new IndexWriterConfig()
+            .setCodec(
+                new Lucene95Codec() {
+                  @Override
+                  public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                    return new Lucene95HnswVectorsFormat(M, beamWidth);
+                  }
+                })
+            .setIndexSort(new Sort(new SortField("sortkey", SortField.Type.LONG)));
+
+    try (Directory dir = newDirectory();
+        Directory dir2 = newDirectory()) {
+      int indexedDoc = 0;
+      try (IndexWriter iw = new IndexWriter(dir, iwc);
+          IndexWriter iw2 = new IndexWriter(dir2, iwc2)) {
+        while (vectors.nextDoc() != NO_MORE_DOCS) {
+          while (indexedDoc < vectors.docID()) {
+            // increment docId in the index by adding empty documents
+            iw.addDocument(new Document());
+            indexedDoc++;
+          }
+          Document doc = new Document();
+          doc.add(knnVectorField("vector", vectors.vectorValue(), similarityFunction));
+          doc.add(new StoredField("id", vectors.docID()));
+          doc.add(new NumericDocValuesField("sortkey", random().nextLong()));
+          iw.addDocument(doc);
+          iw2.addDocument(doc);
+          indexedDoc++;
+        }
+      }
+      try (IndexReader reader = DirectoryReader.open(dir);
+          IndexReader reader2 = DirectoryReader.open(dir2)) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+        IndexSearcher searcher2 = new IndexSearcher(reader2);
+        OUTER:
+        for (int i = 0; i < 10; i++) {
+          // ask to explore a lot of candidates to ensure the same returned hits,
+          // as graphs of 2 indices are organized differently
+          Query query = knnQuery("vector", randomVector(dim), 50);
+          int searchSize = 5;
+          List<String> ids1 = new ArrayList<>(searchSize);
+          List<Integer> docs1 = new ArrayList<>(searchSize);
+          List<String> ids2 = new ArrayList<>(searchSize);
+          List<Integer> docs2 = new ArrayList<>(searchSize);
+
+          // Check if a duplicate score exists in n+1, if so, this test is invalid
+          // Else, continue to fail on ID equality as this test failed
+          TopDocs topDocs = searcher.search(query, searchSize + 1);
+          float lastScore = -1;
+          StoredFields storedFields = reader.storedFields();
+          for (int j = 0; j < searchSize + 1; j++) {
+            ScoreDoc scoreDoc = topDocs.scoreDocs[j];
+            if (scoreDoc.score == lastScore) {
+              // if we have repeated score this test is invalid
+              continue OUTER;
+            } else {
+              lastScore = scoreDoc.score;
+            }
+            if (j < searchSize) {
+              Document doc = storedFields.document(scoreDoc.doc, Set.of("id"));
+              ids1.add(doc.get("id"));
+              docs1.add(scoreDoc.doc);
+            }
+          }
+          TopDocs topDocs2 = searcher2.search(query, searchSize);
+          StoredFields storedFields2 = reader2.storedFields();
+          for (ScoreDoc scoreDoc : topDocs2.scoreDocs) {
+            Document doc = storedFields2.document(scoreDoc.doc, Set.of("id"));
+            ids2.add(doc.get("id"));
+            docs2.add(scoreDoc.doc);
+          }
+          assertEquals(ids1, ids2);
+          // doc IDs are not equal, as in the second sorted index docs are organized differently
+          assertNotEquals(docs1, docs2);
+        }
+      }
+    }
+  }
+
+  List<Integer> sortedNodesOnLevel(HnswGraph h, int level) throws IOException {
+    NodesIterator nodesOnLevel = h.getNodesOnLevel(level);
+    List<Integer> nodes = new ArrayList<>();
+    while (nodesOnLevel.hasNext()) {
+      nodes.add(nodesOnLevel.next());
+    }
+    Collections.sort(nodes);
+    return nodes;
+  }
+
+  void assertGraphEqual(HnswGraph g, HnswGraph h) throws IOException {
+    // construct these up front since they call seek which will mess up our test loop
+    String prettyG = prettyPrint(g);
+    String prettyH = prettyPrint(h);
+    assertEquals(
+        String.format(
+            Locale.ROOT,
+            "the number of levels in the graphs are different:%n%s%n%s",
+            prettyG,
+            prettyH),
+        g.numLevels(),
+        h.numLevels());
+    assertEquals(
+        String.format(
+            Locale.ROOT,
+            "the number of nodes in the graphs are different:%n%s%n%s",
+            prettyG,
+            prettyH),
+        g.size(),
+        h.size());
+
+    // assert equal nodes on each level
+    for (int level = 0; level < g.numLevels(); level++) {
+      List<Integer> hNodes = sortedNodesOnLevel(h, level);
+      List<Integer> gNodes = sortedNodesOnLevel(g, level);
+      assertEquals(
+          String.format(
+              Locale.ROOT,
+              "nodes in the graphs are different on level %d:%n%s%n%s",
+              level,
+              prettyG,
+              prettyH),
+          gNodes,
+          hNodes);
+    }
+
+    // assert equal nodes' neighbours on each level
+    for (int level = 0; level < g.numLevels(); level++) {
+      NodesIterator nodesOnLevel = g.getNodesOnLevel(level);
+      while (nodesOnLevel.hasNext()) {
+        int node = nodesOnLevel.nextInt();
+        g.seek(level, node);
+        h.seek(level, node);
+        assertEquals(
+            String.format(
+                Locale.ROOT,
+                "arcs differ for node %d on level %d:%n%s%n%s",
+                node,
+                level,
+                prettyG,
+                prettyH),
+            getNeighborNodes(g),
+            getNeighborNodes(h));
+      }
+    }
+  }
+
+  // Make sure we actually approximately find the closest k elements. Mostly this is about
+  // ensuring that we have all the distance functions, comparators, priority queues and so on
+  // oriented in the right directions
+  @SuppressWarnings("unchecked")
+  public void testAknnDiverse() throws IOException {
+    int nDoc = 100;
+    similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
+    RandomAccessVectorValues<T> vectors = circularVectorValues(nDoc);
+    VectorEncoding vectorEncoding = getVectorEncoding();
+    ConcurrentHnswGraphBuilder<T> builder =
+        new ConcurrentHnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, 10, 100);
+    ConcurrentOnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    // run some searches
+    NeighborQueue nn =
+        switch (getVectorEncoding()) {
+          case BYTE -> HnswGraphSearcher.search(
+              (byte[]) getTargetVector(),
+              10,
+              (RandomAccessVectorValues<byte[]>) vectors.copy(),
+              getVectorEncoding(),
+              similarityFunction,
+              hnsw.getView(),
+              null,
+              Integer.MAX_VALUE);
+          case FLOAT32 -> HnswGraphSearcher.search(
+              (float[]) getTargetVector(),
+              10,
+              (RandomAccessVectorValues<float[]>) vectors.copy(),
+              getVectorEncoding(),
+              similarityFunction,
+              hnsw.getView(),
+              null,
+              Integer.MAX_VALUE);
+        };
+
+    int[] nodes = nn.nodes();
+    assertEquals("Number of found results is not equal to [10].", 10, nodes.length);
+    int sum = 0;
+    for (int node : nodes) {
+      sum += node;
+    }
+    // We expect to get approximately 100% recall;
+    // the lowest docIds are closest to zero; sum(0,9) = 45
+    assertTrue("sum(result docs)=" + sum, sum < 75);
+
+    for (int i = 0; i < nDoc; i++) {
+      ConcurrentNeighborSet neighbors = hnsw.getNeighbors(0, i);
+      Iterator<Integer> it = neighbors.nodeIterator();
+      while (it.hasNext()) {
+        // all neighbors should be valid node ids.
+        assertTrue(it.next() < nDoc);
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testSearchWithAcceptOrds() throws IOException {
+    int nDoc = 100;
+    RandomAccessVectorValues<T> vectors = circularVectorValues(nDoc);
+    similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
+    VectorEncoding vectorEncoding = getVectorEncoding();
+    ConcurrentHnswGraphBuilder<T> builder =
+        new ConcurrentHnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, 16, 100);
+    ConcurrentOnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    // the first 10 docs must not be deleted to ensure the expected recall
+    Bits acceptOrds = createRandomAcceptOrds(10, nDoc);
+    NeighborQueue nn =
+        switch (getVectorEncoding()) {
+          case BYTE -> HnswGraphSearcher.search(
+              (byte[]) getTargetVector(),
+              10,
+              (RandomAccessVectorValues<byte[]>) vectors.copy(),
+              getVectorEncoding(),
+              similarityFunction,
+              hnsw.getView(),
+              acceptOrds,
+              Integer.MAX_VALUE);
+          case FLOAT32 -> HnswGraphSearcher.search(
+              (float[]) getTargetVector(),
+              10,
+              (RandomAccessVectorValues<float[]>) vectors.copy(),
+              getVectorEncoding(),
+              similarityFunction,
+              hnsw.getView(),
+              acceptOrds,
+              Integer.MAX_VALUE);
+        };
+    int[] nodes = nn.nodes();
+    assertEquals("Number of found results is not equal to [10].", 10, nodes.length);
+    int sum = 0;
+    for (int node : nodes) {
+      assertTrue("the results include a deleted document: " + node, acceptOrds.get(node));
+      sum += node;
+    }
+    // We expect to get approximately 100% recall;
+    // the lowest docIds are closest to zero; sum(0,9) = 45
+    assertTrue("sum(result docs)=" + sum, sum < 75);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testSearchWithSelectiveAcceptOrds() throws IOException {
+    int nDoc = 100;
+    RandomAccessVectorValues<T> vectors = circularVectorValues(nDoc);
+    similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
+    VectorEncoding vectorEncoding = getVectorEncoding();
+    ConcurrentHnswGraphBuilder<T> builder =
+        new ConcurrentHnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, 16, 100);
+    ConcurrentOnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    // Only mark a few vectors as accepted
+    BitSet acceptOrds = new FixedBitSet(nDoc);
+    for (int i = 0; i < nDoc; i += random().nextInt(15, 20)) {
+      acceptOrds.set(i);
+    }
+
+    // Check the search finds all accepted vectors
+    int numAccepted = acceptOrds.cardinality();
+    NeighborQueue nn =
+        switch (getVectorEncoding()) {
+          case FLOAT32 -> HnswGraphSearcher.search(
+              (float[]) getTargetVector(),
+              numAccepted,
+              (RandomAccessVectorValues<float[]>) vectors.copy(),
+              getVectorEncoding(),
+              similarityFunction,
+              hnsw.getView(),
+              acceptOrds,
+              Integer.MAX_VALUE);
+          case BYTE -> HnswGraphSearcher.search(
+              (byte[]) getTargetVector(),
+              numAccepted,
+              (RandomAccessVectorValues<byte[]>) vectors.copy(),
+              getVectorEncoding(),
+              similarityFunction,
+              hnsw.getView(),
+              acceptOrds,
+              Integer.MAX_VALUE);
+        };
+
+    int[] nodes = nn.nodes();
+    assertEquals(numAccepted, nodes.length);
+    for (int node : nodes) {
+      assertTrue("the results include a deleted document: " + node, acceptOrds.get(node));
+    }
+  }
+
+  public void testBuildOnHeapHnswGraphOutOfOrder() throws IOException {
+    int maxNumLevels = randomIntBetween(2, 10);
+    int nodeCount = randomIntBetween(1, 100);
+
+    List<List<Integer>> nodesPerLevel = new ArrayList<>();
+    for (int i = 0; i < maxNumLevels; i++) {
+      nodesPerLevel.add(new ArrayList<>());
+    }
+
+    int numLevels = 0;
+    for (int currNode = 0; currNode < nodeCount; currNode++) {
+      int nodeMaxLevel = random().nextInt(1, maxNumLevels + 1);
+      numLevels = Math.max(numLevels, nodeMaxLevel);
+      for (int currLevel = 0; currLevel < nodeMaxLevel; currLevel++) {
+        nodesPerLevel.get(currLevel).add(currNode);
+      }
+    }
+
+    ConcurrentOnHeapHnswGraph topDownOrderReversedHnsw = new ConcurrentOnHeapHnswGraph(10);
+    for (int currLevel = numLevels - 1; currLevel >= 0; currLevel--) {
+      List<Integer> currLevelNodes = nodesPerLevel.get(currLevel);
+      int currLevelNodesSize = currLevelNodes.size();
+      for (int currNodeInd = currLevelNodesSize - 1; currNodeInd >= 0; currNodeInd--) {
+        topDownOrderReversedHnsw.addNode(currLevel, currLevelNodes.get(currNodeInd));
+      }
+    }
+
+    ConcurrentOnHeapHnswGraph bottomUpOrderReversedHnsw = new ConcurrentOnHeapHnswGraph(10);
+    for (int currLevel = 0; currLevel < numLevels; currLevel++) {
+      List<Integer> currLevelNodes = nodesPerLevel.get(currLevel);
+      int currLevelNodesSize = currLevelNodes.size();
+      for (int currNodeInd = currLevelNodesSize - 1; currNodeInd >= 0; currNodeInd--) {
+        bottomUpOrderReversedHnsw.addNode(currLevel, currLevelNodes.get(currNodeInd));
+      }
+    }
+
+    ConcurrentOnHeapHnswGraph topDownOrderRandomHnsw = new ConcurrentOnHeapHnswGraph(10);
+    for (int currLevel = numLevels - 1; currLevel >= 0; currLevel--) {
+      List<Integer> currLevelNodes = new ArrayList<>(nodesPerLevel.get(currLevel));
+      Collections.shuffle(currLevelNodes, random());
+      for (Integer currNode : currLevelNodes) {
+        topDownOrderRandomHnsw.addNode(currLevel, currNode);
+      }
+    }
+
+    ConcurrentOnHeapHnswGraph bottomUpExpectedHnsw = new ConcurrentOnHeapHnswGraph(10);
+    for (int currLevel = 0; currLevel < numLevels; currLevel++) {
+      for (Integer currNode : nodesPerLevel.get(currLevel)) {
+        bottomUpExpectedHnsw.addNode(currLevel, currNode);
+      }
+    }
+
+    assertEquals(nodeCount, bottomUpExpectedHnsw.getNodesOnLevel(0).size());
+    for (Integer node : nodesPerLevel.get(0)) {
+      assertEquals(0, bottomUpExpectedHnsw.getNeighbors(0, node).size());
+    }
+
+    for (int currLevel = 1; currLevel < numLevels; currLevel++) {
+      List<Integer> expectedNodesOnLevel = nodesPerLevel.get(currLevel);
+      List<Integer> sortedNodes = sortedNodesOnLevel(bottomUpExpectedHnsw, currLevel);
+      assertEquals(
+          String.format(Locale.ROOT, "Nodes on level %d do not match", currLevel),
+          expectedNodesOnLevel,
+          sortedNodes);
+    }
+
+    assertGraphEqual(bottomUpExpectedHnsw.getView(), topDownOrderReversedHnsw.getView());
+    assertGraphEqual(bottomUpExpectedHnsw.getView(), bottomUpOrderReversedHnsw.getView());
+    assertGraphEqual(bottomUpExpectedHnsw.getView(), topDownOrderRandomHnsw.getView());
+  }
+
+  public void testHnswGraphBuilderInitializationFromGraph_withOffsetZero() throws IOException {
+    int totalSize = atLeast(100);
+    int initializerSize = random().nextInt(5, totalSize);
+    int docIdOffset = 0;
+    int dim = atLeast(10);
+    long seed = random().nextLong();
+
+    AbstractMockVectorValues<T> initializerVectors = vectorValues(initializerSize, dim);
+    HnswGraphBuilder<T> initializerBuilder =
+        HnswGraphBuilder.create(
+            initializerVectors, getVectorEncoding(), similarityFunction, 10, 30, seed);
+
+    OnHeapHnswGraph initializerGraph = initializerBuilder.build(initializerVectors.copy());
+    AbstractMockVectorValues<T> finalVectorValues =
+        vectorValues(totalSize, dim, initializerVectors, docIdOffset);
+
+    Map<Integer, Integer> initializerOrdMap =
+        createOffsetOrdinalMap(initializerSize, finalVectorValues, docIdOffset);
+
+    HnswGraphBuilder<T> finalBuilder =
+        HnswGraphBuilder.create(
+            finalVectorValues,
+            getVectorEncoding(),
+            similarityFunction,
+            10,
+            30,
+            seed,
+            initializerGraph,
+            initializerOrdMap);
+
+    // When offset is 0, the graphs should be identical before vectors are added
+    assertGraphEqual(initializerGraph, finalBuilder.getGraph());
+
+    OnHeapHnswGraph finalGraph = finalBuilder.build(finalVectorValues.copy());
+    assertGraphContainsGraph(finalGraph, initializerGraph, initializerOrdMap);
+  }
+
+  public void testHnswGraphBuilderInitializationFromGraph_withNonZeroOffset() throws IOException {
+    int totalSize = atLeast(100);
+    int initializerSize = random().nextInt(5, totalSize);
+    int docIdOffset = random().nextInt(1, totalSize - initializerSize + 1);
+    int dim = atLeast(10);
+    long seed = random().nextLong();
+
+    AbstractMockVectorValues<T> initializerVectors = vectorValues(initializerSize, dim);
+    HnswGraphBuilder<T> initializerBuilder =
+        HnswGraphBuilder.create(
+            initializerVectors.copy(), getVectorEncoding(), similarityFunction, 10, 30, seed);
+    OnHeapHnswGraph initializerGraph = initializerBuilder.build(initializerVectors.copy());
+    AbstractMockVectorValues<T> finalVectorValues =
+        vectorValues(totalSize, dim, initializerVectors.copy(), docIdOffset);
+    Map<Integer, Integer> initializerOrdMap =
+        createOffsetOrdinalMap(initializerSize, finalVectorValues.copy(), docIdOffset);
+
+    HnswGraphBuilder<T> finalBuilder =
+        HnswGraphBuilder.create(
+            finalVectorValues,
+            getVectorEncoding(),
+            similarityFunction,
+            10,
+            30,
+            seed,
+            initializerGraph,
+            initializerOrdMap);
+
+    assertGraphInitializedFromGraph(finalBuilder.getGraph(), initializerGraph, initializerOrdMap);
+
+    // Confirm that the graph is appropriately constructed by checking that the nodes in the old
+    // graph are present in the levels of the new graph
+    OnHeapHnswGraph finalGraph = finalBuilder.build(finalVectorValues.copy());
+    assertGraphContainsGraph(finalGraph, initializerGraph, initializerOrdMap);
+  }
+
+  private void assertGraphContainsGraph(
+      HnswGraph g, HnswGraph h, Map<Integer, Integer> oldToNewOrdMap) throws IOException {
+    for (int i = 0; i < h.numLevels(); i++) {
+      int[] finalGraphNodesOnLevel = nodesIteratorToArray(g.getNodesOnLevel(i));
+      int[] initializerGraphNodesOnLevel =
+          mapArrayAndSort(nodesIteratorToArray(h.getNodesOnLevel(i)), oldToNewOrdMap);
+      int overlap = computeOverlap(finalGraphNodesOnLevel, initializerGraphNodesOnLevel);
+      assertEquals(initializerGraphNodesOnLevel.length, overlap);
+    }
+  }
+
+  private void assertGraphInitializedFromGraph(
+      HnswGraph g, HnswGraph h, Map<Integer, Integer> oldToNewOrdMap) throws IOException {
+    assertEquals("the number of levels in the graphs are different!", g.numLevels(), h.numLevels());
+    // Confirm that the size of the new graph includes all nodes up to an including the max new
+    // ordinal in the old to
+    // new ordinal mapping
+    assertEquals(
+        "the number of nodes in the graphs are different!",
+        g.size(),
+        Collections.max(oldToNewOrdMap.values()) + 1);
+
+    // assert the nodes from the previous graph are successfully to levels > 0 in the new graph
+    for (int level = 1; level < g.numLevels(); level++) {
+      List<Integer> nodesOnLevel = sortedNodesOnLevel(g, level);
+      List<Integer> nodesOnLevel2 =
+          sortedNodesOnLevel(h, level).stream().map(oldToNewOrdMap::get).toList();
+      assertEquals(nodesOnLevel, nodesOnLevel2);
+    }
+
+    // assert that the neighbors from the old graph are successfully transferred to the new graph
+    for (int level = 0; level < g.numLevels(); level++) {
+      NodesIterator nodesOnLevel = h.getNodesOnLevel(level);
+      while (nodesOnLevel.hasNext()) {
+        int node = nodesOnLevel.nextInt();
+        g.seek(level, oldToNewOrdMap.get(node));
+        h.seek(level, node);
+        assertEquals(
+            "arcs differ for node " + node,
+            getNeighborNodes(g),
+            getNeighborNodes(h).stream().map(oldToNewOrdMap::get).collect(Collectors.toSet()));
+      }
+    }
+  }
+
+  private Map<Integer, Integer> createOffsetOrdinalMap(
+      int docIdSize, AbstractMockVectorValues<T> totalVectorValues, int docIdOffset) {
+    // Compute the offset for the ordinal map to be the number of non-null vectors in the total
+    // vector values
+    // before the docIdOffset
+    int ordinalOffset = 0;
+    while (totalVectorValues.nextDoc() < docIdOffset) {
+      ordinalOffset++;
+    }
+
+    Map<Integer, Integer> offsetOrdinalMap = new HashMap<>();
+    for (int curr = 0;
+        totalVectorValues.docID() < docIdOffset + docIdSize;
+        totalVectorValues.nextDoc()) {
+      offsetOrdinalMap.put(curr, ordinalOffset + curr++);
+    }
+
+    return offsetOrdinalMap;
+  }
+
+  private int[] nodesIteratorToArray(NodesIterator nodesIterator) {
+    int[] arr = new int[nodesIterator.size()];
+    int i = 0;
+    while (nodesIterator.hasNext()) {
+      arr[i++] = nodesIterator.nextInt();
+    }
+    return arr;
+  }
+
+  private int[] mapArrayAndSort(int[] arr, Map<Integer, Integer> map) {
+    int[] mappedA = new int[arr.length];
+    for (int i = 0; i < arr.length; i++) {
+      mappedA[i] = map.get(arr[i]);
+    }
+    Arrays.sort(mappedA);
+    return mappedA;
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testVisitedLimit() throws IOException {
+    int nDoc = 500;
+    similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
+    RandomAccessVectorValues<T> vectors = circularVectorValues(nDoc);
+    VectorEncoding vectorEncoding = getVectorEncoding();
+    ConcurrentHnswGraphBuilder<T> builder =
+        new ConcurrentHnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, 16, 100);
+    ConcurrentOnHeapHnswGraph hnsw = builder.build(vectors.copy());
+
+    int topK = 50;
+    int visitedLimit = topK + random().nextInt(5);
+    NeighborQueue nn =
+        switch (getVectorEncoding()) {
+          case FLOAT32 -> HnswGraphSearcher.search(
+              (float[]) getTargetVector(),
+              topK,
+              (RandomAccessVectorValues<float[]>) vectors.copy(),
+              getVectorEncoding(),
+              similarityFunction,
+              hnsw.getView(),
+              createRandomAcceptOrds(0, nDoc),
+              visitedLimit);
+          case BYTE -> HnswGraphSearcher.search(
+              (byte[]) getTargetVector(),
+              topK,
+              (RandomAccessVectorValues<byte[]>) vectors.copy(),
+              getVectorEncoding(),
+              similarityFunction,
+              hnsw.getView(),
+              createRandomAcceptOrds(0, nDoc),
+              visitedLimit);
+        };
+
+    assertTrue(nn.incomplete());
+    // The visited count shouldn't exceed the limit
+    assertTrue(nn.visitedCount() <= visitedLimit);
+  }
+
+  public void testHnswGraphBuilderInvalid() {
+    expectThrows(
+        NullPointerException.class, () -> new ConcurrentHnswGraphBuilder<>(null, null, null, 0, 0));
+    // M must be > 0
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          RandomAccessVectorValues<T> vectors = vectorValues(1, 1);
+          VectorEncoding vectorEncoding = getVectorEncoding();
+          new ConcurrentHnswGraphBuilder<>(
+              vectors, vectorEncoding, VectorSimilarityFunction.EUCLIDEAN, 0, 10);
+        });
+    // beamWidth must be > 0
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          RandomAccessVectorValues<T> vectors = vectorValues(1, 1);
+          VectorEncoding vectorEncoding = getVectorEncoding();
+          new ConcurrentHnswGraphBuilder<>(
+              vectors, vectorEncoding, VectorSimilarityFunction.EUCLIDEAN, 10, 0);
+        });
+  }
+
+  public void testRamUsageEstimate() throws IOException {
+    int size = atLeast(2000);
+    int dim = randomIntBetween(100, 1024);
+    int M = randomIntBetween(4, 96);
+
+    VectorSimilarityFunction similarityFunction =
+        RandomizedTest.randomFrom(VectorSimilarityFunction.values());
+    RandomAccessVectorValues<T> vectors = vectorValues(size, dim);
+
+    VectorEncoding vectorEncoding = getVectorEncoding();
+    random().nextLong();
+    ConcurrentHnswGraphBuilder<T> builder =
+        new ConcurrentHnswGraphBuilder<>(
+            vectors.copy(), vectorEncoding, similarityFunction, M, M * 2);
+    AtomicLong incrementalEstimate = new AtomicLong(builder.getGraph().ramBytesUsed());
+    IntStream.range(0, vectors.size())
+        .forEach(
+            i -> {
+              try {
+                long bytes = builder.addGraphNode(i, vectors);
+                incrementalEstimate.addAndGet(bytes);
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            });
+    ConcurrentOnHeapHnswGraph hnsw = builder.getGraph();
+    long estimated = RamUsageEstimator.sizeOfObject(hnsw);
+    long actual = ramUsed(hnsw);
+
+    assertEquals((double) actual, (double) estimated, (double) actual * 0.3);
+    assertEquals((double) estimated, (double) incrementalEstimate.get(), (double) estimated * 0.1);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testDiversity() throws IOException {
+    similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
+    // Some carefully checked test cases with simple 2d vectors on the unit circle:
+    float[][] values = {
+      unitVector2d(0.5),
+      unitVector2d(0.75),
+      unitVector2d(0.2),
+      unitVector2d(0.9),
+      unitVector2d(0.8),
+      unitVector2d(0.77),
+      unitVector2d(0.6)
+    };
+    AbstractMockVectorValues<T> vectors = vectorValues(values);
+    // First add nodes until everybody gets a full neighbor list
+    VectorEncoding vectorEncoding = getVectorEncoding();
+    ConcurrentHnswGraphBuilder<T> builder =
+        new ConcurrentHnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, 2, 10);
+    // node 0 is added by the builder constructor
+    RandomAccessVectorValues<T> vectorsCopy = vectors.copy();
+    builder.addGraphNode(0, vectorsCopy);
+    builder.addGraphNode(1, vectorsCopy);
+    builder.addGraphNode(2, vectorsCopy);
+    // now every node has tried to attach every other node as a neighbor, but
+    // some were excluded based on diversity check.
+    assertLevel0Neighbors(builder.hnsw, 0, 1, 2);
+    assertLevel0Neighbors(builder.hnsw, 1, 0);
+    assertLevel0Neighbors(builder.hnsw, 2, 0);
+
+    builder.addGraphNode(3, vectorsCopy);
+    assertLevel0Neighbors(builder.hnsw, 0, 1, 2);
+    // we added 3 here
+    assertLevel0Neighbors(builder.hnsw, 1, 0, 3);
+    assertLevel0Neighbors(builder.hnsw, 2, 0);
+    assertLevel0Neighbors(builder.hnsw, 3, 1);
+
+    // supplant an existing neighbor
+    builder.addGraphNode(4, vectorsCopy);
+    // 4 is the same distance from 0 that 2 is; we leave the existing node in place
+    assertLevel0Neighbors(builder.hnsw, 0, 1, 2);
+    assertLevel0Neighbors(builder.hnsw, 1, 0, 3, 4);
+    assertLevel0Neighbors(builder.hnsw, 2, 0);
+    // 1 survives the diversity check
+    assertLevel0Neighbors(builder.hnsw, 3, 1, 4);
+    assertLevel0Neighbors(builder.hnsw, 4, 1, 3);
+
+    builder.addGraphNode(5, vectorsCopy);
+    assertLevel0Neighbors(builder.hnsw, 0, 1, 2);
+    assertLevel0Neighbors(builder.hnsw, 1, 0, 3, 4, 5);
+    assertLevel0Neighbors(builder.hnsw, 2, 0);
+    // even though 5 is closer, 3 is not a neighbor of 5, so no update to *its* neighbors occurs
+    assertLevel0Neighbors(builder.hnsw, 3, 1, 4);
+    assertLevel0Neighbors(builder.hnsw, 4, 1, 3, 5);
+    assertLevel0Neighbors(builder.hnsw, 5, 1, 4);
+  }
+
+  public void testDiversityFallback() throws IOException {
+    similarityFunction = VectorSimilarityFunction.EUCLIDEAN;
+    // Some test cases can't be exercised in two dimensions;
+    // in particular if a new neighbor displaces an existing neighbor
+    // by being closer to the target, yet none of the existing neighbors is closer to the new vector
+    // than to the target -- ie they all remain diverse, so we simply drop the farthest one.
+    float[][] values = {
+      {0, 0, 0},
+      {0, 10, 0},
+      {0, 0, 20},
+      {10, 0, 0},
+      {0, 4, 0}
+    };
+    AbstractMockVectorValues<T> vectors = vectorValues(values);
+    // First add nodes until everybody gets a full neighbor list
+    VectorEncoding vectorEncoding = getVectorEncoding();
+    ConcurrentHnswGraphBuilder<T> builder =
+        new ConcurrentHnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, 1, 10);
+    RandomAccessVectorValues<T> vectorsCopy = vectors.copy();
+    builder.addGraphNode(0, vectorsCopy);
+    builder.addGraphNode(1, vectorsCopy);
+    builder.addGraphNode(2, vectorsCopy);
+    assertLevel0Neighbors(builder.hnsw, 0, 1, 2);
+    // 2 is closer to 0 than 1, so it is excluded as non-diverse
+    assertLevel0Neighbors(builder.hnsw, 1, 0);
+    // 1 is closer to 0 than 2, so it is excluded as non-diverse
+    assertLevel0Neighbors(builder.hnsw, 2, 0);
+
+    builder.addGraphNode(3, vectorsCopy);
+    // this is one case we are testing; 2 has been displaced by 3
+    assertLevel0Neighbors(builder.hnsw, 0, 1, 3);
+    assertLevel0Neighbors(builder.hnsw, 1, 0);
+    assertLevel0Neighbors(builder.hnsw, 2, 0);
+    assertLevel0Neighbors(builder.hnsw, 3, 0);
+  }
+
+  public void testDiversity3d() throws IOException {
+    similarityFunction = VectorSimilarityFunction.EUCLIDEAN;
+    // test the case when a neighbor *becomes* non-diverse when a newer better neighbor arrives
+    float[][] values = {
+      {0, 0, 0},
+      {0, 10, 0},
+      {0, 0, 20},
+      {0, 9, 0}
+    };
+    AbstractMockVectorValues<T> vectors = vectorValues(values);
+    // First add nodes until everybody gets a full neighbor list
+    VectorEncoding vectorEncoding = getVectorEncoding();
+    ConcurrentHnswGraphBuilder<T> builder =
+        new ConcurrentHnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, 1, 10);
+    RandomAccessVectorValues<T> vectorsCopy = vectors.copy();
+    builder.addGraphNode(0, vectorsCopy);
+    builder.addGraphNode(1, vectorsCopy);
+    builder.addGraphNode(2, vectorsCopy);
+    assertLevel0Neighbors(builder.hnsw, 0, 1, 2);
+    // 2 is closer to 0 than 1, so it is excluded as non-diverse
+    assertLevel0Neighbors(builder.hnsw, 1, 0);
+    // 1 is closer to 0 than 2, so it is excluded as non-diverse
+    assertLevel0Neighbors(builder.hnsw, 2, 0);
+
+    builder.addGraphNode(3, vectorsCopy);
+    // this is one case we are testing; 1 has been displaced by 3
+    assertLevel0Neighbors(builder.hnsw, 0, 2, 3);
+    assertLevel0Neighbors(builder.hnsw, 1, 0, 3);
+    assertLevel0Neighbors(builder.hnsw, 2, 0);
+    assertLevel0Neighbors(builder.hnsw, 3, 0, 1);
+  }
+
+  private void assertLevel0Neighbors(ConcurrentOnHeapHnswGraph graph, int node, int... expected) {
+    Arrays.sort(expected);
+    ConcurrentNeighborSet nn = graph.getNeighbors(0, node);
+    Iterator<Integer> it = nn.nodeIterator();
+    int[] actual = new int[nn.size()];
+    for (int i = 0; i < actual.length; i++) {
+      actual[i] = it.next();
+    }
+    Arrays.sort(actual);
+    assertArrayEquals(
+        "expected: " + Arrays.toString(expected) + " actual: " + Arrays.toString(actual),
+        expected,
+        actual);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testRandom() throws IOException {
+    int size = atLeast(100);
+    int dim = atLeast(10);
+    AbstractMockVectorValues<T> vectors = vectorValues(size, dim);
+    int topK = 5;
+    VectorEncoding vectorEncoding = getVectorEncoding();
+    ConcurrentHnswGraphBuilder<T> builder =
+        new ConcurrentHnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, 10, 30);
+    ConcurrentOnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    Bits acceptOrds = random().nextBoolean() ? null : createRandomAcceptOrds(0, size);
+
+    int totalMatches = 0;
+    for (int i = 0; i < 100; i++) {
+      NeighborQueue actual;
+      T query = randomVector(dim);
+      actual =
+          switch (getVectorEncoding()) {
+            case BYTE -> HnswGraphSearcher.search(
+                (byte[]) query,
+                100,
+                (RandomAccessVectorValues<byte[]>) vectors,
+                getVectorEncoding(),
+                similarityFunction,
+                hnsw.getView(),
+                acceptOrds,
+                Integer.MAX_VALUE);
+            case FLOAT32 -> HnswGraphSearcher.search(
+                (float[]) query,
+                100,
+                (RandomAccessVectorValues<float[]>) vectors,
+                getVectorEncoding(),
+                similarityFunction,
+                hnsw.getView(),
+                acceptOrds,
+                Integer.MAX_VALUE);
+          };
+
+      while (actual.size() > topK) {
+        actual.pop();
+      }
+      NeighborQueue expected = new NeighborQueue(topK, false);
+      for (int j = 0; j < size; j++) {
+        if (vectors.vectorValue(j) != null && (acceptOrds == null || acceptOrds.get(j))) {
+          if (getVectorEncoding() == VectorEncoding.BYTE) {
+            assert query instanceof byte[];
+            expected.add(
+                j, similarityFunction.compare((byte[]) query, (byte[]) vectors.vectorValue(j)));
+          } else {
+            assert query instanceof float[];
+            expected.add(
+                j, similarityFunction.compare((float[]) query, (float[]) vectors.vectorValue(j)));
+          }
+          if (expected.size() > topK) {
+            expected.pop();
+          }
+        }
+      }
+      assertEquals(topK, actual.size());
+      totalMatches += computeOverlap(actual.nodes(), expected.nodes());
+    }
+    double overlap = totalMatches / (double) (100 * topK);
+    assertTrue("overlap=" + overlap, overlap > 0.9);
+  }
+
+  private int computeOverlap(int[] a, int[] b) {
+    Arrays.sort(a);
+    Arrays.sort(b);
+    int overlap = 0;
+    for (int i = 0, j = 0; i < a.length && j < b.length; ) {
+      if (a[i] == b[j]) {
+        ++overlap;
+        ++i;
+        ++j;
+      } else if (a[i] > b[j]) {
+        ++j;
+      } else {
+        ++i;
+      }
+    }
+    return overlap;
+  }
+
+  public void testConcurrentNeighbors() throws IOException {
+    RandomAccessVectorValues<T> vectors = circularVectorValues(3);
+    ConcurrentHnswGraphBuilder<T> builder =
+        new ConcurrentHnswGraphBuilder<>(vectors, getVectorEncoding(), similarityFunction, 1, 30) {
+          @Override
+          protected float scoreBetween(T v1, T v2) {
+            try {
+              Thread.sleep(10);
+            } catch (InterruptedException e) {
+              throw new ThreadInterruptedException(e);
+            }
+            return super.scoreBetween(v1, v2);
+          }
+        };
+    ConcurrentOnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    for (int i = 0; i < vectors.size(); i++) {
+      assertTrue(hnsw.getNeighbors(0, i).size() <= 2); // Level 0 gets 2x neighbors
+    }
+  }
+
+  /** Returns vectors evenly distributed around the upper unit semicircle. */
+  static class CircularFloatVectorValues extends FloatVectorValues
+      implements RandomAccessVectorValues<float[]> {
+    private final int size;
+
+    int doc = -1;
+
+    CircularFloatVectorValues(int size) {
+      this.size = size;
+    }
+
+    @Override
+    public CircularFloatVectorValues copy() {
+      return new CircularFloatVectorValues(size);
+    }
+
+    @Override
+    public int dimension() {
+      return 2;
+    }
+
+    @Override
+    public int size() {
+      return size;
+    }
+
+    @Override
+    public float[] vectorValue() {
+      return vectorValue(doc);
+    }
+
+    @Override
+    public int docID() {
+      return doc;
+    }
+
+    @Override
+    public int nextDoc() {
+      return advance(doc + 1);
+    }
+
+    @Override
+    public int advance(int target) {
+      if (target >= 0 && target < size) {
+        doc = target;
+      } else {
+        doc = NO_MORE_DOCS;
+      }
+      return doc;
+    }
+
+    @Override
+    public float[] vectorValue(int ord) {
+      return unitVector2d(ord / (double) size);
+    }
+  }
+
+  /** Returns vectors evenly distributed around the upper unit semicircle. */
+  static class CircularByteVectorValues extends ByteVectorValues
+      implements RandomAccessVectorValues<byte[]> {
+    private final int size;
+
+    int doc = -1;
+
+    CircularByteVectorValues(int size) {
+      this.size = size;
+    }
+
+    @Override
+    public CircularByteVectorValues copy() {
+      return new CircularByteVectorValues(size);
+    }
+
+    @Override
+    public int dimension() {
+      return 2;
+    }
+
+    @Override
+    public int size() {
+      return size;
+    }
+
+    @Override
+    public byte[] vectorValue() {
+      return vectorValue(doc);
+    }
+
+    @Override
+    public int docID() {
+      return doc;
+    }
+
+    @Override
+    public int nextDoc() {
+      return advance(doc + 1);
+    }
+
+    @Override
+    public int advance(int target) {
+      if (target >= 0 && target < size) {
+        doc = target;
+      } else {
+        doc = NO_MORE_DOCS;
+      }
+      return doc;
+    }
+
+    @Override
+    public byte[] vectorValue(int ord) {
+      float[] value = unitVector2d(ord / (double) size);
+      byte[] bValue = new byte[value.length];
+      for (int i = 0; i < value.length; i++) {
+        bValue[i] = (byte) (value[i] * 127);
+      }
+      return bValue;
+    }
+  }
+
+  private static float[] unitVector2d(double piRadians) {
+    return unitVector2d(piRadians, new float[2]);
+  }
+
+  private static float[] unitVector2d(double piRadians, float[] value) {
+    return new float[] {
+      (float) Math.cos(Math.PI * piRadians), (float) Math.sin(Math.PI * piRadians)
+    };
+  }
+
+  private Set<Integer> getNeighborNodes(HnswGraph g) throws IOException {
+    Set<Integer> neighbors = new HashSet<>();
+    for (int n = g.nextNeighbor(); n != NO_MORE_DOCS; n = g.nextNeighbor()) {
+      neighbors.add(n);
+    }
+    return neighbors;
+  }
+
+  void assertVectorsEqual(AbstractMockVectorValues<T> u, AbstractMockVectorValues<T> v)
+      throws IOException {
+    int uDoc, vDoc;
+    while (true) {
+      uDoc = u.nextDoc();
+      vDoc = v.nextDoc();
+      assertEquals(uDoc, vDoc);
+      if (uDoc == NO_MORE_DOCS) {
+        break;
+      }
+      switch (getVectorEncoding()) {
+        case BYTE -> assertArrayEquals(
+            "vectors do not match for doc=" + uDoc,
+            (byte[]) u.vectorValue(),
+            (byte[]) v.vectorValue());
+        case FLOAT32 -> assertArrayEquals(
+            "vectors do not match for doc=" + uDoc,
+            (float[]) u.vectorValue(),
+            (float[]) v.vectorValue(),
+            1e-4f);
+        default -> throw new IllegalArgumentException(
+            "unknown vector encoding: " + getVectorEncoding());
+      }
+    }
+  }
+
+  static float[][] createRandomFloatVectors(int size, int dimension, Random random) {
+    float[][] vectors = new float[size][];
+    for (int offset = 0; offset < size; offset += random.nextInt(3) + 1) {
+      vectors[offset] = randomVector(random, dimension);
+    }
+    return vectors;
+  }
+
+  static byte[][] createRandomByteVectors(int size, int dimension, Random random) {
+    byte[][] vectors = new byte[size][];
+    for (int offset = 0; offset < size; offset += random.nextInt(3) + 1) {
+      vectors[offset] = randomVector8(random, dimension);
+    }
+    return vectors;
+  }
+
+  /**
+   * Generate a random bitset where before startIndex all bits are set, and after startIndex each
+   * entry has a 2/3 probability of being set.
+   */
+  private static Bits createRandomAcceptOrds(int startIndex, int length) {
+    FixedBitSet bits = new FixedBitSet(length);
+    // all bits are set before startIndex
+    for (int i = 0; i < startIndex; i++) {
+      bits.set(i);
+    }
+    // after startIndex, bits are set with 2/3 probability
+    for (int i = startIndex; i < bits.length(); i++) {
+      if (random().nextFloat() < 0.667f) {
+        bits.set(i);
+      }
+    }
+    return bits;
+  }
+
+  static float[] randomVector(Random random, int dim) {
+    float[] vec = new float[dim];
+    for (int i = 0; i < dim; i++) {
+      vec[i] = random.nextFloat();
+      if (random.nextBoolean()) {
+        vec[i] = -vec[i];
+      }
+    }
+    VectorUtil.l2normalize(vec);
+    return vec;
+  }
+
+  static byte[] randomVector8(Random random, int dim) {
+    float[] fvec = randomVector(random, dim);
+    byte[] bvec = new byte[dim];
+    for (int i = 0; i < dim; i++) {
+      bvec[i] = (byte) (fvec[i] * 127);
+    }
+    return bvec;
+  }
+
+  static String prettyPrint(HnswGraph hnsw) {
+    if (hnsw instanceof ConcurrentOnHeapHnswGraph) {
+      hnsw = ((ConcurrentOnHeapHnswGraph) hnsw).getView();
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append(hnsw);
+    sb.append("\n");
+
+    try {
+      for (int level = 0; level < hnsw.numLevels(); level++) {
+        sb.append("# Level ").append(level).append("\n");
+        NodesIterator it = hnsw.getNodesOnLevel(level);
+        while (it.hasNext()) {
+          int node = it.nextInt();
+          sb.append("  ").append(node).append(" -> ");
+          hnsw.seek(level, node);
+          while (true) {
+            int neighbor = hnsw.nextNeighbor();
+            if (neighbor == NO_MORE_DOCS) {
+              break;
+            }
+            sb.append(" ").append(neighbor);
+          }
+          sb.append("\n");
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return sb.toString();
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/ConcurrentHnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/ConcurrentHnswGraphTestCase.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.lucene.codecs.KnnVectorsFormat;

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/ConcurrentHnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/ConcurrentHnswGraphTestCase.java
@@ -394,7 +394,9 @@ abstract class ConcurrentHnswGraphTestCase<T> extends LuceneTestCase {
     }
   }
 
-  static <T> ConcurrentOnHeapHnswGraph buildParallel(ConcurrentHnswGraphBuilder<T> builder, RandomAccessVectorValues<T> vectors) throws IOException {
+  static <T> ConcurrentOnHeapHnswGraph buildParallel(
+      ConcurrentHnswGraphBuilder<T> builder, RandomAccessVectorValues<T> vectors)
+      throws IOException {
     ExecutorService es;
     int threadCount = Math.max(3, Runtime.getRuntime().availableProcessors());
     es =

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/ConcurrentHnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/ConcurrentHnswGraphTestCase.java
@@ -532,7 +532,7 @@ abstract class ConcurrentHnswGraphTestCase<T> extends LuceneTestCase {
           }
 
           @Override
-          public Function<Integer, Float> scoreProvider(int a) {
+          public ScoreFunction scoreProvider(int a) {
             throw new UnsupportedOperationException();
           }
         };

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -1060,7 +1060,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
                         case BYTE -> HnswGraphSearcher.search(
                             (byte[]) query,
                             100,
-                            (RandomAccessVectorValues<byte[]>) vectors,
+                            (RandomAccessVectorValues<byte[]>) vectors.copy(),
                             getVectorEncoding(),
                             similarityFunction,
                             hnsw,
@@ -1069,7 +1069,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
                         case FLOAT32 -> HnswGraphSearcher.search(
                             (float[]) query,
                             100,
-                            (RandomAccessVectorValues<float[]>) vectors,
+                            (RandomAccessVectorValues<float[]>) vectors.copy(),
                             getVectorEncoding(),
                             similarityFunction,
                             hnsw,

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockByteVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockByteVectorValues.java
@@ -22,6 +22,7 @@ import org.apache.lucene.util.ArrayUtil;
 
 class MockByteVectorValues extends AbstractMockVectorValues<byte[]> {
   private final byte[] scratch;
+  private final byte[] denseScratch;
 
   static MockByteVectorValues fromValues(byte[][] values) {
     int dimension = values[0].length;
@@ -39,6 +40,7 @@ class MockByteVectorValues extends AbstractMockVectorValues<byte[]> {
   MockByteVectorValues(byte[][] values, int dimension, byte[][] denseValues, int numVectors) {
     super(values, dimension, denseValues, numVectors);
     scratch = new byte[dimension];
+    denseScratch = new byte[dimension];
   }
 
   @Override
@@ -62,5 +64,17 @@ class MockByteVectorValues extends AbstractMockVectorValues<byte[]> {
       System.arraycopy(values[pos], 0, scratch, 0, dimension);
       return scratch;
     }
+  }
+
+  @Override
+  public byte[] vectorValue(int targetOrd) {
+    byte[] original = super.vectorValue(targetOrd);
+    if (original == null) {
+      return null;
+    }
+    // present a single vector reference to callers like the disk-backed RAVV implmentations,
+    // to catch cases where they are not making a copy
+    System.arraycopy(original, 0, denseScratch, 0, dimension);
+    return denseScratch;
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
@@ -62,9 +62,4 @@ class MockVectorValues extends AbstractMockVectorValues<float[]> {
       return scratch;
     }
   }
-
-  @Override
-  public float[] vectorValue(int targetOrd) {
-    return denseValues[targetOrd];
-  }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
@@ -22,6 +22,7 @@ import org.apache.lucene.util.ArrayUtil;
 
 class MockVectorValues extends AbstractMockVectorValues<float[]> {
   private final float[] scratch;
+  private final float[] denseScratch;
 
   static MockVectorValues fromValues(float[][] values) {
     int dimension = values[0].length;
@@ -39,6 +40,7 @@ class MockVectorValues extends AbstractMockVectorValues<float[]> {
   MockVectorValues(float[][] values, int dimension, float[][] denseValues, int numVectors) {
     super(values, dimension, denseValues, numVectors);
     this.scratch = new float[dimension];
+    this.denseScratch = new float[dimension];
   }
 
   @Override
@@ -61,5 +63,17 @@ class MockVectorValues extends AbstractMockVectorValues<float[]> {
       System.arraycopy(values[pos], 0, scratch, 0, dimension);
       return scratch;
     }
+  }
+
+  @Override
+  public float[] vectorValue(int targetOrd) {
+    float[] original = super.vectorValue(targetOrd);
+    if (original == null) {
+      return null;
+    }
+    // present a single vector reference to callers like the disk-backed RAVV implmentations,
+    // to catch cases where they are not making a copy
+    System.arraycopy(original, 0, denseScratch, 0, dimension);
+    return denseScratch;
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentHnswByteVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentHnswByteVectorGraph.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import java.io.IOException;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.KnnByteVectorQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.ArrayUtil;
+import org.junit.Before;
+
+/** Tests HNSW KNN graphs */
+public class TestConcurrentHnswByteVectorGraph extends ConcurrentHnswGraphTestCase<byte[]> {
+
+  @Before
+  public void setup() {
+    similarityFunction = RandomizedTest.randomFrom(VectorSimilarityFunction.values());
+  }
+
+  @Override
+  VectorEncoding getVectorEncoding() {
+    return VectorEncoding.BYTE;
+  }
+
+  @Override
+  Query knnQuery(String field, byte[] vector, int k) {
+    return new KnnByteVectorQuery(field, vector, k);
+  }
+
+  @Override
+  byte[] randomVector(int dim) {
+    return randomVector8(random(), dim);
+  }
+
+  @Override
+  AbstractMockVectorValues<byte[]> vectorValues(int size, int dimension) {
+    return MockByteVectorValues.fromValues(createRandomByteVectors(size, dimension, random()));
+  }
+
+  static boolean fitsInByte(float v) {
+    return v <= 127 && v >= -128 && v % 1 == 0;
+  }
+
+  @Override
+  AbstractMockVectorValues<byte[]> vectorValues(float[][] values) {
+    byte[][] bValues = new byte[values.length][];
+    // The case when all floats fit within a byte already.
+    boolean scaleSimple = fitsInByte(values[0][0]);
+    for (int i = 0; i < values.length; i++) {
+      bValues[i] = new byte[values[i].length];
+      for (int j = 0; j < values[i].length; j++) {
+        final float v;
+        if (scaleSimple) {
+          assert fitsInByte(values[i][j]);
+          v = values[i][j];
+        } else {
+          v = values[i][j] * 127;
+        }
+        bValues[i][j] = (byte) v;
+      }
+    }
+    return MockByteVectorValues.fromValues(bValues);
+  }
+
+  @Override
+  AbstractMockVectorValues<byte[]> vectorValues(
+      int size,
+      int dimension,
+      AbstractMockVectorValues<byte[]> pregeneratedVectorValues,
+      int pregeneratedOffset) {
+    byte[][] vectors = new byte[size][];
+    byte[][] randomVectors =
+        createRandomByteVectors(size - pregeneratedVectorValues.values.length, dimension, random());
+
+    for (int i = 0; i < pregeneratedOffset; i++) {
+      vectors[i] = randomVectors[i];
+    }
+
+    int currentDoc;
+    while ((currentDoc = pregeneratedVectorValues.nextDoc()) != NO_MORE_DOCS) {
+      vectors[pregeneratedOffset + currentDoc] = pregeneratedVectorValues.values[currentDoc];
+    }
+
+    for (int i = pregeneratedOffset + pregeneratedVectorValues.values.length;
+        i < vectors.length;
+        i++) {
+      vectors[i] = randomVectors[i - pregeneratedVectorValues.values.length];
+    }
+
+    return MockByteVectorValues.fromValues(vectors);
+  }
+
+  @Override
+  AbstractMockVectorValues<byte[]> vectorValues(LeafReader reader, String fieldName)
+      throws IOException {
+    ByteVectorValues vectorValues = reader.getByteVectorValues(fieldName);
+    byte[][] vectors = new byte[reader.maxDoc()][];
+    while (vectorValues.nextDoc() != NO_MORE_DOCS) {
+      vectors[vectorValues.docID()] =
+          ArrayUtil.copyOfSubArray(
+              vectorValues.vectorValue(), 0, vectorValues.vectorValue().length);
+    }
+    return MockByteVectorValues.fromValues(vectors);
+  }
+
+  @Override
+  Field knnVectorField(String name, byte[] vector, VectorSimilarityFunction similarityFunction) {
+    return new KnnByteVectorField(name, vector, similarityFunction);
+  }
+
+  @Override
+  RandomAccessVectorValues<byte[]> circularVectorValues(int nDoc) {
+    return new CircularByteVectorValues(nDoc);
+  }
+
+  @Override
+  byte[] getTargetVector() {
+    return new byte[] {1, 0};
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentHnswFloatVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentHnswFloatVectorGraph.java
@@ -131,7 +131,7 @@ public class TestConcurrentHnswFloatVectorGraph extends ConcurrentHnswGraphTestC
     random().nextInt();
     ConcurrentHnswGraphBuilder<float[]> builder =
         new ConcurrentHnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, 16, 100);
-    ConcurrentOnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    ConcurrentOnHeapHnswGraph hnsw = buildParallel(builder, vectors);
 
     // Skip over half of the documents that are closest to the query vector
     FixedBitSet acceptOrds = new FixedBitSet(nDoc);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentHnswFloatVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentHnswFloatVectorGraph.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import java.io.IOException;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.FixedBitSet;
+import org.junit.Before;
+
+/** Tests HNSW KNN graphs */
+public class TestConcurrentHnswFloatVectorGraph extends ConcurrentHnswGraphTestCase<float[]> {
+
+  @Before
+  public void setup() {
+    similarityFunction = RandomizedTest.randomFrom(VectorSimilarityFunction.values());
+  }
+
+  @Override
+  VectorEncoding getVectorEncoding() {
+    return VectorEncoding.FLOAT32;
+  }
+
+  @Override
+  Query knnQuery(String field, float[] vector, int k) {
+    return new KnnFloatVectorQuery(field, vector, k);
+  }
+
+  @Override
+  float[] randomVector(int dim) {
+    return randomVector(random(), dim);
+  }
+
+  @Override
+  AbstractMockVectorValues<float[]> vectorValues(int size, int dimension) {
+    return MockVectorValues.fromValues(createRandomFloatVectors(size, dimension, random()));
+  }
+
+  @Override
+  AbstractMockVectorValues<float[]> vectorValues(float[][] values) {
+    return MockVectorValues.fromValues(values);
+  }
+
+  @Override
+  AbstractMockVectorValues<float[]> vectorValues(LeafReader reader, String fieldName)
+      throws IOException {
+    FloatVectorValues vectorValues = reader.getFloatVectorValues(fieldName);
+    float[][] vectors = new float[reader.maxDoc()][];
+    while (vectorValues.nextDoc() != NO_MORE_DOCS) {
+      vectors[vectorValues.docID()] =
+          ArrayUtil.copyOfSubArray(
+              vectorValues.vectorValue(), 0, vectorValues.vectorValue().length);
+    }
+    return MockVectorValues.fromValues(vectors);
+  }
+
+  @Override
+  AbstractMockVectorValues<float[]> vectorValues(
+      int size,
+      int dimension,
+      AbstractMockVectorValues<float[]> pregeneratedVectorValues,
+      int pregeneratedOffset) {
+    float[][] vectors = new float[size][];
+    float[][] randomVectors =
+        createRandomFloatVectors(
+            size - pregeneratedVectorValues.values.length, dimension, random());
+
+    for (int i = 0; i < pregeneratedOffset; i++) {
+      vectors[i] = randomVectors[i];
+    }
+
+    int currentDoc;
+    while ((currentDoc = pregeneratedVectorValues.nextDoc()) != NO_MORE_DOCS) {
+      vectors[pregeneratedOffset + currentDoc] = pregeneratedVectorValues.values[currentDoc];
+    }
+
+    for (int i = pregeneratedOffset + pregeneratedVectorValues.values.length;
+        i < vectors.length;
+        i++) {
+      vectors[i] = randomVectors[i - pregeneratedVectorValues.values.length];
+    }
+
+    return MockVectorValues.fromValues(vectors);
+  }
+
+  @Override
+  Field knnVectorField(String name, float[] vector, VectorSimilarityFunction similarityFunction) {
+    return new KnnFloatVectorField(name, vector, similarityFunction);
+  }
+
+  @Override
+  RandomAccessVectorValues<float[]> circularVectorValues(int nDoc) {
+    return new CircularFloatVectorValues(nDoc);
+  }
+
+  @Override
+  float[] getTargetVector() {
+    return new float[] {1f, 0f};
+  }
+
+  public void testSearchWithSkewedAcceptOrds() throws IOException {
+    int nDoc = 1000;
+    similarityFunction = VectorSimilarityFunction.EUCLIDEAN;
+    RandomAccessVectorValues<float[]> vectors = circularVectorValues(nDoc);
+    VectorEncoding vectorEncoding = getVectorEncoding();
+    random().nextInt();
+    ConcurrentHnswGraphBuilder<float[]> builder =
+        new ConcurrentHnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, 16, 100);
+    ConcurrentOnHeapHnswGraph hnsw = builder.build(vectors.copy());
+
+    // Skip over half of the documents that are closest to the query vector
+    FixedBitSet acceptOrds = new FixedBitSet(nDoc);
+    for (int i = 500; i < nDoc; i++) {
+      acceptOrds.set(i);
+    }
+    NeighborQueue nn =
+        HnswGraphSearcher.search(
+            getTargetVector(),
+            10,
+            vectors.copy(),
+            getVectorEncoding(),
+            similarityFunction,
+            hnsw.getView(),
+            acceptOrds,
+            Integer.MAX_VALUE);
+
+    int[] nodes = nn.nodes();
+    assertEquals("Number of found results is not equal to [10].", 10, nodes.length);
+    int sum = 0;
+    for (int node : nodes) {
+      assertTrue("the results include a deleted document: " + node, acceptOrds.get(node));
+      sum += node;
+    }
+    // We still expect to get reasonable recall. The lowest non-skipped docIds
+    // are closest to the query vector: sum(500,509) = 5045
+    assertTrue("sum(result docs)=" + sum, sum < 5100);
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -33,7 +32,7 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
       new NeighborSimilarity() {
         @Override
         public float score(int a, int b) {
-          return VectorSimilarityFunction.EUCLIDEAN.compare(new float[]{a}, new float[]{b});
+          return VectorSimilarityFunction.EUCLIDEAN.compare(new float[] {a}, new float[] {b});
         }
 
         @Override
@@ -114,8 +113,8 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
     cna.insertSorted(3, 8.0f);
     cna.insertSorted(1, 10.0f); // This is a duplicate and should be ignored
     cna.insertSorted(3, 8.0f); // This is also a duplicate
-    assertArrayEquals(new int[]{1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
-    assertArrayEquals(new float[]{10.0f, 9.0f, 8.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
+    assertArrayEquals(new int[] {1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
+    assertArrayEquals(new float[] {10.0f, 9.0f, 8.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
   }
 
   public void testNoDuplicatesAscOrder() {
@@ -125,8 +124,8 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
     cna.insertSorted(3, 10.0f);
     cna.insertSorted(1, 8.0f); // This is a duplicate and should be ignored
     cna.insertSorted(3, 10.0f); // This is also a duplicate
-    assertArrayEquals(new int[]{1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
-    assertArrayEquals(new float[]{8.0f, 9.0f, 10.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
+    assertArrayEquals(new int[] {1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
+    assertArrayEquals(new float[] {8.0f, 9.0f, 10.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
   }
 
   public void testNoDuplicatesSameScores() {
@@ -136,7 +135,8 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
     cna.insertSorted(3, 10.0f);
     cna.insertSorted(1, 10.0f); // This is a duplicate and should be ignored
     cna.insertSorted(3, 10.0f); // This is also a duplicate
-    assertArrayEquals(new int[]{1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
-    assertArrayEquals(new float[]{10.0f, 10.0f, 10.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
+    assertArrayEquals(new int[] {1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
+    assertArrayEquals(
+        new float[] {10.0f, 10.0f, 10.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.hnsw.ConcurrentNeighborSet.ConcurrentNeighborArray;
 import org.apache.lucene.util.hnsw.ConcurrentNeighborSet.NeighborSimilarity;
 
 public class TestConcurrentNeighborSet extends LuceneTestCase {
@@ -32,7 +33,7 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
       new NeighborSimilarity() {
         @Override
         public float score(int a, int b) {
-          return VectorSimilarityFunction.EUCLIDEAN.compare(new float[] {a}, new float[] {b});
+          return VectorSimilarityFunction.EUCLIDEAN.compare(new float[]{a}, new float[]{b});
         }
 
         @Override
@@ -104,5 +105,38 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
     assertEquals(2, neighbors.size());
     assert neighbors.contains(8);
     assert neighbors.contains(6);
+  }
+
+  public void testNoDuplicatesDescOrder() {
+    ConcurrentNeighborArray cna = new ConcurrentNeighborArray(5, true);
+    cna.insertSorted(1, 10.0f);
+    cna.insertSorted(2, 9.0f);
+    cna.insertSorted(3, 8.0f);
+    cna.insertSorted(1, 10.0f); // This is a duplicate and should be ignored
+    cna.insertSorted(3, 8.0f); // This is also a duplicate
+    assertArrayEquals(new int[]{1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
+    assertArrayEquals(new float[]{10.0f, 9.0f, 8.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
+  }
+
+  public void testNoDuplicatesAscOrder() {
+    ConcurrentNeighborArray cna = new ConcurrentNeighborArray(5, false);
+    cna.insertSorted(1, 8.0f);
+    cna.insertSorted(2, 9.0f);
+    cna.insertSorted(3, 10.0f);
+    cna.insertSorted(1, 8.0f); // This is a duplicate and should be ignored
+    cna.insertSorted(3, 10.0f); // This is also a duplicate
+    assertArrayEquals(new int[]{1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
+    assertArrayEquals(new float[]{8.0f, 9.0f, 10.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
+  }
+
+  public void testNoDuplicatesSameScores() {
+    ConcurrentNeighborArray cna = new ConcurrentNeighborArray(5, true);
+    cna.insertSorted(1, 10.0f);
+    cna.insertSorted(2, 10.0f);
+    cna.insertSorted(3, 10.0f);
+    cna.insertSorted(1, 10.0f); // This is a duplicate and should be ignored
+    cna.insertSorted(3, 10.0f); // This is also a duplicate
+    assertArrayEquals(new int[]{1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
+    assertArrayEquals(new float[]{10.0f, 10.0f, 10.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
@@ -37,7 +37,7 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
         }
 
         @Override
-        public Function<Integer, Float> scoreProvider(int a) {
+        public ScoreFunction scoreProvider(int a) {
           return b -> score(a, b);
         }
       };
@@ -88,7 +88,7 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
           }
 
           @Override
-          public Function<Integer, Float> scoreProvider(int a) {
+          public ScoreFunction scoreProvider(int a) {
             return b -> score(a, b);
           }
         };

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestConcurrentNeighborSet extends LuceneTestCase {
+  private static final ConcurrentNeighborSet.NeighborSimilarity simpleScore =
+      (a, b) -> {
+        return VectorSimilarityFunction.EUCLIDEAN.compare(new float[] {a}, new float[] {b});
+      };
+
+  private static float baseScore(int neighbor) throws IOException {
+    return simpleScore.score(0, neighbor);
+  }
+
+  public void testInsertAndSize() throws IOException {
+    ConcurrentNeighborSet neighbors = new ConcurrentNeighborSet(0, 2);
+    neighbors.insert(1, baseScore(1), simpleScore);
+    neighbors.insert(2, baseScore(2), simpleScore);
+    assertEquals(2, neighbors.size());
+
+    neighbors.insert(3, baseScore(3), simpleScore);
+    assertEquals(2, neighbors.size());
+  }
+
+  public void testRemoveLeastDiverseFromEnd() throws IOException {
+    ConcurrentNeighborSet neighbors = new ConcurrentNeighborSet(0, 3);
+    neighbors.insert(1, baseScore(1), simpleScore);
+    neighbors.insert(2, baseScore(2), simpleScore);
+    neighbors.insert(3, baseScore(3), simpleScore);
+    assertEquals(3, neighbors.size());
+
+    neighbors.insert(4, baseScore(4), simpleScore);
+    assertEquals(3, neighbors.size());
+
+    List<Integer> expectedValues = Arrays.asList(1, 2, 3);
+    Iterator<Integer> iterator = neighbors.nodeIterator();
+    for (Integer expectedValue : expectedValues) {
+      assertTrue(iterator.hasNext());
+      assertEquals(expectedValue, iterator.next());
+    }
+    assertFalse(iterator.hasNext());
+  }
+
+  public void testInsertDiverse() throws IOException {
+    var similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
+    var vectors = new HnswGraphTestCase.CircularFloatVectorValues(10);
+    var vectorsCopy = vectors.copy();
+    var candidates = new NeighborArray(10, false);
+    ConcurrentNeighborSet.NeighborSimilarity scoreBetween =
+        (a, b) -> {
+          return similarityFunction.compare(vectors.vectorValue(a), vectorsCopy.vectorValue(b));
+        };
+    IntStream.range(0, 10)
+        .filter(i -> i != 7)
+        .forEach(
+            i -> {
+              candidates.insertSorted(i, scoreBetween.score(7, i));
+            });
+    assert candidates.size() == 9;
+
+    var neighbors = new ConcurrentNeighborSet(0, 3);
+    neighbors.insertDiverse(candidates, scoreBetween);
+    assertEquals(2, neighbors.size());
+    assert neighbors.contains(8);
+    assert neighbors.contains(6);
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
@@ -114,7 +114,8 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
     cna.insertSorted(1, 10.0f); // This is a duplicate and should be ignored
     cna.insertSorted(3, 8.0f); // This is also a duplicate
     assertArrayEquals(new int[] {1, 2, 3}, ArrayUtil.copyOfSubArray(cna.node(), 0, cna.size()));
-    assertArrayEquals(new float[] {10.0f, 9.0f, 8.0f}, ArrayUtil.copyOfSubArray(cna.score, 0, cna.size()), 0.01f);
+    assertArrayEquals(
+        new float[] {10.0f, 9.0f, 8.0f}, ArrayUtil.copyOfSubArray(cna.score, 0, cna.size()), 0.01f);
   }
 
   public void testNoDuplicatesAscOrder() {
@@ -125,7 +126,8 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
     cna.insertSorted(1, 8.0f); // This is a duplicate and should be ignored
     cna.insertSorted(3, 10.0f); // This is also a duplicate
     assertArrayEquals(new int[] {1, 2, 3}, ArrayUtil.copyOfSubArray(cna.node(), 0, cna.size()));
-    assertArrayEquals(new float[] {8.0f, 9.0f, 10.0f}, ArrayUtil.copyOfSubArray(cna.score, 0, cna.size()), 0.01f);
+    assertArrayEquals(
+        new float[] {8.0f, 9.0f, 10.0f}, ArrayUtil.copyOfSubArray(cna.score, 0, cna.size()), 0.01f);
   }
 
   public void testNoDuplicatesSameScores() {
@@ -137,6 +139,8 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
     cna.insertSorted(3, 10.0f); // This is also a duplicate
     assertArrayEquals(new int[] {1, 2, 3}, ArrayUtil.copyOfSubArray(cna.node(), 0, cna.size()));
     assertArrayEquals(
-        new float[] {10.0f, 10.0f, 10.0f}, ArrayUtil.copyOfSubArray(cna.score, 0, cna.size()), 0.01f);
+        new float[] {10.0f, 10.0f, 10.0f},
+        ArrayUtil.copyOfSubArray(cna.score, 0, cna.size()),
+        0.01f);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
@@ -25,7 +25,6 @@ import java.util.stream.IntStream;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.hnsw.ConcurrentNeighborSet.ConcurrentNeighborArray;
-import org.apache.lucene.util.hnsw.ConcurrentNeighborSet.NeighborSimilarity;
 
 public class TestConcurrentNeighborSet extends LuceneTestCase {
   private static final NeighborSimilarity simpleScore =

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestConcurrentNeighborSet.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.hnsw.ConcurrentNeighborSet.ConcurrentNeighborArray;
 
 public class TestConcurrentNeighborSet extends LuceneTestCase {
@@ -112,8 +113,8 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
     cna.insertSorted(3, 8.0f);
     cna.insertSorted(1, 10.0f); // This is a duplicate and should be ignored
     cna.insertSorted(3, 8.0f); // This is also a duplicate
-    assertArrayEquals(new int[] {1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
-    assertArrayEquals(new float[] {10.0f, 9.0f, 8.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
+    assertArrayEquals(new int[] {1, 2, 3}, ArrayUtil.copyOfSubArray(cna.node(), 0, cna.size()));
+    assertArrayEquals(new float[] {10.0f, 9.0f, 8.0f}, ArrayUtil.copyOfSubArray(cna.score, 0, cna.size()), 0.01f);
   }
 
   public void testNoDuplicatesAscOrder() {
@@ -123,8 +124,8 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
     cna.insertSorted(3, 10.0f);
     cna.insertSorted(1, 8.0f); // This is a duplicate and should be ignored
     cna.insertSorted(3, 10.0f); // This is also a duplicate
-    assertArrayEquals(new int[] {1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
-    assertArrayEquals(new float[] {8.0f, 9.0f, 10.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
+    assertArrayEquals(new int[] {1, 2, 3}, ArrayUtil.copyOfSubArray(cna.node(), 0, cna.size()));
+    assertArrayEquals(new float[] {8.0f, 9.0f, 10.0f}, ArrayUtil.copyOfSubArray(cna.score, 0, cna.size()), 0.01f);
   }
 
   public void testNoDuplicatesSameScores() {
@@ -134,8 +135,8 @@ public class TestConcurrentNeighborSet extends LuceneTestCase {
     cna.insertSorted(3, 10.0f);
     cna.insertSorted(1, 10.0f); // This is a duplicate and should be ignored
     cna.insertSorted(3, 10.0f); // This is also a duplicate
-    assertArrayEquals(new int[] {1, 2, 3}, Arrays.copyOf(cna.node(), cna.size()));
+    assertArrayEquals(new int[] {1, 2, 3}, ArrayUtil.copyOfSubArray(cna.node(), 0, cna.size()));
     assertArrayEquals(
-        new float[] {10.0f, 10.0f, 10.0f}, Arrays.copyOf(cna.score, cna.size()), 0.01f);
+        new float[] {10.0f, 10.0f, 10.0f}, ArrayUtil.copyOfSubArray(cna.score, 0, cna.size()), 0.01f);
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/BaseBitSetTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/BaseBitSetTestCase.java
@@ -17,16 +17,14 @@
 package org.apache.lucene.tests.util;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Random;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BitDocIdSet;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.GrowableBitSet;
 import org.apache.lucene.util.RoaringDocIdSet;
 import org.apache.lucene.util.SparseFixedBitSet;
 import org.junit.Ignore;
@@ -74,7 +72,7 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
   public void testCardinality() throws IOException {
     final int numBits = 1 + random().nextInt(100000);
     for (float percentSet : new float[] {0, 0.01f, 0.1f, 0.5f, 0.9f, 0.99f, 1f}) {
-      BitSet set1 = new JavaUtilBitSet(randomSet(numBits, percentSet), numBits);
+      BitSet set1 = new GrowableBitSet(randomSet(numBits, percentSet));
       T set2 = copyOf(set1, numBits);
       assertEquals(set1.cardinality(), set2.cardinality());
     }
@@ -84,7 +82,7 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
   public void testPrevSetBit() throws IOException {
     final int numBits = 1 + random().nextInt(100000);
     for (float percentSet : new float[] {0, 0.01f, 0.1f, 0.5f, 0.9f, 0.99f, 1f}) {
-      BitSet set1 = new JavaUtilBitSet(randomSet(numBits, percentSet), numBits);
+      BitSet set1 = new GrowableBitSet(randomSet(numBits, percentSet));
       T set2 = copyOf(set1, numBits);
       for (int i = 0; i < numBits; ++i) {
         assertEquals(Integer.toString(i), set1.prevSetBit(i), set2.prevSetBit(i));
@@ -96,7 +94,7 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
   public void testNextSetBit() throws IOException {
     final int numBits = 1 + random().nextInt(100000);
     for (float percentSet : new float[] {0, 0.01f, 0.1f, 0.5f, 0.9f, 0.99f, 1f}) {
-      BitSet set1 = new JavaUtilBitSet(randomSet(numBits, percentSet), numBits);
+      BitSet set1 = new GrowableBitSet(randomSet(numBits, percentSet));
       T set2 = copyOf(set1, numBits);
       for (int i = 0; i < numBits; ++i) {
         assertEquals(set1.nextSetBit(i), set2.nextSetBit(i));
@@ -108,7 +106,7 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
   public void testSet() throws IOException {
     Random random = random();
     final int numBits = 1 + random.nextInt(100000);
-    BitSet set1 = new JavaUtilBitSet(randomSet(numBits, 0), numBits);
+    BitSet set1 = new GrowableBitSet(randomSet(numBits, 0));
     T set2 = copyOf(set1, numBits);
     final int iters = 10000 + random.nextInt(10000);
     for (int i = 0; i < iters; ++i) {
@@ -123,7 +121,7 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
   public void testGetAndSet() throws IOException {
     Random random = random();
     final int numBits = 1 + random.nextInt(100000);
-    BitSet set1 = new JavaUtilBitSet(randomSet(numBits, 0), numBits);
+    BitSet set1 = new GrowableBitSet(randomSet(numBits, 0));
     T set2 = copyOf(set1, numBits);
     final int iters = 10000 + random.nextInt(10000);
     for (int i = 0; i < iters; ++i) {
@@ -140,7 +138,7 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
     Random random = random();
     final int numBits = 1 + random.nextInt(100000);
     for (float percentSet : new float[] {0, 0.01f, 0.1f, 0.5f, 0.9f, 0.99f, 1f}) {
-      BitSet set1 = new JavaUtilBitSet(randomSet(numBits, percentSet), numBits);
+      BitSet set1 = new GrowableBitSet(randomSet(numBits, percentSet));
       T set2 = copyOf(set1, numBits);
       final int iters = 1 + random.nextInt(numBits * 2);
       for (int i = 0; i < iters; ++i) {
@@ -157,7 +155,7 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
     Random random = random();
     final int numBits = 1 + random.nextInt(100000);
     for (float percentSet : new float[] {0, 0.01f, 0.1f, 0.5f, 0.9f, 0.99f, 1f}) {
-      BitSet set1 = new JavaUtilBitSet(randomSet(numBits, percentSet), numBits);
+      BitSet set1 = new GrowableBitSet(randomSet(numBits, percentSet));
       T set2 = copyOf(set1, numBits);
       final int iters = atLeast(random, 10);
       for (int i = 0; i < iters; ++i) {
@@ -175,7 +173,7 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
     Random random = random();
     final int numBits = 1 + random.nextInt(100000);
     for (float percentSet : new float[] {0, 0.01f, 0.1f, 0.5f, 0.9f, 0.99f, 1f}) {
-      BitSet set1 = new JavaUtilBitSet(randomSet(numBits, percentSet), numBits);
+      BitSet set1 = new GrowableBitSet(randomSet(numBits, percentSet));
       T set2 = copyOf(set1, numBits);
       final int iters = atLeast(random, 10);
       for (int i = 0; i < iters; ++i) {
@@ -216,13 +214,12 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
 
   private void testOr(float load) throws IOException {
     final int numBits = 1 + random().nextInt(100000);
-    BitSet set1 = new JavaUtilBitSet(randomSet(numBits, 0), numBits); // empty
+    BitSet set1 = new GrowableBitSet(randomSet(numBits, 0)); // empty
     T set2 = copyOf(set1, numBits);
 
     final int iterations = atLeast(10);
     for (int iter = 0; iter < iterations; ++iter) {
-      DocIdSet otherSet =
-          randomCopy(new JavaUtilBitSet(randomSet(numBits, load), numBits), numBits);
+      DocIdSet otherSet = randomCopy(new GrowableBitSet(randomSet(numBits, load)), numBits);
       DocIdSetIterator otherIterator = otherSet.iterator();
       if (otherIterator != null) {
         set1.or(otherIterator);
@@ -245,90 +242,5 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
   /** Test {@link BitSet#or(DocIdSetIterator)} on a random density. */
   public void testOrRandom() throws IOException {
     testOr(random().nextFloat());
-  }
-
-  private static class JavaUtilBitSet extends BitSet {
-
-    private final java.util.BitSet bitSet;
-    private final int numBits;
-
-    JavaUtilBitSet(java.util.BitSet bitSet, int numBits) {
-      this.bitSet = bitSet;
-      this.numBits = numBits;
-    }
-
-    @Override
-    public void clear() {
-      bitSet.clear();
-    }
-
-    @Override
-    public void clear(int index) {
-      bitSet.clear(index);
-    }
-
-    @Override
-    public boolean get(int index) {
-      return bitSet.get(index);
-    }
-
-    @Override
-    public boolean getAndSet(int index) {
-      boolean v = get(index);
-      set(index);
-      return v;
-    }
-
-    @Override
-    public int length() {
-      return numBits;
-    }
-
-    @Override
-    public long ramBytesUsed() {
-      return -1;
-    }
-
-    @Override
-    public Collection<Accountable> getChildResources() {
-      return Collections.emptyList();
-    }
-
-    @Override
-    public void set(int i) {
-      bitSet.set(i);
-    }
-
-    @Override
-    public void clear(int startIndex, int endIndex) {
-      if (startIndex >= endIndex) {
-        return;
-      }
-      bitSet.clear(startIndex, endIndex);
-    }
-
-    @Override
-    public int cardinality() {
-      return bitSet.cardinality();
-    }
-
-    @Override
-    public int approximateCardinality() {
-      return bitSet.cardinality();
-    }
-
-    @Override
-    public int prevSetBit(int index) {
-      return bitSet.previousSetBit(index);
-    }
-
-    @Override
-    public int nextSetBit(int i) {
-      int next = bitSet.nextSetBit(i);
-      if (next == -1) {
-        next = DocIdSetIterator.NO_MORE_DOCS;
-      }
-      return next;
-    }
   }
 }


### PR DESCRIPTION
### Motivation
I need to support concurrent reads and writes to an HNSW index for Cassandra.  One option would be to partition the document range and assign each range to a single thread with the existing implementation.  However,
* It is much faster to query a single on-heap hnsw index, than to query multiple such indexes and combine the result.  (log(N) vs M log(N/M) where N is the number of documents and M is the number of partitions).
* I need to ultimately write the combined index to disk, so even with some contention necessarily occurring during building of the index, we still come out way ahead in terms of total efficiency vs creating per-thread indexes and combining them, since combining the per-thread indexes boils down to "pick the largest and then add all the other nodes normally," you don't really benefit from having computed the others previously and you end up doing close to 2x the work.

### Performance
Numbers are from my SIFT test harness at https://github.com/jbellis/hnswdemo/tree/lucene-bench.  Numbers are averaged across 5 test runs on my i9-12900 (8 performance cores and 8 efficiency)

Serial construction of 1M nodes: 292.3s
Parallel construction, 1 thread: 379.0s = 129.7% of serial
Parallel construction, 2 threads: 191.3s = 50.5% of parallel/1
Parallel construction, 4 threads: 96.1s = 25.4% of parallel/1
Parallel construction, 8 threads: 52.6s = 13.8% of parallel/1

Serial queries of 100k vectors / top 100: 38.3s
Parallel queries, 1 thread: 41.6s = 1.09% of serial
Parallel queries, 2 threads: 21.0s = 50.5% of parallel/1
Parallel queries, 4 threads: 10.3s = 24.7% of parallel/1
Parallel queries, 8 threads: 5.3s = 12.7% of parallel/1

To summarize, there is about a 30% overhead during construction and 10% overhead at query time from using the concurrent class.  The concurrent class parallelizes construction nearly perfectly through 4 threads, with some additional inefficiency becoming visible at 8.  (Probably this is the effect of having to do more vector comparisons across the concurrently added nodes – I would expect this to remain relatively small and not exploding as thread counts increase.)  Uncontended queries scale close to perfectly to at least 8 threads.

### Design and implementation
ConcurrentOnHeapHnswGraph is very similar to OnHeapHnswGraph with concurrent backing Collections.  The main addition is a getView operation to provide a threadsafe snapshot of the graph for searches.  The View uses a CompletionTracker class to provide a kind of snapshot isolation – otherwise it is impossible to prevent partially added nodes from causing very difficult to debug race conditions.  This is used during construction as well as for user-invoked searches.

(The initial CompletionTracker implementation was just an AtomicInteger clock and a Map<node Integer, clock Integer>, but the constant box/unbox introduced significant CPU and GC overhead.  The current implementation is a result of optimizing that.)

ConcurrentHnswGraphBuilder adds an incremental ram used estimate as a return value to addGraphNode, and a buildAsync method that takes an ExecutorService for fine-grained control over parallelism.  Otherwise, it follows the API of HnswGraphBuilder closely.  (Closely enough that my original PR extracted a common interface and added factories so that they could be plugged in interchangeably, but this is now removed after Michael’s feedback.)

The key to achieving good concurrency while maintaining correctness without synchronization is, we track in-progress node additions across all threads in a ConcurrentSkipListSet. After adding ourselves in addGraphNode, we take a snapshot of this set (this is O(1) for CSLS), and consider all other in-progress updates as neighbor candidates (subject to normal level constraints).

In general, the main concern with the Concurrent Builder compared to the serial is to make sure that partially complete operations never “leak” to other threads.  In particular,
* Neighbor manipulation has been encapsulated in ConcurrentNeighborSet.  CNS implements a copy-on-write NeighborArray – my initial implementation used a ConcurrentSkipListSet but this was significantly slower since even during construction, there are many more “iterate through the neighbors” operations than “change the neighbors.”  We have to subclass NeighborArray here to be able to efficiently handle the case of concurrently inserting the same node (as a forward-link and a back-link).
* Entry point updating is not done until the new node has been fully added.

One more point is a little subtle – 
* When a new node is added, it considers both existing nodes in the graph as candidates, as well as other nodes concurrently in the process of being added. It does this by taking a snapshot of the "insertionsInProgress" set when the node begins adding itself, and using both the snapshot and the current graph state as candidate sources. This allows the graph to remain connected even when many nodes are added concurrently.
* The subtle part is that we compute diversity *separately* for the fully-added and the in-progress candidates.  This is because there is an asymmetry between initial links (you need to be diverse or you’re discarded) and backlinks added later (diversity is not enforced again until you bump up against max connections).  Treating them separately allows us to get very similar results to what you would get adding each node serially.  See the discussion in addGraphNode about over-pruning for an example.
* I think we could simplify this linking of new nodes to consider fully-added and in-progress candidates as a group instead of separately, if we implemented the paper’s “keep pruned connections” suggestion.  I have experimented with this, and I think the recall:memory used benefits are good, but it deserves a followup ticket.

The main graph test suites are identical except for changes to perform concurrent graph builds instead of serial, and the addition of testing the incremental ram usage estimate from ConcurrentHnswGraphBuilder::addGraphNode.  I also added new tests for ConcurrentNeighborSet.

### Minor changes to existing code:
* HnswGraphSearcher gets a new searchConcurrent method that uses a GrowableBitSet, since the size of the graph may change during the search.  For the same reason, removed  "assert friendOrd < size" from the search methods.
* Moved JavaUtilBitSet out of BaseBitSetTestCase and renamed to GrowableBitSet.
* Several NeighborArray fields move to protected since we're subclassing it now.
* Updates OnHeapHnswGraph ramBytesUsed for the TreeMap -> HashMap change made in 3c163745, although apparently it’s close enough either way to mostly not matter.
* Added --add-opens in build.gradle for tests to allow RamUsageEstimator to compute exact values when checking correctness of my estimates.
* Added HnswGraph.addNode (with default unsupportedoperation) to document the shared expectations in one place.
