### PR TITLE
Fix jacoco coverage tests (add createClassLoader to replicator permissions)

### DIFF
--- a/gradle/testing/randomization/policies/replicator-tests.policy
+++ b/gradle/testing/randomization/policies/replicator-tests.policy
@@ -76,6 +76,8 @@ grant {
   permission java.lang.RuntimePermission "shutdownHooks";
   // needed by jacoco to instrument classes
   permission java.lang.RuntimePermission "defineClass";
+  // needed by jacoco for God knows what.
+  permission java.lang.RuntimePermission "createClassLoader";
 };
 
 // Grant all permissions to Gradle test runner classes.


### PR DESCRIPTION
Code coverage tests have been failing with an exception thrown from jacoco's premain:
```
Caused by: java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "createClassLoader")
	at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:485)
	at java.base/java.security.AccessController.checkPermission(AccessController.java:1068)
	at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:416)
	at java.base/java.lang.SecurityManager.checkCreateClassLoader(SecurityManager.java:479)
	at java.base/java.lang.ClassLoader.checkCreateClassLoader(ClassLoader.java:371)
	at java.base/java.lang.ClassLoader.checkCreateClassLoader(ClassLoader.java:360)
	at java.base/java.lang.ClassLoader.<init>(ClassLoader.java:475)
	at org.jacoco.agent.rt.internal_4481564.AgentModule$1.<init>(AgentModule.java:65)
	at org.jacoco.agent.rt.internal_4481564.AgentModule.<init>(AgentModule.java:63)
	at org.jacoco.agent.rt.internal_4481564.PreMain.createRuntime(PreMain.java:59)
	at org.jacoco.agent.rt.internal_4481564.PreMain.premain(PreMain.java:49)
```
I added this permission to the security policy specific to replication tests. Fixes the problem and seems harmless (affects code cov. tests only).