### PR TITLE
Defer #advanceExact on expression dependencies until their values are needed

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -190,6 +190,9 @@ Optimizations
 
 * GITHUB#12490: Faster computation of top-k hits on boolean queries. (Adrien Grand)
 
+* GITHUB#xxx: ExpressionValueSource defers #advanceExact on dependencies until their values are needed, avoiding
+  unnecessary advancing on values that are never evaluated (e.g., because of ternary expressions). (Greg Miller)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -190,7 +190,7 @@ Optimizations
 
 * GITHUB#12490: Faster computation of top-k hits on boolean queries. (Adrien Grand)
 
-* GITHUB#xxx: ExpressionValueSource defers #advanceExact on dependencies until their values are needed, avoiding
+* GITHUB#12560: ExpressionValueSource defers #advanceExact on dependencies until their values are needed, avoiding
   unnecessary advancing on values that are never evaluated (e.g., because of ternary expressions). (Greg Miller)
 
 Changes in runtime behavior

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionFunctionValues.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionFunctionValues.java
@@ -39,9 +39,12 @@ class ExpressionFunctionValues extends DoubleValues {
   }
 
   @Override
-  public boolean advanceExact(int doc) {
+  public boolean advanceExact(int doc) throws IOException {
     if (currentDoc == doc) {
       return true;
+    }
+    for (DoubleValues v : functionValues) {
+      v.advanceExact(doc);
     }
     currentDoc = doc;
     computed = false;
@@ -49,11 +52,8 @@ class ExpressionFunctionValues extends DoubleValues {
   }
 
   @Override
-  public double doubleValue() throws IOException {
+  public double doubleValue() {
     if (computed == false) {
-      for (DoubleValues v : functionValues) {
-        v.advanceExact(currentDoc);
-      }
       currentValue = expression.evaluate(functionValues);
       computed = true;
     }

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionFunctionValues.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionFunctionValues.java
@@ -39,12 +39,9 @@ class ExpressionFunctionValues extends DoubleValues {
   }
 
   @Override
-  public boolean advanceExact(int doc) throws IOException {
+  public boolean advanceExact(int doc) {
     if (currentDoc == doc) {
       return true;
-    }
-    for (DoubleValues v : functionValues) {
-      v.advanceExact(doc);
     }
     currentDoc = doc;
     computed = false;
@@ -52,8 +49,11 @@ class ExpressionFunctionValues extends DoubleValues {
   }
 
   @Override
-  public double doubleValue() {
+  public double doubleValue() throws IOException {
     if (computed == false) {
+      for (DoubleValues v : functionValues) {
+        v.advanceExact(currentDoc);
+      }
       currentValue = expression.evaluate(functionValues);
       computed = true;
     }

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionValueSource.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionValueSource.java
@@ -90,16 +90,24 @@ class ExpressionValueSource extends DoubleValuesSource {
   static DoubleValues zeroWhenUnpositioned(DoubleValues in) {
     return new DoubleValues() {
 
-      boolean positioned = false;
+      int currentDoc = -1;
+      double value;
+      boolean computed = false;
 
       @Override
       public double doubleValue() throws IOException {
-        return positioned ? in.doubleValue() : 0;
+        if (computed == false) {
+          value = in.advanceExact(currentDoc) ? in.doubleValue() : 0;
+          computed = true;
+        }
+        return value;
       }
 
       @Override
-      public boolean advanceExact(int doc) throws IOException {
-        return positioned = in.advanceExact(doc);
+      public boolean advanceExact(int doc) {
+        currentDoc = doc;
+        computed = false;
+        return true;
       }
     };
   }

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionValueSource.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionValueSource.java
@@ -105,6 +105,9 @@ class ExpressionValueSource extends DoubleValuesSource {
 
       @Override
       public boolean advanceExact(int doc) {
+        // This implementation wraps all expression arguments, so we lazily advance it in case the
+        // value is never needed by the expression for a given doc (e.g., ternary branch or
+        // condition short-circuit):
         currentDoc = doc;
         computed = false;
         return true;

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionValueSource.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionValueSource.java
@@ -108,6 +108,9 @@ class ExpressionValueSource extends DoubleValuesSource {
         // This implementation wraps all expression arguments, so we lazily advance it in case the
         // value is never needed by the expression for a given doc (e.g., ternary branch or
         // condition short-circuit):
+        if (currentDoc == doc) {
+          return true;
+        }
         currentDoc = doc;
         computed = false;
         return true;

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/TestExpressionValueSource.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/TestExpressionValueSource.java
@@ -156,14 +156,21 @@ public class TestExpressionValueSource extends LuceneTestCase {
     bindings.add("f1", DoubleValuesSource.constant(42));
     bindings.add("f2", new NoAdvanceDoubleValuesSource());
 
-    // f2 should never be evaluated
+    // f2 should never be evaluated:
     Expression expression = JavascriptCompiler.compile("f0 == 1 ? f1 : f2");
     DoubleValuesSource dvs = expression.getDoubleValuesSource(bindings);
     DoubleValues dv = dvs.getValues(reader.leaves().get(0), null);
-
     dv.advanceExact(0);
     double value = dv.doubleValue();
+    assertEquals(42, value, 0);
 
+    // one more example to show that we will also correctly short-circuit a condition (f2 should
+    // not be advanced or evaluated):
+    expression = JavascriptCompiler.compile("(1 == 1 || f2) ? f1 : 0");
+    dvs = expression.getDoubleValuesSource(bindings);
+    dv = dvs.getValues(reader.leaves().get(0), null);
+    dv.advanceExact(0);
+    value = dv.doubleValue();
     assertEquals(42, value, 0);
   }
 

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/TestExpressionValueSource.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/TestExpressionValueSource.java
@@ -150,6 +150,23 @@ public class TestExpressionValueSource extends LuceneTestCase {
     assertEquals(fib(n), (int) values.doubleValue());
   }
 
+  public void testLazyDependencies() throws Exception {
+    SimpleBindings bindings = new SimpleBindings();
+    bindings.add("f0", DoubleValuesSource.constant(1));
+    bindings.add("f1", DoubleValuesSource.constant(42));
+    bindings.add("f2", new NoAdvanceDoubleValuesSource());
+
+    // f2 should never be evaluated
+    Expression expression = JavascriptCompiler.compile("f0 == 1 ? f1 : f2");
+    DoubleValuesSource dvs = expression.getDoubleValuesSource(bindings);
+    DoubleValues dv = dvs.getValues(reader.leaves().get(0), null);
+
+    dv.advanceExact(0);
+    double value = dv.doubleValue();
+
+    assertEquals(42, value, 0);
+  }
+
   private int fib(int n) {
     if (n == 0) {
       return 0;
@@ -214,5 +231,52 @@ public class TestExpressionValueSource extends LuceneTestCase {
         return false;
       }
     };
+  }
+
+  private static class NoAdvanceDoubleValuesSource extends DoubleValuesSource {
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      return new DoubleValues() {
+        @Override
+        public double doubleValue() throws IOException {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+          throw new UnsupportedOperationException();
+        }
+      };
+    }
+
+    @Override
+    public boolean needsScores() {
+      return false;
+    }
+
+    @Override
+    public DoubleValuesSource rewrite(IndexSearcher reader) throws IOException {
+      return this;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return null;
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
### Description

This extends the idea in GH#11878 to avoid advancing dependencies that are  never referenced because of expression branching (i.e., ternary expressions). I think we should be able to be a little more optimal in terms of not unnecessarily advancing dependent double values.