### PR TITLE
Speedup concurrent multi-segment HNWS graph search

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2708,7 +2708,7 @@ public final class CheckIndex implements Closeable {
     while (values.nextDoc() != NO_MORE_DOCS) {
       // search the first maxNumSearches vectors to exercise the graph
       if (values.docID() % everyNdoc == 0) {
-        KnnCollector collector = new TopKnnCollector(10, Integer.MAX_VALUE);
+        KnnCollector collector = new TopKnnCollector(10, Integer.MAX_VALUE, null);
         codecReader.getVectorReader().search(fieldInfo.name, values.vectorValue(), collector, null);
         TopDocs docs = collector.topDocs();
         if (docs.scoreDocs.length == 0) {
@@ -2752,7 +2752,7 @@ public final class CheckIndex implements Closeable {
     while (values.nextDoc() != NO_MORE_DOCS) {
       // search the first maxNumSearches vectors to exercise the graph
       if (values.docID() % everyNdoc == 0) {
-        KnnCollector collector = new TopKnnCollector(10, Integer.MAX_VALUE);
+        KnnCollector collector = new TopKnnCollector(10, Integer.MAX_VALUE, null);
         codecReader.getVectorReader().search(fieldInfo.name, values.vectorValue(), collector, null);
         TopDocs docs = collector.topDocs();
         if (docs.scoreDocs.length == 0) {

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.MaxScoreAccumulator;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopDocsCollector;
@@ -240,11 +241,18 @@ public abstract non-sealed class LeafReader extends IndexReader {
    * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
    *     if they are all allowed to match.
    * @param visitedLimit the maximum number of nodes that the search is allowed to visit
+   * @param globalMinSimAcc the global minimum competitive similarity tracked across all leaves
    * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
    * @lucene.experimental
    */
   public final TopDocs searchNearestVectors(
-      String field, float[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException {
+      String field,
+      float[] target,
+      int k,
+      Bits acceptDocs,
+      int visitedLimit,
+      MaxScoreAccumulator globalMinSimAcc)
+      throws IOException {
     FieldInfo fi = getFieldInfos().fieldInfo(field);
     if (fi == null || fi.getVectorDimension() == 0) {
       // The field does not exist or does not index vectors
@@ -254,7 +262,7 @@ public abstract non-sealed class LeafReader extends IndexReader {
     if (k == 0) {
       return TopDocsCollector.EMPTY_TOPDOCS;
     }
-    KnnCollector collector = new TopKnnCollector(k, visitedLimit);
+    KnnCollector collector = new TopKnnCollector(k, visitedLimit, globalMinSimAcc);
     searchNearestVectors(field, target, collector, acceptDocs);
     return collector.topDocs();
   }
@@ -281,11 +289,18 @@ public abstract non-sealed class LeafReader extends IndexReader {
    * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
    *     if they are all allowed to match.
    * @param visitedLimit the maximum number of nodes that the search is allowed to visit
+   * @param globalMinSimAcc the global minimum competitive similarity tracked across all leaves
    * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
    * @lucene.experimental
    */
   public final TopDocs searchNearestVectors(
-      String field, byte[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException {
+      String field,
+      byte[] target,
+      int k,
+      Bits acceptDocs,
+      int visitedLimit,
+      MaxScoreAccumulator globalMinSimAcc)
+      throws IOException {
     FieldInfo fi = getFieldInfos().fieldInfo(field);
     if (fi == null || fi.getVectorDimension() == 0) {
       // The field does not exist or does not index vectors
@@ -295,7 +310,7 @@ public abstract non-sealed class LeafReader extends IndexReader {
     if (k == 0) {
       return TopDocsCollector.EMPTY_TOPDOCS;
     }
-    KnnCollector collector = new TopKnnCollector(k, visitedLimit);
+    KnnCollector collector = new TopKnnCollector(k, visitedLimit, globalMinSimAcc);
     searchNearestVectors(field, target, collector, acceptDocs);
     return collector.topDocs();
   }

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnCollector.java
@@ -23,7 +23,7 @@ package org.apache.lucene.search;
  */
 public abstract class AbstractKnnCollector implements KnnCollector {
 
-  private long visitedCount;
+  long visitedCount;
   private final long visitLimit;
   private final int k;
 

--- a/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
@@ -75,10 +75,16 @@ public class KnnByteVectorQuery extends AbstractKnnVectorQuery {
   }
 
   @Override
-  protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
+  protected TopDocs approximateSearch(
+      LeafReaderContext context,
+      Bits acceptDocs,
+      int visitedLimit,
+      MaxScoreAccumulator globalMinSimAcc)
       throws IOException {
     TopDocs results =
-        context.reader().searchNearestVectors(field, target, k, acceptDocs, visitedLimit);
+        context
+            .reader()
+            .searchNearestVectors(field, target, k, acceptDocs, visitedLimit, globalMinSimAcc);
     return results != null ? results : NO_RESULTS;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
@@ -76,10 +76,16 @@ public class KnnFloatVectorQuery extends AbstractKnnVectorQuery {
   }
 
   @Override
-  protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
+  protected TopDocs approximateSearch(
+      LeafReaderContext context,
+      Bits acceptDocs,
+      int visitedLimit,
+      MaxScoreAccumulator globalMinSimAcc)
       throws IOException {
     TopDocs results =
-        context.reader().searchNearestVectors(field, target, k, acceptDocs, visitedLimit);
+        context
+            .reader()
+            .searchNearestVectors(field, target, k, acceptDocs, visitedLimit, globalMinSimAcc);
     return results != null ? results : NO_RESULTS;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreAccumulator.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.LongAccumulator;
 
 /** Maintains the maximum score and its corresponding document id concurrently */
-final class MaxScoreAccumulator {
+public final class MaxScoreAccumulator {
   // we use 2^10-1 to check the remainder with a bitwise operation
   static final int DEFAULT_INTERVAL = 0x3ff;
 

--- a/lucene/core/src/java/org/apache/lucene/search/TopKnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopKnnCollector.java
@@ -26,16 +26,17 @@ import org.apache.lucene.util.hnsw.NeighborQueue;
  * @lucene.experimental
  */
 public final class TopKnnCollector extends AbstractKnnCollector {
+  // greediness of globally non-competitive search: [0,1]
   private static final float DEFAULT_GREEDINESS = 0.9f;
 
   private final NeighborQueue queue;
   private final float greediness;
-  private final NeighborQueue queueg;
+  private final NeighborQueue nonCompetitiveQueue;
   private final MaxScoreAccumulator globalMinSimAcc;
   private boolean kResultsCollected = false;
   private float cachedGlobalMinSim = Float.NEGATIVE_INFINITY;
-
-  // greediness of globally non-competitive search: [0,1]
+  private float minCompetitiveSim = Float.NEGATIVE_INFINITY;
+  private float globalMinCompetitiveSim = Float.NEGATIVE_INFINITY;
 
   /**
    * @param k the number of neighbors to collect
@@ -46,9 +47,13 @@ public final class TopKnnCollector extends AbstractKnnCollector {
     super(k, visitLimit);
     this.greediness = DEFAULT_GREEDINESS;
     this.queue = new NeighborQueue(k, false);
-    int queuegSize = Math.max(1, Math.round((1 - greediness) * k));
-    this.queueg = new NeighborQueue(queuegSize, false);
     this.globalMinSimAcc = globalMinSimAcc;
+    if (globalMinSimAcc == null) {
+      this.nonCompetitiveQueue = null;
+    } else {
+      this.nonCompetitiveQueue =
+          new NeighborQueue(Math.max(1, Math.round((1 - greediness) * k)), false);
+    }
   }
 
   public TopKnnCollector(
@@ -56,40 +61,55 @@ public final class TopKnnCollector extends AbstractKnnCollector {
     super(k, visitLimit);
     this.greediness = greediness;
     this.queue = new NeighborQueue(k, false);
-    this.queueg = new NeighborQueue(Math.round((1 - greediness) * k), false);
     this.globalMinSimAcc = globalMinSimAcc;
+    if (globalMinSimAcc == null) {
+      this.nonCompetitiveQueue = null;
+    } else {
+      this.nonCompetitiveQueue =
+          new NeighborQueue(Math.max(1, Math.round((1 - greediness) * k)), false);
+    }
   }
 
   @Override
   public boolean collect(int docId, float similarity) {
-    boolean result = queue.insertWithOverflow(docId, similarity);
-    queueg.insertWithOverflow(docId, similarity);
-
-    boolean reachedKResults = (kResultsCollected == false && queue.size() == k());
-    if (reachedKResults) {
+    boolean localSimUpdated = queue.insertWithOverflow(docId, similarity);
+    boolean firstKResultsCollected = (kResultsCollected == false && queue.size() == k());
+    if (firstKResultsCollected) {
       kResultsCollected = true;
     }
-    if (globalMinSimAcc != null && kResultsCollected) {
-      // as we've collected k results, we can start exchanging globally
-      globalMinSimAcc.accumulate(queue.topNode(), queue.topScore());
+    if (localSimUpdated && kResultsCollected) {
+      minCompetitiveSim = queue.topScore();
+    }
 
-      // periodically update the local copy of global similarity
-      if (reachedKResults || (visitedCount & globalMinSimAcc.modInterval) == 0) {
-        MaxScoreAccumulator.DocAndScore docAndScore = globalMinSimAcc.get();
-        cachedGlobalMinSim = docAndScore.score;
+    boolean globalSimUpdated = false;
+    if (globalMinSimAcc != null) {
+      globalSimUpdated = nonCompetitiveQueue.insertWithOverflow(docId, similarity);
+      if (kResultsCollected) {
+        // as we've collected k results, we can start exchanging globally
+        globalMinSimAcc.accumulate(queue.topNode(), queue.topScore());
+
+        // periodically update the local copy of global similarity
+        if (firstKResultsCollected || (visitedCount & globalMinSimAcc.modInterval) == 0) {
+          MaxScoreAccumulator.DocAndScore docAndScore = globalMinSimAcc.get();
+          cachedGlobalMinSim = docAndScore.score;
+          globalSimUpdated = true;
+        }
+        if (localSimUpdated || globalSimUpdated) {
+          globalMinCompetitiveSim =
+              Math.max(
+                  minCompetitiveSim, Math.min(nonCompetitiveQueue.topScore(), cachedGlobalMinSim));
+        }
       }
     }
-    return result;
+    return localSimUpdated || globalSimUpdated;
   }
 
   @Override
   public float minCompetitiveSimilarity() {
-    float minSim = kResultsCollected ? queue.topScore() : Float.NEGATIVE_INFINITY;
     if (globalMinSimAcc == null) {
-      return minSim;
+      return minCompetitiveSim;
     } else {
-      float globalAccountedSim = Math.min(queueg.topScore(), cachedGlobalMinSim);
-      return Math.max(minSim, globalAccountedSim);
+      return globalMinCompetitiveSim;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -85,7 +85,7 @@ public class HnswGraphSearcher {
   public static KnnCollector search(
       RandomVectorScorer scorer, int topK, OnHeapHnswGraph graph, Bits acceptOrds, int visitedLimit)
       throws IOException {
-    KnnCollector knnCollector = new TopKnnCollector(topK, visitedLimit);
+    KnnCollector knnCollector = new TopKnnCollector(topK, visitedLimit, null);
     OnHeapHnswGraphSearcher graphSearcher =
         new OnHeapHnswGraphSearcher(
             new NeighborQueue(topK, true), new SparseFixedBitSet(getGraphSize(graph)));

--- a/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
@@ -112,12 +112,12 @@ public class TestPerFieldKnnVectorsFormat extends BaseKnnVectorsFormatTestCase {
         LeafReader reader = ireader.leaves().get(0).reader();
         TopDocs hits1 =
             reader.searchNearestVectors(
-                "field1", new float[] {1, 2, 3}, 10, reader.getLiveDocs(), Integer.MAX_VALUE);
+                "field1", new float[] {1, 2, 3}, 10, reader.getLiveDocs(), Integer.MAX_VALUE, null);
         assertEquals(1, hits1.scoreDocs.length);
 
         TopDocs hits2 =
             reader.searchNearestVectors(
-                "field2", new float[] {1, 2, 3}, 10, reader.getLiveDocs(), Integer.MAX_VALUE);
+                "field2", new float[] {1, 2, 3}, 10, reader.getLiveDocs(), Integer.MAX_VALUE, null);
         assertEquals(1, hits2.scoreDocs.length);
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -469,7 +469,8 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
                   TestVectorUtil.randomVector(dimension),
                   5,
                   leaf.getLiveDocs(),
-                  Integer.MAX_VALUE));
+                  Integer.MAX_VALUE,
+                  null));
     } else {
       DocIdSetIterator iter = leaf.getFloatVectorValues("vector");
       scanAndRetrieve(leaf, iter);
@@ -479,7 +480,8 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
           TestVectorUtil.randomVector(dimension),
           5,
           leaf.getLiveDocs(),
-          Integer.MAX_VALUE);
+          Integer.MAX_VALUE,
+          null);
     }
 
     reader.close();
@@ -544,7 +546,8 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
                   TestVectorUtil.randomVectorBytes(dimension),
                   5,
                   leaf.getLiveDocs(),
-                  Integer.MAX_VALUE));
+                  Integer.MAX_VALUE,
+                  null));
     } else {
       DocIdSetIterator iter = leaf.getByteVectorValues("vector");
       scanAndRetrieve(leaf, iter);
@@ -554,7 +557,8 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
           TestVectorUtil.randomVectorBytes(dimension),
           5,
           leaf.getLiveDocs(),
-          Integer.MAX_VALUE);
+          Integer.MAX_VALUE,
+          null);
     }
 
     reader.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -363,7 +363,7 @@ public class TestKnnGraph extends LuceneTestCase {
       Bits liveDocs = ctx.reader().getLiveDocs();
       results[ctx.ord] =
           ctx.reader()
-              .searchNearestVectors(KNN_GRAPH_FIELD, vector, k, liveDocs, Integer.MAX_VALUE);
+              .searchNearestVectors(KNN_GRAPH_FIELD, vector, k, liveDocs, Integer.MAX_VALUE, null);
       if (ctx.docBase > 0) {
         for (ScoreDoc doc : results[ctx.ord].scoreDocs) {
           doc.doc += ctx.docBase;

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopKnnResults.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopKnnResults.java
@@ -22,7 +22,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 public class TestTopKnnResults extends LuceneTestCase {
 
   public void testCollectAndProvideResults() {
-    TopKnnCollector results = new TopKnnCollector(5, Integer.MAX_VALUE);
+    TopKnnCollector results = new TopKnnCollector(5, Integer.MAX_VALUE, null);
     int[] nodes = new int[] {4, 1, 5, 7, 8, 10, 2};
     float[] scores = new float[] {1f, 0.5f, 0.6f, 2f, 2f, 1.2f, 4f};
     for (int i = 0; i < nodes.length; i++) {
@@ -37,5 +37,61 @@ public class TestTopKnnResults extends LuceneTestCase {
     }
     assertArrayEquals(new int[] {2, 7, 8, 10, 4}, sortedNodes);
     assertArrayEquals(new float[] {4f, 2f, 2f, 1.2f, 1f}, sortedScores, 0f);
+  }
+
+  public void testConcurrentGlobalMinSimilarity() {
+    MaxScoreAccumulator globalMinSimAcc = new MaxScoreAccumulator();
+    TopKnnCollector results1 = new TopKnnCollector(5, Integer.MAX_VALUE, globalMinSimAcc);
+    TopKnnCollector results2 = new TopKnnCollector(5, Integer.MAX_VALUE, globalMinSimAcc);
+
+    int[] nodes1 = new int[] {1, 2, 3, 4, 5, 6, 7};
+    float[] scores1 = new float[] {1f, 2f, 3f, 4f, 5f, 6f, 7f};
+    int[] nodes2 = new int[] {8, 9, 10, 11, 12, 13, 14};
+    float[] scores2 = new float[] {8f, 9f, 10f, 11f, 12f, 13f, 14f};
+
+    for (int i = 0; i < 5; i++) {
+      assertEquals(Float.NEGATIVE_INFINITY, results2.minCompetitiveSimilarity(), 0f);
+      assertEquals(Float.NEGATIVE_INFINITY, results1.minCompetitiveSimilarity(), 0f);
+
+      results2.collect(nodes2[i], scores2[i]);
+      results2.incVisitedCount(1);
+      results1.collect(nodes1[i], scores1[i]);
+      results1.incVisitedCount(1);
+    }
+    // as soon as top k results are collected, both collectors should see the same global
+    // competitive similarity
+    assertEquals(8f, results1.minCompetitiveSimilarity(), 0f);
+    assertEquals(8f, results2.minCompetitiveSimilarity(), 0f);
+
+    results2.collect(nodes2[5], scores2[5]);
+    results2.incVisitedCount(1);
+    results1.collect(nodes1[5], scores1[5]);
+    results1.incVisitedCount(1);
+    assertEquals(9f, results2.minCompetitiveSimilarity(), 0f);
+    // as global similarity is updated periodically, the collect1 still sees the old cached global
+    // value
+    assertEquals(8f, results1.minCompetitiveSimilarity(), 0f);
+
+    results2.collect(nodes2[6], scores2[6]);
+    results2.incVisitedCount(1);
+    results1.collect(nodes1[6], scores1[6]);
+    results1.incVisitedCount(1);
+    assertEquals(10f, results2.minCompetitiveSimilarity(), 0f);
+    // as global similarity is updated periodically, the collect1 still sees the old cached global
+    // value
+    assertEquals(8f, results1.minCompetitiveSimilarity(), 0f);
+
+    TopDocs topDocs1 = results1.topDocs();
+    TopDocs topDocs2 = results2.topDocs();
+    TopDocs topDocs = TopDocs.merge(5, new TopDocs[] {topDocs1, topDocs2});
+
+    int[] sortedNodes = new int[topDocs.scoreDocs.length];
+    float[] sortedScores = new float[topDocs.scoreDocs.length];
+    for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+      sortedNodes[i] = topDocs.scoreDocs[i].doc;
+      sortedScores[i] = topDocs.scoreDocs[i].score;
+    }
+    assertArrayEquals(new int[] {14, 13, 12, 11, 10}, sortedNodes);
+    assertArrayEquals(new float[] {14f, 13, 12f, 11f, 10f}, sortedScores, 0f);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -1051,7 +1051,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     AbstractMockVectorValues<T> queryVectors = vectorValues(1, dim);
     RandomVectorScorer queryScorer = buildScorer(docVectors, queryVectors.vectorValue(0));
 
-    KnnCollector collector = new TopKnnCollector(topK, Integer.MAX_VALUE);
+    KnnCollector collector = new TopKnnCollector(topK, Integer.MAX_VALUE, null);
     HnswGraphSearcher.search(queryScorer, collector, singleLevelGraph, null);
 
     // Check that we visit all nodes

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.HitQueue;
 import org.apache.lucene.search.KnnByteVectorQuery;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.MaxScoreAccumulator;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -123,7 +124,11 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
   }
 
   @Override
-  protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
+  protected TopDocs approximateSearch(
+      LeafReaderContext context,
+      Bits acceptDocs,
+      int visitedLimit,
+      MaxScoreAccumulator globalMinSimAcc)
       throws IOException {
     BitSet parentBitSet = parentsFilter.getBitSet(context);
     if (parentBitSet == null) {

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.HitQueue;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.MaxScoreAccumulator;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -123,7 +124,11 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
   }
 
   @Override
-  protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
+  protected TopDocs approximateSearch(
+      LeafReaderContext context,
+      Bits acceptDocs,
+      int visitedLimit,
+      MaxScoreAccumulator globalMinSimAcc)
       throws IOException {
     BitSet parentBitSet = parentsFilter.getBitSet(context);
     if (parentBitSet == null) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -613,7 +613,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         // assert that knn search doesn't fail on a field with all deleted docs
         TopDocs results =
             leafReader.searchNearestVectors(
-                "v", randomNormalizedVector(3), 1, leafReader.getLiveDocs(), Integer.MAX_VALUE);
+                "v",
+                randomNormalizedVector(3),
+                1,
+                leafReader.getLiveDocs(),
+                Integer.MAX_VALUE,
+                null);
         assertEquals(0, results.scoreDocs.length);
       }
     }
@@ -1071,7 +1076,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           TopDocs results =
               ctx.reader()
                   .searchNearestVectors(
-                      fieldName, randomNormalizedVector(dimension), k, liveDocs, visitedLimit);
+                      fieldName,
+                      randomNormalizedVector(dimension),
+                      k,
+                      liveDocs,
+                      visitedLimit,
+                      null);
           assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, results.totalHits.relation);
           assertEquals(visitedLimit, results.totalHits.value);
 
@@ -1081,7 +1091,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           results =
               ctx.reader()
                   .searchNearestVectors(
-                      fieldName, randomNormalizedVector(dimension), k, liveDocs, visitedLimit);
+                      fieldName,
+                      randomNormalizedVector(dimension),
+                      k,
+                      liveDocs,
+                      visitedLimit,
+                      null);
           assertEquals(TotalHits.Relation.EQUAL_TO, results.totalHits.relation);
           assertTrue(results.totalHits.value <= visitedLimit);
         }
@@ -1157,7 +1172,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           TopDocs results =
               ctx.reader()
                   .searchNearestVectors(
-                      fieldName, randomNormalizedVector(dimension), k, liveDocs, Integer.MAX_VALUE);
+                      fieldName,
+                      randomNormalizedVector(dimension),
+                      k,
+                      liveDocs,
+                      Integer.MAX_VALUE,
+                      null);
           assertEquals(Math.min(k, size), results.scoreDocs.length);
           for (int i = 0; i < k - 1; i++) {
             assertTrue(results.scoreDocs[i].score >= results.scoreDocs[i + 1].score);


### PR DESCRIPTION
Speedup concurrent multi-segment HNWS graph search by exchanging 
the global minimum similarity collected so far across segments. As the global
similarity is used as a minimum threshold that candidates need to pass to be considered, 
this allows earlier stopping for segments that don't have good candidates.

Implementation details:
- `TopKnnCollector` has a new argument `MaxScoreAccumulator` used to keep track of the global minimum similarity collected so far.
-  As soon as a `TopKnnCollector` for a segment collected the local k results, the global similarity is used as minimum required similarity for knn search.

---

Having a global queue is a crude approach and the 1st step for concurrent search.
We don’t want to stop ourselves reaching a portion of a graph which is a good neighbourhood 
of the query if we use a bound from a graph where the search is much further forward. 
Because of this, we would like to  continuing exploring local graphs with some limitations 
even if the candidates don't pass  the global min similarity threshold. For this reason,
we have added a second queue that has a size of (1-g) k, where g is greediness.

A node will be considered a candidate if it has similarity with a query that is larger 
than the current bottom similarity of the 2nd queue.
