### PR TITLE
Fix test failure with zero-length vector

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -1224,10 +1224,10 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
   private float[] randomVector(int dim) {
     assert dim > 0;
     float[] v = new float[dim];
-    double squareSum = 0f;
+    double squareSum = 0.0;
     // keep generating until we don't get a zero-length vector
-    while (squareSum == 0f) {
-      squareSum = 0f;
+    while (squareSum == 0.0) {
+      squareSum = 0.0;
       for (int i = 0; i < dim; i++) {
         v[i] = random().nextFloat();
         squareSum += v[i] * v[i];

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -1222,15 +1222,23 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
   }
 
   private float[] randomVector(int dim) {
+    assert dim > 0;
     float[] v = new float[dim];
-    for (int i = 0; i < dim; i++) {
-      v[i] = random().nextFloat();
+    double squareSum = 0f;
+    // keep generating until we don't get a zero-length vector
+    while (squareSum == 0f) {
+      squareSum = 0f;
+      for (int i = 0; i < dim; i++) {
+        v[i] = random().nextFloat();
+        squareSum += v[i] * v[i];
+      }
     }
     VectorUtil.l2normalize(v);
     return v;
   }
 
   private byte[] randomVector8(int dim) {
+    assert dim > 0;
     float[] v = randomVector(dim);
     byte[] b = new byte[dim];
     for (int i = 0; i < dim; i++) {


### PR DESCRIPTION
Periodically, there is a vector that is randomly generated with zero-length. Here is a seeded reproduction of such a failure:

```
./gradlew test --tests TestLucene95HnswVectorsFormat.testVectorValuesReportCorrectDocs -Dtests.seed=36490CB18A250C0E -Dtests.locale=gsw-FR -Dtests.timezone=US/Hawaii -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```

This adds assertions around the random test vector dimension count and continues to generate random vectors until it has a `squareSum > 0`