### PR TITLE
MMapDirectory with MemorySegment: Confirm that scope/session is no longer alive before throwing AlreadyClosedException

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -183,8 +183,8 @@ Improvements
 
 * GITHUB#12586: Remove over-counting of deleted terms. (Guo Feng)
 
-* GITHUB#12705: Improve handling of NullPointerException in MMapDirectory's IndexInputs.
-  (Uwe Schindler, Michael Sokolov)
+* GITHUB#12705, GITHUB#12705: Improve handling of NullPointerException and IllegalStateException
+  in MMapDirectory's IndexInputs.  (Uwe Schindler, Michael Sokolov)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java20/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java20/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -103,9 +103,11 @@ abstract class MemorySegmentIndexInput extends IndexInput implements RandomAcces
   AlreadyClosedException alreadyClosed(RuntimeException e) {
     // we use NPE to signal if this input is closed (to not have checks everywhere). If NPE happens,
     // we check the "is closed" condition explicitly by checking that our "curSegment" is null.
-    // if it is an IllegalStateException, it can only come from MemorySegment API (other thread has
-    // closed input)
-    if (this.curSegment == null || e instanceof IllegalStateException) {
+    if (this.curSegment == null) {
+      return new AlreadyClosedException("Already closed: " + this);
+    }
+    // we also check if the scope of all segments is still alive:
+    if (Arrays.stream(segments).allMatch(s -> s.scope().isAlive()) == false) {
       return new AlreadyClosedException("Already closed: " + this);
     }
     // otherwise rethrow unmodified NPE/ISE (as it possibly a bug with passing a null parameter to

--- a/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -103,9 +103,11 @@ abstract class MemorySegmentIndexInput extends IndexInput implements RandomAcces
   AlreadyClosedException alreadyClosed(RuntimeException e) {
     // we use NPE to signal if this input is closed (to not have checks everywhere). If NPE happens,
     // we check the "is closed" condition explicitly by checking that our "curSegment" is null.
-    // if it is an IllegalStateException, it can only come from MemorySegment API (other thread has
-    // closed input)
-    if (this.curSegment == null || e instanceof IllegalStateException) {
+    if (this.curSegment == null) {
+      return new AlreadyClosedException("Already closed: " + this);
+    }
+    // we also check if the scope of all segments is still alive:
+    if (Arrays.stream(segments).allMatch(s -> s.scope().isAlive()) == false) {
       return new AlreadyClosedException("Already closed: " + this);
     }
     // otherwise rethrow unmodified NPE/ISE (as it possibly a bug with passing a null parameter to


### PR DESCRIPTION
Followup on #12705: With memory segments we get an IllegalStateException. Instead of always rewriting it to AlreadyClosedException we confirm before if the segment scope (session in Java 19) is no longer alive.