### PR TITLE
Cache buckets to speed up BytesRefHash#sort

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -262,6 +262,8 @@ Optimizations
 
 * GITHUB#11903: Faster sort on high-cardinality string fields. (Adrien Grand)
 
+* GITHUB#12784: Cache buckets to speed up BytesRefHash#sort. (Guo Feng)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
@@ -263,11 +263,10 @@ class BufferedUpdates implements Accountable {
         scratch.field = deleteFieldEntry.getKey();
         BufferedUpdates.BytesRefIntMap terms = deleteFieldEntry.getValue();
         int[] indices = terms.bytesRefHash.sort();
-        for (int index : indices) {
-          if (index != -1) {
-            terms.bytesRefHash.get(index, scratch.bytes);
-            consumer.accept(scratch, terms.values[index]);
-          }
+        for (int i = 0; i < terms.bytesRefHash.size(); i++) {
+          int index = indices[i];
+          terms.bytesRefHash.get(index, scratch.bytes);
+          consumer.accept(scratch, terms.values[index]);
         }
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -175,13 +175,9 @@ public final class BytesRefHash implements Accountable {
           }
 
           @Override
-          protected void sort(int from, int to, int k, int l) {
-            // We lower the fallback threshold because the bucket cache speed up the reorder
-            if (to - from <= LENGTH_THRESHOLD / 2 || l >= LEVEL_THRESHOLD) {
-              getFallbackSorter(k).sort(from, to);
-            } else {
-              radixSort(from, to, k, l);
-            }
+          protected boolean shouldFallback(int from, int to, int l) {
+            // We lower the fallback threshold because the bucket cache speeds up the reorder
+            return to - from <= LENGTH_THRESHOLD / 2 || l >= LEVEL_THRESHOLD;
           }
 
           private void swapBucketCache(int i, int j) {

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -176,6 +176,7 @@ public final class BytesRefHash implements Accountable {
 
           @Override
           protected void sort(int from, int to, int k, int l) {
+            // We lower the fallback threshold because the bucket cache speed up the reorder
             if (to - from <= LENGTH_THRESHOLD / 2 || l >= LEVEL_THRESHOLD) {
               getFallbackSorter(k).sort(from, to);
             } else {

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -174,6 +174,15 @@ public final class BytesRefHash implements Accountable {
             }
           }
 
+          @Override
+          protected void sort(int from, int to, int k, int l) {
+            if (to - from <= LENGTH_THRESHOLD / 2 || l >= LEVEL_THRESHOLD) {
+              getFallbackSorter(k).sort(from, to);
+            } else {
+              radixSort(from, to, k, l);
+            }
+          }
+
           private void swapBucketCache(int i, int j) {
             swap(i, j);
             int tmp = compact[tmpOffset + i];

--- a/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
@@ -129,7 +129,7 @@ public abstract class MSBRadixSorter extends Sorter {
     sort(from, to, 0, 0);
   }
 
-  private void sort(int from, int to, int k, int l) {
+  protected void sort(int from, int to, int k, int l) {
     if (shouldFallback(from, to, l)) {
       getFallbackSorter(k).sort(from, to);
     } else {

--- a/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
@@ -145,7 +145,7 @@ public abstract class MSBRadixSorter extends Sorter {
    * @param k the character number to compare
    * @param l the level of recursion
    */
-  protected void radixSort(int from, int to, int k, int l) {
+  private void radixSort(int from, int to, int k, int l) {
     int[] histogram = histograms[l];
     if (histogram == null) {
       histogram = histograms[l] = new int[HISTOGRAM_SIZE];

--- a/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
@@ -32,11 +32,11 @@ public abstract class MSBRadixSorter extends Sorter {
   // this is used as a protection against the fact that radix sort performs
   // worse when there are long common prefixes (probably because of cache
   // locality)
-  private static final int LEVEL_THRESHOLD = 8;
+  protected static final int LEVEL_THRESHOLD = 8;
   // size of histograms: 256 + 1 to indicate that the string is finished
   protected static final int HISTOGRAM_SIZE = 257;
-  // buckets below this size will be sorted with introsort
-  private static final int LENGTH_THRESHOLD = 100;
+  // buckets below this size will be sorted with fallback sorter
+  protected static final int LENGTH_THRESHOLD = 100;
 
   // we store one histogram per recursion level
   private final int[][] histograms = new int[LEVEL_THRESHOLD][];
@@ -141,7 +141,7 @@ public abstract class MSBRadixSorter extends Sorter {
    * @param k the character number to compare
    * @param l the level of recursion
    */
-  private void radixSort(int from, int to, int k, int l) {
+  protected void radixSort(int from, int to, int k, int l) {
     int[] histogram = histograms[l];
     if (histogram == null) {
       histogram = histograms[l] = new int[HISTOGRAM_SIZE];

--- a/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
@@ -131,14 +131,10 @@ public abstract class MSBRadixSorter extends Sorter {
 
   protected void sort(int from, int to, int k, int l) {
     if (to - from <= LENGTH_THRESHOLD || l >= LEVEL_THRESHOLD) {
-      introSort(from, to, k);
+      getFallbackSorter(k).sort(from, to);
     } else {
       radixSort(from, to, k, l);
     }
-  }
-
-  private void introSort(int from, int to, int k) {
-    getFallbackSorter(k).sort(from, to);
   }
 
   /**
@@ -233,8 +229,6 @@ public abstract class MSBRadixSorter extends Sorter {
         if (b != commonPrefix[j]) {
           commonPrefixLength = j;
           if (commonPrefixLength == 0) { // we have no common prefix
-            histogram[commonPrefix[0] + 1] = i - from;
-            histogram[b + 1] = 1;
             break outer;
           }
           break;
@@ -245,7 +239,7 @@ public abstract class MSBRadixSorter extends Sorter {
     if (i < to) {
       // the loop got broken because there is no common prefix
       assert commonPrefixLength == 0;
-      buildHistogram(i + 1, to, k, histogram);
+      buildHistogram(commonPrefix[0] + 1, i - from, i, to, k, histogram);
     } else {
       assert commonPrefixLength > 0;
       histogram[commonPrefix[0] + 1] = to - from;
@@ -258,7 +252,9 @@ public abstract class MSBRadixSorter extends Sorter {
    * Build an histogram of the k-th characters of values occurring between offsets {@code from} and
    * {@code to}, using {@link #getBucket}.
    */
-  private void buildHistogram(int from, int to, int k, int[] histogram) {
+  protected void buildHistogram(
+      int prefixCommonBucket, int prefixCommonLen, int from, int to, int k, int[] histogram) {
+    histogram[prefixCommonBucket] = prefixCommonLen;
     for (int i = from; i < to; ++i) {
       histogram[getBucket(i, k)]++;
     }

--- a/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
@@ -129,12 +129,16 @@ public abstract class MSBRadixSorter extends Sorter {
     sort(from, to, 0, 0);
   }
 
-  protected void sort(int from, int to, int k, int l) {
-    if (to - from <= LENGTH_THRESHOLD || l >= LEVEL_THRESHOLD) {
+  private void sort(int from, int to, int k, int l) {
+    if (shouldFallback(from, to, l)) {
       getFallbackSorter(k).sort(from, to);
     } else {
       radixSort(from, to, k, l);
     }
+  }
+
+  protected boolean shouldFallback(int from, int to, int l) {
+    return to - from <= LENGTH_THRESHOLD || l >= LEVEL_THRESHOLD;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/StableStringSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StableStringSorter.java
@@ -78,7 +78,9 @@ abstract class StableStringSorter extends StringSorter {
 
       @Override
       protected int compare(int i, int j) {
-        return StableStringSorter.this.compare(i, j);
+        get(scratch1, scratchBytes1, i);
+        get(scratch2, scratchBytes2, j);
+        return cmp.compare(scratchBytes1, scratchBytes2);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/util/StringSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StringSorter.java
@@ -57,6 +57,7 @@ public abstract class StringSorter extends Sorter {
     }
   }
 
+  /** A radix sorter for {@link BytesRef} */
   protected class MSBStringRadixSorter extends MSBRadixSorter {
 
     private final BytesRefComparator cmp;

--- a/lucene/core/src/java/org/apache/lucene/util/StringSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StringSorter.java
@@ -97,7 +97,9 @@ public abstract class StringSorter extends Sorter {
 
       @Override
       protected int compare(int i, int j) {
-        return StringSorter.this.compare(i, j);
+        get(scratch1, scratchBytes1, i);
+        get(scratch2, scratchBytes2, j);
+        return cmp.compare(scratchBytes1, scratchBytes2);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/util/StringSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StringSorter.java
@@ -57,24 +57,34 @@ public abstract class StringSorter extends Sorter {
     }
   }
 
+  protected class MSBStringRadixSorter extends MSBRadixSorter {
+
+    private final BytesRefComparator cmp;
+
+    protected MSBStringRadixSorter(BytesRefComparator cmp) {
+      super(cmp.comparedBytesCount);
+      this.cmp = cmp;
+    }
+
+    @Override
+    protected void swap(int i, int j) {
+      StringSorter.this.swap(i, j);
+    }
+
+    @Override
+    protected int byteAt(int i, int k) {
+      get(scratch1, scratchBytes1, i);
+      return cmp.byteAt(scratchBytes1, k);
+    }
+
+    @Override
+    protected Sorter getFallbackSorter(int k) {
+      return fallbackSorter((o1, o2) -> cmp.compare(o1, o2, k));
+    }
+  }
+
   protected Sorter radixSorter(BytesRefComparator cmp) {
-    return new MSBRadixSorter(cmp.comparedBytesCount) {
-      @Override
-      protected void swap(int i, int j) {
-        StringSorter.this.swap(i, j);
-      }
-
-      @Override
-      protected int byteAt(int i, int k) {
-        get(scratch1, scratchBytes1, i);
-        return cmp.byteAt(scratchBytes1, k);
-      }
-
-      @Override
-      protected Sorter getFallbackSorter(int k) {
-        return fallbackSorter((o1, o2) -> cmp.compare(o1, o2, k));
-      }
-    };
+    return new MSBStringRadixSorter(cmp);
   }
 
   protected Sorter fallbackSorter(Comparator<BytesRef> cmp) {


### PR DESCRIPTION
Following https://github.com/apache/lucene/pull/12775, this PR tries another approach to speed up `BytesRefHash#sort`:
The idea is that since we have extra ints in this map, we can cache the bucket when building the histograms, and reuse them when `reorder`.  I checked this approach on intel chip, showing ~30% speed up. I'll check M2 chip and wikimedium data tomorrow.

```
BASELINE:  sort 5169965 terms, build histogram took: 1968ms, reorder took: 2132ms, total took: 5470ms.
BASELINE:  sort 5169965 terms, build histogram took: 1975ms, reorder took: 2133ms, total took: 5526ms.
BASELINE:  sort 5169965 terms, build histogram took: 1999ms, reorder took: 2157ms, total took: 5573ms.
BASELINE:  sort 5169965 terms, build histogram took: 1955ms, reorder took: 2138ms, total took: 5446ms.
BASELINE:  sort 5169965 terms, build histogram took: 1990ms, reorder took: 2161ms, total took: 5528ms.
BASELINE:  sort 5169965 terms, build histogram took: 1997ms, reorder took: 2175ms, total took: 5571ms.
BASELINE:  sort 5169965 terms, build histogram took: 2004ms, reorder took: 2119ms, total took: 5477ms.
BASELINE:  sort 5169965 terms, build histogram took: 1978ms, reorder took: 2155ms, total took: 5501ms.
BASELINE:  sort 5169965 terms, build histogram took: 2015ms, reorder took: 2169ms, total took: 5572ms.
BASELINE:  sort 5169965 terms, build histogram took: 1941ms, reorder took: 2138ms, total took: 5400ms.
BASELINE:  sort 5169965 terms, build histogram took: 2000ms, reorder took: 2155ms, total took: 5558ms.

CANDIDATE:  sort 5169965 terms, build histogram took: 1996ms, reorder took: 133ms, total took: 3734ms.
CANDIDATE:  sort 5169965 terms, build histogram took: 1989ms, reorder took: 142ms, total took: 3655ms.
CANDIDATE:  sort 5169965 terms, build histogram took: 2031ms, reorder took: 155ms, total took: 3762ms.
CANDIDATE:  sort 5169965 terms, build histogram took: 2016ms, reorder took: 145ms, total took: 3739ms.
CANDIDATE:  sort 5169965 terms, build histogram took: 1994ms, reorder took: 142ms, total took: 3667ms.
CANDIDATE:  sort 5169965 terms, build histogram took: 2010ms, reorder took: 140ms, total took: 3651ms.
CANDIDATE:  sort 5169965 terms, build histogram took: 2021ms, reorder took: 154ms, total took: 3731ms.
CANDIDATE:  sort 5169965 terms, build histogram took: 2019ms, reorder took: 144ms, total took: 3727ms.
CANDIDATE:  sort 5169965 terms, build histogram took: 2064ms, reorder took: 138ms, total took: 3784ms.
CANDIDATE:  sort 5169965 terms, build histogram took: 2043ms, reorder took: 142ms, total took: 3727ms.
CANDIDATE:  sort 5169965 terms, build histogram took: 1964ms, reorder took: 140ms, total took: 3630ms.
```