### PR TITLE
clarify QueryVisitor.acceptField javadoc w.r.t. not being term-specific

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/QueryVisitor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/QueryVisitor.java
@@ -59,7 +59,7 @@ public abstract class QueryVisitor {
   public void visitLeaf(Query query) {}
 
   /**
-   * Whether or not terms from this field are of interest to the visitor
+   * Whether or not this field is of interest to the visitor
    *
    * <p>Implement this to avoid collecting terms from heavy queries such as {@link TermInSetQuery}
    * that are not running on fields of interest


### PR DESCRIPTION
### Description

Adjusting javadocs as suggested by @romseygeek in https://github.com/apache/lucene/issues/12538#issuecomment-1706747711 issue comment.