### PR TITLE
Fix flaky testToString method for Knn Vector queries

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -792,6 +792,15 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
     assertEquals(expectedId, actualId);
   }
 
+  void assertDocScoreQueryToString(Query query) {
+    String queryString = query.toString("ignored");
+    // The string should contain matching docIds and their score.
+    // Since a forceMerge could occur in this test, we must not assert that a specific doc_id is
+    // matched
+    // But that instead the string format is expected and that the score is 1.0
+    assertTrue(queryString.matches("DocAndScoreQuery\\[\\d+,...]\\[1.0,...]"));
+  }
+
   /**
    * A version of {@link AbstractKnnVectorQuery} that throws an error when an exact search is run.
    * This allows us to check what search strategy is being used.

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnByteVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnByteVectorQuery.java
@@ -76,8 +76,7 @@ public class TestKnnByteVectorQuery extends BaseKnnVectorQueryTestCase {
       AbstractKnnVectorQuery query = getKnnVectorQuery("field", new float[] {0, 1}, 10);
       assertEquals("KnnByteVectorQuery:field[0,...][10]", query.toString("ignored"));
 
-      Query rewritten = query.rewrite(newSearcher(reader));
-      assertEquals("DocAndScoreQuery[0,...][1.0,...]", rewritten.toString("ignored"));
+      assertDocScoreQueryToString(query.rewrite(newSearcher(reader)));
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
@@ -75,8 +75,7 @@ public class TestKnnFloatVectorQuery extends BaseKnnVectorQueryTestCase {
       AbstractKnnVectorQuery query = getKnnVectorQuery("field", new float[] {0.0f, 1.0f}, 10);
       assertEquals("KnnFloatVectorQuery:field[0.0,...][10]", query.toString("ignored"));
 
-      Query rewritten = query.rewrite(newSearcher(reader));
-      assertEquals("DocAndScoreQuery[0,...][1.0,...]", rewritten.toString("ignored"));
+      assertDocScoreQueryToString(query.rewrite(newSearcher(reader)));
     }
   }
 


### PR DESCRIPTION
Periodically, the random indexer will force merge on close, this means that what was originally indexed as the zeroth document could no longer be the zeroth document.

This commit adjusts the assertion to ensure the to string format is as expected for `DocAndScoreQuery`, regardless of the matching doc-id in the test.

This seed shows the issue:
```
./gradlew test --tests TestKnnByteVectorQuery.testToString -Dtests.seed=B78CDB966F4B8FC5
```