### PR TITLE
[BROKEN, for reference only] concurrent hnsw 

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/Lucene95HnswVectorsReader.java
@@ -447,7 +447,7 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader implements
   }
 
   /** Read the nearest-neighbors graph from the index input */
-  private static final class OffHeapHnswGraph extends HnswGraph {
+  private static final class OffHeapHnswGraph extends HnswGraph implements HnswGraph.NeighborIterator {
 
     final IndexInput dataIn;
     final int[][] nodesByLevel;
@@ -507,12 +507,22 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader implements
     }
 
     @Override
+    public OffHeapHnswGraph lockNeighbors(int level, int targetOrd) throws IOException {
+      seek(level, targetOrd);
+      return this;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
     public int size() {
       return size;
     }
 
     @Override
-    public int nextNeighbor() throws IOException {
+    public int nextNeighbor() {
       if (arcUpTo >= arcCount) {
         return NO_MORE_DOCS;
       }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -232,13 +232,16 @@ public class HnswGraphSearcher {
       int topCandidateNode = candidates.pop();
       try (HnswGraph.NeighborIterator friends = graph.lockNeighbors(level, topCandidateNode)) {
         int friendOrd;
+        assert friends.size() > 0 || topCandidateNode == eps[0]: "candidate " + topCandidateNode + " has no friends";
         while ((friendOrd = friends.nextNeighbor()) != NO_MORE_DOCS) {
-          // assert friendOrd < graph.size() : "friendOrd=" + friendOrd + "; size=" + size;
+          assert friendOrd < size : "friendOrd=" + friendOrd + "; size=" + size;
+          /*
           if (friendOrd >= size) {
             // this can happen when there are concurrent builders
             extendScratchState(friendOrd);
             size = visited.length();
           }
+          */
           if (visited.getAndSet(friendOrd)) {
             continue;
           }
@@ -253,6 +256,12 @@ public class HnswGraphSearcher {
             if (acceptOrds == null || acceptOrds.get(friendOrd)) {
               if (results.collect(friendOrd, friendSimilarity)) {
                 minAcceptedSimilarity = results.minCompetitiveSimilarity();
+                // nocommit we need to figure out where these friendless results are coming from?
+                /*
+                try (HnswGraph.NeighborIterator friendFriends = graph.lockNeighbors(level, friendOrd)) {
+                  assert friendFriends.size() > 0 : "FUCKME " + friendOrd;
+                }
+                */
               }
             }
           }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -167,6 +167,7 @@ public class NeighborArray {
   public void removeLast() {
     size--;
     sortedNodeSize = Math.min(sortedNodeSize, size);
+    assert size > 0;
   }
 
   public void removeIndex(int idx) {
@@ -176,6 +177,7 @@ public class NeighborArray {
       sortedNodeSize--;
     }
     size--;
+    assert size > 0;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -19,6 +19,8 @@ package org.apache.lucene.util.hnsw;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import org.apache.lucene.util.ArrayUtil;
 
 /**
@@ -31,6 +33,8 @@ import org.apache.lucene.util.ArrayUtil;
  */
 public class NeighborArray {
   private final boolean scoresDescOrder;
+  final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
   private int size;
   float[] score;
   int[] node;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -33,8 +33,7 @@ import org.apache.lucene.util.ArrayUtil;
  */
 public class NeighborArray {
   private final boolean scoresDescOrder;
-  final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-
+  final NeighborLock lock = new NeighborLock();
   private int size;
   float[] score;
   int[] node;
@@ -51,6 +50,7 @@ public class NeighborArray {
    * nodes. This cannot be called after {@link #addOutOfOrder(int, float)}
    */
   public void addInOrder(int newNode, float newScore) {
+    // nocommit we are hitting this assertion
     assert size == sortedNodeSize : "cannot call addInOrder after addOutOfOrder";
     if (size == node.length) {
       node = ArrayUtil.grow(node);
@@ -206,5 +206,11 @@ public class NeighborArray {
       else start = mid + 1;
     }
     return start;
+  }
+
+  static class NeighborLock extends ReentrantReadWriteLock {
+    public Thread getOwner() {
+      return super.getOwner();
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -107,8 +107,8 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
       private int upto;
       @Override
       public int nextNeighbor() {
-        if (++upto < neighbors.size()) {
-          return neighbors.node[upto];
+        if (upto < neighbors.size()) {
+          return neighbors.node[upto++];
         }
         return NO_MORE_DOCS;
       }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -547,7 +547,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     RandomVectorScorerSupplier finalscorerSupplier = buildScorerSupplier(finalVectorValues);
     HnswGraphBuilder finalBuilder =
         HnswGraphBuilder.create(
-            finalscorerSupplier, 10, 30, seed, initializerGraph, initializerOrdMap);
+            finalscorerSupplier, 10, 30, seed, initializerGraph, initializerOrdMap, totalSize);
 
     // When offset is 0, the graphs should be identical before vectors are added
     assertGraphEqual(initializerGraph, finalBuilder.getGraph());
@@ -577,7 +577,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     RandomVectorScorerSupplier finalscorerSupplier = buildScorerSupplier(finalVectorValues);
     HnswGraphBuilder finalBuilder =
         HnswGraphBuilder.create(
-            finalscorerSupplier, 10, 30, seed, initializerGraph, initializerOrdMap);
+            finalscorerSupplier, 10, 30, seed, initializerGraph, initializerOrdMap, totalSize);
 
     assertGraphInitializedFromGraph(finalBuilder.getGraph(), initializerGraph, initializerOrdMap);
 


### PR DESCRIPTION
### Description

adds row locks to OnHeapHnswGraph

seems to be broken in the way it adds new nodes to upper levels such that they become discoverable before they have neighbors?

I shared this mostly because we might want to integrate the `NeighborIterator` in order to keep changes localized to the `HnswGraph` classes and not in `HnswGraphSearcher`. Also this has the idea of passing in an `ExecutorService` rather than creating one in the util/hnsw