### PR TITLE
LockVerifyServer does not need to reuse addresses nor set accept timeout

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/LockStressTest.java
+++ b/lucene/core/src/java/org/apache/lucene/store/LockStressTest.java
@@ -103,7 +103,6 @@ public class LockStressTest {
     System.out.println(
         "Connecting to server " + addr + " and registering as client " + myID + "...");
     try (Socket socket = new Socket()) {
-      socket.setReuseAddress(true);
       socket.connect(addr, 500);
       final OutputStream out = socket.getOutputStream();
       final InputStream in = socket.getInputStream();

--- a/lucene/core/src/java/org/apache/lucene/store/LockStressTest.java
+++ b/lucene/core/src/java/org/apache/lucene/store/LockStressTest.java
@@ -103,7 +103,7 @@ public class LockStressTest {
     System.out.println(
         "Connecting to server " + addr + " and registering as client " + myID + "...");
     try (Socket socket = new Socket()) {
-      socket.connect(addr, 500);
+      socket.connect(addr, 3000); // wait at most 3 seconds to successfully connect, else fail
       final OutputStream out = socket.getOutputStream();
       final InputStream in = socket.getInputStream();
 

--- a/lucene/core/src/java/org/apache/lucene/store/LockVerifyServer.java
+++ b/lucene/core/src/java/org/apache/lucene/store/LockVerifyServer.java
@@ -43,8 +43,6 @@ public class LockVerifyServer {
   static void run(String hostname, int maxClients, Consumer<InetSocketAddress> startClients)
       throws Exception {
     try (final ServerSocket s = new ServerSocket()) {
-      s.setReuseAddress(true);
-      s.setSoTimeout(30000); // initially 30 secs to give clients enough time to startup
       s.bind(new InetSocketAddress(hostname, 0));
       final InetSocketAddress localAddr = (InetSocketAddress) s.getLocalSocketAddress();
       System.out.println("Listening on " + localAddr + "...");

--- a/lucene/core/src/java/org/apache/lucene/store/LockVerifyServer.java
+++ b/lucene/core/src/java/org/apache/lucene/store/LockVerifyServer.java
@@ -43,6 +43,7 @@ public class LockVerifyServer {
   static void run(String hostname, int maxClients, Consumer<InetSocketAddress> startClients)
       throws Exception {
     try (final ServerSocket s = new ServerSocket()) {
+      s.setSoTimeout(30000); // give clients at most 30 secs to connect and send bytes
       s.bind(new InetSocketAddress(hostname, 0));
       final InetSocketAddress localAddr = (InetSocketAddress) s.getLocalSocketAddress();
       System.out.println("Listening on " + localAddr + "...");


### PR DESCRIPTION
Spinoff from [this shocking build failure](https://lists.apache.org/thread/t79ctdmql0j7v4s8gd9ovk6z7lzrl0w9).

The OS will pick a free socket address to bind to since we pass `0`, and we tell the clients to use the assigned port already, so we don't need to ask the OS to reuse the local address.

Also remove the 30 second timeout: the test can wait for crazy slow clients to wake up and connect.

I confirmed I could still run the `LockVerifyServer` and two `LockStressTest` clients from the command-line, testing `NIOFSLockFactory`.  Fortunately, it passed.

Maybe we should move all this lock verifying stuff out of `core`?  I don't think this is a tool users often use?

