### PR TITLE
Optimize reading data from postings/impacts enums.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -182,6 +182,8 @@ Optimizations
 * GITHUB#12631: Write MSB VLong for better outputs sharing in block tree index, decreasing ~14% size
   of .tip file. (Guo Feng)
 
+* GITHUB#12664: Optimize reading data from postings. (Adrien Grand)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/MultiLevelSkipListReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/MultiLevelSkipListReader.java
@@ -113,9 +113,11 @@ public abstract class MultiLevelSkipListReader implements Closeable {
 
     // walk up the levels until highest level is found that has a skip
     // for this target
-    // TODO: start skip docs and postings at -1 instead of 0 to avoid this special case on skipDoc == 0?
+    // TODO: start skip docs and postings at -1 instead of 0 to avoid this special case on
+    // skipDoc == 0?
     int level = 0;
-    while (level < numberOfSkipLevels - 1 && (target > skipDoc[level + 1] || skipDoc[level + 1] == 0)) {
+    while (level < numberOfSkipLevels - 1
+        && (target > skipDoc[level + 1] || skipDoc[level + 1] == 0)) {
       level++;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/MultiLevelSkipListReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/MultiLevelSkipListReader.java
@@ -113,13 +113,14 @@ public abstract class MultiLevelSkipListReader implements Closeable {
 
     // walk up the levels until highest level is found that has a skip
     // for this target
+    // TODO: start skip docs and postings at -1 instead of 0 to avoid this special case on skipDoc == 0?
     int level = 0;
-    while (level < numberOfSkipLevels - 1 && target > skipDoc[level + 1]) {
+    while (level < numberOfSkipLevels - 1 && (target > skipDoc[level + 1] || skipDoc[level + 1] == 0)) {
       level++;
     }
 
     while (level >= 0) {
-      if (target > skipDoc[level]) {
+      if (target > skipDoc[level] || skipDoc[level] == 0) {
         if (!loadNextSkip(level)) {
           continue;
         }


### PR DESCRIPTION
This implements the following optimizations:
 - `ImpactsEnum#advance()` and `PostingsEnum#advance()` now need a single comparison instead of two when the target has already been decoded in the current block.
 - `ImpactsEnum#nextDoc()` now gets a dedicated implementation instead of delegating to `advance()`. Initial support for dynamic pruning via WAND always used `advance()` in Lucene, but we are now using `nextDoc()` since we switched to `MAXSCORE`.
 - `ImpactsEnum#nextDoc()` and `ImpactsEnum#advance()` now decode frequencies lazily. The code was already assuming frequencies would get decoded lazily, it was just missing a small change to actually work.
