### PR TITLE
Fix onlyLongestMatch in DictionaryCompoundWordTokenFilter

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/DictionaryCompoundWordTokenFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/DictionaryCompoundWordTokenFilter.java
@@ -88,7 +88,16 @@ public class DictionaryCompoundWordTokenFilter extends CompoundWordTokenFilterBa
         }
       }
       if (this.onlyLongestMatch && longestMatchToken != null) {
-        tokens.add(longestMatchToken);
+        boolean contained = false;
+        for (CompoundToken addedToken : tokens) {
+          if (addedToken.txt.toString().contains(longestMatchToken.txt)) {
+            contained = true;
+            break;
+          }
+        }
+        if (!contained) {
+          tokens.add(longestMatchToken);
+        }
       }
     }
   }


### PR DESCRIPTION
The commit addresses an issue with the onlyLongestMatch flag in the DictionaryCompoundWordTokenFilter. Prior to this fix, when onlyLongestMatch was set to true, the filter would return a match for "orangen" but not for "oran" when both were present in the dictionary.

With this fix, the filter now also correctly handles cases where the submatch is not at the start of the match, such as "orangen" and "angen".