### PR TITLE
Deprecate IndexSearcher#getExecutor

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -8,7 +8,7 @@ http://s.apache.org/luceneversions
 API Changes
 ---------------------
 * GITHUB#12578: Deprecate IndexSearcher#getExecutor in favour of executing concurrent tasks using
-  the TaskExecutor retrieved via IndexSearcher#getTaskExecutor (Luca Cavanna)
+  the TaskExecutor that the searcher holds, retrieved via IndexSearcher#getTaskExecutor (Luca Cavanna)
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,6 +7,8 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
+* GITHUB#12578: Deprecate IndexSearcher#getExecutor in favour of executing concurrent tasks using
+  the TaskExecutor retrieved via IndexSearcher#getTaskExecutor (Luca Cavanna)
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -984,6 +984,7 @@ public class IndexSearcher {
 
   /**
    * Returns this searchers executor or <code>null</code> if no executor was provided
+   *
    * @deprecated use {@link #getTaskExecutor()} executor instead to execute concurrent tasks
    */
   @Deprecated

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -982,7 +982,11 @@ public class IndexSearcher {
     return new CollectionStatistics(field, reader.maxDoc(), docCount, sumTotalTermFreq, sumDocFreq);
   }
 
-  /** Returns this searchers executor or <code>null</code> if no executor was provided */
+  /**
+   * Returns this searchers executor or <code>null</code> if no executor was provided
+   * @deprecated use {@link #getTaskExecutor()} executor instead to execute concurrent tasks
+   */
+  @Deprecated
   public Executor getExecutor() {
     return executor;
   }


### PR DESCRIPTION
We have recently introduced a TaskExecutor abstraction, which is meant to be used to execute concurrent tasks using the executor provided to the IndexSearcher constructor. All concurrenct tasks should be executed using the TaskExecutor, and there shoul be no reason to retrieve the Executor directly from the IndexSearcher.