### PR TITLE
LUCENE-4056: Japanese Tokenizer (Kuromoji) cannot build UniDic dictionary

### DIFF
--- a/gradle/generation/kuromoji.gradle
+++ b/gradle/generation/kuromoji.gradle
@@ -132,6 +132,42 @@ configure(project(":lucene:analysis:kuromoji")) {
       }
     }
 
+    task compileUnidic(type: Download) {
+      description "Recompile dictionaries from UniDic data from https://clrd.ninjal.ac.jp/unidic_archive"
+      group "generation"
+
+      dependsOn deleteDictionaryData
+      dependsOn sourceSets.main.runtimeClasspath
+
+      def dictionaryName = "unidic-cwj-3.1.1-full"
+      def dictionarySource = "https://clrd.ninjal.ac.jp/unidic_archive/cwj/3.1.1/${dictionaryName}.zip"
+      def dictionaryFile = file("${buildDir}/generate/${dictionaryName}.zip")
+      def unpackedDir = file("${buildDir}/generate/${dictionaryName}")
+
+      src dictionarySource
+      dest dictionaryFile
+      onlyIfModified true
+
+      doLast {
+        // Unpack the downloaded archive.
+        delete unpackedDir
+        ant.unzip(src: dictionaryFile, dest: unpackedDir) {
+          ant.cutdirsmapper(dirs: "1")
+        }
+
+        // Compile the dictionary
+        recompileDictionary(project, dictionaryName, {
+          args += [
+                  "unidic",
+                  unpackedDir,
+                  targetDir,
+                  "UTF-8",
+                  false
+          ]
+        })
+      }
+    }
+
     regenerate.dependsOn compileMecab
   }
 }

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -102,6 +102,8 @@ New Features
 Improvements
 ---------------------
 
+* LUCENE-4056: Japanese Tokenizer (Kuromoji) can build a UniDic dictionary (Jun Ohtani, Alexander Zagniotov)
+
 * LUCENE-10416: Update Korean Dictionary to mecab-ko-dic-2.1.1-20180720 for Nori.
   (Uihyun Kim)
 

--- a/lucene/analysis/kuromoji/build.gradle
+++ b/lucene/analysis/kuromoji/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply plugin: 'java-library'
+apply plugin: 'application'
 
 description = 'Japanese Morphological Analyzer'
 
@@ -24,4 +25,9 @@ dependencies {
   moduleApi project(':lucene:analysis:common')
 
   moduleTestImplementation project(':lucene:test-framework')
+}
+
+application {
+  mainModule = 'org.apache.lucene.analysis.kuromoji' // name defined in module-info.java
+  mainClass = 'org.apache.lucene.analysis.ja.dict.DictionaryBuilder'
 }

--- a/lucene/analysis/kuromoji/build.gradle
+++ b/lucene/analysis/kuromoji/build.gradle
@@ -16,7 +16,6 @@
  */
 
 apply plugin: 'java-library'
-apply plugin: 'application'
 
 description = 'Japanese Morphological Analyzer'
 
@@ -25,9 +24,4 @@ dependencies {
   moduleApi project(':lucene:analysis:common')
 
   moduleTestImplementation project(':lucene:test-framework')
-}
-
-application {
-  mainModule = 'org.apache.lucene.analysis.kuromoji' // name defined in module-info.java
-  mainClass = 'org.apache.lucene.analysis.ja.dict.DictionaryBuilder'
 }

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/DictionaryBuilder.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/DictionaryBuilder.java
@@ -25,7 +25,7 @@ import java.util.Locale;
  * Tool to build dictionaries. Usage:
  *
  * <pre>
