### PR TITLE
Move max vector dims limit to Codec

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -124,6 +124,8 @@ API Changes
 * GITHUB#11248: IntBlockPool's SliceReader, SliceWriter, and all int slice functionality are moved out to MemoryIndex.
   (Stefan Vodita)
 
+* GITHUB#12436: Move max vector dims limit to Codec (Mayya Sharipova)
+
 New Features
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -32,6 +32,9 @@ import org.apache.lucene.util.NamedSPILoader;
  */
 public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
 
+  /** The maximum number of vector dimensions */
+  public static final int DEFAULT_MAX_DIMENSIONS = 1024;
+
   /**
    * This static holder class prevents classloading deadlock by delaying init of doc values formats
    * until needed.
@@ -75,6 +78,17 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
 
   /** Returns a {@link KnnVectorsReader} to read the vectors from the index. */
   public abstract KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException;
+
+  /**
+   * Returns the maximum number of vector dimensions supported by this codec.
+   *
+   * <p>Codecs should override this method to specify the maximum number of dimensions they support.
+   *
+   * @return the maximum number of vector dimensions.
+   */
+  public int getMaxDimensions() {
+    return DEFAULT_MAX_DIMENSIONS;
+  }
 
   /**
    * EMPTY throws an exception when written. It acts as a sentinel indicating a Codec that does not

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -80,13 +80,15 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
   public abstract KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException;
 
   /**
-   * Returns the maximum number of vector dimensions supported by this codec.
+   * Returns the maximum number of vector dimensions supported by this codec for the given field
+   * name
    *
    * <p>Codecs should override this method to specify the maximum number of dimensions they support.
    *
+   * @param fieldName the field name
    * @return the maximum number of vector dimensions.
    */
