### PR TITLE
Bump minimum required Java version to 21

### DIFF
--- a/.github/workflows/run-nightly-smoketester.yml
+++ b/.github/workflows/run-nightly-smoketester.yml
@@ -1,0 +1,74 @@
+name: "Run nightly: buildAndPushRelease and smokeTestRelease.py"
+
+on:
+  # Allow manual dispatch.
+  workflow_dispatch:
+
+  # run nightly at 2:04am.
+  schedule:
+    - cron: '4 2 * * *'
+
+jobs:
+  smokeTestRelease:
+    name: "Smoke test release on jdk ${{ matrix.java-version }}, ${{ matrix.os }}"
+
+    # only run on schedule in the main Lucene repo (not in forks).
+    if: (github.event_name == 'schedule' && github.repository == 'apache/lucene') || (github.event_name != 'schedule')
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        java-version: [ '17', '21', '22-ea' ]
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      LUCENE_RELEASE_DIR: /tmp/lucene-release-dir
+      TMP_DIR: /tmp/lucene-tmp-dir
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-package: jdk
+          check-latest: true
+          # This intentionally lists two versions, the last one is used as the system default (for running gradle).
+          java-version: |
+            ${{ matrix.java-version }}
+            17
+
+      - name: Echo diagnostic paths and locations
+        run: |
+          echo "All installed JDKs:"
+          set | grep "JAVA"
+
+          echo "Gradle's 'RUNTIME_JAVA_HOME' JDK:"
+          RUNTIME_JAVA_HOME_VAR=JAVA_HOME_`echo ${{ matrix.java-version }} | egrep --only "[0-9]+"`_X64
+          echo ${RUNTIME_JAVA_HOME_VAR} points at ${!RUNTIME_JAVA_HOME_VAR}
+
+          # This sets the environment variable and makes it available for subsequent job steps.
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "RUNTIME_JAVA_HOME=${!RUNTIME_JAVA_HOME_VAR}" >> "$GITHUB_ENV"
+
+      - name: "Run buildAndPushRelease.py (--dev-mode)"
+        run: |
+          # Assemble an unsigned release, in dev mode, publish locally.
+          python3 ./dev-tools/scripts/buildAndPushRelease.py --dev-mode --push-local ${{ env.LUCENE_RELEASE_DIR }}
+
+      - name: "Run smokeTestRelease.py (runtime java: ${{ matrix.java-version }})"
+        run: |
+          python3 -u dev-tools/scripts/smokeTestRelease.py \
+            --not-signed \
+            --tmp-dir ${{ env.TMP_DIR }} \
+            file://`realpath ${{ env.LUCENE_RELEASE_DIR }}/lucene*` \
+            -Ptests.filter="@skipall"
+
+      - name: "Store smoke tester logs"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-tester-logs-jdk-${{ matrix.java-version }}
+          path: |
+            ${{ env.TMP_DIR }}/**/*.log

--- a/.github/workflows/run-nightly-smoketester.yml
+++ b/.github/workflows/run-nightly-smoketester.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        java-version: [ '17', '21', '22-ea' ]
+        java-version: [ '21', '22-ea' ]
 
     runs-on: ${{ matrix.os }}
 
@@ -37,7 +37,7 @@ jobs:
           # This intentionally lists two versions, the last one is used as the system default (for running gradle).
           java-version: |
             ${{ matrix.java-version }}
-            17
+            21
 
       - name: Echo diagnostic paths and locations
         run: |

--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -158,9 +158,9 @@ def checkJARMetaData(desc, jarFile, gitRevision, version):
           break
       else:
         if len(verify) == 1:
-          raise RuntimeError('%s is missing "%s" inside its META-INF/MANIFEST.MF' % (desc, verify[0]))
+          raise RuntimeError('%s is missing "%s" inside its META-INF/MANIFEST.MF: %s' % (desc, verify[0], s))
         else:
-          raise RuntimeError('%s is missing one of "%s" inside its META-INF/MANIFEST.MF' % (desc, verify))
+          raise RuntimeError('%s is missing one of "%s" inside its META-INF/MANIFEST.MF: %s' % (desc, verify, s))
 
     if gitRevision != 'skip':
       # Make sure this matches the version and git revision we think we are releasing:
@@ -577,7 +577,7 @@ def verifyUnpacked(java, artifact, unpackPath, gitRevision, version, testArgs):
   #       raise RuntimeError('lucene: file "%s" is missing from artifact %s' % (fileName, artifact))
   #     in_root_folder.remove(fileName)
 
