### PR TITLE
Override `normalize` method in the `PatternReplaceFilterFactory`

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilterFactory.java
@@ -67,4 +67,9 @@ public class PatternReplaceFilterFactory extends TokenFilterFactory {
   public PatternReplaceFilter create(TokenStream input) {
     return new PatternReplaceFilter(input, pattern, replacement, replaceAll);
   }
+
+  @Override
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
+  }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilterFactory.java
@@ -18,7 +18,6 @@ package org.apache.lucene.analysis.pattern;
 
 import java.io.Reader;
 import java.io.StringReader;
-
 import org.apache.lucene.analysis.TokenFilterFactory;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.tests.analysis.BaseTokenStreamFactoryTestCase;
@@ -52,7 +51,7 @@ public class TestPatternReplaceFilterFactory extends BaseTokenStreamFactoryTestC
     Reader reader = new StringReader("123");
     TokenStream stream = whitespaceMockTokenizer(reader);
     TokenFilterFactory factory =
-            tokenFilterFactory("PatternReplace", "pattern", "(-?\\d+)", "replacement", "000$1");
+        tokenFilterFactory("PatternReplace", "pattern", "(-?\\d+)", "replacement", "000$1");
     stream = factory.normalize(stream);
     assertTokenStreamContents(stream, new String[] {"000123"});
   }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilterFactory.java
@@ -18,6 +18,8 @@ package org.apache.lucene.analysis.pattern;
 
 import java.io.Reader;
 import java.io.StringReader;
+
+import org.apache.lucene.analysis.TokenFilterFactory;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.tests.analysis.BaseTokenStreamFactoryTestCase;
 
@@ -43,5 +45,15 @@ public class TestPatternReplaceFilterFactory extends BaseTokenStreamFactoryTestC
                   "PatternReplace", "pattern", "something", "bogusArg", "bogusValue");
             });
     assertTrue(expected.getMessage().contains("Unknown parameters"));
+  }
+
+  /** Test that normalizer is working */
+  public void testNormalize() throws Exception {
+    Reader reader = new StringReader("123");
+    TokenStream stream = whitespaceMockTokenizer(reader);
+    TokenFilterFactory factory =
+            tokenFilterFactory("PatternReplace", "pattern", "(-?\\d+)", "replacement", "000$1");
+    stream = factory.normalize(stream);
+    assertTokenStreamContents(stream, new String[] {"000123"});
   }
 }


### PR DESCRIPTION
### Description

I've been debugging a problem with a classic query parser producing a `TermRangeQuery` with wrong tokens. I'm using  a `CustomAnalyzer` that uses the `PatternReplaceFilterFactory`. It turns out that the query parser calls the `normalize` method and the token filter is not applied.

Funny thing is that the `PatternReplaceCharFilterFactory` overrides the `normalize` method.

Is there any reason why `PatternReplaceFilterFactory` doesn't override `normalize` method?

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
