### PR TITLE
Limit vectorization API to Hotspot VMs (and rename some constants and fix Javadocs)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -200,8 +200,8 @@ Improvements
 * GITHUB#12677: Better detect vector module in non-default setups (e.g., custom module layers).
   (Uwe Schindler)
 
-* GITHUB#12634, GITHUB#12632, GITHUB#12680, GITHUB#12681, GITHUB#12731: Speed up Panama vector support
-  and test improvements. (Uwe Schindler, Robert Muir)
+* GITHUB#12634, GITHUB#12632, GITHUB#12680, GITHUB#12681, GITHUB#12731, GITHUB#12737: Speed up
+  Panama vector support and test improvements. (Uwe Schindler, Robert Muir)
 
 * GITHUB#12586: Remove over-counting of deleted terms. (Guo Feng)
 
@@ -266,6 +266,8 @@ Changes in runtime behavior
 
 * GITHUB#12569: Prevent concurrent tasks from parallelizing execution further which could cause deadlock
   (Luca Cavanna)
+
+* GITHUB#12765: Disable vectorization on VMs that are not Hotspot-based.  (Uwe Schindler, Robert Muir)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -111,6 +111,12 @@ public abstract class VectorizationProvider {
                 + Locale.getDefault());
         return new DefaultVectorizationProvider();
       }
+      // only use vector module with Hotspot VM
+      if (!Constants.IS_HOTSPOT_VM) {
+        LOG.warning(
+            "Java runtime is not using Hotspot VM; Java vector incubator API can't be enabled.");
+        return new DefaultVectorizationProvider();
+      }
       // is the incubator module present and readable (JVM providers may to exclude them or it is
       // build with jlink)
       final var vectorMod = lookupVectorModule();

--- a/lucene/core/src/java/org/apache/lucene/util/Constants.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Constants.java
@@ -59,9 +59,12 @@ public final class Constants {
   /** The value of <code>System.getProperty("java.vendor")</code>. */
   public static final String JAVA_VENDOR = getSysProp("java.vendor", UNKNOWN);
 
-  /** True iff the Java runtime is a client runtime and C2 compiler is not enabled */
+  /** True iff the Java runtime is a client runtime and C2 compiler is not enabled. */
   public static final boolean IS_CLIENT_VM =
       getSysProp("java.vm.info", "").contains("emulated-client");
+
+  /** True iff the Java VM is based on Hotspot and has the Hotspot MX bean readable by Lucene. */
+  public static final boolean IS_HOTSPOT_VM = HotspotVMOptions.IS_HOTSPOT_VM;
 
   /** True iff running on a 64bit JVM */
   public static final boolean JRE_IS_64BIT = is64Bit();
@@ -75,22 +78,22 @@ public final class Constants {
     }
   }
 
-  /** true if FMA likely means a cpu instruction and not BigDecimal logic */
+  /** true if FMA likely means a cpu instruction and not BigDecimal logic. */
   private static final boolean HAS_FMA =
       (IS_CLIENT_VM == false) && HotspotVMOptions.get("UseFMA").map(Boolean::valueOf).orElse(false);
 
-  /** maximum supported vectorsize */
+  /** maximum supported vectorsize. */
   private static final int MAX_VECTOR_SIZE =
       HotspotVMOptions.get("MaxVectorSize").map(Integer::valueOf).orElse(0);
 
-  /** true for an AMD cpu with SSE4a instructions */
+  /** true for an AMD cpu with SSE4a instructions. */
   private static final boolean HAS_SSE4A =
       HotspotVMOptions.get("UseXmmI2F").map(Boolean::valueOf).orElse(false);
 
-  /** true iff we know VFMA has faster throughput than separate vmul/vadd */
+  /** true iff we know VFMA has faster throughput than separate vmul/vadd. */
   public static final boolean HAS_FAST_VECTOR_FMA = hasFastVectorFMA();
 
