### PR TITLE
Make KnnVectorsFormat#getMaxDimensions abstract

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsFormat.java
@@ -121,6 +121,11 @@ public class Lucene90HnswVectorsFormat extends KnnVectorsFormat {
   }
 
   @Override
+  public final int getMaxDimensions(String fieldName) {
+    return 1024;
+  }
+
+  @Override
   public String toString() {
     return "Lucene90HnswVectorsFormat(name = Lucene90HnswVectorsFormat, maxConn = "
         + maxConn

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsFormat.java
@@ -137,6 +137,11 @@ public class Lucene91HnswVectorsFormat extends KnnVectorsFormat {
   }
 
   @Override
+  public final int getMaxDimensions(String fieldName) {
+    return 1024;
+  }
+
+  @Override
   public String toString() {
     return "Lucene91HnswVectorsFormat(name = Lucene91HnswVectorsFormat, maxConn = "
         + maxConn

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsFormat.java
@@ -150,6 +150,11 @@ public class Lucene92HnswVectorsFormat extends KnnVectorsFormat {
   }
 
   @Override
+  public final int getMaxDimensions(String fieldName) {
+    return 1024;
+  }
+
+  @Override
   public String toString() {
     return "Lucene92HnswVectorsFormat(name = Lucene92HnswVectorsFormat, maxConn = "
         + maxConn

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsFormat.java
@@ -156,6 +156,11 @@ public class Lucene94HnswVectorsFormat extends KnnVectorsFormat {
   }
 
   @Override
+  public final int getMaxDimensions(String fieldName) {
+    return 1024;
+  }
+
+  @Override
   public String toString() {
     return "Lucene94HnswVectorsFormat(name=Lucene94HnswVectorsFormat, maxConn="
         + maxConn

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsFormat.java
@@ -47,6 +47,11 @@ public final class SimpleTextKnnVectorsFormat extends KnnVectorsFormat {
     return new SimpleTextKnnVectorsReader(state);
   }
 
+  @Override
+  public int getMaxDimensions(String fieldName) {
+    return KnnVectorsFormat.DEFAULT_MAX_DIMENSIONS;
+  }
+
   /** Extension of vectors data file */
   static final String VECTOR_EXTENSION = "vec";
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -83,14 +83,12 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
    * Returns the maximum number of vector dimensions supported by this codec for the given field
    * name
    *
-   * <p>Codecs should override this method to specify the maximum number of dimensions they support.
+   * <p>Codecs implement this method to specify the maximum number of dimensions they support.
    *
    * @param fieldName the field name
    * @return the maximum number of vector dimensions.
    */
-  public int getMaxDimensions(String fieldName) {
-    return DEFAULT_MAX_DIMENSIONS;
-  }
+  public abstract int getMaxDimensions(String fieldName);
 
   /**
    * EMPTY throws an exception when written. It acts as a sentinel indicating a Codec that does not
@@ -139,6 +137,11 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
               return 0;
             }
           };
+        }
+
+        @Override
+        public int getMaxDimensions(String fieldName) {
+          return 0;
         }
       };
 }

--- a/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
@@ -263,6 +263,11 @@ public class TestPerFieldKnnVectorsFormat extends BaseKnnVectorsFormatTestCase {
     public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
       return delegate.fieldsReader(state);
     }
+
+    @Override
+    public int getMaxDimensions(String fieldName) {
+      return KnnVectorsFormat.DEFAULT_MAX_DIMENSIONS;
+    }
   }
 
   private static class KnnVectorsFormatMaxDims32 extends KnnVectorsFormat {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
@@ -54,6 +54,11 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
     return new AssertingKnnVectorsReader(delegate.fieldsReader(state), state.fieldInfos);
   }
 
+  @Override
+  public int getMaxDimensions(String fieldName) {
+    return KnnVectorsFormat.DEFAULT_MAX_DIMENSIONS;
+  }
+
   static class AssertingKnnVectorsWriter extends KnnVectorsWriter {
     final KnnVectorsWriter delegate;
 


### PR DESCRIPTION
- Backward codecs use 1024 as max dims
- Test classes use the current KnnVectorsFormat#DEFAULT_MAX_DIMENSIONS

Relates to #12436
Closes #12309
