### PR TITLE
Optimize outputs accumulating for SegmentTermsEnum and IntersectTermsEnum 

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/FieldReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/FieldReader.java
@@ -118,11 +118,13 @@ public final class FieldReader extends Terms {
    * <p>Package private for testing.
    */
   static long readMSBVLong(DataInput in) throws IOException {
-    byte b = in.readByte();
-    long l = b & 0x7FL;
-    while (b < 0) {
-      b = in.readByte();
+    long l = 0L;
+    while (true) {
+      byte b = in.readByte();
       l = (l << 7) | (b & 0x7FL);
+      if ((b & 0x80) == 0) {
+        break;
+      }
     }
     return l;
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/FieldReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/FieldReader.java
@@ -118,13 +118,11 @@ public final class FieldReader extends Terms {
    * <p>Package private for testing.
    */
   static long readMSBVLong(DataInput in) throws IOException {
-    long l = 0L;
-    while (true) {
-      byte b = in.readByte();
+    byte b = in.readByte();
+    long l = b & 0x7FL;
+    while (b < 0) {
+      b = in.readByte();
       l = (l << 7) | (b & 0x7FL);
-      if ((b & 0x80) == 0) {
-        break;
-      }
     }
     return l;
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnum.java
@@ -30,9 +30,7 @@ import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.automaton.ByteRunnable;
 import org.apache.lucene.util.automaton.Transition;
 import org.apache.lucene.util.automaton.TransitionAccessor;
-import org.apache.lucene.util.fst.ByteSequenceOutputs;
 import org.apache.lucene.util.fst.FST;
-import org.apache.lucene.util.fst.Outputs;
 
 /**
  * This is used to implement efficient {@link Terms#intersect} for block-tree. Note that it cannot
@@ -46,7 +44,6 @@ final class IntersectTermsEnum extends BaseTermsEnum {
   // static boolean DEBUG = BlockTreeTermsWriter.DEBUG;
 
   final IndexInput in;
-  static final Outputs<BytesRef> fstOutputs = ByteSequenceOutputs.getSingleton();
 
   IntersectTermsEnumFrame[] stack;
 
@@ -67,6 +64,9 @@ final class IntersectTermsEnum extends BaseTermsEnum {
   final FieldReader fr;
 
   private BytesRef savedStartTerm;
+
+  private final SegmentTermsEnum.OutputAccumulator accumulator =
+      new SegmentTermsEnum.OutputAccumulator();
 
   // TODO: in some cases we can filter by length?  eg
   // regexp foo*bar must be at least length 6 bytes
@@ -114,7 +114,6 @@ final class IntersectTermsEnum extends BaseTermsEnum {
     f.prefix = 0;
     f.setState(0);
     f.arc = arc;
-    f.outputPrefix = arc.output();
     f.load(fr.rootCode);
 
     // for assert:
@@ -184,7 +183,9 @@ final class IntersectTermsEnum extends BaseTermsEnum {
     FST.Arc<BytesRef> arc = currentFrame.arc;
     int idx = currentFrame.prefix;
     assert currentFrame.suffix > 0;
-    BytesRef output = currentFrame.outputPrefix;
+
+    accumulator.reset();
+    accumulator.push(arc.output());
     while (idx < f.prefix) {
       final int target = term.bytes[idx] & 0xff;
       // TODO: we could be more efficient for the next()
@@ -192,14 +193,14 @@ final class IntersectTermsEnum extends BaseTermsEnum {
       // passed to findTargetArc
       arc = fr.index.findTargetArc(target, arc, getArc(1 + idx), fstReader);
       assert arc != null;
-      output = fstOutputs.add(output, arc.output());
+      accumulator.push(arc.output());
       idx++;
     }
 
     f.arc = arc;
-    f.outputPrefix = output;
     assert arc.isFinal();
-    f.load(fstOutputs.add(output, arc.nextFinalOutput()));
+    accumulator.push(arc.nextFinalOutput());
+    f.load(accumulator);
     return f;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnum.java
@@ -65,7 +65,7 @@ final class IntersectTermsEnum extends BaseTermsEnum {
 
   private BytesRef savedStartTerm;
 
-  private final SegmentTermsEnum.OutputAccumulator accumulator =
+  private final SegmentTermsEnum.OutputAccumulator outputAccumulator =
       new SegmentTermsEnum.OutputAccumulator();
 
   // TODO: in some cases we can filter by length?  eg
@@ -184,8 +184,8 @@ final class IntersectTermsEnum extends BaseTermsEnum {
     int idx = currentFrame.prefix;
     assert currentFrame.suffix > 0;
 
-    accumulator.reset();
-    accumulator.push(arc.output());
+    outputAccumulator.reset();
+    outputAccumulator.push(arc.output());
     while (idx < f.prefix) {
       final int target = term.bytes[idx] & 0xff;
       // TODO: we could be more efficient for the next()
@@ -193,14 +193,14 @@ final class IntersectTermsEnum extends BaseTermsEnum {
       // passed to findTargetArc
       arc = fr.index.findTargetArc(target, arc, getArc(1 + idx), fstReader);
       assert arc != null;
-      accumulator.push(arc.output());
+      outputAccumulator.push(arc.output());
       idx++;
     }
 
     f.arc = arc;
     assert arc.isFinal();
-    accumulator.push(arc.nextFinalOutput());
-    f.load(accumulator);
+    outputAccumulator.push(arc.nextFinalOutput());
+    f.load(outputAccumulator);
     return f;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnumFrame.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnumFrame.java
@@ -144,14 +144,16 @@ final class IntersectTermsEnumFrame {
 
   void load(SegmentTermsEnum.OutputAccumulator accumulator) throws IOException {
     accumulator.prepareRead();
-    final long code = ite.fr.readVLongOutput(accumulator);
+    long code = ite.fr.readVLongOutput(accumulator);
     accumulator.setFloorData(floorDataReader);
     load(code);
   }
 
-  void load(Long boxCode) throws IOException {
-    if (boxCode != null) {
-      if ((boxCode & Lucene90BlockTreeTermsReader.OUTPUT_FLAG_IS_FLOOR) != 0) {
+  void load(Long blockCode) throws IOException {
+    if (blockCode != null) {
+      // This block is the first one in a possible sequence of floor blocks corresponding to a
+      // single seek point from the FST terms index
+      if ((blockCode & Lucene90BlockTreeTermsReader.OUTPUT_FLAG_IS_FLOOR) != 0) {
         // Floor frame
         numFollowFloorBlocks = floorDataReader.readVInt();
         nextFloorLabel = floorDataReader.readByte() & 0xff;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnumFrame.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnumFrame.java
@@ -144,7 +144,7 @@ final class IntersectTermsEnumFrame {
 
   void load(SegmentTermsEnum.OutputAccumulator outputAccumulator) throws IOException {
     outputAccumulator.prepareRead();
-    final long code = ite.fr.readVLongOutput(outputAccumulator);
+    long code = ite.fr.readVLongOutput(outputAccumulator);
     outputAccumulator.setFloorData(floorDataReader);
     load(code);
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnumFrame.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/IntersectTermsEnumFrame.java
@@ -142,10 +142,10 @@ final class IntersectTermsEnumFrame {
     load(ite.fr.readVLongOutput(floorDataReader));
   }
 
-  void load(SegmentTermsEnum.OutputAccumulator accumulator) throws IOException {
-    accumulator.prepareRead();
-    final long code = ite.fr.readVLongOutput(accumulator);
-    accumulator.setFloorData(floorDataReader);
+  void load(SegmentTermsEnum.OutputAccumulator outputAccumulator) throws IOException {
+    outputAccumulator.prepareRead();
+    final long code = ite.fr.readVLongOutput(outputAccumulator);
+    outputAccumulator.setFloorData(floorDataReader);
     load(code);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
@@ -1195,17 +1195,18 @@ final class SegmentTermsEnum extends BaseTermsEnum {
     }
 
     void pop() {
-      this.num--;
+      assert num > 0;
+      num--;
     }
 
     void reset() {
-      this.num = 0;
+      num = 0;
     }
 
     void prepareRead() {
-      this.index = 0;
-      this.outputIndex = 0;
-      this.current = outputs[0];
+      index = 0;
+      outputIndex = 0;
+      current = outputs[0];
     }
 
     void setFloorData(ByteArrayDataInput floorData) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
@@ -49,7 +49,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
 
   // static boolean DEBUG = BlockTreeTermsWriter.DEBUG;
 
-  private final OutputAccumulator accumulator = new OutputAccumulator();
+  private final OutputAccumulator outputAccumulator = new OutputAccumulator();
 
   // What prefix of the current term was present in the index; when we only next() through the
   // index, this stays at 0.  It's only set when
@@ -235,22 +235,22 @@ final class SegmentTermsEnum extends BaseTermsEnum {
 
   SegmentTermsEnumFrame pushFrame(FST.Arc<BytesRef> arc, BytesRef frameData, int length)
       throws IOException {
-    accumulator.reset();
-    accumulator.push(frameData);
+    outputAccumulator.reset();
+    outputAccumulator.push(frameData);
     return pushFrame(arc, length);
   }
 
   // Pushes a frame we seek'd to
   SegmentTermsEnumFrame pushFrame(FST.Arc<BytesRef> arc, int length) throws IOException {
-    accumulator.prepareRead();
-    final long code = fr.readVLongOutput(accumulator);
+    outputAccumulator.prepareRead();
+    final long code = fr.readVLongOutput(outputAccumulator);
     final long fpSeek = code >>> Lucene90BlockTreeTermsReader.OUTPUT_FLAGS_NUM_BITS;
     final SegmentTermsEnumFrame f = getFrame(1 + currentFrame.ord);
     f.hasTerms = (code & Lucene90BlockTreeTermsReader.OUTPUT_FLAG_HAS_TERMS) != 0;
     f.hasTermsOrig = f.hasTerms;
     f.isFloor = (code & Lucene90BlockTreeTermsReader.OUTPUT_FLAG_IS_FLOOR) != 0;
     if (f.isFloor) {
-      f.setFloorData(accumulator);
+      f.setFloorData(outputAccumulator);
     }
     pushFrame(arc, fpSeek, length);
 
@@ -353,7 +353,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
     int targetUpto;
 
     targetBeforeCurrentLength = currentFrame.ord;
-    accumulator.reset();
+    outputAccumulator.reset();
 
     if (currentFrame != staticFrame) {
 
@@ -370,7 +370,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
 
       arc = arcs[0];
       assert arc.isFinal();
-      accumulator.push(arc.output());
+      outputAccumulator.push(arc.output());
       targetUpto = 0;
 
       SegmentTermsEnumFrame lastFrame = stack[0];
@@ -398,7 +398,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
                 + (char) arc.label()
                 + " targetLabel="
                 + (char) (target.bytes[target.offset + targetUpto] & 0xFF);
-        accumulator.push(arc.output());
+        outputAccumulator.push(arc.output());
 
         if (arc.isFinal()) {
           lastFrame = stack[1 + lastFrame.ord];
@@ -487,15 +487,15 @@ final class SegmentTermsEnum extends BaseTermsEnum {
       //   System.out.println("    no seek state; push root frame");
       // }
 
-      accumulator.push(arc.output());
+      outputAccumulator.push(arc.output());
 
       currentFrame = staticFrame;
 
       // term.length = 0;
       targetUpto = 0;
-      accumulator.push(arc.nextFinalOutput());
+      outputAccumulator.push(arc.nextFinalOutput());
       currentFrame = pushFrame(arc, 0);
-      accumulator.pop();
+      outputAccumulator.pop();
     }
 
     // if (DEBUG) {
@@ -557,7 +557,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
         term.setByteAt(targetUpto, (byte) targetLabel);
         // Aggregate output as we go:
         assert arc.output() != null;
-        accumulator.push(arc.output());
+        outputAccumulator.push(arc.output());
 
         // if (DEBUG) {
         //   System.out.println("    index: follow label=" + toHex(target.bytes[target.offset +
@@ -567,9 +567,9 @@ final class SegmentTermsEnum extends BaseTermsEnum {
 
         if (arc.isFinal()) {
           // if (DEBUG) System.out.println("    arc is final!");
-          accumulator.push(arc.nextFinalOutput());
+          outputAccumulator.push(arc.nextFinalOutput());
           currentFrame = pushFrame(arc, targetUpto);
-          accumulator.pop();
+          outputAccumulator.pop();
           // if (DEBUG) System.out.println("    curFrame.ord=" + currentFrame.ord + " hasTerms=" +
           // currentFrame.hasTerms);
         }
@@ -631,7 +631,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
     int targetUpto;
 
     targetBeforeCurrentLength = currentFrame.ord;
-    accumulator.reset();
+    outputAccumulator.reset();
 
     if (currentFrame != staticFrame) {
 
@@ -648,7 +648,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
 
       arc = arcs[0];
       assert arc.isFinal();
-      accumulator.push(arc.output());
+      outputAccumulator.push(arc.output());
       targetUpto = 0;
 
       SegmentTermsEnumFrame lastFrame = stack[0];
@@ -677,7 +677,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
                 + " targetLabel="
                 + (char) (target.bytes[target.offset + targetUpto] & 0xFF);
 
-        accumulator.push(arc.output());
+        outputAccumulator.push(arc.output());
         if (arc.isFinal()) {
           lastFrame = stack[1 + lastFrame.ord];
         }
@@ -759,15 +759,15 @@ final class SegmentTermsEnum extends BaseTermsEnum {
       // System.out.println("    no seek state; push root frame");
       // }
 
-      accumulator.push(arc.output());
+      outputAccumulator.push(arc.output());
 
       currentFrame = staticFrame;
 
       // term.length = 0;
       targetUpto = 0;
-      accumulator.push(arc.nextFinalOutput());
+      outputAccumulator.push(arc.nextFinalOutput());
       currentFrame = pushFrame(arc, 0);
-      accumulator.pop();
+      outputAccumulator.pop();
     }
 
     // if (DEBUG) {
@@ -829,7 +829,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
         arc = nextArc;
         // Aggregate output as we go:
         assert arc.output() != null;
-        accumulator.push(arc.output());
+        outputAccumulator.push(arc.output());
 
         // if (DEBUG) {
         // System.out.println("    index: follow label=" + (target.bytes[target.offset +
@@ -839,9 +839,9 @@ final class SegmentTermsEnum extends BaseTermsEnum {
 
         if (arc.isFinal()) {
           // if (DEBUG) System.out.println("    arc is final!");
-          accumulator.push(arc.nextFinalOutput());
+          outputAccumulator.push(arc.nextFinalOutput());
           currentFrame = pushFrame(arc, targetUpto);
-          accumulator.pop();
+          outputAccumulator.pop();
           // if (DEBUG) System.out.println("    curFrame.ord=" + currentFrame.ord + " hasTerms=" +
           // currentFrame.hasTerms);
         }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
@@ -1179,17 +1179,15 @@ final class SegmentTermsEnum extends BaseTermsEnum {
 
   static class OutputAccumulator extends DataInput {
 
-    /** We could have at most 10 no-empty arcs: 9 for vLong and 1 for floor data. */
-    private static final int MAX_ARC = 10;
-
-    BytesRef[] outputs = new BytesRef[MAX_ARC];
+    BytesRef[] outputs = new BytesRef[16];
     BytesRef current;
-    int num = 0;
-    int outputIndex = 0;
-    int index = 0;
+    int num;
+    int outputIndex;
+    int index;
 
     void push(BytesRef output) {
       if (output != Lucene90BlockTreeTermsReader.NO_OUTPUT) {
+        outputs = ArrayUtil.grow(outputs, num + 1);
         outputs[num++] = output;
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
@@ -1207,6 +1207,10 @@ final class SegmentTermsEnum extends BaseTermsEnum {
       current = outputs[0];
     }
 
+    /**
+     * Set the last arc as the source of the floorData. This won't change the reading position of
+     * this {@link OutputAccumulator}
+     */
     void setFloorData(ByteArrayDataInput floorData) {
       assert outputIndex == num - 1
           : "floor data should be stored in last arc, get outputIndex: "

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnumFrame.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnumFrame.java
@@ -55,7 +55,7 @@ final class SegmentTermsEnumFrame {
   int statsSingletonRunLength = 0;
   final ByteArrayDataInput statsReader = new ByteArrayDataInput();
 
-  byte[] floorData = new byte[32];
+  int rewindPos;
   final ByteArrayDataInput floorDataReader = new ByteArrayDataInput();
 
   // Length of prefix shared by all terms in this block
@@ -104,13 +104,9 @@ final class SegmentTermsEnumFrame {
     suffixLengthsReader = new ByteArrayDataInput();
   }
 
-  public void setFloorData(ByteArrayDataInput in, BytesRef source) {
-    final int numBytes = source.length - (in.getPosition() - source.offset);
-    if (numBytes > floorData.length) {
-      floorData = new byte[ArrayUtil.oversize(numBytes, 1)];
-    }
-    System.arraycopy(source.bytes, source.offset + in.getPosition(), floorData, 0, numBytes);
-    floorDataReader.reset(floorData, 0, numBytes);
+  public void setFloorData(SegmentTermsEnum.OutputAccumulator accumulator) {
+    accumulator.setFloorData(floorDataReader);
+    rewindPos = floorDataReader.getPosition();
     numFollowFloorBlocks = floorDataReader.readVInt();
     nextFloorLabel = floorDataReader.readByte() & 0xff;
     // if (DEBUG) {
@@ -247,7 +243,7 @@ final class SegmentTermsEnumFrame {
     nextEnt = -1;
     hasTerms = hasTermsOrig;
     if (isFloor) {
-      floorDataReader.rewind();
+      floorDataReader.setPosition(rewindPos);
       numFollowFloorBlocks = floorDataReader.readVInt();
       assert numFollowFloorBlocks > 0;
       nextFloorLabel = floorDataReader.readByte() & 0xff;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnumFrame.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnumFrame.java
@@ -104,8 +104,8 @@ final class SegmentTermsEnumFrame {
     suffixLengthsReader = new ByteArrayDataInput();
   }
 
-  public void setFloorData(SegmentTermsEnum.OutputAccumulator accumulator) {
-    accumulator.setFloorData(floorDataReader);
+  public void setFloorData(SegmentTermsEnum.OutputAccumulator outputAccumulator) {
+    outputAccumulator.setFloorData(floorDataReader);
     rewindPos = floorDataReader.getPosition();
     numFollowFloorBlocks = floorDataReader.readVInt();
     nextFloorLabel = floorDataReader.readByte() & 0xff;


### PR DESCRIPTION
## Description
Previous talk is too long to track so i opened a new PR to make a summery here. More details are available in https://github.com/apache/lucene/pull/12661.

After merging of https://github.com/apache/lucene/pull/12631, we found a [regression](https://home.apache.org/~mikemccand/lucenebench/2023.10.10.18.03.55.html) for term-dictionary-related tasks like PKLookup, Fuzzy ... After some digging I suspect that the regression is caused by  more `Outputs#add` and `Outputs#read` on reading side, as the 'MSB VLong output format' making FST sharing more output prefix. The difference of calling times of `Outputs#add` and `Outputs#read` is shown below:

  | LSB VLong | MSB VLong | diff
-- | -- | -- | --
Outputs#read times | 116097 | 149803 | 29.03%
Outputs#add times | 144 | 111568 | 77377.78%

## Solution

This patch tries to do two optimizations to get back the speed:
* Instead of combining all outputs into single one, this patch collect all BytesRefs into an array and build a DataInput view over it, reducing the cost of objects construction and memory copy.
* Instead of copying bytes into floor data, this patch directly uses the last output as floor data. Floor data is guaranteed continuous in single arc because we can not have two same `fp` encoded before floor data.

## Benchmark

> Both run 30 JVM round and 50 tasks per JVM:

### Comparing to after merging of https://github.com/apache/lucene/pull/12631

BaseLine ( **After** merging of https://github.com/apache/lucene/pull/12631 )

> $ git log
> Write MSB VLong for better outputs sharing in block tree index (#12631)
> DeletedTerms#clear should reset ByteBlockPool (#12630)

Candidate

> $ git log
> Optimize output accumulating
> Write MSB VLong for better outputs sharing in block tree index
> DeletedTerms#clear should reset ByteBlockPool

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                   OrHighNotHigh      166.79      (4.5%)      165.12      (4.3%)   -1.0% (  -9% -    8%) 0.376
                    OrHighNotLow      258.47      (4.3%)      256.46      (3.3%)   -0.8% (  -7% -    7%) 0.430
            HighIntervalsOrdered        0.38      (3.3%)        0.38      (3.1%)   -0.8% (  -6% -    5%) 0.359
                 LowSloppyPhrase        1.64      (3.4%)        1.63      (4.9%)   -0.7% (  -8% -    7%) 0.544
                   OrNotHighHigh      150.83      (5.1%)      149.86      (4.4%)   -0.6% (  -9% -    9%) 0.597
                HighSloppyPhrase        3.67      (3.3%)        3.64      (3.6%)   -0.6% (  -7% -    6%) 0.470
                         Prefix3       67.16      (4.3%)       66.78      (2.8%)   -0.6% (  -7% -    6%) 0.543
                    OrNotHighMed      135.65      (4.4%)      134.95      (3.7%)   -0.5% (  -8% -    7%) 0.620
                    OrNotHighLow      257.14      (2.0%)      255.85      (1.7%)   -0.5% (  -4% -    3%) 0.291
                     AndHighHigh       19.33      (2.8%)       19.25      (2.2%)   -0.4% (  -5% -    4%) 0.517
                    OrHighNotMed      128.51      (5.3%)      128.06      (4.2%)   -0.3% (  -9% -    9%) 0.778
                 MedSloppyPhrase        9.56      (3.6%)        9.54      (3.8%)   -0.3% (  -7% -    7%) 0.788
                      OrHighHigh       13.23      (3.3%)       13.20      (3.2%)   -0.2% (  -6% -    6%) 0.801
                       OrHighLow      199.40      (1.9%)      199.18      (1.7%)   -0.1% (  -3% -    3%) 0.812
                        Wildcard       69.22      (2.7%)       69.19      (1.9%)   -0.0% (  -4% -    4%) 0.952
                      AndHighMed       42.14      (3.7%)       42.14      (2.9%)    0.0% (  -6% -    6%) 0.993
                    HighSpanNear        7.00      (3.1%)        7.00      (3.1%)    0.1% (  -5% -    6%) 0.945
                          Fuzzy1       44.05      (1.8%)       44.08      (1.7%)    0.1% (  -3% -    3%) 0.872
                       OrHighMed       38.54      (2.6%)       38.59      (3.2%)    0.1% (  -5% -    6%) 0.871
                         Respell       28.40      (2.2%)       28.45      (2.2%)    0.2% (  -4% -    4%) 0.790
                     LowSpanNear        4.23      (1.7%)        4.24      (1.5%)    0.2% (  -2% -    3%) 0.580
             MedIntervalsOrdered        3.47      (6.6%)        3.49      (7.3%)    0.3% ( -12% -   15%) 0.856
             LowIntervalsOrdered        2.76      (4.3%)        2.77      (5.0%)    0.4% (  -8% -   10%) 0.761
                          Fuzzy2       35.28      (1.6%)       35.42      (1.6%)    0.4% (  -2% -    3%) 0.325
                      HighPhrase       38.91      (2.6%)       39.07      (2.5%)    0.4% (  -4% -    5%) 0.532
                         MedTerm      248.39      (4.2%)      249.48      (4.2%)    0.4% (  -7% -    9%) 0.685
                       LowPhrase       26.44      (2.0%)       26.57      (2.3%)    0.5% (  -3% -    4%) 0.385
                       MedPhrase        9.51      (2.3%)        9.57      (2.6%)    0.6% (  -4% -    5%) 0.365
                      AndHighLow      338.26      (3.0%)      340.61      (2.6%)    0.7% (  -4% -    6%) 0.339
                         LowTerm      242.60      (4.5%)      244.38      (4.8%)    0.7% (  -8% -   10%) 0.545
                     MedSpanNear        1.11      (1.4%)        1.12      (1.5%)    0.8% (  -2% -    3%) 0.042
                        HighTerm      230.63      (3.8%)      233.01      (4.6%)    1.0% (  -7% -    9%) 0.339
                        PKLookup      100.76      (2.9%)      105.17      (3.2%)    4.4% (  -1% -   10%) 0.000
```

### Comparing to before merging of https://github.com/apache/lucene/pull/12631

BaseLine ( **Before** merging of https://github.com/apache/lucene/pull/12631 )

> $ git log
> DeletedTerms#clear should reset ByteBlockPool 

Candidate

> $ git log
> Optimize output accumulating
> Write MSB VLong for better outputs sharing in block tree index
> DeletedTerms#clear should reset ByteBlockPool

(Not sure why seeing tiny speed up for Orxxx tasks. I suspect it is a noise)
```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
             MedIntervalsOrdered        3.50      (7.9%)        3.43      (7.4%)   -2.2% ( -16% -   14%) 0.269
                        Wildcard       70.27      (2.9%)       69.22      (2.2%)   -1.5% (  -6% -    3%) 0.023
            HighIntervalsOrdered        0.38      (4.0%)        0.37      (4.0%)   -1.3% (  -8% -    6%) 0.194
             LowIntervalsOrdered        2.78      (5.3%)        2.75      (5.2%)   -1.1% ( -10% -    9%) 0.417
                         Prefix3       66.95      (4.3%)       66.25      (3.1%)   -1.0% (  -8% -    6%) 0.282
                         LowTerm      246.48      (8.3%)      244.15      (6.8%)   -0.9% ( -14% -   15%) 0.631
                       MedPhrase        9.57      (3.6%)        9.50      (3.1%)   -0.8% (  -7% -    6%) 0.366
                HighSloppyPhrase        3.63      (3.5%)        3.62      (3.8%)   -0.3% (  -7% -    7%) 0.761
                      HighPhrase       39.07      (3.5%)       38.96      (3.3%)   -0.3% (  -6% -    6%) 0.749
                        PKLookup      105.27      (2.8%)      105.13      (3.0%)   -0.1% (  -5% -    5%) 0.859
                 MedSloppyPhrase        9.49      (3.2%)        9.48      (3.9%)   -0.1% (  -6% -    7%) 0.920
                         Respell       28.45      (2.6%)       28.46      (2.2%)    0.0% (  -4% -    5%) 0.957
                 LowSloppyPhrase        1.63      (5.0%)        1.63      (5.6%)    0.1% (  -9% -   11%) 0.929
                       LowPhrase       26.31      (3.3%)       26.36      (2.1%)    0.2% (  -5% -    5%) 0.782
                          Fuzzy1       43.71      (1.3%)       43.82      (1.7%)    0.3% (  -2% -    3%) 0.509
                   OrHighNotHigh      164.97      (3.7%)      165.40      (4.4%)    0.3% (  -7% -    8%) 0.806
                     AndHighHigh       19.17      (2.1%)       19.23      (2.3%)    0.3% (  -3% -    4%) 0.569
                     MedSpanNear        1.11      (2.0%)        1.12      (2.0%)    0.6% (  -3% -    4%) 0.266
                      AndHighLow      338.06      (2.1%)      340.30      (1.9%)    0.7% (  -3% -    4%) 0.196
                     LowSpanNear        4.20      (2.4%)        4.23      (2.1%)    0.7% (  -3% -    5%) 0.194
                      OrHighHigh       13.15      (4.0%)       13.26      (4.5%)    0.8% (  -7% -    9%) 0.454
                   OrNotHighHigh      148.59      (3.9%)      149.94      (5.1%)    0.9% (  -7% -   10%) 0.442
                        HighTerm      229.24      (3.7%)      231.60      (4.2%)    1.0% (  -6% -    9%) 0.314
                    HighSpanNear        6.94      (3.3%)        7.01      (3.6%)    1.1% (  -5% -    8%) 0.224
                    OrHighNotMed      126.33      (4.3%)      127.74      (4.9%)    1.1% (  -7% -   10%) 0.343
                    OrHighNotLow      254.19      (3.1%)      257.19      (3.9%)    1.2% (  -5% -    8%) 0.200
                      AndHighMed       41.35      (5.0%)       42.00      (3.2%)    1.6% (  -6% -   10%) 0.148
                          Fuzzy2       34.61      (1.8%)       35.34      (2.1%)    2.1% (  -1% -    6%) 0.000
                       OrHighMed       37.84      (5.8%)       38.65      (4.2%)    2.1% (  -7% -   12%) 0.107
                    OrNotHighLow      248.52      (2.8%)      254.75      (2.5%)    2.5% (  -2% -    7%) 0.000
                       OrHighLow      193.81      (2.3%)      200.07      (2.5%)    3.2% (  -1% -    8%) 0.000
                    OrNotHighMed      130.29      (3.6%)      134.66      (4.7%)    3.4% (  -4% -   12%) 0.002
                         MedTerm      241.15      (3.8%)      249.46      (4.5%)    3.4% (  -4% -   12%) 0.001
```
