### PR TITLE
Avoid NPEx if the end of the stream has been reached without reading any characters

### DIFF
--- a/lucene/demo/src/java/org/apache/lucene/demo/SearchFiles.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/SearchFiles.java
@@ -195,7 +195,7 @@ public class SearchFiles {
                 + " total matching documents collected.");
         System.out.println("Collect more (y/n) ?");
         String line = in.readLine();
-        if (line.length() == 0 || line.charAt(0) == 'n') {
+        if (line == null || line.length() == 0 || line.charAt(0) == 'n') {
           break;
         }
 
@@ -241,7 +241,7 @@ public class SearchFiles {
           System.out.println("(q)uit or enter number to jump to a page.");
 
           String line = in.readLine();
-          if (line.length() == 0 || line.charAt(0) == 'q') {
+          if (line == null || line.length() == 0 || line.charAt(0) == 'q') {
             quit = true;
             break;
           }


### PR DESCRIPTION
e.g. by user responding with ^D
```
Press (n)ext page, (q)uit or enter number to jump to a page.
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "String.length()" because "line" is null
	at org.apache.lucene.demo.SearchFiles.doPagingSearch(SearchFiles.java:244)
	at org.apache.lucene.demo.SearchFiles.main(SearchFiles.java:152)
```

```
Press (p)revious page, (n)ext page, (q)uit or enter number to jump to a page.
n
Only results 1 - 50 of 104 total matching documents collected.
Collect more (y/n) ?
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "String.length()" because "line" is null
	at org.apache.lucene.demo.SearchFiles.doPagingSearch(SearchFiles.java:198)
	at org.apache.lucene.demo.SearchFiles.main(SearchFiles.java:152)
```

### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
