### PR TITLE
Use a MergeSorter taking advantage of extra storage for StableMSBRadixSorter

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -173,6 +173,8 @@ Optimizations
 * GITHUB#12604: Estimate the block size of FST BytesStore in BlockTreeTermsWriter
   to reduce GC load during indexing. (Guo Feng)
 
+* GITHUB#12623: Use a MergeSorter taking advantage of extra storage for StableMSBRadixSorter. (Guo Feng)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
@@ -88,7 +88,7 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
     }
 
     private void mergeSort(int from, int to) {
-      if (to - from < 5) {
+      if (to - from < BINARY_SORT_THRESHOLD) {
         binarySort(from, to);
       } else {
         final int mid = (from + to) >>> 1;

--- a/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
@@ -110,6 +110,10 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
 
     private void merge(int from, int to, int mid) {
       assert to > mid && mid > from;
+      if (compare(mid - 1, mid) <= 0) {
+        // already sorted.
+        return;
+      }
       int left = from;
       int right = mid;
       int index = from;

--- a/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
@@ -112,18 +112,20 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
       assert to > mid && mid > from;
       int left = from;
       int right = mid;
-      int index = 0;
+      int index = from;
       while (true) {
         int cmp = compare(left, right);
         if (cmp <= 0) {
           save(left++, index++);
           if (left == mid) {
+            assert index == right;
             bulkSave(right, index, to - right);
             break;
           }
         } else {
           save(right++, index++);
           if (right == to) {
+            assert to - index == mid - left;
             bulkSave(left, index, mid - left);
             break;
           }

--- a/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
@@ -38,7 +38,7 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
 
   @Override
   protected Sorter getFallbackSorter(int k) {
-    return new InPlaceMergeSorter() {
+    return new MergeSorter() {
       @Override
       protected void swap(int i, int j) {
         StableMSBRadixSorter.this.swap(i, j);
@@ -77,5 +77,58 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
       }
     }
     restore(from, to);
+  }
+
+  protected abstract class MergeSorter extends Sorter {
+    @Override
+    public void sort(int from, int to) {
+      checkRange(from, to);
+      mergeSort(from, to);
+    }
+
+    protected void mergeSort(int from, int to) {
+      if (to - from < INSERTION_SORT_THRESHOLD) {
+        binarySort(from, to);
+      } else {
+        final int mid = (from + to) >>> 1;
+        mergeSort(from, mid);
+        mergeSort(mid, to);
+        merge(from, to, mid);
+      }
+    }
+
+    /**
+     * We tried to expose this to implementations to get a bulk copy optimization. But it did not bring a
+     * noticeable improvement in benchmark as {@code len} is usually small.
+     */
+    private void bulkSave(int from, int tmpFrom, int len) {
+      for (int i = 0; i < len; i++) {
+        save(from + i, tmpFrom + i);
+      }
+    }
+
+    private void merge(int from, int to, int mid) {
+      assert to > mid && mid > from;
+      int left = from;
+      int right = mid;
+      int index = 0;
+      while (true) {
+        int cmp = compare(left, right);
+        if (cmp <= 0) {
+          save(left++, index++);
+          if (left == mid) {
+            bulkSave(right, index, to - right);
+            break;
+          }
+        } else {
+          save(right++, index++);
+          if (right == to) {
+            bulkSave(left, index, mid - left);
+            break;
+          }
+        }
+      }
+      restore(from, to);
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
@@ -79,6 +79,7 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
     restore(from, to);
   }
 
+  /** A MergeSorter taking advantage of temporary storage. */
   protected abstract class MergeSorter extends Sorter {
     @Override
     public void sort(int from, int to) {
@@ -87,7 +88,7 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
     }
 
     private void mergeSort(int from, int to) {
-      if (to - from < BINARY_SORT_THRESHOLD) {
+      if (to - from < 5) {
         binarySort(from, to);
       } else {
         final int mid = (from + to) >>> 1;

--- a/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
@@ -98,8 +98,8 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
     }
 
     /**
-     * We tried to expose this to implementations to get a bulk copy optimization. But it did not bring a
-     * noticeable improvement in benchmark as {@code len} is usually small.
+     * We tried to expose this to implementations to get a bulk copy optimization. But it did not
+     * bring a noticeable improvement in benchmark as {@code len} is usually small.
      */
     private void bulkSave(int from, int tmpFrom, int len) {
       for (int i = 0; i < len; i++) {

--- a/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
@@ -87,7 +87,7 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
     }
 
     protected void mergeSort(int from, int to) {
-      if (to - from < INSERTION_SORT_THRESHOLD) {
+      if (to - from < BINARY_SORT_THRESHOLD) {
         binarySort(from, to);
       } else {
         final int mid = (from + to) >>> 1;

--- a/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
@@ -86,7 +86,7 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
       mergeSort(from, to);
     }
 
-    protected void mergeSort(int from, int to) {
+    private void mergeSort(int from, int to) {
       if (to - from < BINARY_SORT_THRESHOLD) {
         binarySort(from, to);
       } else {

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/MutablePointTreeReaderUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/MutablePointTreeReaderUtils.java
@@ -55,6 +55,7 @@ public final class MutablePointTreeReaderUtils {
     // This should be a common situation as IndexWriter accumulates data in doc ID order when
     // index sorting is not enabled.
     final int bitsPerDocId = sortedByDocID ? 0 : PackedInts.bitsRequired(maxDoc - 1);
+
     new StableMSBRadixSorter(config.packedBytesLength + (bitsPerDocId + 7) / 8) {
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/MutablePointTreeReaderUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/MutablePointTreeReaderUtils.java
@@ -55,7 +55,6 @@ public final class MutablePointTreeReaderUtils {
     // This should be a common situation as IndexWriter accumulates data in doc ID order when
     // index sorting is not enabled.
     final int bitsPerDocId = sortedByDocID ? 0 : PackedInts.bitsRequired(maxDoc - 1);
-
     new StableMSBRadixSorter(config.packedBytesLength + (bitsPerDocId + 7) / 8) {
 
       @Override

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
@@ -1597,12 +1597,12 @@ public class TestBKD extends LuceneTestCase {
 
           @Override
           public void save(int i, int j) {
-            throw new UnsupportedOperationException();
+            // do nothing
           }
 
           @Override
           public void restore(int i, int j) {
-            throw new UnsupportedOperationException();
+            // do nothing
           }
 
           @Override
@@ -1689,6 +1689,10 @@ public class TestBKD extends LuceneTestCase {
     }
     MutablePointTree val =
         new MutablePointTree() {
+
+          final byte[][] tmpValues = new byte[numValues][];
+          final int[] tmpDocs = new int[numValues];
+
           @Override
           public void getValue(int i, BytesRef packedValue) {
             packedValue.bytes = pointValue[i];
@@ -1718,12 +1722,14 @@ public class TestBKD extends LuceneTestCase {
 
           @Override
           public void save(int i, int j) {
-            throw new UnsupportedOperationException();
+            tmpValues[j] = pointValue[i];
+            tmpDocs[j] = docId[i];
           }
 
           @Override
           public void restore(int i, int j) {
-            throw new UnsupportedOperationException();
+            System.arraycopy(tmpValues, i, pointValue, i, j - i);
+            System.arraycopy(tmpDocs, i, docId, i, j - i);
           }
 
           @Override


### PR DESCRIPTION
### Description

As `StableMSBRadixSorter` always requires a `O(n)` extra memory. We can use a `MergeSorter` taking advantage of the extra memory instead of `InPlaceMergeSorter`.

### Benchmark

This reduces around 12% took of sorting ~10,000,000 timestamp values (LongPoint) during indexing.
<!--StartFragment--><byte-sheet-html-origin data-id="1696443928669" data-version="4" data-is-embed="false" data-grid-line-hidden="false" data-importRangeRawData-spreadSource="https://bytedance.feishu.cn/sheets/HSetsPqDrhicnet5lWrcOXMtnRc" data-importRangeRawData-range="&#39;Sheet1&#39;!A1:D2">

  | baseline | candidate | took diff
-- | -- | -- | --
sort took | 5333 | 4667 | -12.49%

</byte-sheet-html-origin><!--EndFragment-->
