### PR TITLE
Unwrap execution exceptions cause and rethrow as is when possible

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -189,7 +189,7 @@ Optimizations
 Changes in runtime behavior
 ---------------------
 
-* GITHUB#12516: Unwrap and rethrow execution exceptions cause when performing concurrent search
+* GITHUB#12516: Unwrap and throw execution exceptions cause when performing concurrent search
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -186,6 +186,11 @@ Optimizations
 
 * GITHUB##12371: Lazy computation of similarity score during initializeFromGraph (Jack Wang)
 
+Changes in runtime behavior
+---------------------
+
+* GITHUB#12516: Unwrap and rethrow execution exceptions cause when performing concurrent search
+
 Bug Fixes
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -189,7 +189,7 @@ Optimizations
 Changes in runtime behavior
 ---------------------
 
-* GITHUB#12516: Unwrap and throw execution exceptions cause when performing concurrent search
+* GITHUB#12516: Unwrap and throw execution exceptions cause when performing concurrent search (Luca Cavanna)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -108,7 +108,8 @@ abstract class AbstractKnnVectorQuery extends Query {
   }
 
   private TopDocs[] parallelSearch(
-      List<LeafReaderContext> leafReaderContexts, Weight filterWeight, TaskExecutor taskExecutor) {
+      List<LeafReaderContext> leafReaderContexts, Weight filterWeight, TaskExecutor taskExecutor)
+      throws IOException {
     List<RunnableFuture<TopDocs>> tasks = new ArrayList<>();
     for (LeafReaderContext context : leafReaderContexts) {
       tasks.add(new FutureTask<>(() -> searchLeaf(context, filterWeight)));

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -95,16 +95,12 @@ abstract class AbstractKnnVectorQuery extends Query {
   }
 
   private TopDocs[] sequentialSearch(
-      List<LeafReaderContext> leafReaderContexts, Weight filterWeight) {
-    try {
-      TopDocs[] perLeafResults = new TopDocs[leafReaderContexts.size()];
-      for (LeafReaderContext ctx : leafReaderContexts) {
-        perLeafResults[ctx.ord] = searchLeaf(ctx, filterWeight);
-      }
-      return perLeafResults;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+      List<LeafReaderContext> leafReaderContexts, Weight filterWeight) throws IOException {
+    TopDocs[] perLeafResults = new TopDocs[leafReaderContexts.size()];
+    for (LeafReaderContext ctx : leafReaderContexts) {
+      perLeafResults[ctx.ord] = searchLeaf(ctx, filterWeight);
     }
+    return perLeafResults;
   }
 
   private TopDocs[] parallelSearch(

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -58,6 +58,9 @@ class TaskExecutor {
       } catch (InterruptedException e) {
         throw new ThreadInterruptedException(e);
       } catch (ExecutionException e) {
+        if (e.getCause() instanceof Error error) {
+          throw error;
+        }
         if (e.getCause() instanceof IOException ioException) {
           throw ioException;
         }

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.lucene.search;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -46,7 +47,7 @@ class TaskExecutor {
    * @return a list containing the results from the tasks execution
    * @param <T> the return type of the task execution
    */
-  final <T> List<T> invokeAll(Collection<RunnableFuture<T>> tasks) {
+  final <T> List<T> invokeAll(Collection<RunnableFuture<T>> tasks) throws IOException {
     for (Runnable task : tasks) {
       executor.execute(task);
     }
@@ -57,6 +58,12 @@ class TaskExecutor {
       } catch (InterruptedException e) {
         throw new ThreadInterruptedException(e);
       } catch (ExecutionException e) {
+        if (e.getCause() instanceof IOException ioException) {
+          throw ioException;
+        }
+        if (e.getCause() instanceof RuntimeException runtimeException) {
+          throw runtimeException;
+        }
         throw new RuntimeException(e.getCause());
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.RunnableFuture;
+import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.ThreadInterruptedException;
 
 /**
@@ -58,16 +59,7 @@ class TaskExecutor {
       } catch (InterruptedException e) {
         throw new ThreadInterruptedException(e);
       } catch (ExecutionException e) {
-        if (e.getCause() instanceof Error error) {
-          throw error;
-        }
-        if (e.getCause() instanceof IOException ioException) {
-          throw ioException;
-        }
-        if (e.getCause() instanceof RuntimeException runtimeException) {
-          throw runtimeException;
-        }
-        throw new RuntimeException(e.getCause());
+        throw IOUtils.rethrowAlways(e.getCause());
       }
     }
     return results;

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -533,15 +533,10 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
           assertEquals(results.totalHits.value, results.scoreDocs.length);
           expectThrows(
               UnsupportedOperationException.class,
-              () -> {
-                try {
+              () ->
                   searcher.search(
                       getThrowingKnnVectorQuery("field", randomVector(dimension), 10, filter1),
-                      numDocs);
-                } catch (Exception e) {
-                  throw e;
-                }
-              });
+                      numDocs));
 
           // Test a restrictive filter and check we use exact search
           Query filter2 = IntPoint.newRangeQuery("tag", lower, lower + 6);

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -224,10 +224,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
       IndexSearcher searcher = newSearcher(reader);
       AbstractKnnVectorQuery kvq = getKnnVectorQuery("field", new float[] {0}, 10);
       IllegalArgumentException e =
-          expectThrows(
-              RuntimeException.class,
-              IllegalArgumentException.class,
-              () -> searcher.search(kvq, 10));
+          expectThrows(IllegalArgumentException.class, () -> searcher.search(kvq, 10));
       assertEquals("vector query dimension: 1 differs from field dimension: 2", e.getMessage());
     }
   }
@@ -535,12 +532,16 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
           assertEquals(9, results.totalHits.value);
           assertEquals(results.totalHits.value, results.scoreDocs.length);
           expectThrows(
-              RuntimeException.class,
               UnsupportedOperationException.class,
-              () ->
+              () -> {
+                try {
                   searcher.search(
                       getThrowingKnnVectorQuery("field", randomVector(dimension), 10, filter1),
-                      numDocs));
+                      numDocs);
+                } catch (Exception e) {
+                  throw e;
+                }
+              });
 
           // Test a restrictive filter and check we use exact search
           Query filter2 = IntPoint.newRangeQuery("tag", lower, lower + 6);
@@ -550,7 +551,6 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
           assertEquals(5, results.totalHits.value);
           assertEquals(results.totalHits.value, results.scoreDocs.length);
           expectThrows(
-              RuntimeException.class,
               UnsupportedOperationException.class,
               () ->
                   searcher.search(
@@ -578,7 +578,6 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
           // Test a filter that exhausts visitedLimit in upper levels, and switches to exact search
           Query filter4 = IntPoint.newRangeQuery("tag", lower, lower + 2);
           expectThrows(
-              RuntimeException.class,
               UnsupportedOperationException.class,
               () ->
                   searcher.search(
@@ -751,7 +750,6 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
 
         Query filter = new ThrowingBitSetQuery(new FixedBitSet(numDocs));
         expectThrows(
-            RuntimeException.class,
             UnsupportedOperationException.class,
             () ->
                 searcher.search(

--- a/lucene/core/src/test/org/apache/lucene/search/TestTaskExecutor.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTaskExecutor.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.search;
 
 import java.io.IOException;

--- a/lucene/core/src/test/org/apache/lucene/search/TestTaskExecutor.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTaskExecutor.java
@@ -6,11 +6,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.NamedThreadFactory;
 
 public class TestTaskExecutor extends LuceneTestCase {
 
   public void testUnwrapExceptions() {
-    ExecutorService executorService = Executors.newFixedThreadPool(1);
+    ExecutorService executorService = Executors.newFixedThreadPool(1, new NamedThreadFactory(TestTaskExecutor.class.getSimpleName()));
     try {
       TaskExecutor taskExecutor = new TaskExecutor(executorService);
       {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTaskExecutor.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTaskExecutor.java
@@ -27,7 +27,9 @@ import org.apache.lucene.util.NamedThreadFactory;
 public class TestTaskExecutor extends LuceneTestCase {
 
   public void testUnwrapExceptions() {
-    ExecutorService executorService = Executors.newFixedThreadPool(1, new NamedThreadFactory(TestTaskExecutor.class.getSimpleName()));
+    ExecutorService executorService =
+        Executors.newFixedThreadPool(
+            1, new NamedThreadFactory(TestTaskExecutor.class.getSimpleName()));
     try {
       TaskExecutor taskExecutor = new TaskExecutor(executorService);
       {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTaskExecutor.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTaskExecutor.java
@@ -1,0 +1,56 @@
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestTaskExecutor extends LuceneTestCase {
+
+  public void testUnwrapExceptions() {
+    ExecutorService executorService = Executors.newFixedThreadPool(1);
+    try {
+      TaskExecutor taskExecutor = new TaskExecutor(executorService);
+      {
+        FutureTask<?> task =
+            new FutureTask<>(
+                () -> {
+                  throw new IOException("io exception");
+                });
+        IOException ioException =
+            expectThrows(
+                IOException.class, () -> taskExecutor.invokeAll(Collections.singletonList(task)));
+        assertEquals("io exception", ioException.getMessage());
+      }
+      {
+        FutureTask<?> task =
+            new FutureTask<>(
+                () -> {
+                  throw new RuntimeException("runtime");
+                });
+        RuntimeException runtimeException =
+            expectThrows(
+                RuntimeException.class,
+                () -> taskExecutor.invokeAll(Collections.singletonList(task)));
+        assertEquals("runtime", runtimeException.getMessage());
+        assertNull(runtimeException.getCause());
+      }
+      {
+        FutureTask<?> task =
+            new FutureTask<>(
+                () -> {
+                  throw new Exception("exc");
+                });
+        RuntimeException runtimeException =
+            expectThrows(
+                RuntimeException.class,
+                () -> taskExecutor.invokeAll(Collections.singletonList(task)));
+        assertEquals("exc", runtimeException.getCause().getMessage());
+      }
+    } finally {
+      executorService.shutdown();
+    }
+  }
+}


### PR DESCRIPTION
When performing concurrent search, we may get an execution exception from one or more slices. In that case, we'd like to rethrow the cause of the execution exception, which we do by wrapping it into a new runtime exception. Instead, we can rethrow runtime exceptions as-is, and the same is true for io exceptions. Any other exception is still wrapped into a new runtime exception. This unifies the exceptions that get thrown between sequential codepath (when no executor is provided) and concurrent codepath (when an executor is provided).