### PR TITLE
Scorer should sum up scores into a double

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -214,6 +214,8 @@ Bug Fixes
 
 * GITHUB#12642: Ensure #finish only gets called once on the base collector during drill-sideways (Greg Miller)
 
+* GITHUB#12682: Scorer should sum up scores into a double. (Shubham Chaudhary)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/similarities/MultiSimilarity.java
+++ b/lucene/core/src/java/org/apache/lucene/search/similarities/MultiSimilarity.java
@@ -62,11 +62,11 @@ public class MultiSimilarity extends Similarity {
 
     @Override
     public float score(float freq, long norm) {
-      float sum = 0.0f;
+      double sum = 0d;
       for (SimScorer subScorer : subScorers) {
         sum += subScorer.score(freq, norm);
       }
-      return sum;
+      return (float) sum;
     }
 
     @Override

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/PassageScorer.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/PassageScorer.java
@@ -112,7 +112,7 @@ public class PassageScorer {
   }
 
   public float score(Passage passage, int contentLength) {
-    float score = 0;
+    double score = 0d;
     BytesRefHash termsHash = new BytesRefHash();
     int hitCount = passage.getNumMatches();
     int[] termFreqsInPassage = new int[hitCount]; // maximum size
@@ -134,6 +134,6 @@ public class PassageScorer {
           tf(termFreqsInPassage[i], passage.getLength()) * weight(contentLength, termFreqsInDoc[i]);
     }
     score *= norm(passage.getStartOffset());
-    return score;
+    return (float) score;
   }
 }


### PR DESCRIPTION
### Description

Addresses #12675 . Along with `MultiSimilarity.MultiSimScorer` found some others candidate scorer implementations for this fix.
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
