### PR TITLE
Specialize `BlockImpactsDocsEnum#nextDoc()`.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PostingsReader.java
@@ -1183,13 +1183,23 @@ public final class Lucene90PostingsReader extends PostingsReaderBase {
 
     @Override
     public Impacts getImpacts() throws IOException {
+      // nextDoc() doesn't advance skip lists, so it's important to do it here to make sure we're
+      // not returning impacts over a bigger range of doc IDs than necessary.
       advanceShallow(doc);
       return skipper.getImpacts();
     }
 
     @Override
     public int nextDoc() throws IOException {
-      return advance(doc + 1);
+      if (docBufferUpto == BLOCK_SIZE) {
+        if (seekTo >= 0) {
+          docIn.seek(seekTo);
+          isFreqsRead = true; // reset isFreqsRead
+          seekTo = -1;
+        }
+        refillDocs();
+      }
+      return this.doc = (int) docBuffer[docBufferUpto++];
     }
 
     @Override


### PR DESCRIPTION
When we initially introduced support for dynamic pruning, we had an implementation of WAND that would almost exclusively use `advance()`. Now that we switched to MAXSCORE and rely much more on `nextDoc()`, it makes sense to specialize nextDoc() as well.