### PR TITLE
avoid-circular-jar-checks

### DIFF
--- a/gradle/validation/jar-checks.gradle
+++ b/gradle/validation/jar-checks.gradle
@@ -110,14 +110,21 @@ subprojects {
       }
 
       def visited = new HashSet<>()
+      def seenDeps = new HashSet<>()
       def infos = []
 
       while (!queue.isEmpty()) {
         def dep = queue.removeFirst()
+        seenDeps.add(dep)
 
         // Skip any artifacts from Lucene modules.
         if (!dep.moduleGroup.startsWith("org.apache.lucene")) {
-          queue.addAll(dep.children)
+          // Make sure we don't keep visiting the same children over and over again
+          dep.children.each { child ->
+            if (!seenDeps.contains(child)) {
+              queue.add(child)
+            }
+          }
           dep.moduleArtifacts.each { resolvedArtifact ->
             def file = resolvedArtifact.file
             if (visited.add(file)) {


### PR DESCRIPTION
### Description

jar-checks.gradle can go into an infinite loop if there are dependencies that could be circular. In Solr, grpc-utils has a compile dependency on grpc-core and grpc-core has a runtime dependency on grpc-utils. In jar-checks this is circular since there is no distinction between runtime and compile dependencies. This change adds a check to make sure we don't visit the same dependency twice.

[Related to https://github.com/apache/solr/pull/1769](https://github.com/apache/solr/pull/1769#discussion_r1344543174)