### PR TITLE
Speedup integer functions for 128-bit neon vectors

### DIFF
--- a/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -269,12 +269,12 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         for (; i < upperBound; i += PREF_BYTE_SPECIES.length()) {
           ByteVector va8 = ByteVector.fromArray(PREF_BYTE_SPECIES, a, i);
           ByteVector vb8 = ByteVector.fromArray(PREF_BYTE_SPECIES, b, i);
-          // widen to 32 bits, multiply and add
-          Vector<Integer> va32 =
-              va8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
-          Vector<Integer> vb32 =
-              vb8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
-          acc = acc.add(va32.mul(vb32));
+          Vector<Short> va16 = va8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
+          Vector<Short> vb16 = vb8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
+          Vector<Short> prod16 = va16.mul(vb16);
+          Vector<Integer> prod32 =
+              prod16.convertShape(VectorOperators.S2I, IntVector.SPECIES_PREFERRED, 0);
+          acc = acc.add(prod32);
         }
         // reduce
         res += acc.reduceLanes(VectorOperators.ADD);
@@ -330,14 +330,20 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         for (; i < upperBound; i += PREF_BYTE_SPECIES.length()) {
           ByteVector va8 = ByteVector.fromArray(PREF_BYTE_SPECIES, a, i);
           ByteVector vb8 = ByteVector.fromArray(PREF_BYTE_SPECIES, b, i);
-          // widen to 32-bits, square, multiply, and add
-          Vector<Integer> va32 =
-              va8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
-          accNorm1 = accNorm1.add(va32.mul(va32));
-          Vector<Integer> vb32 =
-              vb8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
-          accNorm2 = accNorm2.add(vb32.mul(vb32));
-          accSum = accSum.add(va32.mul(vb32));
+          Vector<Short> va16 = va8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
+          Vector<Short> vb16 = vb8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
+          Vector<Short> prod16 = va16.mul(vb16);
+          Vector<Short> norm1_16 = va16.mul(va16);
+          Vector<Short> norm2_16 = vb16.mul(vb16);
+          Vector<Integer> prod32 =
+              prod16.convertShape(VectorOperators.S2I, IntVector.SPECIES_PREFERRED, 0);
+          Vector<Integer> norm1_32 =
+              norm1_16.convertShape(VectorOperators.S2I, IntVector.SPECIES_PREFERRED, 0);
+          Vector<Integer> norm2_32 =
+              norm2_16.convertShape(VectorOperators.S2I, IntVector.SPECIES_PREFERRED, 0);
+          accSum = accSum.add(prod32);
+          accNorm1 = accNorm1.add(norm1_32);
+          accNorm2 = accNorm2.add(norm2_32);
         }
         // reduce
         sum += accSum.reduceLanes(VectorOperators.ADD);
@@ -411,12 +417,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         for (; i < upperBound; i += PREF_BYTE_SPECIES.length()) {
           ByteVector va8 = ByteVector.fromArray(PREF_BYTE_SPECIES, a, i);
           ByteVector vb8 = ByteVector.fromArray(PREF_BYTE_SPECIES, b, i);
-          // widen to 32-bits, subtract, square, and add
-          Vector<Integer> va32 =
-              va8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
-          Vector<Integer> vb32 =
-              vb8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
-          Vector<Integer> diff32 = va32.sub(vb32);
+          Vector<Short> va16 = va8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
+          Vector<Short> vb16 = vb8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
+          Vector<Short> diff16 = va16.sub(vb16);
+          Vector<Integer> diff32 =
+              diff16.convertShape(VectorOperators.S2I, IntVector.SPECIES_PREFERRED, 0);
           acc = acc.add(diff32.mul(diff32));
         }
         // reduce

--- a/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -361,8 +361,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           Vector<Short> prod16 = va16.mul(vb16);
 
           // sum into accumulators
-          accNorm1 = accNorm1.add(norm1_16.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0));
-          accNorm2 = accNorm2.add(norm2_16.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0));
+          accNorm1 =
+              accNorm1.add(norm1_16.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0));
+          accNorm2 =
+              accNorm2.add(norm2_16.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0));
           accSum = accSum.add(prod16.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0));
         }
         // reduce

