### PR TITLE
Introduce a random vector scorer in HNSW builder/searcher 

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
@@ -53,7 +53,7 @@ public class Word2VecSynonymProvider {
     HnswGraphBuilder builder =
         HnswGraphBuilder.create(
             scorerProvider, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, HnswGraphBuilder.randSeed);
-    this.hnswGraph = builder.build(word2VecModel.copy());
+    this.hnswGraph = builder.build(word2VecModel.size());
   }
 
   public List<TermAndBoost> getSynonyms(

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
@@ -27,7 +27,11 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.hnsw.*;
+import org.apache.lucene.util.hnsw.HnswGraphBuilder;
+import org.apache.lucene.util.hnsw.HnswGraphSearcher;
+import org.apache.lucene.util.hnsw.OnHeapHnswGraph;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 
 /**
  * The Word2VecSynonymProvider generates the list of sysnonyms of a term.
@@ -48,11 +52,11 @@ public class Word2VecSynonymProvider {
    */
   public Word2VecSynonymProvider(Word2VecModel model) throws IOException {
     this.word2VecModel = model;
-    RandomVectorScorerProvider scorerProvider =
-        RandomVectorScorerProvider.createFloats(word2VecModel, SIMILARITY_FUNCTION);
+    RandomVectorScorerSupplier scorerSupplier =
+        RandomVectorScorerSupplier.createFloats(word2VecModel, SIMILARITY_FUNCTION);
     HnswGraphBuilder builder =
         HnswGraphBuilder.create(
-            scorerProvider, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, HnswGraphBuilder.randSeed);
+                scorerSupplier, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, HnswGraphBuilder.randSeed);
     this.hnswGraph = builder.build(word2VecModel.size());
   }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
@@ -23,14 +23,11 @@ import static org.apache.lucene.util.hnsw.HnswGraphBuilder.DEFAULT_MAX_CONN;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.hnsw.HnswGraphBuilder;
-import org.apache.lucene.util.hnsw.HnswGraphSearcher;
-import org.apache.lucene.util.hnsw.OnHeapHnswGraph;
+import org.apache.lucene.util.hnsw.*;
 
 /**
  * The Word2VecSynonymProvider generates the list of sysnonyms of a term.
@@ -41,7 +38,6 @@ public class Word2VecSynonymProvider {
 
   private static final VectorSimilarityFunction SIMILARITY_FUNCTION =
       VectorSimilarityFunction.DOT_PRODUCT;
-  private static final VectorEncoding VECTOR_ENCODING = VectorEncoding.FLOAT32;
   private final Word2VecModel word2VecModel;
   private final OnHeapHnswGraph hnswGraph;
 
@@ -51,16 +47,12 @@ public class Word2VecSynonymProvider {
    * @param model containing the set of TermAndVector entries
    */
   public Word2VecSynonymProvider(Word2VecModel model) throws IOException {
-    word2VecModel = model;
-
-    HnswGraphBuilder<float[]> builder =
+    this.word2VecModel = model;
+    RandomVectorScorerProvider scorerProvider =
+        RandomVectorScorerProvider.createFloats(word2VecModel, SIMILARITY_FUNCTION);
+    HnswGraphBuilder builder =
         HnswGraphBuilder.create(
-            word2VecModel,
-            VECTOR_ENCODING,
-            SIMILARITY_FUNCTION,
-            DEFAULT_MAX_CONN,
-            DEFAULT_BEAM_WIDTH,
-            HnswGraphBuilder.randSeed);
+            scorerProvider, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, HnswGraphBuilder.randSeed);
     this.hnswGraph = builder.build(word2VecModel.copy());
   }
 
@@ -74,15 +66,14 @@ public class Word2VecSynonymProvider {
     LinkedList<TermAndBoost> result = new LinkedList<>();
     float[] query = word2VecModel.vectorValue(term);
     if (query != null) {
+      RandomVectorScorer scorer =
+          RandomVectorScorer.createFloats(word2VecModel, SIMILARITY_FUNCTION, query);
       KnnCollector synonyms =
           HnswGraphSearcher.search(
-              query,
+              scorer,
               // The query vector is in the model. When looking for the top-k
               // it's always the nearest neighbour of itself so, we look for the top-k+1
               maxSynonymsPerTerm + 1,
-              word2VecModel,
-              VECTOR_ENCODING,
-              SIMILARITY_FUNCTION,
               hnswGraph,
               null,
               Integer.MAX_VALUE);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
@@ -56,7 +56,7 @@ public class Word2VecSynonymProvider {
         RandomVectorScorerSupplier.createFloats(word2VecModel, SIMILARITY_FUNCTION);
     HnswGraphBuilder builder =
         HnswGraphBuilder.create(
-                scorerSupplier, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, HnswGraphBuilder.randSeed);
+            scorerSupplier, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, HnswGraphBuilder.randSeed);
     this.hnswGraph = builder.build(word2VecModel.size());
   }
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -354,6 +354,7 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
     final IndexInput dataIn;
 
     final int byteSize;
+    int lastOrd = -1;
     final float[] value;
 
     int ord = -1;
@@ -380,9 +381,7 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
 
     @Override
     public float[] vectorValue() throws IOException {
-      dataIn.seek((long) ord * byteSize);
-      dataIn.readFloats(value, 0, value.length);
-      return value;
+      return vectorValue(ord);
     }
 
     @Override
@@ -423,8 +422,12 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
 
     @Override
     public float[] vectorValue(int targetOrd) throws IOException {
+      if (lastOrd == targetOrd) {
+        return value;
+      }
       dataIn.seek((long) targetOrd * byteSize);
       dataIn.readFloats(value, 0, value.length);
+      lastOrd = targetOrd;
       return value;
     }
   }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
