### PR TITLE
Remove deprecated IndexSearcher#getExecutor method

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -57,7 +57,7 @@ API Changes
 
 * GITHUB#12407: Removed Scorable#docID. (Adrien Grand)
 
-* GITHUB#*****: Remove deprecated IndexSearcher#getExecutor in favour of executing concurrent tasks using
+* GITHUB#12580: Remove deprecated IndexSearcher#getExecutor in favour of executing concurrent tasks using
   the TaskExecutor that the searcher holds, retrieved via IndexSearcher#getTaskExecutor (Luca Cavanna)
 
 New Features

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -57,6 +57,9 @@ API Changes
 
 * GITHUB#12407: Removed Scorable#docID. (Adrien Grand)
 
+* GITHUB#*****: Remove deprecated IndexSearcher#getExecutor in favour of executing concurrent tasks using
+  the TaskExecutor that the searcher holds, retrieved via IndexSearcher#getTaskExecutor (Luca Cavanna)
+
 New Features
 ---------------------
 
@@ -131,6 +134,8 @@ Other
 
 API Changes
 ---------------------
+* GITHUB#12578: Deprecate IndexSearcher#getExecutor in favour of executing concurrent tasks using
+  the TaskExecutor that the searcher holds, retrieved via IndexSearcher#getTaskExecutor (Luca Cavanna)
 
 New Features
 ---------------------

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -95,6 +95,11 @@ Callers should remove the parameter when calling this method.
 The former `DaciukMihovAutomatonBuilder#build` functionality is exposed through `Automata#makeStringUnion`.
 Users should be able to directly migrate to the `Automata` static method as a 1:1 replacement.
 
+### Remove deprecated IndexSearcher#getExecutor (GITHUB#****) 
+
+The deprecated getter for the `Executor` that was optionally provided to the `IndexSearcher` constructors 
+has been removed. Users that want to execute concurrent tasks should rely instead on the `TaskExecutor` 
+that the searcher holds, retrieved via `IndexSearcher#getTaskExecutor`.
 
 ## Migration from Lucene 9.0 to Lucene 9.1
 

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -95,7 +95,7 @@ Callers should remove the parameter when calling this method.
 The former `DaciukMihovAutomatonBuilder#build` functionality is exposed through `Automata#makeStringUnion`.
 Users should be able to directly migrate to the `Automata` static method as a 1:1 replacement.
 
-### Remove deprecated IndexSearcher#getExecutor (GITHUB#****) 
+### Remove deprecated IndexSearcher#getExecutor (GITHUB#12580) 
 
 The deprecated getter for the `Executor` that was optionally provided to the `IndexSearcher` constructors 
 has been removed. Users that want to execute concurrent tasks should rely instead on the `TaskExecutor` 

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -946,11 +946,6 @@ public class IndexSearcher {
     return new CollectionStatistics(field, reader.maxDoc(), docCount, sumTotalTermFreq, sumDocFreq);
   }
 
-  /** Returns this searchers executor or <code>null</code> if no executor was provided */
-  public Executor getExecutor() {
-    return executor;
-  }
-
   /**
    * Returns the {@link TaskExecutor} that this searcher relies on to execute concurrent operations
    *


### PR DESCRIPTION
Use getTaskExecutor instead. This is important to enforce tracking of tasks that run in each thread.

Relates to #12578