- *    java -cp [lucene classpath] org.apache.lucene.analysis.ja.util.DictionaryBuilder \
+ *    java -cp [lucene classpath] org.apache.lucene.analysis.ja.dict.DictionaryBuilder \
  *          ${inputDir} ${outputDir} ${encoding} ${normalizeEntry}
  * </pre>
  *

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/DictionaryBuilder.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/DictionaryBuilder.java
@@ -66,7 +66,7 @@ public class DictionaryBuilder {
         .build(inputDir)
         .write(outputDir);
 
-    new UnknownDictionaryBuilder(encoding).build(inputDir).write(outputDir);
+    new UnknownDictionaryBuilder(format, encoding).build(inputDir).write(outputDir);
 
     ConnectionCostsBuilder.build(inputDir.resolve("matrix.def"))
         .write(outputDir, DictionaryConstants.CONN_COSTS_HEADER, DictionaryConstants.VERSION);

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryBuilder.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryBuilder.java
@@ -157,9 +157,10 @@ class TokenInfoDictionaryBuilder {
    * 3   - word cost
    * 4-9 - pos
    * 10  - base form reading
-   * 11  - base form
+   * 11  - lexeme - not used
    * 12  - surface form
    * 13  - surface reading
+   * 14  - orthographic form
    */
 
   private String[] formatEntry(String[] features) {
@@ -177,7 +178,7 @@ class TokenInfoDictionaryBuilder {
       features2[7] = features[7];
       features2[8] = features[8];
       features2[9] = features[9];
-      features2[10] = features[11];
+      features2[10] = features[14];
 
       // If the surface reading is non-existent, use surface form for reading and pronunciation.
       // This happens with punctuation in UniDic and there are possibly other cases as well

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryBuilder.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryBuilder.java
@@ -72,10 +72,7 @@ class TokenInfoDictionaryBuilder {
         while ((line = reader.readLine()) != null) {
           String[] entry = CSVUtil.parse(line);
 
-          if (entry.length < 13) {
-            throw new IllegalArgumentException(
-                "Entry in CSV is not valid (13 field values expected): " + line);
-          }
+          validateEntryLengthWithThrow(line, entry);
 
           lines.add(formatEntry(entry));
 
@@ -128,6 +125,16 @@ class TokenInfoDictionaryBuilder {
     }
     dictionary.setFST(FST.fromFSTReader(fstCompiler.compile(), fstCompiler.getFSTReader()));
     return dictionary;
+  }
+
+  private void validateEntryLengthWithThrow(final String line, String[] entry) {
+    if (this.format == DictionaryBuilder.DictionaryFormat.IPADIC && entry.length < 13) {
+      throw new IllegalArgumentException(
+          "Entry in CSV is not valid (13 field values expected): " + line);
+    } else if (this.format == DictionaryBuilder.DictionaryFormat.UNIDIC && entry.length < 21) {
+      throw new IllegalArgumentException(
+          "Entry in CSV is not valid (21 field values expected): " + line);
+    }
   }
 
   /*

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryBuilder.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryBuilder.java
@@ -62,7 +62,7 @@ class TokenInfoDictionaryBuilder {
   }
 
   private TokenInfoDictionaryWriter buildDictionary(List<Path> csvFiles) throws IOException {
-    TokenInfoDictionaryWriter dictionary = new TokenInfoDictionaryWriter(10 * 1024 * 1024);
+    TokenInfoDictionaryWriter dictionary = new TokenInfoDictionaryWriter(format, 10 * 1024 * 1024);
     Charset cs = Charset.forName(encoding);
     // all lines in the file
     List<String[]> lines = new ArrayList<>(400000);

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
@@ -27,6 +27,11 @@ import org.apache.lucene.util.ArrayUtil;
 /** Writes system dictionary entries */
 class TokenInfoDictionaryEntryWriter extends DictionaryEntryWriter {
   private static final int IPADIC_ID_LIMIT = 8192;
+
+  // E.g.: unidic-cwj-3.1.1-full:   15388
+  // E.g.: unidic-cwj-202302_full:  18859
+  private static final int UNIDIC_ID_LIMIT = 18859;
+
   private final DictionaryBuilder.DictionaryFormat format;
 
   TokenInfoDictionaryEntryWriter(DictionaryBuilder.DictionaryFormat format, int size) {
@@ -131,12 +136,7 @@ class TokenInfoDictionaryEntryWriter extends DictionaryEntryWriter {
       flags |= TokenInfoMorphData.HAS_PRONUNCIATION;
     }
 
-    if (leftId != rightId) {
-      throw new IllegalArgumentException("rightId != leftId: " + rightId + " " + leftId);
-    }
-    if (leftId >= IPADIC_ID_LIMIT) {
-      throw new IllegalArgumentException("leftId >= " + IPADIC_ID_LIMIT + ": " + leftId);
-    }
+    validateLeftRightIdsWithThrow(leftId, rightId);
     // add pos mapping
     int toFill = 1 + leftId - posDict.size();
     for (int i = 0; i < toFill; i++) {
@@ -194,6 +194,20 @@ class TokenInfoDictionaryEntryWriter extends DictionaryEntryWriter {
     }
 
     return buffer.position();
+  }
+
+  private void validateLeftRightIdsWithThrow(short leftId, short rightId) {
+    if (this.format == DictionaryBuilder.DictionaryFormat.IPADIC && leftId != rightId) {
+      throw new IllegalArgumentException("IpaDic rightId != leftId: " + rightId + " " + leftId);
+    }
+
+    if (this.format == DictionaryBuilder.DictionaryFormat.IPADIC && leftId >= IPADIC_ID_LIMIT) {
+      throw new IllegalArgumentException("IpaDic leftId >= " + IPADIC_ID_LIMIT + ": " + leftId);
+    }
+
+    if (this.format == DictionaryBuilder.DictionaryFormat.UNIDIC && leftId >= UNIDIC_ID_LIMIT) {
+      throw new IllegalArgumentException("UniDic leftId >= " + UNIDIC_ID_LIMIT + ": " + leftId);
+    }
   }
 
   private boolean isKatakana(String s) {

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
@@ -26,7 +26,7 @@ import org.apache.lucene.util.ArrayUtil;
 
 /** Writes system dictionary entries */
 class TokenInfoDictionaryEntryWriter extends DictionaryEntryWriter {
-  private static final int ID_LIMIT = 8192;
+  private static final int IPADIC_ID_LIMIT = 8192;
   private final DictionaryBuilder.DictionaryFormat format;
 
   TokenInfoDictionaryEntryWriter(DictionaryBuilder.DictionaryFormat format, int size) {
@@ -119,8 +119,8 @@ class TokenInfoDictionaryEntryWriter extends DictionaryEntryWriter {
     if (leftId != rightId) {
       throw new IllegalArgumentException("rightId != leftId: " + rightId + " " + leftId);
     }
-    if (leftId >= ID_LIMIT) {
-      throw new IllegalArgumentException("leftId >= " + ID_LIMIT + ": " + leftId);
+    if (leftId >= IPADIC_ID_LIMIT) {
+      throw new IllegalArgumentException("leftId >= " + IPADIC_ID_LIMIT + ": " + leftId);
     }
     // add pos mapping
     int toFill = 1 + leftId - posDict.size();

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
@@ -143,11 +143,6 @@ class TokenInfoDictionaryEntryWriter extends DictionaryEntryWriter {
       posDict.add(null);
     }
 
-    String existing = posDict.get(leftId);
-    if (existing != null && existing.equals(fullPOSData) == false) {
-      // TODO: test me
-      throw new IllegalArgumentException("Multiple entries found for leftID=" + leftId);
-    }
     posDict.set(leftId, fullPOSData);
 
     buffer.putShort((short) (leftId << 3 | flags));

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
@@ -49,6 +49,21 @@ class TokenInfoDictionaryEntryWriter extends DictionaryEntryWriter {
    * 11  - reading
    * 12  - pronounciation
    * </pre>
+   *
+   * <p>unidic features
+   *
+   * <pre>
+   * 0   - surface
+   * 1   - left cost
+   * 2   - right cost
+   * 3   - word cost
+   * 4-9 - pos
+   * 10  - base form reading
+   * 11  - lexeme - not used
+   * 12  - surface form
+   * 13  - surface reading
+   * 14  - orthographic form
+   * </pre>
    */
   @Override
   protected int putEntry(String[] entry) {

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
@@ -27,9 +27,11 @@ import org.apache.lucene.util.ArrayUtil;
 /** Writes system dictionary entries */
 class TokenInfoDictionaryEntryWriter extends DictionaryEntryWriter {
   private static final int ID_LIMIT = 8192;
+  private final DictionaryBuilder.DictionaryFormat format;
 
-  TokenInfoDictionaryEntryWriter(int size) {
+  TokenInfoDictionaryEntryWriter(DictionaryBuilder.DictionaryFormat format, int size) {
     super(size);
+    this.format = format;
   }
 
   /**

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryEntryWriter.java
@@ -154,8 +154,16 @@ class TokenInfoDictionaryEntryWriter extends DictionaryEntryWriter {
     buffer.putShort(wordCost);
 
     if ((flags & TokenInfoMorphData.HAS_BASEFORM) != 0) {
-      if (baseForm.length() >= 16) {
-        throw new IllegalArgumentException("Length of base form " + baseForm + " is >= 16");
+      if (this.format == DictionaryBuilder.DictionaryFormat.IPADIC && baseForm.length() >= 16) {
+        throw new IllegalArgumentException(
+            "IPADIC base form length " + baseForm.length() + " is >= 16");
+      }
+
+      // Added the following check because when trying to build unidic-cwj-3.1.1-full,
+      // the base form length was greater than 16, thus, the original check was failing.
+      if (this.format == DictionaryBuilder.DictionaryFormat.UNIDIC && baseForm.length() >= 35) {
+        throw new IllegalArgumentException(
+            "UNIDIC base form length " + baseForm.length() + " is >= 35");
       }
       int shared = sharedPrefix(entry[0], baseForm);
       int suffix = baseForm.length() - shared;

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryWriter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionaryWriter.java
@@ -26,8 +26,8 @@ class TokenInfoDictionaryWriter
     extends org.apache.lucene.analysis.morph.BinaryDictionaryWriter<TokenInfoDictionary> {
   private FST<Long> fst;
 
-  TokenInfoDictionaryWriter(int size) {
-    super(TokenInfoDictionary.class, new TokenInfoDictionaryEntryWriter(size));
+  TokenInfoDictionaryWriter(DictionaryBuilder.DictionaryFormat format, int size) {
+    super(TokenInfoDictionary.class, new TokenInfoDictionaryEntryWriter(format, size));
   }
 
   public void setFST(FST<Long> fst) {

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionaryBuilder.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionaryBuilder.java
@@ -30,9 +30,11 @@ import org.apache.lucene.analysis.util.CSVUtil;
 class UnknownDictionaryBuilder {
   private static final String NGRAM_DICTIONARY_ENTRY = "NGRAM,5,5,-32768,記号,一般,*,*,*,*,*,*,*";
 
+  private final DictionaryBuilder.DictionaryFormat format;
   private final String encoding;
 
-  UnknownDictionaryBuilder(String encoding) {
+  UnknownDictionaryBuilder(DictionaryBuilder.DictionaryFormat format, String encoding) {
+    this.format = format;
     this.encoding = encoding;
   }
 
@@ -60,11 +62,8 @@ class UnknownDictionaryBuilder {
       String line;
       while ((line = lineReader.readLine()) != null) {
         // note: unk.def only has 10 fields, it simplifies the writer to just append empty reading
-        // and pronunciation,
-        // even though the unknown dictionary returns hardcoded null here.
-        final String[] parsed =
-            CSVUtil.parse(line + ",*,*"); // Probably we don't need to validate entry
-        lines.add(parsed);
+        // and pronunciation, even though the unknown dictionary returns hardcoded null here.
+        lines.add(parseCSVLine(line));
       }
     }
 
@@ -76,6 +75,14 @@ class UnknownDictionaryBuilder {
     }
 
     return dictionary;
+  }
+
+  private String[] parseCSVLine(final String line) {
+    if (this.format == DictionaryBuilder.DictionaryFormat.UNIDIC) {
+      return CSVUtil.parse(line + ",*,*,*"); // UniDic needs one more column
+    } else {
+      return CSVUtil.parse(line + ",*,*"); // Probably we don't need to validate entry
+    }
   }
 
   private void readCharacterDefinition(Path path, UnknownDictionaryWriter dictionary)

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionaryBuilder.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionaryBuilder.java
@@ -51,7 +51,7 @@ class UnknownDictionaryBuilder {
 
   private UnknownDictionaryWriter readDictionaryFile(Path path, String encoding)
       throws IOException {
-    UnknownDictionaryWriter dictionary = new UnknownDictionaryWriter(5 * 1024 * 1024);
+    UnknownDictionaryWriter dictionary = new UnknownDictionaryWriter(format, 5 * 1024 * 1024);
 
     List<String[]> lines = new ArrayList<>();
     try (Reader reader = Files.newBufferedReader(path, Charset.forName(encoding));

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionaryWriter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/UnknownDictionaryWriter.java
@@ -29,8 +29,8 @@ class UnknownDictionaryWriter extends BinaryDictionaryWriter<UnknownDictionary> 
           CharacterDefinition.CLASS_COUNT,
           CharacterDefinition::lookupCharacterClass);
 
-  public UnknownDictionaryWriter(int size) {
-    super(UnknownDictionary.class, new TokenInfoDictionaryEntryWriter(size));
+  public UnknownDictionaryWriter(DictionaryBuilder.DictionaryFormat format, int size) {
+    super(UnknownDictionary.class, new TokenInfoDictionaryEntryWriter(format, size));
   }
 
   @Override

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestUnknownDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestUnknownDictionary.java
@@ -25,7 +25,8 @@ public class TestUnknownDictionary extends LuceneTestCase {
 
   @Test
   public void testPutCharacterCategory() {
-    UnknownDictionaryWriter unkDic = new UnknownDictionaryWriter(10 * 1024 * 1024);
+    UnknownDictionaryWriter unkDic =
+        new UnknownDictionaryWriter(DictionaryBuilder.DictionaryFormat.IPADIC, 10 * 1024 * 1024);
 
     expectThrows(Exception.class, () -> unkDic.putCharacterCategory(0, "DUMMY_NAME"));
 
@@ -40,7 +41,8 @@ public class TestUnknownDictionary extends LuceneTestCase {
 
   @Test
   public void testPut() {
-    UnknownDictionaryWriter unkDic = new UnknownDictionaryWriter(10 * 1024 * 1024);
+    UnknownDictionaryWriter unkDic =
+        new UnknownDictionaryWriter(DictionaryBuilder.DictionaryFormat.IPADIC, 10 * 1024 * 1024);
     expectThrows(
         NumberFormatException.class,
         () -> unkDic.put(CSVUtil.parse("KANJI,1285,11426,名詞,一般,*,*,*,*,*,*,*")));


### PR DESCRIPTION
## TL;DR

The current PR attempts to remediate https://issues.apache.org/jira/browse/LUCENE-4056 (`Japanese Tokenizer (Kuromoji) cannot build UniDic dictionary`)

## Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

The current PR builds up upon @johtani's past PR: https://github.com/apache/lucene-solr/pull/935 and attempts to bring the code into a mergeable state, or at least to re-ignite the conversation about building a UniDic dictionary. 

Before exporting the current PR, I verified the @johtani's added behavior in the aforementioned PR (plus some changes of my own) by successfully building a number of dictionaries outlined below and posted my findings in the comment: https://github.com/apache/lucene-solr/pull/935#issuecomment-1685887305 

### Philosophy of changes

I tried to pick up @johtani's added behavior as-is, while minimizing the amount of changes that I added additionally.

To be honest, I do not really like how `DictionaryBuilder.DictionaryFormat format` is being passed everywhere, as it creates these small decision trees `if IPADIC do this else do that`. If this PR gets merged, I would be happy to refactor in order to make the code more modular (where possible) and perhaps with a better separation of concerns. But, I defer to the maintainers of the Lucene library on this one. 🙇🏼‍♀️ 

The commits are fairly atomic and I hope this can make the reviewing experience more easier

## Built Dictionaries 

- [unidic-cwj-202302_full](https://clrd.ninjal.ac.jp/unidic_archive/2302/) (NINJAL)
- [unidic-cwj-3.1.1-full](https://clrd.ninjal.ac.jp/unidic_archive/cwj/3.1.1/) (NINJAL) (See **Caveat** below 👇🏼 )
- [unidic-mecab-2.1.2_src](https://clrd.ninjal.ac.jp/unidic_archive/cwj/2.1.2/) (NINJAL)
- [mecab-ipadic-2.7.0-20070801](https://taku910.github.io/mecab/)

### Caveat
RE: Building the [unidic-cwj-3.1.1-full](https://clrd.ninjal.ac.jp/unidic_archive/cwj/3.1.1/): 

1. I had to increase the the [length check of the baseForm](https://github.com/apache/lucene/commit/4bb6000cdc85aa4cc266d0a32a149d4d517d2e95) from `16` to `35`
2. I had to stop [throwing an exception for multiple entries of LeftID](https://github.com/apache/lucene/commit/011efbe480dce5eafc2c81cdbf44a3fc2f07b61c), which, to be honest I do not understand the full ramifications of. I did print some of the values for the same left IDs instead of throwing when debugging and that's how they look like:
    ```
    Multiple entries found for leftID=4644: existing=[動詞-一般,五段-ガ行,連用形-融合], new fullPOSData=[動詞-一般,五段-ガ行,仮定形-融合]
    Multiple entries found for leftID=4644: existing=[動詞-一般,五段-ガ行,仮定形-融合], new fullPOSData=[動詞-一般,五段-ガ行,連用形-融合]
    Multiple entries found for leftID=4644: existing=[動詞-一般,五段-ガ行,連用形-融合], new fullPOSData=[動詞-一般,五段-ガ行,仮定形-融合]
    Multiple entries found for leftID=4644: existing=[動詞-一般,五段-ガ行,仮定形-融合], new fullPOSData=[動詞-一般,五段-ガ行,連用形-融合]
    Multiple entries found for leftID=14172: existing=[動詞-一般,五段-バ行,仮定形-融合], new fullPOSData=[動詞-一般,五段-バ行,連用形-融合]
    Multiple entries found for leftID=1121: existing=[動詞-一般,五段-ガ行,連用形-融合], new fullPOSData=[動詞-一般,五段-ガ行,仮定形-融合]
    Multiple entries found for leftID=1121: existing=[動詞-一般,五段-ガ行,仮定形-融合], new fullPOSData=[動詞-一般,五段-ガ行,連用形-融合]
    Multiple entries found for leftID=4644: existing=[動詞-一般,五段-ガ行,連用形-融合], new fullPOSData=[動詞-一般,五段-ガ行,仮定形-融合]
    Multiple entries found for leftID=4644: existing=[動詞-一般,五段-ガ行,仮定形-融合], new fullPOSData=[動詞-一般,五段-ガ行,連用形-融合]
    ```
Some `Inflection form` values are different for the same `leftID`, also, why do we have duplicated IDs? ^. Thus, I would value the input of the Subject matter experts here 🙇🏼‍♀️ 

## Building a dictionary

### Gradle command

My build command leverages the new Gradle setup and the [DictionaryBuilder JavaDoc comment](https://github.com/apache/lucene/commit/963ddc66f6d822bf877c7e6155d903babf937c13) about how to do it:

I added in `lucene/analysis/kuromoji/build.gradle` a [default run task from the Gradle's application plugin](https://github.com/apache/lucene/commit/8d52f66d57b354fad6426c7c02b05a3b736d7dcd), which allows to build a dictionary are as follows. The command should be executed under the root directory `lucene`, where the `gradlew` file is.

For example, the following is my command when building `unidic-cwj-3.1.1-full` dictionary without the NFKD normalization:
```
./gradlew -p lucene/analysis/kuromoji run --args='unidic "/Users/azagniotov/Downloads/unidic-cwj-3.1.1-full" "/Users/azagniotov/Downloads/unidic-cwj-3.1.1-full/build" "UTF-8" false'
```

## Unit testing

Unfortunately, the current PR does not include unit tests because the built dictionaries files are very big, e.g.: built `unidic-cwj-202302_full ` connection costs .DAT file is around ~700MB, while the `unidic-cwj-3.1.1-full` connection costs .DAT file is around ~450 MB . Thus, the following unit tests were added and ran locally on my machine to verify that the built dictionaries can be used at runtime. 

I did see there there is a [main/gradle/generation/kuromoji.gradle](https://github.com/apache/lucene/blob/main/gradle/generation/kuromoji.gradle) that downloads dictionaries and compiles them, ~~but for now, I resorted not to add changes there~~ (https://github.com/apache/lucene/pull/12517/commits/bc9d2e3bb38d096ad193ce41e46c644b4c5673f9).

I also think a dictionary should be decoupled (this is related to the existing discussion in:
- https://github.com/apache/lucene/issues/9860.

The built dictionaries were tested using the following Japanese strings (no particular reason, I just picked these four strings): 

- `"にじさんじ"`
- `"ちいかわ"`
- `"桃太郎電鉄"`
- `"聖川真斗"`

The dictionaries metadata  were placed (dictionary after dictionary) under the [lucene/analysis/kuromoji/src/resources/org/apache/lucene/analysis/ja/dict](https://github.com/apache/lucene/tree/main/lucene/analysis/kuromoji/src/resources/org/apache/lucene/analysis/ja/dict) and a few unit test cases were added: 

#### Existing default dictionary already included in Lucene
```
assertAnalyzesTo(analyzerNoPunct, "にじさんじ", new String[] {"に", "じさ", "ん", "じ"}, new int[] {1, 1, 1, 1});
assertAnalyzesTo(analyzerNoPunct, "ちいかわ", new String[] {"ちい", "か", "わ"}, new int[] {1, 1, 1});
assertAnalyzesTo(analyzerNoPunct, "桃太郎電鉄", new String[] {"桃太郎", "電鉄"}, new int[] {1, 1});
assertAnalyzesTo(analyzerNoPunct, "聖川真斗", new String[] {"聖川", "真", "斗"}, new int[] {1, 1, 1});
```

#### Built unidic-cwj-202302_full 

I needed to increase memory before running the tests, as the `ConnectionCosts.dat` is ~700MB: in [main/gradle/testing/defaults-tests.gradle#L50](https://github.com/apache/lucene/blob/main/gradle/testing/defaults-tests.gradle#L50)
```
-           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", isCIBuild ? "" : "-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1") },
+           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", isCIBuild ? "" : "-XX:MaxDirectMemorySize=2g -XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1") },
```

```
assertAnalyzesTo(analyzerNoPunct, "にじさんじ", new String[] {"にじ", "さん", "じ"}, new int[] {1, 1, 1});
assertAnalyzesTo(analyzerNoPunct, "ちいかわ", new String[] {"ちい", "かわ"}, new int[] {1, 1});
assertAnalyzesTo(analyzerNoPunct, "桃太郎電鉄", new String[] {"桃", "桃太郎", "太郎", "電鉄"}, new int[] {1, 0, 1, 1});
assertAnalyzesTo(analyzerNoPunct, "聖川真斗", new String[] {"聖", "川", "真", "斗"}, new int[] {1, 1, 1, 1});
```

#### Built unidic-cwj-3.1.1-full
```
assertAnalyzesTo(analyzerNoPunct, "にじさんじ", new String[] {"にじ", "さ", "ん", "じ"}, new int[] {1, 1, 1, 1});
assertAnalyzesTo(analyzerNoPunct, "ちいかわ", new String[] {"ちい", "かわ"}, new int[] {1, 1});
assertAnalyzesTo(analyzerNoPunct, "桃太郎電鉄", new String[] {"桃太郎", "電鉄"}, new int[] {1, 1});
assertAnalyzesTo(analyzerNoPunct, "聖川真斗", new String[] {"聖", "川", "真斗"}, new int[] {1, 1, 1});
```

#### Built unidic-mecab-2.1.2_src
```
assertAnalyzesTo(analyzerNoPunct, "にじさんじ", new String[] {"にじ", "さん", "じ"}, new int[] {1, 1, 1});
assertAnalyzesTo(analyzerNoPunct, "ちいかわ", new String[] {"ちい", "か", "わ"}, new int[] {1, 1, 1});
assertAnalyzesTo(analyzerNoPunct, "桃太郎電鉄", new String[] {"桃", "桃太郎", "太郎", "電鉄"}, new int[] {1, 0, 1, 1});
assertAnalyzesTo(analyzerNoPunct, "聖川真斗", new String[] {"聖", "川", "真", "斗"}, new int[] {1, 1, 1, 1});
```

#### Built mecab-ipadic-2.7.0-20070801
```
 assertAnalyzesTo(analyzerNoPunct, "にじさんじ", new String[] {"に", "じさ", "ん", "じ"}, new int[] {1, 1, 1, 1});
 assertAnalyzesTo(analyzerNoPunct, "ちいかわ", new String[] {"ちい", "か", "わ"}, new int[] {1, 1, 1});
 assertAnalyzesTo(analyzerNoPunct, "桃太郎電鉄", new String[] {"桃太郎", "電鉄"}, new int[] {1, 1});
 assertAnalyzesTo(analyzerNoPunct, "聖川真斗", new String[] {"聖川", "真", "斗"}, new int[] {1, 1, 1});
```
