### PR TITLE
Fix file handle leak in Lucene99ScalarQuantizedVectorsWriter.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
@@ -260,7 +260,7 @@ public final class Lucene99ScalarQuantizedVectorsWriter implements Accountable {
                   quantizationDataInput)));
     } finally {
       if (success == false) {
-        IOUtils.closeWhileHandlingException(quantizationDataInput);
+        IOUtils.closeWhileHandlingException(tempQuantizedVectorData, quantizationDataInput);
         IOUtils.deleteFilesIgnoringExceptions(
             segmentWriteState.directory, tempQuantizedVectorData.getName());
       }


### PR DESCRIPTION
If `mergeQuantizedByteVectorValues` fails with an exception, the temp output never gets closed. This was found by the test that throws random exceptions.