### PR TITLE
Clean up ordinal map in default SSDV reader state

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/DefaultSortedSetDocValuesReaderState.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/DefaultSortedSetDocValuesReaderState.java
@@ -53,7 +53,13 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
   /** {@link IndexReader} passed to the constructor. */
   public final IndexReader reader;
 
-  private final Map<String, OrdinalMap> cachedOrdMaps = new HashMap<>();
+  /**
+   * There is only ever one cached ordinal map, but storing it in a hash map together with the field
+   * name is convenient. It enables us to have code blocks synchronized on the ordinal map even when
+   * the ordinal map is null and it makes it easy to call to {@link
+   * Accountables#namedAccountables(String, Map)} in {@link #getChildResources()}.
+   */
+  private final Map<String, OrdinalMap> cachedOrdMap = new HashMap<>();
 
   private final FacetsConfig config;
 
@@ -233,13 +239,13 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
   /** Return the memory usage of this object in bytes. Negative values are illegal. */
   @Override
   public long ramBytesUsed() {
-    synchronized (cachedOrdMaps) {
-      long bytes = 0;
-      for (OrdinalMap map : cachedOrdMaps.values()) {
-        bytes += map.ramBytesUsed();
+    synchronized (cachedOrdMap) {
+      OrdinalMap map = cachedOrdMap.get(field);
+      if (map == null) {
+        return 0;
+      } else {
+        return map.ramBytesUsed();
       }
-
-      return bytes;
     }
   }
 
@@ -251,8 +257,8 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
    */
   @Override
   public Collection<Accountable> getChildResources() {
-    synchronized (cachedOrdMaps) {
-      return Accountables.namedAccountables("DefaultSortedSetDocValuesReaderState", cachedOrdMaps);
+    synchronized (cachedOrdMap) {
+      return Accountables.namedAccountables("DefaultSortedSetDocValuesReaderState", cachedOrdMap);
     }
   }
 
@@ -264,15 +270,9 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
   /** Return top-level doc values. */
   @Override
   public SortedSetDocValues getDocValues() throws IOException {
-    // TODO: this is dup'd from slow composite reader wrapper ... can we factor it out to share?
     OrdinalMap map = null;
-    // TODO: why are we lazy about this?  It's better if ctor pays the cost, not first query?  Oh,
-    // but we
-    // call this method from ctor, ok.  Also, we only ever store one entry in the map (for
-    // key=field) so
-    // why are we using a map?
-    synchronized (cachedOrdMaps) {
-      map = cachedOrdMaps.get(field);
+    synchronized (cachedOrdMap) {
+      map = cachedOrdMap.get(field);
       if (map == null) {
         // uncached, or not a multi dv
         SortedSetDocValues dv = MultiDocValues.getSortedSetValues(reader, field);
@@ -280,7 +280,7 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
           map = ((MultiDocValues.MultiSortedSetDocValues) dv).mapping;
           IndexReader.CacheHelper cacheHelper = reader.getReaderCacheHelper();
           if (cacheHelper != null && map.owner == cacheHelper.getKey()) {
-            cachedOrdMaps.put(field, map);
+            cachedOrdMap.put(field, map);
           }
         }
         return dv;

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/DefaultSortedSetDocValuesReaderState.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/DefaultSortedSetDocValuesReaderState.java
@@ -26,8 +26,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesType;
@@ -55,8 +53,7 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
   /** {@link IndexReader} passed to the constructor. */
   public final IndexReader reader;
 
-  private OrdinalMap ordinalMap = null;
-  private Lock ordinalMapLock = new ReentrantLock();
+  private final Map<String, OrdinalMap> cachedOrdMaps = new HashMap<>();
 
   private final FacetsConfig config;
 
@@ -236,10 +233,14 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
   /** Return the memory usage of this object in bytes. Negative values are illegal. */
   @Override
   public long ramBytesUsed() {
-    ordinalMapLock.lock();
-    long ramBytesUsed = ordinalMap.ramBytesUsed();
-    ordinalMapLock.unlock();
-    return ramBytesUsed;
+    synchronized (cachedOrdMaps) {
+      long bytes = 0;
+      for (OrdinalMap map : cachedOrdMaps.values()) {
+        bytes += map.ramBytesUsed();
+      }
+
+      return bytes;
+    }
   }
 
   /**
@@ -250,15 +251,9 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
    */
   @Override
   public Collection<Accountable> getChildResources() {
-    Map<String, OrdinalMap> snapshot = new HashMap<>();
-    ordinalMapLock.lock();
-    if (ordinalMap != null) {
-      snapshot.put(field, ordinalMap);
+    synchronized (cachedOrdMaps) {
+      return Accountables.namedAccountables("DefaultSortedSetDocValuesReaderState", cachedOrdMaps);
     }
-    Collection<Accountable> resources =
-        Accountables.namedAccountables("DefaultSortedSetDocValuesReaderState", snapshot);
-    ordinalMapLock.unlock();
-    return resources;
   }
 
   @Override
@@ -269,22 +264,30 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
   /** Return top-level doc values. */
   @Override
   public SortedSetDocValues getDocValues() throws IOException {
-    ordinalMapLock.lock();
-    if (ordinalMap == null) {
-      // uncached, or not a multi dv
-      SortedSetDocValues dv = MultiDocValues.getSortedSetValues(reader, field);
-      if (dv instanceof MultiDocValues.MultiSortedSetDocValues) {
-        OrdinalMap map = ((MultiDocValues.MultiSortedSetDocValues) dv).mapping;
-        IndexReader.CacheHelper cacheHelper = reader.getReaderCacheHelper();
-        if (cacheHelper != null && map.owner == cacheHelper.getKey()) {
-          ordinalMap = map;
+    // TODO: this is dup'd from slow composite reader wrapper ... can we factor it out to share?
+    OrdinalMap map = null;
+    // TODO: why are we lazy about this?  It's better if ctor pays the cost, not first query?  Oh,
+    // but we
+    // call this method from ctor, ok.  Also, we only ever store one entry in the map (for
+    // key=field) so
+    // why are we using a map?
+    synchronized (cachedOrdMaps) {
+      map = cachedOrdMaps.get(field);
+      if (map == null) {
+        // uncached, or not a multi dv
+        SortedSetDocValues dv = MultiDocValues.getSortedSetValues(reader, field);
+        if (dv instanceof MultiDocValues.MultiSortedSetDocValues) {
+          map = ((MultiDocValues.MultiSortedSetDocValues) dv).mapping;
+          IndexReader.CacheHelper cacheHelper = reader.getReaderCacheHelper();
+          if (cacheHelper != null && map.owner == cacheHelper.getKey()) {
+            cachedOrdMaps.put(field, map);
+          }
         }
+        return dv;
       }
-      return dv;
     }
-    ordinalMapLock.unlock();
 
-    assert ordinalMap != null;
+    assert map != null;
     int size = reader.leaves().size();
     final SortedSetDocValues[] values = new SortedSetDocValues[size];
     final int[] starts = new int[size + 1];
@@ -305,7 +308,7 @@ public class DefaultSortedSetDocValuesReaderState extends SortedSetDocValuesRead
       cost += v.cost();
     }
     starts[size] = reader.maxDoc();
-    return new MultiSortedSetDocValues(values, starts, ordinalMap, cost);
+    return new MultiSortedSetDocValues(values, starts, map, cost);
   }
 
   /** Indexed field we are reading. */


### PR DESCRIPTION
`DefaultSortedSetDocValuesReaderState` has a cache of ordinal maps, but it only has one ordinal map in it at most.

This PR preserves the functionality of the class, but removes `cachedOrdMaps`. We can't synchronise on the ordinal map itself, since it could be `null`, so we introduce an ordinal map lock instead.

Overall, I like the previous code a bit better, it's cleaner and more concise, although `cachedOrdMaps` looks confusing at first. Maybe it just needs a comment explaining why using a map is convenient (we can synchronize on it, we can call `Accountables.namedAccountables` with it)? I'd like to hear what others think.