### PR TITLE
Changed byte to int for prefix_length_key

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TruncateTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TruncateTokenFilterFactory.java
@@ -46,11 +46,11 @@ public class TruncateTokenFilterFactory extends TokenFilterFactory {
   public static final String NAME = "truncate";
 
   public static final String PREFIX_LENGTH_KEY = "prefixLength";
-  private final byte prefixLength;
+  private final int prefixLength;
 
   public TruncateTokenFilterFactory(Map<String, String> args) {
     super(args);
-    prefixLength = Byte.parseByte(get(args, PREFIX_LENGTH_KEY, "5"));
+    prefixLength = Integer.parseInt(get(args, PREFIX_LENGTH_KEY, "5"));
     if (prefixLength < 1)
       throw new IllegalArgumentException(
           PREFIX_LENGTH_KEY + " parameter must be a positive number: " + prefixLength);

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestTruncateTokenFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestTruncateTokenFilterFactory.java
@@ -68,4 +68,23 @@ public class TestTruncateTokenFilterFactory extends BaseTokenStreamFactoryTestCa
                 TruncateTokenFilterFactory.PREFIX_LENGTH_KEY
                     + " parameter must be a positive number: -5"));
   }
+
+  /** Test that takes length greater than byte limit accepts it */
+  public void testLengthGreaterThanByteLimitArgument() throws Exception {
+    Reader reader =
+        new StringReader(
+            "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw128characters From here");
+    TokenStream stream = new MockTokenizer(MockTokenizer.WHITESPACE, false);
+    ((Tokenizer) stream).setReader(reader);
+    stream =
+        tokenFilterFactory("Truncate", TruncateTokenFilterFactory.PREFIX_LENGTH_KEY, "128")
+            .create(stream);
+    assertTokenStreamContents(
+        stream,
+        new String[] {
+          "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw1",
+          "From",
+          "here"
+        });
+  }
 }


### PR DESCRIPTION
### Description
Lucene's TruncateTokenFilterFactory.java has prefixLength as **byte** but the class TruncateTokenFilter.java reads it as **int**. So to make the behavior consistent changed the byte to int in the factory and added a test case for the same.

#12449 

Any length greater than 127 given would be accepted in TruncateTokenFilter but not in TruncateTokenFilterFactory. An exception is thrown due to parsing error from Byte.parseByte method. 