--- a/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -269,12 +269,12 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         for (; i < upperBound; i += PREF_BYTE_SPECIES.length()) {
           ByteVector va8 = ByteVector.fromArray(PREF_BYTE_SPECIES, a, i);
           ByteVector vb8 = ByteVector.fromArray(PREF_BYTE_SPECIES, b, i);
-          Vector<Short> va16 = va8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
-          Vector<Short> vb16 = vb8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
-          Vector<Short> prod16 = va16.mul(vb16);
-          Vector<Integer> prod32 =
-              prod16.convertShape(VectorOperators.S2I, IntVector.SPECIES_PREFERRED, 0);
-          acc = acc.add(prod32);
+          // widen to 32 bits, multiply and add
+          Vector<Integer> va32 =
+              va8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
+          Vector<Integer> vb32 =
+              vb8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
+          acc = acc.add(va32.mul(vb32));
         }
         // reduce
         res += acc.reduceLanes(VectorOperators.ADD);
@@ -327,20 +327,14 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         for (; i < upperBound; i += PREF_BYTE_SPECIES.length()) {
           ByteVector va8 = ByteVector.fromArray(PREF_BYTE_SPECIES, a, i);
           ByteVector vb8 = ByteVector.fromArray(PREF_BYTE_SPECIES, b, i);
-          Vector<Short> va16 = va8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
-          Vector<Short> vb16 = vb8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
-          Vector<Short> prod16 = va16.mul(vb16);
-          Vector<Short> norm1_16 = va16.mul(va16);
-          Vector<Short> norm2_16 = vb16.mul(vb16);
-          Vector<Integer> prod32 =
-              prod16.convertShape(VectorOperators.S2I, IntVector.SPECIES_PREFERRED, 0);
-          Vector<Integer> norm1_32 =
-              norm1_16.convertShape(VectorOperators.S2I, IntVector.SPECIES_PREFERRED, 0);
-          Vector<Integer> norm2_32 =
-              norm2_16.convertShape(VectorOperators.S2I, IntVector.SPECIES_PREFERRED, 0);
-          accSum = accSum.add(prod32);
-          accNorm1 = accNorm1.add(norm1_32);
-          accNorm2 = accNorm2.add(norm2_32);
+          // widen to 32-bits, square, multiply, and add
+          Vector<Integer> va32 =
+              va8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
+          accNorm1 = accNorm1.add(va32.mul(va32));
+          Vector<Integer> vb32 =
+              vb8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
+          accNorm2 = accNorm2.add(vb32.mul(vb32));
+          accSum = accSum.add(va32.mul(vb32));
         }
         // reduce
         sum += accSum.reduceLanes(VectorOperators.ADD);
@@ -415,11 +409,12 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         for (; i < upperBound; i += PREF_BYTE_SPECIES.length()) {
           ByteVector va8 = ByteVector.fromArray(PREF_BYTE_SPECIES, a, i);
           ByteVector vb8 = ByteVector.fromArray(PREF_BYTE_SPECIES, b, i);
-          Vector<Short> va16 = va8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
-          Vector<Short> vb16 = vb8.convertShape(VectorOperators.B2S, PREF_SHORT_SPECIES, 0);
-          Vector<Short> diff16 = va16.sub(vb16);
-          Vector<Integer> diff32 =
-              diff16.convertShape(VectorOperators.S2I, IntVector.SPECIES_PREFERRED, 0);
+          // widen to 32-bits, subtract, square, and add
+          Vector<Integer> va32 =
+              va8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
+          Vector<Integer> vb32 =
+              vb8.convertShape(VectorOperators.B2I, IntVector.SPECIES_PREFERRED, 0);
+          Vector<Integer> diff32 = va32.sub(vb32);
           acc = acc.add(diff32.mul(diff32));
         }
         // reduce

