### PR TITLE
Allow implementers of AbstractKnnVectorQuery to access final topK results

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -219,14 +219,13 @@ abstract class AbstractKnnVectorQuery extends Query {
   /**
    * Merges all segment-level kNN results to get the index-level kNN results.
    *
-   * <p>The default implementation delegates to {@link TopDocs#merge(int, TopDocs[])} to find the overall top
-   * {@link #k}, which requires input results to be sorted.</p>
+   * <p>The default implementation delegates to {@link TopDocs#merge(int, TopDocs[])} to find the
+   * overall top {@link #k}, which requires input results to be sorted.
    *
-   * <p>This method is useful for reading and / or modifying the final results as needed.</p>
+   * <p>This method is useful for reading and / or modifying the final results as needed.
    *
-   * @param perLeafResults  array of segment-level kNN results.
-   * @return                index-level kNN results (no constraint on their ordering).
-   *
+   * @param perLeafResults array of segment-level kNN results.
+   * @return index-level kNN results (no constraint on their ordering).
    * @lucene.experimental
    */
   protected TopDocs mergeLeafResults(TopDocs[] perLeafResults) {

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -86,9 +86,6 @@ abstract class AbstractKnnVectorQuery extends Query {
 
     // Merge sort the results
     TopDocs topK = TopDocs.merge(k, perLeafResults);
-    if (topK.scoreDocs.length == 0) {
-      return new MatchNoDocsQuery();
-    }
     return createRewrittenQuery(reader, topK);
   }
 
@@ -216,10 +213,12 @@ abstract class AbstractKnnVectorQuery extends Query {
     return new TopDocs(totalHits, topScoreDocs);
   }
 
-  private Query createRewrittenQuery(IndexReader reader, TopDocs topK) {
+  protected Query createRewrittenQuery(IndexReader reader, TopDocs topK) {
     int len = topK.scoreDocs.length;
+    if (len == 0) {
+      return new MatchNoDocsQuery();
+    }
 
-    assert len > 0;
     float maxScore = topK.scoreDocs[0].score;
 
     Arrays.sort(topK.scoreDocs, Comparator.comparingInt(a -> a.doc));

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -216,6 +216,19 @@ abstract class AbstractKnnVectorQuery extends Query {
     return new TopDocs(totalHits, topScoreDocs);
   }
 
+  /**
+   * Merges all segment-level kNN results to get the index-level kNN results.
+   *
+   * <p>The default implementation delegates to {@link TopDocs#merge(int, TopDocs[])} to find the overall top
+   * {@link #k}, which requires input results to be sorted.</p>
+   *
+   * <p>This method is useful for reading and / or modifying the final results as needed.</p>
+   *
+   * @param perLeafResults  array of segment-level kNN results.
+   * @return                index-level kNN results (no constraint on their ordering).
+   *
+   * @lucene.experimental
+   */
   protected TopDocs mergeLeafResults(TopDocs[] perLeafResults) {
     return TopDocs.merge(k, perLeafResults);
   }


### PR DESCRIPTION
### Context

Vector search is performed in [`AbstractKnnVectorQuery`](https://github.com/kaivalnp/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java), where individual HNSW searches are delegated to sub-classes via [`#approximateSearch`](https://github.com/kaivalnp/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java#L174). This is useful to implement custom functionality (like say pro-rating `k` across segments for performance, or requesting some additional results over `k` for higher recall with Exact KNN)

While the class in itself is `package-private`, we extend the corresponding sub-classes for [byte](https://github.com/kaivalnp/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java) and [float](https://github.com/kaivalnp/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java) vectors (which are `public`) for implementing any custom functionality like above

### Issue

After searching across all segments, we retain the index-level `topk` results [here](https://github.com/kaivalnp/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java#L88), and immediately call [`#createRewrittenQuery`](https://github.com/kaivalnp/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java#L219) to rewrite them as a [`DocAndScoreQuery`](https://github.com/kaivalnp/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java#L297)

So the implementing classes do not have access to the final `topK` results anywhere, which may be useful to read / modify like a post-process step (for example metric emission, or counting / only keeping results above a threshold)

### Proposal

Can we make [`#createRewrittenQuery`](https://github.com/kaivalnp/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java#L219) `protected` to allow sub-classes to override it (and ultimately access the `topK` results)?
They can simply delegate to the original function at the end, or even implement a custom `Query` if required

I don't how common of a use-case this is, and wanted to get some opinions

Closes #12575