### PR TITLE
Close all files when hitting an I/O exception with vectors.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -92,18 +92,8 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
       } catch (Throwable exception) {
         priorE = exception;
       } finally {
-        try {
-          CodecUtil.checkFooter(meta, priorE);
-          success = true;
-        } finally {
-          if (success == false) {
-            IOUtils.close(flatVectorsReader);
-          }
-        }
+        CodecUtil.checkFooter(meta, priorE);
       }
-    }
-    success = false;
-    try {
       vectorIndex =
           openDataInput(
               state,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
@@ -58,6 +58,7 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
 
   Lucene99ScalarQuantizedVectorsReader(SegmentReadState state, FlatVectorsReader rawVectorsReader)
       throws IOException {
+    this.rawVectorsReader = rawVectorsReader;
     int versionMeta = -1;
     String metaFileName =
         IndexFileNames.segmentFileName(
@@ -80,19 +81,8 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
       } catch (Throwable exception) {
         priorE = exception;
       } finally {
-        try {
-          CodecUtil.checkFooter(meta, priorE);
-          success = true;
-        } finally {
-          if (success == false) {
-            IOUtils.close(rawVectorsReader);
-          }
-        }
+        CodecUtil.checkFooter(meta, priorE);
       }
-    }
-    success = false;
-    this.rawVectorsReader = rawVectorsReader;
-    try {
       quantizedVectorData =
           openDataInput(
               state,


### PR DESCRIPTION
This was found by `testRandomExceptions()`: if an exception occurs when opening the meta file, then the `rawVectorsReader` that is passed to the constructor never gets closed.