### PR TITLE
StringsToAutomaton#build to take List as parameter instead of Collection

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
@@ -43,8 +43,8 @@ import org.apache.lucene.util.StringHelper;
  */
 public final class Automata {
   /**
-   * {@link #makeStringUnion(Collection)} limits terms of this max length to ensure the stack
-   * doesn't overflow while building, since our algorithm currently relies on recursion.
+   * {@link #makeStringUnion(Iterable)} limits terms of this max length to ensure the stack doesn't
+   * overflow while building, since our algorithm currently relies on recursion.
    */
   public static final int MAX_STRING_UNION_TERM_LENGTH = 1000;
 
@@ -576,8 +576,8 @@ public final class Automata {
    * @return An {@link Automaton} accepting all input strings. The resulting automaton is codepoint
    *     based (full unicode codepoints on transitions).
    */
-  public static Automaton makeStringUnion(Collection<BytesRef> utf8Strings) {
-    if (utf8Strings.isEmpty()) {
+  public static Automaton makeStringUnion(Iterable<BytesRef> utf8Strings) {
+    if (utf8Strings.iterator().hasNext() == false) {
       return makeEmpty();
     } else {
       return StringsToAutomaton.build(utf8Strings, false);
@@ -593,8 +593,8 @@ public final class Automata {
    * @return An {@link Automaton} accepting all input strings. The resulting automaton is binary
    *     based (UTF-8 encoded byte transition labels).
    */
-  public static Automaton makeBinaryStringUnion(Collection<BytesRef> utf8Strings) {
-    if (utf8Strings.isEmpty()) {
+  public static Automaton makeBinaryStringUnion(Iterable<BytesRef> utf8Strings) {
+    if (utf8Strings.iterator().hasNext() == false) {
       return makeEmpty();
     } else {
       return StringsToAutomaton.build(utf8Strings, true);


### PR DESCRIPTION
### Description

- This addresses issue #12319 
- `StringsToAutomaton` previously called `DaciukMihovAutomatonBuilder`(renamed in [this PR](https://github.com/apache/lucene/issues/12276)) should take List as input  instead of Collection as it expects sorted input.

&nbsp;
Closes #12319

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
