### PR TITLE
Add interface VectorValues to be implemented by [Float/Byte]VectorValues

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -380,7 +380,7 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       return vectorValue(ord);
     }
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
@@ -415,7 +415,7 @@ public final class Lucene91HnswVectorsReader extends KnnVectorsReader {
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       dataIn.seek((long) ord * byteSize);
       dataIn.readFloats(value, 0, value.length);
       return value;

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/OffHeapFloatVectorValues.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/OffHeapFloatVectorValues.java
@@ -91,7 +91,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       return vectorValue(doc);
     }
 
@@ -153,7 +153,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       return vectorValue(disi.index());
     }
 
@@ -221,7 +221,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       throw new UnsupportedOperationException();
     }
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapByteVectorValues.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapByteVectorValues.java
@@ -100,7 +100,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
     }
 
     @Override
-    public byte[] vectorValue() throws IOException {
+    public byte[] vectorByteValue() throws IOException {
       return vectorValue(doc);
     }
 
@@ -165,7 +165,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
     }
 
     @Override
-    public byte[] vectorValue() throws IOException {
+    public byte[] vectorByteValue() throws IOException {
       return vectorValue(disi.index());
     }
 
@@ -233,7 +233,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
     }
 
     @Override
-    public byte[] vectorValue() throws IOException {
+    public byte[] vectorByteValue() throws IOException {
       throw new UnsupportedOperationException();
     }
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapFloatVectorValues.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapFloatVectorValues.java
@@ -97,7 +97,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       return vectorValue(doc);
     }
 
@@ -162,7 +162,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       return vectorValue(disi.index());
     }
 
