### PR TITLE
Remove unused variable in BKDWriter

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -214,6 +214,8 @@ Other
 * GITHUB#12428: Replace consecutive close() calls and close() calls with null checks with IOUtils.close().
   (Shubham Chaudhary)
 
+* GITHUB#12512: Remove unused variable in BKDWriter. (Chao Zhang)
+
 ======================== Lucene 9.7.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -104,7 +104,6 @@ public class BKDWriter implements Closeable {
 
   final byte[] scratchDiff;
   final byte[] scratch1;
-  final byte[] scratch2;
   final BytesRef scratchBytesRef1 = new BytesRef();
   final BytesRef scratchBytesRef2 = new BytesRef();
   final int[] commonPrefixLengths;
@@ -157,7 +156,6 @@ public class BKDWriter implements Closeable {
 
     scratchDiff = new byte[config.bytesPerDim];
     scratch1 = new byte[config.packedBytesLength];
-    scratch2 = new byte[config.packedBytesLength];
     commonPrefixLengths = new int[config.numDims];
 
     minPackedValue = new byte[config.packedIndexBytesLength];

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -103,7 +103,7 @@ public class BKDWriter implements Closeable {
   final double maxMBSortInHeap;
 
   final byte[] scratchDiff;
-  final byte[] scratch1;
+  final byte[] scratch;
   final BytesRef scratchBytesRef1 = new BytesRef();
   final BytesRef scratchBytesRef2 = new BytesRef();
   final int[] commonPrefixLengths;
@@ -155,7 +155,7 @@ public class BKDWriter implements Closeable {
     docsSeen = new FixedBitSet(maxDoc);
 
     scratchDiff = new byte[config.bytesPerDim];
-    scratch1 = new byte[config.packedBytesLength];
+    scratch = new byte[config.packedBytesLength];
     commonPrefixLengths = new int[config.numDims];
 
     minPackedValue = new byte[config.packedIndexBytesLength];
@@ -1321,21 +1321,21 @@ public class BKDWriter implements Closeable {
       writeActualBounds(out, commonPrefixLengths, count, packedValues);
     }
     BytesRef value = packedValues.apply(0);
-    System.arraycopy(value.bytes, value.offset, scratch1, 0, config.packedBytesLength);
+    System.arraycopy(value.bytes, value.offset, scratch, 0, config.packedBytesLength);
     int cardinality = 1;
     for (int i = 1; i < count; i++) {
       value = packedValues.apply(i);
       for (int dim = 0; dim < config.numDims; dim++) {
         final int start = dim * config.bytesPerDim;
-        if (equalsPredicate.test(value.bytes, value.offset + start, scratch1, start) == false) {
+        if (equalsPredicate.test(value.bytes, value.offset + start, scratch, start) == false) {
           out.writeVInt(cardinality);
           for (int j = 0; j < config.numDims; j++) {
             out.writeBytes(
-                scratch1,
+                scratch,
                 j * config.bytesPerDim + commonPrefixLengths[j],
                 config.bytesPerDim - commonPrefixLengths[j]);
           }
-          System.arraycopy(value.bytes, value.offset, scratch1, 0, config.packedBytesLength);
+          System.arraycopy(value.bytes, value.offset, scratch, 0, config.packedBytesLength);
           cardinality = 1;
           break;
         } else if (dim == config.numDims - 1) {
@@ -1346,7 +1346,7 @@ public class BKDWriter implements Closeable {
     out.writeVInt(cardinality);
     for (int i = 0; i < config.numDims; i++) {
       out.writeBytes(
-          scratch1,
+          scratch,
           i * config.bytesPerDim + commonPrefixLengths[i],
           config.bytesPerDim - commonPrefixLengths[i]);
     }
@@ -1543,8 +1543,8 @@ public class BKDWriter implements Closeable {
     int splitDim = -1;
     for (int dim = 0; dim < config.numIndexDims; dim++) {
       NumericUtils.subtract(config.bytesPerDim, dim, maxPackedValue, minPackedValue, scratchDiff);
-      if (splitDim == -1 || comparator.compare(scratchDiff, 0, scratch1, 0) > 0) {
-        System.arraycopy(scratchDiff, 0, scratch1, 0, config.bytesPerDim);
+      if (splitDim == -1 || comparator.compare(scratchDiff, 0, scratch, 0) > 0) {
+        System.arraycopy(scratchDiff, 0, scratch, 0, config.bytesPerDim);
         splitDim = dim;
       }
     }
@@ -1686,8 +1686,8 @@ public class BKDWriter implements Closeable {
       // Write the common prefixes:
       reader.getValue(from, scratchBytesRef1);
       System.arraycopy(
-          scratchBytesRef1.bytes, scratchBytesRef1.offset, scratch1, 0, config.packedBytesLength);
-      writeCommonPrefixes(out, commonPrefixLengths, scratch1);
+          scratchBytesRef1.bytes, scratchBytesRef1.offset, scratch, 0, config.packedBytesLength);
+      writeCommonPrefixes(out, commonPrefixLengths, scratch);
 
       // Write the full values:
       IntFunction<BytesRef> packedValues =
@@ -1884,8 +1884,8 @@ public class BKDWriter implements Closeable {
 
       int from = Math.toIntExact(points.start);
       int to = Math.toIntExact(points.start + points.count);
-      // we store common prefix on scratch1
-      computeCommonPrefixLength(heapSource, scratch1, from, to);
+      // we store common prefix on scratch
+      computeCommonPrefixLength(heapSource, scratch, from, to);
 
       int sortedDim = 0;
       int sortedDimCardinality = Integer.MAX_VALUE;
@@ -1940,7 +1940,7 @@ public class BKDWriter implements Closeable {
       // from the index, much like how terms dict does so from the FST:
 
       // Write the common prefixes:
-      writeCommonPrefixes(out, commonPrefixLengths, scratch1);
+      writeCommonPrefixes(out, commonPrefixLengths, scratch);
 
       // Write the full values:
       IntFunction<BytesRef> packedValues =


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

The variable `scratch2` is never used