-  public int getMaxDimensions() {
+  public int getMaxDimensions(String fieldName) {
     return DEFAULT_MAX_DIMENSIONS;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsFormat.java
@@ -108,6 +108,9 @@ public final class Lucene95HnswVectorsFormat extends KnnVectorsFormat {
   public static final int VERSION_START = 0;
   public static final int VERSION_CURRENT = VERSION_START;
 
+  /** A maximum number of vector dimensions supported by this codeс */
+  public static final int MAX_DIMENSIONS = 1024;
+
   /**
    * A maximum configurable maximum max conn.
    *
@@ -183,6 +186,11 @@ public final class Lucene95HnswVectorsFormat extends KnnVectorsFormat {
   @Override
   public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
     return new Lucene95HnswVectorsReader(state);
+  }
+
+  @Override
+  public int getMaxDimensions() {
+    return MAX_DIMENSIONS;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsFormat.java
@@ -108,9 +108,6 @@ public final class Lucene95HnswVectorsFormat extends KnnVectorsFormat {
   public static final int VERSION_START = 0;
   public static final int VERSION_CURRENT = VERSION_START;
 
-  /** A maximum number of vector dimensions supported by this codeс */
-  public static final int MAX_DIMENSIONS = 1024;
-
   /**
    * A maximum configurable maximum max conn.
    *
@@ -190,7 +187,7 @@ public final class Lucene95HnswVectorsFormat extends KnnVectorsFormat {
 
   @Override
   public int getMaxDimensions(String fieldName) {
-    return MAX_DIMENSIONS;
+    return 1024;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsFormat.java
@@ -189,7 +189,7 @@ public final class Lucene95HnswVectorsFormat extends KnnVectorsFormat {
   }
 
   @Override
-  public int getMaxDimensions() {
+  public int getMaxDimensions(String fieldName) {
     return MAX_DIMENSIONS;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
@@ -80,6 +80,11 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
     return new FieldsReader(state);
   }
 
+  @Override
+  public int getMaxDimensions(String fieldName) {
+    return getKnnVectorsFormatForField(fieldName).getMaxDimensions(fieldName);
+  }
+
   /**
    * Returns the numeric vector format that should be used for writing new segments of <code>field
    * </code>.

--- a/lucene/core/src/java/org/apache/lucene/document/FieldType.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FieldType.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.lucene.analysis.Analyzer; // javadocs
 import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.index.PointValues;
@@ -377,13 +376,6 @@ public class FieldType implements IndexableFieldType {
     checkIfFrozen();
     if (numDimensions <= 0) {
       throw new IllegalArgumentException("vector numDimensions must be > 0; got " + numDimensions);
-    }
-    if (numDimensions > FloatVectorValues.MAX_DIMENSIONS) {
-      throw new IllegalArgumentException(
-          "vector numDimensions must be <= FloatVectorValues.MAX_DIMENSIONS (="
-              + FloatVectorValues.MAX_DIMENSIONS
-              + "); got "
-              + numDimensions);
     }
     this.vectorDimension = numDimensions;
     this.vectorSimilarityFunction = Objects.requireNonNull(similarity);

--- a/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
@@ -46,10 +46,6 @@ public class KnnByteVectorField extends Field {
     if (dimension == 0) {
       throw new IllegalArgumentException("cannot index an empty vector");
     }
-    if (dimension > ByteVectorValues.MAX_DIMENSIONS) {
-      throw new IllegalArgumentException(
-          "cannot index vectors with dimension greater than " + ByteVectorValues.MAX_DIMENSIONS);
-    }
     if (similarityFunction == null) {
       throw new IllegalArgumentException("similarity function must not be null");
     }

--- a/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
@@ -47,10 +47,6 @@ public class KnnFloatVectorField extends Field {
     if (dimension == 0) {
       throw new IllegalArgumentException("cannot index an empty vector");
     }
-    if (dimension > FloatVectorValues.MAX_DIMENSIONS) {
-      throw new IllegalArgumentException(
-          "cannot index vectors with dimension greater than " + FloatVectorValues.MAX_DIMENSIONS);
-    }
     if (similarityFunction == null) {
       throw new IllegalArgumentException("similarity function must not be null");
     }

--- a/lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java
@@ -28,9 +28,6 @@ import org.apache.lucene.search.DocIdSetIterator;
  */
 public abstract class ByteVectorValues extends DocIdSetIterator {
 
-  /** The maximum length of a vector */
-  public static final int MAX_DIMENSIONS = 1024;
-
   /** Sole constructor */
   protected ByteVectorValues() {}
 

--- a/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
@@ -28,9 +28,6 @@ import org.apache.lucene.search.DocIdSetIterator;
  */
 public abstract class FloatVectorValues extends DocIdSetIterator {
 
-  /** The maximum length of a vector */
-  public static final int MAX_DIMENSIONS = 1024;
-
   /** Sole constructor */
   protected FloatVectorValues() {}
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -621,6 +621,12 @@ final class IndexingChain implements Accountable {
       final Sort indexSort = indexWriterConfig.getIndexSort();
       validateIndexSortDVType(indexSort, pf.fieldName, s.docValuesType);
     }
+    if (s.vectorDimension != 0) {
+      validateMaxVectorDimension(
+          pf.fieldName,
+          s.vectorDimension,
+          indexWriterConfig.getCodec().knnVectorsFormat().getMaxDimensions());
+    }
     FieldInfo fi =
         fieldInfos.add(
             new FieldInfo(
@@ -828,6 +834,20 @@ final class IndexingChain implements Accountable {
               + "for a field that is not indexed (field=\""
               + name
               + "\")");
+    }
+  }
+
+  private static void validateMaxVectorDimension(
+      String fieldName, int vectorDim, int maxVectorDim) {
+    if (vectorDim > maxVectorDim) {
+      throw new IllegalArgumentException(
+          "Field ["
+              + fieldName
+              + "]"
+              + "vector's dimensions must be <= ["
+              + maxVectorDim
+              + "]; got "
+              + vectorDim);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -625,7 +625,7 @@ final class IndexingChain implements Accountable {
       validateMaxVectorDimension(
           pf.fieldName,
           s.vectorDimension,
-          indexWriterConfig.getCodec().knnVectorsFormat().getMaxDimensions());
+          indexWriterConfig.getCodec().knnVectorsFormat().getMaxDimensions(pf.fieldName));
     }
     FieldInfo fi =
         fieldInfos.add(

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
@@ -32,7 +32,6 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
-import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.index.PointValues;
@@ -319,6 +318,10 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     dir.close();
   }
 
+  private int getVectorsMaxDimensions() {
+    return Codec.getDefault().knnVectorsFormat().getMaxDimensions();
+  }
+
   private IndexableFieldType randomFieldType(Random r) {
     FieldType type = new FieldType();
 
@@ -352,7 +355,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     }
 
     if (r.nextBoolean()) {
-      int dimension = 1 + r.nextInt(FloatVectorValues.MAX_DIMENSIONS);
+      int dimension = 1 + r.nextInt(getVectorsMaxDimensions());
       VectorSimilarityFunction similarityFunction =
           RandomPicks.randomFrom(r, VectorSimilarityFunction.values());
       VectorEncoding encoding = RandomPicks.randomFrom(r, VectorEncoding.values());

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
@@ -279,7 +279,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     var builder = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(softDeletesField);
 
     for (String field : fieldNames) {
-      IndexableFieldType fieldType = randomFieldType(random());
+      IndexableFieldType fieldType = randomFieldType(random(), field);
       boolean storeTermVectors = false;
       boolean storePayloads = false;
       boolean omitNorms = false;
@@ -318,11 +318,11 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     dir.close();
   }
 
-  private int getVectorsMaxDimensions() {
-    return Codec.getDefault().knnVectorsFormat().getMaxDimensions();
+  private int getVectorsMaxDimensions(String fieldName) {
+    return Codec.getDefault().knnVectorsFormat().getMaxDimensions(fieldName);
   }
 
-  private IndexableFieldType randomFieldType(Random r) {
+  private IndexableFieldType randomFieldType(Random r, String fieldName) {
     FieldType type = new FieldType();
 
     if (r.nextBoolean()) {
@@ -355,7 +355,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     }
 
     if (r.nextBoolean()) {
-      int dimension = 1 + r.nextInt(getVectorsMaxDimensions());
+      int dimension = 1 + r.nextInt(getVectorsMaxDimensions(fieldName));
       VectorSimilarityFunction similarityFunction =
           RandomPicks.randomFrom(r, VectorSimilarityFunction.values());
       VectorEncoding encoding = RandomPicks.randomFrom(r, VectorEncoding.values());

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -85,8 +85,8 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     }
   }
 
-  private int getVectorsMaxDimensions() {
-    return Codec.getDefault().knnVectorsFormat().getMaxDimensions();
+  private int getVectorsMaxDimensions(String fieldName) {
+    return Codec.getDefault().knnVectorsFormat().getMaxDimensions(fieldName);
   }
 
   public void testFieldConstructor() {
@@ -475,11 +475,13 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       Document doc = new Document();
       doc.add(
           new KnnFloatVectorField(
-              "f", new float[getVectorsMaxDimensions() + 1], VectorSimilarityFunction.DOT_PRODUCT));
+              "f",
+              new float[getVectorsMaxDimensions("f") + 1],
+              VectorSimilarityFunction.DOT_PRODUCT));
       Exception exc = expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
       assertTrue(
           exc.getMessage()
-              .contains("vector's dimensions must be <= [" + getVectorsMaxDimensions() + "]"));
+              .contains("vector's dimensions must be <= [" + getVectorsMaxDimensions("f") + "]"));
 
       Document doc2 = new Document();
       doc2.add(new KnnFloatVectorField("f", new float[1], VectorSimilarityFunction.DOT_PRODUCT));
@@ -488,7 +490,9 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       Document doc3 = new Document();
       doc3.add(
           new KnnFloatVectorField(
-              "f", new float[getVectorsMaxDimensions() + 1], VectorSimilarityFunction.DOT_PRODUCT));
+              "f",
+              new float[getVectorsMaxDimensions("f") + 1],
+              VectorSimilarityFunction.DOT_PRODUCT));
       exc = expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc3));
       assertTrue(
           exc.getMessage()
@@ -498,11 +502,13 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       Document doc4 = new Document();
       doc4.add(
           new KnnFloatVectorField(
-              "f", new float[getVectorsMaxDimensions() + 1], VectorSimilarityFunction.DOT_PRODUCT));
+              "f",
+              new float[getVectorsMaxDimensions("f") + 1],
+              VectorSimilarityFunction.DOT_PRODUCT));
       exc = expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc4));
       assertTrue(
           exc.getMessage()
-              .contains("vector's dimensions must be <= [" + getVectorsMaxDimensions() + "]"));
+              .contains("vector's dimensions must be <= [" + getVectorsMaxDimensions("f") + "]"));
     }
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -27,7 +27,6 @@ import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -86,6 +85,10 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     }
   }
 
