### PR TITLE
Fix stack overflow in RegExp for long string

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -166,6 +166,8 @@ Bug Fixes
 
 * GITHUB#9660: Throw an ArithmeticException when the offset overflows in a ByteBlockPool. (Stefan Vodita)
 
+* GITHUB#11537: Fix stack overflow in RegExp for long strings by reducing recursion. (Jakub Slowinski)
+
 * GITHUB#12388: JoinUtil queries were ignoring boosts. (Alan Woodward)
 
 * GITHUB#12413: Fix HNSW graph search bug that potentially leaked unapproved docs (Ben Trent).

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -30,9 +30,7 @@
 package org.apache.lucene.util.automaton;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -1096,17 +1094,12 @@ public class RegExp {
   }
 
   final RegExp iterativeParseExp(
-      Supplier<RegExp> gather, BooleanSupplier stop, MakeRegexGroup reduce)
+      Supplier<RegExp> gather, BooleanSupplier stop, MakeRegexGroup associativeReduce)
       throws IllegalArgumentException {
-    Deque<RegExp> regExpStack = new ArrayDeque<>();
-    do {
+    RegExp result = gather.get();
+    while (stop.getAsBoolean() == true) {
       RegExp e = gather.get();
-      regExpStack.addFirst(e);
-    } while (stop.getAsBoolean() == true);
-
-    RegExp result = regExpStack.removeFirst();
-    while (regExpStack.isEmpty() == false) {
-      result = reduce.get(flags, regExpStack.removeFirst(), result);
+      result = associativeReduce.get(flags, result, e);
     }
     return result;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -32,6 +32,7 @@ package org.apache.lucene.util.automaton;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -1097,7 +1098,7 @@ public class RegExp {
   final RegExp iterativeParseExp(
       Supplier<RegExp> gather, BooleanSupplier stop, MakeRegexGroup reduce)
       throws IllegalArgumentException {
-    ArrayDeque<RegExp> regExpStack = new ArrayDeque<>();
+    Deque<RegExp> regExpStack = new ArrayDeque<>();
     do {
       RegExp e = gather.get();
       regExpStack.addFirst(e);

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
@@ -245,4 +245,8 @@ public class TestRegExp extends LuceneTestCase {
     }
     return regexPattern;
   }
+
+  public void testRegExpNoStackOverflow() {
+    new RegExp("(a)|".repeat(50000) + "(a)");
+  }
 }


### PR DESCRIPTION
### Description

Removed recursion from `parseUnionExp`, `parseInterExp` and `parseConcatExp` methods.
This prevents hitting stack overflow errors on long string inputs. Added a unit test to demonstrate.

Closes #11537 
