### PR TITLE
BaseTokenStreamTestCase.assertAnalyzesTo fails when Analyzer contains…

### DIFF
--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/path/TestPathHierarchyTokenizer.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/path/TestPathHierarchyTokenizer.java
@@ -19,6 +19,7 @@ package org.apache.lucene.analysis.path;
 import static org.apache.lucene.analysis.path.PathHierarchyTokenizer.DEFAULT_DELIMITER;
 import static org.apache.lucene.analysis.path.PathHierarchyTokenizer.DEFAULT_SKIP;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Random;
@@ -29,6 +30,19 @@ import org.apache.lucene.analysis.charfilter.NormalizeCharMap;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 
 public class TestPathHierarchyTokenizer extends BaseTokenStreamTestCase {
+
+  private Analyzer analyzer =
+      new Analyzer() {
+        @Override
+        protected TokenStreamComponents createComponents(String fieldName) {
+          Tokenizer tokenizer = new PathHierarchyTokenizer();
+          return new TokenStreamComponents(tokenizer);
+        }
+      };
+
+  public void testTokenizerViaAnalyzerOutput() throws IOException {
+    assertAnalyzesTo(analyzer, "/a/b/c", new String[] {"/a", "/a/b", "/a/b/c"});
+  }
 
   public void testBasic() throws Exception {
     String path = "/a/b/c";


### PR DESCRIPTION
… PathHierarchy tokenizer

### Description

This PR is expected to fail. It demonstrates issue with `BaseTokenStreamTestCase.assertAnalyzesTo()` method in connection to `PathHierarchyTokenizer`.

Is there any reason why `PathHierarchyTokenizer` shall not be used in the test like this? There are definitely other tokenizers that are being tested like this, ie. they are wrapped in Analyzer and then `assertAnalyzesTo()` method is called to check the tokens. What is special about PathHierarchy tokenizer that it does not work?

I think the problem might not be in the tokenizer but in the test method itself or in the way I call it (maybe I need to pass in more parameters/flags to get rid of the issue?). The testing method is complex, especially when it gets to `checkAnalysisConsistency()` part.

I am looking for any useful tips. Thank you!
