### PR TITLE
Ensure negative scores are not returned by vector similarity functions

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -256,6 +256,8 @@ Bug Fixes
 
 * GITHUB#12682: Scorer should sum up scores into a double. (Shubham Chaudhary)
 
+* GITHUB#12727: Ensure negative scores are not returned by vector similarity functions (Ben Trent)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
@@ -52,7 +52,11 @@ public enum VectorSimilarityFunction {
   DOT_PRODUCT {
     @Override
     public float compare(float[] v1, float[] v2) {
-      return (1 + dotProduct(v1, v2)) / 2;
+      double dotProduct = dotProduct(v1, v2) + 1.0;
+      if (dotProduct < 0) {
+        return 0;
+      }
+      return (float) (dotProduct / 2.0);
     }
 
     @Override
@@ -70,7 +74,11 @@ public enum VectorSimilarityFunction {
   COSINE {
     @Override
     public float compare(float[] v1, float[] v2) {
-      return (1 + cosine(v1, v2)) / 2;
+      double cosine = cosine(v1, v2) + 1.0;
+      if (cosine < 0) {
+        return 0;
+      }
+      return (float) (cosine / 2.0);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
@@ -52,11 +52,7 @@ public enum VectorSimilarityFunction {
   DOT_PRODUCT {
     @Override
     public float compare(float[] v1, float[] v2) {
-      double dotProduct = dotProduct(v1, v2) + 1.0;
-      if (dotProduct < 0) {
-        return 0;
-      }
-      return (float) (dotProduct / 2.0);
+      return Math.max((1 + dotProduct(v1, v2)) / 2, 0);
     }
 
     @Override
@@ -74,11 +70,7 @@ public enum VectorSimilarityFunction {
   COSINE {
     @Override
     public float compare(float[] v1, float[] v2) {
-      double cosine = cosine(v1, v2) + 1.0;
-      if (cosine < 0) {
-        return 0;
-      }
-      return (float) (cosine / 2.0);
+      return Math.max((1 + cosine(v1, v2)) / 2, 0);
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -17,6 +17,8 @@
 package org.apache.lucene.util;
 
 import java.util.Random;
+
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 
@@ -113,6 +115,22 @@ public class TestVectorUtil extends LuceneTestCase {
   public void testNormalizeZeroThrows() {
     float[] v = {0, 0, 0};
     expectThrows(IllegalArgumentException.class, () -> VectorUtil.l2normalize(v));
+  }
+
+
+  public void testExtremeNumerics() {
+    float[] v1 = new float[1536];
+    float[] v2 = new float[1536];
+    float[] v3 = new float[1536];
+    for (int i = 0; i < 1536; i++) {
+      v1[i] = -0.888888f;
+      v2[i] = 0.888888f;
+      v3[i] = -0.777777f;
+    }
+    for (VectorSimilarityFunction vectorSimilarityFunction : VectorSimilarityFunction.values()) {
+      float v = vectorSimilarityFunction.compare(v2, v3);
+      assertTrue(vectorSimilarityFunction + " expected >=0 got:" + v, v >= 0);
+    }
   }
 
   private static float l2(float[] v) {

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -119,14 +119,12 @@ public class TestVectorUtil extends LuceneTestCase {
   public void testExtremeNumerics() {
     float[] v1 = new float[1536];
     float[] v2 = new float[1536];
-    float[] v3 = new float[1536];
     for (int i = 0; i < 1536; i++) {
-      v1[i] = -0.888888f;
-      v2[i] = 0.888888f;
-      v3[i] = -0.777777f;
+      v1[i] = 0.888888f;
+      v2[i] = -0.777777f;
     }
     for (VectorSimilarityFunction vectorSimilarityFunction : VectorSimilarityFunction.values()) {
-      float v = vectorSimilarityFunction.compare(v2, v3);
+      float v = vectorSimilarityFunction.compare(v1, v2);
       assertTrue(vectorSimilarityFunction + " expected >=0 got:" + v, v >= 0);
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.util;
 
 import java.util.Random;
-
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
@@ -116,7 +115,6 @@ public class TestVectorUtil extends LuceneTestCase {
     float[] v = {0, 0, 0};
     expectThrows(IllegalArgumentException.class, () -> VectorUtil.l2normalize(v));
   }
-
 
   public void testExtremeNumerics() {
     float[] v1 = new float[1536];


### PR DESCRIPTION
We shouldn't ever return negative scores from vector similarity functions. Given vector panama and nearly antipodal float[] vectors, it is possible that cosine and (normalized) dot-product become slightly negative due to compounding floating point errors.

Since we don't want to make panama vector incredibly slow, we stick to float32 operations for now, and just snap to `0` if the score is negative after our correction.

closes: https://github.com/apache/lucene/issues/12700