### PR TITLE
Allow FilteredDocIdSetIterator.match(doc) to throw IOException

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -130,6 +130,8 @@ Other
 API Changes
 ---------------------
 
+* GITHUB#12554: Allow FilteredDocIdSetIterator.match(doc) to throw IOException (Gokul Manoj)
+
 * GITHUB#11248: IntBlockPool's SliceReader, SliceWriter, and all int slice functionality are moved out to MemoryIndex.
   (Stefan Vodita)
 

--- a/lucene/core/src/java/org/apache/lucene/search/FilteredDocIdSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FilteredDocIdSetIterator.java
@@ -51,7 +51,7 @@ public abstract class FilteredDocIdSetIterator extends DocIdSetIterator {
    * @return true if input docid should be in the result set, false otherwise.
    * @see #FilteredDocIdSetIterator(DocIdSetIterator)
    */
-  protected abstract boolean match(int doc);
+  protected abstract boolean match(int doc) throws IOException;
 
   @Override
   public int docID() {


### PR DESCRIPTION
### Description

Allows `org.apache.lucene.search.FilteredDocIdSetIterator#match(doc)` to throw an IOException so that users don't have to explicitly catch it

Closes #12492 