### PR TITLE
Fix issues with BP tests and the security manager.

### DIFF
--- a/lucene/misc/src/java/org/apache/lucene/misc/index/BPIndexReorderer.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/index/BPIndexReorderer.java
@@ -74,7 +74,9 @@ import org.apache.lucene.util.OfflineSorter.BufferSize;
  *
  * Directory targetDir = FSDirectory.open(targetPath);
  * BPIndexReorderer reorderer = new BPIndexReorderer();
- * reorderer.setForkJoinPool(ForkJoinPool.commonPool());
+ * ForkJoinPool pool = new ForkJoinPool(Runtime.getRuntime().availableProcessors(),
+ *     p -> new ForkJoinWorkerThread(p) {}, null, random().nextBoolean());
+ * reorderer.setForkJoinPool(pool);
  * reorderer.setFields(Collections.singleton("body"));
  * CodecReader reorderedReaderView = reorderer.reorder(SlowCodecReaderWrapper.wrap(reader), targetDir);
  * try (IndexWriter w = new IndexWriter(targetDir, new IndexWriterConfig().setOpenMode(OpenMode.CREATE))) {


### PR DESCRIPTION
The default ForkJoinPool implementation uses a thread factory that removes all permissions on threads, so we need to create our own to avoid tests failing with FS-based directories.
