### PR TITLE
[Minor] Improvements to slice pools

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ByteSliceReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ByteSliceReader.java
@@ -22,11 +22,11 @@ import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.ByteBlockPool;
 
-/* IndexInput that knows how to read the byte slices written
- * by Posting and PostingVector.  We read the bytes in
- * each slice until we hit the end of that slice at which
- * point we read the forwarding address of the next slice
- * and then jump to it.*/
+/**
+ * IndexInput that knows how to read the byte slices written by Posting and PostingVector. We read
+ * the bytes in each slice until we hit the end of that slice at which point we read the forwarding
+ * address of the next slice and then jump to it.
+ */
 final class ByteSliceReader extends DataInput {
   ByteBlockPool pool;
   int bufferUpto;

--- a/lucene/core/src/java/org/apache/lucene/util/ByteBlockPool.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ByteBlockPool.java
@@ -132,18 +132,11 @@ public final class ByteBlockPool implements Accountable {
   }
 
   /**
-   * Resets the pool to its initial state, reusing the first buffer and filling all buffers with
-   * {@code 0} bytes before they are reused or passed to {@link
-   * Allocator#recycleByteBlocks(byte[][], int, int)}. Calling {@link ByteBlockPool#nextBuffer()} is
-   * not needed after reset.
-   */
-  public void reset() {
-    reset(true, true);
-  }
-
-  /**
-   * Expert: Resets the pool to its initial state, while reusing the first buffer. Calling {@link
-   * ByteBlockPool#nextBuffer()} is not needed after reset.
+   * Expert: Resets the pool to its initial state, while optionally reusing the first buffer.
+   * Buffers that are not reused are reclaimed by {@link Allocator#recycleByteBlocks(byte[][], int,
+   * int)}. Buffers can be filled with zeros before recycling them. This is useful if a slice pool
+   * works on top of this byte pool and relies on the buffers being filled with zeros to find the
+   * non-zero end of slices.
    *
    * @param zeroFillBuffers if {@code true} the buffers are filled with {@code 0}. This should be
    *     set to {@code true} if this pool is used with slices.
@@ -188,7 +181,8 @@ public final class ByteBlockPool implements Accountable {
   /**
    * Allocates a new buffer and advances the pool to it. This method should be called once after the
    * constructor to initialize the pool. In contrast to the constructor, a {@link
-   * ByteBlockPool#reset()} call will advance the pool to its first buffer immediately.
+   * ByteBlockPool#reset(boolean, boolean)} call will advance the pool to its first buffer
+   * immediately.
    */
   public void nextBuffer() {
     if (1 + bufferUpto == buffers.length) {

--- a/lucene/core/src/java/org/apache/lucene/util/IntBlockPool.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntBlockPool.java
@@ -94,15 +94,11 @@ public class IntBlockPool {
   }
 
   /**
-   * Resets the pool to its initial state reusing the first buffer. Calling {@link
-   * IntBlockPool#nextBuffer()} is not needed after reset.
-   */
-  public void reset() {
-    this.reset(true, true);
-  }
-
-  /**
-   * Expert: Resets the pool to its initial state reusing the first buffer.
+   * Expert: Resets the pool to its initial state, while optionally reusing the first buffer.
+   * Buffers that are not reused are reclaimed by {@link
+   * ByteBlockPool.Allocator#recycleByteBlocks(byte[][], int, int)}. Buffers can be filled with
+   * zeros before recycling them. This is useful if a slice pool works on top of this int pool and
+   * relies on the buffers being filled with zeros to find the non-zero end of slices.
    *
    * @param zeroFillBuffers if <code>true</code> the buffers are filled with <code>0</code>.
    * @param reuseFirst if <code>true</code> the first buffer will be reused and calling {@link
@@ -145,8 +141,8 @@ public class IntBlockPool {
 
   /**
    * Advances the pool to its next buffer. This method should be called once after the constructor
-   * to initialize the pool. In contrast to the constructor a {@link IntBlockPool#reset()} call will
-   * advance the pool to its first buffer immediately.
+   * to initialize the pool. In contrast to the constructor a {@link IntBlockPool#reset(boolean,
+   * boolean)} call will advance the pool to its first buffer immediately.
    */
   public void nextBuffer() {
     if (1 + bufferUpto == buffers.length) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIntBlockPool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIntBlockPool.java
@@ -50,7 +50,7 @@ public class TestIntBlockPool extends LuceneTestCase {
 
     // Reset and fill with zeros, then check there is no data left
     pool.intUpto = count;
-    pool.reset();
+    pool.reset(true, true);
     for (int i = 0; i < count; i++) {
       assertEquals(0, pool.buffers[0][i]);
     }


### PR DESCRIPTION
1. Remove reset method used only in tests.
2. Update Javadocs.
3. Make interleaved slices test a bit more evil by adding pool resets.

Follow-up from #12734