### PR TITLE
Honor topvalue while determining isMissingvalueCompetitive in case bottom is not set

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -99,8 +99,6 @@ Bug Fixes
 
 * GITHUB#12220: Hunspell: disallow hidden title-case entries from compound middle/end
 
-* LUCENE-12521: Sort After returning in-correct result when missing values are competitive
-
 Other
 ---------------------
 
@@ -203,6 +201,8 @@ Bug Fixes
 * GITHUB#2472: UTF32ToUTF8 would sometimes accept extra invalid UTF-8 binary sequences.  This should not have any
   impact on the user, unless you explicitly invoke the convert function of UTF32ToUTF8, and in the extremely rare
   scenario of searching a non-UTF-8 inverted field with Unicode search terms (Tang Donghai).
+
+* LUCENE-12521: Sort After returning in-correct result when missing values are competitive. (Chaitanya Gohel)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -99,6 +99,8 @@ Bug Fixes
 
 * GITHUB#12220: Hunspell: disallow hidden title-case entries from compound middle/end
 
+* LUCENE-12521: Sort After returning in-correct result when missing values are competitive
+
 Other
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/DoubleComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/DoubleComparator.java
@@ -96,9 +96,13 @@ public class DoubleComparator extends NumericComparator<Double> {
     }
 
     @Override