-  expected_folders = ['analysis', 'analysis.tests', 'backward-codecs', 'benchmark', 'classification', 'codecs', 'core', 'core.tests',
+  expected_folders = ['analysis', 'analysis.tests', 'backward-codecs', 'benchmark', 'benchmark-jmh', 'classification', 'codecs', 'core', 'core.tests',
                       'distribution.tests', 'demo', 'expressions', 'facet', 'grouping', 'highlighter', 'join',
                       'luke', 'memory', 'misc', 'monitor', 'queries', 'queryparser', 'replicator',
                       'sandbox', 'spatial-extras', 'spatial-test-fixtures', 'spatial3d', 'suggest', 'test-framework', 'licenses']

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -195,6 +195,9 @@ Improvements
 
 * GITHUB#13041: TokenizedPhraseQueryNode code cleanup (Dmitry Cherniachenko)
 
+* GITHUB#13087: Changed `static final Set` constants to be immutable. Among others it affected
+  ScandinavianNormalizer.ALL_FOLDINGS set with public access. (Dmitry Cherniachenko)
+
 Optimizations
 ---------------------
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ScandinavianNormalizer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ScandinavianNormalizer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.analysis.miscellaneous;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 import org.apache.lucene.analysis.util.StemmerUtil;
@@ -51,7 +52,8 @@ public final class ScandinavianNormalizer {
 
   private final Set<Foldings> foldings;
 
-  public static final Set<Foldings> ALL_FOLDINGS = EnumSet.allOf(Foldings.class);
+  public static final Set<Foldings> ALL_FOLDINGS =
+      Collections.unmodifiableSet(EnumSet.allOf(Foldings.class));
 
   static final char AA = '\u00C5'; // Å
   static final char aa = '\u00E5'; // å

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestFactories.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestFactories.java
@@ -20,9 +20,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.lucene.analysis.AbstractAnalysisFactory;
@@ -55,10 +53,8 @@ public class TestFactories extends BaseTokenStreamTestCase {
 
   /** Factories that are excluded from testing it with random data */
   private static final Set<Class<? extends AbstractAnalysisFactory>> EXCLUDE_FACTORIES_RANDOM_DATA =
-      new HashSet<>(
-          Arrays.asList(
-              DelimitedTermFrequencyTokenFilterFactory.class,
-              DelimitedBoostTokenFilterFactory.class));
+      Set.of(
+          DelimitedTermFrequencyTokenFilterFactory.class, DelimitedBoostTokenFilterFactory.class);
 
   public void test() throws IOException {
     for (String tokenizer : TokenizerFactory.availableTokenizers()) {

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestFactories.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestFactories.java
@@ -20,9 +20,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.lucene.analysis.AbstractAnalysisFactory;
@@ -53,10 +51,8 @@ public class TestFactories extends BaseTokenStreamTestCase {
 
   /** Factories that are excluded from testing it with random data */
   private static final Set<Class<? extends AbstractAnalysisFactory>> EXCLUDE_FACTORIES_RANDOM_DATA =
-      new HashSet<>(
-          Arrays.asList(
-              DelimitedTermFrequencyTokenFilterFactory.class,
-              DelimitedBoostTokenFilterFactory.class));
+      Set.of(
+          DelimitedTermFrequencyTokenFilterFactory.class, DelimitedBoostTokenFilterFactory.class);
 
   public void test() throws IOException {
     for (String tokenizer : TokenizerFactory.availableTokenizers()) {

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/BackwardsCompatibilityTestBase.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/BackwardsCompatibilityTestBase.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -98,7 +99,7 @@ public abstract class BackwardsCompatibilityTestBase extends LuceneTestCase {
       // make sure we never miss a version.
       assertTrue("Version: " + version + " missing", binaryVersions.remove(version));
     }
-    BINARY_SUPPORTED_VERSIONS = binaryVersions;
+    BINARY_SUPPORTED_VERSIONS = Collections.unmodifiableSet(binaryVersions);
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/util/TestFilterIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFilterIterator.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.util;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -25,7 +26,8 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestFilterIterator extends LuceneTestCase {
 
-  private static final Set<String> set = new TreeSet<>(Arrays.asList("a", "b", "c"));
+  private static final Set<String> set =
+      Collections.unmodifiableSet(new TreeSet<>(Arrays.asList("a", "b", "c")));
 
   private static void assertNoMore(Iterator<?> it) {
     assertFalse(it.hasNext());


### PR DESCRIPTION
With all prerequisites complete, this PR bumps the minimum Java release version to Java 21.

~This PR is intended to help tease out potential issues that may arise from compiling with JDK 21. We can use it to identify and pick out the individual issues. So far we know:~

1. ~~we use deprecated java.net URL constructors - usage should likely be replaced with URI::toURL
    Can proceed independent of the version bump~~  ✅ 

2. we use deprecated java.util Locale constructor - ~~usage should likely be replaced with Locale:of
    Locale:of factories are added in Java 19, so this kinda the change to the version bump. Maybe evaluate using Locale.Builder~~ Replace with Locale.Builder ✅ 

3. ~Refactor usage of runFinalization~  ✅ 

4. ~we need a new yet-to-be released ecj jdt - but it is good to validate the unreleased snapshot 
    Await release of 3.36.0~ ✅ 

