### PR TITLE
Fix lazy decoding of frequencies in `BlockImpactsDocsEnum`.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -182,6 +182,9 @@ Optimizations
 * GITHUB#12631: Write MSB VLong for better outputs sharing in block tree index, decreasing ~14% size
   of .tip file. (Guo Feng)
 
+* GITHUB#12668: ImpactsEnums now decode frequencies lazily like PostingsEnums.
+  (Adrien Grand)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
@@ -1143,7 +1143,7 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
       if (left >= BLOCK_SIZE) {
         pforUtil.decodeAndPrefixSum(docIn, accum, docBuffer);
         if (indexHasFreqs) {
-          pforUtil.decode(docIn, freqBuffer);
+          isFreqsRead = false;
         }
         blockUpto += BLOCK_SIZE;
       } else {


### PR DESCRIPTION
The code was written as if frequencies should be lazily decoding, except that when refilling buffers freqs were getting eagerly decoded instead of lazily.