### PR TITLE
Make IndexWriter#flushNextBuffer also apply deletes if necessary

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -166,6 +166,9 @@ Changes in runtime behavior
 * GITHUB#12569: Prevent concurrent tasks from parallelizing execution further which could cause deadlock
   (Luca Cavanna)
 
+* GITHUB#12572: IndexWriter#flushNextBuffer now also applies deletes if necessary even if no DWPT has been flushed.
+  (Simon Willnauer)
+
 Bug Fixes
 ---------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
@@ -246,10 +246,14 @@ final class DocumentsWriter implements Closeable, Accountable {
     if (documentsWriterPerThread == null) {
       documentsWriterPerThread = flushControl.checkoutLargestNonPendingWriter();
     }
+    boolean hasEvents = false;
     if (documentsWriterPerThread != null) {
-      return doFlush(documentsWriterPerThread);
+      hasEvents = doFlush(documentsWriterPerThread);
     }
-    return false; // we didn't flush anything here
+    // just in case we have pending deletes to apply we can now write them
+    // doFlush will only do it if the deletes consume a significant amount of ram as a safety net
+    hasEvents |= applyAllDeletes();
+    return hasEvents;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
@@ -566,6 +566,9 @@ final class DocumentsWriter implements Closeable, Accountable {
     final double ramBufferSizeMB = config.getRAMBufferSizeMB();
     if (ramBufferSizeMB != IndexWriterConfig.DISABLE_AUTO_FLUSH
         && flushControl.getDeleteBytesUsed() > (1024 * 1024 * ramBufferSizeMB / 2)) {
+      // TODO this looks flaky we need to setApplyAllDeletes() on FlushControl in order to
+      // trigger a flush but this doesn't do it.. looks like a bug and we need a test too for this
+      // safety net
       hasEvents = true;
       if (applyAllDeletes() == false) {
         if (infoStream.isEnabled("DW")) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -3110,9 +3110,16 @@ public class TestIndexWriter extends LuceneTestCase {
         w.docWriter.flushControl.findLargestNonPendingWriter();
     assertFalse(largestNonPendingWriter.isFlushPending());
     assertEquals(1, w.numRamDocs());
-    w.flushNextBuffer();
+    assertTrue(w.flushNextBuffer());
     assertEquals(0, w.numRamDocs());
     assertFalse("deletes were not flushed", w.docWriter.flushControl.getAndResetApplyAllDeletes());
+    // test flush deletes without any docs
+    w.deleteDocuments(new Term("id", "foo"));
+    assertNull(w.docWriter.flushControl.findLargestNonPendingWriter());
+    w.docWriter.flushControl.setApplyAllDeletes();
+    assertTrue(w.flushNextBuffer());
+    // now nothing should happen since no docs no deletes pending
+    assertFalse(w.flushNextBuffer());
     w.close();
     dir.close();
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -3107,7 +3107,7 @@ public class TestIndexWriter extends LuceneTestCase {
     // ensure we mark deletes pending
     w.docWriter.flushControl.setApplyAllDeletes();
     DocumentsWriterPerThread largestNonPendingWriter =
-            w.docWriter.flushControl.findLargestNonPendingWriter();
+        w.docWriter.flushControl.findLargestNonPendingWriter();
     assertFalse(largestNonPendingWriter.isFlushPending());
     assertEquals(1, w.numRamDocs());
     w.flushNextBuffer();


### PR DESCRIPTION
`IndexWriter#flushNextBuffer()` is a convenient way to control indexing buffer sizes across multiple index writers. This change also flushes deletes if necessary when `#flushNextBuffer()` is called even if there is no buffer to be flushed.