### PR TITLE
Improve hash mixing in FST's double-barrel LRU hash

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -190,6 +190,8 @@ Improvements
 * GITHUB#12705, GITHUB#12705: Improve handling of NullPointerException and IllegalStateException
   in MMapDirectory's IndexInputs.  (Uwe Schindler, Michael Sokolov)
 
+* GITHUB#12716: Improve hash mixing in FST's double-barrel LRU hash. (Shubham Chaudhary)
+
 Optimizations
 ---------------------
 * GITHUB#12183: Make TermStates#build concurrent. (Shubham Chaudhary)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -190,7 +190,7 @@ Improvements
 * GITHUB#12705, GITHUB#12705: Improve handling of NullPointerException and IllegalStateException
   in MMapDirectory's IndexInputs.  (Uwe Schindler, Michael Sokolov)
 
-* GITHUB#12716: Improve hash mixing in FST's double-barrel LRU hash. (Shubham Chaudhary)
+* GITHUB#12716: Making FST compilation faster and more RAM-efficient using hash mixing. (Shubham Chaudhary)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
@@ -183,7 +183,8 @@ final class NodeHash<T> {
         h += 17;
       }
     }
-
+    // Here we multiply the hash with the gold constant BitMixer#PHI_C64
+    // This makes a real difference in the evenness of the value distribution
     return h * BitMixer.PHI_C64;
   }
 
@@ -207,7 +208,8 @@ final class NodeHash<T> {
       }
       fstCompiler.fst.readNextRealArc(scratchArc, in);
     }
-
+    // Here we multiply the hash with the gold constant BitMixer#PHI_C64
+    // This makes a real difference in the evenness of the value distribution
     return h * BitMixer.PHI_C64;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
@@ -80,7 +80,6 @@ final class NodeHash<T> {
       return 0;
     }
     long pos = hash & fallbackTable.mask;
-    int c = 0;
     while (true) {
       long node = fallbackTable.get(pos);
       if (node == 0) {
@@ -91,8 +90,8 @@ final class NodeHash<T> {
         return node;
       }
 
-      // quadratic probe (but is it, really?)
-      pos = (pos + (++c)) & fallbackTable.mask;
+      // simple linear probing
+      pos = (pos + 1) & fallbackTable.mask;
     }
   }
 
@@ -101,7 +100,6 @@ final class NodeHash<T> {
     long hash = hash(nodeIn);
 
     long pos = hash & primaryTable.mask;
-    int c = 0;
 
     while (true) {
 
@@ -149,8 +147,8 @@ final class NodeHash<T> {
           // TODO: we could clear & reuse the previous fallbackTable, instead of allocating a new
           //       to reduce GC load
           primaryTable = new PagedGrowableHash(node, Math.max(16, primaryTable.entries.size()));
-        } else if (primaryTable.count > primaryTable.entries.size() * (2f / 3)) {
-          // rehash at 2/3 occupancy
+        } else if (primaryTable.count > primaryTable.entries.size() * (3f / 4)) {
+          // rehash at 3/4 occupancy
           primaryTable.rehash(node);
         }
 
@@ -161,8 +159,8 @@ final class NodeHash<T> {
         return node;
       }
 
-      // quadratic probe (but is it, really?)
-      pos = (pos + (++c)) & primaryTable.mask;
+      // simple linear probing
+      pos = (pos + 1) & primaryTable.mask;
     }
   }
 
@@ -317,15 +315,14 @@ final class NodeHash<T> {
         long address = entries.get(idx);
         if (address != 0) {
           long pos = hash(address) & newMask;
-          int c = 0;
           while (true) {
             if (newEntries.get(pos) == 0) {
               newEntries.set(pos, address);
               break;
             }
 
-            // quadratic probe
-            pos = (pos + (++c)) & newMask;
+            // simple linear probing
+            pos = (pos + 1) & newMask;
           }
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.util.fst;
 
 import java.io.IOException;
+import org.apache.lucene.util.hppc.BitMixer;
 import org.apache.lucene.util.packed.PackedInts;
 import org.apache.lucene.util.packed.PagedGrowableWriter;
 
@@ -183,7 +184,7 @@ final class NodeHash<T> {
       }
     }
 
-    return h;
+    return h * BitMixer.PHI_C64;
   }
 
   // hash code for a frozen node.  this must precisely match the hash computation of an unfrozen
@@ -207,7 +208,7 @@ final class NodeHash<T> {
       fstCompiler.fst.readNextRealArc(scratchArc, in);
     }
 
-    return h;
+    return h * BitMixer.PHI_C64;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/BitMixer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/BitMixer.java
@@ -88,6 +88,8 @@ public final class BitMixer {
    */
 
   private static final int PHI_C32 = 0x9e3779b9;
+
+  // https://softwareengineering.stackexchange.com/questions/402542/where-do-magic-hashing-constants-like-0x9e3779b9-and-0x9e3779b1-come-from
   public static final long PHI_C64 = 0x9e3779b97f4a7c15L;
 
   public static int mixPhi(byte k) {

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/BitMixer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/BitMixer.java
@@ -88,7 +88,7 @@ public final class BitMixer {
    */
 
   private static final int PHI_C32 = 0x9e3779b9;
-  private static final long PHI_C64 = 0x9e3779b97f4a7c15L;
+  public static final long PHI_C64 = 0x9e3779b97f4a7c15L;
 
   public static int mixPhi(byte k) {
     final int h = k * PHI_C32;


### PR DESCRIPTION
### Description

 Addresses #12704. Below is the comment that inspired this ([link](https://github.com/apache/lucene/pull/12633#discussion_r1366847986)),


```
Instead, we should multiply with the gold constant BitMixer#PHI_C64 (make it public).
This really makes a difference in the evenness of the value distribution. This is one of the secrets of the HPPC hashing. By applying this, we get multiple advantages:

  * lookup should be improved (less hash collision)
  * we can try to rehash at 3/4 occupancy because the performance should not be impacted until this point.
  * in case of hash collision, we can lookup linearly with a pos = pos + 1 instead of quadratic probe (lines 95 and 327); this may avoid some mem cache miss.
  
(same for the other hash method)
```

Closes #12704 
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
