### PR TITLE
Fix errorprone with alternative runtime

### DIFF
--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -37,7 +37,7 @@ if (skipReason) {
 
 allprojects { prj ->
   plugins.withType(JavaPlugin) {
-    // LUCENE-9650: Errorprone on master/gradle does not work with JDK-16+ when running as plugin
+    // LUCENE-9650: Errorprone on master/gradle does not work when running as plugin
     // inside a forked Javac process. Javac running inside Gradle works, because we have
     // additional module system opens in place.
     // This is a hack to keep the dependency (so that palantir's version check doesn't complain)

--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -17,8 +17,8 @@
 
 def skipReason
 
-if (rootProject.usesAltJvm && rootProject.runtimeJavaVersion > JavaVersion.VERSION_15) {
-  skipReason = "won't work with JDK ${rootProject.runtimeJavaVersion} if used as alternative java toolchain"
+if (rootProject.usesAltJvm) {
+  skipReason = "won't work with alternative java toolchain"
 }
 
 if (!propertyOrDefault("validation.errorprone", isCIBuild).asBoolean()) {


### PR DESCRIPTION
See analysis on dev@lucene.apache.org: https://lists.apache.org/thread/svt6bqqwdkb4kq7b9zhx630n4sj27ovq

This fixes the recent Jenkins failures with branch_9x. On main branch the extra check is useless anyways, as JDK versions are always >=17.

Basically this PR disables errorprone completely when an alternative runtime is used. According to the errorprone plugin documentation, they only support running it in the Gradle JVM or if it uses Gradle Toolchains. The way how we pass an alternative runtime JVM (`RUNTIME_JAVA_HOME`) is not supported and causes in newest versions of the plugin that the Gradle JVM options are passed down unmodified, causing the bug.