### PR TITLE
Avoid object construction when linear searching arcs

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -746,7 +746,8 @@ public final class FST<T> implements Accountable {
     }
   }
 
-  private void readFirstArcInfo(long nodeAddress, Arc<T> arc, final BytesReader in) throws IOException {
+  private void readFirstArcInfo(long nodeAddress, Arc<T> arc, final BytesReader in)
+      throws IOException {
     in.setPosition(nodeAddress);
     // System.out.println("   flags=" + arc.flags);
 

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -1106,7 +1106,7 @@ public final class FST<T> implements Accountable {
         if (flag(flags, BIT_ARC_HAS_FINAL_OUTPUT)) {
           outputs.skipFinalOutput(in);
         }
-        if (!flag(flags, BIT_STOP_NODE) && !flag(flags, BIT_TARGET_NEXT)) {
+        if (flag(flags, BIT_STOP_NODE) == false && !flag(flags, BIT_TARGET_NEXT) == false) {
           readUnpackedNodeTarget(in);
         }
       }
@@ -1128,7 +1128,7 @@ public final class FST<T> implements Accountable {
         outputs.skipFinalOutput(in);
       }
 
-      if (!flag(flags, BIT_STOP_NODE) && !flag(flags, BIT_TARGET_NEXT)) {
+      if (flag(flags, BIT_STOP_NODE) == false && flag(flags, BIT_TARGET_NEXT) == false) {
         readUnpackedNodeTarget(in);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -1106,7 +1106,7 @@ public final class FST<T> implements Accountable {
         if (flag(flags, BIT_ARC_HAS_FINAL_OUTPUT)) {
           outputs.skipFinalOutput(in);
         }
-        if (flag(flags, BIT_STOP_NODE) == false && !flag(flags, BIT_TARGET_NEXT) == false) {
+        if (flag(flags, BIT_STOP_NODE) == false && flag(flags, BIT_TARGET_NEXT) == false) {
           readUnpackedNodeTarget(in);
         }
       }


### PR DESCRIPTION
### Description

This PR resolves a todo left in `FST` that we construct some useless objects during linear search. This is also an effort that tries to avoid `Outputs#read` as we have more outputs distributed in arcs with MSB VLong format.

I'll run luceneutil soon.

See also https://github.com/apache/lucene/pull/12661 
