### PR TITLE
Fix Gradle toolchain download with Gradle 8.4 (#12655)

### DIFF
--- a/gradle/generation/extract-jdk-apis.gradle
+++ b/gradle/generation/extract-jdk-apis.gradle
@@ -38,7 +38,7 @@ configure(project(":lucene:core")) {
     apiextractor "org.ow2.asm:asm:${scriptDepVersions['asm']}"
   }
 
-  for (jdkVersion : mrjarJavaVersions) {
+  mrjarJavaVersions.each { jdkVersion ->
     def task = tasks.create(name: "generateJdkApiJar${jdkVersion}", type: JavaExec) {
       description "Regenerate the API-only JAR file with public Panama Foreign & Vector API from JDK ${jdkVersion}"
       group "generation"

--- a/gradle/java/core-mrjar.gradle
+++ b/gradle/java/core-mrjar.gradle
@@ -19,7 +19,7 @@
 
 configure(project(":lucene:core")) {
   plugins.withType(JavaPlugin) {
-    for (jdkVersion : mrjarJavaVersions) {
+    mrjarJavaVersions.each { jdkVersion ->
       sourceSets.create("main${jdkVersion}") {
         java {
           srcDirs = ["src/java${jdkVersion}"]

--- a/gradle/java/core-mrjar.gradle
+++ b/gradle/java/core-mrjar.gradle
@@ -46,7 +46,7 @@ configure(project(":lucene:core")) {
     }
     
     tasks.named('jar').configure {
-      for (jdkVersion : mrjarJavaVersions) {
+      mrjarJavaVersions.each { jdkVersion ->
         into("META-INF/versions/${jdkVersion}") {
           from sourceSets["main${jdkVersion}"].output
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}
+
 rootProject.name = "lucene-root"
 
 includeBuild("dev-tools/missing-doclet")


### PR DESCRIPTION
Fix the toolchain support when using 8.4:

- Logging of failures is wrong as in Groovy the for loop varaibale is not final, wo when it is used in closure which is executed later you get the last value of the loop.
- Use foojay API plugin to download JDK versions

This closes #12655