### PR TITLE
Reduce SegmentTermsEnumFrame Object Construction

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
@@ -158,7 +158,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
             break allTerms;
           }
           final long lastFP = currentFrame.fpOrig;
-          currentFrame = stack[currentFrame.ord - 1];
+          currentFrame = getFrame(currentFrame.ord - 1);
           assert lastFP == currentFrame.lastSubFP;
           // if (DEBUG) {
           //   System.out.println("  reset validIndexPrefix=" + validIndexPrefix);
@@ -209,10 +209,10 @@ final class SegmentTermsEnum extends BaseTermsEnum {
           new SegmentTermsEnumFrame
               [ArrayUtil.oversize(1 + ord, RamUsageEstimator.NUM_BYTES_OBJECT_REF)];
       System.arraycopy(stack, 0, next, 0, stack.length);
-      for (int stackOrd = stack.length; stackOrd < next.length; stackOrd++) {
-        next[stackOrd] = new SegmentTermsEnumFrame(this, stackOrd);
-      }
       stack = next;
+    }
+    if (stack[ord] == null) {
+      stack[ord] = new SegmentTermsEnumFrame(this, ord);
     }
     assert stack[ord].ord == ord;
     return stack[ord];
@@ -398,7 +398,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
           output = Lucene90BlockTreeTermsReader.FST_OUTPUTS.add(output, arc.output());
         }
         if (arc.isFinal()) {
-          lastFrame = stack[1 + lastFrame.ord];
+          lastFrame = getFrame(1 + lastFrame.ord);
         }
         targetUpto++;
       }
@@ -689,7 +689,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
           output = Lucene90BlockTreeTermsReader.FST_OUTPUTS.add(output, arc.output());
         }
         if (arc.isFinal()) {
-          lastFrame = stack[1 + lastFrame.ord];
+          lastFrame = getFrame(1 + lastFrame.ord);
         }
         targetUpto++;
       }
@@ -1066,7 +1066,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
           return null;
         }
         final long lastFP = currentFrame.fpOrig;
-        currentFrame = stack[currentFrame.ord - 1];
+        currentFrame = getFrame(currentFrame.ord - 1);
 
         if (currentFrame.nextEnt == -1 || currentFrame.lastSubFP != lastFP) {
           // We popped into a frame that's not loaded


### PR DESCRIPTION
Recently I found that `SegmentTermsEnumFrame#init` occupied a high percentage in flame graph. It seems like there are a couple of array and objects constructed when calling `SegmentTermsEnumFrame::new`. This PR gives a try to reduce the SegmentTermsEnumFrame objects construction.


![image](https://github.com/apache/lucene/assets/52390227/ddcd8905-cb34-4f13-a7f4-7223564cdd23)
