### PR TITLE
ToParentBlockJoin[Byte|Float]KnnVectorQuery needs to handle the case when parents are missing

### DIFF
--- a/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinByteKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinByteKnnVectorQuery.java
@@ -75,6 +75,9 @@ public class ToParentBlockJoinByteKnnVectorQuery extends KnnByteVectorQuery {
       return null;
     }
     BitSet parentBitSet = parentsFilter.getBitSet(context);
+    if (parentBitSet == null) {
+      return NO_RESULTS;
+    }
     ParentBlockJoinByteVectorScorer vectorScorer =
         new ParentBlockJoinByteVectorScorer(
             context.reader().getByteVectorValues(field),
@@ -112,6 +115,9 @@ public class ToParentBlockJoinByteKnnVectorQuery extends KnnByteVectorQuery {
   protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
       throws IOException {
     BitSet parentBitSet = parentsFilter.getBitSet(context);
+    if (parentBitSet == null) {
+      return NO_RESULTS;
+    }
     KnnCollector collector = new ToParentJoinKnnCollector(k, visitedLimit, parentBitSet);
     context.reader().searchNearestVectors(field, query, collector, acceptDocs);
     return collector.topDocs();

--- a/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinFloatKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinFloatKnnVectorQuery.java
@@ -77,6 +77,9 @@ public class ToParentBlockJoinFloatKnnVectorQuery extends KnnFloatVectorQuery {
       return null;
     }
     BitSet parentBitSet = parentsFilter.getBitSet(context);
+    if (parentBitSet == null) {
+      return NO_RESULTS;
+    }
     ParentBlockJoinFloatVectorScorer vectorScorer =
         new ParentBlockJoinFloatVectorScorer(
             context.reader().getFloatVectorValues(field),
@@ -114,6 +117,9 @@ public class ToParentBlockJoinFloatKnnVectorQuery extends KnnFloatVectorQuery {
   protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
       throws IOException {
     BitSet parentBitSet = parentsFilter.getBitSet(context);
+    if (parentBitSet == null) {
+      return NO_RESULTS;
+    }
     KnnCollector collector = new ToParentJoinKnnCollector(k, visitedLimit, parentBitSet);
     context.reader().searchNearestVectors(field, query, collector, acceptDocs);
     return collector.topDocs();


### PR DESCRIPTION
This is a follow up to: https://github.com/apache/lucene/pull/12434

Adds a test for when parents are missing in the index and verifies we return no hits. Previously this would have thrown an NPE

Doesn't really justify a CHANGES update as its fixing an unreleased bug due to this previous change.