### PR TITLE
Fix CheckIndex to detect major corruption with old (not the latest) commit point

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -607,7 +607,7 @@ public final class CheckIndex implements Closeable {
     SegmentInfos lastCommit = null;
 
     for (String fileName : files) {
-      if (fileName.startsWith(IndexFileNames.SEGMENTS)) {
+      if (fileName.startsWith(IndexFileNames.SEGMENTS) && fileName.equals(SegmentInfos.OLD_SEGMENTS_GEN) == false) {
 
         boolean isLastCommit = fileName.equals(lastSegmentsFile);
 
@@ -637,7 +637,6 @@ public final class CheckIndex implements Closeable {
                     + "\" in directory";
           }
           msg(infoStream, message);
-
           result.missingSegments = true;
           if (infoStream != null) {
             t.printStackTrace(infoStream);
@@ -650,6 +649,17 @@ public final class CheckIndex implements Closeable {
           lastCommit = infos;
         }
       }
+    }
+
+    // we know there is a lastSegmentsFileName, so we must've attempted to load it in the above for loop.  if it failed to load,
+    // we threw the exception (fastFail == true) or we returned the failure (fastFail == false).  so if we get here, we should
+    // always have a valid lastCommit:
+    assert lastCommit != null;
+
+    if (lastCommit == null) {
+      msg(infoStream, "ERROR: could not read any segments file in directory");
+      result.missingSegments = true;
+      return result;
     }
 
     if (infoStream != null) {

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -611,14 +611,18 @@ public final class CheckIndex implements Closeable {
       return result;
     }
 
-    // https://github.com/apache/lucene/issues/7820: also attempt to open any older commit points (segments_N), which will catch certain
-    // corruption like missing _N.si files for segments not also referenced by the newest commit point (which was already loaded,
-    // successfully, above).  Note that we do not do a deeper check of segments referenced ONLY by these older commit points, because such
-    // corruption would not prevent a new IndexWriter from opening on the newest commit point.  but it is still corruption, e.g. a reader
-    // opened on those old commit points can hit corruption exceptions which we (still) will not detect here.  progress not perfection!
+    // https://github.com/apache/lucene/issues/7820: also attempt to open any older commit
+    // points (segments_N), which will catch certain corruption like missing _N.si files
+    // for segments not also referenced by the newest commit point (which was already
+    // loaded, successfully, above).  Note that we do not do a deeper check of segments
+    // referenced ONLY by these older commit points, because such corruption would not
+    // prevent a new IndexWriter from opening on the newest commit point.  but it is still
+    // corruption, e.g. a reader opened on those old commit points can hit corruption
+    // exceptions which we (still) will not detect here.  progress not perfection!
 
     for (String fileName : files) {
-      if (fileName.startsWith(IndexFileNames.SEGMENTS) && fileName.equals(lastSegmentsFile) == false) {
+      if (fileName.startsWith(IndexFileNames.SEGMENTS)
+          && fileName.equals(lastSegmentsFile) == false) {
         try {
           // Do not use SegmentInfos.read(Directory) since the spooky
           // retrying it does is not necessary here (we hold the write lock):
@@ -628,7 +632,11 @@ public final class CheckIndex implements Closeable {
           if (failFast) {
             throw IOUtils.rethrowAlways(t);
           }
-          msg(infoStream, "ERROR: could not read old (not latest) commit point segments file \"" + fileName + "\" in directory");
+          msg(
+              infoStream,
+              "ERROR: could not read old (not latest) commit point segments file \""
+                  + fileName
+                  + "\" in directory");
           result.missingSegments = true;
           if (infoStream != null) t.printStackTrace(infoStream);
           return result;
@@ -855,9 +863,9 @@ public final class CheckIndex implements Closeable {
       msg(
           infoStream,
           "ERROR: Next segment name counter "
-          + sis.counter
-          + " is not greater than max segment name "
-          + result.maxSegmentName);
+              + sis.counter
+              + " is not greater than max segment name "
+              + result.maxSegmentName);
     }
 
     if (result.clean) {

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -605,14 +605,14 @@ public final class CheckIndex implements Closeable {
     // exceptions which we (still) will not detect here.  progress not perfection!
 
     SegmentInfos lastCommit = null;
-    
+
     for (String fileName : files) {
       if (fileName.startsWith(IndexFileNames.SEGMENTS)) {
 
         boolean isLastCommit = fileName.equals(lastSegmentsFile);
 
         SegmentInfos infos;
-        
+
         try {
           // Do not use SegmentInfos.read(Directory) since the spooky
           // retrying it does is not necessary here (we hold the write lock):
@@ -626,12 +626,18 @@ public final class CheckIndex implements Closeable {
           String message;
 
           if (isLastCommit) {
-            message = "ERROR: could not read latest commit point from segments file \"" + fileName + "\" in directory";
+            message =
+                "ERROR: could not read latest commit point from segments file \""
+                    + fileName
+                    + "\" in directory";
           } else {
-            message = "ERROR: could not read old (not latest) commit point segments file \"" + fileName + "\" in directory";
+            message =
+                "ERROR: could not read old (not latest) commit point segments file \""
+                    + fileName
+                    + "\" in directory";
           }
           msg(infoStream, message);
-              
+
           result.missingSegments = true;
           if (infoStream != null) {
             t.printStackTrace(infoStream);

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -607,7 +607,8 @@ public final class CheckIndex implements Closeable {
     SegmentInfos lastCommit = null;
 
     for (String fileName : files) {
-      if (fileName.startsWith(IndexFileNames.SEGMENTS) && fileName.equals(SegmentInfos.OLD_SEGMENTS_GEN) == false) {
+      if (fileName.startsWith(IndexFileNames.SEGMENTS)
+          && fileName.equals(SegmentInfos.OLD_SEGMENTS_GEN) == false) {
 
         boolean isLastCommit = fileName.equals(lastSegmentsFile);
 
@@ -651,9 +652,9 @@ public final class CheckIndex implements Closeable {
       }
     }
 
-    // we know there is a lastSegmentsFileName, so we must've attempted to load it in the above for loop.  if it failed to load,
-    // we threw the exception (fastFail == true) or we returned the failure (fastFail == false).  so if we get here, we should
-    // always have a valid lastCommit:
+    // we know there is a lastSegmentsFileName, so we must've attempted to load it in the above for
+    // loop.  if it failed to load, we threw the exception (fastFail == true) or we returned the
+    // failure (fastFail == false).  so if we get here, we should // always have a valid lastCommit:
     assert lastCommit != null;
 
     if (lastCommit == null) {

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -838,7 +838,7 @@ public final class CheckIndex implements Closeable {
 
     if (0 == result.numBadSegments) {
       result.clean = true;
-    } else
+    } else {
       msg(
           infoStream,
           "WARNING: "
@@ -846,16 +846,18 @@ public final class CheckIndex implements Closeable {
               + " broken segments (containing "
               + result.totLoseDocCount
               + " documents) detected");
+    }
 
-    if (!(result.validCounter = (result.maxSegmentName < sis.counter))) {
+    result.validCounter = result.maxSegmentName < sis.counter;
+    if (result.validCounter == false) {
       result.clean = false;
       result.newSegments.counter = result.maxSegmentName + 1;
       msg(
           infoStream,
           "ERROR: Next segment name counter "
-              + sis.counter
-              + " is not greater than max segment name "
-              + result.maxSegmentName);
+          + sis.counter
+          + " is not greater than max segment name "
+          + result.maxSegmentName);
     }
 
     if (result.clean) {
@@ -946,7 +948,7 @@ public final class CheckIndex implements Closeable {
         msg(infoStream, "    diagnostics = " + diagnostics);
       }
 
-      if (!info.hasDeletions()) {
+      if (info.hasDeletions() == false) {
         msg(infoStream, "    no deletions");
         segInfoStat.hasDeletions = false;
       } else {
@@ -1238,7 +1240,7 @@ public final class CheckIndex implements Closeable {
         if (liveDocs != null) {
           // it's ok for it to be non-null here, as long as none are set right?
           for (int j = 0; j < liveDocs.length(); j++) {
-            if (!liveDocs.get(j)) {
+            if (liveDocs.get(j) == false) {
               throw new CheckIndexException(
                   "liveDocs mismatch: info says no deletions but doc " + j + " is deleted.");
             }
@@ -1475,7 +1477,7 @@ public final class CheckIndex implements Closeable {
                 + hasFreqs);
       }
 
-      if (!isVectors) {
+      if (isVectors == false) {
         final boolean expectedHasPositions =
             fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;
         if (hasPositions != expectedHasPositions) {
@@ -1835,7 +1837,7 @@ public final class CheckIndex implements Closeable {
                   // free-for-all before?
                   // but for offsets in the postings lists these checks are fine: they were always
                   // enforced by IndexWriter
-                  if (!isVectors) {
+                  if (isVectors == false) {
                     if (startOffset < 0) {
                       throw new CheckIndexException(
                           "term "
@@ -3685,7 +3687,7 @@ public final class CheckIndex implements Closeable {
 
               // Make sure FieldInfo thinks this field is vector'd:
               final FieldInfo fieldInfo = fieldInfos.fieldInfo(field);
-              if (!fieldInfo.hasVectors()) {
+              if (fieldInfo.hasVectors() == false) {
                 throw new CheckIndexException(
                     "docID="
                         + j
@@ -3721,7 +3723,7 @@ public final class CheckIndex implements Closeable {
                   postings = termsEnum.postings(postings, PostingsEnum.ALL);
                   assert postings != null;
 
-                  if (!postingsTermsEnum.seekExact(term)) {
+                  if (postingsTermsEnum.seekExact(term) == false) {
                     throw new CheckIndexException(
                         "vector term="
                             + term
@@ -3877,7 +3879,7 @@ public final class CheckIndex implements Closeable {
                                       + " but postings does not.");
                             }
                             BytesRef postingsPayload = postingsDocs.getPayload();
-                            if (!payload.equals(postingsPayload)) {
+                            if (payload.equals(postingsPayload) == false) {
                               throw new CheckIndexException(
                                   "vector term="
                                       + term
@@ -4036,9 +4038,10 @@ public final class CheckIndex implements Closeable {
       return 1;
     }
 
-    if (!assertsOn())
+    if (assertsOn() == false) {
       System.out.println(
           "\nNOTE: testing will be more thorough if you run java with '-ea:org.apache.lucene...', so assertions are enabled");
+    }
 
     System.out.println("\nOpening index @ " + opts.indexPath + "\n");
     Directory directory = null;

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -146,7 +146,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
    *
    * @see #setInfoStream
    */
-  private static PrintStream infoStream = null;
+  private static PrintStream infoStream;
 
   /** Id for this commit; only written starting with Lucene 5.0 */
   private byte[] id;

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -122,7 +122,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
   static final int VERSION_CURRENT = VERSION_86;
 
   /** Name of the generation reference file name */
-  private static final String OLD_SEGMENTS_GEN = "segments.gen";
+  static final String OLD_SEGMENTS_GEN = "segments.gen";
 
   /** Used to name new segments. */
   public long counter;

--- a/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
@@ -230,8 +230,10 @@ public class TestCheckIndex extends BaseTestCheckIndex {
       // NO
     }
 
+    @Override
     public void onInit(List<? extends IndexCommit> commits) {}
 
+    @Override
     public void onCommit(List<? extends IndexCommit> commits) {}
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
@@ -18,15 +18,12 @@ package org.apache.lucene.index;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.List;
 import org.apache.lucene.document.BinaryPoint;
 import org.apache.lucene.document.Document;
-import org.apache.lucene.tests.store.MockDirectoryWrapper;
-import java.util.List;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnFloatVectorField;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
@@ -38,6 +35,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.CannedTokenStream;
 import org.apache.lucene.tests.analysis.Token;
 import org.apache.lucene.tests.index.BaseTestCheckIndex;
+import org.apache.lucene.tests.store.MockDirectoryWrapper;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
@@ -223,47 +221,37 @@ public class TestCheckIndex extends BaseTestCheckIndex {
     return v;
   }
 
-  //import org.apache.lucene.analysis.standard.StandardAnalyzer;
-  //import org.apache.lucene.codecs.lucene410.Lucene410Codec;
-  //import org.apache.lucene.document.Document;
-  //import org.apache.lucene.document.Field.Store;
-  //import org.apache.lucene.document.IntField;
-  //import org.apache.lucene.index.CheckIndex;
-  //import org.apache.lucene.index.IndexWriter;
-  //import org.apache.lucene.index.IndexWriterConfig;
-  //import org.apache.lucene.index.NoMergePolicy;
-  //import org.apache.lucene.store.FSDirectory;
-  //import org.apache.lucene.util.Version;
-
   // Never deletes any commit points!  Do not use in production!!
   private static class DeleteNothingIndexDeletionPolicy extends IndexDeletionPolicy {
 
     public static final IndexDeletionPolicy INSTANCE = new DeleteNothingIndexDeletionPolicy();
-    
+
     private DeleteNothingIndexDeletionPolicy() {
       // NO
     }
-    public void onInit(List<? extends IndexCommit> commits) {
-    }
 
-    public void onCommit(List<? extends IndexCommit> commits) {
-    }
+    public void onInit(List<? extends IndexCommit> commits) {}
+
+    public void onCommit(List<? extends IndexCommit> commits) {}
   }
 
-  // https://github.com/apache/lucene/issues/7820 -- when the most recent commit point in the index is OK, but
-  // older commit points are broken, CheckIndex fails to detect and correct that, while opening an IndexWriter
-  // on the index will fail since IndexWriter loads all commit points on init
+  // https://github.com/apache/lucene/issues/7820 -- when the most recent commit point in
+  // the index is OK, but older commit points are broken, CheckIndex fails to detect and
+  // correct that, while opening an IndexWriter on the index will fail since IndexWriter
+  // loads all commit points on init
   public void testPriorBrokenCommitPoint() throws Exception {
 
     try (MockDirectoryWrapper dir = newMockDirectory()) {
 
-      // disable this normally useful test infra feature since this test intentionally leaves broken indices:
+      // disable this normally useful test infra feature since this test intentionally leaves broken
+      // indices:
       dir.setCheckIndexOnClose(false);
-      
-      IndexWriterConfig iwc = new IndexWriterConfig()
-        .setMergePolicy(NoMergePolicy.INSTANCE)
-        .setIndexDeletionPolicy(DeleteNothingIndexDeletionPolicy.INSTANCE);
-    
+
+      IndexWriterConfig iwc =
+          new IndexWriterConfig()
+              .setMergePolicy(NoMergePolicy.INSTANCE)
+              .setIndexDeletionPolicy(DeleteNothingIndexDeletionPolicy.INSTANCE);
+
       try (IndexWriter iw = new IndexWriter(dir, iwc)) {
 
         // create first segment, and commit point referencing only segment 0
@@ -272,7 +260,8 @@ public class TestCheckIndex extends BaseTestCheckIndex {
         iw.addDocument(doc);
         iw.commit();
 
-        // NOTE: we are (illegally) relying on precise file naming here -- if Codec or IW's behaviour changes, this may need fixing:
+        // NOTE: we are (illegally) relying on precise file naming here -- if Codec or IW's
+        // behaviour changes, this may need fixing:
         assertTrue(slowFileExists(dir, "_0.si"));
 
         // create second segment, and another commit point referencing only segment 1
@@ -280,7 +269,8 @@ public class TestCheckIndex extends BaseTestCheckIndex {
         iw.updateDocument(new Term("id", "a"), doc);
         iw.commit();
 
-        // NOTE: we are (illegally) relying on precise file naming here -- if Codec or IW's behaviour changes, this may need fixing:
+        // NOTE: we are (illegally) relying on precise file naming here -- if Codec or IW's
+        // behaviour changes, this may need fixing:
         assertTrue(slowFileExists(dir, "_0.si"));
         assertTrue(slowFileExists(dir, "_1.si"));
       }
@@ -290,7 +280,8 @@ public class TestCheckIndex extends BaseTestCheckIndex {
         assertTrue(checkIndexStatus.clean);
       }
 
-      // now corrupt segment 0, which is referenced by only the first commit point, by removing its .si file (_0.si)
+      // now corrupt segment 0, which is referenced by only the first commit point, by removing its
+      // .si file (_0.si)
       dir.deleteFile("_0.si");
 
       try (CheckIndex checkers = new CheckIndex(dir)) {


### PR DESCRIPTION
### Description

Relates #7820.

`CheckIndex` today only detects and exorcises corruption with the latest commit point, yet `IndexWriter` will be angry on init if there are older commit points and they have "on load" corruption (e.g. missing `_N.si` files).

This is badly inconsistent: if `IndexWriter` or `IndexReader` will hit an index corruption, `CheckIndex` should always be able to find it too.  And it is conceivable though exceptionally unlikely for an index to legitimately get into this broken state on power loss, OS/JVM crash, at just the right/wrong time during `IndexWriter.commit`.

This PR is just a first step: it fixes the detection bug in `CheckIndex`, adding a new test case carried over and iterated from [this nice test case](https://github.com/apache/lucene/issues/7009#issuecomment-1223544484) (thank you @buzztaiki!).  So `CheckIndex` will now catch this exotic form of corruption.

But it does not yet fix `-exorcise` to be able to correct such a situation.  That's trickier, especially for `_N.si` files missing since `CheckIndex -exorcise` even on the latest commit point cannot correct that error either.  Progress not perfection!
