### PR TITLE
Ensure LeafCollector#finish is only called once on the main collector during drill-sideways

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -192,6 +192,8 @@ Bug Fixes
 
 * GITHUB#11556: HTMLStripCharFilter fails on '>' or '<' characters in attribute values. (Elliot Lin)
 
+* GITHUB#12642: Ensure #finish only gets called once on the base collector during drill-sideways (Greg Miller)
+
 Build
 ---------------------
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysScorer.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysScorer.java
@@ -199,7 +199,7 @@ class DrillSidewaysScorer extends BulkScorer {
 
       docID = baseApproximation.nextDoc();
     }
-    finish(collector, Collections.singleton(dim));
+    finish(Collections.singleton(dim));
   }
 
   /**
@@ -338,7 +338,7 @@ class DrillSidewaysScorer extends BulkScorer {
       docID = baseApproximation.nextDoc();
     }
 
-    finish(collector, sidewaysDims);
+    finish(sidewaysDims);
   }
 
   private static int advanceIfBehind(int docID, DocIdSetIterator iterator) throws IOException {
@@ -557,7 +557,7 @@ class DrillSidewaysScorer extends BulkScorer {
 
       nextChunkStart += CHUNK;
     }
-    finish(collector, Arrays.asList(dims));
+    finish(Arrays.asList(dims));
   }
 
   private void doUnionScoring(Bits acceptDocs, LeafCollector collector, DocsAndCost[] dims)
@@ -713,7 +713,7 @@ class DrillSidewaysScorer extends BulkScorer {
       nextChunkStart += CHUNK;
     }
 
-    finish(collector, Arrays.asList(dims));
+    finish(Arrays.asList(dims));
   }
 
   private void collectHit(LeafCollector collector, DocsAndCost[] dims) throws IOException {
@@ -765,8 +765,10 @@ class DrillSidewaysScorer extends BulkScorer {
     sidewaysCollector.collect(collectDocID);
   }
 
-  private void finish(LeafCollector collector, Collection<DocsAndCost> dims) throws IOException {
-    collector.finish();
+  private void finish(Collection<DocsAndCost> dims) throws IOException {
+    // Note: We _only_ call #finish on the facets collectors we're managing here, but not the
+    // "main" collector. This is because IndexSearcher handles calling #finish on the main
+    // collector.
     if (drillDownLeafCollector != null) {
       drillDownLeafCollector.finish();
     }

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -82,7 +82,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.AssertingCollector;
-import org.apache.lucene.tests.search.AssertingIndexSearcher;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
@@ -318,7 +317,7 @@ public class TestDrillSideways extends FacetTestCase {
     IOUtils.close(searcher.getIndexReader(), taxoReader, taxoWriter, dir, taxoDir);
   }
 
-  public void testCollectionTerminated() throws Exception {
+  public void testLeafCollectorSingleFinishCall() throws Exception {
     try (Directory dir = newDirectory();
         Directory taxoDir = newDirectory();
         RandomIndexWriter w = new RandomIndexWriter(random(), dir);
@@ -332,7 +331,7 @@ public class TestDrillSideways extends FacetTestCase {
 
       try (IndexReader r = w.getReader();
           TaxonomyReader taxoR = new DirectoryTaxonomyReader(taxoW)) {
-        IndexSearcher searcher = new AssertingIndexSearcher(random(), r);
+        IndexSearcher searcher = new IndexSearcher(r);
 
         Query baseQuery = new MatchAllDocsQuery();
         Query dimQ = new TermQuery(new Term("foo", "bar"));

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -81,6 +81,7 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.search.AssertingLeafCollector;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
@@ -347,7 +348,16 @@ public class TestDrillSideways extends FacetTestCase {
                   @Override
                   public LeafCollector getLeafCollector(LeafReaderContext context)
                       throws IOException {
-                    return new FinishOnceLeafCollector();
+                    return new AssertingLeafCollector(
+                        new LeafCollector() {
+                          @Override
+                          public void setScorer(Scorable scorer) throws IOException {}
+
+                          @Override
+                          public void collect(int doc) throws IOException {}
+                        },
+                        0,
+                        1);
                   }
 
                   @Override
@@ -1540,22 +1550,6 @@ public class TestDrillSideways extends FacetTestCase {
           .map(cr -> new DocAndScore(cr.docAndScore))
           .limit(numDocs)
           .collect(Collectors.toList());
-    }
-  }
-
-  private static class FinishOnceLeafCollector implements LeafCollector {
-    boolean finished;
-
-    @Override
-    public void setScorer(Scorable scorer) throws IOException {}
-
-    @Override
-    public void collect(int doc) throws IOException {}
-
-    @Override
-    public void finish() throws IOException {
-      assertFalse(finished);
-      finished = true;
     }
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingCollector.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingCollector.java
@@ -25,7 +25,7 @@ import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Weight;
 
 /** A collector that asserts that it is used correctly. */
