### PR TITLE
Expression: add a set of duplicate variables

### DIFF
--- a/lucene/expressions/build.gradle
+++ b/lucene/expressions/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 
   moduleImplementation project(':lucene:codecs')
 
+  moduleImplementation 'com.carrotsearch:hppc'
+
   moduleImplementation 'org.antlr:antlr4-runtime'
 
   moduleImplementation 'org.ow2.asm:asm'

--- a/lucene/expressions/src/java/module-info.java
+++ b/lucene/expressions/src/java/module-info.java
@@ -17,6 +17,7 @@
 
 @SuppressWarnings({"requires-automatic"})
 module org.apache.lucene.expressions {
+  requires com.carrotsearch.hppc;
   requires org.objectweb.asm;
   requires org.objectweb.asm.commons;
   requires org.antlr.antlr4.runtime;

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/Expression.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/Expression.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.expressions;
 
+import com.carrotsearch.hppc.IntSet;
 import org.apache.lucene.expressions.js.JavascriptCompiler;
 import org.apache.lucene.search.DoubleValues;
 import org.apache.lucene.search.DoubleValuesSource;
@@ -73,14 +74,32 @@ public abstract class Expression {
   public final String[] variables;
 
   /**
+   * Variable ords that are used more than one time in this expression. This can be used to decide
+   * which variables can benefit from caching. Null if selected parser doesn't support this attribute.
+   */
+  public final IntSet duplicateVariableOrds;
+
+  /**
    * Creates a new {@code Expression}.
    *
    * @param sourceText Source text for the expression: e.g. {@code ln(popularity)}
    * @param variables Names of external variables referred to by the expression
    */
   protected Expression(String sourceText, String[] variables) {
+    this(sourceText, variables, null);
+  }
+
+  /**
+   * Creates a new {@code Expression}.
+   *
+   * @param sourceText Source text for the expression: e.g. {@code ln(popularity)}
+   * @param variables Names of external variables referred to by the expression
+   * @param duplicateVariableOrds Ords of variables that are used more than once in the expression.
+   */
+  protected Expression(String sourceText, String[] variables, IntSet duplicateVariableOrds) {
     this.sourceText = sourceText;
     this.variables = variables;
+    this.duplicateVariableOrds = duplicateVariableOrds;
   }
 
   /**

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/TestDemoExpressions.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/TestDemoExpressions.java
@@ -137,6 +137,8 @@ public class TestDemoExpressions extends LuceneTestCase {
       float actual = ((Double) d.fields[0]).floatValue();
       assertEquals(expected, actual, 0d);
     }
+    // assert that first and only variable is marked as duplicated
+    assertTrue(expr.duplicateVariableOrds.contains(0));
   }
 
   /** Uses variables with $ */


### PR DESCRIPTION
Keep a set of Expression variables that are used more than once. This set can then be used by Lucene application to decide if corresponding DoubleValuesSource can benefit from caching caching.

