### PR TITLE
Potential bug in IndexedDISI90#SPARSE->advanceExactWithinBlock

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/IndexedDISI.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/IndexedDISI.java
@@ -575,7 +575,10 @@ final class IndexedDISI extends DocIdSetIterator {
             return true;
           }
         }
-        disi.exists = false;
+        disi.exists =
+            false; // in this previous version of DISI we were also setting disi.exists as false for
+        // a doc that was backwards (and were not failing on an assert). Do we want to do that for
+        // Lucene 9.x?
         return false;
       }
     },

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -564,20 +564,22 @@ public final class IndexedDISI extends DocIdSetIterator {
         final int targetInBlock = target & 0xFFFF;
         // TODO: binary search
         if (disi.nextExistDocInBlock > targetInBlock) {
-          assert !disi.exists;
+          assert !disi.exists; // this assert statement should not exist?
+          // Why do we check the previous state of the disi and assert on it?
           return false;
         }
         if (target == disi.doc) {
-          return disi.exists;
+          return disi.exists; // cursor is exactly at the target doc
         }
         for (; disi.index < disi.nextBlockIndex; ) {
-          int doc = Short.toUnsignedInt(disi.slice.readShort());
+          int doc = Short.toUnsignedInt(disi.slice.readShort()); // read document at cursor position
           disi.index++;
           if (doc >= targetInBlock) {
             disi.nextExistDocInBlock = doc;
             if (doc != targetInBlock) {
               disi.index--;
-              disi.slice.seek(disi.slice.getFilePointer() - Short.BYTES);
+              disi.slice.seek(
+                  disi.slice.getFilePointer() - Short.BYTES); // cursor goes back by one doc
               break;
             }
             disi.exists = true;
@@ -674,12 +676,18 @@ public final class IndexedDISI extends DocIdSetIterator {
     /**
      * Advance to the first doc from the block that is equal to or greater than {@code target}.
      * Return true if there is such a doc and false otherwise.
+     *
+     * <p>TODO: We need better javadoc here as well.
      */
     abstract boolean advanceWithinBlock(IndexedDISI disi, int target) throws IOException;
 
     /**
      * Advance the iterator exactly to the position corresponding to the given {@code target} and
      * return whether this document exists.
+     *
+     * <p>TODO: We need better javadoc here to explain what exactly is the behavior if you were to
+     * call it with a target that is behind the current position of the cursor, if it is exactly at
+     * the position of the cursor.
      */
     abstract boolean advanceExactWithinBlock(IndexedDISI disi, int target) throws IOException;
   }


### PR DESCRIPTION
While upgrading our Lucene to 9.7 from 9.6 we noticed that a few tests were failing.

On digging deeper into the tests we realized that they were failing on a particular assert. This one:

```
if (disi.nextExistDocInBlock > targetInBlock) {
          assert !disi.exists;
          return false;
        }
```

This changes the behavior of this function as compared to the behavior in Lucene 9.6 (and before). It could be possible that we intentionally decided to change the behavior of this function, but to my eye, it feels like that was not the case?

I attached a test that shows the assert failing. The test tries to call `advanceExact` which underneath it calls `advanceExactWithinBlock` on a document that is behind the current doc position. In the previous version of Lucene this would return a `false` and would exit. But with the upgrade, it fails mysteriously on an assert. 

I created this PR because IIUC the assert checks for something that is completely unrelated to the current method call? Why would we want to assert on the existence of a previous document when calling for `advanceExactWithinBlock` on a new document.. My preference here would be to remove just the assert statement and to revert to the previous behavior (of returning false when calling for a document that is behind the current cursor position). 

I could also be wrong though. Would appreciate a second look from some folks in the community.. Thanks!

Related PR that added the assert: https://github.com/apache/lucene/pull/12324
