### PR TITLE
Fix off-by-one error in SimpleSortedSetFacetsExample

### DIFF
--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleSortedSetFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleSortedSetFacetsExample.java
@@ -150,7 +150,7 @@ public class SimpleSortedSetFacetsExample {
     SimpleSortedSetFacetsExample example = new SimpleSortedSetFacetsExample();
     List<FacetResult> results = example.runSearch();
     System.out.println("Author: " + results.get(0));
-    System.out.println("Publish Year: " + results.get(0));
+    System.out.println("Publish Year: " + results.get(1));
 
     System.out.println("\n");
     System.out.println("Facet drill-down example (Publish Year/2010):");


### PR DESCRIPTION
We're only printing results for the `Author` dimension instead of printing `Publish Year` too.