### PR TITLE
Shared executor for LuceneTestCase#newSearcher callers

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1880,7 +1880,7 @@ public abstract class LuceneTestCase extends Assert {
 
   @BeforeClass
   public static void setUpExecutorService() {
-    int threads = TestUtil.nextInt(random(), 1, 8);
+    int threads = TestUtil.nextInt(random(), 1, 2);
     executor =
         new ThreadPoolExecutor(
             threads,

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1892,7 +1892,7 @@ public abstract class LuceneTestCase extends Assert {
     // uncomment to intensify LUCENE-3840
     // executor.prestartAllCoreThreads();
     if (VERBOSE) {
-      System.out.println("NOTE: newSearcher using ExecutorService with " + threads + " threads");
+      System.out.println("NOTE: Created shared ExecutorService with " + threads + " threads");
     }
   }
 
@@ -1965,7 +1965,15 @@ public abstract class LuceneTestCase extends Assert {
       ret.setSimilarity(classEnvRule.similarity);
       return ret;
     } else {
-      final ExecutorService ex = random.nextBoolean() ? null : executor;
+      final ExecutorService ex;
+      if (random.nextBoolean()) {
+        ex = null;
+      } else {
+        ex = executor;
+        if (VERBOSE) {
+          System.out.println("NOTE: newSearcher using shared ExecutorService");
+        }
+      }
       IndexSearcher ret;
       int maxDocPerSlice = random.nextBoolean() ? 1 : 1 + random.nextInt(1000);
       int maxSegmentsPerSlice = random.nextBoolean() ? 1 : 1 + random.nextInt(10);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1965,12 +1965,7 @@ public abstract class LuceneTestCase extends Assert {
       ret.setSimilarity(classEnvRule.similarity);
       return ret;
     } else {
-      final ExecutorService ex;
-      if (r.getReaderCacheHelper() == null || random.nextBoolean()) {
-        ex = null;
-      } else {
-        ex = executor;
-      }
+      final ExecutorService ex = random.nextBoolean() ? null : executor;
       IndexSearcher ret;
       int maxDocPerSlice = random.nextBoolean() ? 1 : 1 + random.nextInt(1000);
       int maxSegmentsPerSlice = random.nextBoolean() ? 1 : 1 + random.nextInt(10);


### PR DESCRIPTION
Until now, LuceneTestCase#newSearcher randomly associates the returned IndexSearcher instance with an executor that is ad-hoc created, which gets shut down when the index reader is closed.

This has made us catch a couple of cases where we were not properly closing readers in tests. Most recently, we have been seeing test failures (OOM - unable to create thread) due to too many executor instances created as part of the same test. This is to be attributed to creating too many searcher instance, each one getting its separate executor, which all get shutdown at the end of the entire suite. The main offender for this is QueryUtils which creates a new searcher for each leaf reader, and the top-level reader gets closed in the AfterClass, hence all the executors will stay around for the entire duration of the test suite that relies on QueryUtils.

This commit eagerly creates an executor in an additional before class method for LuceneTestCase, and associates that with each searcher that is supposed to get a non null executor.

Note that the executor is shutdown in the after class to ensure that no threads leak in tests.

This has the additional advantage that it removes the need to close the executor as part of an index reader close listener, which requires the reader to have an associated reader cache helper.

As part of this change we are also reducing the number of max threads from 8 to 2.