### PR TITLE
tests.multiplier could be omitted in failed test reproduce line

### DIFF
--- a/gradle/testing/randomization.gradle
+++ b/gradle/testing/randomization.gradle
@@ -67,7 +67,7 @@ allprojects {
           // seed, repetition and amplification.
           [propName: 'tests.seed', value: { -> rootSeed }, description: "Sets the master randomization seed."],
           [propName: 'tests.iters', value: null, description: "Duplicate (re-run) each test case N times."],
-          [propName: 'tests.multiplier', value: 1, description: "Value multiplier for randomized tests."],
+          [propName: 'tests.multiplier', value: null, description: "Value multiplier for randomized tests."],
           [propName: 'tests.maxfailures', value: null, description: "Skip tests after a given number of failures."],
           [propName: 'tests.timeoutSuite', value: null, description: "Timeout (in millis) for an entire suite."],
           [propName: 'tests.failfast', value: "false", description: "Stop the build early on failure.", buildOnly: true],

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -285,7 +285,8 @@ Bug Fixes
 Build
 ---------------------
 
-* GITHUB#?: tests.multiplier could be omitted in test failure reproduce lines (esp. in nightly mode). (Dawid Weiss)
+* GITHUB#12752: tests.multiplier could be omitted in test failure reproduce lines (esp. in
+  nightly mode). (Dawid Weiss)
 
 * GITHUB#12742: JavaCompile tasks may be in up-to-date state when modular dependencies have changed 
   leading to odd runtime errors (Chris Hostetter, Dawid Weiss)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -285,6 +285,8 @@ Bug Fixes
 Build
 ---------------------
 
+* GITHUB#?: tests.multiplier could be omitted in test failure reproduce lines (esp. in nightly mode). (Dawid Weiss)
+
 * GITHUB#12742: JavaCompile tasks may be in up-to-date state when modular dependencies have changed 
   leading to odd runtime errors (Chris Hostetter, Dawid Weiss)
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -476,7 +476,12 @@ public abstract class LuceneTestCase extends Assert {
    * of iterations to scale your tests (for nightly builds).
    */
   public static final int RANDOM_MULTIPLIER =
-      systemPropertyAsInt("tests.multiplier", TEST_NIGHTLY ? 2 : 1);
+      systemPropertyAsInt("tests.multiplier", defaultRandomMultiplier());
+
+  /** Compute the default value of the random multiplier (based on {@link #TEST_NIGHTLY}). */
+  private static int defaultRandomMultiplier() {
+    return TEST_NIGHTLY ? 2 : 1;
+  }
 
   /** Leave temporary files on disk, even on successful runs. */
   public static final boolean LEAVE_TEMPORARY;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -479,7 +479,7 @@ public abstract class LuceneTestCase extends Assert {
       systemPropertyAsInt("tests.multiplier", defaultRandomMultiplier());
 
   /** Compute the default value of the random multiplier (based on {@link #TEST_NIGHTLY}). */
-  private static int defaultRandomMultiplier() {
+  static int defaultRandomMultiplier() {
     return TEST_NIGHTLY ? 2 : 1;
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
@@ -189,7 +189,8 @@ public final class RunListenerPrintReproduceInfo extends RunListener {
     addVmOpt(b, "tests.seed", RandomizedContext.current().getRunnerSeedAsString());
 
     // Test groups and multipliers.
-    if (RANDOM_MULTIPLIER > 1) addVmOpt(b, "tests.multiplier", RANDOM_MULTIPLIER);
+    if (RANDOM_MULTIPLIER != defaultMultiplier())
+      addVmOpt(b, "tests.multiplier", RANDOM_MULTIPLIER);
     if (TEST_NIGHTLY) addVmOpt(b, SYSPROP_NIGHTLY, TEST_NIGHTLY);
     if (TEST_WEEKLY) addVmOpt(b, SYSPROP_WEEKLY, TEST_WEEKLY);
     if (TEST_MONSTER) addVmOpt(b, SYSPROP_MONSTER, TEST_MONSTER);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
@@ -189,7 +189,7 @@ public final class RunListenerPrintReproduceInfo extends RunListener {
     addVmOpt(b, "tests.seed", RandomizedContext.current().getRunnerSeedAsString());
 
     // Test groups and multipliers.
-    if (RANDOM_MULTIPLIER != defaultMultiplier())
+    if (RANDOM_MULTIPLIER != LuceneTestCase.defaultRandomMultiplier())
       addVmOpt(b, "tests.multiplier", RANDOM_MULTIPLIER);
     if (TEST_NIGHTLY) addVmOpt(b, SYSPROP_NIGHTLY, TEST_NIGHTLY);
     if (TEST_WEEKLY) addVmOpt(b, SYSPROP_WEEKLY, TEST_WEEKLY);


### PR DESCRIPTION
LuceneTestCase computes its default value of tests.multiplier from TESTS_NIGHTLY. This could lead to subtle errors: nightly mode failures would not report tests.multipler=1 and when started from the IDE, the tests.multiplier would be set to 2 (leading to different randomness).

LuceneTestCase now compares the actual value of the multiplier to the "default" value computed based off TESTS_NIGHTLY. I also opted to change gradle's test defaults to _not_ pass tests.multiplier at all, unless specified explicitly.