### PR TITLE
Remove angry errant lurking semicolons

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemmer.java
@@ -777,7 +777,6 @@ class KStemmer {
   private int stemLength() {
     return j + 1;
   }
-  ;
 
   private boolean endsIn(char[] s) {
     if (s.length > k) return false;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterFilter.java
@@ -163,7 +163,6 @@ public final class WordDelimiterFilter extends TokenFilter {
 
   private final CharTermAttribute termAttribute = addAttribute(CharTermAttribute.class);
   private final KeywordAttribute keywordAttribute = addAttribute(KeywordAttribute.class);
-  ;
   private final OffsetAttribute offsetAttribute = addAttribute(OffsetAttribute.class);
   private final PositionIncrementAttribute posIncAttribute =
       addAttribute(PositionIncrementAttribute.class);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilter.java
@@ -164,7 +164,6 @@ public final class WordDelimiterGraphFilter extends TokenFilter {
 
   private final CharTermAttribute termAttribute = addAttribute(CharTermAttribute.class);
   private final KeywordAttribute keywordAttribute = addAttribute(KeywordAttribute.class);
-  ;
   private final OffsetAttribute offsetAttribute = addAttribute(OffsetAttribute.class);
   private final PositionIncrementAttribute posIncAttribute =
       addAttribute(PositionIncrementAttribute.class);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymFilter.java
@@ -216,7 +216,6 @@ public final class SynonymFilter extends TokenFilter {
       count++;
     }
   }
-  ;
 
   private final ByteArrayDataInput bytesReader = new ByteArrayDataInput();
 

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/charfilter/TestHTMLStripCharFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/charfilter/TestHTMLStripCharFilter.java
@@ -595,8 +595,8 @@ public class TestHTMLStripCharFilter extends BaseTokenStreamTestCase {
         }
     }
     Reader reader = new HTMLStripCharFilter(new StringReader(text.toString()));
-    while (reader.read() != -1)
-      ;
+    while (reader.read() != -1) {
+    }
   }
 
   public void testUTF16Surrogates() throws Exception {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/charfilter/TestHTMLStripCharFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/charfilter/TestHTMLStripCharFilter.java
@@ -595,8 +595,7 @@ public class TestHTMLStripCharFilter extends BaseTokenStreamTestCase {
         }
     }
     Reader reader = new HTMLStripCharFilter(new StringReader(text.toString()));
-    while (reader.read() != -1) {
-    }
+    while (reader.read() != -1) {}
   }
 
   public void testUTF16Surrogates() throws Exception {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestDuelingAnalyzers.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestDuelingAnalyzers.java
@@ -230,7 +230,6 @@ public class TestDuelingAnalyzers extends BaseTokenStreamTestCase {
       assertEquals(
           "wrong end offset for input: " + s, leftOffset.endOffset(), rightOffset.endOffset());
     }
-    ;
     assertFalse("wrong number of tokens for input: " + s, right.incrementToken());
     left.end();
     right.end();

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/in/TestIndicNormalizer.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/in/TestIndicNormalizer.java
@@ -41,7 +41,6 @@ public class TestIndicNormalizer extends BaseTokenStreamTestCase {
 
   private void check(String input, String output) throws IOException {
     Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
-    ;
     tokenizer.setReader(new StringReader(input));
     TokenFilter tf = new IndicNormalizationFilter(tokenizer);
     assertTokenStreamContents(tf, new String[] {output});

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestKeywordMarkerFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestKeywordMarkerFilterFactory.java
@@ -89,7 +89,6 @@ public class TestKeywordMarkerFilterFactory extends BaseTokenStreamFactoryTestCa
     stream =
         tokenFilterFactory("KeywordMarker", "pattern", "Cats", "ignoreCase", "true").create(stream);
     stream = tokenFilterFactory("PorterStem").create(stream);
-    ;
     assertTokenStreamContents(stream, new String[] {"dog", "cats", "Cats"});
   }
 

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/ngram/TestEdgeNGramTokenizer.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/ngram/TestEdgeNGramTokenizer.java
@@ -69,7 +69,6 @@ public class TestEdgeNGramTokenizer extends BaseTokenStreamTestCase {
   public void testOversizedNgrams() throws Exception {
     EdgeNGramTokenizer tokenizer = new EdgeNGramTokenizer(6, 6);
     tokenizer.setReader(input);
-    ;
     assertTokenStreamContents(tokenizer, new String[0], new int[0], new int[0], 5 /* abcde */);
   }
 

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/TestCharArrayIterator.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/TestCharArrayIterator.java
@@ -156,7 +156,6 @@ public class TestCharArrayIterator extends LuceneTestCase {
 
   private void consume(BreakIterator bi, CharacterIterator ci) {
     bi.setText(ci);
-    while (bi.next() != BreakIterator.DONE) {
-    }
+    while (bi.next() != BreakIterator.DONE) {}
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/TestCharArrayIterator.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/TestCharArrayIterator.java
@@ -156,7 +156,7 @@ public class TestCharArrayIterator extends LuceneTestCase {
 
   private void consume(BreakIterator bi, CharacterIterator ci) {
     bi.setText(ci);
-    while (bi.next() != BreakIterator.DONE)
-      ;
+    while (bi.next() != BreakIterator.DONE) {
+    }
   }
 }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseTokenizer.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseTokenizer.java
@@ -758,8 +758,7 @@ public class TestJapaneseTokenizer extends BaseTokenStreamTestCase {
     for (int i = 0; i < numIterations; i++) {
       try (TokenStream ts = analyzer.tokenStream("ignored", line)) {
         ts.reset();
-        while (ts.incrementToken()) {
-        }
+        while (ts.incrementToken()) {}
         ts.end();
       }
     }
@@ -775,8 +774,7 @@ public class TestJapaneseTokenizer extends BaseTokenStreamTestCase {
       for (String sentence : sentences) {
         try (TokenStream ts = analyzer.tokenStream("ignored", sentence)) {
           ts.reset();
-          while (ts.incrementToken()) {
-          }
+          while (ts.incrementToken()) {}
           ts.end();
         }
       }
@@ -831,8 +829,7 @@ public class TestJapaneseTokenizer extends BaseTokenStreamTestCase {
         new JapaneseTokenizer(newAttributeFactory(), readDict(), false, Mode.NORMAL);
     tokenizer.setReader(new StringReader(doc));
     tokenizer.reset();
-    while (tokenizer.incrementToken()) {
-    }
+    while (tokenizer.incrementToken()) {}
   }
 
   public void testPatchedSystemDict() throws Exception {

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseTokenizer.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseTokenizer.java
@@ -758,8 +758,8 @@ public class TestJapaneseTokenizer extends BaseTokenStreamTestCase {
     for (int i = 0; i < numIterations; i++) {
       try (TokenStream ts = analyzer.tokenStream("ignored", line)) {
         ts.reset();
-        while (ts.incrementToken())
-          ;
+        while (ts.incrementToken()) {
+        }
         ts.end();
       }
     }
@@ -775,8 +775,8 @@ public class TestJapaneseTokenizer extends BaseTokenStreamTestCase {
       for (String sentence : sentences) {
         try (TokenStream ts = analyzer.tokenStream("ignored", sentence)) {
           ts.reset();
-          while (ts.incrementToken())
-            ;
+          while (ts.incrementToken()) {
+          }
           ts.end();
         }
       }
@@ -831,8 +831,8 @@ public class TestJapaneseTokenizer extends BaseTokenStreamTestCase {
         new JapaneseTokenizer(newAttributeFactory(), readDict(), false, Mode.NORMAL);
     tokenizer.setReader(new StringReader(doc));
     tokenizer.reset();
-    while (tokenizer.incrementToken())
-      ;
+    while (tokenizer.incrementToken()) {
+    }
   }
 
   public void testPatchedSystemDict() throws Exception {

--- a/lucene/analysis/stempel/src/test/org/apache/lucene/analysis/pl/TestPolishAnalyzer.java
+++ b/lucene/analysis/stempel/src/test/org/apache/lucene/analysis/pl/TestPolishAnalyzer.java
@@ -41,7 +41,6 @@ public class TestPolishAnalyzer extends BaseTokenStreamTestCase {
   /** test use of exclusion set */
   public void testExclude() throws IOException {
     CharArraySet exclusionSet = new CharArraySet(asSet("studenta"), false);
-    ;
     Analyzer a = new PolishAnalyzer(PolishAnalyzer.getDefaultStopSet(), exclusionSet);
     checkOneTerm(a, "studenta", "studenta");
     checkOneTerm(a, "studenci", "student");

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextStoredFieldsFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextStoredFieldsFormat.java
@@ -37,7 +37,6 @@ public class SimpleTextStoredFieldsFormat extends StoredFieldsFormat {
   @Override
   public StoredFieldsReader fieldsReader(
       Directory directory, SegmentInfo si, FieldInfos fn, IOContext context) throws IOException {
-    ;
     return new SimpleTextStoredFieldsReader(directory, si, fn, context);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/TermVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/TermVectorsWriter.java
@@ -70,7 +70,6 @@ public abstract class TermVectorsWriter implements Closeable, Accountable {
 
   /** Called after a doc and all its fields have been added. */
   public void finishDocument() throws IOException {}
-  ;
 
   /**
    * Called before writing the terms of the field. {@link #startTerm(BytesRef, int)} will be called
@@ -82,7 +81,6 @@ public abstract class TermVectorsWriter implements Closeable, Accountable {
 
   /** Called after a field and all its terms have been added. */
   public void finishField() throws IOException {}
-  ;
 
   /**
    * Adds a term and its term frequency <code>freq</code>. If this field has positions and/or

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
@@ -119,7 +119,6 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
       }
     }
   }
-  ;
 
   static String getSuffix(String formatName, String suffix) {
     return formatName + "_" + suffix;

--- a/lucene/core/src/java/org/apache/lucene/document/FeatureField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FeatureField.java
@@ -272,7 +272,6 @@ public final class FeatureField extends Field {
       return true;
     }
   }
-  ;
 
   static final class LogFunction extends FeatureFunction {
 

--- a/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
@@ -694,7 +694,7 @@ abstract class SpatialQuery extends Query {
       final SpatialVisitor spatialVisitor, QueryRelation queryRelation, final FixedBitSet result) {
     final BiFunction<byte[], byte[], Relation> innerFunction =
         spatialVisitor.getInnerFunction(queryRelation);
-    ;
+
     return new IntersectVisitor() {
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
@@ -1254,8 +1254,8 @@ public final class Tessellator {
         ++numMerges;
         // step 'insize' places along from p
         q = p;
-        for (i = 0, pSize = 0; i < inSize && q != null; ++i, ++pSize, q = q.nextZ)
-          ;
+        for (i = 0, pSize = 0; i < inSize && q != null; ++i, ++pSize, q = q.nextZ) {
+        }
         // if q hasn't fallen off end, we have two lists to merge
         qSize = inSize;
 

--- a/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
@@ -1254,8 +1254,7 @@ public final class Tessellator {
         ++numMerges;
         // step 'insize' places along from p
         q = p;
-        for (i = 0, pSize = 0; i < inSize && q != null; ++i, ++pSize, q = q.nextZ) {
-        }
+        for (i = 0, pSize = 0; i < inSize && q != null; ++i, ++pSize, q = q.nextZ) {}
         // if q hasn't fallen off end, we have two lists to merge
         qSize = inSize;
 

--- a/lucene/core/src/java/org/apache/lucene/index/FieldUpdatesBuffer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldUpdatesBuffer.java
@@ -270,7 +270,6 @@ final class FieldUpdatesBuffer {
   static class BufferedUpdate {
 
     private BufferedUpdate() {}
-    ;
 
     /** the max document ID this update should be applied to */
     int docUpTo;

--- a/lucene/core/src/java/org/apache/lucene/index/PointValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValues.java
@@ -325,7 +325,6 @@ public abstract class PointValues {
 
     /** Notifies the caller that this many documents are about to be visited */
     default void grow(int count) {}
-    ;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -526,7 +526,6 @@ final class ReadersAndUpdates {
       return docIDOut;
     }
   }
-  ;
 
   private synchronized Set<String> writeFieldInfosGen(
       FieldInfos fieldInfos, Directory dir, FieldInfosFormat infosFormat) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
@@ -69,7 +69,6 @@ public abstract class PointInSetQuery extends Query implements Accountable {
     @Override
     public abstract BytesRef next();
   }
-  ;
 
   /** The {@code packedPoints} iterator must be in sorted order. */
   protected PointInSetQuery(String field, int numDims, int bytesPerDim, Stream packedPoints) {

--- a/lucene/core/src/java/org/apache/lucene/search/similarities/AxiomaticF3LOG.java
+++ b/lucene/core/src/java/org/apache/lucene/search/similarities/AxiomaticF3LOG.java
@@ -81,7 +81,6 @@ public class AxiomaticF3LOG extends Axiomatic {
         "tf, term frequency computed as 1 + log(1 + log(freq)) from:",
         Explanation.match((float) freq, "freq, number of occurrences of term in the document"));
   }
-  ;
 
   @Override
   protected Explanation lnExplain(BasicStats stats, double freq, double docLen) {

--- a/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
@@ -26,7 +26,6 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
 
   private static final ByteBuffer EMPTY_BYTEBUFFER =
       ByteBuffer.allocate(0).order(ByteOrder.LITTLE_ENDIAN);
-  ;
 
   /** Default buffer size set to {@value #BUFFER_SIZE}. */
   public static final int BUFFER_SIZE = 1024;

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
@@ -500,7 +500,6 @@ public final class ByteBuffersDataInput extends DataInput
 
     if (buffers.size() == 1) {
       ByteBuffer cloned = buffers.get(0).asReadOnlyBuffer().order(ByteOrder.LITTLE_ENDIAN);
-      ;
       cloned.position(Math.toIntExact(cloned.position() + offset));
       cloned.limit(Math.toIntExact(cloned.position() + length));
       return Arrays.asList(cloned);

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
@@ -241,7 +241,6 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
     } else {
       for (ByteBuffer bb : blocks) {
         bb = bb.asReadOnlyBuffer().flip().order(ByteOrder.LITTLE_ENDIAN);
-        ;
         result.add(bb);
       }
     }
@@ -501,7 +500,6 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
 
     final int requiredBlockSize = 1 << blockBits;
     currentBlock = blockAllocate.apply(requiredBlockSize).order(ByteOrder.LITTLE_ENDIAN);
-    ;
     assert currentBlock.capacity() == requiredBlockSize;
     blocks.add(currentBlock);
     ramBytesUsed += RamUsageEstimator.NUM_BYTES_OBJECT_REF + currentBlock.capacity();

--- a/lucene/core/src/java/org/apache/lucene/util/CharsRef.java
+++ b/lucene/core/src/java/org/apache/lucene/util/CharsRef.java
@@ -172,7 +172,6 @@ public final class CharsRef implements Comparable<CharsRef>, CharSequence, Clone
   private static class UTF16SortedAsUTF8Comparator implements Comparator<CharsRef> {
     // Only singleton
     private UTF16SortedAsUTF8Comparator() {}
-    ;
 
     @Override
     public int compare(CharsRef a, CharsRef b) {

--- a/lucene/core/src/java/org/apache/lucene/util/Counter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Counter.java
@@ -69,7 +69,6 @@ public abstract class Counter {
     public long get() {
       return count;
     }
-    ;
   }
 
   private static final class AtomicCounter extends Counter {

--- a/lucene/core/src/java/org/apache/lucene/util/PagedBytes.java
+++ b/lucene/core/src/java/org/apache/lucene/util/PagedBytes.java
@@ -250,7 +250,6 @@ public final class PagedBytes implements Accountable {
   @Override
   public long ramBytesUsed() {
     long size = BASE_RAM_BYTES_USED + RamUsageEstimator.shallowSizeOf(blocks);
-    ;
     if (numBlocks > 0) {
       size += (numBlocks - 1) * bytesUsedPerBlock;
       size += RamUsageEstimator.sizeOf(blocks[numBlocks - 1]);

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automaton.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automaton.java
@@ -378,7 +378,6 @@ public class Automaton implements Accountable, TransitionAccessor {
           swapOne(iStart + 1, jStart + 1);
           swapOne(iStart + 2, jStart + 2);
         }
-        ;
 
         @Override
         protected int compare(int i, int j) {
@@ -434,7 +433,6 @@ public class Automaton implements Accountable, TransitionAccessor {
           swapOne(iStart + 1, jStart + 1);
           swapOne(iStart + 2, jStart + 2);
         }
-        ;
 
         @Override
         protected int compare(int i, int j) {
@@ -810,7 +808,6 @@ public class Automaton implements Accountable, TransitionAccessor {
             swapOne(iStart + 2, jStart + 2);
             swapOne(iStart + 3, jStart + 3);
           }
-          ;
 
           @Override
           protected int compare(int i, int j) {

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/LevenshteinAutomata.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/LevenshteinAutomata.java
@@ -263,7 +263,6 @@ public class LevenshteinAutomata {
     int size() {
       return minErrors.length * (w + 1);
     }
-    ;
 
     /**
      * Returns true if the <code>state</code> in any Levenshtein DFA is an accept state (final

--- a/lucene/core/src/java/org/apache/lucene/util/fst/PairOutputs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/PairOutputs.java
@@ -66,7 +66,6 @@ public class PairOutputs<A, B> extends Outputs<PairOutputs.Pair<A, B>> {
       return "Pair(" + output1 + "," + output2 + ")";
     }
   }
-  ;
 
   public PairOutputs(Outputs<A> outputs1, Outputs<B> outputs2) {
     this.outputs1 = outputs1;

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/IntIntHashMap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/IntIntHashMap.java
@@ -523,7 +523,6 @@ public class IntIntHashMap implements Iterable<IntIntHashMap.IntIntCursor>, Clon
       return new KeysIterator();
     }
   }
-  ;
 
   /** An iterator over the set of assigned keys. */
   private final class KeysIterator extends AbstractIterator<IntCursor> {

--- a/lucene/core/src/java/org/apache/lucene/util/packed/DirectReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/DirectReader.java
@@ -233,7 +233,6 @@ public class DirectReader {
     DirectPackedReader4(RandomAccessInput in, long offset) {
       this.in = in;
       this.offset = offset;
-      ;
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/document/BaseLatLonPointTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/document/BaseLatLonPointTestCase.java
@@ -128,7 +128,6 @@ public abstract class BaseLatLonPointTestCase extends BaseLatLonSpatialTestCase 
     }
     // different shape
     Polygon newPolygon = GeoTestUtil.nextPolygon();
-    ;
     Query q5 = newPolygonQuery(fieldName, queryRelation, newPolygon);
     if (polygon.equals(newPolygon)) {
       QueryUtils.checkEqual(q1, q5);

--- a/lucene/core/src/test/org/apache/lucene/document/BaseLatLonShapeTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/document/BaseLatLonShapeTestCase.java
@@ -230,7 +230,6 @@ public abstract class BaseLatLonShapeTestCase extends BaseLatLonSpatialTestCase 
     }
     // different shape
     Polygon newPolygon = GeoTestUtil.nextPolygon();
-    ;
     Query q5 = newPolygonQuery(fieldName, queryRelation, newPolygon);
     if (polygon.equals(newPolygon)) {
       QueryUtils.checkEqual(q1, q5);

--- a/lucene/core/src/test/org/apache/lucene/index/TestByteSlicePool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestByteSlicePool.java
@@ -245,8 +245,8 @@ public class TestByteSlicePool extends LuceneTestCase {
         boolean succeeded = sliceWriters[i].writeSlice();
         if (succeeded == false) {
           for (int j = 0; j < n; j++) {
-            while (sliceWriters[j].writeSlice())
-              ;
+            while (sliceWriters[j].writeSlice()) {
+            }
           }
           break;
         }
@@ -268,8 +268,8 @@ public class TestByteSlicePool extends LuceneTestCase {
         boolean succeeded = sliceReaders[i].readSlice();
         if (succeeded == false) {
           for (int j = 0; j < n; j++) {
-            while (sliceReaders[j].readSlice())
-              ;
+            while (sliceReaders[j].readSlice()) {
+            }
           }
           break;
         }

--- a/lucene/core/src/test/org/apache/lucene/index/TestByteSlicePool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestByteSlicePool.java
@@ -245,8 +245,7 @@ public class TestByteSlicePool extends LuceneTestCase {
         boolean succeeded = sliceWriters[i].writeSlice();
         if (succeeded == false) {
           for (int j = 0; j < n; j++) {
-            while (sliceWriters[j].writeSlice()) {
-            }
+            while (sliceWriters[j].writeSlice()) {}
           }
           break;
         }
@@ -268,8 +267,7 @@ public class TestByteSlicePool extends LuceneTestCase {
         boolean succeeded = sliceReaders[i].readSlice();
         if (succeeded == false) {
           for (int j = 0; j < n; j++) {
-            while (sliceReaders[j].readSlice()) {
-            }
+            while (sliceReaders[j].readSlice()) {}
           }
           break;
         }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -3038,7 +3038,6 @@ public class TestIndexWriter extends LuceneTestCase {
         assertEquals(1, writer.getDocStats().maxDoc);
         // now check that we moved to 3
         dir.openInput("segments_3", IOContext.READ).close();
-        ;
       }
       reader.close();
       in.close();
@@ -3771,7 +3770,6 @@ public class TestIndexWriter extends LuceneTestCase {
       try (IndexReader reader = DirectoryReader.open(writer)) {
         assertEquals(1, reader.numDocs());
       }
-      ;
       t.join();
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestComplexExplanations.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestComplexExplanations.java
@@ -76,7 +76,6 @@ public class TestComplexExplanations extends BaseExplanationTestCase {
 
   public void testDMQ10() throws Exception {
     BooleanQuery.Builder query = new BooleanQuery.Builder();
-    ;
     query.add(new TermQuery(new Term(FIELD, "yy")), Occur.SHOULD);
     TermQuery boostedQuery = new TermQuery(new Term(FIELD, "w5"));
     query.add(new BoostQuery(boostedQuery, 100), Occur.SHOULD);
@@ -100,7 +99,6 @@ public class TestComplexExplanations extends BaseExplanationTestCase {
   public void testBQ12() throws Exception {
     // NOTE: using qtest not bqtest
     BooleanQuery.Builder query = new BooleanQuery.Builder();
-    ;
     query.add(new TermQuery(new Term(FIELD, "w1")), Occur.SHOULD);
     TermQuery boostedQuery = new TermQuery(new Term(FIELD, "w2"));
     query.add(new BoostQuery(boostedQuery, 0), Occur.SHOULD);
@@ -111,7 +109,6 @@ public class TestComplexExplanations extends BaseExplanationTestCase {
   public void testBQ13() throws Exception {
     // NOTE: using qtest not bqtest
     BooleanQuery.Builder query = new BooleanQuery.Builder();
-    ;
     query.add(new TermQuery(new Term(FIELD, "w1")), Occur.SHOULD);
     TermQuery boostedQuery = new TermQuery(new Term(FIELD, "w5"));
     query.add(new BoostQuery(boostedQuery, 0), Occur.MUST_NOT);
@@ -122,7 +119,6 @@ public class TestComplexExplanations extends BaseExplanationTestCase {
   public void testBQ18() throws Exception {
     // NOTE: using qtest not bqtest
     BooleanQuery.Builder query = new BooleanQuery.Builder();
-    ;
     TermQuery boostedQuery = new TermQuery(new Term(FIELD, "w1"));
     query.add(new BoostQuery(boostedQuery, 0), Occur.MUST);
     query.add(new TermQuery(new Term(FIELD, "w2")), Occur.SHOULD);
@@ -132,7 +128,6 @@ public class TestComplexExplanations extends BaseExplanationTestCase {
 
   public void testBQ21() throws Exception {
     BooleanQuery.Builder builder = new BooleanQuery.Builder();
-    ;
     builder.add(new TermQuery(new Term(FIELD, "w1")), Occur.MUST);
     builder.add(new TermQuery(new Term(FIELD, "w2")), Occur.SHOULD);
 
@@ -143,7 +138,6 @@ public class TestComplexExplanations extends BaseExplanationTestCase {
 
   public void testBQ22() throws Exception {
     BooleanQuery.Builder builder = new BooleanQuery.Builder();
-    ;
     TermQuery boostedQuery = new TermQuery(new Term(FIELD, "w1"));
     builder.add(new BoostQuery(boostedQuery, 0), Occur.MUST);
     builder.add(new TermQuery(new Term(FIELD, "w2")), Occur.SHOULD);

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermQuery.java
@@ -288,5 +288,4 @@ public class TestTermQuery extends LuceneTestCase {
       return in.getReaderCacheHelper();
     }
   }
-  ;
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestWildcardRandom.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestWildcardRandom.java
@@ -105,7 +105,6 @@ public class TestWildcardRandom extends LuceneTestCase {
   }
 
   public void testWildcards() throws Exception {
-    ;
     int num = atLeast(1);
     for (int i = 0; i < num; i++) {
       assertPatternHits("NNN", 1);

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataInput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataInput.java
@@ -204,7 +204,6 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
   public void testSlicingWindow() throws Exception {
     ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
     assertEquals(0, dst.toDataInput().slice(0, 0).size());
-    ;
 
     dst.writeBytes(randomBytesOfLength(1024 * 8));
     ByteBuffersDataInput in = dst.toDataInput();

--- a/lucene/core/src/test/org/apache/lucene/util/SelectorBenchmark.java
+++ b/lucene/core/src/test/org/apache/lucene/util/SelectorBenchmark.java
@@ -58,6 +58,7 @@ public class SelectorBenchmark {
           };
         }),
     ;
+
     final String name;
     final Builder builder;
 

--- a/lucene/core/src/test/org/apache/lucene/util/SorterBenchmark.java
+++ b/lucene/core/src/test/org/apache/lucene/util/SorterBenchmark.java
@@ -50,6 +50,7 @@ public class SorterBenchmark {
           return new ArrayInPlaceMergeSorter<>(arr, Entry::compareTo);
         }),
     ;
+    
     final String name;
     final Builder builder;
 

--- a/lucene/core/src/test/org/apache/lucene/util/SorterBenchmark.java
+++ b/lucene/core/src/test/org/apache/lucene/util/SorterBenchmark.java
@@ -50,7 +50,7 @@ public class SorterBenchmark {
           return new ArrayInPlaceMergeSorter<>(arr, Entry::compareTo);
         }),
     ;
-    
+
     final String name;
     final Builder builder;
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestVersion.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVersion.java
@@ -34,7 +34,6 @@ public class TestVersion extends LuceneTestCase {
       }
     }
     assertTrue(Version.LUCENE_10_0_0.onOrAfter(Version.LUCENE_9_0_0));
-    ;
   }
 
   public void testToString() {

--- a/lucene/core/src/test/org/apache/lucene/util/TestWeakIdentityMap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestWeakIdentityMap.java
@@ -219,8 +219,8 @@ public class TestWeakIdentityMap extends LuceneTestCase {
       }
     } finally {
       exec.shutdown();
-      while (!exec.awaitTermination(1000L, TimeUnit.MILLISECONDS))
-        ;
+      while (!exec.awaitTermination(1000L, TimeUnit.MILLISECONDS)) {
+      }
     }
 
     // clear strong refs

--- a/lucene/core/src/test/org/apache/lucene/util/TestWeakIdentityMap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestWeakIdentityMap.java
@@ -219,8 +219,7 @@ public class TestWeakIdentityMap extends LuceneTestCase {
       }
     } finally {
       exec.shutdown();
-      while (!exec.awaitTermination(1000L, TimeUnit.MILLISECONDS)) {
-      }
+      while (!exec.awaitTermination(1000L, TimeUnit.MILLISECONDS)) {}
     }
 
     // clear strong refs

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestNFARunAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestNFARunAutomaton.java
@@ -44,7 +44,6 @@ public class TestNFARunAutomaton extends LuceneTestCase {
   public void testWithRandomRegex() {
     for (int i = 0; i < 100; i++) {
       RegExp regExp = new RegExp(AutomatonTestUtil.randomRegexp(random()), RegExp.NONE);
-      ;
       Automaton nfa = regExp.toAutomaton();
       if (nfa.isDeterministic()) {
         i--;
@@ -87,8 +86,8 @@ public class TestNFARunAutomaton extends LuceneTestCase {
       int termNum = random().nextInt(20) + 30;
       while (perDocVocab.size() < termNum) {
         String randomString;
-        while ((randomString = TestUtil.randomUnicodeString(random())).length() == 0)
-          ;
+        while ((randomString = TestUtil.randomUnicodeString(random())).length() == 0) {
+        }
         perDocVocab.add(randomString);
         vocab.add(randomString);
       }
@@ -105,8 +104,8 @@ public class TestNFARunAutomaton extends LuceneTestCase {
     Set<String> foreignVocab = new HashSet<>();
     while (foreignVocab.size() < vocab.size()) {
       String randomString;
-      while ((randomString = TestUtil.randomUnicodeString(random())).length() == 0)
-        ;
+      while ((randomString = TestUtil.randomUnicodeString(random())).length() == 0) {
+      }
       foreignVocab.add(randomString);
     }
 

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestNFARunAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestNFARunAutomaton.java
@@ -86,8 +86,7 @@ public class TestNFARunAutomaton extends LuceneTestCase {
       int termNum = random().nextInt(20) + 30;
       while (perDocVocab.size() < termNum) {
         String randomString;
-        while ((randomString = TestUtil.randomUnicodeString(random())).length() == 0) {
-        }
+        while ((randomString = TestUtil.randomUnicodeString(random())).length() == 0) {}
         perDocVocab.add(randomString);
         vocab.add(randomString);
       }
@@ -104,8 +103,7 @@ public class TestNFARunAutomaton extends LuceneTestCase {
     Set<String> foreignVocab = new HashSet<>();
     while (foreignVocab.size() < vocab.size()) {
       String randomString;
-      while ((randomString = TestUtil.randomUnicodeString(random())).length() == 0) {
-      }
+      while ((randomString = TestUtil.randomUnicodeString(random())).length() == 0) {}
       foreignVocab.add(randomString);
     }
 

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
@@ -222,7 +222,6 @@ public class TestRegExp extends LuceneTestCase {
         caseSensitiveQuery
             ? Pattern.compile(regexPattern)
             : Pattern.compile(regexPattern, Pattern.CASE_INSENSITIVE);
-    ;
     Matcher matcher = pattern.matcher(docValue);
     assertTrue(
         "Java regex " + regexPattern + " did not match doc value " + docValue, matcher.matches());

--- a/lucene/core/src/test/org/apache/lucene/util/hppc/TestIntIntHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hppc/TestIntIntHashMap.java
@@ -612,7 +612,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   @Test
   public void testEqualsSubClass() {
     class Sub extends IntIntHashMap {}
-    ;
 
     IntIntHashMap l1 = newInstance();
     l1.put(k1, value0);

--- a/lucene/join/src/java/org/apache/lucene/search/join/GlobalOrdinalsWithScoreCollector.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/GlobalOrdinalsWithScoreCollector.java
@@ -50,7 +50,6 @@ abstract class GlobalOrdinalsWithScoreCollector implements Collector {
     this.doMinMax = min > 1 || max < Integer.MAX_VALUE;
     this.min = min;
     this.max = max;
-    ;
     this.ordinalMap = ordinalMap;
     this.collectedOrds = new LongBitSet(valueCount);
     if (scoreMode != ScoreMode.None) {

--- a/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinSortField.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinSortField.java
@@ -233,7 +233,6 @@ public class ToParentBlockJoinSortField extends SortField {
           }
         };
       }
-      ;
     };
   }
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/DocumentsPanelProvider.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/DocumentsPanelProvider.java
@@ -834,7 +834,6 @@ public final class DocumentsPanelProvider implements DocumentsTabOperator {
   public void displayDoc(int docid) {
     showDoc(docid);
   }
-  ;
 
   private void showDoc(int docid) {
     docNumSpnr.setValue(docid);

--- a/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndexAgainstDirectory.java
+++ b/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndexAgainstDirectory.java
@@ -283,7 +283,6 @@ public class TestMemoryIndexAgainstDirectory extends BaseTokenStreamTestCase {
       }
     }
   }
-  ;
 
   /**
    * Some terms to be indexed, in addition to random words. These terms are commonly used in the

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/MonitorUpdateListener.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/MonitorUpdateListener.java
@@ -24,21 +24,16 @@ public interface MonitorUpdateListener {
 
   /** Called after a set of queries have been added to the Monitor's query index */
   default void afterUpdate(List<MonitorQuery> updates) {}
-  ;
 
   /** Called after a set of queries have been deleted from the Monitor's query index */
   default void afterDelete(List<String> queryIds) {}
-  ;
 
   /** Called after all queries have been removed from the Monitor's query index */
   default void afterClear() {}
-  ;
 
   /** Called after the Monitor's query cache has been purged of deleted queries */
   default void onPurge() {}
-  ;
 
   /** Called if there was an error removing deleted queries from the Monitor's query cache */
   default void onPurgeError(Throwable t) {}
-  ;
 }

--- a/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanExplanations.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanExplanations.java
@@ -261,7 +261,7 @@ public class TestSpanExplanations extends BaseSpanExplanationTestCase {
     disjuncts.add(new TermQuery(new Term(FIELD, "QQ")));
 
     BooleanQuery.Builder xxYYZZ = new BooleanQuery.Builder();
-    ;
+
     xxYYZZ.add(new TermQuery(new Term(FIELD, "xx")), Occur.SHOULD);
     xxYYZZ.add(new TermQuery(new Term(FIELD, "yy")), Occur.SHOULD);
     xxYYZZ.add(new TermQuery(new Term(FIELD, "zz")), Occur.MUST_NOT);
@@ -269,7 +269,7 @@ public class TestSpanExplanations extends BaseSpanExplanationTestCase {
     disjuncts.add(xxYYZZ.build());
 
     BooleanQuery.Builder xxW1 = new BooleanQuery.Builder();
-    ;
+
     xxW1.add(new TermQuery(new Term(FIELD, "xx")), Occur.MUST_NOT);
     xxW1.add(new TermQuery(new Term(FIELD, "w1")), Occur.MUST_NOT);
 
@@ -284,7 +284,7 @@ public class TestSpanExplanations extends BaseSpanExplanationTestCase {
     q.add(new DisjunctionMaxQuery(disjuncts, 0.2f), Occur.SHOULD);
 
     BooleanQuery.Builder b = new BooleanQuery.Builder();
-    ;
+
     b.setMinimumNumberShouldMatch(2);
     b.add(snear("w1", "w2", 1, true), Occur.SHOULD);
     b.add(snear("w2", "w3", 1, true), Occur.SHOULD);
@@ -319,7 +319,7 @@ public class TestSpanExplanations extends BaseSpanExplanationTestCase {
     disjuncts.add(new TermQuery(new Term(FIELD, "QQ")));
 
     BooleanQuery.Builder xxYYZZ = new BooleanQuery.Builder();
-    ;
+
     xxYYZZ.add(new TermQuery(new Term(FIELD, "xx")), Occur.SHOULD);
     xxYYZZ.add(new TermQuery(new Term(FIELD, "yy")), Occur.SHOULD);
     xxYYZZ.add(new TermQuery(new Term(FIELD, "zz")), Occur.MUST_NOT);
@@ -327,7 +327,7 @@ public class TestSpanExplanations extends BaseSpanExplanationTestCase {
     disjuncts.add(xxYYZZ.build());
 
     BooleanQuery.Builder xxW1 = new BooleanQuery.Builder();
-    ;
+
     xxW1.add(new TermQuery(new Term(FIELD, "xx")), Occur.MUST_NOT);
     xxW1.add(new TermQuery(new Term(FIELD, "w1")), Occur.MUST_NOT);
 
@@ -345,7 +345,7 @@ public class TestSpanExplanations extends BaseSpanExplanationTestCase {
     q.add(new DisjunctionMaxQuery(disjuncts, 0.2f), Occur.SHOULD);
 
     BooleanQuery.Builder builder = new BooleanQuery.Builder();
-    ;
+
     builder.setMinimumNumberShouldMatch(2);
     builder.add(snear("w1", "w2", 1, true), Occur.SHOULD);
     builder.add(snear("w2", "w3", 1, true), Occur.SHOULD);

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/parser/QueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/parser/QueryParser.java
@@ -174,6 +174,7 @@ import org.apache.lucene.queryparser.charstream.FastCharStream;
     label_1:
     while (true) {
       if (jj_2_1(2)) {
+        ;
       } else {
         break label_1;
       }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/parser/QueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/parser/QueryParser.java
@@ -174,7 +174,6 @@ import org.apache.lucene.queryparser.charstream.FastCharStream;
     label_1:
     while (true) {
       if (jj_2_1(2)) {
-        ;
       } else {
         break label_1;
       }

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleCopyJob.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleCopyJob.java
@@ -271,8 +271,7 @@ class SimpleCopyJob extends CopyJob {
 
   @Override
   public void runBlocking() throws IOException {
-    while (visit() == false) {
-    }
+    while (visit() == false) {}
 
     if (getFailed()) {
       throw new RuntimeException("copy failed: " + cancelReason, exc);

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleCopyJob.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleCopyJob.java
@@ -271,8 +271,8 @@ class SimpleCopyJob extends CopyJob {
 
   @Override
   public void runBlocking() throws IOException {
-    while (visit() == false)
-      ;
+    while (visit() == false) {
+    }
 
     if (getFailed()) {
       throw new RuntimeException("copy failed: " + cancelReason, exc);

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/PackedQuadPrefixTree.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/PackedQuadPrefixTree.java
@@ -507,8 +507,7 @@ public class PackedQuadPrefixTree extends QuadPrefixTree {
       if (rel == SpatialRelation.INTERSECTS && leafyPrune && level == detailLevel - 1) {
         for (leaves = 0, pruneIter = thisCell.getNextLevelCells(shape);
             pruneIter.hasNext();
-             pruneIter.next(), ++leaves) {
-        }
+            pruneIter.next(), ++leaves) {}
         return leaves == 4;
       }
       return false;

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/PackedQuadPrefixTree.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/PackedQuadPrefixTree.java
@@ -507,8 +507,8 @@ public class PackedQuadPrefixTree extends QuadPrefixTree {
       if (rel == SpatialRelation.INTERSECTS && leafyPrune && level == detailLevel - 1) {
         for (leaves = 0, pruneIter = thisCell.getNextLevelCells(shape);
             pruneIter.hasNext();
-            pruneIter.next(), ++leaves)
-          ;
+             pruneIter.next(), ++leaves) {
+        }
         return leaves == 4;
       }
       return false;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -1332,8 +1332,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           for (int i = 0; i < numdocs; i++) {
             // randomly advance to i
             if (random().nextInt(4) == 3) {
-              while (vectorDocs[++cur] < i) {
-              }
+              while (vectorDocs[++cur] < i) {}
               assertEquals(vectorDocs[cur], vectorValues.advance(i));
               assertEquals(vectorDocs[cur], vectorValues.docID());
               if (vectorValues.docID() == NO_MORE_DOCS) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -1332,8 +1332,8 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           for (int i = 0; i < numdocs; i++) {
             // randomly advance to i
             if (random().nextInt(4) == 3) {
-              while (vectorDocs[++cur] < i)
-                ;
+              while (vectorDocs[++cur] < i) {
+              }
               assertEquals(vectorDocs[cur], vectorValues.advance(i));
               assertEquals(vectorDocs[cur], vectorValues.docID());
               if (vectorValues.docID() == NO_MORE_DOCS) {


### PR DESCRIPTION
I noticed yet another errant `;` and then grep'd and found tons of them and removed them.

Note that it was a bit tricky because some lines that have only whitespace and a semicolon are actually meaningful, e.g.:

```
  while(something)
      ;
```

I translated those cases to:

```
  while(something) {
  }
```

instead.

If a `for` loop definition spans multiple lines, it can have a meaningful semicolon-only line -- there was at least one case of this.

I tried not to touch any auto-gen'd code, which seem to contain many errant semicolons, unfortunately.

I wonder if there is a "useless semicolon" static checker?  Now that I see these things I cannot unsee them!