### PR TITLE
Improve handling of NullPointerException in MMapDirectory's IndexInputs (check the "closed" condition)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -183,6 +183,9 @@ Improvements
 
 * GITHUB#12586: Remove over-counting of deleted terms. (Guo Feng)
 
+* GITHUB#12705: Improve handling of NullPointerException in MMapDirectory's IndexInputs.
+  (Uwe Schindler, Michael Sokolov)
+
 Optimizations
 ---------------------
 * GITHUB#12183: Make TermStates#build concurrent. (Shubham Chaudhary)

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferGuard.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferGuard.java
@@ -78,6 +78,10 @@ final class ByteBufferGuard {
     }
   }
 
+  public boolean isInvalidated() {
+    return invalidated;
+  }
+
   private void ensureValid() {
     if (invalidated) {
       // this triggers an AlreadyClosedException in ByteBufferIndexInput:

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -99,9 +99,16 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     }
   }
 
-  // the unused parameter is just to silence javac about unused variables
-  AlreadyClosedException alreadyClosed(RuntimeException unused) {
-    return new AlreadyClosedException("Already closed: " + this);
+  AlreadyClosedException alreadyClosed(NullPointerException npe) {
+    // we use NPE to signal if this input is closed (to not have checks everywhere). If NPE happens,
+    // we check the "is closed" condition explicitly by checking that our "buffers" are null or
+    // the guard was invalidated.
+    if (this.buffers == null || this.curBuf == null || guard.isInvalidated()) {
+      return new AlreadyClosedException("Already closed: " + this);
+    }
+    // otherwise rethrow unmodified NPE (as it possibly a bug with passing a null parameter to the
+    // IndexInput method):
+    throw npe;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -466,7 +466,7 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
 
   /** Builds the actual sliced IndexInput (may apply extra offset in subclasses). * */
   protected ByteBufferIndexInput buildSlice(String sliceDescription, long offset, long length) {
-    if (buffers == null) {
+    if (buffers == null || guard.isInvalidated()) {
       throw alreadyClosed(null);
     }
 

--- a/lucene/core/src/java19/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java19/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -102,9 +102,17 @@ abstract class MemorySegmentIndexInput extends IndexInput implements RandomAcces
     }
   }
 
-  // the unused parameter is just to silence javac about unused variables
-  AlreadyClosedException alreadyClosed(RuntimeException unused) {
-    return new AlreadyClosedException("Already closed: " + this);
+  AlreadyClosedException alreadyClosed(RuntimeException e) {
+    // we use NPE to signal if this input is closed (to not have checks everywhere). If NPE happens,
+    // we check the "is closed" condition explicitly by checking that our "curSegment" is null.
+    // if it is an IllegalStateException, it can only come from MemorySegment API (other thread has
+    // closed input)
+    if (this.curSegment == null || e instanceof IllegalStateException) {
+      return new AlreadyClosedException("Already closed: " + this);
+    }
+    // otherwise rethrow unmodified NPE/ISE (as it possibly a bug with passing a null parameter to
+    // the IndexInput method):
+    throw e;
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/store/TestMmapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMmapDirectory.java
@@ -104,4 +104,17 @@ public class TestMmapDirectory extends BaseDirectoryTestCase {
       dir.close();
     }
   }
+
+  public void testNullParamsIndexInput() throws Exception {
+    try (Directory mmapDir = getDirectory(createTempDir("testNullParamsIndexInput"))) {
+      try (IndexOutput out = mmapDir.createOutput("bytes", newIOContext(random()))) {
+        out.alignFilePointer(16);
+      }
+      try (IndexInput in = mmapDir.openInput("bytes", IOContext.DEFAULT)) {
+        assertThrows(NullPointerException.class, () -> in.readBytes(null, 0, 1));
+        assertThrows(NullPointerException.class, () -> in.readFloats(null, 0, 1));
+        assertThrows(NullPointerException.class, () -> in.readLongs(null, 0, 1));
+      }
+    }
+  }
 }


### PR DESCRIPTION
See the dev thread by @msokolov  @ https://lists.apache.org/thread/qts8wvrjs54gkgz04pk4p93fg0wjbq3o

The handling of NPE is very special in ByteBufferIndexInput and also MemorySegmentIndexInput: To signal a closed input we set the buffers to NULL so any code trying to work on the inputs hits an NullPointerException. This is to avoid any null checks or isOpen checks everywhere in the code, which might be expensive, as the variable/field is not constant.

But it must on the other hand be avoided that the NPE gets visible outside of the IndexInputs, because it looks like a buggy null checks and may cause support issues. So we have to hide it by all means, as the NPE is *not* an error but a signal that the IndexInput was closed.

There are a few cases where a real NPE can still happen, e.g., when somebody accidentally passes a null array to one of the read  methods. In that case the NPE is important and should be re-thrown unmodified for the visibility of the caller.

The workaround here to not add the NPE as a cause (and making it visible to call er outside code) is to do a safety check when the excapetion actually happens (so it does not slow down anything): If the NPE is catched, the code in this PR checks that the "closed" condition applies to current state of IndexInput (buffers are null or the byte buffer guard is invalided). If and only if the "closed" check is true, it throws AlreadyCosedException. In all other cases it rethrows the original NPE.

I also added a test which failed before my change to demonstrate that it works. We may possibly add this check also to BaseDirectoryTestCase,

The changes were applied to all MemorySegmentIndexInput variants in the MR-JAR and the original ByteBufferIndexInput (+ its guard).