### PR TITLE
Fix NFAQuery in TestRegexpRandom2

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestRegexpRandom2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRegexpRandom2.java
@@ -181,7 +181,9 @@ public class TestRegexpRandom2 extends LuceneTestCase {
             0,
             RegexpQuery.DEFAULT_PROVIDER,
             0,
-            MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE,
+            // TODO: The NFA query is not able to use rewrite method that will utilize the
+            // concurrency
+            MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE,
             false);
     DumbRegexpQuery dumb = new DumbRegexpQuery(new Term(fieldName, regexp), RegExp.NONE);
 


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

I didn't realize our random searcher will use threadpool randomly, fixed it to use a rewrite method that will not do concurrent rewrite