### PR TITLE
Replace usage of deprecated java.net.URL constructor with URI

### DIFF
--- a/lucene/analysis/common/src/tools/java/org/apache/lucene/analysis/standard/GenerateJflexTLDMacros.java
+++ b/lucene/analysis/common/src/tools/java/org/apache/lucene/analysis/standard/GenerateJflexTLDMacros.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
@@ -111,7 +112,7 @@ public class GenerateJflexTLDMacros {
 
   public GenerateJflexTLDMacros(String tldFileURL, String jflexFile, String tldListFile)
       throws Exception {
-    this.tldFileURL = new URL(tldFileURL);
+    this.tldFileURL = URI.create(tldFileURL).toURL();
     this.jflexMacroFile = Paths.get(jflexFile);
     this.tldListFile = Paths.get(tldListFile);
   }

--- a/lucene/analysis/icu/src/tools/java/org/apache/lucene/analysis/icu/GenerateUTR30DataFiles.java
+++ b/lucene/analysis/icu/src/tools/java/org/apache/lucene/analysis/icu/GenerateUTR30DataFiles.java
@@ -158,7 +158,7 @@ public class GenerateUTR30DataFiles {
   private static void getNFKCDataFilesFromIcuProject(String releaseTag) throws IOException {
     URI icuTagsURI = URI.create(ICU_GIT_TAG_URL + "/");
     URI icuReleaseTagURI = icuTagsURI.resolve(releaseTag + "/");
-    URI norm2uri = icuReleaseTagURI.resolve( ICU_DATA_NORM2_PATH + "/");
+    URI norm2uri = icuReleaseTagURI.resolve(ICU_DATA_NORM2_PATH + "/");
 
     System.err.print("Downloading " + NFKC_TXT + " ... ");
     download(norm2uri.resolve(NFKC_TXT), NFKC_TXT);

--- a/lucene/analysis/icu/src/tools/java/org/apache/lucene/analysis/icu/GenerateUTR30DataFiles.java
+++ b/lucene/analysis/icu/src/tools/java/org/apache/lucene/analysis/icu/GenerateUTR30DataFiles.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
@@ -155,19 +156,19 @@ public class GenerateUTR30DataFiles {
   }
 
   private static void getNFKCDataFilesFromIcuProject(String releaseTag) throws IOException {
-    URL icuTagsURL = new URL(ICU_GIT_TAG_URL + "/");
-    URL icuReleaseTagURL = new URL(icuTagsURL, releaseTag + "/");
-    URL norm2url = new URL(icuReleaseTagURL, ICU_DATA_NORM2_PATH + "/");
+    URI icuTagsURI = URI.create(ICU_GIT_TAG_URL + "/");
+    URI icuReleaseTagURI = icuTagsURI.resolve(releaseTag + "/");
+    URI norm2uri = icuReleaseTagURI.resolve( ICU_DATA_NORM2_PATH + "/");
 
     System.err.print("Downloading " + NFKC_TXT + " ... ");
-    download(new URL(norm2url, NFKC_TXT), NFKC_TXT);
+    download(norm2uri.resolve(NFKC_TXT), NFKC_TXT);
     System.err.println("done.");
     System.err.print("Downloading " + NFKC_CF_TXT + " ... ");
-    download(new URL(norm2url, NFKC_CF_TXT), NFKC_CF_TXT);
+    download(norm2uri.resolve(NFKC_CF_TXT), NFKC_CF_TXT);
     System.err.println("done.");
 
     System.err.print("Downloading " + NFKC_CF_TXT + " and making diacritic rules one-way ... ");
-    URLConnection connection = openConnection(new URL(norm2url, NFC_TXT));
+    URLConnection connection = openConnection(norm2uri.resolve(NFC_TXT).toURL());
     try (BufferedReader reader =
             new BufferedReader(
                 new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
@@ -210,8 +211,8 @@ public class GenerateUTR30DataFiles {
     System.err.println("done.");
   }
 
-  private static void download(URL url, String outputFile) throws IOException {
-    final URLConnection connection = openConnection(url);
+  private static void download(URI uri, String outputFile) throws IOException {
+    final URLConnection connection = openConnection(uri.toURL());
     try (InputStream inputStream = connection.getInputStream();
         OutputStream outputStream = Files.newOutputStream(Path.of(outputFile))) {
       inputStream.transferTo(outputStream);

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/URLLabel.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/URLLabel.java
@@ -43,7 +43,7 @@ public final class URLLabel extends JLabel {
       throw new LukeException(e.getMessage(), e);
     }
 
-      setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
     addMouseListener(
         new MouseAdapter() {

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/URLLabel.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/URLLabel.java
@@ -23,6 +23,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import javax.swing.JLabel;
@@ -37,12 +38,12 @@ public final class URLLabel extends JLabel {
     super(text);
 
     try {
-      this.link = new URL(text);
-    } catch (MalformedURLException e) {
+      this.link = (new URI(text)).toURL();
+    } catch (URISyntaxException | MalformedURLException e) {
       throw new LukeException(e.getMessage(), e);
     }
 
-    setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+      setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
     addMouseListener(
         new MouseAdapter() {


### PR DESCRIPTION
This commit replaces the usage of the deprecated `java.net.URL` constructor with `URI`, later converting `toURL` where necessary to interoperate with the URLConnection API.  The usage is mostly in tools, which I verified with `gradlew regenerate`.

The motivation for this change is to address tech debt identified when experimenting with bumping to Java 21. 

relates #12753