### PR TITLE
Move private static classes or functions out of DoubleValuesSource

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -208,7 +208,8 @@ Build
 
 Other
 ---------------------
-(No changes)
+
+* GITHUB#12671: Move some private static classes or functions out of DoubleValuesSource. (Shubham Chaudhary)
 
 ======================== Lucene 9.8.0 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/search/ByteVectorSimilarityValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ByteVectorSimilarityValuesSource.java
@@ -25,7 +25,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.VectorSimilarityFunction;
 
 /**
- * A {@link DoubleValuesSource} which computes the vector similarity scores between the query vector
+ * A {@link DoubleValuesSource} that computes the vector similarity scores between the query vector
  * and the {@link org.apache.lucene.document.KnnByteVectorField} for documents.
  */
 class ByteVectorSimilarityValuesSource extends VectorSimilarityValuesSource {

--- a/lucene/core/src/java/org/apache/lucene/search/DoubleValuesSourceUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DoubleValuesSourceUtil.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.LongToDoubleFunction;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+
+/**
+ * Provides some concrete implementations of {@link DoubleValuesSource} class to be used by
+ * different APIs
+ */
+final class DoubleValuesSourceUtil {
+
+  static final DoubleValuesSource SCORES =
+      new DoubleValuesSource() {
+        @Override
+        public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores)
+            throws IOException {
+          assert scores != null;
+          return scores;
+        }
+
+        @Override
+        public boolean needsScores() {
+          return true;
+        }
+
+        @Override
+        public boolean isCacheable(LeafReaderContext ctx) {
+          return false;
+        }
+
+        @Override
+        public Explanation explain(LeafReaderContext ctx, int docId, Explanation scoreExplanation) {
+          return scoreExplanation;
+        }
+
+        @Override
+        public int hashCode() {
+          return 0;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+          return obj == this;
+        }
+
+        @Override
+        public String toString() {
+          return "scores";
+        }
+
+        @Override
+        public DoubleValuesSource rewrite(IndexSearcher searcher) {
+          return this;
+        }
+      };
+
+  static class ConstantValuesSource extends DoubleValuesSource {
+
+    private final DoubleValues doubleValues;
+    private final double value;
+
+    ConstantValuesSource(double value) {
+      this.value = value;
+      this.doubleValues =
+          new DoubleValues() {
+            @Override
+            public double doubleValue() {
+              return value;
+            }
+
+            @Override
+            public boolean advanceExact(int doc) {
+              return true;
+            }
+          };
+    }
+
+    @Override
+    public DoubleValuesSource rewrite(IndexSearcher searcher) {
+      return this;
+    }
+
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      return doubleValues;
+    }
+
+    @Override
+    public boolean needsScores() {
+      return false;
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return true;
+    }
+
+    @Override
+    public Explanation explain(LeafReaderContext ctx, int docId, Explanation scoreExplanation) {
+      return Explanation.match(value, "constant(" + value + ")");
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      ConstantValuesSource that = (ConstantValuesSource) o;
+      return Double.compare(that.value, value) == 0;
+    }
+
+    @Override
+    public String toString() {
+      return "constant(" + value + ")";
+    }
+  }
+
+  static class FieldValuesSource extends DoubleValuesSource {
+
+    final String field;
+    final LongToDoubleFunction decoder;
+
+    FieldValuesSource(String field, LongToDoubleFunction decoder) {
+      this.field = field;
+      this.decoder = decoder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      FieldValuesSource that = (FieldValuesSource) o;
+      return Objects.equals(field, that.field) && Objects.equals(decoder, that.decoder);
+    }
+
+    @Override
+    public String toString() {
+      return "double(" + field + ")";
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field, decoder);
+    }
+
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      final NumericDocValues values = DocValues.getNumeric(ctx.reader(), field);
+      return new DoubleValues() {
+        @Override
+        public double doubleValue() throws IOException {
+          return decoder.applyAsDouble(values.longValue());
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          return values.advanceExact(target);
+        }
+      };
+    }
+
+    @Override
+    public boolean needsScores() {
+      return false;
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return DocValues.isCacheable(ctx, field);
+    }
+
+    @Override
+    public Explanation explain(LeafReaderContext ctx, int docId, Explanation scoreExplanation)
+        throws IOException {
+      DoubleValues values = getValues(ctx, null);
+      if (values.advanceExact(docId))
+        return Explanation.match(values.doubleValue(), this.toString());
+      else return Explanation.noMatch(this.toString());
+    }
+
+    @Override
+    public DoubleValuesSource rewrite(IndexSearcher searcher) throws IOException {
+      return this;
+    }
+  }
+
+  static class QueryDoubleValuesSource extends DoubleValuesSource {
+
+    private final Query query;
+
+    QueryDoubleValuesSource(Query query) {
+      this.query = query;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      QueryDoubleValuesSource that = (QueryDoubleValuesSource) o;
+      return Objects.equals(query, that.query);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(query);
+    }
+
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      throw new UnsupportedOperationException("This DoubleValuesSource must be rewritten");
+    }
+
+    @Override
+    public boolean needsScores() {
+      return false;
+    }
+
+    @Override
+    public DoubleValuesSource rewrite(IndexSearcher searcher) throws IOException {
+      return new WeightDoubleValuesSource(
+          searcher.rewrite(query).createWeight(searcher, ScoreMode.COMPLETE, 1f));
+    }
+
+    @Override
+    public String toString() {
+      return "score(" + query.toString() + ")";
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return false;
+    }
+  }
+
+  static class WeightDoubleValuesSource extends DoubleValuesSource {
+
+    private final Weight weight;
+
+    private WeightDoubleValuesSource(Weight weight) {
+      this.weight = weight;
+    }
+
+    @Override
+    public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      Scorer scorer = weight.scorer(ctx);
+      if (scorer == null) return DoubleValues.EMPTY;
+
+      return new DoubleValues() {
+        private final TwoPhaseIterator tpi = scorer.twoPhaseIterator();
+        private final DocIdSetIterator disi =
+            (tpi == null) ? scorer.iterator() : tpi.approximation();
+        private Boolean tpiMatch = null; // cache tpi.matches()
+
+        @Override
+        public double doubleValue() throws IOException {
+          return scorer.score();
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+          if (disi.docID() < doc) {
+            disi.advance(doc);
+            tpiMatch = null;
+          }
+          if (disi.docID() == doc) {
+            if (tpi == null) {
+              return true;
+            } else if (tpiMatch == null) {
+              tpiMatch = tpi.matches();
+            }
+            return tpiMatch;
+          }
+          return false;
+        }
+      };
+    }
+
+    @Override
+    public Explanation explain(LeafReaderContext ctx, int docId, Explanation scoreExplanation)
+        throws IOException {
+      return weight.explain(ctx, docId);
+    }
+
+    @Override
+    public boolean needsScores() {
+      return false;
+    }
+
+    @Override
+    public DoubleValuesSource rewrite(IndexSearcher searcher) throws IOException {
+      return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      WeightDoubleValuesSource that = (WeightDoubleValuesSource) o;
+      return Objects.equals(weight, that.weight);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(weight);
+    }
+
+    @Override
+    public String toString() {
+      return "score(" + weight.parentQuery.toString() + ")";
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return false;
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/FloatVectorSimilarityValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FloatVectorSimilarityValuesSource.java
@@ -25,7 +25,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.VectorSimilarityFunction;
 
 /**
- * A {@link DoubleValuesSource} which computes the vector similarity scores between the query vector
+ * A {@link DoubleValuesSource} that computes the vector similarity scores between the query vector
  * and the {@link org.apache.lucene.document.KnnFloatVectorField} for documents.
  */
 class FloatVectorSimilarityValuesSource extends VectorSimilarityValuesSource {

--- a/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
@@ -156,6 +156,64 @@ public abstract class LongValuesSource implements SegmentCacheable {
     return new ConstantLongValuesSource(value);
   }
 
+  static class LongDoubleValuesSource extends LongValuesSource {
+
+    private final DoubleValuesSource inner;
+
+    LongDoubleValuesSource(DoubleValuesSource inner) {
+      this.inner = inner;
+    }
+
+    @Override
+    public LongValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
+      DoubleValues in = inner.getValues(ctx, scores);
+      return new LongValues() {
+        @Override
+        public long longValue() throws IOException {
+          return (long) in.doubleValue();
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+          return in.advanceExact(doc);
+        }
+      };
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      return inner.isCacheable(ctx);
+    }
+
+    @Override
+    public boolean needsScores() {
+      return inner.needsScores();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      LongDoubleValuesSource that = (LongDoubleValuesSource) o;
+      return Objects.equals(inner, that.inner);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(inner);
+    }
+
+    @Override
+    public String toString() {
+      return "long(" + inner.toString() + ")";
+    }
+
+    @Override
+    public LongValuesSource rewrite(IndexSearcher searcher) throws IOException {
+      return inner.rewrite(searcher).toLongValuesSource();
+    }
+  }
+
   /**
    * A ConstantLongValuesSource that always returns a constant value
    *

--- a/lucene/core/src/java/org/apache/lucene/search/VectorSimilarityValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/VectorSimilarityValuesSource.java
@@ -19,6 +19,7 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.VectorEncoding;
 
 /**
  * An abstract class that provides the vector similarity scores between the query vector and the
@@ -30,6 +31,52 @@ abstract class VectorSimilarityValuesSource extends DoubleValuesSource {
 
   public VectorSimilarityValuesSource(String fieldName) {
     this.fieldName = fieldName;
+  }
+
+  /**
+   * Returns a DoubleValues instance for computing the vector similarity score per document against
+   * the byte query vector
+   *
+   * @param ctx the context for which to return the DoubleValues
+   * @param queryVector byte query vector
+   * @param vectorField knn byte field name
+   * @return DoubleValues instance
+   * @throws IOException if an {@link IOException} occurs
+   */
+  public static DoubleValues similarityToQueryVector(
+      LeafReaderContext ctx, byte[] queryVector, String vectorField) throws IOException {
+    if (ctx.reader().getFieldInfos().fieldInfo(vectorField).getVectorEncoding()
+        != VectorEncoding.BYTE) {
+      throw new IllegalArgumentException(
+          "Field "
+              + vectorField
+              + " does not have the expected vector encoding: "
+              + VectorEncoding.BYTE);
+    }
+    return new ByteVectorSimilarityValuesSource(queryVector, vectorField).getValues(ctx, null);
+  }
+
+  /**
+   * Returns a DoubleValues instance for computing the vector similarity score per document against
+   * the float query vector
+   *
+   * @param ctx the context for which to return the DoubleValues
+   * @param queryVector float query vector
+   * @param vectorField knn float field name
+   * @return DoubleValues instance
+   * @throws IOException if an {@link IOException} occurs
+   */
+  public static DoubleValues similarityToQueryVector(
+      LeafReaderContext ctx, float[] queryVector, String vectorField) throws IOException {
+    if (ctx.reader().getFieldInfos().fieldInfo(vectorField).getVectorEncoding()
+        != VectorEncoding.FLOAT32) {
+      throw new IllegalArgumentException(
+          "Field "
+              + vectorField
+              + " does not have the expected vector encoding: "
+              + VectorEncoding.FLOAT32);
+    }
+    return new FloatVectorSimilarityValuesSource(queryVector, vectorField).getValues(ctx, null);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestVectorSimilarityValuesSource.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestVectorSimilarityValuesSource.java
@@ -149,7 +149,7 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
     // Checks the computed similarity score between indexed vectors and query vector
     // using DVS is correct by passing indexed and query vector in #compare
     DoubleValues dv =
-        DoubleValuesSource.similarityToQueryVector(
+        VectorSimilarityValuesSource.similarityToQueryVector(
             searcher.reader.leaves().get(0), floatQueryVector, "knnFloatField1");
     assertTrue(
         dv.advanceExact(0)
@@ -168,7 +168,7 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
                     new float[] {1.f, 2.f, 3.f}, floatQueryVector));
 
     dv =
-        DoubleValuesSource.similarityToQueryVector(
+        VectorSimilarityValuesSource.similarityToQueryVector(
             searcher.reader.leaves().get(0), floatQueryVector, "knnFloatField5");
     assertTrue(
         dv.advanceExact(0)
@@ -189,7 +189,7 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
     byte[] byteQueryVector = new byte[] {-128, 2, 127};
 
     dv =
-        DoubleValuesSource.similarityToQueryVector(
+        VectorSimilarityValuesSource.similarityToQueryVector(
             searcher.reader.leaves().get(0), byteQueryVector, "knnByteField1");
     assertTrue(
         dv.advanceExact(0)
@@ -208,7 +208,7 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
                     new byte[] {-128, 0, 127}, byteQueryVector));
 
     dv =
-        DoubleValuesSource.similarityToQueryVector(
+        VectorSimilarityValuesSource.similarityToQueryVector(
             searcher.reader.leaves().get(0), byteQueryVector, "knnByteField5");
     assertFalse(dv.advanceExact(0));
     assertFalse(dv.advanceExact(1));
@@ -225,7 +225,7 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
     // Checks the computed similarity score between indexed vectors and query vector
     // using DVS is correct by passing indexed and query vector in #compare
     DoubleValues dv =
-        DoubleValuesSource.similarityToQueryVector(
+        VectorSimilarityValuesSource.similarityToQueryVector(
             searcher.reader.leaves().get(0), floatQueryVector, "knnFloatField2");
     assertTrue(
         dv.advanceExact(0)
@@ -246,7 +246,7 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
     byte[] byteQueryVector = new byte[] {-128, 2, 127};
 
     dv =
-        DoubleValuesSource.similarityToQueryVector(
+        VectorSimilarityValuesSource.similarityToQueryVector(
             searcher.reader.leaves().get(0), byteQueryVector, "knnByteField2");
     assertTrue(
         dv.advanceExact(0)
@@ -271,7 +271,7 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
     // Checks the computed similarity score between indexed vectors and query vector
     // using DVS is correct by passing indexed and query vector in #compare
     DoubleValues dv =
-        DoubleValuesSource.similarityToQueryVector(
+        VectorSimilarityValuesSource.similarityToQueryVector(
             searcher.reader.leaves().get(0), floatQueryVector, "knnFloatField3");
     assertTrue(
         dv.advanceExact(0)
@@ -288,7 +288,7 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
     byte[] byteQueryVector = new byte[] {-10, 8, 0};
 
     dv =
-        DoubleValuesSource.similarityToQueryVector(
+        VectorSimilarityValuesSource.similarityToQueryVector(
             searcher.reader.leaves().get(0), byteQueryVector, "knnByteField3");
     assertTrue(
         dv.advanceExact(0)
@@ -311,7 +311,7 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
     // Checks the computed similarity score between indexed vectors and query vector
     // using DVS is correct by passing indexed and query vector in #compare
     DoubleValues dv =
-        DoubleValuesSource.similarityToQueryVector(
+        VectorSimilarityValuesSource.similarityToQueryVector(
             searcher.reader.leaves().get(0), floatQueryVector, "knnFloatField4");
     assertTrue(
         dv.advanceExact(0)
@@ -324,7 +324,7 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
     byte[] byteQueryVector = new byte[] {-127, 127, 127};
 
     dv =
-        DoubleValuesSource.similarityToQueryVector(
+        VectorSimilarityValuesSource.similarityToQueryVector(
             searcher.reader.leaves().get(0), byteQueryVector, "knnByteField4");
     assertTrue(
         dv.advanceExact(0)
@@ -350,16 +350,16 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
     expectThrows(
         IllegalArgumentException.class,
         () ->
-            DoubleValuesSource.similarityToQueryVector(
+            VectorSimilarityValuesSource.similarityToQueryVector(
                 searcher.reader.leaves().get(0), floatQueryVector, "knnByteField1"));
     expectThrows(
         IllegalArgumentException.class,
         () ->
-            DoubleValuesSource.similarityToQueryVector(
+            VectorSimilarityValuesSource.similarityToQueryVector(
                 searcher.reader.leaves().get(0), byteQueryVector, "knnFloatField1"));
 
     DoubleValues dv =
-        DoubleValuesSource.similarityToQueryVector(
+        VectorSimilarityValuesSource.similarityToQueryVector(
             searcher.reader.leaves().get(0), floatQueryVector, "knnFloatField1");
     assertTrue(dv.advanceExact(0));
     assertEquals(


### PR DESCRIPTION
### Description

This is a followup PR of #12548 


Changes in this PR :

- Move some of the private static classes or functions etc out of `DoubleValuesSource` class to keep it lean for better readability and keeping only have the required APIs. Moved some of the private classes to a new final class `DoubleValuesSourceUtil` and made those pkg-private.
- Moved `similarityToQueryVector` API to `VectorSimilarityValuesSource` as discussed on the PR.


<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
