### PR TITLE
Copy directly between 2 ByteBlockPool to avoid double-copy

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/NodeHash.java
@@ -124,7 +124,7 @@ final class NodeHash<T> {
 
           // it was already in fallback -- promote to primary
           primaryTable.setNodeAddress(hashSlot, nodeAddress);
-          primaryTable.setBytes(
+          primaryTable.copyFallbackNodeBytes(
               hashSlot, fallbackTable, lastFallbackHashSlot, lastFallbackNodeLength);
         } else {
           // not in fallback either -- freeze & add the incoming node
@@ -141,7 +141,7 @@ final class NodeHash<T> {
           fstCompiler.bytes.copyBytes(startAddress, buf, 0, buf.length);
 
           primaryTable.setNodeAddress(hashSlot, nodeAddress);
-          primaryTable.setBytes(hashSlot, buf);
+          primaryTable.copyNodeBytes(hashSlot, buf);
 
           // confirm frozen hash and unfrozen hash are the same
           assert primaryTable.hash(nodeAddress, hashSlot) == hash
@@ -284,7 +284,8 @@ final class NodeHash<T> {
       count++;
     }
 
-    private void setBytes(long hashSlot, byte[] bytes) {
+    /** copy the node bytes from the FST */
+    private void copyNodeBytes(long hashSlot, byte[] bytes) {
       assert copiedNodeAddress.get(hashSlot) == 0;
       copiedNodes.append(bytes);
       // write the offset, which points to the last byte of the node we copied since we later read
@@ -293,7 +294,7 @@ final class NodeHash<T> {
     }
 
     /** promote the node bytes from the fallback table */
-    private void setBytes(
+    private void copyFallbackNodeBytes(
         long hashSlot, PagedGrowableHash fallbackTable, long fallbackHashSlot, int nodeLength) {
       assert copiedNodeAddress.get(hashSlot) == 0;
       long fallbackAddress = fallbackTable.copiedNodeAddress.get(fallbackHashSlot);

--- a/lucene/core/src/test/org/apache/lucene/util/TestByteBlockPool.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestByteBlockPool.java
@@ -27,9 +27,10 @@ import org.apache.lucene.tests.util.TestUtil;
 public class TestByteBlockPool extends LuceneTestCase {
 
   public void testAppendFromOtherPool() {
+    Random random = random();
+
     ByteBlockPool pool = new ByteBlockPool(new ByteBlockPool.DirectAllocator());
     final int numBytes = atLeast(2 << 16);
-    Random random = random();
     byte[] bytes = RandomBytes.randomBytesOfLength(random, numBytes);
     pool.append(bytes);
 
@@ -39,7 +40,10 @@ public class TestByteBlockPool extends LuceneTestCase {
 
     // now slice and append to another pool
     int offset = TestUtil.nextInt(random, 1, 2 << 15);
-    int length = TestUtil.nextInt(random, 1, bytes.length - offset);
+    int length = bytes.length - offset;
+    if (random.nextBoolean()) {
+      length = TestUtil.nextInt(random, 1, length);
+    }
     anotherPool.append(pool, offset, length);
 
     assertEquals(existingBytes.length + length, anotherPool.getPosition());

--- a/lucene/core/src/test/org/apache/lucene/util/TestByteBlockPool.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestByteBlockPool.java
@@ -16,9 +16,11 @@
  */
 package org.apache.lucene.util;
 
+import com.carrotsearch.randomizedtesting.generators.RandomBytes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 
@@ -27,10 +29,8 @@ public class TestByteBlockPool extends LuceneTestCase {
   public void testAppendFromOtherPool() {
     ByteBlockPool pool = new ByteBlockPool(new ByteBlockPool.DirectAllocator());
     final int numBytes = atLeast(2 << 16);
-    byte[] bytes = new byte[numBytes];
-    for (int i = 0; i < numBytes; i++) {
-      bytes[i] = (byte) random().nextInt(256);
-    }
+    Random random = random();
+    byte[] bytes = RandomBytes.randomBytesOfLength(random, numBytes);
     pool.append(bytes);
 
     ByteBlockPool anotherPool = new ByteBlockPool(new ByteBlockPool.DirectAllocator());
@@ -38,8 +38,8 @@ public class TestByteBlockPool extends LuceneTestCase {
     anotherPool.append(existingBytes);
 
     // now slice and append to another pool
-    int offset = random().nextInt(2 << 15);
-    int length = random().nextInt(bytes.length - offset);
+    int offset = TestUtil.nextInt(random, 1, 2 << 15);
+    int length = TestUtil.nextInt(random, 1, bytes.length - offset);
     anotherPool.append(pool, offset, length);
 
     assertEquals(existingBytes.length + length, anotherPool.getPosition());


### PR DESCRIPTION
### Description

This fixes one of the TODO in https://github.com/apache/lucene/issues/12760

The random().nextInt is supposed to be banned, I'll use another API.