### PR TITLE
Assert IdxOrDvQuery subqueries and document useful fields

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
@@ -42,6 +42,12 @@ import org.apache.lucene.index.LeafReaderContext;
  * otherwise, ie. in the case that another part of the query is already leading iteration but we
  * still need the ability to verify that some documents match.
  *
+ * <p>Some field types that work well with {@link IndexOrDocValuesQuery} are {@link
+ * org.apache.lucene.document.IntField}, {@link org.apache.lucene.document.LongField}, {@link
+ * org.apache.lucene.document.FloatField}, {@link org.apache.lucene.document.DoubleField}, and
+ * {@link org.apache.lucene.document.KeywordField}. These fields provide both an indexed structure
+ * and doc values.
+ *
  * <p><b>NOTE</b>This query currently only works well with point range/exact queries and their
  * equivalent doc values queries.
  *

--- a/lucene/core/src/test/org/apache/lucene/search/TestIndexOrDocValuesQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestIndexOrDocValuesQuery.java
@@ -31,6 +31,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.search.QueryUtils;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 
@@ -76,6 +77,7 @@ public class TestIndexOrDocValuesQuery extends LuceneTestCase {
                     NumericDocValuesField.newSlowRangeQuery("f2", 2L, 2L)),
                 Occur.MUST)
             .build();
+    QueryUtils.check(random(), q1, searcher);
 
     final Weight w1 = searcher.createWeight(searcher.rewrite(q1), ScoreMode.COMPLETE, 1);
     final Scorer s1 = w1.scorer(searcher.getIndexReader().leaves().get(0));
@@ -91,6 +93,7 @@ public class TestIndexOrDocValuesQuery extends LuceneTestCase {
                     NumericDocValuesField.newSlowRangeQuery("f2", 42L, 42L)),
                 Occur.MUST)
             .build();
+    QueryUtils.check(random(), q2, searcher);
 
     final Weight w2 = searcher.createWeight(searcher.rewrite(q2), ScoreMode.COMPLETE, 1);
     final Scorer s2 = w2.scorer(searcher.getIndexReader().leaves().get(0));
@@ -142,6 +145,7 @@ public class TestIndexOrDocValuesQuery extends LuceneTestCase {
                     SortedNumericDocValuesField.newSlowRangeQuery("f2", 2L, 2L)),
                 Occur.MUST)
             .build();
+    QueryUtils.check(random(), q1, searcher);
 
     final Weight w1 = searcher.createWeight(searcher.rewrite(q1), ScoreMode.COMPLETE, 1);
     final Scorer s1 = w1.scorer(searcher.getIndexReader().leaves().get(0));
@@ -157,6 +161,7 @@ public class TestIndexOrDocValuesQuery extends LuceneTestCase {
                     SortedNumericDocValuesField.newSlowRangeQuery("f2", 42, 42L)),
                 Occur.MUST)
             .build();
+    QueryUtils.check(random(), q2, searcher);
 
     final Weight w2 = searcher.createWeight(searcher.rewrite(q2), ScoreMode.COMPLETE, 1);
     final Scorer s2 = w2.scorer(searcher.getIndexReader().leaves().get(0));
@@ -172,6 +177,7 @@ public class TestIndexOrDocValuesQuery extends LuceneTestCase {
                     SortedNumericDocValuesField.newSlowRangeQuery("f2", 42, 42L)),
                 Occur.MUST)
             .build();
+    QueryUtils.check(random(), q3, searcher);
 
     final Weight w3 = searcher.createWeight(searcher.rewrite(q3), ScoreMode.COMPLETE, 1);
     final Scorer s3 = w3.scorer(searcher.getIndexReader().leaves().get(0));
@@ -206,6 +212,7 @@ public class TestIndexOrDocValuesQuery extends LuceneTestCase {
         new IndexOrDocValuesQuery(
             LongPoint.newExactQuery("f2", 42),
             SortedNumericDocValuesField.newSlowRangeQuery("f2", 42, 42L));
+    QueryUtils.check(random(), query, searcher);
 
     final int searchCount = searcher.count(query);
     final Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE, 1);


### PR DESCRIPTION
This is a follow-up from #12426. We introduce assertions in `TestIndexOrDocValuesQuery` that the two wrapped queries are behaving the same way and we document fields that produce indexed structures and doc values, which are good candidates for being used with `IndexOrDocValuesQuery`.