### PR TITLE
Use radix sort to speed up the sorting of deleted terms

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -143,7 +143,8 @@ Improvements
 
 Optimizations
 ---------------------
-(No changes)
+
+* GITHUB#12573: Speed up sort on deleted terms. (Guo Feng)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -144,7 +144,7 @@ Improvements
 Optimizations
 ---------------------
 
-* GITHUB#12573: Speed up sort on deleted terms. (Guo Feng)
+* GITHUB#12573: Use radix sort to speed up the sorting of deleted terms. (Guo Feng)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -148,7 +148,6 @@ Improvements
 
 Optimizations
 ---------------------
-
 * GITHUB#12183: Make TermStates#build concurrent. (Shubham Chaudhary)
 
 * GITHUB#12573: Use radix sort to speed up the sorting of deleted terms. (Guo Feng)

--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
@@ -281,7 +281,7 @@ class BufferedUpdates implements Accountable {
         }
       }
       long end = System.currentTimeMillis();
-      System.out.println("sort took:" + (end - start));
+      System.out.println("sort took:" + (end - start) + ", deleted terms: " + size());
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
@@ -264,7 +264,6 @@ class BufferedUpdates implements Accountable {
      * @see BytesRefHash#sort
      */
     <E extends Exception> void forEachOrdered(DeletedTermConsumer<E> consumer) throws E {
-      long start = System.currentTimeMillis();
       List<Map.Entry<String, BytesRefIntMap>> deleteFields =
           new ArrayList<>(deleteTerms.entrySet());
       deleteFields.sort(Map.Entry.comparingByKey());
@@ -280,8 +279,6 @@ class BufferedUpdates implements Accountable {
           }
         }
       }
-      long end = System.currentTimeMillis();
-      System.out.println("sort took:" + (end - start) + ", deleted terms: " + size());
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
@@ -16,13 +16,22 @@
  */
 package org.apache.lucene.index;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.apache.lucene.index.DocValuesUpdate.BinaryDocValuesUpdate;
 import org.apache.lucene.index.DocValuesUpdate.NumericDocValuesUpdate;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.ByteBlockPool;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefHash;
 import org.apache.lucene.util.Counter;
 import org.apache.lucene.util.RamUsageEstimator;
 
