### PR TITLE
Update outdated comment about maxPointsInLeafNode in BKD tree

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene86/Lucene86PointsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene86/Lucene86PointsWriter.java
@@ -111,7 +111,7 @@ public class Lucene86PointsWriter extends PointsWriter {
   }
 
   /**
-   * Uses the defaults values for {@code maxPointsInLeafNode} (1024) and {@code maxMBSortInHeap}
+   * Uses the defaults values for {@code maxPointsInLeafNode} (512) and {@code maxMBSortInHeap}
    * (16.0)
    */
   public Lucene86PointsWriter(SegmentWriteState writeState) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsWriter.java
@@ -105,7 +105,7 @@ public class Lucene90PointsWriter extends PointsWriter {
   }
 
   /**
-   * Uses the defaults values for {@code maxPointsInLeafNode} (1024) and {@code maxMBSortInHeap}
+   * Uses the defaults values for {@code maxPointsInLeafNode} (512) and {@code maxMBSortInHeap}
    * (16.0)
    */
   public Lucene90PointsWriter(SegmentWriteState writeState) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
@@ -352,7 +352,7 @@ public abstract class PointInSetQuery extends Query implements Accountable {
         if (cmpMin == 0 && cmpMax == 0) {
           // NOTE: we only hit this if we are on a cell whose min and max values are exactly equal
           // to our point,
-          // which can easily happen if many (> 1024) docs share this one value
+          // which can easily happen if many (> 512) docs share this one value
           return Relation.CELL_INSIDE_QUERY;
         } else {
           return Relation.CELL_CROSSES_QUERY;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
@@ -90,7 +90,7 @@ public class RandomCodec extends AssertingCodec {
   private final int perFieldSeed;
 
   // a little messy: randomize the default codec's parameters here.
-  // with the default values, we have e,g, 1024 points in leaf nodes,
+  // with the default values, we have e,g, 512 points in leaf nodes,
   // which is less effective for testing.
   // TODO: improve how we randomize this...
   private final int maxPointsInLeafNode;


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

Sice https://github.com/apache/lucene-solr/pull/1464 , the default for maxPointsPerLeafNode is changed from 1024 to 512,  some comments is outdated.
