### PR TITLE
Optimize: Use DocIdSetIterator Reduce bkd docvalues iteration

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/DocBaseBitSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocBaseBitSetIterator.java
@@ -69,6 +69,9 @@ public class DocBaseBitSetIterator extends DocIdSetIterator {
 
   @Override
   public int nextDoc() {
+    if (doc == NO_MORE_DOCS) {
+      return NO_MORE_DOCS;
+    }
     return advance(doc + 1);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -886,9 +886,7 @@ public class BKDReader extends PointValues {
 
     // point is under commonPrefix
     private void visitUniqueRawDocValues(
-        byte[] scratchPackedValue,
-        DocIdSetIterator iterator,
-        PointValues.IntersectVisitor visitor)
+        byte[] scratchPackedValue, DocIdSetIterator iterator, PointValues.IntersectVisitor visitor)
         throws IOException {
       visitor.visit(iterator, scratchPackedValue);
     }
@@ -1011,17 +1009,13 @@ public class BKDReader extends PointValues {
     }
   }
 
-  static class IntArrayIterator  extends DocIdSetIterator {
+  static class IntArrayIterator extends DocIdSetIterator {
 
     final int[] docIDs;
     private int offset;
     private int length;
     private int idx;
     private int docID;
-
-    public IntArrayIterator(int maxLen) {
-      this.docIDs = new int[maxLen];
-    }
 
     public IntArrayIterator(int[] docIDs, int length) {
       this.docIDs = docIDs;

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -819,9 +819,7 @@ public class BKDReader extends PointValues {
           visitor.grow(count);
 
           if (r == PointValues.Relation.CELL_INSIDE_QUERY) {
-            for (int i = 0; i < count; ++i) {
-              visitor.visit(iterator);
-            }
+            visitor.visit(iterator);
             return;
           }
         } else {

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
@@ -206,13 +206,6 @@ final class DocIdsWriter {
     return new DocBaseBitSetIterator(bitSet, count, offset);
   }
 
-  private static void readContinuousIds(IndexInput in, int count, int[] docIDs) throws IOException {
-    int start = in.readVInt();
-    for (int i = 0; i < count; i++) {
-      docIDs[i] = start + i;
-    }
-  }
-
   private static void readLegacyDeltaVInts(IndexInput in, int count, int[] docIDs)
       throws IOException {
     int doc = 0;
@@ -220,15 +213,6 @@ final class DocIdsWriter {
       doc += in.readVInt();
       docIDs[i] = doc;
     }
-  }
-
-  private static void readBitSet(IndexInput in, int count, int[] docIDs) throws IOException {
-    DocIdSetIterator iterator = readBitSetIterator(in, count);
-    int docId, pos = 0;
-    while ((docId = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-      docIDs[pos++] = docId;
-    }
-    assert pos == count : "pos: " + pos + "count: " + count;
   }
 
   private static void readDelta16(IndexInput in, int count, int[] docIDs) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
@@ -195,7 +195,8 @@ final class DocIdsWriter {
     return new DocBaseBitSetIterator(bitSet, count, offsetWords << 6);
   }
 
-  private static DocIdSetIterator readContinuousIdsIterator(IndexInput in, int count) throws IOException {
+  private static DocIdSetIterator readContinuousIdsIterator(IndexInput in, int count)
+      throws IOException {
     int start = in.readVInt();
     int extra = start & 63;
     int offset = start - extra;

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Set;
 import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
@@ -118,7 +119,11 @@ public class TestDocIdsWriter extends LuceneTestCase {
     }
     try (IndexInput in = dir.openInput("tmp", IOContext.READONCE)) {
       int[] read = new int[ints.length];
-      docIdsWriter.readInts(in, ints.length, read);
+      DocIdSetIterator iterator = docIdsWriter.readInts(in, ints.length, read);
+      int docId, pos = 0;
+      while ((docId = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+        read[pos++] = docId;
+      }
       assertArrayEquals(ints, read);
       assertEquals(len, in.getFilePointer());
     }


### PR DESCRIPTION
### Description

I see some hot_thread like following stack, 
```
   java.lang.Thread.State: RUNNABLE
        at org.apache.lucene.store.DataInput.readVInt(DataInput.java:112)
        at org.apache.lucene.util.bkd.BKDReader$BKDPointTree.readDocIDs(BKDReader.java:636)
        at org.apache.lucene.util.bkd.BKDReader$BKDPointTree.visitDocValues(BKDReader.java:608)
        at org.apache.lucene.util.bkd.BKDReader$BKDPointTree.visitLeavesOneByOne(BKDReader.java:595)
        at org.apache.lucene.util.bkd.BKDReader$BKDPointTree.visitDocValues(BKDReader.java:589)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:364)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:357)
        at org.apache.lucene.index.PointValues.intersect(PointValues.java:337)
        at org.apache.lucene.document.SpatialQuery$RelationScorerSupplier.getSparseScorer(SpatialQuery.java:340)
        at org.apache.lucene.document.SpatialQuery$RelationScorerSupplier.getScorer(SpatialQuery.java:306)
        at org.apache.lucene.document.SpatialQuery$2.get(SpatialQuery.java:203)
        at org.apache.lucene.search.Weight.bulkScorer(Weight.java:175)
        at org.apache.lucene.search.IndexSearcher.search(IndexSearcher.java:724)
```

and when we call `BKDPointTree#visitDocValues#readDocIDs`->`DocIdWriter#readInts`
 
https://github.com/apache/lucene/blob/c701a5d9be4d8dc677ea994f8ef5fdd8945760d6/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java#L165-L174

it would do iteration to copy docids into `int[] docIDs` when type is `BITSET_IDS` or `CONTINUOUS_IDS`, 
and After copy, 
it do iteration again to get docvalues in `visitDocValuesWithCardinality`

----
### Proposal

i think we can only do only one iteration like this pr shows. AND it can also reuse `visit(DocIdSetIterator iterator)` optimize when type is `DocBaseBitSetIterator`

i do benchmark with luceneutil `IndexAndSearchShapes` tests, use params `-intersects -point -file osmdata.wkt`

it shows:

baseline:  BEST QPS: 282.4637999101765
candidate: BEST QPS: 316.8185015110912