### PR TITLE
Choose sparse values in IntTaxonomyFacets when FacetsCollector has em…

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/IntTaxonomyFacets.java
@@ -159,7 +159,7 @@ abstract class IntTaxonomyFacets extends TaxonomyFacets {
     }
 
     // if our result set is < 10% of the index, we collect sparsely (use hash map):
-    return sumTotalHits < maxDoc / 10;
+    return maxDoc == 0 || sumTotalHits < maxDoc / 10;
   }
 
   @Override


### PR DESCRIPTION
This PR is to address the bug when TaxonomyFacets chooses dense values array if FacetsCollector has no MatchingDocs. The issue is described in more detail in described in [#12558](https://github.com/apache/lucene/issues/12558).