### PR TITLE
disable vectors (and don't warn to add incubator module) for jvmci/graal

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -118,7 +118,7 @@ public abstract class VectorizationProvider {
         return new DefaultVectorizationProvider();
       }
       // don't use vector module with JVMCI (it does not work)
-      if (Constants.IS_JVMCI) {
+      if (Constants.IS_JVMCI_VM) {
         LOG.warning(
             "Java runtime is using JVMCI Compiler; Java vector incubator API can't be enabled.");
         return new DefaultVectorizationProvider();

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -117,6 +117,12 @@ public abstract class VectorizationProvider {
             "Java runtime is not using Hotspot VM; Java vector incubator API can't be enabled.");
         return new DefaultVectorizationProvider();
       }
+      // don't use vector module with JVMCI (it does not work)
+      if (Constants.IS_JVMCI) {
+        LOG.warning(
+            "Java runtime is using JVMCI Compiler; Java vector incubator API can't be enabled.");
+        return new DefaultVectorizationProvider();
+      }
       // is the incubator module present and readable (JVM providers may to exclude them or it is
       // build with jlink)
       final var vectorMod = lookupVectorModule();

--- a/lucene/core/src/java/org/apache/lucene/util/Constants.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Constants.java
@@ -66,6 +66,10 @@ public final class Constants {
   /** True iff the Java VM is based on Hotspot and has the Hotspot MX bean readable by Lucene. */
   public static final boolean IS_HOTSPOT_VM = HotspotVMOptions.IS_HOTSPOT_VM;
 
+  /** True if jvmci is enabled (e.g. graalvm) */
+  public static final boolean IS_JVMCI =
+      HotspotVMOptions.get("UseJVMCICompiler").map(Boolean::valueOf).orElse(false);
+
   /** True iff running on a 64bit JVM */
   public static final boolean JRE_IS_64BIT = is64Bit();
 

--- a/lucene/core/src/java/org/apache/lucene/util/Constants.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Constants.java
@@ -67,7 +67,7 @@ public final class Constants {
   public static final boolean IS_HOTSPOT_VM = HotspotVMOptions.IS_HOTSPOT_VM;
 
   /** True if jvmci is enabled (e.g. graalvm) */
-  public static final boolean IS_JVMCI =
+  public static final boolean IS_JVMCI_VM =
       HotspotVMOptions.get("UseJVMCICompiler").map(Boolean::valueOf).orElse(false);
 
   /** True iff running on a 64bit JVM */


### PR DESCRIPTION
Another performance trap. I see use of this stuff a lot in the wild, lots of users/apps doing native image stuff, but we don't want to use vector api here, we should definitely not be encouraging the user to enable it either, as it makes things slow...

```
java version "21.0.1" 2023-10-17
Java(TM) SE Runtime Environment Oracle GraalVM 21.0.1+12.1 (build 21.0.1+12-jvmci-23.1-b19)
Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 21.0.1+12.1 (build 21.0.1+12-jvmci-23.1-b19, mixed mode, sharing)
```

Main:
```
Benchmark                                   (size)   Mode  Cnt  Score   Error   Units
VectorUtilBenchmark.binaryCosineScalar        1024  thrpt   15  0.932 ± 0.006  ops/us
VectorUtilBenchmark.binaryCosineVector        1024  thrpt   15  0.411 ± 0.011  ops/us
VectorUtilBenchmark.binaryDotProductScalar    1024  thrpt   15  6.773 ± 0.161  ops/us
VectorUtilBenchmark.binaryDotProductVector    1024  thrpt   15  1.196 ± 0.043  ops/us
VectorUtilBenchmark.binarySquareScalar        1024  thrpt   15  6.318 ± 0.040  ops/us
VectorUtilBenchmark.binarySquareVector        1024  thrpt   15  1.172 ± 0.016  ops/us
VectorUtilBenchmark.floatCosineScalar         1024  thrpt   15  1.038 ± 0.039  ops/us
VectorUtilBenchmark.floatCosineVector         1024  thrpt   75  0.178 ± 0.002  ops/us
VectorUtilBenchmark.floatDotProductScalar     1024  thrpt   15  1.726 ± 0.036  ops/us
VectorUtilBenchmark.floatDotProductVector     1024  thrpt   75  0.512 ± 0.011  ops/us
VectorUtilBenchmark.floatSquareScalar         1024  thrpt   15  2.135 ± 0.112  ops/us
VectorUtilBenchmark.floatSquareVector         1024  thrpt   75  0.506 ± 0.011  ops/us
```

Patch:
```
Benchmark                                   (size)   Mode  Cnt  Score   Error   Units
VectorUtilBenchmark.binaryCosineScalar        1024  thrpt   15  0.930 ± 0.006  ops/us
VectorUtilBenchmark.binaryCosineVector        1024  thrpt   15  0.930 ± 0.005  ops/us
VectorUtilBenchmark.binaryDotProductScalar    1024  thrpt   15  6.827 ± 0.033  ops/us
VectorUtilBenchmark.binaryDotProductVector    1024  thrpt   15  6.822 ± 0.050  ops/us
VectorUtilBenchmark.binarySquareScalar        1024  thrpt   15  6.286 ± 0.096  ops/us
VectorUtilBenchmark.binarySquareVector        1024  thrpt   15  6.305 ± 0.029  ops/us
VectorUtilBenchmark.floatCosineScalar         1024  thrpt   15  1.059 ± 0.012  ops/us
VectorUtilBenchmark.floatCosineVector         1024  thrpt   75  1.052 ± 0.015  ops/us
VectorUtilBenchmark.floatDotProductScalar     1024  thrpt   15  1.669 ± 0.047  ops/us
VectorUtilBenchmark.floatDotProductVector     1024  thrpt   75  1.661 ± 0.049  ops/us
VectorUtilBenchmark.floatSquareScalar         1024  thrpt   15  2.157 ± 0.070  ops/us
VectorUtilBenchmark.floatSquareVector         1024  thrpt   75  2.152 ± 0.045  ops/us
``