### PR TITLE
Offload single slice to executor

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -186,6 +186,11 @@ Optimizations
 
 * GITHUB##12371: Lazy computation of similarity score during initializeFromGraph (Jack Wang)
 
+Changes in runtime behavior
+---------------------
+
+* GITHUB#12515: Offload sequential search execution to the executor that's optionally provided to the IndexSearcher (Luca Cavanna)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -654,7 +654,7 @@ public class IndexSearcher {
   private <C extends Collector, T> T search(
       Weight weight, CollectorManager<C, T> collectorManager, C firstCollector) throws IOException {
     final LeafSlice[] leafSlices = getSlices();
-    if (leafSlices == null || leafSlices.length <= 1) {
+    if (leafSlices == null || leafSlices.length == 0) {
       search(leafContexts, weight, firstCollector);
       return collectorManager.reduce(Collections.singletonList(firstCollector));
     } else {

--- a/lucene/core/src/test/org/apache/lucene/search/TestIndexSearcher.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestIndexSearcher.java
@@ -248,7 +248,7 @@ public class TestIndexSearcher extends LuceneTestCase {
     IOUtils.close(r, dir);
   }
 
-  public void testMultipleSegmentsExecuteOnTheExecutor() throws IOException {
+  public void testSlicesAllOffloadedToTheExecutor() throws IOException {
     List<LeafReaderContext> leaves = reader.leaves();
     AtomicInteger numExecutions = new AtomicInteger(0);
     IndexSearcher searcher =
@@ -268,10 +268,6 @@ public class TestIndexSearcher extends LuceneTestCase {
           }
         };
     searcher.search(new MatchAllDocsQuery(), 10);
-    if (leaves.size() <= 1) {
-      assertEquals(0, numExecutions.get());
-    } else {
-      assertEquals(leaves.size(), numExecutions.get());
-    }
+    assertEquals(leaves.size(), numExecutions.get());
   }
 }


### PR DESCRIPTION
When an executor is set to the IndexSearcher, we should try and offload most of the computation to such executor. Ideally, the caller thread would only do light coordination work, and the executor is responsible for the heavier workload. If we don't offload sequential execution to the executor, it becomes very difficult to make any distinction about the type of workload performed on the two sides.

