### PR TITLE
Add timeouts to github jobs.

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   test:
     name: Run distribution tests
+    timeout-minutes: 15
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -17,6 +17,7 @@ jobs:
   # This runs all validation checks without tests.
   checks:
     name: gradle check -x test (JDK ${{ matrix.java }} on ${{ matrix.os }})
+    timeout-minutes: 15
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -45,6 +46,7 @@ jobs:
   # This runs all tests without any other validation checks.
   tests:
     name: gradle test (JDK ${{ matrix.java }} on ${{ matrix.os }})
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/hunspell.yml
+++ b/.github/workflows/hunspell.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test:
     name: Run Hunspell regression tests
+    timeout-minutes: 15
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Estimates taken from empirical run times (actions history), with a generous buffer added.