### PR TITLE
Faster bulk numeric reads from BufferedIndexInput

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -84,8 +84,6 @@ Optimizations
 
 * GITHUB#12372: Reduce allocation during HNSW construction (Jonathan Ellis)
 
-* GITHUB#12453: Faster bulk numeric reads from BufferedIndexInput (Armin Braun)
-
 Bug Fixes
 ---------------------
 
@@ -160,6 +158,8 @@ Optimizations
 * GITHUB#12385: Restore parallel knn query rewrite across segments rather than slices (Luca Cavanna)
 
 * GITHUB#12381: Speed up NumericDocValuesWriter with index sorting. (Chao Zhang)
+
+* GITHUB#12453: Faster bulk numeric reads from BufferedIndexInput (Armin Braun)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -84,6 +84,8 @@ Optimizations
 
 * GITHUB#12372: Reduce allocation during HNSW construction (Jonathan Ellis)
 
+* GITHUB#12453: Faster bulk numeric reads from BufferedIndexInput (Armin Braun)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
@@ -169,7 +169,7 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
       remaining -= cnt;
       if (remaining > 0) {
         if (buffer.hasRemaining()) {
-          floats[len - remaining] = Float.intBitsToFloat(readInt());
+          floats[offset + len - remaining] = Float.intBitsToFloat(readInt());
           --remaining;
         } else {
           refill();
@@ -188,7 +188,7 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
       remaining -= cnt;
       if (remaining > 0) {
         if (buffer.hasRemaining()) {
-          dst[length - remaining] = readLong();
+          dst[offset + length - remaining] = readLong();
           --remaining;
         } else {
           refill();
@@ -207,7 +207,7 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
       remaining -= cnt;
       if (remaining > 0) {
         if (buffer.hasRemaining()) {
-          dst[length - remaining] = readInt();
+          dst[offset + length - remaining] = readInt();
           --remaining;
         } else {
           refill();

--- a/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
@@ -160,17 +160,17 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
   }
 
   @Override
-  public void readFloats(float[] floats, int offset, int len) throws IOException {
-    int remaining = len;
-    while (remaining > 0) {
-      int cnt = Math.min(buffer.remaining() / Float.BYTES, remaining);
-      buffer.asFloatBuffer().get(floats, offset + len - remaining, cnt);
+  public void readFloats(float[] dst, int offset, int len) throws IOException {
+    int remainingDst = len;
+    while (remainingDst > 0) {
+      int cnt = Math.min(buffer.remaining() / Float.BYTES, remainingDst);
+      buffer.asFloatBuffer().get(dst, offset + len - remainingDst, cnt);
       buffer.position(buffer.position() + Float.BYTES * cnt);
-      remaining -= cnt;
-      if (remaining > 0) {
+      remainingDst -= cnt;
+      if (remainingDst > 0) {
         if (buffer.hasRemaining()) {
-          floats[offset + len - remaining] = Float.intBitsToFloat(readInt());
-          --remaining;
+          dst[offset + len - remainingDst] = Float.intBitsToFloat(readInt());
+          --remainingDst;
         } else {
           refill();
         }
@@ -179,17 +179,17 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
   }
 
   @Override
-  public void readLongs(long[] dst, int offset, int length) throws IOException {
-    int remaining = length;
-    while (remaining > 0) {
-      int cnt = Math.min(buffer.remaining() / Long.BYTES, remaining);
-      buffer.asLongBuffer().get(dst, offset + length - remaining, cnt);
+  public void readLongs(long[] dst, int offset, int len) throws IOException {
+    int remainingDst = len;
+    while (remainingDst > 0) {
+      int cnt = Math.min(buffer.remaining() / Long.BYTES, remainingDst);
+      buffer.asLongBuffer().get(dst, offset + len - remainingDst, cnt);
       buffer.position(buffer.position() + Long.BYTES * cnt);
-      remaining -= cnt;
-      if (remaining > 0) {
+      remainingDst -= cnt;
+      if (remainingDst > 0) {
         if (buffer.hasRemaining()) {
-          dst[offset + length - remaining] = readLong();
-          --remaining;
+          dst[offset + len - remainingDst] = readLong();
+          --remainingDst;
         } else {
           refill();
         }
@@ -198,17 +198,17 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
   }
 
   @Override
-  public void readInts(int[] dst, int offset, int length) throws IOException {
-    int remaining = length;
-    while (remaining > 0) {
-      int cnt = Math.min(buffer.remaining() / Integer.BYTES, remaining);
-      buffer.asIntBuffer().get(dst, offset + length - remaining, cnt);
+  public void readInts(int[] dst, int offset, int len) throws IOException {
+    int remainingDst = len;
+    while (remainingDst > 0) {
+      int cnt = Math.min(buffer.remaining() / Integer.BYTES, remainingDst);
+      buffer.asIntBuffer().get(dst, offset + len - remainingDst, cnt);
       buffer.position(buffer.position() + Integer.BYTES * cnt);
-      remaining -= cnt;
-      if (remaining > 0) {
+      remainingDst -= cnt;
+      if (remainingDst > 0) {
         if (buffer.hasRemaining()) {
-          dst[offset + length - remaining] = readInt();
-          --remaining;
+          dst[offset + len - remainingDst] = readInt();
+          --remainingDst;
         } else {
           refill();
         }

--- a/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
@@ -159,6 +159,63 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
     }
   }
 
+  @Override
+  public void readFloats(float[] floats, int offset, int len) throws IOException {
+    int remaining = len;
+    while (remaining > 0) {
+      int cnt = Math.min(buffer.remaining() / Float.BYTES, remaining);
+      buffer.asFloatBuffer().get(floats, offset + len - remaining, cnt);
+      buffer.position(buffer.position() + Float.BYTES * cnt);
+      remaining -= cnt;
+      if (remaining > 0) {
+        if (buffer.hasRemaining()) {
+          floats[len - remaining] = Float.intBitsToFloat(readInt());
+          --remaining;
+        } else {
+          refill();
+        }
+      }
+    }
+  }
+
+  @Override
+  public void readLongs(long[] dst, int offset, int length) throws IOException {
+    int remaining = length;
+    while (remaining > 0) {
+      int cnt = Math.min(buffer.remaining() / Long.BYTES, remaining);
+      buffer.asLongBuffer().get(dst, offset + length - remaining, cnt);
+      buffer.position(buffer.position() + Long.BYTES * cnt);
+      remaining -= cnt;
+      if (remaining > 0) {
+        if (buffer.hasRemaining()) {
+          dst[length - remaining] = readLong();
+          --remaining;
+        } else {
+          refill();
+        }
+      }
+    }
+  }
+
+  @Override
+  public void readInts(int[] dst, int offset, int length) throws IOException {
+    int remaining = length;
+    while (remaining > 0) {
+      int cnt = Math.min(buffer.remaining() / Integer.BYTES, remaining);
+      buffer.asIntBuffer().get(dst, offset + length - remaining, cnt);
+      buffer.position(buffer.position() + Integer.BYTES * cnt);
+      remaining -= cnt;
+      if (remaining > 0) {
+        if (buffer.hasRemaining()) {
+          dst[length - remaining] = readInt();
+          --remaining;
+        } else {
+          refill();
+        }
+      }
+    }
+  }
+
   // Computes an offset into the current buffer from an absolute position to read
   // `width` bytes from.  If the buffer does not contain the position, then we
   // readjust the bufferStart and refill.

--- a/lucene/core/src/test/org/apache/lucene/store/TestBufferedIndexInput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestBufferedIndexInput.java
@@ -234,7 +234,8 @@ public class TestBufferedIndexInput extends LuceneTestCase {
               .put(byten(offset + 1))
               .put(byten(offset + 2))
               .put(byten(offset + 3));
-          assertEquals(bb.getFloat(0), floatBuffer[idx], 0f);
+          assertEquals(
+              Float.floatToRawIntBits(bb.getFloat(0)), Float.floatToRawIntBits(floatBuffer[idx]));
         }
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/store/TestBufferedIndexInput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestBufferedIndexInput.java
@@ -209,6 +209,103 @@ public class TestBufferedIndexInput extends LuceneTestCase {
         "Expected 4 or 3, got " + input.readCount, input.readCount == 4 || input.readCount == 3);
   }
 
+  public void testReadFloats() throws IOException {
+    final int length = 1024 * 8;
+    MyBufferedIndexInput input = new MyBufferedIndexInput(length);
+    ByteBuffer bb = ByteBuffer.allocate(Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    final int bufferLength = 128;
+    float[] floatBuffer = new float[bufferLength];
+
+    for (int alignment = 0; alignment < Float.BYTES; alignment++) {
+      input.seek(0);
+      for (int i = 0; i < alignment; i++) {
+        input.readByte();
+      }
+      final int bulkReads = length / (bufferLength * Float.BYTES) - 1;
+      for (int i = 0; i < bulkReads; i++) {
+        int pos = alignment + i * bufferLength * Float.BYTES;
+        final int floatOffset = random().nextInt(3);
+        input.skipBytes(floatOffset * Float.BYTES);
+        input.readFloats(floatBuffer, floatOffset, bufferLength - floatOffset);
+        for (int idx = floatOffset; idx < bufferLength; idx++) {
+          final int offset = pos + idx * Float.BYTES;
+          bb.position(0)
+              .put(byten(offset))
+              .put(byten(offset + 1))
+              .put(byten(offset + 2))
+              .put(byten(offset + 3));
+          assertEquals(bb.getFloat(0), floatBuffer[idx], 0f);
+        }
+      }
+    }
+  }
+
+  public void testReadInts() throws IOException {
+    final int length = 1024 * 8;
+    MyBufferedIndexInput input = new MyBufferedIndexInput(length);
+    ByteBuffer bb = ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    final int bufferLength = 128;
+    int[] intBuffer = new int[bufferLength];
+
+    for (int alignment = 0; alignment < Integer.BYTES; alignment++) {
+      input.seek(0);
+      for (int i = 0; i < alignment; i++) {
+        input.readByte();
+      }
+      final int bulkReads = length / (bufferLength * Integer.BYTES) - 1;
+      for (int i = 0; i < bulkReads; i++) {
+        int pos = alignment + i * bufferLength * Integer.BYTES;
+        final int intOffset = random().nextInt(3);
+        input.skipBytes(intOffset * Integer.BYTES);
+        input.readInts(intBuffer, intOffset, bufferLength - intOffset);
+        for (int idx = intOffset; idx < bufferLength; idx++) {
+          final int offset = pos + idx * Integer.BYTES;
+          bb.position(0)
+              .put(byten(offset))
+              .put(byten(offset + 1))
+              .put(byten(offset + 2))
+              .put(byten(offset + 3));
+          assertEquals(bb.getInt(0), intBuffer[idx]);
+        }
+      }
+    }
+  }
+
+  public void testReadLongs() throws IOException {
+    final int length = 1024 * 8;
+    MyBufferedIndexInput input = new MyBufferedIndexInput(length);
+    ByteBuffer bb = ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    final int bufferLength = 128;
+    long[] longBuffer = new long[bufferLength];
+
+    for (int alignment = 0; alignment < Long.BYTES; alignment++) {
+      input.seek(0);
+      for (int i = 0; i < alignment; i++) {
+        input.readByte();
+      }
+      final int bulkReads = length / (bufferLength * Long.BYTES) - 1;
+      for (int i = 0; i < bulkReads; i++) {
+        int pos = alignment + i * bufferLength * Long.BYTES;
+        final int longOffset = random().nextInt(3);
+        input.skipBytes(longOffset * Long.BYTES);
+        input.readLongs(longBuffer, longOffset, bufferLength - longOffset);
+        for (int idx = longOffset; idx < bufferLength; idx++) {
+          final int offset = pos + idx * Long.BYTES;
+          bb.position(0)
+              .put(byten(offset))
+              .put(byten(offset + 1))
+              .put(byten(offset + 2))
+              .put(byten(offset + 3))
+              .put(byten(offset + 4))
+              .put(byten(offset + 5))
+              .put(byten(offset + 6))
+              .put(byten(offset + 7));
+          assertEquals(bb.getLong(0), longBuffer[idx]);
+        }
+      }
+    }
+  }
+
   // byten emulates a file - byten(n) returns the n'th byte in that file.
   // MyBufferedIndexInput reads this "file".
   private static byte byten(long n) {


### PR DESCRIPTION
Reading ints/floats/longs one-by-one from a heap-byte-buffer, including doing our own bounds checks is not very efficient. We can use the ability to translate the buffer and read in bulk while taking turns with one-off reading/refilling instead.