### PR TITLE
TaskExecutor to cancel all tasks on exception

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -101,7 +101,7 @@ public final class TaskExecutor {
       this.futures = Collections.unmodifiableCollection(tasks);
     }
 
-    FutureTask<T> createTask(Callable<T> callable) {
+    RunnableFuture<T> createTask(Callable<T> callable) {
       // -1: cancelled; 0: not yet started; 1: started
       AtomicInteger taskState = new AtomicInteger(0);
       return new FutureTask<>(

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.ThreadInterruptedException;
 
@@ -73,15 +72,16 @@ public final class TaskExecutor {
   }
 
   /**
-   * Holds all the sub-tasks that a certain operation gets split into as it gets parallelized and exposes the ability to invoke such
-   * tasks and wait for them all to complete their execution and provide their results.
-   * Ensures that each task does not get parallelized further: this is important to avoid a deadlock in situations where one executor
-   * thread waits on other executor threads to complete before it can progress. This happens in situations where for instance
-   * {@link Query#createWeight(IndexSearcher, ScoreMode, float)} is called as part of searching each slice,
-   * like {@link TopFieldCollector#populateScores(ScoreDoc[], IndexSearcher, Query)} does.
-   * Additionally, if one task throws an exception, all other tasks from the same group are cancelled, to avoid needless computation as
-   * their results would not be exposed anyways.
-   * Creates one {@link FutureTask} for each {@link Callable} provided
+   * Holds all the sub-tasks that a certain operation gets split into as it gets parallelized and
+   * exposes the ability to invoke such tasks and wait for them all to complete their execution and
+   * provide their results. Ensures that each task does not get parallelized further: this is
+   * important to avoid a deadlock in situations where one executor thread waits on other executor
+   * threads to complete before it can progress. This happens in situations where for instance
+   * {@link Query#createWeight(IndexSearcher, ScoreMode, float)} is called as part of searching each
+   * slice, like {@link TopFieldCollector#populateScores(ScoreDoc[], IndexSearcher, Query)} does.
+   * Additionally, if one task throws an exception, all other tasks from the same group are
+   * cancelled, to avoid needless computation as their results would not be exposed anyways. Creates
+   * one {@link FutureTask} for each {@link Callable} provided
    *
    * @param <T> the return type of all the callables
    */
@@ -111,7 +111,8 @@ public final class TaskExecutor {
               numberOfRunningTasksInCurrentThread.set(counter - 1);
             }
           } else {
-            //task is cancelled hence it has no results to return. That's fine: they would be ignored anyway.
+            // task is cancelled hence it has no results to return. That's fine: they would be
+            // ignored anyway.
             set(null);
           }
         }

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -20,6 +20,7 @@ package org.apache.lucene.search;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
@@ -27,6 +28,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.ThreadInterruptedException;
 
@@ -64,64 +68,122 @@ public final class TaskExecutor {
    * @param <T> the return type of the task execution
    */
   public <T> List<T> invokeAll(Collection<Callable<T>> callables) throws IOException {
-    List<Task<T>> tasks = new ArrayList<>(callables.size());
-    boolean runOnCallerThread = numberOfRunningTasksInCurrentThread.get() > 0;
-    for (Callable<T> callable : callables) {
-      Task<T> task = new Task<>(callable);
-      tasks.add(task);
-      if (runOnCallerThread) {
-        task.run();
-      } else {
-        executor.execute(task);
-      }
-    }
-
-    Throwable exc = null;
-    final List<T> results = new ArrayList<>();
-    for (Future<T> future : tasks) {
-      try {
-        results.add(future.get());
-      } catch (InterruptedException e) {
-        var newException = new ThreadInterruptedException(e);
-        if (exc == null) {
-          exc = newException;
-        } else {
-          exc.addSuppressed(newException);
-        }
-      } catch (ExecutionException e) {
-        if (exc == null) {
-          exc = e.getCause();
-        } else {
-          exc.addSuppressed(e.getCause());
-        }
-      }
-    }
-    if (exc != null) {
-      throw IOUtils.rethrowAlways(exc);
-    }
-    return results;
+    TaskGroup<T> taskGroup = new TaskGroup<>(callables);
+    return taskGroup.invokeAll(executor);
   }
 
   /**
-   * Extension of {@link FutureTask} that tracks the number of tasks that are running in each
-   * thread.
+   * Holds all the sub-tasks that a certain operation gets split into as it gets parallelized and exposes the ability to invoke such
+   * tasks and wait for them all to complete their execution and provide their results.
+   * Ensures that each task does not get parallelized further: this is important to avoid a deadlock in situations where one executor
+   * thread waits on other executor threads to complete before it can progress. This happens in situations where for instance
+   * {@link Query#createWeight(IndexSearcher, ScoreMode, float)} is called as part of searching each slice,
+   * like {@link TopFieldCollector#populateScores(ScoreDoc[], IndexSearcher, Query)} does.
+   * Additionally, if one task throws an exception, all other tasks from the same group are cancelled, to avoid needless computation as
+   * their results would not be exposed anyways.
+   * Creates one {@link FutureTask} for each {@link Callable} provided
    *
-   * @param <V> the return type of the task
+   * @param <T> the return type of all the callables
    */
-  private static final class Task<V> extends FutureTask<V> {
-    private Task(Callable<V> callable) {
-      super(callable);
+  private static final class TaskGroup<T> {
+    private final Collection<RunnableFuture<T>> futures;
+
+    TaskGroup(Collection<Callable<T>> callables) {
+      List<RunnableFuture<T>> tasks = new ArrayList<>(callables.size());
+      for (Callable<T> callable : callables) {
+        tasks.add(createTask(callable));
+      }
+      this.futures = Collections.unmodifiableCollection(tasks);
     }
 
-    @Override
-    public void run() {
-      try {
-        Integer counter = numberOfRunningTasksInCurrentThread.get();
-        numberOfRunningTasksInCurrentThread.set(counter + 1);
-        super.run();
-      } finally {
-        Integer counter = numberOfRunningTasksInCurrentThread.get();
-        numberOfRunningTasksInCurrentThread.set(counter - 1);
+    private FutureTask<T> createTask(Callable<T> callable) {
+      AtomicBoolean started = new AtomicBoolean(false);
+      return new FutureTask<>(callable) {
+        @Override
+        public void run() {
+          if (started.compareAndSet(false, true)) {
+            try {
+              Integer counter = numberOfRunningTasksInCurrentThread.get();
+              numberOfRunningTasksInCurrentThread.set(counter + 1);
+              super.run();
+            } finally {
+              Integer counter = numberOfRunningTasksInCurrentThread.get();
+              numberOfRunningTasksInCurrentThread.set(counter - 1);
+            }
+          } else {
+            //task is cancelled hence it has no results to return. That's fine: they would be ignored anyway.
+            set(null);
+          }
+        }
+
+        @Override
+        protected void setException(Throwable t) {
+          cancelAll();
+          super.setException(t);
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+          assert mayInterruptIfRunning == false;
+          /*
+          Future#get (called in invokeAll) throws CancellationException for a cancelled task when invoked but leaves the task running.
+          We rather want to make sure that invokeAll does not leave any running tasks behind when it returns.
+          Overriding cancel ensures that tasks that are already started will complete normally once cancelled, and Future#get will
+          wait for them to finish instead of throwing CancellationException. Tasks that are cancelled before they are started won't start.
+           */
+          return started.compareAndSet(false, true);
+        }
+      };
+    }
+
+    List<T> invokeAll(Executor executor) throws IOException {
+      boolean runOnCallerThread = numberOfRunningTasksInCurrentThread.get() > 0;
+      for (Runnable runnable : futures) {
+        if (runOnCallerThread) {
+          runnable.run();
+        } else {
+          executor.execute(runnable);
+        }
+      }
+      Throwable exc = null;
+      List<T> results = new ArrayList<>(futures.size());
+      for (Future<T> future : futures) {
+        try {
+          results.add(future.get());
+        } catch (InterruptedException e) {
+          var newException = new ThreadInterruptedException(e);
+          if (exc == null) {
+            exc = newException;
+          } else {
+            exc.addSuppressed(newException);
+          }
+        } catch (ExecutionException e) {
+          if (exc == null) {
+            exc = e.getCause();
+          } else {
+            exc.addSuppressed(e.getCause());
+          }
+        }
+      }
+      assert assertAllFuturesCompleted() : "Some tasks are still running?";
+      if (exc != null) {
+        throw IOUtils.rethrowAlways(exc);
+      }
+      return results;
+    }
+
+    private boolean assertAllFuturesCompleted() {
+      for (RunnableFuture<T> future : futures) {
+        if (future.isDone() == false) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private void cancelAll() {
+      for (Future<T> future : futures) {
+        future.cancel(false);
       }
     }
   }


### PR DESCRIPTION
When operations are parallelized, like query rewrite, or search, or
createWeight, one of the tasks may throw an exception. In that case we
wait for all tasks to be completed before re-throwing the exception that
were caught. Tasks that were not started when the exception is captured
though can be safely skipped. Ideally we would also cancel ongoing tasks
but I left that for another time.