--- a/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -279,27 +279,21 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         // reduce
         res += acc.reduceLanes(VectorOperators.ADD);
       } else {
-        // 128-bit implementation, which must "split up" vectors due to widening conversions
-        int upperBound = ByteVector.SPECIES_128.loopBound(a.length);
+        // 128-bit impl, which is tricky since we don't have SPECIES_32, it does "overlapping read"
+        int upperBound = ByteVector.SPECIES_64.loopBound(a.length - ByteVector.SPECIES_64.length());
         IntVector acc = IntVector.zero(IntVector.SPECIES_128);
-        for (; i < upperBound; i += ByteVector.SPECIES_128.length()) {
-          ByteVector va8 = ByteVector.fromArray(ByteVector.SPECIES_128, a, i);
-          ByteVector vb8 = ByteVector.fromArray(ByteVector.SPECIES_128, b, i);
+        // 4 bytes at a time
+        for (; i < upperBound; i += ByteVector.SPECIES_64.length() >> 1) {
+          // load 8 bytes
+          ByteVector va8 = ByteVector.fromArray(ByteVector.SPECIES_64, a, i);
+          ByteVector vb8 = ByteVector.fromArray(ByteVector.SPECIES_64, b, i);
 
-          // first half
-          Vector<Short> va16_1 = va8.convert(VectorOperators.B2S, 0);
-          Vector<Short> vb16_1 = vb8.convert(VectorOperators.B2S, 0);
-          Vector<Short> prod16_1 = va16_1.mul(vb16_1);
+          // process first "half" only
+          Vector<Short> va16 = va8.convert(VectorOperators.B2S, 0);
+          Vector<Short> vb16 = vb8.convert(VectorOperators.B2S, 0);
+          Vector<Short> prod16 = va16.mul(vb16);
 
-          // second half
-          Vector<Short> va16_2 = va8.convert(VectorOperators.B2S, 1);
-          Vector<Short> vb16_2 = vb8.convert(VectorOperators.B2S, 1);
-          Vector<Short> prod16_2 = va16_2.mul(vb16_2);
-
-          // sum into accumulators
-          Vector<Short> prod16 = prod16_1.add(prod16_2);
-          acc = acc.add(prod16.convert(VectorOperators.S2I, 0));
-          acc = acc.add(prod16.convert(VectorOperators.S2I, 1));
+          acc = acc.add(prod16.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0));
         }
         // reduce
         res += acc.reduceLanes(VectorOperators.ADD);

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.internal.vectorization;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import java.util.Arrays;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToIntFunction;
 import java.util.stream.IntStream;
@@ -57,6 +58,35 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
     var b = new byte[size];
     random().nextBytes(a);
     random().nextBytes(b);
+    assertIntReturningProviders(p -> p.dotProduct(a, b));
+    assertIntReturningProviders(p -> p.squareDistance(a, b));
+    assertFloatReturningProviders(p -> p.cosine(a, b));
+  }
+
+  public void testBinaryVectorsBoundaries() {
+    var a = new byte[size];
+    var b = new byte[size];
+
+    Arrays.fill(a, Byte.MIN_VALUE);
+    Arrays.fill(b, Byte.MIN_VALUE);
+    assertIntReturningProviders(p -> p.dotProduct(a, b));
+    assertIntReturningProviders(p -> p.squareDistance(a, b));
+    assertFloatReturningProviders(p -> p.cosine(a, b));
+
+    Arrays.fill(a, Byte.MAX_VALUE);
+    Arrays.fill(b, Byte.MAX_VALUE);
+    assertIntReturningProviders(p -> p.dotProduct(a, b));
+    assertIntReturningProviders(p -> p.squareDistance(a, b));
+    assertFloatReturningProviders(p -> p.cosine(a, b));
+
+    Arrays.fill(a, Byte.MIN_VALUE);
+    Arrays.fill(b, Byte.MAX_VALUE);
+    assertIntReturningProviders(p -> p.dotProduct(a, b));
+    assertIntReturningProviders(p -> p.squareDistance(a, b));
+    assertFloatReturningProviders(p -> p.cosine(a, b));
+
+    Arrays.fill(a, Byte.MAX_VALUE);
+    Arrays.fill(b, Byte.MIN_VALUE);
     assertIntReturningProviders(p -> p.dotProduct(a, b));
     assertIntReturningProviders(p -> p.squareDistance(a, b));
     assertFloatReturningProviders(p -> p.cosine(a, b));


### PR DESCRIPTION
gives a little love to the mac for dot-product and binary-cosine. 

I see on m1 some improvement:
You can reproduce with `java -jar target/vectorbench.jar Binary -p size=1024`
See https://github.com/rmuir/vectorbench with has a README now!

```
Benchmark                                   (size)   Mode  Cnt  Score   Error   Units
BinaryDotProductBenchmark.dotProductNew       1024  thrpt    5  6.135 ± 0.008  ops/us
BinaryDotProductBenchmark.dotProductNewNew    1024  thrpt    5  7.197 ± 0.028  ops/us
BinaryCosineBenchmark.cosineDistanceNew       1024  thrpt    5  2.259 ± 0.003  ops/us
BinaryCosineBenchmark.cosineDistanceNewNew    1024  thrpt    5  3.622 ± 0.017  ops/us
```


edit: originally I tried to optimize the 256/512-bit path, but it caused slowdowns on avx-512 so i reverted the changes. Sorry for confusion. hopefully we get some improvement to something that can stick :)