### PR TITLE
Upgrade forbiddenapis to 3.6 and ASM for APIJAR extraction to 9.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
   id "base"
   id "com.palantir.consistent-versions" version "2.11.0"
   id "org.owasp.dependencycheck" version "7.2.0"
-  id 'de.thetaphi.forbiddenapis' version '3.5' apply false
+  id 'de.thetaphi.forbiddenapis' version '3.6' apply false
   id "de.undercouch.download" version "5.2.0" apply false
   id "net.ltgt.errorprone" version "3.0.1" apply false
   id 'com.diffplug.spotless' version "6.5.2" apply false

--- a/buildSrc/scriptDepVersions.gradle
+++ b/buildSrc/scriptDepVersions.gradle
@@ -22,7 +22,7 @@
 ext {
   scriptDepVersions = [
       "apache-rat": "0.14",
-      "asm": "9.5",
+      "asm": "9.6",
       "commons-codec": "1.13",
       "ecj": "3.30.0",
       "flexmark": "0.61.24",

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -171,6 +171,11 @@ Bug Fixes
 ---------------------
 (No changes)
 
+Build
+---------------------
+
+* GITHUB#xxxx: Upgrade forbiddenapis to version 3.6.  (Uwe Schindler)
+
 Other
 ---------------------
 (No changes)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -174,7 +174,7 @@ Bug Fixes
 Build
 ---------------------
 
-* GITHUB#xxxx: Upgrade forbiddenapis to version 3.6.  (Uwe Schindler)
+* GITHUB#12612: Upgrade forbiddenapis to version 3.6 and ASM for APIJAR extraction to 9.6.  (Uwe Schindler)
 
 Other
 ---------------------


### PR DESCRIPTION
the usual maintenance. Allows us to process Java 22 APIs soon.