### PR TITLE
[Minor] Quick exit for non-zero slice buffers

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -174,6 +174,9 @@ Improvements
 
 * GITHUB#12870: Tighten synchronized loop in DirectoryTaxonomyReader#getOrdinal. (Stefan Vodita)
 
+* GITHUB#12812: Correct int slice buffer filled with zeros assertion and make it exit quickly if the condition
+  is not met. (Stefan Vodita)
+
 Optimizations
 ---------------------
 (No changes)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -174,8 +174,7 @@ Improvements
 
 * GITHUB#12870: Tighten synchronized loop in DirectoryTaxonomyReader#getOrdinal. (Stefan Vodita)
 
-* GITHUB#12812: Correct int slice buffer filled with zeros assertion and make it exit quickly if the condition
-  is not met. (Stefan Vodita)
+* GITHUB#12812: Avoid overflows and false negatives in int slice buffer filled-with-zeros assertion. (Stefan Vodita)
 
 Optimizations
 ---------------------

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -180,6 +180,19 @@ public class MemoryIndex {
     }
 
     /**
+     * For slices, buffers must be filled with zeros, so that we can find a slice's end based on a
+     * non-zero final value.
+     */
+    private static boolean assertSliceBuffer(int[] buffer) {
+      for (int value : buffer) {
+        if (value != 0) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    /**
      * Creates a new int slice with the given starting size and returns the slices offset in the
      * pool.
      *
@@ -195,14 +208,6 @@ public class MemoryIndex {
       intUpto += size;
       buffer[intUpto - 1] = 16;
       return upto;
-    }
-
-    private static boolean assertSliceBuffer(int[] buffer) {
-      int count = 0;
-      for (int i = 0; i < buffer.length; i++) {
-        count += buffer[i]; // for slices the buffer must only have 0 values
-      }
-      return count == 0;
     }
 
     /** Allocates a new slice from the given offset */


### PR DESCRIPTION
In `SlicedIntBlockPool`, we assert that a buffer we're about to use has previously been filled with zeros.
This PR makes it so we exit faster if we find a non-zero value. It also prevents overflow cases that could happen before.

Follow-up from #12734.