+  private int getVectorsMaxDimensions() {
+    return Codec.getDefault().knnVectorsFormat().getMaxDimensions();
+  }
+
   public void testFieldConstructor() {
     float[] v = new float[1];
     KnnFloatVectorField field = new KnnFloatVectorField("f", v);
@@ -101,14 +104,6 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         IllegalArgumentException.class,
         () -> new KnnFloatVectorField("f", new float[1], (VectorSimilarityFunction) null));
     expectThrows(IllegalArgumentException.class, () -> new KnnFloatVectorField("f", new float[0]));
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> new KnnFloatVectorField("f", new float[FloatVectorValues.MAX_DIMENSIONS + 1]));
-    expectThrows(
-        IllegalArgumentException.class,
-        () ->
-            new KnnFloatVectorField(
-                "f", new float[FloatVectorValues.MAX_DIMENSIONS + 1], (FieldType) null));
   }
 
   public void testFieldSetValue() {
@@ -478,18 +473,36 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      expectThrows(
-          IllegalArgumentException.class,
-          () ->
-              doc.add(
-                  new KnnFloatVectorField(
-                      "f",
-                      new float[FloatVectorValues.MAX_DIMENSIONS + 1],
-                      VectorSimilarityFunction.DOT_PRODUCT)));
+      doc.add(
+          new KnnFloatVectorField(
+              "f", new float[getVectorsMaxDimensions() + 1], VectorSimilarityFunction.DOT_PRODUCT));
+      Exception exc = expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
+      assertTrue(
+          exc.getMessage()
+              .contains("vector's dimensions must be <= [" + getVectorsMaxDimensions() + "]"));
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[1], VectorSimilarityFunction.EUCLIDEAN));
+      doc2.add(new KnnFloatVectorField("f", new float[1], VectorSimilarityFunction.DOT_PRODUCT));
       w.addDocument(doc2);
+
+      Document doc3 = new Document();
+      doc3.add(
+          new KnnFloatVectorField(
+              "f", new float[getVectorsMaxDimensions() + 1], VectorSimilarityFunction.DOT_PRODUCT));
+      exc = expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc3));
+      assertTrue(
+          exc.getMessage()
+              .contains("Inconsistency of field data structures across documents for field [f]"));
+      w.flush();
+
+      Document doc4 = new Document();
+      doc4.add(
+          new KnnFloatVectorField(
+              "f", new float[getVectorsMaxDimensions() + 1], VectorSimilarityFunction.DOT_PRODUCT));
+      exc = expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc4));
+      assertTrue(
+          exc.getMessage()
+              .contains("vector's dimensions must be <= [" + getVectorsMaxDimensions() + "]"));
     }
   }
 


### PR DESCRIPTION
Move vector max dimension limits enforcement into the default Codec's 
KnnVectorsFormat implementation. This allows different implementation 
of knn search algorithms define their own limits of a maximum 
vector dimensions that they can handle.

Closes #12309
