### PR TITLE
Detect J9 and disable vectorization completely (it is not supported there)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -131,6 +131,10 @@ public abstract class VectorizationProvider {
           LOG.warning("C2 compiler is disabled; Java vector incubator API can't be enabled");
           return new DefaultVectorizationProvider();
         }
+        if (Constants.IS_J9_VM) {
+          LOG.warning("J9 VM detected; Java vector incubator API can't be enabled");
+          return new DefaultVectorizationProvider();
+        }
       }
       try {
         // we use method handles with lookup, so we do not need to deal with setAccessible as we

--- a/lucene/core/src/java/org/apache/lucene/util/Constants.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Constants.java
@@ -63,6 +63,9 @@ public final class Constants {
   public static final boolean IS_CLIENT_VM =
       getSysProp("java.vm.info", "").contains("emulated-client");
 
+  /** True when using a J9 VM */
+  public static final boolean IS_J9_VM = getSysProp("java.vm.vendor", "").contains("J9");
+
   /** True iff running on a 64bit JVM */
   public static final boolean JRE_IS_64BIT = is64Bit();
 


### PR DESCRIPTION
J9 VM doesn't seem to actually implement the vector api, so it falls back to hundreds-of-times-slower-pure-java impl. Currently:
```
VectorUtilBenchmark.floatCosineScalar         1024  thrpt   15  0.860 ±  0.011  ops/us
VectorUtilBenchmark.floatCosineVector         1024  thrpt   75  0.010 ±  0.001  ops/us (!)
VectorUtilBenchmark.floatDotProductScalar     1024  thrpt   15  2.325 ±  0.047  ops/us
VectorUtilBenchmark.floatDotProductVector     1024  thrpt   75  0.021 ±  0.001  ops/us (!)
VectorUtilBenchmark.floatSquareScalar         1024  thrpt   15  1.797 ±  0.020  ops/us
VectorUtilBenchmark.floatSquareVector         1024  thrpt   75  0.015 ±  0.001  ops/us (!)
```

Look, i realize somehow it seems "culturally acceptable" in the java world to fall back to hundreds-of-times-slower code whenever it is convenient (e.g. `Math.fma` in the jdk), but this is so, so, so, wrong. We must never allow it to happen when it can be easily prevented: we have to detect and prevent such performance landmines.

Many users have no idea of the differences between different JVMs and I don't want them hitting any traps like this. It may not really be their fault, perhaps some java-based software they are running is turning on the vector flags for them in a shell script/bat file, and they just happen to have J9 VM in their path.

Patch:
```
Benchmark                                   (size)   Mode  Cnt  Score   Error   Units
VectorUtilBenchmark.floatCosineScalar         1024  thrpt   15  0.858 ± 0.012  ops/us
VectorUtilBenchmark.floatCosineVector         1024  thrpt   75  0.864 ± 0.002  ops/us
VectorUtilBenchmark.floatDotProductScalar     1024  thrpt   15  2.327 ± 0.027  ops/us
VectorUtilBenchmark.floatDotProductVector     1024  thrpt   75  2.331 ± 0.013  ops/us
VectorUtilBenchmark.floatSquareScalar         1024  thrpt   15  1.782 ± 0.022  ops/us
VectorUtilBenchmark.floatSquareVector         1024  thrpt   75  1.779 ± 0.021  ops/us
```