### PR TITLE
Simplify TaskExecutor API

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -152,7 +152,7 @@ Improvements
   outside of the o.a.l.search package (Luca Cavanna)
 
 * GITHUB#12603: Simplify the TaskExecutor API by exposing a single invokeAll method that takes a
-  collection, executes them and returns their results  (Luca Cavanna)
+  collection of callables, executes them and returns their results  (Luca Cavanna)
 
 Optimizations
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -151,6 +151,9 @@ Improvements
 * GITHUB#12574: Make TaskExecutor public so that it can be retrieved from the searcher and used
   outside of the o.a.l.search package (Luca Cavanna)
 
+* GITHUB#12603: Simplify the TaskExecutor API by exposing a single invokeAll method that takes a
+  collection, executes them and returns their results  (Luca Cavanna)
+
 Optimizations
 ---------------------
 * GITHUB#12183: Make TermStates#build concurrent. (Shubham Chaudhary)

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Callable;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexReader;
@@ -104,9 +105,9 @@ abstract class AbstractKnnVectorQuery extends Query {
   private TopDocs[] parallelSearch(
       List<LeafReaderContext> leafReaderContexts, Weight filterWeight, TaskExecutor taskExecutor)
       throws IOException {
-    List<TaskExecutor.Task<TopDocs>> tasks = new ArrayList<>();
+    List<Callable<TopDocs>> tasks = new ArrayList<>(leafReaderContexts.size());
     for (LeafReaderContext context : leafReaderContexts) {
-      tasks.add(taskExecutor.createTask(() -> searchLeaf(context, filterWeight)));
+      tasks.add(() -> searchLeaf(context, filterWeight));
     }
     return taskExecutor.invokeAll(tasks).toArray(TopDocs[]::new);
   }

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -667,17 +668,15 @@ public class IndexSearcher {
               "CollectorManager does not always produce collectors with the same score mode");
         }
       }
-      final List<TaskExecutor.Task<C>> listTasks = new ArrayList<>();
+      final List<Callable<C>> listTasks = new ArrayList<>(leafSlices.length);
       for (int i = 0; i < leafSlices.length; ++i) {
         final LeafReaderContext[] leaves = leafSlices[i].leaves;
         final C collector = collectors.get(i);
-        TaskExecutor.Task<C> task =
-            taskExecutor.createTask(
-                () -> {
-                  search(Arrays.asList(leaves), weight, collector);
-                  return collector;
-                });
-        listTasks.add(task);
+        listTasks.add(
+            () -> {
+              search(Arrays.asList(leaves), weight, collector);
+              return collector;
+            });
       }
       List<C> results = taskExecutor.invokeAll(listTasks);
       return collectorManager.reduce(results);


### PR DESCRIPTION
We recently made TaskExecutor public. It currently exposes two methods: one to create tasks given a collection of callables, and one to execute all tasks created at step 1. We can rather expose a single public method that takes a collection of callables which internally creates the appropriate tasks. This simplifies the API, and stops us from leaking the internal Task abstraction which can be kept private.

Note that this is backwards compatible as we have not released yet a version where the TaskExecutor was made public. It is marked experimental anyways.
