### PR TITLE
[DRAFT] Add unsigned byte vector operations for uint8 quantization

### DIFF
--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
@@ -33,7 +33,7 @@ public class VectorUtilBenchmark {
   private float[] floatsA;
   private float[] floatsB;
 
-  @Param({"128", "207", "256", "1024"})
+  @Param({"1", "128", "207", "256", "300", "512", "702", "1024"})
   int size;
 
   @Setup(Level.Trial)
@@ -111,65 +111,59 @@ public class VectorUtilBenchmark {
     return VectorUtil.dotProductUnsigned(bytesA, bytesB);
   }
 
-//  @Benchmark
-//  @Fork(value = 1)
-//  public float floatSquareScalar() {
-//    return VectorUtil.squareDistance(floatsA, floatsB);
-//  }
+  @Benchmark
+  @Fork(value = 1)
+  public int binarySquareScalar() {
+    return VectorUtil.squareDistance(bytesA, bytesB);
+  }
 
-//  @Benchmark
-//  @Fork(value = 1)
-//  public int binarySquareScalar() {
-//    return VectorUtil.squareDistance(bytesA, bytesB);
-//  }
-//
-//  @Benchmark
-//  @Fork(
-//      value = 1,
-//      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
-//  public int binarySquareVector() {
-//    return VectorUtil.squareDistance(bytesA, bytesB);
-//  }
-//
-//  @Benchmark
-//  @Fork(value = 1)
-//  public float floatCosineScalar() {
-//    return VectorUtil.cosine(floatsA, floatsB);
-//  }
-//
-//  @Benchmark
-//  @Fork(
-//      value = 1,
-//      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
-//  public float floatCosineVector() {
-//    return VectorUtil.cosine(floatsA, floatsB);
-//  }
-//
-//  @Benchmark
-//  @Fork(value = 1)
-//  public float floatDotProductScalar() {
-//    return VectorUtil.dotProduct(floatsA, floatsB);
-//  }
-//
-//  @Benchmark
-//  @Fork(
-//      value = 1,
-//      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
-//  public float floatDotProductVector() {
-//    return VectorUtil.dotProduct(floatsA, floatsB);
-//  }
-//
-//  @Benchmark
-//  @Fork(value = 1)
-//  public float floatSquareScalar() {
-//    return VectorUtil.squareDistance(floatsA, floatsB);
-//  }
-//
-//  @Benchmark
-//  @Fork(
-//      value = 1,
-//      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
-//  public float floatSquareVector() {
-//    return VectorUtil.squareDistance(floatsA, floatsB);
-//  }
+  @Benchmark
+  @Fork(
+      value = 1,
+      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  public int binarySquareVector() {
+    return VectorUtil.squareDistance(bytesA, bytesB);
+  }
+
+  @Benchmark
+  @Fork(value = 1)
+  public float floatCosineScalar() {
+    return VectorUtil.cosine(floatsA, floatsB);
+  }
+
+  @Benchmark
+  @Fork(
+      value = 1,
+      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  public float floatCosineVector() {
+    return VectorUtil.cosine(floatsA, floatsB);
+  }
+
+  @Benchmark
+  @Fork(value = 1)
+  public float floatDotProductScalar() {
+    return VectorUtil.dotProduct(floatsA, floatsB);
+  }
+
+  @Benchmark
+  @Fork(
+      value = 1,
+      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  public float floatDotProductVector() {
+    return VectorUtil.dotProduct(floatsA, floatsB);
+  }
+
+  @Benchmark
+  @Fork(value = 1)
+  public float floatSquareScalar() {
+    return VectorUtil.squareDistance(floatsA, floatsB);
+  }
+
+  @Benchmark
+  @Fork(
+      value = 1,
+      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  public float floatSquareVector() {
+    return VectorUtil.squareDistance(floatsA, floatsB);
+  }
 }

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
@@ -77,8 +77,8 @@ public class VectorUtilBenchmark {
 
   @Benchmark
   @Fork(
-    value = 1,
-    jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+      value = 1,
+      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
   public float binaryCosineUnsignedVector() {
     return VectorUtil.cosineUnsigned(bytesA, bytesB);
   }
@@ -105,8 +105,8 @@ public class VectorUtilBenchmark {
 
   @Benchmark
   @Fork(
-    value = 1,
-    jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+      value = 1,
+      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
   public int binaryDotProductUnsignedVector() {
     return VectorUtil.dotProductUnsigned(bytesA, bytesB);
   }

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
@@ -33,7 +33,7 @@ public class VectorUtilBenchmark {
   private float[] floatsA;
   private float[] floatsB;
 
-  @Param({"1", "128", "207", "256", "300", "512", "702", "1024"})
+  @Param({"128", "207", "256", "1024"})
   int size;
 
   @Setup(Level.Trial)
@@ -71,6 +71,20 @@ public class VectorUtilBenchmark {
 
   @Benchmark
   @Fork(value = 1)
+  public float binaryCosineUnsignedScalar() {
+    return VectorUtil.cosineUnsigned(bytesA, bytesB);
+  }
+
+  @Benchmark
+  @Fork(
+    value = 1,
+    jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  public float binaryCosineUnsignedVector() {
+    return VectorUtil.cosineUnsigned(bytesA, bytesB);
+  }
+
+  @Benchmark
+  @Fork(value = 1)
   public int binaryDotProductScalar() {
     return VectorUtil.dotProduct(bytesA, bytesB);
   }
@@ -85,57 +99,77 @@ public class VectorUtilBenchmark {
 
   @Benchmark
   @Fork(value = 1)
-  public int binarySquareScalar() {
-    return VectorUtil.squareDistance(bytesA, bytesB);
+  public int binaryDotProductUnsignedScalar() {
+    return VectorUtil.dotProductUnsigned(bytesA, bytesB);
   }
 
   @Benchmark
   @Fork(
-      value = 1,
-      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
-  public int binarySquareVector() {
-    return VectorUtil.squareDistance(bytesA, bytesB);
+    value = 1,
+    jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  public int binaryDotProductUnsignedVector() {
+    return VectorUtil.dotProductUnsigned(bytesA, bytesB);
   }
 
-  @Benchmark
-  @Fork(value = 1)
-  public float floatCosineScalar() {
-    return VectorUtil.cosine(floatsA, floatsB);
-  }
+//  @Benchmark
+//  @Fork(value = 1)
+//  public float floatSquareScalar() {
+//    return VectorUtil.squareDistance(floatsA, floatsB);
+//  }
 
-  @Benchmark
-  @Fork(
-      value = 1,
-      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
-  public float floatCosineVector() {
-    return VectorUtil.cosine(floatsA, floatsB);
-  }
-
-  @Benchmark
-  @Fork(value = 1)
-  public float floatDotProductScalar() {
-    return VectorUtil.dotProduct(floatsA, floatsB);
-  }
-
-  @Benchmark
-  @Fork(
-      value = 1,
-      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
-  public float floatDotProductVector() {
-    return VectorUtil.dotProduct(floatsA, floatsB);
-  }
-
-  @Benchmark
-  @Fork(value = 1)
-  public float floatSquareScalar() {
-    return VectorUtil.squareDistance(floatsA, floatsB);
-  }
-
-  @Benchmark
-  @Fork(
-      value = 1,
-      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
-  public float floatSquareVector() {
-    return VectorUtil.squareDistance(floatsA, floatsB);
-  }
+//  @Benchmark
+//  @Fork(value = 1)
+//  public int binarySquareScalar() {
+//    return VectorUtil.squareDistance(bytesA, bytesB);
+//  }
+//
+//  @Benchmark
+//  @Fork(
+//      value = 1,
+//      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+//  public int binarySquareVector() {
+//    return VectorUtil.squareDistance(bytesA, bytesB);
+//  }
+//
+//  @Benchmark
+//  @Fork(value = 1)
+//  public float floatCosineScalar() {
+//    return VectorUtil.cosine(floatsA, floatsB);
+//  }
+//
+//  @Benchmark
+//  @Fork(
+//      value = 1,
+//      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+//  public float floatCosineVector() {
+//    return VectorUtil.cosine(floatsA, floatsB);
+//  }
+//
+//  @Benchmark
+//  @Fork(value = 1)
+//  public float floatDotProductScalar() {
+//    return VectorUtil.dotProduct(floatsA, floatsB);
+//  }
+//
+//  @Benchmark
+//  @Fork(
+//      value = 1,
+//      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+//  public float floatDotProductVector() {
+//    return VectorUtil.dotProduct(floatsA, floatsB);
+//  }
+//
+//  @Benchmark
+//  @Fork(value = 1)
+//  public float floatSquareScalar() {
+//    return VectorUtil.squareDistance(floatsA, floatsB);
+//  }
+//
+//  @Benchmark
+//  @Fork(
+//      value = 1,
+//      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+//  public float floatSquareVector() {
+//    return VectorUtil.squareDistance(floatsA, floatsB);
+//  }
 }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
@@ -151,7 +151,7 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
   public int dotProductUnsigned(byte[] a, byte[] b) {
     int total = 0;
     for (int i = 0; i < a.length; i++) {
-      total += (a[i]&0xFF) * (b[i]&0xFF);
+      total += (a[i] & 0xFF) * (b[i] & 0xFF);
     }
     return total;
   }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
@@ -148,6 +148,15 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public int dotProductUnsigned(byte[] a, byte[] b) {
+    int total = 0;
+    for (int i = 0; i < a.length; i++) {
+      total += (a[i]&0xFF) * (b[i]&0xFF);
+    }
+    return total;
+  }
+
+  @Override
   public float cosine(byte[] a, byte[] b) {
     // Note: this will not overflow if dim < 2^18, since max(byte * byte) = 2^14.
     int sum = 0;
@@ -157,6 +166,23 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
     for (int i = 0; i < a.length; i++) {
       byte elem1 = a[i];
       byte elem2 = b[i];
+      sum += elem1 * elem2;
+      norm1 += elem1 * elem1;
+      norm2 += elem2 * elem2;
+    }
+    return (float) (sum / Math.sqrt((double) norm1 * (double) norm2));
+  }
+
+  @Override
+  public float cosineUnsigned(byte[] a, byte[] b) {
+    // Note: this will not overflow if dim < 2^18, since max(byte * byte) = 2^14.
+    int sum = 0;
+    int norm1 = 0;
+    int norm2 = 0;
+
+    for (int i = 0; i < a.length; i++) {
+      int elem1 = a[i] & 0xFF;
+      int elem2 = b[i] & 0xFF;
       sum += elem1 * elem2;
       norm1 += elem1 * elem1;
       norm2 += elem2 * elem2;

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
@@ -36,8 +36,14 @@ public interface VectorUtilSupport {
   /** Returns the dot product computed over signed bytes. */
   int dotProduct(byte[] a, byte[] b);
 
-  /** Returns the cosine similarity between the two byte vectors. */
+  /** Returns the dot product computed over unsigned bytes. */
+  int dotProductUnsigned(byte[] a, byte[] b);
+
+  /** Returns the cosine similarity between the two signed byte vectors. */
   float cosine(byte[] a, byte[] b);
+
+  /** Returns the cosine similarity between the two unsigned byte vectors. */
+  float cosineUnsigned(byte[] a, byte[] b);
 
   /** Returns the sum of squared differences of the two byte vectors. */
   int squareDistance(byte[] a, byte[] b);

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -64,6 +64,21 @@ public final class VectorUtil {
     return IMPL.cosine(a, b);
   }
 
+
+  /**
+   * The cosine similarity between two vectors, computed over unsigned bytes.
+   * @param a bytes containing a vector
+   * @param b bytes containing another vector, of the same dimension
+   * @return the value of the cosine similarity of the two vectors
+   */
+  public static float cosineUnsigned(byte[] a, byte[] b) {
+    if (a.length != b.length) {
+      throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
+    }
+    return IMPL.cosineUnsigned(a, b);
+  }
+
+
   /**
    * Returns the sum of squared differences of the two vectors.
    *
@@ -146,6 +161,20 @@ public final class VectorUtil {
       throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
     }
     return IMPL.dotProduct(a, b);
+  }
+
+  /**
+   * Dot product computed over unsigned bytes.
+   *
+   * @param a bytes containing a vector
+   * @param b bytes containing another vector, of the same dimension
+   * @return the value of the dot product of the two vectors
+   */
+  public static int dotProductUnsigned(byte[] a, byte[] b) {
+    if (a.length != b.length) {
+      throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
+    }
+    return IMPL.dotProductUnsigned(a, b);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -64,9 +64,9 @@ public final class VectorUtil {
     return IMPL.cosine(a, b);
   }
 
-
   /**
    * The cosine similarity between two vectors, computed over unsigned bytes.
+   *
    * @param a bytes containing a vector
    * @param b bytes containing another vector, of the same dimension
    * @return the value of the cosine similarity of the two vectors
@@ -77,7 +77,6 @@ public final class VectorUtil {
     }
     return IMPL.cosineUnsigned(a, b);
   }
-
 
   /**
    * Returns the sum of squared differences of the two vectors.

--- a/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java20/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -16,8 +16,8 @@
  */
 package org.apache.lucene.internal.vectorization;
 
-import static jdk.incubator.vector.VectorOperators.AND;
 import static jdk.incubator.vector.VectorOperators.ADD;
+import static jdk.incubator.vector.VectorOperators.AND;
 import static jdk.incubator.vector.VectorOperators.B2I;
 import static jdk.incubator.vector.VectorOperators.B2S;
 import static jdk.incubator.vector.VectorOperators.S2I;
@@ -367,7 +367,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     // scalar tail
     for (; i < a.length; i++) {
-      res += (b[i]&0xFF) * (a[i] & 0xFF);
+      res += (b[i] & 0xFF) * (a[i] & 0xFF);
     }
     return res;
   }
@@ -519,7 +519,6 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     }
     return (float) (sum / Math.sqrt((double) norm1 * (double) norm2));
   }
-
 
   /** vectorized cosine body (512 bit vectors) */
   private float[] cosineBody512(byte[] a, byte[] b, boolean unsigned, int limit) {


### PR DESCRIPTION
{DRAFT}

After finalizing work and merging: https://github.com/apache/lucene/pull/12582

Investigation on if adding unsigned vector operations should occur. Quantizing within `[0-255]` can reduce error. However, panama vector operations over unsigned bytes is slightly more expensive (see JMH benchmarks below). Need to benchmark recall vs. latency over some data sets to verify if this is worth it or not.

<details>
<summary> M1 (AMD 128 NEON) </summary>

```
Benchmark                                           (size)   Mode  Cnt   Score   Error   Units
VectorUtilBenchmark.binaryCosineScalar                 128  thrpt    5   8.369 ± 0.208  ops/us
VectorUtilBenchmark.binaryCosineScalar                 207  thrpt    5   5.124 ± 0.210  ops/us
VectorUtilBenchmark.binaryCosineScalar                 256  thrpt    5   4.193 ± 0.014  ops/us
VectorUtilBenchmark.binaryCosineScalar                1024  thrpt    5   1.043 ± 0.002  ops/us
VectorUtilBenchmark.binaryCosineUnsignedScalar         128  thrpt    5   8.359 ± 0.100  ops/us
VectorUtilBenchmark.binaryCosineUnsignedScalar         207  thrpt    5   5.193 ± 0.025  ops/us
VectorUtilBenchmark.binaryCosineUnsignedScalar         256  thrpt    5   4.194 ± 0.015  ops/us
VectorUtilBenchmark.binaryCosineUnsignedScalar        1024  thrpt    5   1.043 ± 0.002  ops/us
VectorUtilBenchmark.binaryCosineUnsignedVector         128  thrpt    5  21.068 ± 0.072  ops/us
VectorUtilBenchmark.binaryCosineUnsignedVector         207  thrpt    5  12.901 ± 0.041  ops/us
VectorUtilBenchmark.binaryCosineUnsignedVector         256  thrpt    5  11.595 ± 0.128  ops/us
VectorUtilBenchmark.binaryCosineUnsignedVector        1024  thrpt    5   3.197 ± 0.007  ops/us
VectorUtilBenchmark.binaryCosineVector                 128  thrpt    5  23.552 ± 0.081  ops/us
VectorUtilBenchmark.binaryCosineVector                 207  thrpt    5  14.358 ± 0.077  ops/us
VectorUtilBenchmark.binaryCosineVector                 256  thrpt    5  13.165 ± 0.053  ops/us
VectorUtilBenchmark.binaryCosineVector                1024  thrpt    5   3.681 ± 0.027  ops/us
VectorUtilBenchmark.binaryDotProductScalar             128  thrpt    5  25.125 ± 0.043  ops/us
VectorUtilBenchmark.binaryDotProductScalar             207  thrpt    5  15.512 ± 0.061  ops/us
VectorUtilBenchmark.binaryDotProductScalar             256  thrpt    5  12.557 ± 0.044  ops/us
VectorUtilBenchmark.binaryDotProductScalar            1024  thrpt    5   3.110 ± 0.029  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedScalar     128  thrpt    5  25.115 ± 0.082  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedScalar     207  thrpt    5  15.518 ± 0.039  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedScalar     256  thrpt    5  12.554 ± 0.037  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedScalar    1024  thrpt    5   3.112 ± 0.011  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedVector     128  thrpt    5  38.071 ± 0.060  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedVector     207  thrpt    5  25.039 ± 0.120  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedVector     256  thrpt    5  20.578 ± 0.062  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedVector    1024  thrpt    5   5.465 ± 0.008  ops/us
VectorUtilBenchmark.binaryDotProductVector             128  thrpt    5  45.923 ± 0.150  ops/us
VectorUtilBenchmark.binaryDotProductVector             207  thrpt    5  30.516 ± 0.053  ops/us
VectorUtilBenchmark.binaryDotProductVector             256  thrpt    5  25.510 ± 0.053  ops/us
VectorUtilBenchmark.binaryDotProductVector            1024  thrpt    5   6.744 ± 0.046  ops/us
```

</details>

<details> 

<summary> GCP AVX512 </summary>

```
Benchmark                                           (size)   Mode  Cnt   Score   Error   Units
VectorUtilBenchmark.binaryCosineScalar                 128  thrpt    5   7.290 ± 0.003  ops/us
VectorUtilBenchmark.binaryCosineScalar                 207  thrpt    5   4.236 ± 0.015  ops/us
VectorUtilBenchmark.binaryCosineScalar                 256  thrpt    5   3.452 ± 0.015  ops/us
VectorUtilBenchmark.binaryCosineScalar                1024  thrpt    5   0.885 ± 0.003  ops/us
VectorUtilBenchmark.binaryCosineUnsignedScalar         128  thrpt    5   7.304 ± 0.007  ops/us
VectorUtilBenchmark.binaryCosineUnsignedScalar         207  thrpt    5   4.225 ± 0.013  ops/us
VectorUtilBenchmark.binaryCosineUnsignedScalar         256  thrpt    5   3.431 ± 0.026  ops/us
VectorUtilBenchmark.binaryCosineUnsignedScalar        1024  thrpt    5   0.879 ± 0.006  ops/us
VectorUtilBenchmark.binaryCosineUnsignedVector         128  thrpt    5  29.931 ± 0.049  ops/us
VectorUtilBenchmark.binaryCosineUnsignedVector         207  thrpt    5  17.284 ± 0.018  ops/us
VectorUtilBenchmark.binaryCosineUnsignedVector         256  thrpt    5  19.145 ± 0.067  ops/us
VectorUtilBenchmark.binaryCosineUnsignedVector        1024  thrpt    5   6.109 ± 0.004  ops/us
VectorUtilBenchmark.binaryCosineVector                 128  thrpt    5  32.736 ± 0.027  ops/us
VectorUtilBenchmark.binaryCosineVector                 207  thrpt    5  18.272 ± 0.640  ops/us
VectorUtilBenchmark.binaryCosineVector                 256  thrpt    5  21.435 ± 0.051  ops/us
VectorUtilBenchmark.binaryCosineVector                1024  thrpt    5   7.029 ± 0.011  ops/us
VectorUtilBenchmark.binaryDotProductScalar             128  thrpt    5  16.971 ± 0.053  ops/us
VectorUtilBenchmark.binaryDotProductScalar             207  thrpt    5   9.508 ± 0.091  ops/us
VectorUtilBenchmark.binaryDotProductScalar             256  thrpt    5   8.121 ± 0.059  ops/us
VectorUtilBenchmark.binaryDotProductScalar            1024  thrpt    5   2.501 ± 0.011  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedScalar     128  thrpt    5  16.977 ± 0.056  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedScalar     207  thrpt    5  10.448 ± 0.045  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedScalar     256  thrpt    5   8.352 ± 0.042  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedScalar    1024  thrpt    5   2.502 ± 0.042  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedVector     128  thrpt    5  69.663 ± 0.079  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedVector     207  thrpt    5  44.077 ± 0.059  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedVector     256  thrpt    5  41.963 ± 0.030  ops/us
VectorUtilBenchmark.binaryDotProductUnsignedVector    1024  thrpt    5  11.856 ± 0.020  ops/us
VectorUtilBenchmark.binaryDotProductVector             128  thrpt    5  85.247 ± 0.175  ops/us
VectorUtilBenchmark.binaryDotProductVector             207  thrpt    5  48.486 ± 0.055  ops/us
VectorUtilBenchmark.binaryDotProductVector             256  thrpt    5  50.560 ± 0.045  ops/us
VectorUtilBenchmark.binaryDotProductVector            1024  thrpt    5  14.697 ± 0.010  ops/us
```

</details> 