### PR TITLE
Introduce dynamic segment efSearch to Knn{Byte|Float}VectorQuery

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -104,7 +104,8 @@ abstract class AbstractKnnVectorQuery extends Query {
     if (ef == k) {
       return k;
     }
-    // We reduce the value of 'ef' proportionally based on the ratio of documents within the segment.
+    // We reduce the value of 'ef' proportionally based on the ratio of documents within the
+    // segment.
     int efSearch = (int) Math.round(Math.log((double) maxDoc / maxDocSegment));
     return Math.max(ef / efSearch, k);
   }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
@@ -56,7 +56,7 @@ public class KnnByteVectorQuery extends AbstractKnnVectorQuery {
    * @throws IllegalArgumentException if <code>k</code> is less than 1
    */
   public KnnByteVectorQuery(String field, byte[] target, int k) {
-    this(field, target, k, null);
+    this(field, target, k, k, null);
   }
 
   /**
@@ -70,15 +70,34 @@ public class KnnByteVectorQuery extends AbstractKnnVectorQuery {
    * @throws IllegalArgumentException if <code>k</code> is less than 1
    */
   public KnnByteVectorQuery(String field, byte[] target, int k, Query filter) {
-    super(field, k, filter);
+    this(field, target, k, k, filter);
+  }
+
+  /**
+   * Find the <code>k</code> nearest documents to the target vector according to the vectors in the
+   * given field. <code>target</code> vector.
+   *
+   * @param field a field that has been indexed as a {@link KnnFloatVectorField}.
+   * @param target the target of the search
+   * @param k the number of documents to find
+   * @param ef maximum size of the priority queue for the nearest neighbors. Higher ef leads to
+   *     enhanced precision at the expense of slower search speeds. This value is scaled between k
+   *     and ef on a per-segment basis based on the size of the segment. ef cannot be set lower than
+   *     the provided k.
+   * @param filter a filter applied before the vector search
+   * @throws IllegalArgumentException if <code>k</code> is less than 1
+   */
+  public KnnByteVectorQuery(String field, byte[] target, int k, int ef, Query filter) {
+    super(field, k, ef, filter);
     this.target = Objects.requireNonNull(target, "target");
   }
 
   @Override
-  protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
+  protected TopDocs approximateSearch(
+      LeafReaderContext context, Bits acceptDocs, int efSearch, int visitedLimit)
       throws IOException {
     TopDocs results =
-        context.reader().searchNearestVectors(field, target, k, acceptDocs, visitedLimit);
+        context.reader().searchNearestVectors(field, target, efSearch, acceptDocs, visitedLimit);
     return results != null ? results : NO_RESULTS;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
@@ -57,7 +57,7 @@ public class KnnFloatVectorQuery extends AbstractKnnVectorQuery {
    * @throws IllegalArgumentException if <code>k</code> is less than 1
    */
   public KnnFloatVectorQuery(String field, float[] target, int k) {
-    this(field, target, k, null);
+    this(field, target, k, k, null);
   }
 
   /**
@@ -71,15 +71,34 @@ public class KnnFloatVectorQuery extends AbstractKnnVectorQuery {
    * @throws IllegalArgumentException if <code>k</code> is less than 1
    */
   public KnnFloatVectorQuery(String field, float[] target, int k, Query filter) {
-    super(field, k, filter);
+    this(field, target, k, k, filter);
+  }
+
+  /**
+   * Find the <code>k</code> nearest documents to the target vector according to the vectors in the
+   * given field. <code>target</code> vector.
+   *
+   * @param field a field that has been indexed as a {@link KnnFloatVectorField}.
+   * @param target the target of the search
+   * @param k the number of documents to find
+   * @param ef maximum size of the priority queue for the nearest neighbors. Higher ef leads to
+   *     enhanced precision at the expense of slower search speeds. This value is scaled between k
+   *     and ef on a per-segment basis based on the size of the segment. ef cannot be set lower than
+   *     the provided k.
+   * @param filter a filter applied before the vector search
+   * @throws IllegalArgumentException if <code>k</code> is less than 1
+   */
+  public KnnFloatVectorQuery(String field, float[] target, int k, int ef, Query filter) {
+    super(field, k, ef, filter);
     this.target = VectorUtil.checkFinite(Objects.requireNonNull(target, "target"));
   }
 
   @Override
-  protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
+  protected TopDocs approximateSearch(
+      LeafReaderContext context, Bits acceptDocs, int efSearch, int visitedLimit)
       throws IOException {
     TopDocs results =
-        context.reader().searchNearestVectors(field, target, k, acceptDocs, visitedLimit);
+        context.reader().searchNearestVectors(field, target, efSearch, acceptDocs, visitedLimit);
     return results != null ? results : NO_RESULTS;
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnByteVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnByteVectorQuery.java
@@ -24,12 +24,22 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.TestVectorUtil;
 
 public class TestKnnByteVectorQuery extends BaseKnnVectorQueryTestCase {
   @Override
-  AbstractKnnVectorQuery getKnnVectorQuery(String field, float[] query, int k, Query queryFilter) {
-    return new KnnByteVectorQuery(field, floatToBytes(query), k, queryFilter);
+  AbstractKnnVectorQuery getKnnVectorQuery(
+      String field, float[] query, int k, int ef, Query queryFilter) {
+    return new KnnByteVectorQuery(field, floatToBytes(query), k, ef, queryFilter) {
+      @Override
+      protected TopDocs approximateSearch(
+          LeafReaderContext context, Bits acceptDocs, int efSearch, int visitedLimit)
+          throws IOException {
+        assertTrue(efSearch >= k);
+        return super.approximateSearch(context, acceptDocs, efSearch, visitedLimit);
+      }
+    };
   }
 
   @Override
@@ -73,7 +83,7 @@ public class TestKnnByteVectorQuery extends BaseKnnVectorQueryTestCase {
     try (Directory indexStore =
             getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
         IndexReader reader = DirectoryReader.open(indexStore)) {
-      AbstractKnnVectorQuery query = getKnnVectorQuery("field", new float[] {0, 1}, 10);
+      AbstractKnnVectorQuery query = new KnnByteVectorQuery("field", new byte[] {0, 1}, 10);
       assertEquals("KnnByteVectorQuery:field[0,...][10]", query.toString("ignored"));
 
       assertDocScoreQueryToString(query.rewrite(newSearcher(reader)));

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
@@ -123,14 +123,15 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
   }
 
   @Override
-  protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
+  protected TopDocs approximateSearch(
+      LeafReaderContext context, Bits acceptDocs, int efSearch, int visitedLimit)
       throws IOException {
     BitSet parentBitSet = parentsFilter.getBitSet(context);
     if (parentBitSet == null) {
       return NO_RESULTS;
     }
     KnnCollector collector =
-        new DiversifyingNearestChildrenKnnCollector(k, visitedLimit, parentBitSet);
+        new DiversifyingNearestChildrenKnnCollector(efSearch, visitedLimit, parentBitSet);
     context.reader().searchNearestVectors(field, query, collector, acceptDocs);
     return collector.topDocs();
   }

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
@@ -123,14 +123,15 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
   }
 
   @Override
-  protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
+  protected TopDocs approximateSearch(
+      LeafReaderContext context, Bits acceptDocs, int efSearch, int visitedLimit)
       throws IOException {
     BitSet parentBitSet = parentsFilter.getBitSet(context);
     if (parentBitSet == null) {
       return NO_RESULTS;
     }
     KnnCollector collector =
-        new DiversifyingNearestChildrenKnnCollector(k, visitedLimit, parentBitSet);
+        new DiversifyingNearestChildrenKnnCollector(efSearch, visitedLimit, parentBitSet);
     context.reader().searchNearestVectors(field, query, collector, acceptDocs);
     return collector.topDocs();
   }


### PR DESCRIPTION
This PR introduces a new parameter known as 'efSearch' to the knn vector query. 'efSearch' governs the maximum size of the priority queue employed for nearest neighbor searches. As each segment may contain a varying number of elements, 'efSearch' is dynamically adjusted on a per-segment basis, taking into account the segment's size.

This addition is valuable for improving the precision of a knn query while accommodating variations in segment sizes within a single search. For instance, if an index comprises 2 segments, with one holding 90% of the total documents and the other 10%, setting 'efSearch' to 100 and 'k' to 10 will result in a priority queue size of 90 for the first segment and 10 for the other.

I have initiated this PR to solicit feedback on the heuristic used to determine the 'ef' size for each segment. Meanwhile, I will be conducting tests to assess the recall and performance differences between single segments and multiple segments using different 'k' and 'efSearch' values.