### PR TITLE
Streamline FST constructors and make it fully read-only

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -61,6 +61,8 @@ import org.apache.lucene.util.RamUsageEstimator;
  */
 public final class FST<T> implements Accountable {
 
+  final FSTMetadata<T> metadata;
+
   /** Specifies allowed range of each int input label for this FST. */
   public enum INPUT_TYPE {
     BYTE1,
@@ -100,7 +102,7 @@ public final class FST<T> implements Accountable {
   private static final String FILE_FORMAT_NAME = "FST";
   private static final int VERSION_START = 6;
   private static final int VERSION_LITTLE_ENDIAN = 8;
-  private static final int VERSION_CURRENT = VERSION_LITTLE_ENDIAN;
+  static final int VERSION_CURRENT = VERSION_LITTLE_ENDIAN;
 
   // Never serialized; just used to represent the virtual
   // final node w/ no arcs:
@@ -113,23 +115,13 @@ public final class FST<T> implements Accountable {
   /** If arc has this label then that arc is final/accepted */
   public static final int END_LABEL = -1;
 
-  final INPUT_TYPE inputType;
-
-  // if non-null, this FST accepts the empty string and
-  // produces this output
-  T emptyOutput;
-
   /**
    * A {@link BytesStore}, used during building, or during reading when the FST is very large (more
    * than 1 GB). If the FST is less than 1 GB then bytesArray is set instead.
    */
   private final FSTReader fstReader;
 
-  private long startNode = -1;
-
   public final Outputs<T> outputs;
-
-  private final int version;
 
   /** Represents a single arc. */
   public static final class Arc<T> {
@@ -395,13 +387,11 @@ public final class FST<T> implements Accountable {
     return (flags & bit) != 0;
   }
 
-  // make a new empty FST, for building; Builder invokes this
-  FST(INPUT_TYPE inputType, Outputs<T> outputs, FSTReader fstReader) {
-    this.inputType = inputType;
+  // make a new FST; Builder invokes this
+  FST(FSTMetadata<T> metadata, Outputs<T> outputs, FSTReader fstReader) {
+    this.metadata = metadata;
     this.outputs = outputs;
-    emptyOutput = null;
     this.fstReader = fstReader;
-    this.version = VERSION_CURRENT;
   }
 
   private static final int DEFAULT_MAX_BLOCK_BITS = Constants.JRE_IS_64BIT ? 30 : 28;
@@ -411,17 +401,42 @@ public final class FST<T> implements Accountable {
     this(metaIn, in, outputs, new OnHeapFSTStore(DEFAULT_MAX_BLOCK_BITS));
   }
 
+  /** Load a previously saved FST. */
+  public FST(DataInput metaIn, DataInput in, Outputs<T> outputs, FSTStore fstStore)
+      throws IOException {
+    this(parseMetadata(metaIn, outputs), in, outputs, fstStore);
+  }
+
   /**
    * Load a previously saved FST; maxBlockBits allows you to control the size of the byte[] pages
    * used to hold the FST bytes.
    */
-  public FST(DataInput metaIn, DataInput in, Outputs<T> outputs, FSTStore fstStore)
+  public FST(FSTMetadata<T> metadata, DataInput in, Outputs<T> outputs, FSTStore fstStore)
       throws IOException {
-    this.outputs = outputs;
+    this(metadata, outputs, initStore(fstStore, metadata.numBytes, in));
+  }
 
+  private static FSTReader initStore(FSTStore fstStore, long numBytes, DataInput in)
+      throws IOException {
+    fstStore.init(in, numBytes);
+    return fstStore;
+  }
+
+  /**
+   * Parse the FST metadata from DataInput
+   *
+   * @param metaIn the DataInput of the metadata
+   * @param outputs the FST outputs
+   * @return the FST metadata
+   * @param <T> the output type
+   * @throws IOException if exception occurred during parsing
+   */
+  public static <T> FSTMetadata<T> parseMetadata(DataInput metaIn, Outputs<T> outputs)
+      throws IOException {
     // NOTE: only reads formats VERSION_START up to VERSION_CURRENT; we don't have
     // back-compat promise for FSTs (they are experimental), but we are sometimes able to offer it
-    this.version = CodecUtil.checkHeader(metaIn, FILE_FORMAT_NAME, VERSION_START, VERSION_CURRENT);
+    int version = CodecUtil.checkHeader(metaIn, FILE_FORMAT_NAME, VERSION_START, VERSION_CURRENT);
+    T emptyOutput;
     if (metaIn.readByte() == 1) {
       // accepts empty string
       // 1 KB blocks:
@@ -441,6 +456,7 @@ public final class FST<T> implements Accountable {
     } else {
       emptyOutput = null;
     }
+    INPUT_TYPE inputType;
     final byte t = metaIn.readByte();
     switch (t) {
       case 0:
@@ -453,13 +469,11 @@ public final class FST<T> implements Accountable {
         inputType = INPUT_TYPE.BYTE4;
         break;
       default:
-        throw new CorruptIndexException("invalid input type " + t, in);
+        throw new CorruptIndexException("invalid input type " + t, metaIn);
     }
-    startNode = metaIn.readVLong();
-
+    long startNode = metaIn.readVLong();
     long numBytes = metaIn.readVLong();
-    fstStore.init(in, numBytes);
-    this.fstReader = fstStore;
+    return new FSTMetadata<>(inputType, emptyOutput, startNode, version, numBytes);
   }
 
   @Override
@@ -469,50 +483,42 @@ public final class FST<T> implements Accountable {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "(input=" + inputType + ",output=" + outputs;
-  }
-
-  void finish(long newStartNode) throws IOException {
-    assert newStartNode <= fstReader.size();
-    if (startNode != -1) {
-      throw new IllegalStateException("already finished");
-    }
-    if (newStartNode == FINAL_END_NODE && emptyOutput != null) {
-      newStartNode = 0;
-    }
-    startNode = newStartNode;
+    return getClass().getSimpleName() + "(input=" + metadata.inputType + ",output=" + outputs;
   }
 
   public long numBytes() {
-    return fstReader.size();
+    return metadata.numBytes;
   }
 
   public T getEmptyOutput() {
-    return emptyOutput;
+    return metadata.emptyOutput;
   }
 
-  void setEmptyOutput(T v) {
-    if (emptyOutput != null) {
-      emptyOutput = outputs.merge(emptyOutput, v);
-    } else {
-      emptyOutput = v;
-    }
+  public FSTMetadata<T> getMetadata() {
+    return metadata;
   }
 
   public void save(DataOutput metaOut, DataOutput out) throws IOException {
-    if (startNode == -1) {
-      throw new IllegalStateException("call finish first");
-    }
+    saveMetadata(metaOut);
+    fstReader.writeTo(out);
+  }
+
+  /**
+   * Save the metadata to a DataOutput
+   *
+   * @param metaOut the DataOutput to save
+   */
+  public void saveMetadata(DataOutput metaOut) throws IOException {
     CodecUtil.writeHeader(metaOut, FILE_FORMAT_NAME, VERSION_CURRENT);
     // TODO: really we should encode this as an arc, arriving
     // to the root node, instead of special casing here:
-    if (emptyOutput != null) {
+    if (metadata.emptyOutput != null) {
       // Accepts empty string
       metaOut.writeByte((byte) 1);
 
       // Serialize empty-string output:
       ByteBuffersDataOutput ros = new ByteBuffersDataOutput();
-      outputs.writeFinalOutput(emptyOutput, ros);
+      outputs.writeFinalOutput(metadata.emptyOutput, ros);
       byte[] emptyOutputBytes = ros.toArrayCopy();
       int emptyLen = emptyOutputBytes.length;
 
@@ -531,17 +537,16 @@ public final class FST<T> implements Accountable {
       metaOut.writeByte((byte) 0);
     }
     final byte t;
-    if (inputType == INPUT_TYPE.BYTE1) {
+    if (metadata.inputType == INPUT_TYPE.BYTE1) {
       t = 0;
-    } else if (inputType == INPUT_TYPE.BYTE2) {
+    } else if (metadata.inputType == INPUT_TYPE.BYTE2) {
       t = 1;
     } else {
       t = 2;
     }
     metaOut.writeByte(t);
-    metaOut.writeVLong(startNode);
+    metaOut.writeVLong(metadata.startNode);
     metaOut.writeVLong(numBytes());
-    fstReader.writeTo(out);
   }
 
   /** Writes an automaton to a file. */
@@ -563,12 +568,12 @@ public final class FST<T> implements Accountable {
   /** Reads one BYTE1/2/4 label from the provided {@link DataInput}. */
   public int readLabel(DataInput in) throws IOException {
     final int v;
-    if (inputType == INPUT_TYPE.BYTE1) {
+    if (metadata.inputType == INPUT_TYPE.BYTE1) {
       // Unsigned byte:
       v = in.readByte() & 0xFF;
-    } else if (inputType == INPUT_TYPE.BYTE2) {
+    } else if (metadata.inputType == INPUT_TYPE.BYTE2) {
       // Unsigned short:
-      if (version < VERSION_LITTLE_ENDIAN) {
+      if (metadata.version < VERSION_LITTLE_ENDIAN) {
         v = Short.reverseBytes(in.readShort()) & 0xFFFF;
       } else {
         v = in.readShort() & 0xFFFF;
@@ -608,10 +613,10 @@ public final class FST<T> implements Accountable {
   public Arc<T> getFirstArc(Arc<T> arc) {
     T NO_OUTPUT = outputs.getNoOutput();
 
-    if (emptyOutput != null) {
+    if (metadata.emptyOutput != null) {
       arc.flags = BIT_FINAL_ARC | BIT_LAST_ARC;
-      arc.nextFinalOutput = emptyOutput;
-      if (emptyOutput != NO_OUTPUT) {
+      arc.nextFinalOutput = metadata.emptyOutput;
+      if (metadata.emptyOutput != NO_OUTPUT) {
         arc.flags = (byte) (arc.flags() | BIT_ARC_HAS_FINAL_OUTPUT);
       }
     } else {
@@ -622,7 +627,7 @@ public final class FST<T> implements Accountable {
 
     // If there are no nodes, ie, the FST only accepts the
     // empty string, then startNode is 0
-    arc.target = startNode;
+    arc.target = metadata.startNode;
     return arc;
   }
 
@@ -1131,5 +1136,29 @@ public final class FST<T> implements Accountable {
 
     /** Returns true if this reader uses reversed bytes under-the-hood. */
     public abstract boolean reversed();
+  }
+
+  /**
+   * Represent the FST metadata
+   *
+   * @param <T> the FST output type
+   */
+  public static class FSTMetadata<T> {
+    INPUT_TYPE inputType;
+    // if non-null, this FST accepts the empty string and
+    // produces this output
+    T emptyOutput;
+    long startNode;
+    private int version;
+    long numBytes;
+
+    public FSTMetadata(
+        INPUT_TYPE inputType, T emptyOutput, long startNode, int version, long numBytes) {
+      this.inputType = inputType;
+      this.emptyOutput = emptyOutput;
+      this.startNode = startNode;
+      this.version = version;
+      this.numBytes = numBytes;
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -387,13 +387,6 @@ public final class FST<T> implements Accountable {
     return (flags & bit) != 0;
   }
 
-  // make a new FST; Builder invokes this
-  FST(FSTMetadata<T> metadata, Outputs<T> outputs, FSTReader fstReader) {
-    this.metadata = metadata;
-    this.outputs = outputs;
-    this.fstReader = fstReader;
-  }
-
   private static final int DEFAULT_MAX_BLOCK_BITS = Constants.JRE_IS_64BIT ? 30 : 28;
 
   /**
@@ -415,7 +408,7 @@ public final class FST<T> implements Accountable {
   }
 
   /**
-   * Load a previously saved FST with a metadata object and a FSTStore. If using {@link
+   * Load a previously saved FST with a metdata object and a FSTStore. If using {@link
    * OnHeapFSTStore}, setting maxBlockBits allows you to control the size of the byte[] pages used
    * to hold the FST bytes.
    */
@@ -424,8 +417,15 @@ public final class FST<T> implements Accountable {
     this(metadata, outputs, fstStore.init(in, metadata.numBytes));
   }
 
+  /** Create the FST with a metadata object and a FSTReader. */
+  FST(FSTMetadata<T> metadata, Outputs<T> outputs, FSTReader fstReader) {
+    this.metadata = metadata;
+    this.outputs = outputs;
+    this.fstReader = fstReader;
+  }
+
   /**
-   * Parse the FST metadata from DataInput
+   * Read the FST metadata from DataInput
    *
    * @param metaIn the DataInput of the metadata
    * @param outputs the FST outputs

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -26,6 +26,7 @@ import static org.apache.lucene.util.fst.FST.BIT_STOP_NODE;
 import static org.apache.lucene.util.fst.FST.BIT_TARGET_NEXT;
 import static org.apache.lucene.util.fst.FST.FINAL_END_NODE;
 import static org.apache.lucene.util.fst.FST.NON_FINAL_END_NODE;
+import static org.apache.lucene.util.fst.FST.VERSION_CURRENT;
 import static org.apache.lucene.util.fst.FST.getNumPresenceBytes;
 
 import java.io.IOException;
@@ -141,7 +142,7 @@ public class FSTCompiler<T> {
     // pad: ensure no node gets address 0 which is reserved to mean
     // the stop state w/ no arcs
     bytes.writeByte((byte) 0);
-    fst = new FST<>(inputType, outputs, bytes);
+    fst = new FST<>(new FST.FSTMetadata<>(inputType, null, -1, VERSION_CURRENT, 0), outputs, bytes);
     if (suffixRAMLimitMB < 0) {
       throw new IllegalArgumentException("ramLimitMB must be >= 0; got: " + suffixRAMLimitMB);
     } else if (suffixRAMLimitMB > 0) {
@@ -462,10 +463,10 @@ public class FSTCompiler<T> {
 
   private void writeLabel(DataOutput out, int v) throws IOException {
     assert v >= 0 : "v=" + v;
-    if (fst.inputType == INPUT_TYPE.BYTE1) {
+    if (fst.metadata.inputType == INPUT_TYPE.BYTE1) {
       assert v <= 255 : "v=" + v;
       out.writeByte((byte) v);
-    } else if (fst.inputType == INPUT_TYPE.BYTE2) {
+    } else if (fst.metadata.inputType == INPUT_TYPE.BYTE2) {
       assert v <= 65535 : "v=" + v;
       out.writeShort((short) v);
     } else {
@@ -746,7 +747,7 @@ public class FSTCompiler<T> {
       // 'finalness' is stored on the incoming arc, not on
       // the node
       frontier[0].isFinal = true;
-      fst.setEmptyOutput(output);
+      setEmptyOutput(output);
       return;
     }
 
@@ -828,6 +829,26 @@ public class FSTCompiler<T> {
     lastInput.copyInts(input);
   }
 
+  void setEmptyOutput(T v) {
+    if (fst.metadata.emptyOutput != null) {
+      fst.metadata.emptyOutput = fst.outputs.merge(fst.metadata.emptyOutput, v);
+    } else {
+      fst.metadata.emptyOutput = v;
+    }
+  }
+
+  void finish(long newStartNode) {
+    assert newStartNode <= bytes.size();
+    if (fst.metadata.startNode != -1) {
+      throw new IllegalStateException("already finished");
+    }
+    if (newStartNode == FINAL_END_NODE && fst.metadata.emptyOutput != null) {
+      newStartNode = 0;
+    }
+    fst.metadata.startNode = newStartNode;
+    fst.metadata.numBytes = bytes.getPosition();
+  }
+
   private boolean validOutput(T output) {
     return output == NO_OUTPUT || !output.equals(NO_OUTPUT);
   }
@@ -840,14 +861,14 @@ public class FSTCompiler<T> {
     // minimize nodes in the last word's suffix
     freezeTail(0);
     if (root.numArcs == 0) {
-      if (fst.emptyOutput == null) {
+      if (fst.metadata.emptyOutput == null) {
         return null;
       }
     }
 
     // if (DEBUG) System.out.println("  builder.finish root.isFinal=" + root.isFinal + "
     // root.output=" + root.output);
-    fst.finish(compileNode(root, lastInput.length()).node);
+    finish(compileNode(root, lastInput.length()).node);
     bytes.finish();
 
     return fst;

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTStore.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTStore.java
@@ -21,5 +21,14 @@ import org.apache.lucene.store.DataInput;
 
 /** A type of {@link FSTReader} which needs data to be initialized before use */
 public interface FSTStore extends FSTReader {
-  void init(DataInput in, long numBytes) throws IOException;
+
+  /**
+   * Initialize the FSTStore
+   *
+   * @param in the DataInput to read from
+   * @param numBytes the number of bytes to read
+   * @return this FSTStore
+   * @throws IOException if exception occurred during reading the DataInput
+   */
+  FSTStore init(DataInput in, long numBytes) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/util/fst/OffHeapFSTStore.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/OffHeapFSTStore.java
@@ -38,7 +38,7 @@ public final class OffHeapFSTStore implements FSTStore {
   private long numBytes;
 
   @Override
-  public void init(DataInput in, long numBytes) throws IOException {
+  public FSTStore init(DataInput in, long numBytes) throws IOException {
     if (in instanceof IndexInput) {
       this.in = (IndexInput) in;
       this.numBytes = numBytes;
@@ -48,6 +48,7 @@ public final class OffHeapFSTStore implements FSTStore {
           "parameter:in should be an instance of IndexInput for using OffHeapFSTStore, not a "
               + in.getClass().getName());
     }
+    return this;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/fst/OnHeapFSTStore.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/OnHeapFSTStore.java
@@ -51,7 +51,7 @@ public final class OnHeapFSTStore implements FSTStore {
   }
 
   @Override
-  public void init(DataInput in, long numBytes) throws IOException {
+  public FSTStore init(DataInput in, long numBytes) throws IOException {
     if (numBytes > 1 << this.maxBlockBits) {
       // FST is big: we need multiple pages
       bytes = new BytesStore(this.maxBlockBits);
@@ -61,6 +61,7 @@ public final class OnHeapFSTStore implements FSTStore {
       bytesArray = new byte[(int) numBytes];
       in.readBytes(bytesArray, 0, bytesArray.length);
     }
+    return this;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/fst/Util.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/Util.java
@@ -69,7 +69,7 @@ public final class Util {
 
   /** Looks up the output for this input, or null if the input is not accepted */
   public static <T> T get(FST<T> fst, BytesRef input) throws IOException {
-    assert fst.inputType == FST.INPUT_TYPE.BYTE1;
+    assert fst.metadata.inputType == FST.INPUT_TYPE.BYTE1;
 
     final BytesReader fstReader = fst.getBytesReader();
 

--- a/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
@@ -1275,7 +1275,7 @@ public class TestFSTs extends LuceneTestCase {
       rootNode.arcs[1].target = frozen;
     }
 
-    fst.finish(fstCompiler.addNode(rootNode));
+    fstCompiler.finish(fstCompiler.addNode(rootNode));
 
     StringWriter w = new StringWriter();
     // Writer w = new OutputStreamWriter(new FileOutputStream("/x/tmp3/out.dot"));


### PR DESCRIPTION
### Description

- Streamline FST constructors by grouping the medata attributes into FSTMetadata, so that the FST construction won't be diverged too much
- Make it fully read-only by moving `finish()` and `setEmptyOutput` to FSTCompiler
- Split the metadata saving into `saveMetadata()`

Eventually we would want to remove/deprecate the constructors with `DataInput metaIn`.

This will also make it easier to stream the FST to disk, as a FST written with DataOutput won't be able to read and only contain the metadata. The flow would then be:
- Create the FSTCompiler with a DataOutput (e.g an IndexOutput). Adding nodes as usual and finishing with `compile()`
- Create a new DataInput from the DataOutput with a FSTStore (on-heap/off-heap)
- Create the FST with the metadata and FSTStore

Note: We also might want to remove the constructor with FSTStore completely, and users need to call `init()` themselves?