### PR TITLE
Use MergeSorter in StableStringSorter

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
@@ -40,6 +40,16 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
   protected Sorter getFallbackSorter(int k) {
     return new MergeSorter() {
       @Override
+      protected void save(int i, int j) {
+        StableMSBRadixSorter.this.save(i, j);
+      }
+
+      @Override
+      protected void restore(int i, int j) {
+        StableMSBRadixSorter.this.restore(i, j);
+      }
+
+      @Override
       protected void swap(int i, int j) {
         StableMSBRadixSorter.this.swap(i, j);
       }
@@ -80,7 +90,7 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
   }
 
   /** A MergeSorter taking advantage of temporary storage. */
-  protected abstract class MergeSorter extends Sorter {
+  protected static abstract class MergeSorter extends Sorter {
     @Override
     public void sort(int from, int to) {
       checkRange(from, to);
@@ -97,6 +107,12 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
         merge(from, to, mid);
       }
     }
+
+    /** Save the i-th value into the j-th position in temporary storage. */
+    protected abstract void save(int i, int j);
+
+    /** Restore values between i-th and j-th(excluding) in temporary storage into original storage. */
+    protected abstract void restore(int i, int j);
 
     /**
      * We tried to expose this to implementations to get a bulk copy optimization. But it did not

--- a/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableMSBRadixSorter.java
@@ -90,7 +90,7 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
   }
 
   /** A MergeSorter taking advantage of temporary storage. */
-  protected static abstract class MergeSorter extends Sorter {
+  protected abstract static class MergeSorter extends Sorter {
     @Override
     public void sort(int from, int to) {
       checkRange(from, to);
@@ -111,7 +111,9 @@ public abstract class StableMSBRadixSorter extends MSBRadixSorter {
     /** Save the i-th value into the j-th position in temporary storage. */
     protected abstract void save(int i, int j);
 
-    /** Restore values between i-th and j-th(excluding) in temporary storage into original storage. */
+    /**
+     * Restore values between i-th and j-th(excluding) in temporary storage into original storage.
+     */
     protected abstract void restore(int i, int j);
 
     /**

--- a/lucene/core/src/java/org/apache/lucene/util/StableStringSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableStringSorter.java
@@ -65,7 +65,17 @@ abstract class StableStringSorter extends StringSorter {
   @Override
   protected Sorter fallbackSorter(Comparator<BytesRef> cmp) {
     // TODO: Maybe tim sort is better?
-    return new InPlaceMergeSorter() {
+    return new StableMSBRadixSorter.MergeSorter() {
+      @Override
+      protected void save(int i, int j) {
+        StableStringSorter.this.save(i, j);
+      }
+
+      @Override
+      protected void restore(int i, int j) {
+        StableStringSorter.this.restore(i, j);
+      }
+
       @Override
       protected int compare(int i, int j) {
         return StableStringSorter.this.compare(i, j);


### PR DESCRIPTION
In #12623, we introduced a `MergeSorter` to take advantage of extra memory to speed up sorting.
This PR enables `StringStableSorter` to also benefit from this optimization.