### PR TITLE
Fix minor (excess reallocation) performance bug when building FSTs

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
@@ -146,7 +146,7 @@ final class NodeHash<T> {
         table.set(pos, node);
         // Rehash at 2/3 occupancy:
         if (count > 2 * table.size() / 3) {
-          rehash();
+          rehash(node);
         }
         return node;
       } else if (nodesEqual(nodeIn, v)) {
@@ -174,12 +174,15 @@ final class NodeHash<T> {
     }
   }
 
-  private void rehash() throws IOException {
+  private void rehash(long lastNodeAddress) throws IOException {
     final PagedGrowableWriter oldTable = table;
 
     table =
         new PagedGrowableWriter(
-            2 * oldTable.size(), 1 << 30, PackedInts.bitsRequired(count), PackedInts.COMPACT);
+            2 * oldTable.size(),
+            1 << 27,
+            PackedInts.bitsRequired(lastNodeAddress),
+            PackedInts.COMPACT);
     mask = table.size() - 1;
     for (long idx = 0; idx < oldTable.size(); idx++) {
       final long address = oldTable.get(idx);


### PR DESCRIPTION
The bitsRequired passed during NodeHash rehash (when building an FST) was too small, causing excess/wasted reallocations.  This is just a performance bug, especially impacting larger FSTs, but likely a small overall impact even then.

I also reduced the page size during rehashing from 1 GB (1 << 30) back down to the initial 128 MB (1 << 27) created on init.

Relates #12542
