### PR TITLE
Better detect vector module in non-default setups (e.g., custom module layers)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -168,6 +168,9 @@ Improvements
   is too old. It also logs partial vectorization support if old CPU or disabled AVX.
   (Uwe Schindler, Robert Muir)
 
+* GITHUB#12677: Better detect vector module in non-default setups (e.g., custom module layers).
+  (Uwe Schindler)
+
 Optimizations
 ---------------------
 * GITHUB#12183: Make TermStates#build concurrent. (Shubham Chaudhary)

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -83,7 +83,7 @@ public abstract class VectorizationProvider {
       }
       // is the incubator module present and readable (JVM providers may to exclude them or it is
       // build with jlink)
-      var vectorMod = lookupVectorModule();
+      final var vectorMod = lookupVectorModule();
       if (vectorMod.isEmpty()) {
         LOG.warning(
             "Java vector incubator module is not readable. For optimal vector performance, pass '--add-modules jdk.incubator.vector' to enable Vector API.");

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -130,6 +130,11 @@ public abstract class VectorizationProvider {
     return new DefaultVectorizationProvider();
   }
 
+  /**
+   * Check if this class can see the vector module in its {@link ModuleLayer} or the root layer, if
+   * unnamed. When the module is found, a combiner ({@link BiConsumer}) which accepts this and the
+   * found vector module, can be used to add reads.
+   */
   private static boolean vectorModulePresent(BiConsumer<Module, Module> combiner) {
     var thisMod = VectorizationProvider.class.getModule();
     var opt =

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -83,11 +83,14 @@ public abstract class VectorizationProvider {
       }
       // is the incubator module present and readable (JVM providers may to exclude them or it is
       // build with jlink)
-      if (!vectorModulePresent(true)) {
+      var vectorMod = lookupVectorModule();
+      if (vectorMod.isEmpty()) {
         LOG.warning(
             "Java vector incubator module is not readable. For optimal vector performance, pass '--add-modules jdk.incubator.vector' to enable Vector API.");
         return new DefaultVectorizationProvider();
       }
+      vectorMod.ifPresent(VectorizationProvider.class.getModule()::addReads);
+      // check if client VM
       if (!testMode && isClientVM()) {
         LOG.warning("C2 compiler is disabled; Java vector incubator API can't be enabled");
         return new DefaultVectorizationProvider();
@@ -121,7 +124,7 @@ public abstract class VectorizationProvider {
     } else if (runtimeVersion >= 22) {
       LOG.warning(
           "You are running with Java 22 or later. To make full use of the Vector API, please update Apache Lucene.");
-    } else if (vectorModulePresent(false)) {
+    } else if (lookupVectorModule().isPresent()) {
       LOG.warning(
           "Java vector incubator module was enabled by command line flags, but your Java version is too old: "
               + runtimeVersion);
@@ -130,19 +133,12 @@ public abstract class VectorizationProvider {
   }
 
   /**
-   * Check if this class can see the vector module in its {@link ModuleLayer} or the root layer, if
-   * unnamed. When the module is found, the method optionally adds it to reads.
+   * Looks up the vector module from Lucene's {@link ModuleLayer} or the root layer (if unnamed).
    */
-  private static boolean vectorModulePresent(boolean doAddReads) {
-    var thisMod = VectorizationProvider.class.getModule();
-    var opt =
-        Optional.ofNullable(thisMod.getLayer())
-            .orElse(ModuleLayer.boot())
-            .findModule("jdk.incubator.vector");
-    if (doAddReads) {
-      opt.ifPresent(thisMod::addReads);
-    }
-    return opt.isPresent();
+  private static Optional<Module> lookupVectorModule() {
+    return Optional.ofNullable(VectorizationProvider.class.getModule().getLayer())
+        .orElse(ModuleLayer.boot())
+        .findModule("jdk.incubator.vector");
   }
 
   /**


### PR DESCRIPTION
Hi @ChrisHegarty, 
while working on #12667 and #12676 I noticed that the code which detects if vector module is enabled and readable has some limitations because it only looks into the boot layer.

If you create your own module layer with Lucene and the incubator module, Lucene does not detect it correctly. This code uses the `ModuleLayer` of the Lucene module and uses `findModule` to check if it is there (we do this in other Lucene code in the same way, e.g. to detect `sun.misc.Unsafe`,...). Only in case of unnamed module (then `getLayer()` returns null), then the code uses boot layer.

In addition to #12676 it also only calls `thisModule.addReads(vectorModule)` when it actually wants to enable it. For the pure check (e.g., java 17) ist does not add a read.