-    protected boolean isMissingValueCompetitive() {
-      int result = Double.compare(missingValue, bottom);
-      return reverse ? (result >= 0) : (result <= 0);
+    protected int compareMissingValueWithBottomValue() {
+      return Double.compare(missingValue, bottom);
+    }
+
+    @Override
+    protected int compareMissingValueWithTopValue() {
+      return Double.compare(missingValue, topValue);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/FloatComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/FloatComparator.java
@@ -96,9 +96,13 @@ public class FloatComparator extends NumericComparator<Float> {
     }
 
     @Override
-    protected boolean isMissingValueCompetitive() {
-      int result = Float.compare(missingValue, bottom);
-      return reverse ? (result >= 0) : (result <= 0);
+    protected int compareMissingValueWithBottomValue() {
+      return Float.compare(missingValue, bottom);
+    }
+
+    @Override
+    protected int compareMissingValueWithTopValue() {
+      return Float.compare(missingValue, topValue);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/IntComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/IntComparator.java
@@ -96,11 +96,13 @@ public class IntComparator extends NumericComparator<Integer> {
     }
 
     @Override
-    protected boolean isMissingValueCompetitive() {
-      int result = Integer.compare(missingValue, bottom);
-      // in reverse (desc) sort missingValue is competitive when it's greater or equal to bottom,
-      // in asc sort missingValue is competitive when it's smaller or equal to bottom
-      return reverse ? (result >= 0) : (result <= 0);
+    protected int compareMissingValueWithBottomValue() {
+      return Integer.compare(missingValue, bottom);
+    }
+
+    @Override
+    protected int compareMissingValueWithTopValue() {
+      return Integer.compare(missingValue, topValue);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/LongComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/LongComparator.java
@@ -96,11 +96,13 @@ public class LongComparator extends NumericComparator<Long> {
     }
 
     @Override
-    protected boolean isMissingValueCompetitive() {
-      int result = Long.compare(missingValue, bottom);
-      // in reverse (desc) sort missingValue is competitive when it's greater or equal to bottom,
-      // in asc sort missingValue is competitive when it's smaller or equal to bottom
-      return reverse ? (result >= 0) : (result <= 0);
+    protected int compareMissingValueWithBottomValue() {
+      return Long.compare(missingValue, bottom);
+    }
+
+    @Override
+    protected int compareMissingValueWithTopValue() {
+      return Long.compare(missingValue, topValue);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -309,6 +309,26 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
       }
     }
 
+    private boolean isMissingValueCompetitive() {
+      // if queue is full, always compare with bottom,
+      // if not, check if we can compare with topValue
+      if (queueFull) {
+        int result = compareMissingValueWithBottomValue();
+        // in reverse (desc) sort missingValue is competitive when it's greater or equal to bottom,
+        // in asc sort missingValue is competitive when it's smaller or equal to bottom
+        return reverse ? (result >= 0) : (result <= 0);
+      } else if (topValueSet) {
+        int result = compareMissingValueWithTopValue();
+        // in reverse (desc) sort missingValue is competitive when it's smaller or equal to
+        // topValue,
+        // in asc sort missingValue is competitive when it's greater or equal to topValue
+        return reverse ? (result <= 0) : (result >= 0);
+      } else {
+        // by default competitive
+        return true;
+      }
+    }
+
     @Override
     public DocIdSetIterator competitiveIterator() {
       if (enableSkipping == false) return null;
@@ -337,7 +357,9 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
       };
     }
 
-    protected abstract boolean isMissingValueCompetitive();
+    protected abstract int compareMissingValueWithTopValue();
+
+    protected abstract int compareMissingValueWithBottomValue();
 
     protected abstract void encodeBottom(byte[] packedValue);
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -245,7 +245,7 @@ public class TestSortOptimization extends LuceneTestCase {
       final int afterDocID = 10 + random().nextInt(1000);
       FieldDoc after = new FieldDoc(afterDocID, Float.NaN, new Long[] {afterValue});
       final SortField sortField = new SortField("my_field", SortField.Type.LONG);
-      sortField.setMissingValue(Long.MAX_VALUE); // set a NON competitive missing value
+      sortField.setMissingValue(Long.MAX_VALUE); // set a competitive missing value
       final Sort sort = new Sort(sortField);
       CollectorManager<TopFieldCollector, TopFieldDocs> manager =
           TopFieldCollector.createSharedManager(sort, numHits, after, totalHitsThreshold);
@@ -262,7 +262,7 @@ public class TestSortOptimization extends LuceneTestCase {
       final int afterDocID = 10 + random().nextInt(1000);
       FieldDoc after = new FieldDoc(afterDocID, Float.NaN, new Long[] {afterValue});
       final SortField sortField = new SortField("my_field", SortField.Type.LONG, true);
-      sortField.setMissingValue(Long.MAX_VALUE); // set a NON competitive missing value
+      sortField.setMissingValue(Long.MAX_VALUE); // set a competitive missing value
       final Sort sort = new Sort(sortField);
       CollectorManager<TopFieldCollector, TopFieldDocs> manager =
           TopFieldCollector.createSharedManager(sort, numHits, after, totalHitsThreshold);

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -240,11 +240,28 @@ public class TestSortOptimization extends LuceneTestCase {
     }
 
     { // test that optimization is not run when missing value setting of SortField is competitive
-      // with after
+      // with after on asc order
       final long afterValue = Long.MAX_VALUE;
       final int afterDocID = 10 + random().nextInt(1000);
       FieldDoc after = new FieldDoc(afterDocID, Float.NaN, new Long[] {afterValue});
       final SortField sortField = new SortField("my_field", SortField.Type.LONG);
+      sortField.setMissingValue(Long.MAX_VALUE); // set a NON competitive missing value
+      final Sort sort = new Sort(sortField);
+      CollectorManager<TopFieldCollector, TopFieldDocs> manager =
+          TopFieldCollector.createSharedManager(sort, numHits, after, totalHitsThreshold);
+      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), manager);
+      assertEquals(topDocs.scoreDocs.length, numHits);
+      assertEquals(
+          topDocs.totalHits.value,
+          numDocs); // assert that all documents were collected => optimization was not run
+    }
+
+    { // test that optimization is not run when missing value setting of SortField is competitive
+      // with after on desc order
+      final long afterValue = Long.MAX_VALUE;
+      final int afterDocID = 10 + random().nextInt(1000);
+      FieldDoc after = new FieldDoc(afterDocID, Float.NaN, new Long[] {afterValue});
+      final SortField sortField = new SortField("my_field", SortField.Type.LONG, true);
       sortField.setMissingValue(Long.MAX_VALUE); // set a NON competitive missing value
       final Sort sort = new Sort(sortField);
       CollectorManager<TopFieldCollector, TopFieldDocs> manager =


### PR DESCRIPTION
### Description

There is a bug introduced with #12334 when field contains missing value and if those missing values are competitive.
`isMissingValueCompetitive()` implementation gets invoked comparing `missingValue` with `bottom` when bottom is not even set when `After` is set. 

We should check with topValue in cases when `bottom` is not set. This PR adds that check.
Added tests for this scenario as well. 

### Lucene issue
#12521

