### PR TITLE
TaskExecutor waits for all tasks to complete before returning

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -147,6 +147,9 @@ New Features
 
 Improvements
 ---------------------
+* GITHUB#12523: TaskExecutor waits for all tasks to complete before returning when Exceptions
+  are thrown during concurrent operations (Michael Peterson)
+
 * GITHUB#12574: Make TaskExecutor public so that it can be retrieved from the searcher and used
   outside of the o.a.l.search package (Luca Cavanna)
 

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -56,8 +56,8 @@ public final class TaskExecutor {
 
   /**
    * Execute all the callables provided as an argument, wait for them to complete and return the
-   * obtained results. If an exception is thrown by more than one task, the subsequent ones
-   * will be added as suppressed exceptions to the first one that was caught.
+   * obtained results. If an exception is thrown by more than one callable, the subsequent ones will
+   * be added as suppressed exceptions to the first one that was caught.
    *
    * @param callables the callables to execute
    * @return a list containing the results from the tasks execution

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -82,9 +82,18 @@ public final class TaskExecutor {
       try {
         results.add(future.get());
       } catch (InterruptedException e) {
-        exc = new ThreadInterruptedException(e);
+        var newException = new ThreadInterruptedException(e);
+        if (exc == null) {
+          exc = newException;
+        } else {
+          exc.addSuppressed(newException);
+        }
       } catch (ExecutionException e) {
-        exc = e.getCause();
+        if (exc == null) {
+          exc = e.getCause();
+        } else {
+          exc.addSuppressed(e.getCause());
+        }
       }
     }
     if (exc != null) {

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -76,7 +76,7 @@ public final class TaskExecutor {
       }
     }
 
-    RuntimeException exc = null;
+    Throwable exc = null;
     final List<T> results = new ArrayList<>();
     for (Future<T> future : tasks) {
       try {
@@ -84,7 +84,7 @@ public final class TaskExecutor {
       } catch (InterruptedException e) {
         exc = new ThreadInterruptedException(e);
       } catch (ExecutionException e) {
-        exc = new RuntimeException(e.getCause());
+        exc = e.getCause();
       }
     }
     if (exc != null) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestIndexSearcher.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestIndexSearcher.java
@@ -328,8 +328,8 @@ public class TestIndexSearcher extends LuceneTestCase {
      * is called. Otherwise, it delegates all calls to the MatchAllDocsQuery.
      *
      * @param numExceptions number of exceptions to throw from scorer method
-     * @param callsToScorer where to record the number of times the {@code scorer}
-     *                      method has been called
+     * @param callsToScorer where to record the number of times the {@code scorer} method has been
+     *     called
      */
     public MatchAllOrThrowExceptionQuery(int numExceptions, AtomicInteger callsToScorer) {
       this.numExceptionsToThrow = new AtomicInteger(numExceptions);


### PR DESCRIPTION
The TaskExecutor used by IndexSearcher and AbstractKnnVectorQuery
waits until all tasks have finished before returning, even when
one or more of the tasks throw an Exception.

Relates [#12278](https://github.com/apache/lucene/issues/12278)

