### PR TITLE
Larger default block size for block tree index

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
@@ -217,13 +217,13 @@ public final class Lucene90BlockTreeTermsWriter extends FieldsConsumer {
    * Suggested default value for the {@code minItemsInBlock} parameter to {@link
    * #Lucene90BlockTreeTermsWriter(SegmentWriteState,PostingsWriterBase,int,int)}.
    */
-  public static final int DEFAULT_MIN_BLOCK_SIZE = 25;
+  public static final int DEFAULT_MIN_BLOCK_SIZE = 15;
 
   /**
    * Suggested default value for the {@code maxItemsInBlock} parameter to {@link
    * #Lucene90BlockTreeTermsWriter(SegmentWriteState,PostingsWriterBase,int,int)}.
    */
-  public static final int DEFAULT_MAX_BLOCK_SIZE = 48;
+  public static final int DEFAULT_MAX_BLOCK_SIZE = 28;
 
   // public static boolean DEBUG = false;
   // public static boolean DEBUG2 = false;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
@@ -217,13 +217,13 @@ public final class Lucene90BlockTreeTermsWriter extends FieldsConsumer {
    * Suggested default value for the {@code minItemsInBlock} parameter to {@link
    * #Lucene90BlockTreeTermsWriter(SegmentWriteState,PostingsWriterBase,int,int)}.
    */
-  public static final int DEFAULT_MIN_BLOCK_SIZE = 15;
+  public static final int DEFAULT_MIN_BLOCK_SIZE = 35;
 
   /**
    * Suggested default value for the {@code maxItemsInBlock} parameter to {@link
    * #Lucene90BlockTreeTermsWriter(SegmentWriteState,PostingsWriterBase,int,int)}.
    */
-  public static final int DEFAULT_MAX_BLOCK_SIZE = 28;
+  public static final int DEFAULT_MAX_BLOCK_SIZE = 68;
 
   // public static boolean DEBUG = false;
   // public static boolean DEBUG2 = false;

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90PostingsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90PostingsFormat.java
@@ -24,6 +24,7 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.CompetitiveImpactAccumulator;
 import org.apache.lucene.codecs.lucene90.Lucene90ScoreSkipReader.MutableImpactList;
 import org.apache.lucene.codecs.lucene90.blocktree.FieldReader;
+import org.apache.lucene.codecs.lucene90.blocktree.Lucene90BlockTreeTermsWriter;
 import org.apache.lucene.codecs.lucene90.blocktree.Stats;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -52,7 +53,7 @@ public class TestLucene90PostingsFormat extends BasePostingsFormatTestCase {
   public void testFinalBlock() throws Exception {
     Directory d = newDirectory();
     IndexWriter w = new IndexWriter(d, new IndexWriterConfig(new MockAnalyzer(random())));
-    for (int i = 0; i < 25; i++) {
+    for (int i = 0; i < Lucene90BlockTreeTermsWriter.DEFAULT_MIN_BLOCK_SIZE; i++) {
       Document doc = new Document();
       doc.add(newStringField("field", Character.toString((char) (97 + i)), Field.Store.NO));
       doc.add(newStringField("field", "z" + Character.toString((char) (97 + i)), Field.Store.NO));


### PR DESCRIPTION
I tried to adjust the block size to [min:35, max:68] and run perf tasks on `wikimediumall`. Surprisingly, I see almost every term-related task get faster, including PKLookup, which expected to be slower for lager block.

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
             MedIntervalsOrdered       12.35      (7.4%)       12.38      (6.6%)    0.2% ( -12% -   15%) 0.937
                    OrHighNotMed      256.78      (4.8%)      257.44      (4.9%)    0.3% (  -9% -   10%) 0.869
                      HighPhrase      159.53      (4.1%)      160.56      (5.4%)    0.6% (  -8% -   10%) 0.668
             LowIntervalsOrdered      133.19      (6.9%)      134.07      (6.3%)    0.7% ( -11% -   14%) 0.753
                   OrNotHighHigh      201.88      (4.9%)      203.52      (4.9%)    0.8% (  -8% -   11%) 0.598
                         MedTerm      522.26      (5.2%)      529.07      (6.2%)    1.3% (  -9% -   13%) 0.472
                    OrNotHighMed      217.49      (4.6%)      220.33      (2.9%)    1.3% (  -5% -    9%) 0.278
            HighIntervalsOrdered        7.23      (6.1%)        7.33      (5.5%)    1.4% (  -9% -   13%) 0.459
                          Fuzzy2       49.21      (2.6%)       49.93      (2.8%)    1.5% (  -3% -    7%) 0.084
                   OrHighNotHigh      228.82      (5.9%)      232.33      (5.3%)    1.5% (  -9% -   13%) 0.382
                    OrHighNotLow      324.13      (6.5%)      329.20      (6.4%)    1.6% ( -10% -   15%) 0.445
                      AndHighLow      368.95      (3.3%)      375.60      (5.1%)    1.8% (  -6% -   10%) 0.189
                          Fuzzy1       60.17      (3.0%)       61.28      (2.9%)    1.8% (  -3% -    8%) 0.050
                       OrHighMed       88.36      (2.4%)       90.16      (2.2%)    2.0% (  -2% -    6%) 0.004
                       MedPhrase       33.16      (3.3%)       33.86      (2.9%)    2.1% (  -3% -    8%) 0.032
                    OrNotHighLow      784.23      (4.3%)      801.26      (4.5%)    2.2% (  -6% -   11%) 0.118
                         LowTerm      532.41      (7.1%)      545.39      (7.5%)    2.4% ( -11% -   18%) 0.293
                        HighTerm      425.38      (5.2%)      436.50      (7.1%)    2.6% (  -9% -   15%) 0.184
                      OrHighHigh       22.36      (3.8%)       22.96      (3.2%)    2.7% (  -4% -   10%) 0.017
                        PKLookup      191.59      (3.7%)      196.76      (3.4%)    2.7% (  -4% -   10%) 0.016
                      AndHighMed       90.93      (2.9%)       93.40      (3.2%)    2.7% (  -3% -    9%) 0.005
                 MedSloppyPhrase       27.63      (2.9%)       28.40      (2.6%)    2.8% (  -2% -    8%) 0.001
                       OrHighLow      439.51      (3.1%)      452.09      (2.9%)    2.9% (  -3% -    9%) 0.002
                       LowPhrase       70.77      (3.5%)       72.86      (3.9%)    3.0% (  -4% -   10%) 0.012
                     AndHighHigh       48.15      (2.9%)       49.63      (3.0%)    3.1% (  -2% -    9%) 0.001
                 LowSloppyPhrase        5.67      (3.4%)        5.85      (2.5%)    3.2% (  -2% -    9%) 0.001
                         Respell       40.92      (2.9%)       42.22      (3.2%)    3.2% (  -2% -    9%) 0.001
                HighSloppyPhrase        3.86      (4.4%)        4.02      (5.0%)    4.1% (  -5% -   14%) 0.006
                    HighSpanNear        3.44      (2.4%)        3.58      (3.9%)    4.2% (  -2% -   10%) 0.000
                     LowSpanNear       11.14      (3.0%)       11.61      (3.8%)    4.2% (  -2% -   11%) 0.000
                     MedSpanNear        6.64      (3.8%)        6.92      (4.7%)    4.2% (  -4% -   13%) 0.002
                        Wildcard       35.31      (4.6%)       37.31      (4.7%)    5.7% (  -3% -   15%) 0.000
                         Prefix3      183.28      (5.6%)      198.93      (7.1%)    8.5% (  -3% -   22%) 0.000
```

**Storage**
> NOTE: Both candidate and baseline indices were built before merge of #12631 
<!--StartFragment--><byte-sheet-html-origin data-id="1697040405762" data-version="4" data-is-embed="false" data-grid-line-hidden="false" data-importRangeRawData-spreadSource="https://bytedance.feishu.cn/sheets/HSetsPqDrhicnet5lWrcOXMtnRc" data-importRangeRawData-range="&#39;Sheet1&#39;!A1:D34">

  | baseline | candidate | diff
-- | -- | -- | --
_32_Lucene90_0.tim | 194257275 | 193916738 | -0.18%
_65_Lucene90_0.tim | 193532711 | 193132810 | -0.21%
_98_Lucene90_0.tim | 211351029 | 210891460 | -0.22%
_cb_Lucene90_0.tim | 210865115 | 210270956 | -0.28%
_fe_Lucene90_0.tim | 208104480 | 207559271 | -0.26%
_fp_Lucene90_0.tim | 32316265 | 32316035 | 0.00%
_g0_Lucene90_0.tim | 31915904 | 31896206 | -0.06%
_gb_Lucene90_0.tim | 30308367 | 30315717 | 0.02%
_gm_Lucene90_0.tim | 30074932 | 30073662 | 0.00%
_gx_Lucene90_0.tim | 36108718 | 36087292 | -0.06%
_gy_Lucene90_0.tim | 6385725 | 6408719 | 0.36%
_gz_Lucene90_0.tim | 5485929 | 5508979 | 0.42%
_h0_Lucene90_0.tim | 4866529 | 4882283 | 0.32%
_h1_Lucene90_0.tim | 5938484 | 5925249 | -0.22%
_h2_Lucene90_0.tim | 4667251 | 4686859 | 0.42%
_32_Lucene90_0.tip | 5166889 | 4017129 | -22.25%
_65_Lucene90_0.tip | 5192450 | 4042156 | -22.15%
_98_Lucene90_0.tip | 5555704 | 4306529 | -22.48%
_cb_Lucene90_0.tip | 5591898 | 4339264 | -22.40%
_fe_Lucene90_0.tip | 5549684 | 4296480 | -22.58%
_fp_Lucene90_0.tip | 776845 | 589229 | -24.15%
_g0_Lucene90_0.tip | 775054 | 587345 | -24.22%
_gb_Lucene90_0.tip | 745250 | 565873 | -24.07%
_gm_Lucene90_0.tip | 738168 | 559389 | -24.22%
_gx_Lucene90_0.tip | 880015 | 659106 | -25.10%
_gy_Lucene90_0.tip | 151737 | 110820 | -26.97%
_gz_Lucene90_0.tip | 133664 | 96100 | -28.10%
_h0_Lucene90_0.tip | 116959 | 86837 | -25.75%
_h1_Lucene90_0.tip | 120897 | 88143 | -27.09%
_h2_Lucene90_0.tip | 111570 | 81065 | -27.34%
sum of .tim | 1206178714 | 1203872236 | -0.19%
sum of .tip | 31606784 | 24425465 | -22.72%
total sum | 1237785498 | 1228297701 | -0.77%

</byte-sheet-html-origin><!--EndFragment-->
