### PR TITLE
Optimize OnHeapHnswGraph's data structure

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -189,6 +189,8 @@ Optimizations
 
 * GITHUB#12668: ImpactsEnums now decode frequencies lazily like PostingsEnums.
   (Adrien Grand)
+  
+* GITHUB#12651: Use 2d array for OnHeapHnswGraph representation. (Patrick Zhai)
 
 Changes in runtime behavior
 ---------------------

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
@@ -56,7 +56,11 @@ public class Word2VecSynonymProvider {
         RandomVectorScorerSupplier.createFloats(word2VecModel, SIMILARITY_FUNCTION);
     HnswGraphBuilder builder =
         HnswGraphBuilder.create(
-            scorerSupplier, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, HnswGraphBuilder.randSeed, word2VecModel.size());
+            scorerSupplier,
+            DEFAULT_MAX_CONN,
+            DEFAULT_BEAM_WIDTH,
+            HnswGraphBuilder.randSeed,
+            word2VecModel.size());
     this.hnswGraph = builder.build(word2VecModel.size());
   }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProvider.java
@@ -56,7 +56,7 @@ public class Word2VecSynonymProvider {
         RandomVectorScorerSupplier.createFloats(word2VecModel, SIMILARITY_FUNCTION);
     HnswGraphBuilder builder =
         HnswGraphBuilder.create(
-            scorerSupplier, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, HnswGraphBuilder.randSeed);
+            scorerSupplier, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, HnswGraphBuilder.randSeed, word2VecModel.size());
     this.hnswGraph = builder.build(word2VecModel.size());
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -438,7 +438,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                     RandomVectorScorerSupplier.createBytes(
                         vectorValues, fieldInfo.getVectorSimilarityFunction());
                 HnswGraphBuilder hnswGraphBuilder =
-                    createHnswGraphBuilder(mergeState, fieldInfo, scorerSupplier, initializerIndex);
+                    createHnswGraphBuilder(mergeState, fieldInfo, scorerSupplier, initializerIndex, vectorValues.size());
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.size());
               }
@@ -453,7 +453,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                     RandomVectorScorerSupplier.createFloats(
                         vectorValues, fieldInfo.getVectorSimilarityFunction());
                 HnswGraphBuilder hnswGraphBuilder =
-                    createHnswGraphBuilder(mergeState, fieldInfo, scorerSupplier, initializerIndex);
+                    createHnswGraphBuilder(mergeState, fieldInfo, scorerSupplier, initializerIndex, vectorValues.size());
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.size());
               }
@@ -488,10 +488,11 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
       MergeState mergeState,
       FieldInfo fieldInfo,
       RandomVectorScorerSupplier scorerSupplier,
-      int initializerIndex)
+      int initializerIndex,
+      int graphSize)
       throws IOException {
     if (initializerIndex == -1) {
-      return HnswGraphBuilder.create(scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed);
+      return HnswGraphBuilder.create(scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed, graphSize);
     }
 
     HnswGraph initializerGraph =

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -438,7 +438,12 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                     RandomVectorScorerSupplier.createBytes(
                         vectorValues, fieldInfo.getVectorSimilarityFunction());
                 HnswGraphBuilder hnswGraphBuilder =
-                    createHnswGraphBuilder(mergeState, fieldInfo, scorerSupplier, initializerIndex, vectorValues.size());
+                    createHnswGraphBuilder(
+                        mergeState,
+                        fieldInfo,
+                        scorerSupplier,
+                        initializerIndex,
+                        vectorValues.size());
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.size());
               }
@@ -453,7 +458,12 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                     RandomVectorScorerSupplier.createFloats(
                         vectorValues, fieldInfo.getVectorSimilarityFunction());
                 HnswGraphBuilder hnswGraphBuilder =
-                    createHnswGraphBuilder(mergeState, fieldInfo, scorerSupplier, initializerIndex, vectorValues.size());
+                    createHnswGraphBuilder(
+                        mergeState,
+                        fieldInfo,
+                        scorerSupplier,
+                        initializerIndex,
+                        vectorValues.size());
                 hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
                 yield hnswGraphBuilder.build(vectorValues.size());
               }
