### PR TITLE
Fix failure in BaseKnnVectorsFormatTestCase#testIllegalDimensionTooLarge

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -496,7 +496,10 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       exc = expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc3));
       assertTrue(
           exc.getMessage()
-              .contains("Inconsistency of field data structures across documents for field [f]"));
+                  .contains("Inconsistency of field data structures across documents for field [f]")
+              || exc.getMessage()
+                  .contains(
+                      "vector's dimensions must be <= [" + getVectorsMaxDimensions("f") + "]"));
       w.flush();
 
       Document doc4 = new Document();


### PR DESCRIPTION
Depending whether a document with dimensions > maxDims created on a new segment or already existing segment, we may get different error messages. This fix adds another possible error message we may get.

Relates to #12436