@@ -40,21 +49,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 class BufferedUpdates implements Accountable {
 
   /* Rough logic: HashMap has an array[Entry] w/ varying
-  load factor (say 2 * POINTER).  Entry is object w/ Term
-  key, Integer val, int hash, Entry next
-  (OBJ_HEADER + 3*POINTER + INT).  Term is object w/
-  String field and String text (OBJ_HEADER + 2*POINTER).
-  Term's field is String (OBJ_HEADER + 4*INT + POINTER +
-  OBJ_HEADER + string.length*CHAR).
-  Term's text is String (OBJ_HEADER + 4*INT + POINTER +
-  OBJ_HEADER + string.length*CHAR).  Integer is
-  OBJ_HEADER + INT. */
-  static final int BYTES_PER_DEL_TERM =
-      9 * RamUsageEstimator.NUM_BYTES_OBJECT_REF
-          + 7 * RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
-          + 10 * Integer.BYTES;
-
-  /* Rough logic: HashMap has an array[Entry] w/ varying
   load factor (say 2 * POINTER).  Entry is object w/
   Query key, Integer val, int hash, Entry next
   (OBJ_HEADER + 3*POINTER + INT).  Query we often
@@ -67,8 +61,7 @@ class BufferedUpdates implements Accountable {
   final AtomicInteger numTermDeletes = new AtomicInteger();
   final AtomicInteger numFieldUpdates = new AtomicInteger();
 
-  final Map<Term, Integer> deleteTerms =
-      new HashMap<>(); // TODO cut this over to FieldUpdatesBuffer
+  final DeletedTerms deleteTerms = new DeletedTerms();
   final Map<Query, Integer> deleteQueries = new HashMap<>();
 
   final Map<String, FieldUpdatesBuffer> fieldUpdates = new HashMap<>();
@@ -77,7 +70,6 @@ class BufferedUpdates implements Accountable {
 
   private final Counter bytesUsed = Counter.newCounter(true);
   final Counter fieldUpdatesBytesUsed = Counter.newCounter(true);
-  private final Counter termsBytesUsed = Counter.newCounter(true);
 
   private static final boolean VERBOSE_DELETES = false;
 
@@ -127,8 +119,8 @@ class BufferedUpdates implements Accountable {
   }
 
   public void addTerm(Term term, int docIDUpto) {
-    Integer current = deleteTerms.get(term);
-    if (current != null && docIDUpto < current) {
+    int current = deleteTerms.get(term);
+    if (current != -1 && docIDUpto < current) {
       // Only record the new number if it's greater than the
       // current one.  This is important because if multiple
       // threads are replacing the same doc at nearly the
@@ -139,15 +131,11 @@ class BufferedUpdates implements Accountable {
       return;
     }
 
-    deleteTerms.put(term, Integer.valueOf(docIDUpto));
-    // note that if current != null then it means there's already a buffered
+    deleteTerms.put(term, docIDUpto);
+    // note that if current != -1 then it means there's already a buffered
     // delete on that term, therefore we seem to over-count. this over-counting
     // is done to respect IndexWriterConfig.setMaxBufferedDeleteTerms.
     numTermDeletes.incrementAndGet();
-    if (current == null) {
-      termsBytesUsed.addAndGet(
-          BYTES_PER_DEL_TERM + term.bytes.length + (Character.BYTES * term.field().length()));
-    }
   }
 
   void addNumericUpdate(NumericDocValuesUpdate update, int docIDUpto) {
@@ -176,7 +164,6 @@ class BufferedUpdates implements Accountable {
 
   void clearDeleteTerms() {
     numTermDeletes.set(0);
-    termsBytesUsed.addAndGet(-termsBytesUsed.get());
     deleteTerms.clear();
   }
 
@@ -188,7 +175,6 @@ class BufferedUpdates implements Accountable {
     fieldUpdates.clear();
     bytesUsed.addAndGet(-bytesUsed.get());
     fieldUpdatesBytesUsed.addAndGet(-fieldUpdatesBytesUsed.get());
-    termsBytesUsed.addAndGet(-termsBytesUsed.get());
   }
 
   boolean any() {
@@ -197,6 +183,160 @@ class BufferedUpdates implements Accountable {
 
   @Override
   public long ramBytesUsed() {
-    return bytesUsed.get() + fieldUpdatesBytesUsed.get() + termsBytesUsed.get();
+    return bytesUsed.get() + fieldUpdatesBytesUsed.get() + deleteTerms.ramBytesUsed();
+  }
+
+  static class DeletedTerms implements Accountable {
+
+    private final Counter bytesUsed = Counter.newCounter();
+    private final Map<String, BytesRefIntMap> deleteTerms = new HashMap<>();
+    private int termsSize;
+
+    DeletedTerms() {
+      this.termsSize = 0;
+    }
+
+    /**
+     * Get the newest doc id of the deleted term.
+     *
+     * @param term The deleted term.
+     * @return The newest doc id of this deleted term.
+     */
+    int get(Term term) {
+      BytesRefIntMap hash = deleteTerms.get(term.field);
+      if (hash == null) {
+        return -1;
+      }
+      return hash.get(term.bytes);
+    }
+
+    /**
+     * Put the newest doc id of the deleted term.
+     *
+     * @param term The deleted term.
+     * @param value The newest doc id of the deleted term.
+     */
+    void put(Term term, int value) {
+      BytesRefIntMap hash =
+          deleteTerms.computeIfAbsent(
+              term.field,
+              k -> {
+                bytesUsed.addAndGet(RamUsageEstimator.sizeOf(term.field));
+                return new BytesRefIntMap(bytesUsed);
+              });
+      int v = hash.put(term.bytes, value);
+      if (v == -1) {
+        termsSize++;
+      }
+    }
+
+    void clear() {
+      bytesUsed.addAndGet(-bytesUsed.get());
+      deleteTerms.clear();
+      termsSize = 0;
+    }
+
+    int size() {
+      return termsSize;
+    }
+
+    boolean isEmpty() {
+      return termsSize == 0;
+    }
+
+    /** Just for test, not efficient. */
+    Set<Term> keySet() {
+      return deleteTerms.entrySet().stream()
+          .flatMap(
+              entry -> entry.getValue().keySet().stream().map(b -> new Term(entry.getKey(), b)))
+          .collect(Collectors.toSet());
+    }
+
+    interface DeletedTermConsumer<E extends Exception> {
+      void accept(Term term, int docId) throws E;
+    }
+
+    /**
+     * Consume all terms in a sorted order.
+     *
+     * <p>Note: This is a destructive operation as it calls {@link BytesRefHash#sort()}.
+     *
+     * @see BytesRefHash#sort
+     */
+    <E extends Exception> void forEachSorted(DeletedTermConsumer<E> consumer) throws E {
+      List<Map.Entry<String, BytesRefIntMap>> deleteFields =
+          new ArrayList<>(deleteTerms.entrySet());
+      deleteFields.sort(Map.Entry.comparingByKey());
+      Term scratch = new Term("", new BytesRef());
+      for (Map.Entry<String, BufferedUpdates.BytesRefIntMap> deleteFieldEntry : deleteFields) {
+        scratch.field = deleteFieldEntry.getKey();
+        BufferedUpdates.BytesRefIntMap terms = deleteFieldEntry.getValue();
+        int[] indices = terms.bytesRefHash.sort();
+        for (int index : indices) {
+          if (index != -1) {
+            terms.bytesRefHash.get(index, scratch.bytes);
+            consumer.accept(scratch, terms.values[index]);
+          }
+        }
+      }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+      return bytesUsed.get();
+    }
+  }
+
+  private static class BytesRefIntMap {
+
+    private final Counter counter;
+    private final BytesRefHash bytesRefHash;
+    private int[] values;
+
+    private BytesRefIntMap(Counter counter) {
+      this.counter = counter;
+      this.bytesRefHash =
+          new BytesRefHash(
+              new ByteBlockPool(new ByteBlockPool.DirectTrackingAllocator(counter)),
+              BytesRefHash.DEFAULT_CAPACITY,
+              new BytesRefHash.DirectBytesStartArray(BytesRefHash.DEFAULT_CAPACITY, counter));
+      this.values = new int[BytesRefHash.DEFAULT_CAPACITY];
+      counter.addAndGet(BytesRefHash.DEFAULT_CAPACITY * Integer.BYTES);
+    }
+
+    private Set<BytesRef> keySet() {
+      BytesRef scratch = new BytesRef();
+      Set<BytesRef> set = new HashSet<>();
+      for (int i = 0; i < bytesRefHash.size(); i++) {
+        bytesRefHash.get(i, scratch);
+        set.add(BytesRef.deepCopyOf(scratch));
+      }
+      return set;
+    }
+
+    private int put(BytesRef key, int value) {
+      assert value >= 0;
+      int e = bytesRefHash.add(key);
+      if (e < 0) {
+        values[-e - 1] = value;
+        return value;
+      } else {
+        if (e >= values.length) {
+          int originLength = values.length;
+          values = ArrayUtil.grow(values, e + 1);
+          counter.addAndGet((long) (values.length - originLength) * Integer.BYTES);
+        }
+        values[e] = value;
+        return -1;
+      }
+    }
+
+    private int get(BytesRef key) {
+      int e = bytesRefHash.find(key);
+      if (e == -1) {
+        return -1;
+      }
+      return values[e];
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
@@ -263,7 +263,8 @@ class BufferedUpdates implements Accountable {
      *
      * @see BytesRefHash#sort
      */
-    <E extends Exception> void forEachSorted(DeletedTermConsumer<E> consumer) throws E {
+    <E extends Exception> void forEachOrdered(DeletedTermConsumer<E> consumer) throws E {
+      long start = System.currentTimeMillis();
       List<Map.Entry<String, BytesRefIntMap>> deleteFields =
           new ArrayList<>(deleteTerms.entrySet());
       deleteFields.sort(Map.Entry.comparingByKey());
@@ -279,6 +280,8 @@ class BufferedUpdates implements Accountable {
           }
         }
       }
+      long end = System.currentTimeMillis();
+      System.out.println("sort took:" + (end - start));
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
@@ -17,7 +17,10 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.search.DocIdSetIterator;

--- a/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
@@ -17,10 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -55,29 +52,29 @@ final class FreqProxTermsWriter extends TermsHash {
     // Process any pending Term deletes for this newly
     // flushed segment:
     if (state.segUpdates != null && state.segUpdates.deleteTerms.size() > 0) {
-      Map<Term, Integer> segDeletes = state.segUpdates.deleteTerms;
-      List<Term> deleteTerms = new ArrayList<>(segDeletes.keySet());
-      Collections.sort(deleteTerms);
+
+      BufferedUpdates.DeletedTerms segDeletes = state.segUpdates.deleteTerms;
       FrozenBufferedUpdates.TermDocsIterator iterator =
           new FrozenBufferedUpdates.TermDocsIterator(fields, true);
-      for (Term deleteTerm : deleteTerms) {
-        DocIdSetIterator postings = iterator.nextTerm(deleteTerm.field(), deleteTerm.bytes());
-        if (postings != null) {
-          int delDocLimit = segDeletes.get(deleteTerm);
-          assert delDocLimit < PostingsEnum.NO_MORE_DOCS;
-          int doc;
-          while ((doc = postings.nextDoc()) < delDocLimit) {
-            if (state.liveDocs == null) {
-              state.liveDocs = new FixedBitSet(state.segmentInfo.maxDoc());
-              state.liveDocs.set(0, state.segmentInfo.maxDoc());
+
+      segDeletes.forEachSorted(
+          (term, docId) -> {
+            DocIdSetIterator postings = iterator.nextTerm(term.field(), term.bytes());
+            if (postings != null) {
+              assert docId < PostingsEnum.NO_MORE_DOCS;
+              int doc;
+              while ((doc = postings.nextDoc()) < docId) {
+                if (state.liveDocs == null) {
+                  state.liveDocs = new FixedBitSet(state.segmentInfo.maxDoc());
+                  state.liveDocs.set(0, state.segmentInfo.maxDoc());
+                }
+                if (state.liveDocs.get(doc)) {
+                  state.delCountOnFlush++;
+                  state.liveDocs.clear(doc);
+                }
+              }
             }
-            if (state.liveDocs.get(doc)) {
-              state.delCountOnFlush++;
-              state.liveDocs.clear(doc);
-            }
-          }
-        }
-      }
+          });
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
@@ -57,7 +57,7 @@ final class FreqProxTermsWriter extends TermsHash {
       FrozenBufferedUpdates.TermDocsIterator iterator =
           new FrozenBufferedUpdates.TermDocsIterator(fields, true);
 
-      segDeletes.forEachSorted(
+      segDeletes.forEachOrdered(
           (term, docId) -> {
             DocIdSetIterator postings = iterator.nextTerm(term.field(), term.bytes());
             if (postings != null) {

--- a/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.search.DocIdSetIterator;

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -87,7 +87,7 @@ final class FrozenBufferedUpdates {
         : "segment private packet should only have del queries";
 
     PrefixCodedTerms.Builder builder = new PrefixCodedTerms.Builder();
-    updates.deleteTerms.forEachSorted((term, doc) -> builder.add(term));
+    updates.deleteTerms.forEachOrdered((term, doc) -> builder.add(term));
     deleteTerms = builder.finish();
 
     deleteQueries = new Query[updates.deleteQueries.size()];

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -31,7 +31,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.InfoStream;
@@ -86,12 +85,9 @@ final class FrozenBufferedUpdates {
     this.privateSegment = privateSegment;
     assert privateSegment == null || updates.deleteTerms.isEmpty()
         : "segment private packet should only have del queries";
-    Term[] termsArray = updates.deleteTerms.keySet().toArray(new Term[updates.deleteTerms.size()]);
-    ArrayUtil.timSort(termsArray);
+
     PrefixCodedTerms.Builder builder = new PrefixCodedTerms.Builder();
-    for (Term term : termsArray) {
-      builder.add(term);
-    }
+    updates.deleteTerms.forEachSorted((term, doc) -> builder.add(term));
     deleteTerms = builder.finish();
 
     deleteQueries = new Query[updates.deleteQueries.size()];

--- a/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
@@ -16,14 +16,13 @@
  */
 package org.apache.lucene.index;
 
-import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.tests.util.LuceneTestCase;
-import org.apache.lucene.util.BytesRef;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.BytesRef;
 
 /** Unit test for {@link BufferedUpdates} */
 public class TestBufferedUpdates extends LuceneTestCase {

--- a/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
@@ -16,10 +16,14 @@
  */
 package org.apache.lucene.index;
 
-import java.util.*;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** Unit test for {@link BufferedUpdates} */
 public class TestBufferedUpdates extends LuceneTestCase {

--- a/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
@@ -16,8 +16,10 @@
  */
 package org.apache.lucene.index;
 
+import java.util.*;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.BytesRef;
 
 /** Unit test for {@link BufferedUpdates} */
 public class TestBufferedUpdates extends LuceneTestCase {
@@ -28,14 +30,14 @@ public class TestBufferedUpdates extends LuceneTestCase {
     assertFalse(bu.any());
     int queries = atLeast(1);
     for (int i = 0; i < queries; i++) {
-      final int docIDUpto = random().nextBoolean() ? Integer.MAX_VALUE : random().nextInt();
+      final int docIDUpto = random().nextBoolean() ? Integer.MAX_VALUE : random().nextInt(100000);
       final Term term = new Term("id", Integer.toString(random().nextInt(100)));
       bu.addQuery(new TermQuery(term), docIDUpto);
     }
 
     int terms = atLeast(1);
     for (int i = 0; i < terms; i++) {
-      final int docIDUpto = random().nextBoolean() ? Integer.MAX_VALUE : random().nextInt();
+      final int docIDUpto = random().nextBoolean() ? Integer.MAX_VALUE : random().nextInt(100000);
       final Term term = new Term("id", Integer.toString(random().nextInt(100)));
       bu.addTerm(term, docIDUpto);
     }
@@ -51,5 +53,45 @@ public class TestBufferedUpdates extends LuceneTestCase {
     bu.clear();
     assertFalse(bu.any());
     assertEquals(bu.ramBytesUsed(), 0L);
+  }
+
+  public void testDeletedTerms() {
+    int iters = atLeast(10);
+    String[] fields = new String[] {"a", "b", "c"};
+    for (int iter = 0; iter < iters; iter++) {
+
+      Map<Term, Integer> expected = new HashMap<>();
+      BufferedUpdates.DeletedTerms actual = new BufferedUpdates.DeletedTerms();
+      assertTrue(actual.isEmpty());
+
+      int termCount = atLeast(5000);
+      int maxBytesNum = random().nextInt(3) + 1;
+      for (int i = 0; i < termCount; i++) {
+        int byteNum = random().nextInt(maxBytesNum) + 1;
+        byte[] bytes = new byte[byteNum];
+        random().nextBytes(bytes);
+        Term term = new Term(fields[random().nextInt(fields.length)], new BytesRef(bytes));
+        int value = random().nextInt(10000000);
+        expected.put(term, value);
+        actual.put(term, value);
+      }
+
+      assertEquals(expected.size(), actual.size());
+
+      for (Map.Entry<Term, Integer> entry : expected.entrySet()) {
+        assertEquals(entry.getValue(), Integer.valueOf(actual.get(entry.getKey())));
+      }
+
+      List<Map.Entry<Term, Integer>> expectedSorted =
+          expected.entrySet().stream().sorted(Map.Entry.comparingByKey()).toList();
+      List<Map.Entry<Term, Integer>> actualSorted = new ArrayList<>();
+      actual.forEachSorted(
+          ((term, docId) -> {
+            Term copy = new Term(term.field, BytesRef.deepCopyOf(term.bytes));
+            actualSorted.add(Map.entry(copy, docId));
+          }));
+
+      assertEquals(expectedSorted, actualSorted);
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
@@ -85,7 +85,7 @@ public class TestBufferedUpdates extends LuceneTestCase {
       List<Map.Entry<Term, Integer>> expectedSorted =
           expected.entrySet().stream().sorted(Map.Entry.comparingByKey()).toList();
       List<Map.Entry<Term, Integer>> actualSorted = new ArrayList<>();
-      actual.forEachSorted(
+      actual.forEachOrdered(
           ((term, docId) -> {
             Term copy = new Term(term.field, BytesRef.deepCopyOf(term.bytes));
             actualSorted.add(Map.entry(copy, docId));

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterDeleteQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterDeleteQueue.java
@@ -84,8 +84,7 @@ public class TestDocumentsWriterDeleteQueue extends LuceneTestCase {
 
   private void assertAllBetween(int start, int end, BufferedUpdates deletes, Integer[] ids) {
     for (int i = start; i <= end; i++) {
-      assertEquals(
-          Integer.valueOf(end), deletes.deleteTerms.get(new Term("id", ids[i].toString())));
+      assertEquals(end, deletes.deleteTerms.get(new Term("id", ids[i].toString())));
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
@@ -1158,7 +1158,7 @@ public class TestIndexWriterDelete extends LuceneTestCase {
         new IndexWriter(
             dir,
             newIndexWriterConfig(new MockAnalyzer(random()))
-                .setRAMBufferSizeMB(0.1f)
+                .setRAMBufferSizeMB(0.5f)
                 .setMaxBufferedDocs(1000)
                 .setMergePolicy(NoMergePolicy.INSTANCE)
                 .setReaderPooling(false));


### PR DESCRIPTION
### Description

Recently, we captured a flame graph in a scene with frequent updates, which showed that sorting deleted terms occupied a high CPU ratio.

In scenarios with many deleted terms, most terms could have the same field name. So a data structure like `Map<String, Map<BytesRef, Integer>>` instead of `Map<Term, Integer>` could be better here —— We can avoid field name compare and use `MSBRadixSort` to sort the bytes for each field.

We can also take advantage of `BytesRefHash` to implement `Map<BytesRef, Integer>` to get a more efficient memory layout, and there's already a `MSBRadixSort` impl in `BytesRefHash` we can reuse.

### Benchmark

We benchmarked the sort logic for 1,000,000 terms, showing 66% took decreasing:

<!--StartFragment--><byte-sheet-html-origin data-id="1695273514525" data-version="4" data-is-embed="false" data-grid-line-hidden="false" data-importRangeRawData-spreadSource="https://bytedance.feishu.cn/sheets/LcVzsNpiphJeqjtIGi5c738Jnyh" data-importRangeRawData-range="&#39;Sheet1&#39;!A5:D6">

  | Baseline | Candidate | Took Diff
-- | -- | -- | --
total took | 692 | 234 | -66.18%

</byte-sheet-html-origin><!--EndFragment-->

An E2E benchmark that delete document with term 1,000,000 times showing took decreased 43% (with default iw config).

<!--StartFragment--><byte-sheet-html-origin data-id="1695273836843" data-version="4" data-is-embed="false" data-grid-line-hidden="false" data-importRangeRawData-spreadSource="https://bytedance.feishu.cn/sheets/LcVzsNpiphJeqjtIGi5c738Jnyh" data-importRangeRawData-range="&#39;Sheet1&#39;!A1:D2">

  | Baseline | Candidate | Took Diff
-- | -- | -- | --
total took | 1629 | 923 | -43.34%

</byte-sheet-html-origin><!--EndFragment-->

