### PR TITLE
Use panama vector for l2normalize

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -182,6 +182,8 @@ Optimizations
 
 * GITHUB#12415: Optimized counts on disjunctive queries. (Adrien Grand)
 
+* GITHUB#12518: Use panama vector API to speed up l2norm calculations (Ben Trent)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -106,11 +106,8 @@ public final class VectorUtil {
    * @throws IllegalArgumentException when the vector is all zero and throwOnZero is true
    */
   public static float[] l2normalize(float[] v, boolean throwOnZero) {
-    double squareSum = 0.0f;
+    double squareSum = IMPL.dotProduct(v, v);
     int dim = v.length;
-    for (float x : v) {
-      squareSum += x * x;
-    }
     if (squareSum == 0) {
       if (throwOnZero) {
         throw new IllegalArgumentException("Cannot normalize a zero-length vector");


### PR DESCRIPTION
Seems like a minor oversight, but we should use panama vector for l2normlize. 

While this code isn't really used in hot-paths, it is a public API I could easily see folks using before indexing vectors into Lucene.