@@ -33,7 +33,6 @@ import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.SegmentReadState;
-import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.store.ChecksumIndexInput;
@@ -42,9 +41,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.apache.lucene.util.hnsw.HnswGraph;
-import org.apache.lucene.util.hnsw.HnswGraphSearcher;
-import org.apache.lucene.util.hnsw.RandomAccessVectorValues;
+import org.apache.lucene.util.hnsw.*;
 
 /**
  * Reads vectors from the index segments along with index data structures supporting KNN search.
@@ -235,13 +232,11 @@ public final class Lucene91HnswVectorsReader extends KnnVectorsReader {
     }
 
     OffHeapFloatVectorValues vectorValues = getOffHeapVectorValues(fieldEntry);
-
+    RandomVectorScorer scorer =
+        RandomVectorScorer.createFloats(vectorValues, fieldEntry.similarityFunction, target);
     HnswGraphSearcher.search(
-        target,
-        knnCollector,
-        vectorValues,
-        VectorEncoding.FLOAT32,
-        fieldEntry.similarityFunction,
+        scorer,
+        new OrdinalTranslatedKnnCollector(knnCollector, vectorValues::ordToDoc),
         getGraph(fieldEntry),
         getAcceptOrds(acceptDocs, fieldEntry));
   }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
@@ -41,7 +41,11 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.apache.lucene.util.hnsw.*;
+import org.apache.lucene.util.hnsw.HnswGraph;
+import org.apache.lucene.util.hnsw.HnswGraphSearcher;
+import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
+import org.apache.lucene.util.hnsw.RandomAccessVectorValues;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
 
 /**
  * Reads vectors from the index segments along with index data structures supporting KNN search.

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsReader.java
@@ -32,7 +32,6 @@ import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.SegmentReadState;
-import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.store.ChecksumIndexInput;
@@ -43,6 +42,8 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.hnsw.HnswGraph;
 import org.apache.lucene.util.hnsw.HnswGraphSearcher;
+import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.packed.DirectMonotonicReader;
 
 /**
@@ -231,13 +232,11 @@ public final class Lucene92HnswVectorsReader extends KnnVectorsReader {
     }
 
     OffHeapFloatVectorValues vectorValues = OffHeapFloatVectorValues.load(fieldEntry, vectorData);
-
+    RandomVectorScorer scorer =
+        RandomVectorScorer.createFloats(vectorValues, fieldEntry.similarityFunction, target);
     HnswGraphSearcher.search(
-        target,
-        knnCollector,
-        vectorValues,
-        VectorEncoding.FLOAT32,
-        fieldEntry.similarityFunction,
+        scorer,
+        new OrdinalTranslatedKnnCollector(knnCollector, vectorValues::ordToDoc),
         getGraph(fieldEntry),
         vectorValues.getAcceptOrds(acceptDocs));
   }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/OffHeapFloatVectorValues.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/OffHeapFloatVectorValues.java
@@ -34,6 +34,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
   protected final int size;
   protected final IndexInput slice;
   protected final int byteSize;
+  protected int lastOrd = -1;
   protected final float[] value;
 
   OffHeapFloatVectorValues(int dimension, int size, IndexInput slice) {
@@ -56,8 +57,12 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
 
   @Override
   public float[] vectorValue(int targetOrd) throws IOException {
+    if (lastOrd == targetOrd) {
+      return value;
+    }
     slice.seek((long) targetOrd * byteSize);
     slice.readFloats(value, 0, value.length);
+    lastOrd = targetOrd;
     return value;
   }
 
@@ -87,9 +92,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
 
     @Override
     public float[] vectorValue() throws IOException {
-      slice.seek((long) doc * byteSize);
-      slice.readFloats(value, 0, value.length);
-      return value;
+      return vectorValue(doc);
     }
 
     @Override
@@ -151,9 +154,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
 
     @Override
     public float[] vectorValue() throws IOException {
-      slice.seek((long) (disi.index()) * byteSize);
-      slice.readFloats(value, 0, value.length);
-      return value;
+      return vectorValue(disi.index());
     }
 
     @Override

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsReader.java
@@ -43,6 +43,8 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.hnsw.HnswGraph;
 import org.apache.lucene.util.hnsw.HnswGraphSearcher;
+import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.packed.DirectMonotonicReader;
 
 /**
@@ -267,13 +269,11 @@ public final class Lucene94HnswVectorsReader extends KnnVectorsReader {
     }
 
     OffHeapFloatVectorValues vectorValues = OffHeapFloatVectorValues.load(fieldEntry, vectorData);
-
+    RandomVectorScorer scorer =
+        RandomVectorScorer.createFloats(vectorValues, fieldEntry.similarityFunction, target);
     HnswGraphSearcher.search(
-        target,
-        knnCollector,
-        vectorValues,
-        fieldEntry.vectorEncoding,
-        fieldEntry.similarityFunction,
+        scorer,
+        new OrdinalTranslatedKnnCollector(knnCollector, vectorValues::ordToDoc),
         getGraph(fieldEntry),
         vectorValues.getAcceptOrds(acceptDocs));
   }
@@ -288,13 +288,11 @@ public final class Lucene94HnswVectorsReader extends KnnVectorsReader {
     }
 
     OffHeapByteVectorValues vectorValues = OffHeapByteVectorValues.load(fieldEntry, vectorData);
-
+    RandomVectorScorer scorer =
+        RandomVectorScorer.createBytes(vectorValues, fieldEntry.similarityFunction, target);
     HnswGraphSearcher.search(
-        target,
-        knnCollector,
-        vectorValues,
-        fieldEntry.vectorEncoding,
-        fieldEntry.similarityFunction,
+        scorer,
+        new OrdinalTranslatedKnnCollector(knnCollector, vectorValues::ordToDoc),
         getGraph(fieldEntry),
         vectorValues.getAcceptOrds(acceptDocs));
   }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapByteVectorValues.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapByteVectorValues.java
@@ -35,6 +35,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
   protected final int dimension;
   protected final int size;
   protected final IndexInput slice;
+  protected int lastOrd = -1;
   protected final byte[] binaryValue;
   protected final ByteBuffer byteBuffer;
   protected final int byteSize;
@@ -60,7 +61,10 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
 
   @Override
   public byte[] vectorValue(int targetOrd) throws IOException {
-    readValue(targetOrd);
+    if (lastOrd != targetOrd) {
+      readValue(targetOrd);
+      lastOrd = targetOrd;
+    }
     return binaryValue;
   }
 
@@ -97,9 +101,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
 
     @Override
     public byte[] vectorValue() throws IOException {
-      slice.seek((long) doc * byteSize);
-      slice.readBytes(byteBuffer.array(), byteBuffer.arrayOffset(), byteSize);
-      return binaryValue;
+      return vectorValue(doc);
     }
 
     @Override
@@ -164,9 +166,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
 
     @Override
     public byte[] vectorValue() throws IOException {
-      slice.seek((long) (disi.index()) * byteSize);
-      slice.readBytes(byteBuffer.array(), byteBuffer.arrayOffset(), byteSize, false);
-      return binaryValue;
+      return vectorValue(disi.index());
     }
 
     @Override

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapFloatVectorValues.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapFloatVectorValues.java
@@ -34,6 +34,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
   protected final int size;
   protected final IndexInput slice;
   protected final int byteSize;
+  protected int lastOrd = -1;
   protected final float[] value;
 
   OffHeapFloatVectorValues(int dimension, int size, IndexInput slice, int byteSize) {
@@ -56,8 +57,12 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
 
   @Override
   public float[] vectorValue(int targetOrd) throws IOException {
+    if (lastOrd == targetOrd) {
+      return value;
+    }
     slice.seek((long) targetOrd * byteSize);
     slice.readFloats(value, 0, value.length);
+    lastOrd = targetOrd;
     return value;
   }
 
@@ -93,9 +98,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
 
     @Override
     public float[] vectorValue() throws IOException {
-      slice.seek((long) doc * byteSize);
-      slice.readFloats(value, 0, value.length);
-      return value;
+      return vectorValue(doc);
     }
 
     @Override
@@ -160,9 +163,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
 
     @Override
     public float[] vectorValue() throws IOException {
-      slice.seek((long) (disi.index()) * byteSize);
-      slice.readFloats(value, 0, value.length);
-      return value;
+      return vectorValue(disi.index());
     }
 
     @Override

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
@@ -279,7 +279,7 @@ public final class Lucene92HnswVectorsWriter extends BufferingKnnVectorsWriter {
         HnswGraphBuilder.create(scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed);
     hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
 
-    OnHeapHnswGraph graph = hnswGraphBuilder.build(vectorValues.copy());
+    OnHeapHnswGraph graph = hnswGraphBuilder.build(vectorValues.size());
 
     // write vectors' neighbours on each level into the vectorIndex file
     int countOnLevel0 = graph.size();

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
@@ -39,7 +39,11 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.hnsw.*;
+import org.apache.lucene.util.hnsw.HnswGraphBuilder;
+import org.apache.lucene.util.hnsw.NeighborArray;
+import org.apache.lucene.util.hnsw.OnHeapHnswGraph;
+import org.apache.lucene.util.hnsw.RandomAccessVectorValues;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.apache.lucene.util.packed.DirectMonotonicWriter;
 
 /**
@@ -273,10 +277,10 @@ public final class Lucene92HnswVectorsWriter extends BufferingKnnVectorsWriter {
       throws IOException {
 
     // build graph
-    RandomVectorScorerProvider scorerProvider =
-        RandomVectorScorerProvider.createFloats(vectorValues, similarityFunction);
+    RandomVectorScorerSupplier scorerSupplier =
+        RandomVectorScorerSupplier.createFloats(vectorValues, similarityFunction);
     HnswGraphBuilder hnswGraphBuilder =
-        HnswGraphBuilder.create(scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed);
+        HnswGraphBuilder.create(scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed);
     hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
 
     OnHeapHnswGraph graph = hnswGraphBuilder.build(vectorValues.size());

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
@@ -34,16 +34,12 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.SegmentWriteState;
-import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.hnsw.HnswGraphBuilder;
-import org.apache.lucene.util.hnsw.NeighborArray;
-import org.apache.lucene.util.hnsw.OnHeapHnswGraph;
-import org.apache.lucene.util.hnsw.RandomAccessVectorValues;
+import org.apache.lucene.util.hnsw.*;
 import org.apache.lucene.util.packed.DirectMonotonicWriter;
 
 /**
@@ -277,15 +273,12 @@ public final class Lucene92HnswVectorsWriter extends BufferingKnnVectorsWriter {
       throws IOException {
 
     // build graph
-    HnswGraphBuilder<float[]> hnswGraphBuilder =
-        HnswGraphBuilder.create(
-            vectorValues,
-            VectorEncoding.FLOAT32,
-            similarityFunction,
-            M,
-            beamWidth,
-            HnswGraphBuilder.randSeed);
+    RandomVectorScorerProvider scorerProvider =
+        RandomVectorScorerProvider.createFloats(vectorValues, similarityFunction);
+    HnswGraphBuilder hnswGraphBuilder =
+        HnswGraphBuilder.create(scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed);
     hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
+
     OnHeapHnswGraph graph = hnswGraphBuilder.build(vectorValues.copy());
 
     // write vectors' neighbours on each level into the vectorIndex file

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
@@ -426,7 +426,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
                         vectorValues, fieldInfo.getVectorSimilarityFunction());
                 HnswGraphBuilder hnswGraphBuilder =
                     HnswGraphBuilder.create(
-                            scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed);
+                        scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed);
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.size());
               }
@@ -442,7 +442,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
                         vectorValues, fieldInfo.getVectorSimilarityFunction());
                 HnswGraphBuilder hnswGraphBuilder =
                     HnswGraphBuilder.create(
-                            scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed);
+                        scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed);
                 yield hnswGraphBuilder.build(vectorValues.size());
               }
             };

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
@@ -423,7 +423,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
                     HnswGraphBuilder.create(
                         scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed);
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
-                yield hnswGraphBuilder.build(vectorValues.copy());
+                yield hnswGraphBuilder.build(vectorValues.size());
               }
               case FLOAT32 -> {
                 OffHeapFloatVectorValues.DenseOffHeapVectorValues vectorValues =
@@ -438,7 +438,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
                 HnswGraphBuilder hnswGraphBuilder =
                     HnswGraphBuilder.create(
                         scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed);
-                yield hnswGraphBuilder.build(vectorValues.copy());
+                yield hnswGraphBuilder.build(vectorValues.size());
               }
             };
         writeGraph(graph);

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
@@ -47,12 +47,8 @@ import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.apache.lucene.util.hnsw.HnswGraph;
+import org.apache.lucene.util.hnsw.*;
 import org.apache.lucene.util.hnsw.HnswGraph.NodesIterator;
-import org.apache.lucene.util.hnsw.HnswGraphBuilder;
-import org.apache.lucene.util.hnsw.NeighborArray;
-import org.apache.lucene.util.hnsw.OnHeapHnswGraph;
-import org.apache.lucene.util.hnsw.RandomAccessVectorValues;
 import org.apache.lucene.util.packed.DirectMonotonicWriter;
 
 /**
@@ -420,14 +416,12 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
                         docsWithField.cardinality(),
                         vectorDataInput,
                         byteSize);
-                HnswGraphBuilder<byte[]> hnswGraphBuilder =
+                RandomVectorScorerProvider scorerProvider =
+                    RandomVectorScorerProvider.createBytes(
+                        vectorValues, fieldInfo.getVectorSimilarityFunction());
+                HnswGraphBuilder hnswGraphBuilder =
                     HnswGraphBuilder.create(
-                        vectorValues,
-                        fieldInfo.getVectorEncoding(),
-                        fieldInfo.getVectorSimilarityFunction(),
-                        M,
-                        beamWidth,
-                        HnswGraphBuilder.randSeed);
+                        scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed);
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.copy());
               }
@@ -438,15 +432,12 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
                         docsWithField.cardinality(),
                         vectorDataInput,
                         byteSize);
-                HnswGraphBuilder<float[]> hnswGraphBuilder =
+                RandomVectorScorerProvider scorerProvider =
+                    RandomVectorScorerProvider.createFloats(
+                        vectorValues, fieldInfo.getVectorSimilarityFunction());
+                HnswGraphBuilder hnswGraphBuilder =
                     HnswGraphBuilder.create(
-                        vectorValues,
-                        fieldInfo.getVectorEncoding(),
-                        fieldInfo.getVectorSimilarityFunction(),
-                        M,
-                        beamWidth,
-                        HnswGraphBuilder.randSeed);
-                hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
+                        scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed);
                 yield hnswGraphBuilder.build(vectorValues.copy());
               }
             };
@@ -630,7 +621,8 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
     private final int dim;
     private final DocsWithFieldSet docsWithField;
     private final List<T> vectors;
-    private final HnswGraphBuilder<T> hnswGraphBuilder;
+    private final RandomAccessVectorValues<T> raVectors;
+    private final HnswGraphBuilder hnswGraphBuilder;
 
     private int lastDocID = -1;
     private int node = 0;
@@ -654,21 +646,25 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
       };
     }
 
+    @SuppressWarnings("unchecked")
     FieldWriter(FieldInfo fieldInfo, int M, int beamWidth, InfoStream infoStream)
         throws IOException {
       this.fieldInfo = fieldInfo;
       this.dim = fieldInfo.getVectorDimension();
       this.docsWithField = new DocsWithFieldSet();
       vectors = new ArrayList<>();
-      RAVectorValues<T> raVectorValues = new RAVectorValues<>(vectors, dim);
+      raVectors = new RAVectorValues<>(vectors, dim);
+      RandomVectorScorerProvider scorerProvider =
+          switch (fieldInfo.getVectorEncoding()) {
+            case BYTE -> RandomVectorScorerProvider.createBytes(
+                (RandomAccessVectorValues<byte[]>) raVectors,
+                fieldInfo.getVectorSimilarityFunction());
+            case FLOAT32 -> RandomVectorScorerProvider.createFloats(
+                (RandomAccessVectorValues<float[]>) raVectors,
+                fieldInfo.getVectorSimilarityFunction());
+          };
       hnswGraphBuilder =
-          HnswGraphBuilder.create(
-              raVectorValues,
-              fieldInfo.getVectorEncoding(),
-              fieldInfo.getVectorSimilarityFunction(),
-              M,
-              beamWidth,
-              HnswGraphBuilder.randSeed);
+          HnswGraphBuilder.create(scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed);
       hnswGraphBuilder.setInfoStream(infoStream);
     }
 
@@ -685,7 +681,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
       assert docID > lastDocID;
       docsWithField.add(docID);
       vectors.add(copyValue(vectorValue));
-      hnswGraphBuilder.addGraphNode(node, vectorValue);
+      hnswGraphBuilder.addGraphNode(node);
       node++;
       lastDocID = docID;
     }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
@@ -621,7 +621,6 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
     private final int dim;
     private final DocsWithFieldSet docsWithField;
     private final List<T> vectors;
-    private final RandomAccessVectorValues<T> raVectors;
     private final HnswGraphBuilder hnswGraphBuilder;
 
     private int lastDocID = -1;
@@ -653,7 +652,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
       this.dim = fieldInfo.getVectorDimension();
       this.docsWithField = new DocsWithFieldSet();
       vectors = new ArrayList<>();
-      raVectors = new RAVectorValues<>(vectors, dim);
+      RandomAccessVectorValues<T> raVectors = new RAVectorValues<>(vectors, dim);
       RandomVectorScorerProvider scorerProvider =
           switch (fieldInfo.getVectorEncoding()) {
             case BYTE -> RandomVectorScorerProvider.createBytes(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsReader.java
@@ -45,6 +45,8 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.hnsw.HnswGraph;
 import org.apache.lucene.util.hnsw.HnswGraphSearcher;
+import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.packed.DirectMonotonicReader;
 
 /**
@@ -274,12 +276,11 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader {
     }
 
     OffHeapFloatVectorValues vectorValues = OffHeapFloatVectorValues.load(fieldEntry, vectorData);
+    RandomVectorScorer scorer =
+        RandomVectorScorer.createFloats(vectorValues, fieldEntry.similarityFunction, target);
     HnswGraphSearcher.search(
-        target,
-        knnCollector,
-        vectorValues,
-        fieldEntry.vectorEncoding,
-        fieldEntry.similarityFunction,
+        scorer,
+        new OrdinalTranslatedKnnCollector(knnCollector, vectorValues::ordToDoc),
         getGraph(fieldEntry),
         vectorValues.getAcceptOrds(acceptDocs));
   }
@@ -296,12 +297,11 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader {
     }
 
     OffHeapByteVectorValues vectorValues = OffHeapByteVectorValues.load(fieldEntry, vectorData);
+    RandomVectorScorer scorer =
+        RandomVectorScorer.createBytes(vectorValues, fieldEntry.similarityFunction, target);
     HnswGraphSearcher.search(
-        target,
-        knnCollector,
-        vectorValues,
-        fieldEntry.vectorEncoding,
-        fieldEntry.similarityFunction,
+        scorer,
+        new OrdinalTranslatedKnnCollector(knnCollector, vectorValues::ordToDoc),
         getGraph(fieldEntry),
         vectorValues.getAcceptOrds(acceptDocs));
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -434,11 +434,11 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                         docsWithField.cardinality(),
                         vectorDataInput,
                         byteSize);
-                RandomVectorScorerProvider scorerProvider =
-                    RandomVectorScorerProvider.createBytes(
+                RandomVectorScorerSupplier scorerSupplier =
+                    RandomVectorScorerSupplier.createBytes(
                         vectorValues, fieldInfo.getVectorSimilarityFunction());
                 HnswGraphBuilder hnswGraphBuilder =
-                    createHnswGraphBuilder(mergeState, fieldInfo, scorerProvider, initializerIndex);
+                    createHnswGraphBuilder(mergeState, fieldInfo, scorerSupplier, initializerIndex);
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.size());
               }
@@ -449,11 +449,11 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                         docsWithField.cardinality(),
                         vectorDataInput,
                         byteSize);
-                RandomVectorScorerProvider scorerProvider =
-                    RandomVectorScorerProvider.createFloats(
+                RandomVectorScorerSupplier scorerSupplier =
+                    RandomVectorScorerSupplier.createFloats(
                         vectorValues, fieldInfo.getVectorSimilarityFunction());
                 HnswGraphBuilder hnswGraphBuilder =
-                    createHnswGraphBuilder(mergeState, fieldInfo, scorerProvider, initializerIndex);
+                    createHnswGraphBuilder(mergeState, fieldInfo, scorerSupplier, initializerIndex);
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.size());
               }
@@ -487,11 +487,11 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
   private HnswGraphBuilder createHnswGraphBuilder(
       MergeState mergeState,
       FieldInfo fieldInfo,
-      RandomVectorScorerProvider scorerProvider,
+      RandomVectorScorerSupplier scorerSupplier,
       int initializerIndex)
       throws IOException {
     if (initializerIndex == -1) {
-      return HnswGraphBuilder.create(scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed);
+      return HnswGraphBuilder.create(scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed);
     }
 
     HnswGraph initializerGraph =
@@ -499,7 +499,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     Map<Integer, Integer> ordinalMapper =
         getOldToNewOrdinalMap(mergeState, fieldInfo, initializerIndex);
     return HnswGraphBuilder.create(
-        scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed, initializerGraph, ordinalMapper);
+            scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed, initializerGraph, ordinalMapper);
   }
 
   private int selectGraphForInitialization(MergeState mergeState, FieldInfo fieldInfo)
@@ -889,17 +889,17 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
       this.docsWithField = new DocsWithFieldSet();
       vectors = new ArrayList<>();
       RAVectorValues<T> raVectors = new RAVectorValues<>(vectors, dim);
-      RandomVectorScorerProvider scorerProvider =
+      RandomVectorScorerSupplier scorerSupplier =
           switch (fieldInfo.getVectorEncoding()) {
-            case BYTE -> RandomVectorScorerProvider.createBytes(
+            case BYTE -> RandomVectorScorerSupplier.createBytes(
                 (RandomAccessVectorValues<byte[]>) raVectors,
                 fieldInfo.getVectorSimilarityFunction());
-            case FLOAT32 -> RandomVectorScorerProvider.createFloats(
+            case FLOAT32 -> RandomVectorScorerSupplier.createFloats(
                 (RandomAccessVectorValues<float[]>) raVectors,
                 fieldInfo.getVectorSimilarityFunction());
           };
       hnswGraphBuilder =
-          HnswGraphBuilder.create(scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed);
+          HnswGraphBuilder.create(scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed);
       hnswGraphBuilder.setInfoStream(infoStream);
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -857,7 +857,6 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     private final int dim;
     private final DocsWithFieldSet docsWithField;
     private final List<T> vectors;
-    private final RAVectorValues<T> raVectors;
     private final HnswGraphBuilder hnswGraphBuilder;
 
     private int lastDocID = -1;
@@ -889,7 +888,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
       this.dim = fieldInfo.getVectorDimension();
       this.docsWithField = new DocsWithFieldSet();
       vectors = new ArrayList<>();
-      raVectors = new RAVectorValues<>(vectors, dim);
+      RAVectorValues<T> raVectors;raVectors = new RAVectorValues<>(vectors, dim);
       RandomVectorScorerProvider scorerProvider =
           switch (fieldInfo.getVectorEncoding()) {
             case BYTE -> RandomVectorScorerProvider.createBytes(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -434,8 +434,11 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                         docsWithField.cardinality(),
                         vectorDataInput,
                         byteSize);
+                RandomVectorScorerProvider scorerProvider =
+                    RandomVectorScorerProvider.createBytes(
+                        vectorValues, fieldInfo.getVectorSimilarityFunction());
                 HnswGraphBuilder hnswGraphBuilder =
-                    createHnswGraphBuilder(mergeState, fieldInfo, vectorValues, initializerIndex);
+                    createHnswGraphBuilder(mergeState, fieldInfo, scorerProvider, initializerIndex);
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.size());
               }
@@ -446,8 +449,11 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                         docsWithField.cardinality(),
                         vectorDataInput,
                         byteSize);
+                RandomVectorScorerProvider scorerProvider =
+                    RandomVectorScorerProvider.createFloats(
+                        vectorValues, fieldInfo.getVectorSimilarityFunction());
                 HnswGraphBuilder hnswGraphBuilder =
-                    createHnswGraphBuilder(mergeState, fieldInfo, vectorValues, initializerIndex);
+                    createHnswGraphBuilder(mergeState, fieldInfo, scorerProvider, initializerIndex);
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.size());
               }
@@ -478,20 +484,12 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     }
   }
 
-  @SuppressWarnings("unchecked")
   private HnswGraphBuilder createHnswGraphBuilder(
       MergeState mergeState,
       FieldInfo fieldInfo,
-      RandomAccessVectorValues<?> vectors,
+      RandomVectorScorerProvider scorerProvider,
       int initializerIndex)
       throws IOException {
-    RandomVectorScorerProvider scorerProvider =
-        switch (fieldInfo.getVectorEncoding()) {
-          case BYTE -> RandomVectorScorerProvider.createBytes(
-              (RandomAccessVectorValues<byte[]>) vectors, fieldInfo.getVectorSimilarityFunction());
-          case FLOAT32 -> RandomVectorScorerProvider.createFloats(
-              (RandomAccessVectorValues<float[]>) vectors, fieldInfo.getVectorSimilarityFunction());
-        };
     if (initializerIndex == -1) {
       return HnswGraphBuilder.create(scorerProvider, M, beamWidth, HnswGraphBuilder.randSeed);
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -499,7 +499,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     Map<Integer, Integer> ordinalMapper =
         getOldToNewOrdinalMap(mergeState, fieldInfo, initializerIndex);
     return HnswGraphBuilder.create(
-            scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed, initializerGraph, ordinalMapper);
+        scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed, initializerGraph, ordinalMapper);
   }
 
   private int selectGraphForInitialization(MergeState mergeState, FieldInfo fieldInfo)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -437,7 +437,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                 HnswGraphBuilder hnswGraphBuilder =
                     createHnswGraphBuilder(mergeState, fieldInfo, vectorValues, initializerIndex);
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
-                yield hnswGraphBuilder.build(vectorValues.copy());
+                yield hnswGraphBuilder.build(vectorValues.size());
               }
               case FLOAT32 -> {
                 OffHeapFloatVectorValues.DenseOffHeapVectorValues vectorValues =
@@ -449,7 +449,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                 HnswGraphBuilder hnswGraphBuilder =
                     createHnswGraphBuilder(mergeState, fieldInfo, vectorValues, initializerIndex);
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
-                yield hnswGraphBuilder.build(vectorValues.copy());
+                yield hnswGraphBuilder.build(vectorValues.size());
               }
             };
         vectorIndexNodeOffsets = writeGraph(graph);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -888,7 +888,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
       this.dim = fieldInfo.getVectorDimension();
       this.docsWithField = new DocsWithFieldSet();
       vectors = new ArrayList<>();
-      RAVectorValues<T> raVectors;raVectors = new RAVectorValues<>(vectors, dim);
+      RAVectorValues<T> raVectors = new RAVectorValues<>(vectors, dim);
       RandomVectorScorerProvider scorerProvider =
           switch (fieldInfo.getVectorEncoding()) {
             case BYTE -> RandomVectorScorerProvider.createBytes(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
@@ -71,7 +71,6 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
   private void readValue(int targetOrd) throws IOException {
     slice.seek((long) targetOrd * byteSize);
     slice.readBytes(byteBuffer.array(), byteBuffer.arrayOffset(), byteSize);
-    lastOrd = targetOrd;
   }
 
   static OffHeapByteVectorValues load(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
@@ -35,6 +35,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
   protected final int dimension;
   protected final int size;
   protected final IndexInput slice;
+  protected int lastOrd = -1;
   protected final byte[] binaryValue;
   protected final ByteBuffer byteBuffer;
   protected final int byteSize;
@@ -60,13 +61,17 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
 
   @Override
   public byte[] vectorValue(int targetOrd) throws IOException {
-    readValue(targetOrd);
+    if (lastOrd != targetOrd) {
+      readValue(targetOrd);
+      lastOrd = targetOrd;
+    }
     return binaryValue;
   }
 
   private void readValue(int targetOrd) throws IOException {
     slice.seek((long) targetOrd * byteSize);
     slice.readBytes(byteBuffer.array(), byteBuffer.arrayOffset(), byteSize);
+    lastOrd = targetOrd;
   }
 
   static OffHeapByteVectorValues load(
@@ -97,9 +102,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
 
     @Override
     public byte[] vectorValue() throws IOException {
-      slice.seek((long) doc * byteSize);
-      slice.readBytes(byteBuffer.array(), byteBuffer.arrayOffset(), byteSize);
-      return binaryValue;
+      return vectorValue(doc);
     }
 
     @Override
@@ -164,9 +167,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
 
     @Override
     public byte[] vectorValue() throws IOException {
-      slice.seek((long) (disi.index()) * byteSize);
-      slice.readBytes(byteBuffer.array(), byteBuffer.arrayOffset(), byteSize, false);
-      return binaryValue;
+      return vectorValue(disi.index());
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
@@ -35,6 +35,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
   protected final int size;
   protected final IndexInput slice;
   protected final int byteSize;
+  protected int lastOrd = -1;
   protected final float[] value;
 
   OffHeapFloatVectorValues(int dimension, int size, IndexInput slice, int byteSize) {
@@ -57,8 +58,12 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
 
   @Override
   public float[] vectorValue(int targetOrd) throws IOException {
+    if (lastOrd == targetOrd) {
+      return value;
+    }
     slice.seek((long) targetOrd * byteSize);
     slice.readFloats(value, 0, value.length);
+    lastOrd = targetOrd;
     return value;
   }
 
@@ -91,9 +96,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
 
     @Override
     public float[] vectorValue() throws IOException {
-      slice.seek((long) doc * byteSize);
-      slice.readFloats(value, 0, value.length);
-      return value;
+      return vectorValue(doc);
     }
 
     @Override
@@ -158,9 +161,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
 
     @Override
     public float[] vectorValue() throws IOException {
-      slice.seek((long) (disi.index()) * byteSize);
-      slice.readFloats(value, 0, value.length);
-      return value;
+      return vectorValue(disi.index());
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -74,7 +74,7 @@ public final class HnswGraphBuilder {
   private final Set<Integer> initializedNodes;
 
   public static HnswGraphBuilder create(
-          RandomVectorScorerSupplier scorerSupplier, int M, int beamWidth, long seed)
+      RandomVectorScorerSupplier scorerSupplier, int M, int beamWidth, long seed)
       throws IOException {
     return new HnswGraphBuilder(scorerSupplier, M, beamWidth, seed);
   }
@@ -104,7 +104,7 @@ public final class HnswGraphBuilder {
    *     to ensure repeatable construction.
    */
   private HnswGraphBuilder(
-          RandomVectorScorerSupplier scorerSupplier, int M, int beamWidth, long seed)
+      RandomVectorScorerSupplier scorerSupplier, int M, int beamWidth, long seed)
       throws IOException {
     if (M <= 0) {
       throw new IllegalArgumentException("maxConn must be positive");

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -18,15 +18,10 @@
 package org.apache.lucene.util.hnsw;
 
 import static java.lang.Math.log;
-import static java.lang.Math.max;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.SplittableRandom;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TopDocs;
@@ -112,6 +107,7 @@ public final class HnswGraphBuilder {
       throw new IllegalArgumentException("beamWidth must be positive");
     }
     this.M = M;
+    this.scorerProvider = Objects.requireNonNull(scorerProvider, "scorer provider must not be null");
     // normalization factor for level generation; currently not configurable
     this.ml = M == 1 ? 1 : 1 / Math.log(1.0 * M);
     this.random = new SplittableRandom(seed);
@@ -124,7 +120,6 @@ public final class HnswGraphBuilder {
     entryCandidates = new GraphBuilderKnnCollector(1);
     beamCandidates = new GraphBuilderKnnCollector(beamWidth);
     this.initializedNodes = new HashSet<>();
-    this.scorerProvider = scorerProvider;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -21,7 +21,12 @@ import static java.lang.Math.log;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SplittableRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TopDocs;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -24,12 +24,9 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.SplittableRandom;
 import java.util.concurrent.TimeUnit;
-import org.apache.lucene.index.VectorEncoding;
-import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.FixedBitSet;
@@ -37,11 +34,9 @@ import org.apache.lucene.util.InfoStream;
 
 /**
  * Builder for HNSW graph. See {@link HnswGraph} for a gloss on the algorithm and the meaning of the
- * hyperparameters.
- *
- * @param <T> the type of vector
+ * hyper-parameters.
  */
-public final class HnswGraphBuilder<T> {
+public final class HnswGraphBuilder {
 
   /** Default number of maximum connections per node */
   public static final int DEFAULT_MAX_CONN = 16;
@@ -64,11 +59,9 @@ public final class HnswGraphBuilder<T> {
   private final double ml;
   private final NeighborArray scratch;
 
-  private final VectorSimilarityFunction similarityFunction;
-  private final VectorEncoding vectorEncoding;
-  private final RandomAccessVectorValues<T> vectors;
   private final SplittableRandom random;
-  private final HnswGraphSearcher<T> graphSearcher;
+  private final RandomVectorScorerProvider scorerProvider;
+  private final HnswGraphSearcher graphSearcher;
   private final GraphBuilderKnnCollector entryCandidates; // for upper levels of graph search
   private final GraphBuilderKnnCollector
       beamCandidates; // for levels of graph where we add the node
@@ -77,34 +70,23 @@ public final class HnswGraphBuilder<T> {
 
   private InfoStream infoStream = InfoStream.getDefault();
 
-  // we need two sources of vectors in order to perform diversity check comparisons without
-  // colliding
-  private final RandomAccessVectorValues<T> vectorsCopy;
   private final Set<Integer> initializedNodes;
 
-  public static <T> HnswGraphBuilder<T> create(
-      RandomAccessVectorValues<T> vectors,
-      VectorEncoding vectorEncoding,
-      VectorSimilarityFunction similarityFunction,
-      int M,
-      int beamWidth,
-      long seed)
+  public static HnswGraphBuilder create(
+      RandomVectorScorerProvider scorerProvider, int M, int beamWidth, long seed)
       throws IOException {
-    return new HnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, M, beamWidth, seed);
+    return new HnswGraphBuilder(scorerProvider, M, beamWidth, seed);
   }
 
-  public static <T> HnswGraphBuilder<T> create(
-      RandomAccessVectorValues<T> vectors,
-      VectorEncoding vectorEncoding,
-      VectorSimilarityFunction similarityFunction,
+  public static HnswGraphBuilder create(
+      RandomVectorScorerProvider scorerProvider,
       int M,
       int beamWidth,
       long seed,
       HnswGraph initializerGraph,
       Map<Integer, Integer> oldToNewOrdinalMap)
       throws IOException {
-    HnswGraphBuilder<T> hnswGraphBuilder =
-        new HnswGraphBuilder<>(vectors, vectorEncoding, similarityFunction, M, beamWidth, seed);
+    HnswGraphBuilder hnswGraphBuilder = new HnswGraphBuilder(scorerProvider, M, beamWidth, seed);
     hnswGraphBuilder.initializeFromGraph(initializerGraph, oldToNewOrdinalMap);
     return hnswGraphBuilder;
   }
@@ -113,8 +95,6 @@ public final class HnswGraphBuilder<T> {
    * Reads all the vectors from vector values, builds a graph connecting them by their dense
    * ordinals, using the given hyperparameter settings, and returns the resulting graph.
    *
-   * @param vectors the vectors whose relations are represented by the graph - must provide a
-   *     different view over those vectors than the one used to add via addGraphNode.
    * @param M – graph fanout parameter used to calculate the maximum number of connections a node
    *     can have – M on upper layers, and M * 2 on the lowest level.
    * @param beamWidth the size of the beam search to use when finding nearest neighbors.
@@ -122,17 +102,8 @@ public final class HnswGraphBuilder<T> {
    *     to ensure repeatable construction.
    */
   private HnswGraphBuilder(
-      RandomAccessVectorValues<T> vectors,
-      VectorEncoding vectorEncoding,
-      VectorSimilarityFunction similarityFunction,
-      int M,
-      int beamWidth,
-      long seed)
+      RandomVectorScorerProvider scorerProvider, int M, int beamWidth, long seed)
       throws IOException {
-    this.vectors = vectors;
-    this.vectorsCopy = vectors.copy();
-    this.vectorEncoding = Objects.requireNonNull(vectorEncoding);
-    this.similarityFunction = Objects.requireNonNull(similarityFunction);
     if (M <= 0) {
       throw new IllegalArgumentException("maxConn must be positive");
     }
@@ -145,16 +116,14 @@ public final class HnswGraphBuilder<T> {
     this.random = new SplittableRandom(seed);
     this.hnsw = new OnHeapHnswGraph(M);
     this.graphSearcher =
-        new HnswGraphSearcher<>(
-            vectorEncoding,
-            similarityFunction,
-            new NeighborQueue(beamWidth, true),
-            new FixedBitSet(this.vectors.size()));
+        new HnswGraphSearcher(
+            new NeighborQueue(beamWidth, true), new FixedBitSet(this.getGraph().size()));
     // in scratch we store candidates in reverse order: worse candidates are first
     scratch = new NeighborArray(Math.max(beamWidth, M + 1), false);
     entryCandidates = new GraphBuilderKnnCollector(1);
     beamCandidates = new GraphBuilderKnnCollector(beamWidth);
     this.initializedNodes = new HashSet<>();
+    this.scorerProvider = scorerProvider;
   }
 
   /**
@@ -165,11 +134,7 @@ public final class HnswGraphBuilder<T> {
    * @param vectorsToAdd the vectors for which to build a nearest neighbors graph. Must be an
    *     independent accessor for the vectors
    */
-  public OnHeapHnswGraph build(RandomAccessVectorValues<T> vectorsToAdd) throws IOException {
-    if (vectorsToAdd == this.vectors) {
-      throw new IllegalArgumentException(
-          "Vectors to build must be independent of the source of vectors provided to HnswGraphBuilder()");
-    }
+  public OnHeapHnswGraph build(RandomAccessVectorValues<?> vectorsToAdd) throws IOException {
     if (infoStream.isEnabled(HNSW_COMPONENT)) {
       infoStream.message(HNSW_COMPONENT, "build graph from " + vectorsToAdd.size() + " vectors");
     }
@@ -190,8 +155,6 @@ public final class HnswGraphBuilder<T> {
   private void initializeFromGraph(
       HnswGraph initializerGraph, Map<Integer, Integer> oldToNewOrdinalMap) throws IOException {
     assert hnsw.size() == 0;
-    float[] vectorValue = null;
-    byte[] binaryValue = null;
     for (int level = 0; level < initializerGraph.numLevels(); level++) {
       HnswGraph.NodesIterator it = initializerGraph.getNodesOnLevel(level);
 
@@ -205,41 +168,18 @@ public final class HnswGraphBuilder<T> {
           initializedNodes.add(newOrd);
         }
 
-        switch (this.vectorEncoding) {
-          case FLOAT32 -> vectorValue = (float[]) vectors.vectorValue(newOrd);
-          case BYTE -> binaryValue = (byte[]) vectors.vectorValue(newOrd);
-        }
-
         NeighborArray newNeighbors = this.hnsw.getNeighbors(level, newOrd);
         initializerGraph.seek(level, oldOrd);
+        RandomVectorScorer scorer = scorerProvider.scorer(newOrd);
         for (int oldNeighbor = initializerGraph.nextNeighbor();
             oldNeighbor != NO_MORE_DOCS;
             oldNeighbor = initializerGraph.nextNeighbor()) {
           int newNeighbor = oldToNewOrdinalMap.get(oldNeighbor);
-          float score =
-              switch (this.vectorEncoding) {
-                case FLOAT32 -> this.similarityFunction.compare(
-                    vectorValue, (float[]) vectorsCopy.vectorValue(newNeighbor));
-                case BYTE -> this.similarityFunction.compare(
-                    binaryValue, (byte[]) vectorsCopy.vectorValue(newNeighbor));
-              };
+          float score = scorer.symmetricScore(newOrd, newNeighbor);
           // we are not sure whether the previous graph contains
           // unchecked nodes, so we have to assume they're all unchecked
           newNeighbors.addOutOfOrder(newNeighbor, score);
         }
-      }
-    }
-  }
-
-  private void addVectors(RandomAccessVectorValues<T> vectorsToAdd) throws IOException {
-    long start = System.nanoTime(), t = start;
-    for (int node = 0; node < vectorsToAdd.size(); node++) {
-      if (initializedNodes.contains(node)) {
-        continue;
-      }
-      addGraphNode(node, vectorsToAdd);
-      if ((node % 10000 == 0) && infoStream.isEnabled(HNSW_COMPONENT)) {
-        t = printGraphBuildStatus(node, start, t);
       }
     }
   }
@@ -253,8 +193,25 @@ public final class HnswGraphBuilder<T> {
     return hnsw;
   }
 
+  private void addVectors(RandomAccessVectorValues<?> vectorsToAdd) throws IOException {
+    long start = System.nanoTime(), t = start;
+    for (int node = 0; node < vectorsToAdd.size(); node++) {
+      if (initializedNodes.contains(node)) {
+        continue;
+      }
+      addGraphNode(node);
+      if ((node % 10000 == 0) && infoStream.isEnabled(HNSW_COMPONENT)) {
+        t = printGraphBuildStatus(node, start, t);
+      }
+    }
+  }
+
   /** Inserts a doc with vector value to the graph */
-  public void addGraphNode(int node, T value) throws IOException {
+  public void addGraphNode(int node) throws IOException {
+    RandomVectorScorer scorer = scorerProvider.scorer(node);
+    if (initializedNodes.contains(node)) {
+      return;
+    }
     final int nodeLevel = getRandomGraphLevel(ml, random);
     int curMaxLevel = hnsw.numLevels() - 1;
 
@@ -276,22 +233,18 @@ public final class HnswGraphBuilder<T> {
     GraphBuilderKnnCollector candidates = entryCandidates;
     for (int level = curMaxLevel; level > nodeLevel; level--) {
       candidates.clear();
-      graphSearcher.searchLevel(candidates, value, level, eps, vectors, hnsw, null);
+      graphSearcher.searchLevel(candidates, scorer, level, eps, hnsw, null);
       eps = new int[] {candidates.popNode()};
     }
     // for levels <= nodeLevel search with topk = beamWidth, and add connections
     candidates = beamCandidates;
     for (int level = Math.min(nodeLevel, curMaxLevel); level >= 0; level--) {
       candidates.clear();
-      graphSearcher.searchLevel(candidates, value, level, eps, vectors, hnsw, null);
+      graphSearcher.searchLevel(candidates, scorer, level, eps, hnsw, null);
       eps = candidates.popUntilNearestKNodes();
       hnsw.addNode(level, node);
-      addDiverseNeighbors(level, node, candidates);
+      addDiverseNeighbors(level, node, scorer, candidates);
     }
-  }
-
-  public void addGraphNode(int node, RandomAccessVectorValues<T> values) throws IOException {
-    addGraphNode(node, values.vectorValue(node));
   }
 
   private long printGraphBuildStatus(int node, long start, long t) {
@@ -307,7 +260,8 @@ public final class HnswGraphBuilder<T> {
     return now;
   }
 
-  private void addDiverseNeighbors(int level, int node, GraphBuilderKnnCollector candidates)
+  private void addDiverseNeighbors(
+      int level, int node, RandomVectorScorer scorer, GraphBuilderKnnCollector candidates)
       throws IOException {
     /* For each of the beamWidth nearest candidates (going from best to worst), select it only if it
      * is closer to target than it is to any of the already-selected neighbors (ie selected in this method,
@@ -317,7 +271,7 @@ public final class HnswGraphBuilder<T> {
     assert neighbors.size() == 0; // new node
     popToScratch(candidates);
     int maxConnOnLevel = level == 0 ? M * 2 : M;
-    selectAndLinkDiverse(neighbors, scratch, maxConnOnLevel);
+    selectAndLinkDiverse(scorer, neighbors, scratch, maxConnOnLevel);
 
     // Link the selected nodes to the new node, and the new node to the selected nodes (again
     // applying diversity heuristic)
@@ -327,14 +281,18 @@ public final class HnswGraphBuilder<T> {
       NeighborArray nbrsOfNbr = hnsw.getNeighbors(level, nbr);
       nbrsOfNbr.addOutOfOrder(node, neighbors.score[i]);
       if (nbrsOfNbr.size() > maxConnOnLevel) {
-        int indexToRemove = findWorstNonDiverse(nbrsOfNbr);
+        int indexToRemove = findWorstNonDiverse(scorer, nbrsOfNbr);
         nbrsOfNbr.removeIndex(indexToRemove);
       }
     }
   }
 
   private void selectAndLinkDiverse(
-      NeighborArray neighbors, NeighborArray candidates, int maxConnOnLevel) throws IOException {
+      RandomVectorScorer scorer,
+      NeighborArray neighbors,
+      NeighborArray candidates,
+      int maxConnOnLevel)
+      throws IOException {
     // Select the best maxConnOnLevel neighbors of the new node, applying the diversity heuristic
     for (int i = candidates.size() - 1; neighbors.size() < maxConnOnLevel && i >= 0; i--) {
       // compare each neighbor (in distance order) against the closer neighbors selected so far,
@@ -342,7 +300,7 @@ public final class HnswGraphBuilder<T> {
       int cNode = candidates.node[i];
       float cScore = candidates.score[i];
       assert cNode < hnsw.size();
-      if (diversityCheck(cNode, cScore, neighbors)) {
+      if (diversityCheck(scorer, cNode, cScore, neighbors)) {
         neighbors.addInOrder(cNode, cScore);
       }
     }
@@ -366,38 +324,11 @@ public final class HnswGraphBuilder<T> {
    * @param neighbors the neighbors selected so far
    * @return whether the candidate is diverse given the existing neighbors
    */
-  private boolean diversityCheck(int candidate, float score, NeighborArray neighbors)
-      throws IOException {
-    return isDiverse(candidate, neighbors, score);
-  }
-
-  private boolean isDiverse(int candidate, NeighborArray neighbors, float score)
-      throws IOException {
-    return switch (vectorEncoding) {
-      case BYTE -> isDiverse((byte[]) vectors.vectorValue(candidate), neighbors, score);
-      case FLOAT32 -> isDiverse((float[]) vectors.vectorValue(candidate), neighbors, score);
-    };
-  }
-
-  private boolean isDiverse(float[] candidate, NeighborArray neighbors, float score)
+  private boolean diversityCheck(
+      RandomVectorScorer scorer, int candidate, float score, NeighborArray neighbors)
       throws IOException {
     for (int i = 0; i < neighbors.size(); i++) {
-      float neighborSimilarity =
-          similarityFunction.compare(
-              candidate, (float[]) vectorsCopy.vectorValue(neighbors.node[i]));
-      if (neighborSimilarity >= score) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private boolean isDiverse(byte[] candidate, NeighborArray neighbors, float score)
-      throws IOException {
-    for (int i = 0; i < neighbors.size(); i++) {
-      float neighborSimilarity =
-          similarityFunction.compare(
-              candidate, (byte[]) vectorsCopy.vectorValue(neighbors.node[i]));
+      float neighborSimilarity = scorer.symmetricScore(candidate, neighbors.node[i]);
       if (neighborSimilarity >= score) {
         return false;
       }
@@ -409,7 +340,8 @@ public final class HnswGraphBuilder<T> {
    * Find first non-diverse neighbour among the list of neighbors starting from the most distant
    * neighbours
    */
-  private int findWorstNonDiverse(NeighborArray neighbors) throws IOException {
+  private int findWorstNonDiverse(RandomVectorScorer scorer, NeighborArray neighbors)
+      throws IOException {
     int[] uncheckedIndexes = neighbors.sort();
     if (uncheckedIndexes == null) {
       // all nodes are checked, we will directly return the most distant one
@@ -421,7 +353,7 @@ public final class HnswGraphBuilder<T> {
         // no unchecked node left
         break;
       }
-      if (isWorstNonDiverse(i, neighbors, uncheckedIndexes, uncheckedCursor)) {
+      if (isWorstNonDiverse(scorer, i, neighbors, uncheckedIndexes, uncheckedCursor)) {
         return i;
       }
       if (i == uncheckedIndexes[uncheckedCursor]) {
@@ -432,39 +364,18 @@ public final class HnswGraphBuilder<T> {
   }
 
   private boolean isWorstNonDiverse(
-      int candidateIndex, NeighborArray neighbors, int[] uncheckedIndexes, int uncheckedCursor)
+      RandomVectorScorer scorer,
+      int candidateIndex,
+      NeighborArray neighbors,
+      int[] uncheckedIndexes,
+      int uncheckedCursor)
       throws IOException {
     int candidateNode = neighbors.node[candidateIndex];
-    return switch (vectorEncoding) {
-      case BYTE -> isWorstNonDiverse(
-          candidateIndex,
-          (byte[]) vectors.vectorValue(candidateNode),
-          neighbors,
-          uncheckedIndexes,
-          uncheckedCursor);
-      case FLOAT32 -> isWorstNonDiverse(
-          candidateIndex,
-          (float[]) vectors.vectorValue(candidateNode),
-          neighbors,
-          uncheckedIndexes,
-          uncheckedCursor);
-    };
-  }
-
-  private boolean isWorstNonDiverse(
-      int candidateIndex,
-      float[] candidateVector,
-      NeighborArray neighbors,
-      int[] uncheckedIndexes,
-      int uncheckedCursor)
-      throws IOException {
     float minAcceptedSimilarity = neighbors.score[candidateIndex];
     if (candidateIndex == uncheckedIndexes[uncheckedCursor]) {
       // the candidate itself is unchecked
       for (int i = candidateIndex - 1; i >= 0; i--) {
-        float neighborSimilarity =
-            similarityFunction.compare(
-                candidateVector, (float[]) vectorsCopy.vectorValue(neighbors.node[i]));
+        float neighborSimilarity = scorer.symmetricScore(candidateNode, neighbors.node[i]);
         // candidate node is too similar to node i given its score relative to the base node
         if (neighborSimilarity >= minAcceptedSimilarity) {
           return true;
@@ -476,46 +387,7 @@ public final class HnswGraphBuilder<T> {
       assert candidateIndex > uncheckedIndexes[uncheckedCursor];
       for (int i = uncheckedCursor; i >= 0; i--) {
         float neighborSimilarity =
-            similarityFunction.compare(
-                candidateVector,
-                (float[]) vectorsCopy.vectorValue(neighbors.node[uncheckedIndexes[i]]));
-        // candidate node is too similar to node i given its score relative to the base node
-        if (neighborSimilarity >= minAcceptedSimilarity) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private boolean isWorstNonDiverse(
-      int candidateIndex,
-      byte[] candidateVector,
-      NeighborArray neighbors,
-      int[] uncheckedIndexes,
-      int uncheckedCursor)
-      throws IOException {
-    float minAcceptedSimilarity = neighbors.score[candidateIndex];
-    if (candidateIndex == uncheckedIndexes[uncheckedCursor]) {
-      // the candidate itself is unchecked
-      for (int i = candidateIndex - 1; i >= 0; i--) {
-        float neighborSimilarity =
-            similarityFunction.compare(
-                candidateVector, (byte[]) vectorsCopy.vectorValue(neighbors.node[i]));
-        // candidate node is too similar to node i given its score relative to the base node
-        if (neighborSimilarity >= minAcceptedSimilarity) {
-          return true;
-        }
-      }
-    } else {
-      // else we just need to make sure candidate does not violate diversity with the (newly
-      // inserted) unchecked nodes
-      assert candidateIndex > uncheckedIndexes[uncheckedCursor];
-      for (int i = uncheckedCursor; i >= 0; i--) {
-        float neighborSimilarity =
-            similarityFunction.compare(
-                candidateVector,
-                (byte[]) vectorsCopy.vectorValue(neighbors.node[uncheckedIndexes[i]]));
+            scorer.symmetricScore(candidateNode, neighbors.node[uncheckedIndexes[i]]);
         // candidate node is too similar to node i given its score relative to the base node
         if (neighborSimilarity >= minAcceptedSimilarity) {
           return true;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -112,7 +112,8 @@ public final class HnswGraphBuilder {
       throw new IllegalArgumentException("beamWidth must be positive");
     }
     this.M = M;
-    this.scorerProvider = Objects.requireNonNull(scorerProvider, "scorer provider must not be null");
+    this.scorerProvider =
+        Objects.requireNonNull(scorerProvider, "scorer provider must not be null");
     // normalization factor for level generation; currently not configurable
     this.ml = M == 1 ? 1 : 1 / Math.log(1.0 * M);
     this.random = new SplittableRandom(seed);
@@ -255,8 +256,7 @@ public final class HnswGraphBuilder {
     return now;
   }
 
-  private void addDiverseNeighbors(
-      int level, int node, GraphBuilderKnnCollector candidates)
+  private void addDiverseNeighbors(int level, int node, GraphBuilderKnnCollector candidates)
       throws IOException {
     /* For each of the beamWidth nearest candidates (going from best to worst), select it only if it
      * is closer to target than it is to any of the already-selected neighbors (ie selected in this method,
@@ -283,10 +283,7 @@ public final class HnswGraphBuilder {
   }
 
   private void selectAndLinkDiverse(
-      NeighborArray neighbors,
-      NeighborArray candidates,
-      int maxConnOnLevel)
-      throws IOException {
+      NeighborArray neighbors, NeighborArray candidates, int maxConnOnLevel) throws IOException {
     // Select the best maxConnOnLevel neighbors of the new node, applying the diversity heuristic
     for (int i = candidates.size() - 1; neighbors.size() < maxConnOnLevel && i >= 0; i--) {
       // compare each neighbor (in distance order) against the closer neighbors selected so far,
@@ -318,8 +315,7 @@ public final class HnswGraphBuilder {
    * @param neighbors the neighbors selected so far
    * @return whether the candidate is diverse given the existing neighbors
    */
-  private boolean diversityCheck(
-      int candidate, float score, NeighborArray neighbors)
+  private boolean diversityCheck(int candidate, float score, NeighborArray neighbors)
       throws IOException {
     RandomVectorScorer scorer = scorerProvider.scorer(candidate);
     for (int i = 0; i < neighbors.size(); i++) {
@@ -335,8 +331,7 @@ public final class HnswGraphBuilder {
    * Find first non-diverse neighbour among the list of neighbors starting from the most distant
    * neighbours
    */
-  private int findWorstNonDiverse(NeighborArray neighbors)
-      throws IOException {
+  private int findWorstNonDiverse(NeighborArray neighbors) throws IOException {
     int[] uncheckedIndexes = neighbors.sort();
     if (uncheckedIndexes == null) {
       // all nodes are checked, we will directly return the most distant one
@@ -359,10 +354,7 @@ public final class HnswGraphBuilder {
   }
 
   private boolean isWorstNonDiverse(
-      int candidateIndex,
-      NeighborArray neighbors,
-      int[] uncheckedIndexes,
-      int uncheckedCursor)
+      int candidateIndex, NeighborArray neighbors, int[] uncheckedIndexes, int uncheckedCursor)
       throws IOException {
     float minAcceptedSimilarity = neighbors.score[candidateIndex];
     RandomVectorScorer scorer = scorerProvider.scorer(neighbors.node[candidateIndex]);
@@ -380,8 +372,7 @@ public final class HnswGraphBuilder {
       // inserted) unchecked nodes
       assert candidateIndex > uncheckedIndexes[uncheckedCursor];
       for (int i = uncheckedCursor; i >= 0; i--) {
-        float neighborSimilarity =
-            scorer.score(neighbors.node[uncheckedIndexes[i]]);
+        float neighborSimilarity = scorer.score(neighbors.node[uncheckedIndexes[i]]);
         // candidate node is too similar to node i given its score relative to the base node
         if (neighborSimilarity >= minAcceptedSimilarity) {
           return true;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -20,8 +20,6 @@ package org.apache.lucene.util.hnsw;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
-import org.apache.lucene.index.VectorEncoding;
-import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.util.BitSet;
@@ -32,13 +30,8 @@ import org.apache.lucene.util.SparseFixedBitSet;
 /**
  * Searches an HNSW graph to find nearest neighbors to a query vector. For more background on the
  * search algorithm, see {@link HnswGraph}.
- *
- * @param <T> the type of query vector
  */
-public class HnswGraphSearcher<T> {
-  private final VectorSimilarityFunction similarityFunction;
-  private final VectorEncoding vectorEncoding;
-
+public class HnswGraphSearcher {
   /**
    * Scratch data structures that are used in each {@link #searchLevel} call. These can be expensive
    * to allocate, so they're cleared and reused across calls.
@@ -50,17 +43,10 @@ public class HnswGraphSearcher<T> {
   /**
    * Creates a new graph searcher.
    *
-   * @param similarityFunction the similarity function to compare vectors
    * @param candidates max heap that will track the candidate nodes to explore
    * @param visited bit set that will track nodes that have already been visited
    */
-  public HnswGraphSearcher(
-      VectorEncoding vectorEncoding,
-      VectorSimilarityFunction similarityFunction,
-      NeighborQueue candidates,
-      BitSet visited) {
-    this.vectorEncoding = vectorEncoding;
-    this.similarityFunction = similarityFunction;
+  public HnswGraphSearcher(NeighborQueue candidates, BitSet visited) {
     this.candidates = candidates;
     this.visited = visited;
   }
@@ -68,10 +54,27 @@ public class HnswGraphSearcher<T> {
   /**
    * Searches HNSW graph for the nearest neighbors of a query vector.
    *
-   * @param query search query vector
+   * @param scorer the scorer to compare the query with the nodes
+   * @param knnCollector a collector of top knn results to be returned
+   * @param graph the graph values. May represent the entire graph, or a level in a hierarchical
+   *     graph.
+   * @param acceptOrds {@link Bits} that represents the allowed document ordinals to match, or
+   *     {@code null} if they are all allowed to match.
+   */
+  public static void search(
+      RandomVectorScorer scorer, KnnCollector knnCollector, HnswGraph graph, Bits acceptOrds)
+      throws IOException {
+    HnswGraphSearcher graphSearcher =
+        new HnswGraphSearcher(
+            new NeighborQueue(knnCollector.k(), true), new SparseFixedBitSet(graph.size()));
+    search(scorer, knnCollector, graph, graphSearcher, acceptOrds);
+  }
+
+  /**
+   * Search {@link OnHeapHnswGraph}, this method is thread safe.
+   *
+   * @param scorer the scorer to compare the query with the nodes
    * @param topK the number of nodes to be returned
-   * @param vectors the vector values
-   * @param similarityFunction the similarity function to compare vectors
    * @param graph the graph values. May represent the entire graph, or a level in a hierarchical
    *     graph.
    * @param acceptOrds {@link Bits} that represents the allowed document ordinals to match, or
@@ -80,198 +83,36 @@ public class HnswGraphSearcher<T> {
    * @return a set of collected vectors holding the nearest neighbors found
    */
   public static KnnCollector search(
-      float[] query,
-      int topK,
-      RandomAccessVectorValues<float[]> vectors,
-      VectorEncoding vectorEncoding,
-      VectorSimilarityFunction similarityFunction,
-      HnswGraph graph,
-      Bits acceptOrds,
-      int visitedLimit)
+      RandomVectorScorer scorer, int topK, OnHeapHnswGraph graph, Bits acceptOrds, int visitedLimit)
       throws IOException {
     KnnCollector knnCollector = new TopKnnCollector(topK, visitedLimit);
-    search(query, knnCollector, vectors, vectorEncoding, similarityFunction, graph, acceptOrds);
+    OnHeapHnswGraphSearcher graphSearcher =
+        new OnHeapHnswGraphSearcher(
+            new NeighborQueue(topK, true), new SparseFixedBitSet(graph.size()));
+    search(scorer, knnCollector, graph, graphSearcher, acceptOrds);
     return knnCollector;
   }
 
-  /**
-   * Searches HNSW graph for the nearest neighbors of a query vector.
-   *
-   * @param query search query vector
-   * @param knnCollector a collector of top knn results to be returned
-   * @param vectors the vector values
-   * @param similarityFunction the similarity function to compare vectors
-   * @param graph the graph values. May represent the entire graph, or a level in a hierarchical
-   *     graph.
-   * @param acceptOrds {@link Bits} that represents the allowed document ordinals to match, or
-   *     {@code null} if they are all allowed to match.
-   */
-  public static void search(
-      float[] query,
+  private static void search(
+      RandomVectorScorer scorer,
       KnnCollector knnCollector,
-      RandomAccessVectorValues<float[]> vectors,
-      VectorEncoding vectorEncoding,
-      VectorSimilarityFunction similarityFunction,
       HnswGraph graph,
-      Bits acceptOrds)
-      throws IOException {
-    if (query.length != vectors.dimension()) {
-      throw new IllegalArgumentException(
-          "vector query dimension: "
-              + query.length
-              + " differs from field dimension: "
-              + vectors.dimension());
-    }
-    HnswGraphSearcher<float[]> graphSearcher =
-        new HnswGraphSearcher<>(
-            vectorEncoding,
-            similarityFunction,
-            new NeighborQueue(knnCollector.k(), true),
-            new SparseFixedBitSet(vectors.size()));
-    search(query, knnCollector, vectors, graph, graphSearcher, acceptOrds);
-  }
-
-  /**
-   * Search {@link OnHeapHnswGraph}, this method is thread safe, for parameters please refer to
-   * {@link #search(float[], int, RandomAccessVectorValues, VectorEncoding,
-   * VectorSimilarityFunction, HnswGraph, Bits, int)}
-   */
-  public static KnnCollector search(
-      float[] query,
-      int topK,
-      RandomAccessVectorValues<float[]> vectors,
-      VectorEncoding vectorEncoding,
-      VectorSimilarityFunction similarityFunction,
-      OnHeapHnswGraph graph,
-      Bits acceptOrds,
-      int visitedLimit)
-      throws IOException {
-    KnnCollector knnCollector = new TopKnnCollector(topK, visitedLimit);
-    OnHeapHnswGraphSearcher<float[]> graphSearcher =
-        new OnHeapHnswGraphSearcher<>(
-            vectorEncoding,
-            similarityFunction,
-            new NeighborQueue(topK, true),
-            new SparseFixedBitSet(vectors.size()));
-    search(query, knnCollector, vectors, graph, graphSearcher, acceptOrds);
-    return knnCollector;
-  }
-
-  /**
-   * Searches HNSW graph for the nearest neighbors of a query vector.
-   *
-   * @param query search query vector
-   * @param topK the number of nodes to be returned
-   * @param vectors the vector values
-   * @param similarityFunction the similarity function to compare vectors
-   * @param graph the graph values. May represent the entire graph, or a level in a hierarchical
-   *     graph.
-   * @param acceptOrds {@link Bits} that represents the allowed document ordinals to match, or
-   *     {@code null} if they are all allowed to match.
-   * @param visitedLimit the maximum number of nodes that the search is allowed to visit
-   * @return a set of collected vectors holding the nearest neighbors found
-   */
-  public static KnnCollector search(
-      byte[] query,
-      int topK,
-      RandomAccessVectorValues<byte[]> vectors,
-      VectorEncoding vectorEncoding,
-      VectorSimilarityFunction similarityFunction,
-      HnswGraph graph,
-      Bits acceptOrds,
-      int visitedLimit)
-      throws IOException {
-    KnnCollector collector = new TopKnnCollector(topK, visitedLimit);
-    search(query, collector, vectors, vectorEncoding, similarityFunction, graph, acceptOrds);
-    return collector;
-  }
-
-  /**
-   * Searches HNSW graph for the nearest neighbors of a query vector.
-   *
-   * @param query search query vector
-   * @param knnCollector a collector of top knn results to be returned
-   * @param vectors the vector values
-   * @param similarityFunction the similarity function to compare vectors
-   * @param graph the graph values. May represent the entire graph, or a level in a hierarchical
-   *     graph.
-   * @param acceptOrds {@link Bits} that represents the allowed document ordinals to match, or
-   *     {@code null} if they are all allowed to match.
-   */
-  public static void search(
-      byte[] query,
-      KnnCollector knnCollector,
-      RandomAccessVectorValues<byte[]> vectors,
-      VectorEncoding vectorEncoding,
-      VectorSimilarityFunction similarityFunction,
-      HnswGraph graph,
-      Bits acceptOrds)
-      throws IOException {
-    if (query.length != vectors.dimension()) {
-      throw new IllegalArgumentException(
-          "vector query dimension: "
-              + query.length
-              + " differs from field dimension: "
-              + vectors.dimension());
-    }
-    HnswGraphSearcher<byte[]> graphSearcher =
-        new HnswGraphSearcher<>(
-            vectorEncoding,
-            similarityFunction,
-            new NeighborQueue(knnCollector.k(), true),
-            new SparseFixedBitSet(vectors.size()));
-    search(query, knnCollector, vectors, graph, graphSearcher, acceptOrds);
-  }
-
-  /**
-   * Search {@link OnHeapHnswGraph}, this method is thread safe, for parameters please refer to
-   * {@link #search(byte[], int, RandomAccessVectorValues, VectorEncoding, VectorSimilarityFunction,
-   * HnswGraph, Bits, int)}
-   */
-  public static KnnCollector search(
-      byte[] query,
-      int topK,
-      RandomAccessVectorValues<byte[]> vectors,
-      VectorEncoding vectorEncoding,
-      VectorSimilarityFunction similarityFunction,
-      OnHeapHnswGraph graph,
-      Bits acceptOrds,
-      int visitedLimit)
-      throws IOException {
-    OnHeapHnswGraphSearcher<byte[]> graphSearcher =
-        new OnHeapHnswGraphSearcher<>(
-            vectorEncoding,
-            similarityFunction,
-            new NeighborQueue(topK, true),
-            new SparseFixedBitSet(vectors.size()));
-    KnnCollector collector = new TopKnnCollector(topK, visitedLimit);
-    search(query, collector, vectors, graph, graphSearcher, acceptOrds);
-    return collector;
-  }
-
-  private static <T> void search(
-      T query,
-      KnnCollector knnCollector,
-      RandomAccessVectorValues<T> vectors,
-      HnswGraph graph,
-      HnswGraphSearcher<T> graphSearcher,
+      HnswGraphSearcher graphSearcher,
       Bits acceptOrds)
       throws IOException {
     int initialEp = graph.entryNode();
     if (initialEp == -1) {
       return;
     }
-    int[] epAndVisited =
-        graphSearcher.findBestEntryPoint(query, vectors, graph, knnCollector.visitLimit());
+    int[] epAndVisited = graphSearcher.findBestEntryPoint(scorer, graph, knnCollector.visitLimit());
     int numVisited = epAndVisited[1];
     int ep = epAndVisited[0];
     if (ep == -1) {
       knnCollector.incVisitedCount(numVisited);
       return;
     }
-    KnnCollector results = new OrdinalTranslatedKnnCollector(knnCollector, vectors::ordToDoc);
-    results.incVisitedCount(numVisited);
-    graphSearcher.searchLevel(results, query, 0, new int[] {ep}, vectors, graph, acceptOrds);
+    knnCollector.incVisitedCount(numVisited);
+    graphSearcher.searchLevel(knnCollector, scorer, 0, new int[] {ep}, graph, acceptOrds);
   }
 
   /**
@@ -280,48 +121,40 @@ public class HnswGraphSearcher<T> {
    * <p>If the search stops early because it reaches the visited nodes limit, then the results will
    * be marked incomplete through {@link NeighborQueue#incomplete()}.
    *
-   * @param query search query vector
+   * @param scorer the scorer to compare the query with the nodes
    * @param topK the number of nearest to query results to return
    * @param level level to search
    * @param eps the entry points for search at this level expressed as level 0th ordinals
-   * @param vectors vector values
    * @param graph the graph values
    * @return a set of collected vectors holding the nearest neighbors found
    */
   public HnswGraphBuilder.GraphBuilderKnnCollector searchLevel(
       // Note: this is only public because Lucene91HnswGraphBuilder needs it
-      T query,
-      int topK,
-      int level,
-      final int[] eps,
-      RandomAccessVectorValues<T> vectors,
-      HnswGraph graph)
+      RandomVectorScorer scorer, int topK, int level, final int[] eps, HnswGraph graph)
       throws IOException {
     HnswGraphBuilder.GraphBuilderKnnCollector results =
         new HnswGraphBuilder.GraphBuilderKnnCollector(topK);
-    searchLevel(results, query, level, eps, vectors, graph, null);
+    searchLevel(results, scorer, level, eps, graph, null);
     return results;
   }
 
   /**
    * Function to find the best entry point from which to search the zeroth graph layer.
    *
-   * @param query vector query with which to search
-   * @param vectors random access vector values
+   * @param scorer the scorer to compare the query with the nodes
    * @param graph the HNSWGraph
    * @param visitLimit How many vectors are allowed to be visited
    * @return An integer array whose first element is the best entry point, and second is the number
    *     of candidates visited. Entry point of `-1` indicates visitation limit exceed
    * @throws IOException When accessing the vector fails
    */
-  private int[] findBestEntryPoint(
-      T query, RandomAccessVectorValues<T> vectors, HnswGraph graph, long visitLimit)
+  private int[] findBestEntryPoint(RandomVectorScorer scorer, HnswGraph graph, long visitLimit)
       throws IOException {
     int size = graph.size();
     int visitedCount = 1;
-    prepareScratchState(vectors.size());
+    prepareScratchState(graph.size());
     int currentEp = graph.entryNode();
-    float currentScore = compare(query, vectors, currentEp);
+    float currentScore = scorer.queryScore(currentEp);
     boolean foundBetter;
     for (int level = graph.numLevels() - 1; level >= 1; level--) {
       foundBetter = true;
@@ -339,7 +172,7 @@ public class HnswGraphSearcher<T> {
           if (visitedCount >= visitLimit) {
             return new int[] {-1, visitedCount};
           }
-          float friendSimilarity = compare(query, vectors, friendOrd);
+          float friendSimilarity = scorer.queryScore(friendOrd);
           visitedCount++;
           if (friendSimilarity > currentScore
               || (friendSimilarity == currentScore && friendOrd < currentEp)) {
@@ -361,23 +194,22 @@ public class HnswGraphSearcher<T> {
    */
   void searchLevel(
       KnnCollector results,
-      T query,
+      RandomVectorScorer scorer,
       int level,
       final int[] eps,
-      RandomAccessVectorValues<T> vectors,
       HnswGraph graph,
       Bits acceptOrds)
       throws IOException {
 
     int size = graph.size();
-    prepareScratchState(vectors.size());
+    prepareScratchState(graph.size());
 
     for (int ep : eps) {
       if (visited.getAndSet(ep) == false) {
         if (results.earlyTerminated()) {
           break;
         }
-        float score = compare(query, vectors, ep);
+        float score = scorer.queryScore(ep);
         results.incVisitedCount(1);
         candidates.add(ep, score);
         if (acceptOrds == null || acceptOrds.get(ep)) {
@@ -408,7 +240,7 @@ public class HnswGraphSearcher<T> {
         if (results.earlyTerminated()) {
           break;
         }
-        float friendSimilarity = compare(query, vectors, friendOrd);
+        float friendSimilarity = scorer.queryScore(friendOrd);
         results.incVisitedCount(1);
         if (friendSimilarity >= minAcceptedSimilarity) {
           candidates.add(friendOrd, friendSimilarity);
@@ -419,14 +251,6 @@ public class HnswGraphSearcher<T> {
           }
         }
       }
-    }
-  }
-
-  private float compare(T query, RandomAccessVectorValues<T> vectors, int ord) throws IOException {
-    if (vectorEncoding == VectorEncoding.BYTE) {
-      return similarityFunction.compare((byte[]) query, (byte[]) vectors.vectorValue(ord));
-    } else {
-      return similarityFunction.compare((float[]) query, (float[]) vectors.vectorValue(ord));
     }
   }
 
@@ -468,17 +292,13 @@ public class HnswGraphSearcher<T> {
    * <p>Note the class itself is NOT thread safe, but since each search will create a new Searcher,
    * the search methods using this class are thread safe.
    */
-  private static class OnHeapHnswGraphSearcher<C> extends HnswGraphSearcher<C> {
+  private static class OnHeapHnswGraphSearcher extends HnswGraphSearcher {
 
     private NeighborArray cur;
     private int upto;
 
-    private OnHeapHnswGraphSearcher(
-        VectorEncoding vectorEncoding,
-        VectorSimilarityFunction similarityFunction,
-        NeighborQueue candidates,
-        BitSet visited) {
-      super(vectorEncoding, similarityFunction, candidates, visited);
+    private OnHeapHnswGraphSearcher(NeighborQueue candidates, BitSet visited) {
+      super(candidates, visited);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -154,7 +154,7 @@ public class HnswGraphSearcher {
     int visitedCount = 1;
     prepareScratchState(graph.size());
     int currentEp = graph.entryNode();
-    float currentScore = scorer.queryScore(currentEp);
+    float currentScore = scorer.score(currentEp);
     boolean foundBetter;
     for (int level = graph.numLevels() - 1; level >= 1; level--) {
       foundBetter = true;
@@ -172,7 +172,7 @@ public class HnswGraphSearcher {
           if (visitedCount >= visitLimit) {
             return new int[] {-1, visitedCount};
           }
-          float friendSimilarity = scorer.queryScore(friendOrd);
+          float friendSimilarity = scorer.score(friendOrd);
           visitedCount++;
           if (friendSimilarity > currentScore
               || (friendSimilarity == currentScore && friendOrd < currentEp)) {
@@ -209,7 +209,7 @@ public class HnswGraphSearcher {
         if (results.earlyTerminated()) {
           break;
         }
-        float score = scorer.queryScore(ep);
+        float score = scorer.score(ep);
         results.incVisitedCount(1);
         candidates.add(ep, score);
         if (acceptOrds == null || acceptOrds.get(ep)) {
@@ -240,7 +240,7 @@ public class HnswGraphSearcher {
         if (results.earlyTerminated()) {
           break;
         }
-        float friendSimilarity = scorer.queryScore(friendOrd);
+        float friendSimilarity = scorer.score(friendOrd);
         results.incVisitedCount(1);
         if (friendSimilarity >= minAcceptedSimilarity) {
           candidates.add(friendOrd, friendSimilarity);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OrdinalTranslatedKnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OrdinalTranslatedKnnCollector.java
@@ -24,12 +24,12 @@ import org.apache.lucene.search.TotalHits;
 /**
  * Wraps a provided KnnCollector object, translating the provided vectorId ordinal to a documentId
  */
-final class OrdinalTranslatedKnnCollector implements KnnCollector {
+public final class OrdinalTranslatedKnnCollector implements KnnCollector {
 
   private final KnnCollector in;
   private final IntToIntFunction vectorOrdinalToDocId;
 
-  OrdinalTranslatedKnnCollector(KnnCollector in, IntToIntFunction vectorOrdinalToDocId) {
+  public OrdinalTranslatedKnnCollector(KnnCollector in, IntToIntFunction vectorOrdinalToDocId) {
     this.in = in;
     this.vectorOrdinalToDocId = vectorOrdinalToDocId;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
@@ -38,8 +38,8 @@ public interface RandomVectorScorer {
    *
    * @warning The {@link RandomAccessVectorValues} given can contain stateful buffers.
    *          Avoid using it after calling this function. If you plan to use it again
-   *          outside of the returned {@link RandomVectorScorer},
-   *          think about passing a copied version ({@link RandomAccessVectorValues#copy}).
+   *          outside of the returned {@link RandomVectorScorer}, think about passing
+   *          a copied version ({@link RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
@@ -61,6 +61,11 @@ public interface RandomVectorScorer {
 
   /**
    * Creates a default scorer for byte vectors.
+   *
+   * @warning The {@link RandomAccessVectorValues} given can contain stateful buffers.
+   *          Avoid using it after calling this function. If you plan to use it again
+   *          outside of the returned {@link RandomVectorScorer}, think about passing
+   *          a copied version ({@link RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to use to score vectors

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
@@ -20,10 +20,7 @@ package org.apache.lucene.util.hnsw;
 import java.io.IOException;
 import org.apache.lucene.index.VectorSimilarityFunction;
 
-/**
- * A {@link RandomVectorScorer} for scoring random nodes in batches
- * against an abstract query.
- */
+/** A {@link RandomVectorScorer} for scoring random nodes in batches against an abstract query. */
 public interface RandomVectorScorer {
   /**
    * Returns the score between the query and the provided node.
@@ -36,10 +33,10 @@ public interface RandomVectorScorer {
   /**
    * Creates a default scorer for float vectors.
    *
-   * WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers.
-   *          Avoid using it after calling this function. If you plan to use it again
-   *          outside the returned {@link RandomVectorScorer}, think about passing
-   *          a copied version ({@link RandomAccessVectorValues#copy}).
+   * <p>WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers. Avoid
+   * using it after calling this function. If you plan to use it again outside the returned {@link
+   * RandomVectorScorer}, think about passing a copied version ({@link
+   * RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
@@ -62,10 +59,10 @@ public interface RandomVectorScorer {
   /**
    * Creates a default scorer for byte vectors.
    *
-   * WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers.
-   *          Avoid using it after calling this function. If you plan to use it again
-   *          outside the returned {@link RandomVectorScorer}, think about passing
-   *          a copied version ({@link RandomAccessVectorValues#copy}).
+   * <p>WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers. Avoid
+   * using it after calling this function. If you plan to use it again outside the returned {@link
+   * RandomVectorScorer}, think about passing a copied version ({@link
+   * RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to use to score vectors

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
@@ -19,12 +19,10 @@ package org.apache.lucene.util.hnsw;
 
 import java.io.IOException;
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.search.Query;
 
 /**
- * The {@link RandomVectorScorer} calculates scores between an abstract query and a random node. It
- * can also score two random nodes stored in the graph. The scores returned must be strictly
- * positive for them to be usable in a {@link Query}.
+ * A {@link RandomVectorScorer} for scoring random nodes in batches
+ * against an abstract query.
  */
 public interface RandomVectorScorer {
   /**
@@ -33,19 +31,15 @@ public interface RandomVectorScorer {
    * @param node a random node in the graph
    * @return the computed score
    */
-  float queryScore(int node) throws IOException;
-
-  /**
-   * Returns the score between two nodes.
-   *
-   * @param node1 the first node
-   * @param node2 the second node
-   * @return the computed score
-   */
-  float symmetricScore(int node1, int node2) throws IOException;
+  float score(int node) throws IOException;
 
   /**
    * Creates a default scorer for float vectors.
+   *
+   * @warning The {@link RandomAccessVectorValues} given can contain stateful buffers.
+   *          Avoid using it after calling this function. If you plan to use it again
+   *          outside of the returned {@link RandomVectorScorer},
+   *          think about passing a copied version ({@link RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
@@ -54,8 +48,7 @@ public interface RandomVectorScorer {
   static RandomVectorScorer createFloats(
       final RandomAccessVectorValues<float[]> vectors,
       final VectorSimilarityFunction similarityFunction,
-      final float[] query)
-      throws IOException {
+      final float[] query) {
     if (query.length != vectors.dimension()) {
       throw new IllegalArgumentException(
           "vector query dimension: "
@@ -63,19 +56,7 @@ public interface RandomVectorScorer {
               + " differs from field dimension: "
               + vectors.dimension());
     }
-    final RandomAccessVectorValues<float[]> vectorsCopy = vectors.copy();
-    return new RandomVectorScorer() {
-      @Override
-      public float symmetricScore(int node1, int node2) throws IOException {
-        return similarityFunction.compare(
-            vectors.vectorValue(node1), vectorsCopy.vectorValue(node2));
-      }
-
-      @Override
-      public float queryScore(int node) throws IOException {
-        return similarityFunction.compare(query, vectorsCopy.vectorValue(node));
-      }
-    };
+    return node -> similarityFunction.compare(query, vectors.vectorValue(node));
   }
 
   /**
@@ -88,8 +69,7 @@ public interface RandomVectorScorer {
   static RandomVectorScorer createBytes(
       final RandomAccessVectorValues<byte[]> vectors,
       final VectorSimilarityFunction similarityFunction,
-      final byte[] query)
-      throws IOException {
+      final byte[] query) {
     if (query.length != vectors.dimension()) {
       throw new IllegalArgumentException(
           "vector query dimension: "
@@ -97,18 +77,6 @@ public interface RandomVectorScorer {
               + " differs from field dimension: "
               + vectors.dimension());
     }
-    final RandomAccessVectorValues<byte[]> vectorsCopy = vectors.copy();
-    return new RandomVectorScorer() {
-      @Override
-      public float symmetricScore(int node1, int node2) throws IOException {
-        return similarityFunction.compare(
-            vectors.vectorValue(node1), vectorsCopy.vectorValue(node2));
-      }
-
-      @Override
-      public float queryScore(int node) throws IOException {
-        return similarityFunction.compare(query, vectorsCopy.vectorValue(node));
-      }
-    };
+    return node -> similarityFunction.compare(query, vectors.vectorValue(node));
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import java.io.IOException;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.Query;
+
+/**
+ * The {@link RandomVectorScorer} calculates scores between an abstract query and a random node. It
+ * can also score two random nodes stored in the graph. The scores returned must be strictly
+ * positive for them to be usable in a {@link Query}.
+ */
+public interface RandomVectorScorer {
+  /**
+   * Returns the score between the query and the provided node.
+   *
+   * @param node a random node in the graph
+   * @return the computed score
+   */
+  float queryScore(int node) throws IOException;
+
+  /**
+   * Returns the score between two nodes.
+   *
+   * @param node1 the first node
+   * @param node2 the second node
+   * @return the computed score
+   */
+  float symmetricScore(int node1, int node2) throws IOException;
+
+  /**
+   * Creates a default scorer for float vectors.
+   *
+   * @param vectors the underlying storage for vectors
+   * @param similarityFunction the similarity function to score vectors
+   * @param query the actual query
+   */
+  static RandomVectorScorer createFloats(
+      final RandomAccessVectorValues<float[]> vectors,
+      final VectorSimilarityFunction similarityFunction,
+      final float[] query)
+      throws IOException {
+    if (query.length != vectors.dimension()) {
+      throw new IllegalArgumentException(
+          "vector query dimension: "
+              + query.length
+              + " differs from field dimension: "
+              + vectors.dimension());
+    }
+    final RandomAccessVectorValues<float[]> vectorsCopy = vectors.copy();
+    return new RandomVectorScorer() {
+      @Override
+      public float symmetricScore(int node1, int node2) throws IOException {
+        return similarityFunction.compare(
+            vectors.vectorValue(node1), vectorsCopy.vectorValue(node2));
+      }
+
+      @Override
+      public float queryScore(int node) throws IOException {
+        return similarityFunction.compare(query, vectorsCopy.vectorValue(node));
+      }
+    };
+  }
+
+  /**
+   * Creates a default scorer for byte vectors.
+   *
+   * @param vectors the underlying storage for vectors
+   * @param similarityFunction the similarity function to use to score vectors
+   * @param query the actual query
+   */
+  static RandomVectorScorer createBytes(
+      final RandomAccessVectorValues<byte[]> vectors,
+      final VectorSimilarityFunction similarityFunction,
+      final byte[] query)
+      throws IOException {
+    if (query.length != vectors.dimension()) {
+      throw new IllegalArgumentException(
+          "vector query dimension: "
+              + query.length
+              + " differs from field dimension: "
+              + vectors.dimension());
+    }
+    final RandomAccessVectorValues<byte[]> vectorsCopy = vectors.copy();
+    return new RandomVectorScorer() {
+      @Override
+      public float symmetricScore(int node1, int node2) throws IOException {
+        return similarityFunction.compare(
+            vectors.vectorValue(node1), vectorsCopy.vectorValue(node2));
+      }
+
+      @Override
+      public float queryScore(int node) throws IOException {
+        return similarityFunction.compare(query, vectorsCopy.vectorValue(node));
+      }
+    };
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
@@ -36,9 +36,9 @@ public interface RandomVectorScorer {
   /**
    * Creates a default scorer for float vectors.
    *
-   * @warning The {@link RandomAccessVectorValues} given can contain stateful buffers.
+   * WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers.
    *          Avoid using it after calling this function. If you plan to use it again
-   *          outside of the returned {@link RandomVectorScorer}, think about passing
+   *          outside the returned {@link RandomVectorScorer}, think about passing
    *          a copied version ({@link RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
@@ -62,9 +62,9 @@ public interface RandomVectorScorer {
   /**
    * Creates a default scorer for byte vectors.
    *
-   * @warning The {@link RandomAccessVectorValues} given can contain stateful buffers.
+   * WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers.
    *          Avoid using it after calling this function. If you plan to use it again
-   *          outside of the returned {@link RandomVectorScorer}, think about passing
+   *          outside the returned {@link RandomVectorScorer}, think about passing
    *          a copied version ({@link RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
@@ -53,9 +53,7 @@ public interface RandomVectorScorer {
               + " differs from field dimension: "
               + vectors.dimension());
     }
-    float[] queryCopy = new float[query.length];
-    System.arraycopy(query, 0, queryCopy, 0, query.length);
-    return node -> similarityFunction.compare(queryCopy, vectors.vectorValue(node));
+    return node -> similarityFunction.compare(query, vectors.vectorValue(node));
   }
 
   /**
@@ -81,8 +79,6 @@ public interface RandomVectorScorer {
               + " differs from field dimension: "
               + vectors.dimension());
     }
-    byte[] queryCopy = new byte[query.length];
-    System.arraycopy(query, 0, queryCopy, 0, query.length);
-    return node -> similarityFunction.compare(queryCopy, vectors.vectorValue(node));
+    return node -> similarityFunction.compare(query, vectors.vectorValue(node));
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
@@ -53,7 +53,9 @@ public interface RandomVectorScorer {
               + " differs from field dimension: "
               + vectors.dimension());
     }
-    return node -> similarityFunction.compare(query, vectors.vectorValue(node));
+    float[] queryCopy = new float[query.length];
+    System.arraycopy(query, 0, queryCopy, 0, query.length);
+    return node -> similarityFunction.compare(queryCopy, vectors.vectorValue(node));
   }
 
   /**
@@ -79,6 +81,8 @@ public interface RandomVectorScorer {
               + " differs from field dimension: "
               + vectors.dimension());
     }
-    return node -> similarityFunction.compare(query, vectors.vectorValue(node));
+    byte[] queryCopy = new byte[query.length];
+    System.arraycopy(query, 0, queryCopy, 0, query.length);
+    return node -> similarityFunction.compare(queryCopy, vectors.vectorValue(node));
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
@@ -34,10 +34,10 @@ public interface RandomVectorScorerProvider {
   /**
    * Creates a {@link RandomVectorScorerProvider} to compare float vectors.
    *
-   * @warning The {@link RandomAccessVectorValues} given can contain stateful buffers.
+   * WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers.
    *          Avoid using it after calling this function. If you plan to use it again
-   *          outside of the returned {@link RandomVectorScorerProvider},
-   *          think about passing a copied version ({@link RandomAccessVectorValues#copy}).
+   *          outside the returned {@link RandomVectorScorer}, think about passing
+   *          a copied version ({@link RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
@@ -54,10 +54,10 @@ public interface RandomVectorScorerProvider {
   /**
    * Creates a {@link RandomVectorScorerProvider} to compare byte vectors.
    *
-   * @warning The {@link RandomAccessVectorValues} given can contain stateful buffers.
+   * WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers.
    *          Avoid using it after calling this function. If you plan to use it again
-   *          outside of the returned {@link RandomVectorScorerProvider},
-   *          think about passing a copied version ({@link RandomAccessVectorValues#copy}).
+   *          outside the returned {@link RandomVectorScorer}, think about passing
+   *          a copied version ({@link RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
@@ -47,10 +47,10 @@ public interface RandomVectorScorerProvider {
       final VectorSimilarityFunction similarityFunction)
       throws IOException {
     final RandomAccessVectorValues<float[]> vectorsCopy = vectors.copy();
-    return ord ->
+    return queryOrd ->
         (RandomVectorScorer)
-            node ->
-                similarityFunction.compare(vectors.vectorValue(ord), vectorsCopy.vectorValue(ord));
+            cand ->
+                similarityFunction.compare(vectors.vectorValue(queryOrd), vectorsCopy.vectorValue(cand));
   }
 
   /**
@@ -69,9 +69,9 @@ public interface RandomVectorScorerProvider {
       final VectorSimilarityFunction similarityFunction)
       throws IOException {
     final RandomAccessVectorValues<byte[]> vectorsCopy = vectors.copy();
-    return ord ->
+    return queryOrd ->
         (RandomVectorScorer)
-            node ->
-                similarityFunction.compare(vectors.vectorValue(ord), vectorsCopy.vectorValue(ord));
+            cand ->
+                similarityFunction.compare(vectors.vectorValue(queryOrd), vectorsCopy.vectorValue(cand));
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
@@ -34,6 +34,11 @@ public interface RandomVectorScorerProvider {
   /**
    * Creates a {@link RandomVectorScorerProvider} to compare float vectors.
    *
+   * <p>WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers. Avoid
+   * using it after calling this function. If you plan to use it again outside the returned {@link
+   * RandomVectorScorer}, think about passing a copied version ({@link
+   * RandomAccessVectorValues#copy}).
+   *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
    */
@@ -43,11 +48,18 @@ public interface RandomVectorScorerProvider {
       throws IOException {
     final RandomAccessVectorValues<float[]> vectorsCopy = vectors.copy();
     return ord ->
-        RandomVectorScorer.createFloats(vectorsCopy, similarityFunction, vectors.vectorValue(ord));
+        (RandomVectorScorer)
+            node ->
+                similarityFunction.compare(vectors.vectorValue(ord), vectorsCopy.vectorValue(ord));
   }
 
   /**
    * Creates a {@link RandomVectorScorerProvider} to compare byte vectors.
+   *
+   * <p>WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers. Avoid
+   * using it after calling this function. If you plan to use it again outside the returned {@link
+   * RandomVectorScorer}, think about passing a copied version ({@link
+   * RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
@@ -58,6 +70,8 @@ public interface RandomVectorScorerProvider {
       throws IOException {
     final RandomAccessVectorValues<byte[]> vectorsCopy = vectors.copy();
     return ord ->
-        RandomVectorScorer.createBytes(vectorsCopy, similarityFunction, vectors.vectorValue(ord));
+        (RandomVectorScorer)
+            node ->
+                similarityFunction.compare(vectors.vectorValue(ord), vectorsCopy.vectorValue(ord));
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
@@ -23,8 +23,8 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 /** A provider that creates {@link RandomVectorScorer} from an ordinal. */
 public interface RandomVectorScorerProvider {
   /**
-   * This creates a {@link RandomVectorScorer} for scoring random nodes in batches
-   * against the given ordinal.
+   * This creates a {@link RandomVectorScorer} for scoring random nodes in batches against the given
+   * ordinal.
    *
    * @param ord the ordinal of the node to compare
    * @return a new {@link RandomVectorScorer}
@@ -34,40 +34,40 @@ public interface RandomVectorScorerProvider {
   /**
    * Creates a {@link RandomVectorScorerProvider} to compare float vectors.
    *
-   * WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers.
-   *          Avoid using it after calling this function. If you plan to use it again
-   *          outside the returned {@link RandomVectorScorer}, think about passing
-   *          a copied version ({@link RandomAccessVectorValues#copy}).
+   * <p>WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers. Avoid
+   * using it after calling this function. If you plan to use it again outside the returned {@link
+   * RandomVectorScorer}, think about passing a copied version ({@link
+   * RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
    */
   static RandomVectorScorerProvider createFloats(
       final RandomAccessVectorValues<float[]> vectors,
-      final VectorSimilarityFunction similarityFunction) throws IOException {
+      final VectorSimilarityFunction similarityFunction)
+      throws IOException {
     final RandomAccessVectorValues<float[]> vectorsCopy = vectors.copy();
     return ord ->
-        RandomVectorScorer.createFloats(
-            vectorsCopy, similarityFunction, vectors.vectorValue(ord));
+        RandomVectorScorer.createFloats(vectorsCopy, similarityFunction, vectors.vectorValue(ord));
   }
 
   /**
    * Creates a {@link RandomVectorScorerProvider} to compare byte vectors.
    *
-   * WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers.
-   *          Avoid using it after calling this function. If you plan to use it again
-   *          outside the returned {@link RandomVectorScorer}, think about passing
-   *          a copied version ({@link RandomAccessVectorValues#copy}).
+   * <p>WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers. Avoid
+   * using it after calling this function. If you plan to use it again outside the returned {@link
+   * RandomVectorScorer}, think about passing a copied version ({@link
+   * RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
    */
   static RandomVectorScorerProvider createBytes(
       final RandomAccessVectorValues<byte[]> vectors,
-      final VectorSimilarityFunction similarityFunction) throws IOException {
+      final VectorSimilarityFunction similarityFunction)
+      throws IOException {
     final RandomAccessVectorValues<byte[]> vectorsCopy = vectors.copy();
     return ord ->
-        RandomVectorScorer.createBytes(
-            vectorsCopy, similarityFunction, vectors.vectorValue(ord));
+        RandomVectorScorer.createBytes(vectorsCopy, similarityFunction, vectors.vectorValue(ord));
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import java.io.IOException;
+import org.apache.lucene.index.VectorSimilarityFunction;
+
+/** A provider that creates {@link RandomVectorScorer} from an ordinal. */
+public interface RandomVectorScorerProvider {
+  /**
+   * Creates a {@link RandomVectorScorer} to compare random nodes with the provided ordinal.
+   *
+   * @param ord the ordinal of the node to compare
+   * @return a new {@link RandomVectorScorer}
+   */
+  RandomVectorScorer scorer(int ord) throws IOException;
+
+  /**
+   * Creates a {@link RandomVectorScorerProvider} to compare float vectors.
+   *
+   * @param vectors the underlying storage for vectors
+   * @param similarityFunction the similarity function to score vectors
+   */
+  static RandomVectorScorerProvider createFloats(
+      final RandomAccessVectorValues<float[]> vectors,
+      final VectorSimilarityFunction similarityFunction) {
+    return ord ->
+        RandomVectorScorer.createFloats(
+            vectors.copy(), similarityFunction, vectors.vectorValue(ord));
+  }
+
+  /**
+   * Creates a {@link RandomVectorScorerProvider} to compare byte vectors.
+   *
+   * @param vectors the underlying storage for vectors
+   * @param similarityFunction the similarity function to score vectors
+   */
+  static RandomVectorScorerProvider createBytes(
+      final RandomAccessVectorValues<byte[]> vectors,
+      final VectorSimilarityFunction similarityFunction) {
+    return ord ->
+        RandomVectorScorer.createBytes(
+            vectors.copy(), similarityFunction, vectors.vectorValue(ord));
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
@@ -50,7 +50,8 @@ public interface RandomVectorScorerProvider {
     return queryOrd ->
         (RandomVectorScorer)
             cand ->
-                similarityFunction.compare(vectors.vectorValue(queryOrd), vectorsCopy.vectorValue(cand));
+                similarityFunction.compare(
+                    vectors.vectorValue(queryOrd), vectorsCopy.vectorValue(cand));
   }
 
   /**
@@ -72,6 +73,7 @@ public interface RandomVectorScorerProvider {
     return queryOrd ->
         (RandomVectorScorer)
             cand ->
-                similarityFunction.compare(vectors.vectorValue(queryOrd), vectorsCopy.vectorValue(cand));
+                similarityFunction.compare(
+                    vectors.vectorValue(queryOrd), vectorsCopy.vectorValue(cand));
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
@@ -23,7 +23,8 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 /** A provider that creates {@link RandomVectorScorer} from an ordinal. */
 public interface RandomVectorScorerProvider {
   /**
-   * Creates a {@link RandomVectorScorer} to compare random nodes with the provided ordinal.
+   * This creates a {@link RandomVectorScorer} for scoring random nodes in batches
+   * against the given ordinal.
    *
    * @param ord the ordinal of the node to compare
    * @return a new {@link RandomVectorScorer}
@@ -33,28 +34,40 @@ public interface RandomVectorScorerProvider {
   /**
    * Creates a {@link RandomVectorScorerProvider} to compare float vectors.
    *
+   * @warning The {@link RandomAccessVectorValues} given can contain stateful buffers.
+   *          Avoid using it after calling this function. If you plan to use it again
+   *          outside of the returned {@link RandomVectorScorerProvider},
+   *          think about passing a copied version ({@link RandomAccessVectorValues#copy}).
+   *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
    */
   static RandomVectorScorerProvider createFloats(
       final RandomAccessVectorValues<float[]> vectors,
-      final VectorSimilarityFunction similarityFunction) {
+      final VectorSimilarityFunction similarityFunction) throws IOException {
+    final RandomAccessVectorValues<float[]> vectorsCopy = vectors.copy();
     return ord ->
         RandomVectorScorer.createFloats(
-            vectors.copy(), similarityFunction, vectors.vectorValue(ord));
+            vectorsCopy, similarityFunction, vectors.vectorValue(ord));
   }
 
   /**
    * Creates a {@link RandomVectorScorerProvider} to compare byte vectors.
+   *
+   * @warning The {@link RandomAccessVectorValues} given can contain stateful buffers.
+   *          Avoid using it after calling this function. If you plan to use it again
+   *          outside of the returned {@link RandomVectorScorerProvider},
+   *          think about passing a copied version ({@link RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
    */
   static RandomVectorScorerProvider createBytes(
       final RandomAccessVectorValues<byte[]> vectors,
-      final VectorSimilarityFunction similarityFunction) {
+      final VectorSimilarityFunction similarityFunction) throws IOException {
+    final RandomAccessVectorValues<byte[]> vectorsCopy = vectors.copy();
     return ord ->
         RandomVectorScorer.createBytes(
-            vectors.copy(), similarityFunction, vectors.vectorValue(ord));
+            vectorsCopy, similarityFunction, vectors.vectorValue(ord));
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerProvider.java
@@ -34,11 +34,6 @@ public interface RandomVectorScorerProvider {
   /**
    * Creates a {@link RandomVectorScorerProvider} to compare float vectors.
    *
-   * <p>WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers. Avoid
-   * using it after calling this function. If you plan to use it again outside the returned {@link
-   * RandomVectorScorer}, think about passing a copied version ({@link
-   * RandomAccessVectorValues#copy}).
-   *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
    */
@@ -53,11 +48,6 @@ public interface RandomVectorScorerProvider {
 
   /**
    * Creates a {@link RandomVectorScorerProvider} to compare byte vectors.
-   *
-   * <p>WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers. Avoid
-   * using it after calling this function. If you plan to use it again outside the returned {@link
-   * RandomVectorScorer}, think about passing a copied version ({@link
-   * RandomAccessVectorValues#copy}).
    *
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerSupplier.java
@@ -20,8 +20,8 @@ package org.apache.lucene.util.hnsw;
 import java.io.IOException;
 import org.apache.lucene.index.VectorSimilarityFunction;
 
-/** A provider that creates {@link RandomVectorScorer} from an ordinal. */
-public interface RandomVectorScorerProvider {
+/** A supplier that creates {@link RandomVectorScorer} from an ordinal. */
+public interface RandomVectorScorerSupplier {
   /**
    * This creates a {@link RandomVectorScorer} for scoring random nodes in batches against the given
    * ordinal.
@@ -32,7 +32,7 @@ public interface RandomVectorScorerProvider {
   RandomVectorScorer scorer(int ord) throws IOException;
 
   /**
-   * Creates a {@link RandomVectorScorerProvider} to compare float vectors.
+   * Creates a {@link RandomVectorScorerSupplier} to compare float vectors.
    *
    * <p>WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers. Avoid
    * using it after calling this function. If you plan to use it again outside the returned {@link
@@ -42,7 +42,7 @@ public interface RandomVectorScorerProvider {
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
    */
-  static RandomVectorScorerProvider createFloats(
+  static RandomVectorScorerSupplier createFloats(
       final RandomAccessVectorValues<float[]> vectors,
       final VectorSimilarityFunction similarityFunction)
       throws IOException {
@@ -55,7 +55,7 @@ public interface RandomVectorScorerProvider {
   }
 
   /**
-   * Creates a {@link RandomVectorScorerProvider} to compare byte vectors.
+   * Creates a {@link RandomVectorScorerSupplier} to compare byte vectors.
    *
    * <p>WARNING: The {@link RandomAccessVectorValues} given can contain stateful buffers. Avoid
    * using it after calling this function. If you plan to use it again outside the returned {@link
@@ -65,7 +65,7 @@ public interface RandomVectorScorerProvider {
    * @param vectors the underlying storage for vectors
    * @param similarityFunction the similarity function to score vectors
    */
-  static RandomVectorScorerProvider createBytes(
+  static RandomVectorScorerSupplier createBytes(
       final RandomAccessVectorValues<byte[]> vectors,
       final VectorSimilarityFunction similarityFunction)
       throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerSupplier.java
@@ -46,6 +46,8 @@ public interface RandomVectorScorerSupplier {
       final RandomAccessVectorValues<float[]> vectors,
       final VectorSimilarityFunction similarityFunction)
       throws IOException {
+    // We copy the provided random accessor just once during the supplier's initialization
+    // and then reuse it consistently across all scorers for conducting vector comparisons.
     final RandomAccessVectorValues<float[]> vectorsCopy = vectors.copy();
     return queryOrd ->
         (RandomVectorScorer)
@@ -69,6 +71,8 @@ public interface RandomVectorScorerSupplier {
       final RandomAccessVectorValues<byte[]> vectors,
       final VectorSimilarityFunction similarityFunction)
       throws IOException {
+    // We copy the provided random accessor just once during the supplier's initialization
+    // and then reuse it consistently across all scorers for conducting vector comparisons.
     final RandomAccessVectorValues<byte[]> vectorsCopy = vectors.copy();
     return queryOrd ->
         (RandomVectorScorer)

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -692,7 +692,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     assertTrue(nn.visitedCount() <= visitedLimit);
   }
 
-  public void testHnswGraphBuilderInvalid() {
+  public void testHnswGraphBuilderInvalid() throws IOException {
     RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectorValues(1, 1));
     // M must be > 0
     expectThrows(

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -110,7 +110,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
   abstract T getTargetVector();
 
   @SuppressWarnings("unchecked")
-  protected RandomVectorScorerProvider buildScorerProvider(RandomAccessVectorValues<T> vectors) {
+  protected RandomVectorScorerProvider buildScorerProvider(RandomAccessVectorValues<T> vectors) throws IOException {
     return switch (getVectorEncoding()) {
       case BYTE -> RandomVectorScorerProvider.createBytes(
           (RandomAccessVectorValues<byte[]>) vectors, similarityFunction);
@@ -142,7 +142,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     AbstractMockVectorValues<T> v2 = vectors.copy(), v3 = vectors.copy();
     RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectors);
     HnswGraphBuilder builder = HnswGraphBuilder.create(scorerProvider, M, beamWidth, seed);
-    HnswGraph hnsw = builder.build(vectors.copy());
+    HnswGraph hnsw = builder.build(vectors.size());
 
     // Recreate the graph while indexing with the same random seed and write it out
     HnswGraphBuilder.randSeed = seed;
@@ -372,7 +372,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     RandomAccessVectorValues<T> vectors = circularVectorValues(nDoc);
     RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectors);
     HnswGraphBuilder builder = HnswGraphBuilder.create(scorerProvider, 10, 100, random().nextInt());
-    OnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    OnHeapHnswGraph hnsw = builder.build(vectors.size());
 
     // run some searches
     KnnCollector nn =
@@ -405,7 +405,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
     RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectors);
     HnswGraphBuilder builder = HnswGraphBuilder.create(scorerProvider, 16, 100, random().nextInt());
-    OnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    OnHeapHnswGraph hnsw = builder.build(vectors.size());
     // the first 10 docs must not be deleted to ensure the expected recall
     Bits acceptOrds = createRandomAcceptOrds(10, nDoc);
     KnnCollector nn =
@@ -430,7 +430,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
     RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectors);
     HnswGraphBuilder builder = HnswGraphBuilder.create(scorerProvider, 16, 100, random().nextInt());
-    OnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    OnHeapHnswGraph hnsw = builder.build(vectors.size());
     // Only mark a few vectors as accepted
     BitSet acceptOrds = new FixedBitSet(nDoc);
     for (int i = 0; i < nDoc; i += random().nextInt(15, 20)) {
@@ -536,7 +536,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     HnswGraphBuilder initializerBuilder =
         HnswGraphBuilder.create(initialScorerProvider, 10, 30, seed);
 
-    OnHeapHnswGraph initializerGraph = initializerBuilder.build(initializerVectors.copy());
+    OnHeapHnswGraph initializerGraph = initializerBuilder.build(initializerVectors.size());
     AbstractMockVectorValues<T> finalVectorValues =
         vectorValues(totalSize, dim, initializerVectors, docIdOffset);
 
@@ -551,7 +551,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     // When offset is 0, the graphs should be identical before vectors are added
     assertGraphEqual(initializerGraph, finalBuilder.getGraph());
 
-    OnHeapHnswGraph finalGraph = finalBuilder.build(finalVectorValues.copy());
+    OnHeapHnswGraph finalGraph = finalBuilder.build(finalVectorValues.size());
     assertGraphContainsGraph(finalGraph, initializerGraph, initializerOrdMap);
   }
 
@@ -567,7 +567,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     HnswGraphBuilder initializerBuilder =
         HnswGraphBuilder.create(initialScorerProvider, 10, 30, seed);
 
-    OnHeapHnswGraph initializerGraph = initializerBuilder.build(initializerVectors.copy());
+    OnHeapHnswGraph initializerGraph = initializerBuilder.build(initializerVectors.size());
     AbstractMockVectorValues<T> finalVectorValues =
         vectorValues(totalSize, dim, initializerVectors.copy(), docIdOffset);
     Map<Integer, Integer> initializerOrdMap =
@@ -582,7 +582,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
     // Confirm that the graph is appropriately constructed by checking that the nodes in the old
     // graph are present in the levels of the new graph
-    OnHeapHnswGraph finalGraph = finalBuilder.build(finalVectorValues.copy());
+    OnHeapHnswGraph finalGraph = finalBuilder.build(finalVectorValues.size());
     assertGraphContainsGraph(finalGraph, initializerGraph, initializerOrdMap);
   }
 
@@ -676,7 +676,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     RandomAccessVectorValues<T> vectors = circularVectorValues(nDoc);
     RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectors);
     HnswGraphBuilder builder = HnswGraphBuilder.create(scorerProvider, 16, 100, random().nextInt());
-    OnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    OnHeapHnswGraph hnsw = builder.build(vectors.size());
 
     int topK = 50;
     int visitedLimit = topK + random().nextInt(5);
@@ -713,7 +713,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectors);
     HnswGraphBuilder builder =
         HnswGraphBuilder.create(scorerProvider, M, M * 2, random().nextLong());
-    OnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    OnHeapHnswGraph hnsw = builder.build(vectors.size());
     long estimated = RamUsageEstimator.sizeOfObject(hnsw);
     long actual = ramUsed(hnsw);
 
@@ -857,7 +857,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     int topK = 5;
     RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectors);
     HnswGraphBuilder builder = HnswGraphBuilder.create(scorerProvider, 10, 30, random().nextLong());
-    OnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    OnHeapHnswGraph hnsw = builder.build(vectors.size());
     Bits acceptOrds = random().nextBoolean() ? null : createRandomAcceptOrds(0, size);
 
     int totalMatches = 0;
@@ -905,7 +905,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     AbstractMockVectorValues<T> vectors = vectorValues(size, dim);
     RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectors);
     HnswGraphBuilder builder = HnswGraphBuilder.create(scorerProvider, 10, 30, random().nextLong());
-    OnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    OnHeapHnswGraph hnsw = builder.build(vectors.size());
     Bits acceptOrds = random().nextBoolean() ? null : createRandomAcceptOrds(0, size);
 
     List<T> queries = new ArrayList<>();

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -110,7 +110,8 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
   abstract T getTargetVector();
 
   @SuppressWarnings("unchecked")
-  protected RandomVectorScorerProvider buildScorerProvider(RandomAccessVectorValues<T> vectors) throws IOException {
+  protected RandomVectorScorerProvider buildScorerProvider(RandomAccessVectorValues<T> vectors)
+      throws IOException {
     return switch (getVectorEncoding()) {
       case BYTE -> RandomVectorScorerProvider.createBytes(
           (RandomAccessVectorValues<byte[]>) vectors, similarityFunction);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
@@ -130,9 +130,8 @@ public class TestHnswFloatVectorGraph extends HnswGraphTestCase<float[]> {
     int nDoc = 1000;
     similarityFunction = VectorSimilarityFunction.EUCLIDEAN;
     RandomAccessVectorValues<float[]> vectors = circularVectorValues(nDoc);
-    HnswGraphBuilder<float[]> builder =
-        HnswGraphBuilder.create(
-            vectors, getVectorEncoding(), similarityFunction, 16, 100, random().nextInt());
+    RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectors);
+    HnswGraphBuilder builder = HnswGraphBuilder.create(scorerProvider, 16, 100, random().nextInt());
     OnHeapHnswGraph hnsw = builder.build(vectors.copy());
 
     // Skip over half of the documents that are closest to the query vector
@@ -142,14 +141,7 @@ public class TestHnswFloatVectorGraph extends HnswGraphTestCase<float[]> {
     }
     KnnCollector nn =
         HnswGraphSearcher.search(
-            getTargetVector(),
-            10,
-            vectors.copy(),
-            getVectorEncoding(),
-            similarityFunction,
-            hnsw,
-            acceptOrds,
-            Integer.MAX_VALUE);
+            buildScorer(vectors, getTargetVector()), 10, hnsw, acceptOrds, Integer.MAX_VALUE);
 
     TopDocs nodes = nn.topDocs();
     assertEquals("Number of found results is not equal to [10].", 10, nodes.scoreDocs.length);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
@@ -130,8 +130,8 @@ public class TestHnswFloatVectorGraph extends HnswGraphTestCase<float[]> {
     int nDoc = 1000;
     similarityFunction = VectorSimilarityFunction.EUCLIDEAN;
     RandomAccessVectorValues<float[]> vectors = circularVectorValues(nDoc);
-    RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectors);
-    HnswGraphBuilder builder = HnswGraphBuilder.create(scorerProvider, 16, 100, random().nextInt());
+    RandomVectorScorerSupplier scorerSupplier = buildScorerSupplier(vectors);
+    HnswGraphBuilder builder = HnswGraphBuilder.create(scorerSupplier, 16, 100, random().nextInt());
     OnHeapHnswGraph hnsw = builder.build(vectors.size());
 
     // Skip over half of the documents that are closest to the query vector

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
@@ -132,7 +132,7 @@ public class TestHnswFloatVectorGraph extends HnswGraphTestCase<float[]> {
     RandomAccessVectorValues<float[]> vectors = circularVectorValues(nDoc);
     RandomVectorScorerProvider scorerProvider = buildScorerProvider(vectors);
     HnswGraphBuilder builder = HnswGraphBuilder.create(scorerProvider, 16, 100, random().nextInt());
-    OnHeapHnswGraph hnsw = builder.build(vectors.copy());
+    OnHeapHnswGraph hnsw = builder.build(vectors.size());
 
     // Skip over half of the documents that are closest to the query vector
     FixedBitSet acceptOrds = new FixedBitSet(nDoc);


### PR DESCRIPTION
This pull request (PR) involves the refactoring of the HNSW builder and searcher, aiming to create an abstraction for the random access and vector comparisons conducted during graph traversal.

The newly added RandomVectorScorer provides a means to directly compare ordinals, eliminating the need to expose the raw vector primitive type. This scorer takes charge of vector retrieval and comparison during the graph's construction and search processes.

The primary purpose of this abstraction is to enable the implementation of various strategies. For example, it opens the door to constructing the graph using the original float vectors while performing searches using their quantized int8 vector counterparts.