@@ -492,7 +502,8 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
       int graphSize)
       throws IOException {
     if (initializerIndex == -1) {
-      return HnswGraphBuilder.create(scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed, graphSize);
+      return HnswGraphBuilder.create(
+          scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed, graphSize);
     }
 
     HnswGraph initializerGraph =

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -511,7 +511,13 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     Map<Integer, Integer> ordinalMapper =
         getOldToNewOrdinalMap(mergeState, fieldInfo, initializerIndex);
     return HnswGraphBuilder.create(
-        scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed, initializerGraph, ordinalMapper);
+        scorerSupplier,
+        M,
+        beamWidth,
+        HnswGraphBuilder.randSeed,
+        initializerGraph,
+        ordinalMapper,
+        graphSize);
   }
 
   private int selectGraphForInitialization(MergeState mergeState, FieldInfo fieldInfo)

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -66,6 +66,11 @@ public abstract class HnswGraph {
   /** Returns the number of nodes in the graph */
   public abstract int size();
 
+  /** Returns max node id, inclusive, normally this value will be size - 1 */
+  public int maxNodeId() {
+    return size() - 1;
+  }
+
   /**
    * Iterates over the neighbor list. It is illegal to call this method after it returns
    * NO_MORE_DOCS without calling {@link #seek(int, int)}, which resets the iterator.

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -90,10 +90,11 @@ public final class HnswGraphBuilder {
       int beamWidth,
       long seed,
       HnswGraph initializerGraph,
-      Map<Integer, Integer> oldToNewOrdinalMap)
+      Map<Integer, Integer> oldToNewOrdinalMap,
+      int graphSize)
       throws IOException {
     HnswGraphBuilder hnswGraphBuilder =
-        new HnswGraphBuilder(scorerSupplier, M, beamWidth, seed, oldToNewOrdinalMap.size());
+        new HnswGraphBuilder(scorerSupplier, M, beamWidth, seed, graphSize);
     hnswGraphBuilder.initializeFromGraph(initializerGraph, oldToNewOrdinalMap);
     return hnswGraphBuilder;
   }
@@ -294,6 +295,7 @@ public final class HnswGraphBuilder {
       // only adding it if it is closer to the target than to any of the other selected neighbors
       int cNode = candidates.node[i];
       float cScore = candidates.score[i];
+      assert cNode < hnsw.capacity();
       if (diversityCheck(cNode, cScore, neighbors)) {
         neighbors.addInOrder(cNode, cScore);
       }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -80,7 +80,7 @@ public final class HnswGraphBuilder {
   }
 
   public static HnswGraphBuilder create(
-          RandomVectorScorerSupplier scorerSupplier, int M, int beamWidth, long seed, int graphSize) {
+      RandomVectorScorerSupplier scorerSupplier, int M, int beamWidth, long seed, int graphSize) {
     return new HnswGraphBuilder(scorerSupplier, M, beamWidth, seed, graphSize);
   }
 
@@ -92,7 +92,8 @@ public final class HnswGraphBuilder {
       HnswGraph initializerGraph,
       Map<Integer, Integer> oldToNewOrdinalMap)
       throws IOException {
-    HnswGraphBuilder hnswGraphBuilder = new HnswGraphBuilder(scorerSupplier, M, beamWidth, seed, oldToNewOrdinalMap.size());
+    HnswGraphBuilder hnswGraphBuilder =
+        new HnswGraphBuilder(scorerSupplier, M, beamWidth, seed, oldToNewOrdinalMap.size());
     hnswGraphBuilder.initializeFromGraph(initializerGraph, oldToNewOrdinalMap);
     return hnswGraphBuilder;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -295,7 +295,7 @@ public final class HnswGraphBuilder {
       // only adding it if it is closer to the target than to any of the other selected neighbors
       int cNode = candidates.node[i];
       float cScore = candidates.score[i];
-      assert cNode < hnsw.capacity();
+      assert cNode <= hnsw.maxNodeId();
       if (diversityCheck(cNode, cScore, neighbors)) {
         neighbors.addInOrder(cNode, cScore);
       }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -201,7 +201,6 @@ public class HnswGraphSearcher {
       Bits acceptOrds)
       throws IOException {
 
-    int size = graph.size();
     prepareScratchState(graph.size());
 
     for (int ep : eps) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -286,10 +286,7 @@ public class HnswGraphSearcher {
   }
 
   private static int getGraphSize(HnswGraph graph) {
-    if (graph instanceof OnHeapHnswGraph) {
-      return ((OnHeapHnswGraph) graph).capacity();
-    }
-    return graph.size();
+    return graph.maxNodeId() + 1;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -232,7 +232,6 @@ public class HnswGraphSearcher {
       graphSeek(graph, level, topCandidateNode);
       int friendOrd;
       while ((friendOrd = graphNextNeighbor(graph)) != NO_MORE_DOCS) {
-        assert friendOrd < size : "friendOrd=" + friendOrd + "; size=" + size;
         if (visited.getAndSet(friendOrd)) {
           continue;
         }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -194,10 +194,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
    * changed only the first non-zero level call will pay the cost. So it is highly NOT recommended
    * to call this method while the graph is still building.
    *
-   * <p>NOTE: if the node is not inserted in order (e.g. we're init'd from another graph) such that
-   * there are some node in middle are not inserted. (e.g. the largest node inserted is 10 but node
-   * 5 is not yet inserted) Calling getNodesOnLevel(0) will lead to a wrong behavior because it is a
-   * simple iterating over range(size) TODO: maybe we should fix the above behavior?
+   * <p>NOTE: calling this method while the graph is still building is prohibited
    */
   @Override
   public NodesIterator getNodesOnLevel(int level) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -207,7 +207,18 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
     total +=
         size * (neighborArrayBytes0 + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER)
             + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER; // for graph and level 0;
-    total += nonZeroLevelSize * neighborArrayBytes;
+    total += nonZeroLevelSize * neighborArrayBytes; // for non-zero level
+    total += 8 * Integer.BYTES; // all int fields
+    total += RamUsageEstimator.NUM_BYTES_OBJECT_REF; // field: cur
+    total += RamUsageEstimator.NUM_BYTES_ARRAY_HEADER; // field: levelToNodes
+    if (levelToNodes != null) {
+      total += (numLevels - 1) * RamUsageEstimator.NUM_BYTES_OBJECT_REF; // no cost for level 0
+      total +=
+          nonZeroLevelSize
+              * (RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
+                  + RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
+                  + Integer.BYTES);
+    }
     return total;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -42,7 +42,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
   // added to HnswBuilder, and the node values are the ordinals of those vectors.
   // Thus, on all levels, neighbors expressed as the level 0's nodes' ordinals.
   private NeighborArray[][] graph;
-  private  List<Integer>[] levelToNodes;
+  private List<Integer>[] levelToNodes;
   private int lastFreezeSize;
   private int size; // graph size, which is number of nodes in level 0
   private int nonZeroLevelSize; // total number of NeighborArrays created that is not on level 0
@@ -86,7 +86,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
    * Add node on the given level. Nodes can be inserted out of order, but it requires that the nodes
    * preceded by the node inserted out of order are eventually added.
    *
-   * NOTE: You must add a node from the node's top level
+   * <p>NOTE: You must add a node from the node's top level
    *
    * @param level level to add a node on
    * @param node the node to add, represented as an ordinal on the level 0.
@@ -107,7 +107,8 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
 
     assert graph[node] == null || graph[node].length > level;
     if (graph[node] == null) {
-      graph[node] = new NeighborArray[level + 1]; // assumption: we always call this function from top level
+      graph[node] =
+          new NeighborArray[level + 1]; // assumption: we always call this function from top level
       size++;
     }
     if (level == 0) {
@@ -203,8 +204,9 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
             + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2
             + Integer.BYTES * 3;
     long total = 0;
-    total += size * (neighborArrayBytes0 + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER)
-                    + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER; // for graph and level 0;
+    total +=
+        size * (neighborArrayBytes0 + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER)
+            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER; // for graph and level 0;
     total += nonZeroLevelSize * neighborArrayBytes;
     return total;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -20,10 +20,9 @@ package org.apache.lucene.util.hnsw;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
 
 /**
@@ -31,6 +30,8 @@ import org.apache.lucene.util.RamUsageEstimator;
  * construct the HNSW graph before it's written to the index.
  */
 public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
+
+  private static final int INIT_SIZE = 128;
 
   private int numLevels; // the current number of levels in the graph
   private int entryNode; // the current graph entry node on the top level. -1 if not set
@@ -40,31 +41,29 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
   // to vectors
   // added to HnswBuilder, and the node values are the ordinals of those vectors.
   // Thus, on all levels, neighbors expressed as the level 0's nodes' ordinals.
-  private final List<NeighborArray> graphLevel0;
-  // Represents levels 1-N. Each level is represented with a Map that maps a levels level 0
-  // ordinal to its neighbors on that level. All nodes are in level 0, so we do not need to maintain
-  // it in this list. However, to avoid changing list indexing, we always will make the first
-  // element
-  // null.
-  private final List<Map<Integer, NeighborArray>> graphUpperLevels;
-  private final int nsize;
-  private final int nsize0;
+  private NeighborArray[][] graph;
+  private  List<Integer>[] levelToNodes;
+  private int lastFreezeSize;
+  private int size; // graph size, which is number of nodes in level 0
+  private int nonZeroLevelSize; // total number of NeighborArrays created that is not on level 0
+  private final int nsize; // neighbour array size at non-zero level
+  private final int nsize0; // neighbour array size at zero level
 
   // KnnGraphValues iterator members
   private int upto;
   private NeighborArray cur;
 
-  OnHeapHnswGraph(int M) {
+  OnHeapHnswGraph(int M, int numNodes) {
     this.numLevels = 1; // Implicitly start the graph with a single level
-    this.graphLevel0 = new ArrayList<>();
     this.entryNode = -1; // Entry node should be negative until a node is added
     // Neighbours' size on upper levels (nsize) and level 0 (nsize0)
     // We allocate extra space for neighbours, but then prune them to keep allowed maximum
     this.nsize = M + 1;
     this.nsize0 = (M * 2 + 1);
-
-    this.graphUpperLevels = new ArrayList<>(numLevels);
-    graphUpperLevels.add(null); // we don't need this for 0th level, as it contains all nodes
+    if (numNodes == -1) {
+      numNodes = INIT_SIZE;
+    }
+    this.graph = new NeighborArray[numNodes][];
   }
 
   /**
@@ -74,22 +73,20 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
    * @param node the node whose neighbors are returned, represented as an ordinal on the level 0.
    */
   public NeighborArray getNeighbors(int level, int node) {
-    if (level == 0) {
-      return graphLevel0.get(node);
-    }
-    Map<Integer, NeighborArray> levelMap = graphUpperLevels.get(level);
-    assert levelMap.containsKey(node);
-    return levelMap.get(node);
+    assert graph.length > node && graph[node] != null && graph[node][level] != null;
+    return graph[node][level];
   }
 
   @Override
   public int size() {
-    return graphLevel0.size(); // all nodes are located on the 0th level
+    return size;
   }
 
   /**
    * Add node on the given level. Nodes can be inserted out of order, but it requires that the nodes
    * preceded by the node inserted out of order are eventually added.
+   *
+   * NOTE: You must add a node from the node's top level
    *
    * @param level level to add a node on
    * @param node the node to add, represented as an ordinal on the level 0.
@@ -99,27 +96,25 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
       entryNode = node;
     }
 
-    if (level > 0) {
-      // if the new node introduces a new level, add more levels to the graph,
-      // and make this node the graph's new entry point
-      if (level >= numLevels) {
-        for (int i = numLevels; i <= level; i++) {
-          graphUpperLevels.add(new HashMap<>());
-        }
-        numLevels = level + 1;
-        entryNode = node;
-      }
+    if (node >= graph.length) {
+      graph = ArrayUtil.grow(graph, node + 1);
+    }
 
-      graphUpperLevels.get(level).put(node, new NeighborArray(nsize, true));
+    if (level >= numLevels) {
+      numLevels = level + 1;
+      entryNode = node;
+    }
+
+    assert graph[node] == null || graph[node].length > level;
+    if (graph[node] == null) {
+      graph[node] = new NeighborArray[level + 1]; // assumption: we always call this function from top level
+      size++;
+    }
+    if (level == 0) {
+      graph[node][level] = new NeighborArray(nsize0, true);
     } else {
-      // Add nodes all the way up to and including "node" in the new graph on level 0. This will
-      // cause the size of the
-      // graph to differ from the number of nodes added to the graph. The size of the graph and the
-      // number of nodes
-      // added will only be in sync once all nodes from 0...last_node are added into the graph.
-      while (node >= graphLevel0.size()) {
-        graphLevel0.add(new NeighborArray(nsize0, true));
-      }
+      graph[node][level] = new NeighborArray(nsize, true);
+      nonZeroLevelSize++;
     }
   }
 
@@ -163,8 +158,36 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
     if (level == 0) {
       return new ArrayNodesIterator(size());
     } else {
-      return new CollectionNodesIterator(graphUpperLevels.get(level).keySet());
+      generateLevelToNodes();
+      return new CollectionNodesIterator(levelToNodes[level]);
     }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private void generateLevelToNodes() {
+    if (lastFreezeSize == size) {
+      return;
+    }
+
+    levelToNodes = new List[numLevels];
+    for (int i = 1; i < numLevels; i++) {
+      levelToNodes[i] = new ArrayList<>();
+    }
+    int nonNullNode = 0;
+    for (int node = 0; node < graph.length; node++) {
+      // when we init from another graph, we could have holes where some slot is null
+      if (graph[node] == null) {
+        continue;
+      }
+      nonNullNode++;
+      for (int i = 1; i < graph[node].length; i++) {
+        levelToNodes[i].add(node);
+      }
+      if (nonNullNode == size) {
+        break;
+      }
+    }
+    lastFreezeSize = size;
   }
 
   @Override
@@ -180,29 +203,9 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
             + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2
             + Integer.BYTES * 3;
     long total = 0;
-    for (int l = 0; l < numLevels; l++) {
-      if (l == 0) {
-        total +=
-            graphLevel0.size() * neighborArrayBytes0
-                + RamUsageEstimator.NUM_BYTES_OBJECT_REF; // for graph;
-      } else {
-        long numNodesOnLevel = graphUpperLevels.get(l).size();
-
-        // For levels > 0, we represent the graph structure with a tree map.
-        // A single node in the tree contains 3 references (left root, right root, value) as well
-        // as an Integer for the key and 1 extra byte for the color of the node (this is actually 1
-        // bit, but
-        // because we do not have that granularity, we set to 1 byte). In addition, we include 1
-        // more reference for
-        // the tree map itself.
-        total +=
-            numNodesOnLevel * (3L * RamUsageEstimator.NUM_BYTES_OBJECT_REF + Integer.BYTES + 1)
-                + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-
-        // Add the size neighbor of each node
-        total += numNodesOnLevel * neighborArrayBytes;
-      }
-    }
+    total += size * (neighborArrayBytes0 + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER)
+                    + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER; // for graph and level 0;
+    total += nonZeroLevelSize * neighborArrayBytes;
     return total;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -194,12 +194,12 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
   @Override
   public long ramBytesUsed() {
     long neighborArrayBytes0 =
-        nsize0 * (Integer.BYTES + Float.BYTES)
+        (long) nsize0 * (Integer.BYTES + Float.BYTES)
             + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
             + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2
             + Integer.BYTES * 3;
     long neighborArrayBytes =
-        nsize * (Integer.BYTES + Float.BYTES)
+        (long) nsize * (Integer.BYTES + Float.BYTES)
             + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
             + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2
             + Integer.BYTES * 3;
@@ -212,9 +212,10 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
     total += RamUsageEstimator.NUM_BYTES_OBJECT_REF; // field: cur
     total += RamUsageEstimator.NUM_BYTES_ARRAY_HEADER; // field: levelToNodes
     if (levelToNodes != null) {
-      total += (numLevels - 1) * RamUsageEstimator.NUM_BYTES_OBJECT_REF; // no cost for level 0
       total +=
-          nonZeroLevelSize
+          (long) (numLevels - 1) * RamUsageEstimator.NUM_BYTES_OBJECT_REF; // no cost for level 0
+      total +=
+          (long) nonZeroLevelSize
               * (RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
                   + RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
                   + Integer.BYTES);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -48,9 +48,9 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
       lastFreezeSize; // remember the size we are at last time to freeze the graph and generate
   // levelToNodes
   private int size; // graph size, which is number of nodes in level 0
-  // total number of NeighborArrays created that is not on level 0, for now it is only used to
-  // account memory usage
-  private int nonZeroLevelSize;
+  private int
+      nonZeroLevelSize; // total number of NeighborArrays created that is not on level 0, for now it
+  // is only used to account memory usage
   private final int nsize; // neighbour array size at non-zero level
   private final int nsize0; // neighbour array size at zero level
   private final boolean

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -454,77 +454,6 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     }
   }
 
-  public void testBuildOnHeapHnswGraphOutOfOrder() throws IOException {
-    int maxNumLevels = randomIntBetween(2, 10);
-    int nodeCount = randomIntBetween(1, 100);
-
-    List<List<Integer>> nodesPerLevel = new ArrayList<>();
-    for (int i = 0; i < maxNumLevels; i++) {
-      nodesPerLevel.add(new ArrayList<>());
-    }
-
-    int numLevels = 0;
-    for (int currNode = 0; currNode < nodeCount; currNode++) {
-      int nodeMaxLevel = random().nextInt(1, maxNumLevels + 1);
-      numLevels = Math.max(numLevels, nodeMaxLevel);
-      for (int currLevel = 0; currLevel < nodeMaxLevel; currLevel++) {
-        nodesPerLevel.get(currLevel).add(currNode);
-      }
-    }
-
-    OnHeapHnswGraph topDownOrderReversedHnsw = new OnHeapHnswGraph(10);
-    for (int currLevel = numLevels - 1; currLevel >= 0; currLevel--) {
-      List<Integer> currLevelNodes = nodesPerLevel.get(currLevel);
-      int currLevelNodesSize = currLevelNodes.size();
-      for (int currNodeInd = currLevelNodesSize - 1; currNodeInd >= 0; currNodeInd--) {
-        topDownOrderReversedHnsw.addNode(currLevel, currLevelNodes.get(currNodeInd));
-      }
-    }
-
-    OnHeapHnswGraph bottomUpOrderReversedHnsw = new OnHeapHnswGraph(10);
-    for (int currLevel = 0; currLevel < numLevels; currLevel++) {
-      List<Integer> currLevelNodes = nodesPerLevel.get(currLevel);
-      int currLevelNodesSize = currLevelNodes.size();
-      for (int currNodeInd = currLevelNodesSize - 1; currNodeInd >= 0; currNodeInd--) {
-        bottomUpOrderReversedHnsw.addNode(currLevel, currLevelNodes.get(currNodeInd));
-      }
-    }
-
-    OnHeapHnswGraph topDownOrderRandomHnsw = new OnHeapHnswGraph(10);
-    for (int currLevel = numLevels - 1; currLevel >= 0; currLevel--) {
-      List<Integer> currLevelNodes = new ArrayList<>(nodesPerLevel.get(currLevel));
-      Collections.shuffle(currLevelNodes, random());
-      for (Integer currNode : currLevelNodes) {
-        topDownOrderRandomHnsw.addNode(currLevel, currNode);
-      }
-    }
-
-    OnHeapHnswGraph bottomUpExpectedHnsw = new OnHeapHnswGraph(10);
-    for (int currLevel = 0; currLevel < numLevels; currLevel++) {
-      for (Integer currNode : nodesPerLevel.get(currLevel)) {
-        bottomUpExpectedHnsw.addNode(currLevel, currNode);
-      }
-    }
-
-    assertEquals(nodeCount, bottomUpExpectedHnsw.getNodesOnLevel(0).size());
-    for (Integer node : nodesPerLevel.get(0)) {
-      assertEquals(0, bottomUpExpectedHnsw.getNeighbors(0, node).size());
-    }
-
-    for (int currLevel = 1; currLevel < numLevels; currLevel++) {
-      List<Integer> expectedNodesOnLevel = nodesPerLevel.get(currLevel);
-      List<Integer> sortedNodes = sortedNodesOnLevel(bottomUpExpectedHnsw, currLevel);
-      assertEquals(
-          String.format(Locale.ROOT, "Nodes on level %d do not match", currLevel),
-          expectedNodesOnLevel,
-          sortedNodes);
-    }
-
-    assertGraphEqual(bottomUpExpectedHnsw, topDownOrderReversedHnsw);
-    assertGraphEqual(bottomUpExpectedHnsw, bottomUpOrderReversedHnsw);
-    assertGraphEqual(bottomUpExpectedHnsw, topDownOrderRandomHnsw);
-  }
-
   public void testHnswGraphBuilderInitializationFromGraph_withOffsetZero() throws IOException {
     int totalSize = atLeast(100);
     int initializerSize = random().nextInt(5, totalSize);
@@ -599,35 +528,35 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
   }
 
   private void assertGraphInitializedFromGraph(
-      HnswGraph g, HnswGraph h, Map<Integer, Integer> oldToNewOrdMap) throws IOException {
-    assertEquals("the number of levels in the graphs are different!", g.numLevels(), h.numLevels());
+      HnswGraph g, HnswGraph initializer, Map<Integer, Integer> oldToNewOrdMap) throws IOException {
+    assertEquals("the number of levels in the graphs are different!", initializer.numLevels(), g.numLevels());
     // Confirm that the size of the new graph includes all nodes up to an including the max new
     // ordinal in the old to
     // new ordinal mapping
     assertEquals(
         "the number of nodes in the graphs are different!",
-        g.size(),
-        Collections.max(oldToNewOrdMap.values()) + 1);
+        initializer.size(),
+            g.size());
 
     // assert the nodes from the previous graph are successfully to levels > 0 in the new graph
     for (int level = 1; level < g.numLevels(); level++) {
       List<Integer> nodesOnLevel = sortedNodesOnLevel(g, level);
       List<Integer> nodesOnLevel2 =
-          sortedNodesOnLevel(h, level).stream().map(oldToNewOrdMap::get).toList();
+          sortedNodesOnLevel(initializer, level).stream().map(oldToNewOrdMap::get).toList();
       assertEquals(nodesOnLevel, nodesOnLevel2);
     }
 
     // assert that the neighbors from the old graph are successfully transferred to the new graph
     for (int level = 0; level < g.numLevels(); level++) {
-      NodesIterator nodesOnLevel = h.getNodesOnLevel(level);
+      NodesIterator nodesOnLevel = initializer.getNodesOnLevel(level);
       while (nodesOnLevel.hasNext()) {
         int node = nodesOnLevel.nextInt();
         g.seek(level, oldToNewOrdMap.get(node));
-        h.seek(level, node);
+        initializer.seek(level, node);
         assertEquals(
             "arcs differ for node " + node,
             getNeighborNodes(g),
-            getNeighborNodes(h).stream().map(oldToNewOrdMap::get).collect(Collectors.toSet()));
+            getNeighborNodes(initializer).stream().map(oldToNewOrdMap::get).collect(Collectors.toSet()));
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -195,7 +195,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     }
   }
 
-  // test that sorted index returns the same search results are unsorted
+  // test that sorted index returns the same search results as unsorted
   public void testSortedAndUnsortedIndicesReturnSameResults() throws IOException {
     int dim = random().nextInt(10) + 3;
     int nDoc = random().nextInt(200) + 100;
@@ -486,7 +486,6 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
     // When offset is 0, the graphs should be identical before vectors are added
     assertGraphEqual(initializerGraph, finalBuilder.getGraph());
-    assertEquals(finalVectorValues.size(), finalBuilder.getGraph().capacity());
 
     OnHeapHnswGraph finalGraph = finalBuilder.build(finalVectorValues.size());
     assertGraphContainsGraph(finalGraph, initializerGraph, initializerOrdMap);
@@ -522,7 +521,6 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
             finalVectorValues.size());
 
     assertGraphInitializedFromGraph(finalBuilder.getGraph(), initializerGraph, initializerOrdMap);
-    assertEquals(finalVectorValues.size(), finalBuilder.getGraph().capacity());
 
     // Confirm that the graph is appropriately constructed by checking that the nodes in the old
     // graph are present in the levels of the new graph
@@ -552,15 +550,8 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     // new ordinal mapping
     assertEquals("the number of nodes in the graphs are different!", initializer.size(), g.size());
 
-    // assert the nodes from the previous graph are successfully to levels > 0 in the new graph
-    for (int level = 1; level < g.numLevels(); level++) {
-      List<Integer> nodesOnLevel = sortedNodesOnLevel(g, level);
-      List<Integer> nodesOnLevel2 =
-          sortedNodesOnLevel(initializer, level).stream().map(oldToNewOrdMap::get).toList();
-      assertEquals(nodesOnLevel, nodesOnLevel2);
-    }
-
-    // assert that the neighbors from the old graph are successfully transferred to the new graph
+    // assert that all the node from initializer graph can be found in the new graph and
+    // the neighbors from the old graph are successfully transferred to the new graph
     for (int level = 0; level < g.numLevels(); level++) {
       NodesIterator nodesOnLevel = initializer.getNodesOnLevel(level);
       while (nodesOnLevel.hasNext()) {

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -529,14 +529,14 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
   private void assertGraphInitializedFromGraph(
       HnswGraph g, HnswGraph initializer, Map<Integer, Integer> oldToNewOrdMap) throws IOException {
-    assertEquals("the number of levels in the graphs are different!", initializer.numLevels(), g.numLevels());
+    assertEquals(
+        "the number of levels in the graphs are different!",
+        initializer.numLevels(),
+        g.numLevels());
     // Confirm that the size of the new graph includes all nodes up to an including the max new
     // ordinal in the old to
     // new ordinal mapping
-    assertEquals(
-        "the number of nodes in the graphs are different!",
-        initializer.size(),
-            g.size());
+    assertEquals("the number of nodes in the graphs are different!", initializer.size(), g.size());
 
     // assert the nodes from the previous graph are successfully to levels > 0 in the new graph
     for (int level = 1; level < g.numLevels(); level++) {
@@ -556,7 +556,9 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
         assertEquals(
             "arcs differ for node " + node,
             getNeighborNodes(g),
-            getNeighborNodes(initializer).stream().map(oldToNewOrdMap::get).collect(Collectors.toSet()));
+            getNeighborNodes(initializer).stream()
+                .map(oldToNewOrdMap::get)
+                .collect(Collectors.toSet()));
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -476,10 +476,17 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     RandomVectorScorerSupplier finalscorerSupplier = buildScorerSupplier(finalVectorValues);
     HnswGraphBuilder finalBuilder =
         HnswGraphBuilder.create(
-            finalscorerSupplier, 10, 30, seed, initializerGraph, initializerOrdMap);
+            finalscorerSupplier,
+            10,
+            30,
+            seed,
+            initializerGraph,
+            initializerOrdMap,
+            finalVectorValues.size());
 
     // When offset is 0, the graphs should be identical before vectors are added
     assertGraphEqual(initializerGraph, finalBuilder.getGraph());
+    assertEquals(finalVectorValues.size(), finalBuilder.getGraph().capacity());
 
     OnHeapHnswGraph finalGraph = finalBuilder.build(finalVectorValues.size());
     assertGraphContainsGraph(finalGraph, initializerGraph, initializerOrdMap);
@@ -506,9 +513,16 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     RandomVectorScorerSupplier finalscorerSupplier = buildScorerSupplier(finalVectorValues);
     HnswGraphBuilder finalBuilder =
         HnswGraphBuilder.create(
-            finalscorerSupplier, 10, 30, seed, initializerGraph, initializerOrdMap);
+            finalscorerSupplier,
+            10,
+            30,
+            seed,
+            initializerGraph,
+            initializerOrdMap,
+            finalVectorValues.size());
 
     assertGraphInitializedFromGraph(finalBuilder.getGraph(), initializerGraph, initializerOrdMap);
+    assertEquals(finalVectorValues.size(), finalBuilder.getGraph().capacity());
 
     // Confirm that the graph is appropriately constructed by checking that the nodes in the old
     // graph are present in the levels of the new graph

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestOnHeapHnswGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestOnHeapHnswGraph.java
@@ -1,19 +1,21 @@
-package org.apache.lucene.util.hnsw; /*
-                                      * Licensed to the Apache Software Foundation (ASF) under one or more
-                                      * contributor license agreements.  See the NOTICE file distributed with
-                                      * this work for additional information regarding copyright ownership.
-                                      * The ASF licenses this file to You under the Apache License, Version 2.0
-                                      * (the "License"); you may not use this file except in compliance with
-                                      * the License.  You may obtain a copy of the License at
-                                      *
-                                      *     http://www.apache.org/licenses/LICENSE-2.0
-                                      *
-                                      * Unless required by applicable law or agreed to in writing, software
-                                      * distributed under the License is distributed on an "AS IS" BASIS,
-                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                      * See the License for the specific language governing permissions and
-                                      * limitations under the License.
-                                      */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestOnHeapHnswGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestOnHeapHnswGraph.java
@@ -1,0 +1,115 @@
+package org.apache.lucene.util.hnsw; /*
+                                      * Licensed to the Apache Software Foundation (ASF) under one or more
+                                      * contributor license agreements.  See the NOTICE file distributed with
+                                      * this work for additional information regarding copyright ownership.
+                                      * The ASF licenses this file to You under the Apache License, Version 2.0
+                                      * (the "License"); you may not use this file except in compliance with
+                                      * the License.  You may obtain a copy of the License at
+                                      *
+                                      *     http://www.apache.org/licenses/LICENSE-2.0
+                                      *
+                                      * Unless required by applicable law or agreed to in writing, software
+                                      * distributed under the License is distributed on an "AS IS" BASIS,
+                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                      * See the License for the specific language governing permissions and
+                                      * limitations under the License.
+                                      */
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+/**
+ * Test OnHeapHnswGraph's behavior specifically, for more complex test, see {@link
+ * HnswGraphTestCase}
+ */
+public class TestOnHeapHnswGraph extends LuceneTestCase {
+
+  /* assert exception will be thrown when we add out of bound node to a fixed size graph */
+  public void testNoGrowth() {
+    OnHeapHnswGraph graph = new OnHeapHnswGraph(10, 100);
+    expectThrows(IllegalStateException.class, () -> graph.addNode(1, 100));
+  }
+
+  /* AssertionError will be thrown if we add a node not from top most level,
+  (likely NPE will be thrown in prod) */
+  public void testAddLevelOutOfOrder() {
+    OnHeapHnswGraph graph = new OnHeapHnswGraph(10, -1);
+    graph.addNode(0, 0);
+    expectThrows(AssertionError.class, () -> graph.addNode(1, 0));
+  }
+
+  /* assert exception will be thrown when we call getNodeOnLevel for an incomplete graph */
+  public void testIncompleteGraphThrow() {
+    OnHeapHnswGraph graph = new OnHeapHnswGraph(10, 10);
+    graph.addNode(1, 0);
+    graph.addNode(0, 0);
+    assertEquals(1, graph.getNodesOnLevel(1).size());
+    graph.addNode(0, 5);
+    expectThrows(IllegalStateException.class, () -> graph.getNodesOnLevel(0));
+  }
+
+  public void testGraphGrowth() {
+    OnHeapHnswGraph graph = new OnHeapHnswGraph(10, -1);
+    List<List<Integer>> levelToNodes = new ArrayList<>();
+    int maxLevel = 5;
+    for (int i = 0; i < maxLevel; i++) {
+      levelToNodes.add(new ArrayList<>());
+    }
+    for (int i = 0; i < 101; i++) {
+      int level = random().nextInt(maxLevel);
+      for (int l = level; l >= 0; l--) {
+        graph.addNode(l, i);
+        levelToNodes.get(l).add(i);
+      }
+    }
+    assertGraphEquals(graph, levelToNodes);
+  }
+
+  public void testGraphBuildOutOfOrder() {
+    OnHeapHnswGraph graph = new OnHeapHnswGraph(10, -1);
+    List<List<Integer>> levelToNodes = new ArrayList<>();
+    int maxLevel = 5;
+    int numNodes = 100;
+    for (int i = 0; i < maxLevel; i++) {
+      levelToNodes.add(new ArrayList<>());
+    }
+    int[] insertions = new int[numNodes];
+    for (int i = 0; i < numNodes; i++) {
+      insertions[i] = i;
+    }
+    // shuffle the insertion order
+    for (int i = 0; i < 40; i++) {
+      int pos1 = random().nextInt(numNodes);
+      int pos2 = random().nextInt(numNodes);
+      int tmp = insertions[pos1];
+      insertions[pos1] = insertions[pos2];
+      insertions[pos2] = tmp;
+    }
+
+    for (int i : insertions) {
+      int level = random().nextInt(maxLevel);
+      for (int l = level; l >= 0; l--) {
+        graph.addNode(l, i);
+        levelToNodes.get(l).add(i);
+      }
+    }
+
+    for (int i = 0; i < maxLevel; i++) {
+      levelToNodes.get(i).sort(Integer::compare);
+    }
+
+    assertGraphEquals(graph, levelToNodes);
+  }
+
+  private static void assertGraphEquals(OnHeapHnswGraph graph, List<List<Integer>> levelToNodes) {
+    for (int l = 0; l < graph.numLevels(); l++) {
+      HnswGraph.NodesIterator nodesIterator = graph.getNodesOnLevel(l);
+      assertEquals(levelToNodes.get(l).size(), nodesIterator.size());
+      int idx = 0;
+      while (nodesIterator.hasNext()) {
+        assertEquals(levelToNodes.get(l).get(idx++), nodesIterator.next());
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description

Make the `OnHeapHnswGraph` essentially a 2D array of `NeighbourArray`, there're several benefits of this change:
1. We do less resizing of arrays: previously we're using `ArrayList` for level0 and `TreeMap` for rest of the levels which both have overheads on resizing or inserting. After this change, we don't need `TreeMap` anymore, and during indexing time, we only need to resize one array no matter how many levels we have, and the lookup will be a simpler 2d array lookup.
2. Multithread should be easier: this PR doesn't contain any attempt to make indexing concurrent, but in case that we want to make merging HNSW graph concurrent, this change makes things much easier, because when we merge we already know the total size of graph so the first dimension of the graph array is fixed, such that we don't need any sync on the graph for it to resize.

The only regression on this approach is that when we get node for a non-zero level it need to traverse the whole graph. But since that is not a common operation and is only called when we serialize to disk, I made a cache for it such that the cost of first non-zero level call is O(whole_graph) and subsequent call will be trivial.

### Test runs
I use writer buffer of 256MB and forcemerge at the end, and measured forceMerge time as well
#### Baseline
```
recall	latency	nDoc	fanout	maxConn	beamWidth	visited	index ms
Force merge done, time: 3 ms
0.838	 0.28	10000	0	64	250	100	3868	1.00	post-filter
Force merge done, time: 2 ms
0.755	 1.21	100000	0	64	250	100	101113	1.00	post-filter
Force merge done, time: 632325 ms
0.603	10.27	1000000	0	64	250	100	1622348	1.00	post-filter
```
#### Candidate
```
recall	latency	nDoc	fanout	maxConn	beamWidth	visited	index ms
Force merge done, time: 2 ms
0.838	 0.27	10000	0	64	250	100	3652	1.00	post-filter
Force merge done, time: 2 ms
0.755	 1.13	100000	0	64	250	100	92449	1.00	post-filter
Force merge done, time: 625726 ms
0.608	10.22	1000000	0	64	250	100	1529417	1.00	post-filter
```