### PR TITLE
DeletedTerms#clear should reset ByteBlockPool

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
@@ -281,6 +281,13 @@ class BufferedUpdates implements Accountable {
       }
     }
 
+    /**
+     * Visible for testing.
+     */
+    ByteBlockPool getPool() {
+      return pool;
+    }
+
     @Override
     public long ramBytesUsed() {
       return bytesUsed.get();

--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
@@ -230,6 +230,7 @@ class BufferedUpdates implements Accountable {
     }
 
     void clear() {
+      pool.reset(false, false);
       bytesUsed.addAndGet(-bytesUsed.get());
       deleteTerms.clear();
       termsSize = 0;
@@ -283,6 +284,14 @@ class BufferedUpdates implements Accountable {
     @Override
     public long ramBytesUsed() {
       return bytesUsed.get();
+    }
+
+    /** Used for {@link BufferedUpdates#VERBOSE_DELETES}. */
+    @Override
+    public String toString() {
+      return keySet().stream()
+          .map(t -> t + "=" + get(t))
+          .collect(Collectors.joining(", ", "{", "}"));
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
@@ -281,9 +281,7 @@ class BufferedUpdates implements Accountable {
       }
     }
 
-    /**
-     * Visible for testing.
-     */
+    /** Visible for testing. */
     ByteBlockPool getPool() {
       return pool;
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
@@ -61,10 +61,10 @@ public class TestBufferedUpdates extends LuceneTestCase {
   public void testDeletedTerms() {
     int iters = atLeast(10);
     String[] fields = new String[] {"a", "b", "c"};
+    BufferedUpdates.DeletedTerms actual = new BufferedUpdates.DeletedTerms();
     for (int iter = 0; iter < iters; iter++) {
 
       Map<Term, Integer> expected = new HashMap<>();
-      BufferedUpdates.DeletedTerms actual = new BufferedUpdates.DeletedTerms();
       assertTrue(actual.isEmpty());
 
       int termCount = atLeast(5000);
@@ -95,6 +95,11 @@ public class TestBufferedUpdates extends LuceneTestCase {
           }));
 
       assertEquals(expectedSorted, actualSorted);
+
+      actual.clear();
+      assertEquals(0, actual.size());
+      assertEquals(0, actual.ramBytesUsed());
+      assertNull(actual.getPool().buffer);
     }
   }
 }


### PR DESCRIPTION
### Description

This is a bug left by #12573. As we are using a common `ByteBlockPool` across all `BytesRefHash`, the map clear won't help release the memory held by `ByteBlockPool` and the pool will allocate new slices when new terms added because the offset is never reset.

Sorry for the missing! 
