### PR TITLE
Remove outdated comment in Scorer

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/Scorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Scorer.java
@@ -25,8 +25,6 @@ import java.util.Objects;
  * <p>A <code>Scorer</code> exposes an {@link #iterator()} over documents matching a query in
  * increasing order of doc Id.
  *
- * <p>Document scores are computed using a given <code>Similarity</code> implementation.
- *
  * <p><b>NOTE</b>: The values Float.Nan, Float.NEGATIVE_INFINITY and Float.POSITIVE_INFINITY are not
  * valid scores. Certain collectors (eg {@link TopScoreDocCollector}) will not properly collect hits
  * with these scores.

--- a/lucene/core/src/java/org/apache/lucene/search/Scorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Scorer.java
@@ -23,11 +23,7 @@ import java.util.Objects;
  * Expert: Common scoring functionality for different types of queries.
  *
  * <p>A <code>Scorer</code> exposes an {@link #iterator()} over documents matching a query in
- * increasing order of doc Id.
- *
- * <p><b>NOTE</b>: The values Float.Nan, Float.NEGATIVE_INFINITY and Float.POSITIVE_INFINITY are not
- * valid scores. Certain collectors (eg {@link TopScoreDocCollector}) will not properly collect hits
- * with these scores.
+ * increasing order of doc id.
  */
 public abstract class Scorer extends Scorable {
 


### PR DESCRIPTION
Should we delete this comment since this constructor parameters already removed from [LUCENE-2876](https://issues.apache.org/jira/browse/LUCENE-2876) , it's description of 'given Similarity' is a lit bit confuse to reader.