### PR TITLE
stabilize vectorutil benchmark

### DIFF
--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
@@ -24,8 +24,14 @@ import org.openjdk.jmh.annotations.*;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
-@Warmup(iterations = 3, time = 3)
-@Measurement(iterations = 5, time = 3)
+// first iteration is complete garbage, so make sure we really warmup
+@Warmup(iterations = 4, time = 1)
+// real iterations. not useful to spend tons of time here, better to fork more
+@Measurement(iterations = 5, time = 1)
+// engage some noise reduction
+@Fork(
+    value = 3,
+    jvmArgsAppend = {"-Xmx2g", "-Xms2g", "-XX:+AlwaysPreTouch"})
 public class VectorUtilBenchmark {
 
   private byte[] bytesA;
@@ -36,7 +42,7 @@ public class VectorUtilBenchmark {
   @Param({"1", "128", "207", "256", "300", "512", "702", "1024"})
   int size;
 
-  @Setup(Level.Trial)
+  @Setup(Level.Iteration)
   public void init() {
     ThreadLocalRandom random = ThreadLocalRandom.current();
 
@@ -56,84 +62,72 @@ public class VectorUtilBenchmark {
   }
 
   @Benchmark
-  @Fork(value = 1)
   public float binaryCosineScalar() {
     return VectorUtil.cosine(bytesA, bytesB);
   }
 
   @Benchmark
-  @Fork(
-      value = 1,
-      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  @Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
   public float binaryCosineVector() {
     return VectorUtil.cosine(bytesA, bytesB);
   }
 
   @Benchmark
-  @Fork(value = 1)
   public int binaryDotProductScalar() {
     return VectorUtil.dotProduct(bytesA, bytesB);
   }
 
   @Benchmark
-  @Fork(
-      value = 1,
-      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  @Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
   public int binaryDotProductVector() {
     return VectorUtil.dotProduct(bytesA, bytesB);
   }
 
   @Benchmark
-  @Fork(value = 1)
   public int binarySquareScalar() {
     return VectorUtil.squareDistance(bytesA, bytesB);
   }
 
   @Benchmark
-  @Fork(
-      value = 1,
-      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  @Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
   public int binarySquareVector() {
     return VectorUtil.squareDistance(bytesA, bytesB);
   }
 
   @Benchmark
-  @Fork(value = 1)
   public float floatCosineScalar() {
     return VectorUtil.cosine(floatsA, floatsB);
   }
 
   @Benchmark
   @Fork(
-      value = 1,
+      value = 15,
       jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
   public float floatCosineVector() {
     return VectorUtil.cosine(floatsA, floatsB);
   }
 
   @Benchmark
-  @Fork(value = 1)
   public float floatDotProductScalar() {
     return VectorUtil.dotProduct(floatsA, floatsB);
   }
 
   @Benchmark
   @Fork(
-      value = 1,
+      value = 15,
       jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
   public float floatDotProductVector() {
     return VectorUtil.dotProduct(floatsA, floatsB);
   }
 
   @Benchmark
-  @Fork(value = 1)
   public float floatSquareScalar() {
     return VectorUtil.squareDistance(floatsA, floatsB);
   }
 
   @Benchmark
   @Fork(
-      value = 1,
+      value = 15,
       jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
   public float floatSquareVector() {
     return VectorUtil.squareDistance(floatsA, floatsB);


### PR DESCRIPTION
This benchmark is too noisy across forks which makes comparisons impossible and misleading. Especially vectorized float methods on some machines: it is almost useless.

I spent some time to reduce the noise, unfortunately it results in the benchmark being 2x slower. We can do tricky jvm args but what is best is to just do many forks. 

I now see reasonably stable results on Graviton3E with 256-bit ARM SVE (!) and look forward to actually investigating this thing more than just stabilizing this benchmark :)
```
Benchmark                                   (size)   Mode  Cnt   Score    Error   Units
VectorUtilBenchmark.binaryCosineScalar        1024  thrpt   15   0.842 ±  0.001  ops/us
VectorUtilBenchmark.binaryCosineVector        1024  thrpt   15   4.811 ±  0.006  ops/us
VectorUtilBenchmark.binaryDotProductScalar    1024  thrpt   15   2.370 ±  0.001  ops/us
VectorUtilBenchmark.binaryDotProductVector    1024  thrpt   15   8.037 ±  0.001  ops/us
VectorUtilBenchmark.binarySquareScalar        1024  thrpt   15   2.450 ±  0.034  ops/us
VectorUtilBenchmark.binarySquareVector        1024  thrpt   15   6.703 ±  0.010  ops/us
VectorUtilBenchmark.floatCosineScalar         1024  thrpt   15   0.682 ±  0.001  ops/us
VectorUtilBenchmark.floatCosineVector         1024  thrpt   75   5.498 ±  0.004  ops/us
VectorUtilBenchmark.floatDotProductScalar     1024  thrpt   15   2.409 ±  0.013  ops/us
VectorUtilBenchmark.floatDotProductVector     1024  thrpt   75  12.446 ±  0.343  ops/us
VectorUtilBenchmark.floatSquareScalar         1024  thrpt   15   2.172 ±  0.007  ops/us
VectorUtilBenchmark.floatSquareVector         1024  thrpt   75  11.655 ±  0.152  ops/us
```