### PR TITLE
Stop aligning windows in BooleanScorer.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
@@ -320,7 +320,8 @@ final class BooleanScorer extends BulkScorer {
       // special case: only one scorer can match in the current window,
       // we can collect directly
       final BulkScorerAndDoc bulkScorer = leads[0];
-      scoreWindowSingleScorer(bulkScorer, collector, acceptDocs, windowMin, Math.min(max, head.top().next));
+      scoreWindowSingleScorer(
+          bulkScorer, collector, acceptDocs, windowMin, Math.min(max, head.top().next));
       return head.add(bulkScorer);
     } else {
       // general case, collect through a bit set first and then replay

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
@@ -293,13 +293,11 @@ final class BooleanScorer extends BulkScorer {
       LeafCollector collector,
       Bits acceptDocs,
       int windowMin,
-      int windowMax,
-      int max)
+      int windowMax)
       throws IOException {
     assert tail.size() == 0;
-    final int end = Math.max(windowMax, Math.min(max, head.top().next));
 
-    bulkScorer.score(collector, acceptDocs, windowMin, end);
+    bulkScorer.score(collector, acceptDocs, windowMin, windowMax);
 
     // reset the scorer that should be used for the general case
     collector.setScorer(score);
@@ -322,7 +320,7 @@ final class BooleanScorer extends BulkScorer {
       // special case: only one scorer can match in the current window,
       // we can collect directly
       final BulkScorerAndDoc bulkScorer = leads[0];
-      scoreWindowSingleScorer(bulkScorer, collector, acceptDocs, windowMin, windowMax, max);
+      scoreWindowSingleScorer(bulkScorer, collector, acceptDocs, windowMin, Math.min(max, head.top().next));
       return head.add(bulkScorer);
     } else {
       // general case, collect through a bit set first and then replay

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
@@ -256,11 +256,7 @@ final class BooleanScorer extends BulkScorer {
   }
 
   private void scoreWindowMultipleScorers(
-      LeafCollector collector,
-      Bits acceptDocs,
-      int windowMin,
-      int windowMax,
-      int maxFreq)
+      LeafCollector collector, Bits acceptDocs, int windowMin, int windowMax, int maxFreq)
       throws IOException {
     while (maxFreq < minShouldMatch && maxFreq + tail.size() >= minShouldMatch) {
       // a match is still possible
@@ -280,8 +276,7 @@ final class BooleanScorer extends BulkScorer {
       }
       tail.clear();
 
-      scoreWindowIntoBitSetAndReplay(
-          collector, acceptDocs, windowMin, windowMax, leads, maxFreq);
+      scoreWindowIntoBitSetAndReplay(collector, acceptDocs, windowMin, windowMax, leads, maxFreq);
     }
 
     // Push back scorers into head and tail


### PR DESCRIPTION
BooleanScorer aligns windows to multiples of 2048, but it doesn't have to. Actually, not aligning windows can help evaluate fewer windows overall and speed up query evaluation.

This change speeds up counting `title OR 12` on wikimedium10m by ~18%.