### PR TITLE
Fix nested link warning from renderSiteJavadoc

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/analysis/WordlistLoader.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/WordlistLoader.java
@@ -29,7 +29,7 @@ import org.apache.lucene.util.IOUtils;
 /**
  * Loader for text files that represent a list of stopwords.
  *
- * @see IOUtils to obtain {@link Reader} instances
+ * @see IOUtils to obtain Reader instances
  * @lucene.internal
  */
 public class WordlistLoader {


### PR DESCRIPTION
Very minor change.

### Description
Without this change, we are getting this warning in `> Task :lucene:core:renderSiteJavadoc`

```
/local/home/jslowins/upstream_bench/lucene_bench_home_2/lucene_candidate/lucene/core/src/java/org/apache/lucene/analysis/WordlistLoader.java:32: warning: Tag {@link}: nested link
 * @see IOUtils to obtain {@link Reader} instances
                                          ^
```