### PR TITLE
Fix sorted&unsorted graph test flakiness

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -232,7 +232,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
         for (int i = 0; i < 10; i++) {
           // ask to explore a lot of candidates to ensure the same returned hits,
           // as graphs of 2 indices are organized differently
-          Query query = knnQuery("vector", randomVector(dim), 50);
+          Query query = knnQuery("vector", randomVector(dim), 60);
           int searchSize = 5;
           List<String> ids1 = new ArrayList<>(searchSize);
           List<Integer> docs1 = new ArrayList<>(searchSize);


### PR DESCRIPTION
When running `HnswGraphTestCase#testSortedAndUnsortedIndicesReturnSameResults`, we search two separate graph structures. These structures can change depending on the order of the vectors seen and consequently a different result set could be returned from the same query. 

To account for this, the test had a higher number of exploration candidates (ef_search/k) of `50`, but in one particular seed: `C8AAF5E4648B4226`, it failed.

I have verified that bumping the search candidate pool to 60 fixes the failure. 

The total number of vectors still out numbers the requested number of candidates, so the search is still hitting the graph.

I verified further by running the test again over a couple thousand seeds and it didn't fail again.
