### PR TITLE
SuggestIndexSearcher.suggest catches any CollectionTerminatedException (theoretically) thrown by getLeafCollector

### DIFF
--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/SuggestIndexSearcher.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/SuggestIndexSearcher.java
@@ -68,8 +68,9 @@ public class SuggestIndexSearcher extends IndexSearcher {
     for (LeafReaderContext context : getIndexReader().leaves()) {
       BulkScorer scorer = weight.bulkScorer(context);
       if (scorer != null) {
-        LeafCollector leafCollector = collector.getLeafCollector(context);
+        LeafCollector leafCollector = null;
         try {
+          leafCollector = collector.getLeafCollector(context);
           scorer.score(leafCollector, context.reader().getLiveDocs());
         } catch (
             @SuppressWarnings("unused")
@@ -77,7 +78,9 @@ public class SuggestIndexSearcher extends IndexSearcher {
           // collection was terminated prematurely
           // continue with the following leaf
         }
-        leafCollector.finish();
+        if (leafCollector != null) {
+          leafCollector.finish();
+        }
       }
     }
   }


### PR DESCRIPTION
please see https://github.com/apache/lucene/pull/12380#discussion_r1340380526 and https://github.com/apache/lucene/pull/12380#discussion_r1340582160 for context