### PR TITLE
Make IndexSearcher#getSlices final and clarify docs

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -156,6 +156,8 @@ API Changes
 * GITHUB#12646, GITHUB#12690: Move FST#addNode to FSTCompiler to avoid a circular dependency
   between FST and FSTCompiler (Anh Dung Bui)
 
+* GITHUB#12718: Make IndexSearcher#getSlices final as it is not expected to be overridden (Luca Cavanna)
+
 New Features
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -115,10 +115,10 @@ public class IndexSearcher {
   protected final List<LeafReaderContext> leafContexts;
 
   /**
-   * used with executor - LeafSlice supplier where each slice holds a set of leafs executed within
+   * Used with executor - LeafSlice supplier where each slice holds a set of leafs executed within
    * one thread. We are caching it instead of creating it eagerly to avoid calling a protected
-   * method from constructor, which is a bad practice. This is {@code null} if no executor is
-   * provided
+   * method from constructor, which is a bad practice. Always non-null, regardless of whether an
+   * executor is provided or not.
    */
   private final Supplier<LeafSlice[]> leafSlicesSupplier;
 
@@ -425,11 +425,12 @@ public class IndexSearcher {
   }
 
   /**
-   * Returns the leaf slices used for concurrent searching
+   * Returns the leaf slices used for concurrent searching. Override {@link #slices(List)} to
+   * customize how slices are created.
    *
    * @lucene.experimental
    */
-  public LeafSlice[] getSlices() {
+  public final LeafSlice[] getSlices() {
     return leafSlicesSupplier.get();
   }
 


### PR DESCRIPTION
IndexSearcher exposes a public getSlices method, that is used to retriefve the slices that the searcher executes queries against, as well as slices, which is supposed to be overridden to customize the creation of slices.

I believe that getSlices should be final: there is no reason to override the method. Also, it is too easy to confuse the two and end up overriding the wrong one by mistake.

This change was discussed here: https://github.com/apache/lucene/pull/12606#discussion_r1340606929 .