### PR TITLE
Improve vector search speed by using FixedBitSet

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -266,6 +266,9 @@ Optimizations
 
 * GITHUB#12748: Specialize arc store for continuous label in FST. (Guo Feng, Chao Zhang)
 
+* GITHUB#12789: Improve kNN vector search speed by utilizing FixedBitSet instead of SparseFixedBitSet when tracking
+  visited nodes. (Ben Trent)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -25,7 +25,6 @@ import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
-import org.apache.lucene.util.SparseFixedBitSet;
 
 /**
  * Searches an HNSW graph to find nearest neighbors to a query vector. For more background on the
@@ -66,7 +65,7 @@ public class HnswGraphSearcher {
       throws IOException {
     HnswGraphSearcher graphSearcher =
         new HnswGraphSearcher(
-            new NeighborQueue(knnCollector.k(), true), new SparseFixedBitSet(getGraphSize(graph)));
+            new NeighborQueue(knnCollector.k(), true), new FixedBitSet(getGraphSize(graph)));
     search(scorer, knnCollector, graph, graphSearcher, acceptOrds);
   }
 
@@ -88,7 +87,7 @@ public class HnswGraphSearcher {
     KnnCollector knnCollector = new TopKnnCollector(topK, visitedLimit);
     OnHeapHnswGraphSearcher graphSearcher =
         new OnHeapHnswGraphSearcher(
-            new NeighborQueue(topK, true), new SparseFixedBitSet(getGraphSize(graph)));
+            new NeighborQueue(topK, true), new FixedBitSet(getGraphSize(graph)));
     search(scorer, knnCollector, graph, graphSearcher, acceptOrds);
     return knnCollector;
   }


### PR DESCRIPTION
While doing some performance testing and digging into flamegraphs, I noticed for smaller vectors (96dim float32), we were losing a fair bit of time within the `SparseFixedBitSet#getAndSet` method.

I am assuming we are using `SparseFixedBitSet` for performance reasons to reduce memory usage?

I ran some tests with topK=100 and fanOut=1000. To check memory usage, in a separate run, I printed out `bitSet.ramBytesUsed()` after every search.

I tested using FixedBitSet instead with GLOVE and saw almost a 10% improvement in search speed:
```
completed 1000 searches in 803 ms: 1245 QPS CPU time=801ms
checking results
0.695	 0.80	100000	1000	16	100	1100	0	1.00	post-filter
```

Vs. baseline
```
completed 1000 searches in 873 ms: 1145 QPS CPU time=873ms
checking results
0.695	 0.87	100000	1000	16	100	1100	0	1.00	post-filter
```

The total ramBytesUsed (allocated and then gc'd collected) for 1000 searches over glove was `21288656` bytes. For fixed bit set, every search only allocates `12544`, which pans out to `12544000` bytes (actually less than sparse).

To confirm this was still true for larger vectors and a larger graph, I tested against 400k cohere vectors (same params). There is a bit more noise in the measurements, so I averaged the latency over 4 runs:

candidate: `6.115` with a min: `5.96`

baseline: `6.23` with a min: `6.15`. 

Total memory usage for sparse: `103982464` vs for total memory usage for Fixed `50040000`

Do we know the goal for using a SparseFixedBitSet and under what conditions it would actually perform better than a regular FixedBitSet? I will happily test some more.