### PR TITLE
Avoid duplicate array fill in BPIndexReorderer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -178,7 +178,7 @@ Optimizations
 
 * GITHUB#12623: Use a MergeSorter taking advantage of extra storage for StableMSBRadixSorter. (Guo Feng)
 
-* GITHUB#12623: Write MSB VLong for better outputs sharing in block tree index, decreasing ~14% size
+* GITHUB#12631: Write MSB VLong for better outputs sharing in block tree index, decreasing ~14% size
   of .tip file. (Guo Feng)
 
 Changes in runtime behavior

--- a/lucene/misc/src/java/org/apache/lucene/misc/index/BPIndexReorderer.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/index/BPIndexReorderer.java
@@ -293,9 +293,7 @@ public final class BPIndexReorderer {
       int[] leftDocFreqs = state.leftDocFreqs;
       int[] rightDocFreqs = state.rightDocFreqs;
 
-      Arrays.fill(leftDocFreqs, 0);
       computeDocFreqs(left, forwardIndex, leftDocFreqs);
-      Arrays.fill(rightDocFreqs, 0);
       computeDocFreqs(right, forwardIndex, rightDocFreqs);
 
       for (int iter = 0; iter < maxIters; ++iter) {
@@ -921,7 +919,7 @@ public final class BPIndexReorderer {
   }
 
   /** An approximate log() function in base 2 which trades accuracy for much better performance. */
-  static final float fastLog2(int i) {
+  static float fastLog2(int i) {
     assert i > 0 : "Cannot compute log of i=" + i;
     // floorLog2 would be the exponent in the float representation of i
     int floorLog2 = 31 - Integer.numberOfLeadingZeros(i);


### PR DESCRIPTION
No need to fill zero as `computeDocFreqs` will do.