-class AssertingCollector extends FilterCollector {
+public class AssertingCollector extends FilterCollector {
 
   private boolean weightSet = false;
   private int maxDoc = -1;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingCollector.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingCollector.java
@@ -34,7 +34,12 @@ public class AssertingCollector extends FilterCollector {
   private boolean weightSet = false;
   private int maxDoc = -1;
   private int previousLeafMaxDoc = 0;
-  boolean hasFinishedCollectingPreviousLeaf = true;
+
+  // public visibility for drill-sideways testing, since drill-sideways can't directly use
+  // AssertingIndexSearcher
+  // TODO: this is a pretty hacky workaround. It would be nice to rethink drill-sideways (for
+  // multiple reasons) and move this back to pkg-private at some point
+  public boolean hasFinishedCollectingPreviousLeaf = true;
 
   /** Wrap the given collector in order to add assertions. */
   public static AssertingCollector wrap(Collector in) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingCollector.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingCollector.java
@@ -24,7 +24,11 @@ import org.apache.lucene.search.FilterCollector;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Weight;
 
-/** A collector that asserts that it is used correctly. */
+/**
+ * A collector that asserts that it is used correctly.
+ *
+ * @lucene.internal
+ */
 public class AssertingCollector extends FilterCollector {
 
   private boolean weightSet = false;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
@@ -24,12 +24,8 @@ import org.apache.lucene.search.FilterLeafCollector;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
 
-/**
- * Wraps another Collector and checks that order is respected.
- *
- * @lucene.internal
- */
-public class AssertingLeafCollector extends FilterLeafCollector {
+/** Wraps another Collector and checks that order is respected. */
+class AssertingLeafCollector extends FilterLeafCollector {
 
   private final int min;
   private final int max;
@@ -37,7 +33,7 @@ public class AssertingLeafCollector extends FilterLeafCollector {
   private int lastCollected = -1;
   private boolean finishCalled;
 
-  public AssertingLeafCollector(LeafCollector collector, int min, int max) {
+  AssertingLeafCollector(LeafCollector collector, int min, int max) {
     super(collector);
     this.min = min;
     this.max = max;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
@@ -24,8 +24,12 @@ import org.apache.lucene.search.FilterLeafCollector;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
 
-/** Wraps another Collector and checks that order is respected. */
-class AssertingLeafCollector extends FilterLeafCollector {
+/**
+ * Wraps another Collector and checks that order is respected.
+ *
+ * @lucene.internal
+ */
+public class AssertingLeafCollector extends FilterLeafCollector {
 
   private final int min;
   private final int max;
@@ -33,7 +37,7 @@ class AssertingLeafCollector extends FilterLeafCollector {
   private int lastCollected = -1;
   private boolean finishCalled;
 
-  AssertingLeafCollector(LeafCollector collector, int min, int max) {
+  public AssertingLeafCollector(LeafCollector collector, int min, int max) {
     super(collector);
     this.min = min;
     this.max = max;


### PR DESCRIPTION
Small bug fix where `#finish` can be called multiple times on the base collector during drill-sideways