### PR TITLE
Disable suffix sharing for block tree index

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -227,7 +227,8 @@ Optimizations
 
 * GITHUB#12712: Speed up sorting postings file with an offline radix sorter in BPIndexReader. (Guo Feng)
 
-* GITHUB#12702: Disable suffix sharing for block tree index. (Guo Feng)
+* GITHUB#12702: Disable suffix sharing for block tree index, making writing the terms dictionary index faster
+  and less RAM hungry, while making the index a bit (~1.X% for the terms index file on wikipedia). (Guo Feng, Mike McCandless)
 
 Changes in runtime behavior
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -227,6 +227,8 @@ Optimizations
 
 * GITHUB#12712: Speed up sorting postings file with an offline radix sorter in BPIndexReader. (Guo Feng)
 
+* GITHUB#12702: Disable suffix sharing for block tree index. (Guo Feng)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
@@ -521,7 +521,10 @@ public final class Lucene90BlockTreeTermsWriter extends FieldsConsumer {
 
       final ByteSequenceOutputs outputs = ByteSequenceOutputs.getSingleton();
       final FSTCompiler<BytesRef> fstCompiler =
-          new FSTCompiler.Builder<>(FST.INPUT_TYPE.BYTE1, outputs).bytesPageBits(pageBits).build();
+          new FSTCompiler.Builder<>(FST.INPUT_TYPE.BYTE1, outputs)
+              .suffixRAMLimitMB(0d)
+              .bytesPageBits(pageBits)
+              .build();
       // if (DEBUG) {
       //  System.out.println("  compile index for prefix=" + prefix);
       // }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
@@ -522,6 +522,8 @@ public final class Lucene90BlockTreeTermsWriter extends FieldsConsumer {
       final ByteSequenceOutputs outputs = ByteSequenceOutputs.getSingleton();
       final FSTCompiler<BytesRef> fstCompiler =
           new FSTCompiler.Builder<>(FST.INPUT_TYPE.BYTE1, outputs)
+              // Disable suffixes sharing for block tree index because suffixes are mostly dropped
+              // from the FST index and left in the term blocks.
               .suffixRAMLimitMB(0d)
               .bytesPageBits(pageBits)
               .build();


### PR DESCRIPTION
closes https://github.com/apache/lucene/issues/12702