### PR TITLE
Improve logging for vector support

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -164,6 +164,10 @@ Improvements
 * GITHUB#12606: Create a TaskExecutor when an executor is not provided to the IndexSearcher, in
   order to simplify consumer's code (Luca Cavanna)
 
+* GITHUB#12676: Improve logging of vector support if vector module was enabled but Java version
+  is too old. It also logs partial vectorization support if old CPU or disabled AVX.
+  (Uwe Schindler, Robert Muir)
+
 Optimizations
 ---------------------
 * GITHUB#12183: Make TermStates#build concurrent. (Shubham Chaudhary)

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -120,6 +120,10 @@ public abstract class VectorizationProvider {
     } else if (runtimeVersion >= 22) {
       LOG.warning(
           "You are running with Java 22 or later. To make full use of the Vector API, please update Apache Lucene.");
+    } else if (vectorModulePresentAndReadable()) {
+      LOG.warning(
+          "Java vector incubator module was enabled by command line flags, but your Java version is too old: "
+              + runtimeVersion);
     }
     return new DefaultVectorizationProvider();
   }

--- a/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
+++ b/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
@@ -18,6 +18,7 @@ package org.apache.lucene.internal.vectorization;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Locale;
 import java.util.logging.Logger;
 import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.IntVector;
@@ -72,10 +73,12 @@ final class PanamaVectorizationProvider extends VectorizationProvider {
 
     var log = Logger.getLogger(getClass().getName());
     log.info(
-        "Java vector incubator API enabled"
-            + (testMode ? " (test mode)" : "")
-            + "; uses preferredBitSize="
-            + intPreferredBitSize);
+        String.format(
+            Locale.ENGLISH,
+            "Java vector incubator API enabled%s; uses preferredBitSize=%d%s",
+            testMode ? " (test mode)" : "",
+            intPreferredBitSize,
+            hasFastIntegerVectors ? "" : "; floating-point vectors only"));
   }
 
   @Override


### PR DESCRIPTION
This improves logging a bit:
- if java version is too old, but user explicitely enabled the incubator module
- inform user about missing integer support

Robert and I hit this when tetsing the benchmark.