### PR TITLE
Optimize computing number of levels in MultiLevelSkipListWriter#bufferSkip

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -202,6 +202,8 @@ Optimizations
   
 * GITHUB#12651: Use 2d array for OnHeapHnswGraph representation. (Patrick Zhai)
 
+* GITHUB#12653: Optimize computing number of levels in MultiLevelSkipListWriter#bufferSkip. (Shubham Chaudhary)
+
 Changes in runtime behavior
 ---------------------
 


### PR DESCRIPTION
### Description

While going through [MultiLevelSkipListWriter](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/codecs/MultiLevelSkipListWriter.java) I happened to see we always calculate the `numLevels`(number of skip levels) [here](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/codecs/MultiLevelSkipListWriter.java#L132-L139) for a particular doc frequency `df`. Since we know the `skipInterval` and `skipMultiplier`(in the cx) upfront we could those to replace arithmetic operations of dividing `df` by `skipInterval ` and then `(df % skipMultiplier) == 0`) with a single modulo operation for cases where `numLevels` is supposed to be 1 (which is more often?) i.e. **the only `df`(doc frequency) which could have `numLevels > 1` must suffice the check (`df % windowLength == 0`) where windowLength is `skipInterval * skipMultiplier` i.e. Length of the window at which the skips are placed on skip level 1**.

&nbsp; 
```
* Example for skipInterval = 3:
 *                                                     c            (skip level 2)
 *                 c                 c                 c            (skip level 1)
 *     x     x     x     x     x     x     x     x     x     x      (skip level 0)
 * d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d  (posting list)
 *     3     6     9     12    15    18    21    24    27    30     (df)
 *
 * d - document
 * x - skip data
 * c - skip data with child pointer
 ```
 Here `windowLength = skipInterval * skipMultiplier = 3 x 3 = 9` (interval at which skips are placed on skip level 1). So for `df=6,12,18,24,30...` we would perform a single modulo operation to quickly evaluate `numLevels` which would be `1` in those cases.
 
 **NOTE** - This would be more helpful as we increase the `skipMultiplier`. Eg : for `skipInterval=BLOCK_SIZE=128` and `skipMultiplier=8` we would early evaluate `numLevels` to `1` for 6 doc frequencies out of 8 when buffering the skip data.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
