### PR TITLE
Enable search for site javadocs

### DIFF
--- a/gradle/documentation/check-broken-links/checkJavadocLinks.py
+++ b/gradle/documentation/check-broken-links/checkJavadocLinks.py
@@ -41,7 +41,7 @@ class FindHyperlinks(HTMLParser):
   def handle_starttag(self, tag, attrs):
     # NOTE: I don't think 'a' should be in here. But try debugging 
     # NumericRangeQuery.html. (Could be javadocs bug, it's a generic type...)
-    if tag not in ('link', 'meta', 'frame', 'br', 'wbr', 'hr', 'p', 'li', 'img', 'col', 'a', 'dt', 'dd'):
+    if tag not in ('link', 'meta', 'frame', 'br', 'wbr', 'hr', 'p', 'li', 'img', 'col', 'a', 'dt', 'dd', 'input'):
       self.stack.append(tag)
     if tag == 'a':
       id = None
@@ -79,7 +79,7 @@ class FindHyperlinks(HTMLParser):
         raise RuntimeError('couldn\'t find an href nor name in link in %s: only got these attrs: %s' % (self.baseURL, attrs))
 
   def handle_endtag(self, tag):
-    if tag in ('link', 'meta', 'frame', 'br', 'hr', 'p', 'li', 'img', 'col', 'a', 'dt', 'dd'):
+    if tag in ('link', 'meta', 'frame', 'br', 'hr', 'p', 'li', 'img', 'col', 'a', 'dt', 'dd', 'input'):
       return
     
     if len(self.stack) == 0:

--- a/gradle/documentation/render-javadoc.gradle
+++ b/gradle/documentation/render-javadoc.gradle
@@ -75,6 +75,8 @@ allprojects {
 
         relativeProjectLinks = true
 
+        enableSearch = true
+
         // Place the documentation under the documentation directory.
         // docroot is defined in 'documentation.gradle'
         outputDir = project.docroot.toPath().resolve(project.relativeDocPath).toFile()
@@ -273,6 +275,9 @@ class RenderJavadocTask extends DefaultTask {
   boolean linksource = false
 
   @Input
+  boolean enableSearch = false
+
+  @Input
   boolean relativeProjectLinks = false
 
   @Internal
@@ -345,7 +350,9 @@ class RenderJavadocTask extends DefaultTask {
     opts << [ '-encoding', 'UTF-8' ]
     opts << [ '-charset', 'UTF-8' ]
     opts << [ '-docencoding', 'UTF-8' ]
-    opts << '-noindex'
+    if (!enableSearch) {
+      opts << '-noindex'
+    }
     opts << '-author'
     opts << '-version'
     if (linksource) {


### PR DESCRIPTION
### Description

Currently the `noindex` flag is always being used when generating javadocs.

For the site javadocs, we want to enable to search feature, which requires the index, so we must remove that flag.

@madrob's dev list thread that spurred this: https://lists.apache.org/thread/wok69q9mn4f4w6lzq5vh21266lbqdrwm