### PR TITLE
Close index readers in tests

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestSort.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSort.java
@@ -849,11 +849,10 @@ public class TestSort extends LuceneTestCase {
   }
 
   public void testRewrite() throws IOException {
-    try (Directory dir = newDirectory()) {
-      RandomIndexWriter writer = new RandomIndexWriter(random(), dir);
-      IndexSearcher searcher = newSearcher(writer.getReader());
-      writer.close();
-
+    try (Directory dir = newDirectory();
+         RandomIndexWriter writer = new RandomIndexWriter(random(), dir);
+         DirectoryReader reader = writer.getReader()) {
+      IndexSearcher searcher = newSearcher(reader);
       LongValuesSource longSource = LongValuesSource.constant(1L);
       Sort sort = new Sort(longSource.getSortField(false));
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestSort.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSort.java
@@ -850,8 +850,8 @@ public class TestSort extends LuceneTestCase {
 
   public void testRewrite() throws IOException {
     try (Directory dir = newDirectory();
-         RandomIndexWriter writer = new RandomIndexWriter(random(), dir);
-         DirectoryReader reader = writer.getReader()) {
+        RandomIndexWriter writer = new RandomIndexWriter(random(), dir);
+        DirectoryReader reader = writer.getReader()) {
       IndexSearcher searcher = newSearcher(reader);
       LongValuesSource longSource = LongValuesSource.constant(1L);
       Sort sort = new Sort(longSource.getSortField(false));

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestForceNoBulkScoringQuery.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestForceNoBulkScoringQuery.java
@@ -60,18 +60,18 @@ public class TestForceNoBulkScoringQuery extends LuceneTestCase {
       iw.addDocument(doc);
       iw.commit();
 
-      IndexReader reader = DirectoryReader.open(dir);
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        PrefixQuery pq = new PrefixQuery(new Term("field", "term"));
+        ForceNoBulkScoringQuery q = new ForceNoBulkScoringQuery(pq);
 
-      PrefixQuery pq = new PrefixQuery(new Term("field", "term"));
-      ForceNoBulkScoringQuery q = new ForceNoBulkScoringQuery(pq);
+        assertEquals(q.getWrappedQuery(), pq);
 
-      assertEquals(q.getWrappedQuery(), pq);
+        Query rewritten = q.rewrite(newSearcher(reader));
+        assertTrue(rewritten instanceof ForceNoBulkScoringQuery);
 
-      Query rewritten = q.rewrite(newSearcher(reader));
-      assertTrue(rewritten instanceof ForceNoBulkScoringQuery);
-
-      Query inner = ((ForceNoBulkScoringQuery) rewritten).getWrappedQuery();
-      assertNotEquals(inner, pq);
+        Query inner = ((ForceNoBulkScoringQuery) rewritten).getWrappedQuery();
+        assertNotEquals(inner, pq);
+      }
     }
   }
 }

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestForceNoBulkScoringQuery.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestForceNoBulkScoringQuery.java
@@ -30,7 +30,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestForceNoBulkScoringQuery.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestForceNoBulkScoringQuery.java
@@ -52,7 +52,7 @@ public class TestForceNoBulkScoringQuery extends LuceneTestCase {
 
   public void testRewrite() throws IOException {
 
-    try (Directory dir = new ByteBuffersDirectory();
+    try (Directory dir = newDirectory();
         IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(new StandardAnalyzer()))) {
 
       Document doc = new Document();

--- a/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadSpans.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadSpans.java
@@ -72,8 +72,8 @@ public class TestPayloadSpans extends LuceneTestCase {
 
   @Override
   public void tearDown() throws Exception {
-    super.tearDown();
     helper.tearDown();
+    super.tearDown();
   }
 
   public void testSpanTermQuery() throws Exception {

--- a/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadSpans.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadSpans.java
@@ -60,13 +60,20 @@ public class TestPayloadSpans extends LuceneTestCase {
   protected IndexReader indexReader;
   private IndexReader closeIndexReader;
   private Directory directory;
+  private PayloadHelper helper;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    PayloadHelper helper = new PayloadHelper();
+    helper = new PayloadHelper();
     searcher = helper.setUp(random(), similarity, 1000);
     indexReader = searcher.getIndexReader();
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+    helper.tearDown();
   }
 
   public void testSpanTermQuery() throws Exception {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -92,6 +92,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -1877,7 +1879,13 @@ public abstract class LuceneTestCase extends Assert {
 
   /** Create a new searcher over the reader. This searcher might randomly use threads. */
   public static IndexSearcher newSearcher(IndexReader r) {
-    return newSearcher(r, true);
+    IndexSearcher indexSearcher = newSearcher(r, true);
+    if (r.getReaderCacheHelper() != null) {
+      ExecutorService executorService = Executors.newFixedThreadPool(1);
+      executorService.execute(() -> {});
+      r.getReaderCacheHelper().addClosedListener(key -> TestUtil.shutdownExecutorService(executorService));
+    }
+    return indexSearcher;
   }
 
   /** Create a new searcher over the reader. This searcher might randomly use threads. */

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -92,8 +92,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeSet;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -1879,13 +1877,7 @@ public abstract class LuceneTestCase extends Assert {
 
   /** Create a new searcher over the reader. This searcher might randomly use threads. */
   public static IndexSearcher newSearcher(IndexReader r) {
-    IndexSearcher indexSearcher = newSearcher(r, true);
-    if (r.getReaderCacheHelper() != null) {
-      ExecutorService executorService = Executors.newFixedThreadPool(1);
-      executorService.execute(() -> {});
-      r.getReaderCacheHelper().addClosedListener(key -> TestUtil.shutdownExecutorService(executorService));
-    }
-    return indexSearcher;
+    return newSearcher(r, true);
   }
 
   /** Create a new searcher over the reader. This searcher might randomly use threads. */


### PR DESCRIPTION
There are a few places where tests don't close index readers. This has not caused problems so far, but it becomes an issue when the reader gets an executor, because its shutdown happens as a closing listener of the reader. This has become more evident since we now offload sequential execution to the executor. If there's an executor, but it's never used, no threads are created, and no threads are leaked. If we do use the executor, and the reader is not closed, the test leaks threads.
