### PR TITLE
Enable rank-unsafe optimizations for MAXSCORE/WAND.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionScorer.java
@@ -248,4 +248,9 @@ final class BlockMaxConjunctionScorer extends Scorer {
     }
     return children;
   }
+
+  @Override
+  public void setTargetCost(long cost) {
+    scorers[0].setTargetCost(cost);
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/BulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BulkScorer.java
@@ -90,4 +90,13 @@ public abstract class BulkScorer {
 
   /** Same as {@link DocIdSetIterator#cost()} for bulk scorers. */
   public abstract long cost();
+
+  /**
+   * Optional operation: set the target cost. When set to a value that is less that {@link #cost()},
+   * the {@link BulkScorer} may enable rank-unsafe optimizations and trade recall in order to more
+   * efficiently identify some of the top hits. This method only makes sense on queries sorted by
+   * score. Note that this is a best effort only, you should combine it with early termination
+   * and/or timeouts if you need strict guarantees about query runtime.
+   */
+  public void setTargetCost(long cost) {}
 }

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
@@ -35,6 +35,7 @@ final class MaxScoreBulkScorer extends BulkScorer {
   private int firstEssentialScorer;
   private final MaxScoreSumPropagator maxScorePropagator;
   private final long cost;
+  private long targetCost;
   private float minCompetitiveScore;
   private boolean minCompetitiveScoreUpdated;
   private Score scorable = new Score();
@@ -51,6 +52,7 @@ final class MaxScoreBulkScorer extends BulkScorer {
       allScorers[i++] = w;
     }
     this.cost = cost;
+    this.targetCost = cost;
     maxScorePropagator = new MaxScoreSumPropagator(scorers);
     essentialQueue = new DisiPriorityQueue(allScorers.length);
     maxScoreSums = new double[allScorers.length];
@@ -158,6 +160,7 @@ final class MaxScoreBulkScorer extends BulkScorer {
   private boolean partitionScorers() {
     Arrays.sort(allScorers, Comparator.comparingDouble(scorer -> scorer.maxWindowScore));
     double maxScoreSum = 0;
+    long essentialCost = cost;
     for (firstEssentialScorer = 0;
         firstEssentialScorer < allScorers.length;
         ++firstEssentialScorer) {
@@ -168,7 +171,17 @@ final class MaxScoreBulkScorer extends BulkScorer {
       if (maxScoreSumFloat >= minCompetitiveScore) {
         break;
       }
+      essentialCost -= allScorers[firstEssentialScorer].cost;
     }
+
+    // See if we can further reduce the set of essential scorers while still being above the target
+    // cost.
+    while (firstEssentialScorer < allScorers.length - 1
+        && essentialCost - allScorers[firstEssentialScorer].cost >= targetCost) {
+      essentialCost -= allScorers[firstEssentialScorer].cost;
+      firstEssentialScorer++;
+    }
+
     if (firstEssentialScorer == allScorers.length) {
       return false;
     }
@@ -200,6 +213,11 @@ final class MaxScoreBulkScorer extends BulkScorer {
   @Override
   public long cost() {
     return cost;
+  }
+
+  @Override
+  public void setTargetCost(long cost) {
+    this.targetCost = cost;
   }
 
   private class Score extends Scorable {

--- a/lucene/core/src/java/org/apache/lucene/search/ReqOptSumScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ReqOptSumScorer.java
@@ -313,4 +313,9 @@ class ReqOptSumScorer extends Scorer {
     children.add(new ChildScorable(optScorer, "SHOULD"));
     return children;
   }
+
+  @Override
+  public void setTargetCost(long cost) {
+    reqScorer.setTargetCost(cost);
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/Scorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Scorer.java
@@ -104,4 +104,14 @@ public abstract class Scorer extends Scorable {
    * {@link #advanceShallow(int) shallow-advanced} to included and {@code upTo} included.
    */
   public abstract float getMaxScore(int upTo) throws IOException;
+
+  /**
+   * Optional operation: set the target cost. When set to a value that is less that the iterator's
+   * {@link DocIdSetIterator#cost()}, the {@link BulkScorer} may enable rank-unsafe optimizations
+   * and trade recall in order to more efficiently identify some of the top hits. This method only
+   * makes sense on queries sorted by score. Note that this is a best effort only, you should
+   * combine it with early termination and/or timeouts if you need strict guarantees about query
+   * runtime.
+   */
+  public void setTargetCost(long cost) {}
 }


### PR DESCRIPTION
Both MAXSCORE and WAND can easily be tuned to perform rank-unsafe optimizations, by skipping doc IDs that are unlikely to make it to the top-k. The main challenge is how to expose this kind of optimization. One approach could consist of artificially increasing the minimum competitive score as suggested in the original WAND paper. The approach I'm considering here is to configure a target evaluation cost, giving the scorer a budget of documents that it can visit and asking it to compute the best hits it can identify with this budget.

This draft PR tries to give an idea of how it could look like. It's currently only implemented for our MAXSCORE implementation but could easily be ported to our WAND scorer too.

An interesting follow-up could be to integrate this into the timout mechanism, so that `IndexSearcher` would progressively reduce the target cost as the amount of remaining time reduces.

I'm interested in gathering feedback on this approach.