### PR TITLE
Reduce FST block size for BlockTreeTermsWriter

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -163,6 +163,8 @@ Optimizations
 * GITHUB#12382: Faster top-level conjunctions on term queries when sorting by
   descending score. (Adrien Grand)
 
+* GITHUB#12573: Reduce block size of FST BytesStore in BlockTreeTermsWriter. (Guo Feng)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -163,7 +163,8 @@ Optimizations
 * GITHUB#12382: Faster top-level conjunctions on term queries when sorting by
   descending score. (Adrien Grand)
 
-* GITHUB#12604: Reduce block size of FST BytesStore in BlockTreeTermsWriter. (Guo Feng)
+* GITHUB#12604: Estimate the block size of FST BytesStore in BlockTreeTermsWriter
+  to reducing GC load during indexing. (Guo Feng)
 
 Changes in runtime behavior
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -163,7 +163,7 @@ Optimizations
 * GITHUB#12382: Faster top-level conjunctions on term queries when sorting by
   descending score. (Adrien Grand)
 
-* GITHUB#12573: Reduce block size of FST BytesStore in BlockTreeTermsWriter. (Guo Feng)
+* GITHUB#12604: Reduce block size of FST BytesStore in BlockTreeTermsWriter. (Guo Feng)
 
 Changes in runtime behavior
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -164,7 +164,7 @@ Optimizations
   descending score. (Adrien Grand)
 
 * GITHUB#12604: Estimate the block size of FST BytesStore in BlockTreeTermsWriter
-  to reducing GC load during indexing. (Guo Feng)
+  to reduce GC load during indexing. (Guo Feng)
 
 Changes in runtime behavior
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
@@ -52,6 +52,7 @@ import org.apache.lucene.util.fst.BytesRefFSTEnum;
 import org.apache.lucene.util.fst.FST;
 import org.apache.lucene.util.fst.FSTCompiler;
 import org.apache.lucene.util.fst.Util;
+import org.apache.lucene.util.packed.PackedInts;
 
 /*
   TODO:
@@ -490,11 +491,22 @@ public final class Lucene90BlockTreeTermsWriter extends FieldsConsumer {
         }
       }
 
+      long estimateSize = prefix.length;
+      for (PendingBlock block : blocks) {
+        if (block.subIndices != null) {
+          for (FST<BytesRef> subIndex : block.subIndices) {
+            estimateSize += subIndex.numBytes();
+          }
+        }
+      }
+      int estimateBitsRequired = PackedInts.bitsRequired(estimateSize);
+      int pageBits = Math.min(15, Math.max(6, estimateBitsRequired));
+
       final ByteSequenceOutputs outputs = ByteSequenceOutputs.getSingleton();
       final FSTCompiler<BytesRef> fstCompiler =
           new FSTCompiler.Builder<>(FST.INPUT_TYPE.BYTE1, outputs)
               .shouldShareNonSingletonNodes(false)
-              .bytesPageBits(10)
+              .bytesPageBits(pageBits)
               .build();
       // if (DEBUG) {
       //  System.out.println("  compile index for prefix=" + prefix);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
@@ -494,6 +494,7 @@ public final class Lucene90BlockTreeTermsWriter extends FieldsConsumer {
       final FSTCompiler<BytesRef> fstCompiler =
           new FSTCompiler.Builder<>(FST.INPUT_TYPE.BYTE1, outputs)
               .shouldShareNonSingletonNodes(false)
+              .bytesPageBits(10)
               .build();
       // if (DEBUG) {
       //  System.out.println("  compile index for prefix=" + prefix);

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -520,6 +520,10 @@ public final class FST<T> implements Accountable {
     bytes.finish();
   }
 
+  public long numBytes() {
+    return bytes.getPosition();
+  }
+
   public T getEmptyOutput() {
     return emptyOutput;
   }


### PR DESCRIPTION
### Description

https://blunders.io/jfr-demo/indexing-4kb-2023.09.25.18.03.36/allocations-drill-down

Nightly benchmark shows that `FSTCompiler#init` allocated most of the memory during indexing. This is because `FSTCompiler#init` will always allocate 32k bytes as we param `bytesPageBits` default to 15. I counted the usage of BytesStore (`getPosition()` when `BytesStore#finish` called) during the wikimediumall indexing, and the result shows that 99% FST won't even use more than 1k bytes.

```
BytesStore#finish called: 1000000 times

min: 1
mid: 16
avg: 64.555987
pct75: 28
pct90: 57
pct99: 525
pct999: 4957
pct9999: 29124
max: 631700
```

This PR proposes to reduce the block size of `FST` in `Lucene90BlockTreeTermsWriter`.

closes https://github.com/apache/lucene/issues/12598


