### PR TITLE
Make TaskExecutor public

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -131,7 +131,6 @@ Other
 
 API Changes
 ---------------------
-(No changes)
 
 New Features
 ---------------------
@@ -139,7 +138,8 @@ New Features
 
 Improvements
 ---------------------
-(No changes)
+* GITHUB#12574: Make TaskExecutor public so that it can be retrieved from the searcher and used
+  outside of the o.a.l.search package (Luca Cavanna)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -951,7 +951,12 @@ public class IndexSearcher {
     return executor;
   }
 
-  TaskExecutor getTaskExecutor() {
+  /**
+   * Returns the {@link TaskExecutor} that this searcher relies on to execute concurrent operations
+   *
+   * @return the task executor
+   */
+  public TaskExecutor getTaskExecutor() {
     return taskExecutor;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -40,6 +40,8 @@ import org.apache.lucene.util.ThreadInterruptedException;
  * calls, and not for potential {@link #invokeAll(Collection)} calls made from one of the tasks.
  * This is to prevent deadlock with certain types of pool based executors (e.g. {@link
  * java.util.concurrent.ThreadPoolExecutor}).
+ *
+ * @lucene.experimental
  */
 public final class TaskExecutor {
   // a static thread local is ok as long as we use a counter, which accounts for multiple

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -100,7 +100,7 @@ public final class TaskExecutor {
    * Extension of {@link FutureTask} that tracks the number of tasks that are running in each
    * thread.
    *
-   * @param <V> the return tyupe of the task
+   * @param <V> the return type of the task
    */
   public static final class Task<V> extends FutureTask<V> {
     private Task(Callable<V> callable) {

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -41,7 +41,7 @@ import org.apache.lucene.util.ThreadInterruptedException;
  * This is to prevent deadlock with certain types of pool based executors (e.g. {@link
  * java.util.concurrent.ThreadPoolExecutor}).
  */
-class TaskExecutor {
+public final class TaskExecutor {
   // a static thread local is ok as long as we use a counter, which accounts for multiple
   // searchers holding a different TaskExecutor all backed by the same executor
   private static final ThreadLocal<Integer> numberOfRunningTasksInCurrentThread =
@@ -61,7 +61,7 @@ class TaskExecutor {
    * @return a list containing the results from the tasks execution
    * @param <T> the return type of the task execution
    */
-  final <T> List<T> invokeAll(Collection<Task<T>> tasks) throws IOException {
+  public <T> List<T> invokeAll(Collection<Task<T>> tasks) throws IOException {
     if (numberOfRunningTasksInCurrentThread.get() > 0) {
       for (Task<T> task : tasks) {
         task.run();
@@ -85,11 +85,24 @@ class TaskExecutor {
     return results;
   }
 
-  final <C> Task<C> createTask(Callable<C> callable) {
+  /**
+   * Creates a task given the provided {@link Callable}
+   *
+   * @param callable the callable to be executed as part of the task
+   * @return the created task
+   * @param <C> the return type of the task
+   */
+  public <C> Task<C> createTask(Callable<C> callable) {
     return new Task<>(callable);
   }
 
-  static class Task<V> extends FutureTask<V> {
+  /**
+   * Extension of {@link FutureTask} that tracks the number of tasks that are running in each
+   * thread.
+   *
+   * @param <V> the return tyupe of the task
+   */
+  public static final class Task<V> extends FutureTask<V> {
     private Task(Callable<V> callable) {
       super(callable);
     }


### PR DESCRIPTION
TaskExecutor is currently package private. We have scenarios where we want to parallelize the execution and reuse it outside of its package, hence this commit makes it public (and experimental).

Note that its constructor remains package private as it is supposed to be created by the index searcher, and later retrieved from it via the appropriate getter, which is also made public as part of this commit.

This is a pre-requisite for #12183 .