### PR TITLE
Explicitly return needStats flag in TermStates

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/TermStates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermStates.java
@@ -204,6 +204,11 @@ public final class TermStates {
     return docFreq;
   }
 
+  /** Explicitly return needStats flag */
+  public boolean hasStats() {
+    return term == null;
+  }
+
   /**
    * Returns the accumulated term frequency of all {@link TermState} instances passed to {@link
    * #register(TermState, int, int, long)}.


### PR DESCRIPTION
### Description

A simple API in TermStates to expose the `needStats` flag. 

Addresses #12617 #