-  /** true iff we know FMA has faster throughput than separate mul/add */
+  /** true iff we know FMA has faster throughput than separate mul/add. */
   public static final boolean HAS_FAST_SCALAR_FMA = hasFastScalarFMA();
 
   private static boolean hasFastVectorFMA() {

--- a/lucene/core/src/java/org/apache/lucene/util/HotspotVMOptions.java
+++ b/lucene/core/src/java/org/apache/lucene/util/HotspotVMOptions.java
@@ -26,8 +26,8 @@ import java.util.logging.Logger;
 final class HotspotVMOptions {
   private HotspotVMOptions() {} // can't construct
 
-  /** True if the Java VM is based on Hotspot and has the Hotspot MX bean readable by Lucene */
-  public static final boolean IS_HOTSPOT;
+  /** True iff the Java VM is based on Hotspot and has the Hotspot MX bean readable by Lucene */
+  public static final boolean IS_HOTSPOT_VM;
 
   /**
    * Returns an optional with the value of a Hotspot VM option. If the VM option does not exist or
@@ -84,7 +84,7 @@ final class HotspotVMOptions {
             "Lucene cannot optimize algorithms or calculate object sizes for JVMs that are not based on Hotspot or a compatible implementation.");
       }
     }
-    IS_HOTSPOT = isHotspot;
+    IS_HOTSPOT_VM = isHotspot;
     ACCESSOR = accessor;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RamUsageEstimator.java
@@ -113,7 +113,7 @@ public final class RamUsageEstimator {
   /** Initialize constants and try to collect information about the JVM internals. */
   static {
     if (Constants.JRE_IS_64BIT) {
-      JVM_IS_HOTSPOT_64BIT = HotspotVMOptions.IS_HOTSPOT;
+      JVM_IS_HOTSPOT_64BIT = HotspotVMOptions.IS_HOTSPOT_VM;
       // Try to get compressed oops and object alignment (the default seems to be 8 on Hotspot);
       // (this only works on 64 bit, on 32 bits the alignment and reference size is fixed):
       COMPRESSED_REFS_ENABLED =


### PR DESCRIPTION
I did some tests after fixing the bug in VM option detection.

With OpenJ9 (IBM Semeru) Java v20.0.2 there are no optimizations for Panama Vectors. If you enable the `jdk.incubator.vector` module it is like 1000 times slower, because there's no support at all. The module is there, but fallbacks to the default interpreted mode:

```
Benchmark                                   (size)   Mode  Cnt  Score   Error   Units
VectorUtilBenchmark.binaryCosineScalar        1024  thrpt   15  1,202 ± 0,101  ops/us
VectorUtilBenchmark.binaryCosineVector        1024  thrpt   15  1,067 ± 0,034  ops/us
VectorUtilBenchmark.binaryDotProductScalar    1024  thrpt   15  2,312 ± 0,033  ops/us
VectorUtilBenchmark.binaryDotProductVector    1024  thrpt   15  2,303 ± 0,033  ops/us
VectorUtilBenchmark.binarySquareScalar        1024  thrpt   15  1,970 ± 0,019  ops/us
VectorUtilBenchmark.binarySquareVector        1024  thrpt   15  1,785 ± 0,122  ops/us
VectorUtilBenchmark.floatCosineScalar         1024  thrpt   15  0,942 ± 0,081  ops/us
VectorUtilBenchmark.floatCosineVector         1024  thrpt   75  0,009 ± 0,001  ops/us
VectorUtilBenchmark.floatDotProductScalar     1024  thrpt   15  2,391 ± 0,290  ops/us
VectorUtilBenchmark.floatDotProductVector     1024  thrpt   75  0,023 ± 0,002  ops/us
VectorUtilBenchmark.floatSquareScalar         1024  thrpt   15  1,932 ± 0,085  ops/us
VectorUtilBenchmark.floatSquareVector         1024  thrpt   75  0,017 ± 0,001  ops/us
```

Please note: The binary code is not slower, as the vectorization is not used at all:

```
INFORMATION: Java vector incubator API enabled; uses preferredBitSize=128; floating-point vectors only
```

This PR enables vectorization only if Hotspot was detected by it's JVM flags, any other VM type is logged as not compatible.