### PR TITLE
Resolve CompileJava task cache miss

### DIFF
--- a/gradle/generation/extract-jdk-apis.gradle
+++ b/gradle/generation/extract-jdk-apis.gradle
@@ -26,7 +26,7 @@ configure(rootProject) {
 
 configure(project(":lucene:core")) {
   ext {
-    apijars = file('src/generated/jdk');
+    apijars = layout.projectDirectory.dir("src/generated/jdk")
     mrjarJavaVersions = [ 19, 20, 21 ]
   }
   
@@ -66,7 +66,7 @@ configure(project(":lucene:core")) {
       ]
       args = [
         jdkVersion,
-        new File(apijars, "jdk${jdkVersion}.apijar"),
+        apijars.file("jdk${jdkVersion}.apijar"),
       ]
     }
 

--- a/gradle/java/core-mrjar.gradle
+++ b/gradle/java/core-mrjar.gradle
@@ -29,20 +29,19 @@ configure(project(":lucene:core")) {
       dependencies.add("main${jdkVersion}Implementation", sourceSets.main.output)
 
       tasks.named("compileMain${jdkVersion}Java").configure {
-        def apijar = new File(apijars, "jdk${jdkVersion}.apijar")
-        
-        inputs.file(apijar)
+        def apijar = layout.projectDirectory.file("src/generated/jdk/jdk${jdkVersion}.apijar")
         
         int releaseIndex = options.compilerArgs.indexOf("--release")
         options.compilerArgs.removeAt(releaseIndex)
         options.compilerArgs.removeAt(releaseIndex)
         options.compilerArgs += [
           "-Xlint:-options",
-          "--patch-module", "java.base=${apijar}",
           "--add-exports", "java.base/java.lang.foreign=ALL-UNNAMED",
           // for compilation we patch the incubator packages into java.base, this has no effect on resulting class files:
           "--add-exports", "java.base/jdk.incubator.vector=ALL-UNNAMED",
         ]
+
+        options.compilerArgumentProviders.add(new CompilerArgsProvider(apiJarFile: apijar))
       }
     }
     
@@ -57,5 +56,17 @@ configure(project(":lucene:core")) {
         'Multi-Release': 'true'
       )
     }
+  }
+}
+
+class CompilerArgsProvider implements CommandLineArgumentProvider {
+
+  @InputFile
+  @PathSensitive(PathSensitivity.RELATIVE)
+  RegularFile apiJarFile
+
+  @Override
+  Iterable<String> asArguments() {
+    return ["--patch-module", "java.base=${apiJarFile}"]
   }
 }

--- a/gradle/java/core-mrjar.gradle
+++ b/gradle/java/core-mrjar.gradle
@@ -29,7 +29,7 @@ configure(project(":lucene:core")) {
       dependencies.add("main${jdkVersion}Implementation", sourceSets.main.output)
 
       tasks.named("compileMain${jdkVersion}Java").configure {
-        def apijar = layout.projectDirectory.file("src/generated/jdk/jdk${jdkVersion}.apijar")
+        def apijar = apijars.file("jdk${jdkVersion}.apijar")
         
         int releaseIndex = options.compilerArgs.indexOf("--release")
         options.compilerArgs.removeAt(releaseIndex)


### PR DESCRIPTION
### Description

Resolves `CompileJava` cache miss caused by `options.compilerArgs` input difference.

Moved the `apijar` input file to a `CommandLineArgumentProvider` to apply relative path sensitivity, so that changes in the absolute path of the file do not cause a cache miss.

[Task input comparison without fixes](https://ge.solutions-team.gradle.com/c/ndkin5oemsjac/wfrzfdtcomsj6/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure) shows `options.compilerArgs` input differences causing the `CompileJava` tasks to be needlessly re-executed.

[Task input comparison with cache fixes applied](https://ge.solutions-team.gradle.com/c/uwmxltj3pshhe/alpaezxmm5isc/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure) shows no input differences.
