### PR TITLE
Fix onlyLongestMatch in DictionaryCompoundWordTokenFilter

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/DictionaryCompoundWordTokenFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/DictionaryCompoundWordTokenFilter.java
@@ -88,7 +88,16 @@ public class DictionaryCompoundWordTokenFilter extends CompoundWordTokenFilterBa
         }
       }
       if (this.onlyLongestMatch && longestMatchToken != null) {
-        tokens.add(longestMatchToken);
+        boolean contained = false;
+        for (CompoundToken addedToken : tokens) {
+          if (addedToken.txt.toString().contains(longestMatchToken.txt)) {
+            contained = true;
+            break;
+          }
+        }
+        if (!contained) {
+          tokens.add(longestMatchToken);
+        }
       }
     }
   }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/TestCompoundWordTokenFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/TestCompoundWordTokenFilter.java
@@ -255,12 +255,10 @@ public class TestCompoundWordTokenFilter extends BaseTokenStreamTestCase {
 
     assertTokenStreamContents(
         tf,
-        new String[] {
-          "Basfiolsfodralmakaregesäll", "Bas", "fiolsfodral", "fodral", "makare", "gesäll"
-        },
-        new int[] {0, 0, 0, 0, 0, 0},
-        new int[] {26, 26, 26, 26, 26, 26},
-        new int[] {1, 0, 0, 0, 0, 0});
+        new String[] {"Basfiolsfodralmakaregesäll", "Bas", "fiolsfodral", "makare", "gesäll"},
+        new int[] {0, 0, 0, 0, 0},
+        new int[] {26, 26, 26, 26, 26},
+        new int[] {1, 0, 0, 0, 0});
   }
 
   public void testTokenEndingWithWordComponentOfMinimumLength() throws Exception {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/TestDictionaryCompoundWordTokenFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/TestDictionaryCompoundWordTokenFilterFactory.java
@@ -18,6 +18,8 @@ package org.apache.lucene.analysis.compound;
 
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Arrays;
+import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.tests.analysis.BaseTokenStreamFactoryTestCase;
@@ -25,6 +27,9 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 
 /** Simple tests to ensure the Dictionary compound filter factory is working. */
 public class TestDictionaryCompoundWordTokenFilterFactory extends BaseTokenStreamFactoryTestCase {
+  private static CharArraySet makeDictionary(String... dictionary) {
+    return new CharArraySet(Arrays.asList(dictionary), true);
+  }
   /** Ensure the filter actually decompounds text. */
   public void testDecompounding() throws Exception {
     Reader reader = new StringReader("I like to play softball");
@@ -35,6 +40,62 @@ public class TestDictionaryCompoundWordTokenFilterFactory extends BaseTokenStrea
             .create(stream);
     assertTokenStreamContents(
         stream, new String[] {"I", "like", "to", "play", "softball", "soft", "ball"});
+  }
+
+  /** Ensure subtoken are found in token and indexed zero * */
+  public void testDecompounderSubmatches() throws Exception {
+    CharArraySet dict = makeDictionary("ora", "orangen", "schoko", "schokolade");
+
+    DictionaryCompoundWordTokenFilter tf =
+        new DictionaryCompoundWordTokenFilter(
+            whitespaceMockTokenizer("ich will orangenschokolade haben"),
+            dict,
+            CompoundWordTokenFilterBase.DEFAULT_MIN_WORD_SIZE,
+            CompoundWordTokenFilterBase.DEFAULT_MIN_SUBWORD_SIZE,
+            CompoundWordTokenFilterBase.DEFAULT_MAX_SUBWORD_SIZE,
+            false);
+    assertTokenStreamContents(
+        tf,
+        new String[] {
+          "ich", "will", "orangenschokolade", "ora", "orangen", "schoko", "schokolade", "haben"
+        },
+        new int[] {1, 1, 1, 0, 0, 0, 0, 1});
+  }
+
+  /** Ensure subtoken are found in token and only longest match is returned with same start * */
+  public void testDecompounderSubmatchesOnlyLongestMatch() throws Exception {
+    CharArraySet dict = makeDictionary("ora", "orangen", "schoko", "schokolade");
+
+    DictionaryCompoundWordTokenFilter tf =
+        new DictionaryCompoundWordTokenFilter(
+            whitespaceMockTokenizer("ich will orangenschokolade haben"),
+            dict,
+            CompoundWordTokenFilterBase.DEFAULT_MIN_WORD_SIZE,
+            CompoundWordTokenFilterBase.DEFAULT_MIN_SUBWORD_SIZE,
+            CompoundWordTokenFilterBase.DEFAULT_MAX_SUBWORD_SIZE,
+            true);
+    assertTokenStreamContents(
+        tf,
+        new String[] {"ich", "will", "orangenschokolade", "orangen", "schokolade", "haben"},
+        new int[] {1, 1, 1, 0, 0, 1});
+  }
+
+  /** Ensure subtoken are found in token and only longest match is returned without same start * */
+  public void testDecompounderPostSubmatchesOnlyLongestMatch() throws Exception {
+    CharArraySet dict = makeDictionary("ngen", "orangen", "schoko", "schokolade");
+
+    DictionaryCompoundWordTokenFilter tf =
+        new DictionaryCompoundWordTokenFilter(
+            whitespaceMockTokenizer("ich will orangenschokolade haben"),
+            dict,
+            CompoundWordTokenFilterBase.DEFAULT_MIN_WORD_SIZE,
+            CompoundWordTokenFilterBase.DEFAULT_MIN_SUBWORD_SIZE,
+            CompoundWordTokenFilterBase.DEFAULT_MAX_SUBWORD_SIZE,
+            true);
+    assertTokenStreamContents(
+        tf,
+        new String[] {"ich", "will", "orangenschokolade", "orangen", "schokolade", "haben"},
+        new int[] {1, 1, 1, 0, 0, 1});
   }
 
   /** Test that bogus arguments result in exception */


### PR DESCRIPTION
### Description

The commit addresses an issue with the onlyLongestMatch flag in the DictionaryCompoundWordTokenFilter. Currently when onlyLongestMatch is set to true, the filter returns a match for "orangen" but not for "oran" when both were present in the dictionary which is already a partly correct behavior.

With this fix, the filter now also correctly handles cases where the submatch is not at the start of the match, such as "orangen" and "angen".