### PR TITLE
Fix NullPointerException in Monitor.getQuery when query is not present

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -273,6 +273,8 @@ Bug Fixes
 
 * GITHUB#12727: Ensure negative scores are not returned by vector similarity functions (Ben Trent)
 
+* GITHUB#12736: Fix NullPointerException when Monitor.getQuery cannot find the requested queryId (Davis Cook)
+
 Build
 ---------------------
 

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryIndex.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryIndex.java
@@ -68,7 +68,7 @@ abstract class QueryIndex implements Closeable {
     search(
         new TermQuery(new Term(FIELDS.query_id, queryId)),
         (id, query, dataValues) -> bytesHolder[0] = dataValues.mq.binaryValue());
-    return serializer.deserialize(bytesHolder[0]);
+    return bytesHolder[0] != null ? serializer.deserialize(bytesHolder[0]) : null;
   }
 
   public void scan(QueryCollector matcher) throws IOException {


### PR DESCRIPTION
### Description
The [javadoc for Monitor.getQuery](https://github.com/apache/lucene/blob/a0887c7d26df6c9f32afcf8e9f0ff66275115f92/lucene/monitor/src/java/org/apache/lucene/monitor/Monitor.java#L261) suggests that it will return null when the query is not present but instead it throws a NullPointerException.

This is because `bytesHolder[0]` will still be null after the call to `search` if it does not find any query matching the id in the monitor's index. Then when the `serializer.deserialize` call is made, any attempts to index the BytesRef will throw the NullPointerException. This will happen [here](https://github.com/apache/lucene/blob/a0887c7d26df6c9f32afcf8e9f0ff66275115f92/lucene/monitor/src/java/org/apache/lucene/monitor/MonitorQuerySerializer.java#L53) when using the serializer/deserializer created with `MonitorQuerySerializer.fromParser`.

### Alternative Approach
This could instead be fixed just for the case of `MonitorQuerySerializer.fromParser` by making the serializer/deserializer returned from it null-safe (i.e. it checks if the input is null and returns null). But I went with this approach since it would be robust against custom implementations of the `MonitorQuerySerializer` interface that also do not check for null like the `fromParser` implementation.

### Tests
I introduced `testGetQueryNotPresent` which fails on master with the NullPointerException, but passes on this branch. I also added a corresponding `testGetQueryPresent` which passes on both master and this branch. Since I needed a monitor with persistence for these two new tests I refactored creating a monitor with persistence into a helper function `newMonitorWithPersistence` that gets reused throughout the `TestMonitorPersistence` file.