@@ -230,7 +230,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       throw new UnsupportedOperationException();
     }
 

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsWriter.java
@@ -187,7 +187,7 @@ public final class Lucene90HnswVectorsWriter extends BufferingKnnVectorsWriter {
         ByteBuffer.allocate(vectors.dimension() * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
     for (int docV = vectors.nextDoc(); docV != NO_MORE_DOCS; docV = vectors.nextDoc(), count++) {
       // write vector
-      float[] vectorValue = vectors.vectorValue();
+      float[] vectorValue = vectors.vectorFloatValue();
       binaryVector.asFloatBuffer().put(vectorValue);
       output.writeBytes(binaryVector.array(), binaryVector.limit());
       docIds[count] = docV;

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsWriter.java
@@ -181,7 +181,7 @@ public final class Lucene91HnswVectorsWriter extends BufferingKnnVectorsWriter {
         ByteBuffer.allocate(vectors.dimension() * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
     for (int docV = vectors.nextDoc(); docV != NO_MORE_DOCS; docV = vectors.nextDoc()) {
       // write vector
-      float[] vectorValue = vectors.vectorValue();
+      float[] vectorValue = vectors.vectorFloatValue();
       binaryVector.asFloatBuffer().put(vectorValue);
       output.writeBytes(binaryVector.array(), binaryVector.limit());
       docsWithField.add(docV);

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
@@ -188,7 +188,7 @@ public final class Lucene92HnswVectorsWriter extends BufferingKnnVectorsWriter {
         ByteBuffer.allocate(vectors.dimension() * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
     for (int docV = vectors.nextDoc(); docV != NO_MORE_DOCS; docV = vectors.nextDoc()) {
       // write vector
-      float[] vectorValue = vectors.vectorValue();
+      float[] vectorValue = vectors.vectorFloatValue();
       binaryVector.asFloatBuffer().put(vectorValue);
       output.writeBytes(binaryVector.array(), binaryVector.limit());
       docsWithField.add(docV);

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
@@ -587,7 +587,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
         docV != NO_MORE_DOCS;
         docV = byteVectorValues.nextDoc()) {
       // write vector
-      byte[] binaryValue = byteVectorValues.vectorValue();
+      byte[] binaryValue = byteVectorValues.vectorByteValue();
       assert binaryValue.length == byteVectorValues.dimension() * VectorEncoding.BYTE.byteSize;
       output.writeBytes(binaryValue, binaryValue.length);
       docsWithField.add(docV);
@@ -608,7 +608,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
         docV != NO_MORE_DOCS;
         docV = floatVectorValues.nextDoc()) {
       // write vector
-      float[] vectorValue = floatVectorValues.vectorValue();
+      float[] vectorValue = floatVectorValues.vectorFloatValue();
       binaryVector.asFloatBuffer().put(vectorValue);
       output.writeBytes(binaryVector.array(), binaryVector.limit());
       docsWithField.add(docV);

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
@@ -1346,7 +1346,10 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
           for (int doc = values.nextDoc(); doc != NO_MORE_DOCS; doc = values.nextDoc()) {
             float[] expectedVector = {KNN_VECTOR[0], KNN_VECTOR[1], KNN_VECTOR[2] + 0.1f * cnt};
             assertArrayEquals(
-                "vectors do not match for doc=" + cnt, expectedVector, values.vectorValue(), 0);
+                "vectors do not match for doc=" + cnt,
+                expectedVector,
+                values.vectorFloatValue(),
+                0);
             cnt++;
           }
         }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
@@ -200,7 +200,7 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
         break;
       }
 
-      float[] vector = values.vectorValue();
+      float[] vector = values.vectorFloatValue();
       float score = vectorSimilarity.compare(vector, target);
       knnCollector.collect(doc, score);
       knnCollector.incVisitedCount(1);
@@ -231,7 +231,7 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
         break;
       }
 
-      byte[] vector = values.vectorValue();
+      byte[] vector = values.vectorByteValue();
       float score = vectorSimilarity.compare(vector, target);
       knnCollector.collect(doc, score);
       knnCollector.incVisitedCount(1);
@@ -342,7 +342,7 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
     }
 
     @Override
-    public float[] vectorValue() {
+    public float[] vectorFloatValue() {
       return values[curOrd];
     }
 
@@ -434,7 +434,7 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
     }
 
     @Override
-    public byte[] vectorValue() {
+    public byte[] vectorByteValue() {
       binaryValue.bytes = values[curOrd];
       return binaryValue.bytes;
     }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsWriter.java
@@ -89,7 +89,7 @@ public class SimpleTextKnnVectorsWriter extends BufferingKnnVectorsWriter {
 
   private void writeFloatVectorValue(FloatVectorValues vectors) throws IOException {
     // write vector value
-    float[] value = vectors.vectorValue();
+    float[] value = vectors.vectorFloatValue();
     assert value.length == vectors.dimension();
     write(vectorData, Arrays.toString(value));
     newline(vectorData);
@@ -112,7 +112,7 @@ public class SimpleTextKnnVectorsWriter extends BufferingKnnVectorsWriter {
 
   private void writeByteVectorValue(ByteVectorValues vectors) throws IOException {
     // write vector value
-    byte[] value = vectors.vectorValue();
+    byte[] value = vectors.vectorByteValue();
     assert value.length == vectors.dimension();
     write(vectorData, Arrays.toString(value));
     newline(vectorData);

--- a/lucene/core/src/java/org/apache/lucene/codecs/BufferingKnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/BufferingKnnVectorsWriter.java
@@ -141,7 +141,7 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       return randomAccess.vectorValue(docIdOffsets[docId] - 1);
     }
 
@@ -198,7 +198,7 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
     }
 
     @Override
-    public byte[] vectorValue() throws IOException {
+    public byte[] vectorByteValue() throws IOException {
       return randomAccess.vectorValue(docIdOffsets[docId] - 1);
     }
 
@@ -328,7 +328,7 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
     }
 
     @Override
-    public float[] vectorValue() {
+    public float[] vectorFloatValue() {
       return vectors.get(ord);
     }
 
@@ -388,7 +388,7 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
     }
 
     @Override
-    public byte[] vectorValue() {
+    public byte[] vectorByteValue() {
       return vectors.get(ord);
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -55,7 +55,7 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
         for (int doc = mergedBytes.nextDoc();
             doc != DocIdSetIterator.NO_MORE_DOCS;
             doc = mergedBytes.nextDoc()) {
-          byteWriter.addValue(doc, mergedBytes.vectorValue());
+          byteWriter.addValue(doc, mergedBytes.vectorByteValue());
         }
         break;
       case FLOAT32:
@@ -66,7 +66,7 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
         for (int doc = mergedFloats.nextDoc();
             doc != DocIdSetIterator.NO_MORE_DOCS;
             doc = mergedFloats.nextDoc()) {
-          floatWriter.addValue(doc, mergedFloats.vectorValue());
+          floatWriter.addValue(doc, mergedFloats.vectorFloatValue());
         }
         break;
     }
@@ -221,8 +221,8 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
       }
 
       @Override
-      public float[] vectorValue() throws IOException {
-        return current.values.vectorValue();
+      public float[] vectorFloatValue() throws IOException {
+        return current.values.vectorFloatValue();
       }
 
       @Override
@@ -262,8 +262,8 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
       }
 
       @Override
-      public byte[] vectorValue() throws IOException {
-        return current.values.vectorValue();
+      public byte[] vectorByteValue() throws IOException {
+        return current.values.vectorByteValue();
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
@@ -100,7 +100,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
     }
 
     @Override
-    public byte[] vectorValue() throws IOException {
+    public byte[] vectorByteValue() throws IOException {
       return vectorValue(doc);
     }
 
@@ -165,7 +165,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
     }
 
     @Override
-    public byte[] vectorValue() throws IOException {
+    public byte[] vectorByteValue() throws IOException {
       return vectorValue(disi.index());
     }
 
@@ -233,7 +233,7 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues
     }
 
     @Override
-    public byte[] vectorValue() throws IOException {
+    public byte[] vectorByteValue() throws IOException {
       throw new UnsupportedOperationException();
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
@@ -95,7 +95,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       return vectorValue(doc);
     }
 
@@ -160,7 +160,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       return vectorValue(disi.index());
     }
 
@@ -228,7 +228,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       throw new UnsupportedOperationException();
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.index;
 
-import java.io.IOException;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -26,32 +25,13 @@ import org.apache.lucene.search.DocIdSetIterator;
  *
  * @lucene.experimental
  */
-public abstract class ByteVectorValues extends DocIdSetIterator {
+public abstract class ByteVectorValues extends DocIdSetIterator implements VectorValues {
 
   /** Sole constructor */
   protected ByteVectorValues() {}
-
-  /** Return the dimension of the vectors */
-  public abstract int dimension();
-
-  /**
-   * Return the number of vectors for this field.
-   *
-   * @return the number of vectors returned by this iterator
-   */
-  public abstract int size();
 
   @Override
   public final long cost() {
     return size();
   }
-
-  /**
-   * Return the vector value for the current document ID. It is illegal to call this method when the
-   * iterator is not positioned: before advancing, or after failing to advance. The returned array
-   * may be shared across calls, re-used, and modified as the iterator advances.
-   *
-   * @return the vector value
-   */
-  public abstract byte[] vectorValue() throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2657,14 +2657,16 @@ public final class CheckIndex implements Closeable {
       // search the first maxNumSearches vectors to exercise the graph
       if (values.docID() % everyNdoc == 0) {
         KnnCollector collector = new TopKnnCollector(10, Integer.MAX_VALUE);
-        codecReader.getVectorReader().search(fieldInfo.name, values.vectorValue(), collector, null);
+        codecReader
+            .getVectorReader()
+            .search(fieldInfo.name, values.vectorFloatValue(), collector, null);
         TopDocs docs = collector.topDocs();
         if (docs.scoreDocs.length == 0) {
           throw new CheckIndexException(
               "Field \"" + fieldInfo.name + "\" failed to search k nearest neighbors");
         }
       }
-      int valueLength = values.vectorValue().length;
+      int valueLength = values.vectorFloatValue().length;
       if (valueLength != fieldInfo.getVectorDimension()) {
         throw new CheckIndexException(
             "Field \""
@@ -2701,14 +2703,16 @@ public final class CheckIndex implements Closeable {
       // search the first maxNumSearches vectors to exercise the graph
       if (values.docID() % everyNdoc == 0) {
         KnnCollector collector = new TopKnnCollector(10, Integer.MAX_VALUE);
-        codecReader.getVectorReader().search(fieldInfo.name, values.vectorValue(), collector, null);
+        codecReader
+            .getVectorReader()
+            .search(fieldInfo.name, values.vectorByteValue(), collector, null);
         TopDocs docs = collector.topDocs();
         if (docs.scoreDocs.length == 0) {
           throw new CheckIndexException(
               "Field \"" + fieldInfo.name + "\" failed to search k nearest neighbors");
         }
       }
-      int valueLength = values.vectorValue().length;
+      int valueLength = values.vectorByteValue().length;
       if (valueLength != fieldInfo.getVectorDimension()) {
         throw new CheckIndexException(
             "Field \""

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -469,8 +469,8 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       }
 
       @Override
-      public float[] vectorValue() throws IOException {
-        return vectorValues.vectorValue();
+      public float[] vectorFloatValue() throws IOException {
+        return vectorValues.vectorFloatValue();
       }
 
       @Override
@@ -541,8 +541,8 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       }
 
       @Override
-      public byte[] vectorValue() throws IOException {
-        return vectorValues.vectorValue();
+      public byte[] vectorByteValue() throws IOException {
+        return vectorValues.vectorByteValue();
       }
 
       /**

--- a/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.index;
 
-import java.io.IOException;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -26,32 +25,13 @@ import org.apache.lucene.search.DocIdSetIterator;
  *
  * @lucene.experimental
  */
-public abstract class FloatVectorValues extends DocIdSetIterator {
+public abstract class FloatVectorValues extends DocIdSetIterator implements VectorValues {
 
   /** Sole constructor */
   protected FloatVectorValues() {}
-
-  /** Return the dimension of the vectors */
-  public abstract int dimension();
-
-  /**
-   * Return the number of vectors for this field.
-   *
-   * @return the number of vectors returned by this iterator
-   */
-  public abstract int size();
 
   @Override
   public final long cost() {
     return size();
   }
-
-  /**
-   * Return the vector value for the current document ID. It is illegal to call this method when the
-   * iterator is not positioned: before advancing, or after failing to advance. The returned array
-   * may be shared across calls, re-used, and modified as the iterator advances.
-   *
-   * @return the vector value
-   */
-  public abstract float[] vectorValue() throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -229,7 +229,7 @@ public final class SortingCodecReader extends FilterCodecReader {
       for (int doc = delegate.nextDoc(); doc != NO_MORE_DOCS; doc = delegate.nextDoc()) {
         int newDocID = sortMap.oldToNew(doc);
         docsWithField.set(newDocID);
-        vectors[newDocID] = delegate.vectorValue().clone();
+        vectors[newDocID] = delegate.vectorFloatValue().clone();
       }
     }
 
@@ -244,7 +244,7 @@ public final class SortingCodecReader extends FilterCodecReader {
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorFloatValue() throws IOException {
       return vectors[docId];
     }
 
@@ -283,7 +283,7 @@ public final class SortingCodecReader extends FilterCodecReader {
       for (int doc = delegate.nextDoc(); doc != NO_MORE_DOCS; doc = delegate.nextDoc()) {
         int newDocID = sortMap.oldToNew(doc);
         docsWithField.set(newDocID);
-        vectors[newDocID] = delegate.vectorValue().clone();
+        vectors[newDocID] = delegate.vectorByteValue().clone();
       }
     }
 
@@ -298,7 +298,7 @@ public final class SortingCodecReader extends FilterCodecReader {
     }
 
     @Override
-    public byte[] vectorValue() throws IOException {
+    public byte[] vectorByteValue() throws IOException {
       return vectors[docId];
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorValues.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnFloatVectorField;
+
+/**
+ * Provides the common functionality to be implemented by the different classes like {@link
+ * ByteVectorValues} and {@link FloatVectorValues}, providing access to per-document float/byte
+ * vector values indexed as {@link KnnByteVectorField} or {@link KnnFloatVectorField}
+ */
+public interface VectorValues {
+
+  /** Return the dimension of the vectors */
+  int dimension();
+
+  /**
+   * Return the number of vectors for this field.
+   *
+   * @return the number of vectors returned by this iterator
+   */
+  int size();
+
+  /**
+   * Return the vector value (byte/float) for the current document ID. It is illegal to call this
+   * method when the iterator is not positioned: before advancing, or after failing to advance. The
+   * caller needs to cast the returned value correctly into byte[] or float[]. The returned array
+   * may be shared across calls, re-used, and modified as the iterator advances.
+   *
+   * @return the vector value (byte/float)
+   */
+  default Object vectorValue() throws IOException {
+    if (this instanceof FloatVectorValues) {
+      return vectorFloatValue();
+    } else {
+      return vectorByteValue();
+    }
+  }
+
+  /**
+   * Return the byte vector value for the current document ID. It is illegal to call this method
+   * when the iterator is not positioned: before advancing, or after failing to advance. The
+   * returned array may be shared across calls, re-used, and modified as the iterator advances.
+   *
+   * @return the byte vector value
+   */
+  default byte[] vectorByteValue() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Return the float vector value for the current document ID. It is illegal to call this method
+   * when the iterator is not positioned: before advancing, or after failing to advance. The
+   * returned array may be shared across calls, re-used, and modified as the iterator advances.
+   *
+   * @return the float vector value
+   */
+  default float[] vectorFloatValue() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/VectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/VectorScorer.java
@@ -87,7 +87,7 @@ abstract class VectorScorer {
 
     @Override
     public float score() throws IOException {
-      return similarity.compare(query, values.vectorValue());
+      return similarity.compare(query, values.vectorByteValue());
     }
   }
 
@@ -117,7 +117,7 @@ abstract class VectorScorer {
 
     @Override
     public float score() throws IOException {
-      return similarity.compare(query, values.vectorValue());
+      return similarity.compare(query, values.vectorFloatValue());
     }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/document/TestField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestField.java
@@ -714,15 +714,15 @@ public class TestField extends LuceneTestCase {
         ByteVectorValues binary = r.leaves().get(0).reader().getByteVectorValues("binary");
         assertEquals(1, binary.size());
         assertNotEquals(NO_MORE_DOCS, binary.nextDoc());
-        assertNotNull(binary.vectorValue());
-        assertArrayEquals(b, binary.vectorValue());
+        assertNotNull(binary.vectorByteValue());
+        assertArrayEquals(b, binary.vectorByteValue());
         assertEquals(NO_MORE_DOCS, binary.nextDoc());
 
         FloatVectorValues floatValues = r.leaves().get(0).reader().getFloatVectorValues("float");
         assertEquals(1, floatValues.size());
         assertNotEquals(NO_MORE_DOCS, floatValues.nextDoc());
-        assertEquals(vector.length, floatValues.vectorValue().length);
-        assertEquals(vector[0], floatValues.vectorValue()[0], 0);
+        assertEquals(vector.length, floatValues.vectorFloatValue().length);
+        assertEquals(vector[0], floatValues.vectorFloatValue()[0], 0);
         assertEquals(NO_MORE_DOCS, floatValues.nextDoc());
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -574,7 +574,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
       if (random().nextBoolean()
           && iter.docID() != DocIdSetIterator.NO_MORE_DOCS
           && iter instanceof FloatVectorValues) {
-        ((FloatVectorValues) iter).vectorValue();
+        ((FloatVectorValues) iter).vectorFloatValue();
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -421,7 +421,7 @@ public class TestKnnGraph extends LuceneTestCase {
           }
           int id = Integer.parseInt(storedFields.document(i).get("id"));
           // documents with KnnGraphValues have the expected vectors
-          float[] scratch = vectorValues.vectorValue();
+          float[] scratch = vectorValues.vectorFloatValue();
           assertArrayEquals(
               "vector did not match for doc " + i + ", id=" + id + ": " + Arrays.toString(scratch),
               values[id],

--- a/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
@@ -274,7 +274,7 @@ public class TestSortingCodecReader extends LuceneTestCase {
               assertEquals(1, sorted_numeric_dv.docValueCount());
               assertEquals(ids.longValue(), sorted_numeric_dv.nextValue());
 
-              float[] vectorValue = vectorValues.vectorValue();
+              float[] vectorValue = vectorValues.vectorFloatValue();
               assertEquals(1, vectorValue.length);
               assertEquals((float) ids.longValue(), vectorValue[0], 0.001f);
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -1006,7 +1006,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     }
 
     @Override
-    public float[] vectorValue() {
+    public float[] vectorFloatValue() {
       return vectorValue(doc);
     }
 
@@ -1067,7 +1067,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     }
 
     @Override
-    public byte[] vectorValue() {
+    public byte[] vectorByteValue() {
       return vectorValue(doc);
     }
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswByteVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswByteVectorGraph.java
@@ -121,7 +121,7 @@ public class TestHnswByteVectorGraph extends HnswGraphTestCase<byte[]> {
     while (vectorValues.nextDoc() != NO_MORE_DOCS) {
       vectors[vectorValues.docID()] =
           ArrayUtil.copyOfSubArray(
-              vectorValues.vectorValue(), 0, vectorValues.vectorValue().length);
+              vectorValues.vectorByteValue(), 0, vectorValues.vectorByteValue().length);
     }
     return MockByteVectorValues.fromValues(vectors);
   }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
@@ -77,7 +77,7 @@ public class TestHnswFloatVectorGraph extends HnswGraphTestCase<float[]> {
     while (vectorValues.nextDoc() != NO_MORE_DOCS) {
       vectors[vectorValues.docID()] =
           ArrayUtil.copyOfSubArray(
-              vectorValues.vectorValue(), 0, vectorValues.vectorValue().length);
+              vectorValues.vectorFloatValue(), 0, vectorValues.vectorFloatValue().length);
     }
     return MockVectorValues.fromValues(vectors);
   }

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
@@ -199,7 +199,7 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
       currentParent = parentBitSet.nextSetBit(nextChild);
       do {
         values.advance(nextChild);
-        float score = similarity.compare(query, values.vectorValue());
+        float score = similarity.compare(query, values.vectorByteValue());
         if (score > currentScore) {
           bestChild = nextChild;
           currentScore = score;

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
@@ -199,7 +199,7 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
       currentParent = parentBitSet.nextSetBit(nextChild);
       do {
         values.advance(nextChild);
-        float score = similarity.compare(query, values.vectorValue());
+        float score = similarity.compare(query, values.vectorFloatValue());
         if (score > currentScore) {
           bestChild = nextChild;
           currentScore = score;

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/ByteKnnVectorFieldSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/ByteKnnVectorFieldSource.java
@@ -51,7 +51,7 @@ public class ByteKnnVectorFieldSource extends ValueSource {
       @Override
       public byte[] byteVectorVal(int doc) throws IOException {
         if (exists(doc)) {
-          return vectorValues.vectorValue();
+          return vectorValues.vectorByteValue();
         } else {
           return null;
         }

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/FloatKnnVectorFieldSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/FloatKnnVectorFieldSource.java
@@ -50,7 +50,7 @@ public class FloatKnnVectorFieldSource extends ValueSource {
       @Override
       public float[] floatVectorVal(int doc) throws IOException {
         if (exists(doc)) {
-          return vectorValues.vectorValue();
+          return vectorValues.vectorFloatValue();
         } else {
           return null;
         }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -248,7 +248,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           LeafReader r = getOnlyLeafReader(reader);
           FloatVectorValues vectorValues = r.getFloatVectorValues(fieldName);
           assertEquals(0, vectorValues.nextDoc());
-          assertEquals(0, vectorValues.vectorValue()[0], 0);
+          assertEquals(0, vectorValues.vectorFloatValue()[0], 0);
           assertEquals(NO_MORE_DOCS, vectorValues.nextDoc());
         }
       }
@@ -273,7 +273,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           LeafReader r = getOnlyLeafReader(reader);
           FloatVectorValues vectorValues = r.getFloatVectorValues(fieldName);
           assertNotEquals(NO_MORE_DOCS, vectorValues.nextDoc());
-          assertEquals(0, vectorValues.vectorValue()[0], 0);
+          assertEquals(0, vectorValues.vectorFloatValue()[0], 0);
           assertEquals(NO_MORE_DOCS, vectorValues.nextDoc());
         }
       }
@@ -300,10 +300,10 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           FloatVectorValues vectorValues = r.getFloatVectorValues(fieldName);
           assertEquals(0, vectorValues.nextDoc());
           // The merge order is randomized, we might get 0 first, or 1
-          float value = vectorValues.vectorValue()[0];
+          float value = vectorValues.vectorFloatValue()[0];
           assertTrue(value == 0 || value == 1);
           assertEquals(1, vectorValues.nextDoc());
-          value += vectorValues.vectorValue()[0];
+          value += vectorValues.vectorFloatValue()[0];
           assertEquals(1, value, 0);
         }
       }
@@ -686,7 +686,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
                 if (byteVectorValues != null) {
                   docCount += byteVectorValues.size();
                   while (byteVectorValues.nextDoc() != NO_MORE_DOCS) {
-                    checksum += byteVectorValues.vectorValue()[0];
+                    checksum += byteVectorValues.vectorByteValue()[0];
                   }
                 }
               }
@@ -697,7 +697,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
                 if (vectorValues != null) {
                   docCount += vectorValues.size();
                   while (vectorValues.nextDoc() != NO_MORE_DOCS) {
-                    checksum += vectorValues.vectorValue()[0];
+                    checksum += vectorValues.vectorFloatValue()[0];
                   }
                 }
               }
@@ -748,11 +748,11 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         LeafReader r = getOnlyLeafReader(reader);
         FloatVectorValues vectorValues = r.getFloatVectorValues(fieldName);
         vectorValues.nextDoc();
-        assertEquals(1, vectorValues.vectorValue()[0], 0);
+        assertEquals(1, vectorValues.vectorFloatValue()[0], 0);
         vectorValues.nextDoc();
-        assertEquals(1, vectorValues.vectorValue()[0], 0);
+        assertEquals(1, vectorValues.vectorFloatValue()[0], 0);
         vectorValues.nextDoc();
-        assertEquals(2, vectorValues.vectorValue()[0], 0);
+        assertEquals(2, vectorValues.vectorFloatValue()[0], 0);
       }
     }
   }
@@ -776,11 +776,11 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         assertEquals(2, vectorValues.dimension());
         assertEquals(3, vectorValues.size());
         assertEquals("1", storedFields.document(vectorValues.nextDoc()).get("id"));
-        assertEquals(-1f, vectorValues.vectorValue()[0], 0);
+        assertEquals(-1f, vectorValues.vectorFloatValue()[0], 0);
         assertEquals("2", storedFields.document(vectorValues.nextDoc()).get("id"));
-        assertEquals(1, vectorValues.vectorValue()[0], 0);
+        assertEquals(1, vectorValues.vectorFloatValue()[0], 0);
         assertEquals("4", storedFields.document(vectorValues.nextDoc()).get("id"));
-        assertEquals(0, vectorValues.vectorValue()[0], 0);
+        assertEquals(0, vectorValues.vectorFloatValue()[0], 0);
         assertEquals(NO_MORE_DOCS, vectorValues.nextDoc());
       }
     }
@@ -805,11 +805,11 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         assertEquals(2, vectorValues.dimension());
         assertEquals(3, vectorValues.size());
         assertEquals("1", storedFields.document(vectorValues.nextDoc()).get("id"));
-        assertEquals(-1, vectorValues.vectorValue()[0], 0);
+        assertEquals(-1, vectorValues.vectorByteValue()[0], 0);
         assertEquals("2", storedFields.document(vectorValues.nextDoc()).get("id"));
-        assertEquals(1, vectorValues.vectorValue()[0], 0);
+        assertEquals(1, vectorValues.vectorByteValue()[0], 0);
         assertEquals("4", storedFields.document(vectorValues.nextDoc()).get("id"));
-        assertEquals(0, vectorValues.vectorValue()[0], 0);
+        assertEquals(0, vectorValues.vectorByteValue()[0], 0);
         assertEquals(NO_MORE_DOCS, vectorValues.nextDoc());
       }
     }
@@ -840,25 +840,25 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         assertEquals(1, vectorValues.dimension());
         assertEquals(2, vectorValues.size());
         vectorValues.nextDoc();
-        assertEquals(1f, vectorValues.vectorValue()[0], 0);
+        assertEquals(1f, vectorValues.vectorFloatValue()[0], 0);
         vectorValues.nextDoc();
-        assertEquals(2f, vectorValues.vectorValue()[0], 0);
+        assertEquals(2f, vectorValues.vectorFloatValue()[0], 0);
         assertEquals(NO_MORE_DOCS, vectorValues.nextDoc());
 
         FloatVectorValues vectorValues2 = leaf.getFloatVectorValues("field2");
         assertEquals(3, vectorValues2.dimension());
         assertEquals(2, vectorValues2.size());
         vectorValues2.nextDoc();
-        assertEquals(2f, vectorValues2.vectorValue()[1], 0);
+        assertEquals(2f, vectorValues2.vectorFloatValue()[1], 0);
         vectorValues2.nextDoc();
-        assertEquals(2f, vectorValues2.vectorValue()[1], 0);
+        assertEquals(2f, vectorValues2.vectorFloatValue()[1], 0);
         assertEquals(NO_MORE_DOCS, vectorValues2.nextDoc());
 
         FloatVectorValues vectorValues3 = leaf.getFloatVectorValues("field3");
         assertEquals(3, vectorValues3.dimension());
         assertEquals(1, vectorValues3.size());
         vectorValues3.nextDoc();
-        assertEquals(1f, vectorValues3.vectorValue()[0], 0.1);
+        assertEquals(1f, vectorValues3.vectorFloatValue()[0], 0.1);
         assertEquals(NO_MORE_DOCS, vectorValues3.nextDoc());
       }
     }
@@ -921,7 +921,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           StoredFields storedFields = ctx.reader().storedFields();
           int docId;
           while ((docId = vectorValues.nextDoc()) != NO_MORE_DOCS) {
-            float[] v = vectorValues.vectorValue();
+            float[] v = vectorValues.vectorFloatValue();
             assertEquals(dimension, v.length);
             String idString = storedFields.document(docId).getField("id").stringValue();
             int id = Integer.parseInt(idString);
@@ -998,7 +998,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           StoredFields storedFields = ctx.reader().storedFields();
           int docId;
           while ((docId = vectorValues.nextDoc()) != NO_MORE_DOCS) {
-            byte[] v = vectorValues.vectorValue();
+            byte[] v = vectorValues.vectorByteValue();
             assertEquals(dimension, v.length);
             String idString = storedFields.document(docId).getField("id").stringValue();
             int id = Integer.parseInt(idString);
@@ -1115,7 +1115,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           int docId;
           int numLiveDocsWithVectors = 0;
           while ((docId = vectorValues.nextDoc()) != NO_MORE_DOCS) {
-            float[] v = vectorValues.vectorValue();
+            float[] v = vectorValues.vectorFloatValue();
             assertEquals(dimension, v.length);
             String idString = storedFields.document(docId).getField("id").stringValue();
             int id = Integer.parseInt(idString);
@@ -1386,7 +1386,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
                 docCount += byteVectorValues.size();
                 StoredFields storedFields = ctx.reader().storedFields();
                 while (byteVectorValues.nextDoc() != NO_MORE_DOCS) {
-                  checksum += byteVectorValues.vectorValue()[0];
+                  checksum += byteVectorValues.vectorByteValue()[0];
                   Document doc = storedFields.document(byteVectorValues.docID(), Set.of("id"));
                   sumDocIds += Integer.parseInt(doc.get("id"));
                 }
@@ -1400,7 +1400,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
                 docCount += vectorValues.size();
                 StoredFields storedFields = ctx.reader().storedFields();
                 while (vectorValues.nextDoc() != NO_MORE_DOCS) {
-                  checksum += vectorValues.vectorValue()[0];
+                  checksum += vectorValues.vectorFloatValue()[0];
                   Document doc = storedFields.document(vectorValues.docID(), Set.of("id"));
                   sumDocIds += Integer.parseInt(doc.get("id"));
                 }


### PR DESCRIPTION
### Description

The classes [ByteVectorValues](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java) and [FloatVectorValues](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java) share the common functionalities/methods listed below. This PR moves those methods to a new interface `VectorValues`. This tries to address the problem of code duplication (like example - [one](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java#L48-L73), [two](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java#L109-L301) etc.).

- int dimension()
- int size()
- byte[]/float[] vectorValue()

Since the name is clashing, created two new names `vectorByteValue` and `vectorFloatValue`. Also retained the `vectorValue` method whose returned value needs to be casted appropriately.

There could be some other ideas as well(maybe better) to address the code duplication here:
 
1. Making `DISI` implementing an interface which `VectorValues`(interface in this PR) would extend making further room to remove duplication (or) 
2. Making a wrapper over `ByteVectorValues` and `FloatVectorValues` etc?. 

Looking for suggestions or more ideas on how to better handle this and avoid this current duplication.

Addresses #12635

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
