### PR TITLE
Fix randomly failing field info format tests

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -141,7 +141,7 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
 
         @Override
         public int getMaxDimensions(String fieldName) {
-          return 1;
+          return 0;
         }
       };
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -141,7 +141,7 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
 
         @Override
         public int getMaxDimensions(String fieldName) {
-          return 0;
+          return 1;
         }
       };
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
@@ -354,7 +354,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
       type.setDimensions(dimension, indexDimension, dimensionNumBytes);
     }
 
-    if (r.nextBoolean()) {
+    if (r.nextBoolean() && getVectorsMaxDimensions(fieldName) > 0) {
       int dimension = 1 + r.nextInt(getVectorsMaxDimensions(fieldName));
       VectorSimilarityFunction similarityFunction =
           RandomPicks.randomFrom(r, VectorSimilarityFunction.values());


### PR DESCRIPTION
The crux of the issue is that we attempt to generate a vector with at least size 1, but the EMPTY KnnVectorsField type has an upper limit of `0` (and thus is not a valid upper limit for random int). Since the empty field type already protects against usage, I figure making its limit `1` to allow random testing is appropriate.

closes https://github.com/apache/lucene/issues/12471