### PR TITLE
Re-use information from graph traversal during exact search

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswGraphBuilder.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswGraphBuilder.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.SplittableRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.hnsw.HnswGraph;
 import org.apache.lucene.util.hnsw.HnswGraphBuilder;
@@ -103,9 +102,7 @@ public final class Lucene91HnswGraphBuilder {
     this.random = new SplittableRandom(seed);
     int levelOfFirstNode = getRandomGraphLevel(ml, random);
     this.hnsw = new Lucene91OnHeapHnswGraph(maxConn, levelOfFirstNode);
-    this.graphSearcher =
-        new HnswGraphSearcher(
-            new NeighborQueue(beamWidth, true), new FixedBitSet(vectorValues.size()));
+    this.graphSearcher = new HnswGraphSearcher(new NeighborQueue(beamWidth, true));
     bound = Lucene91BoundsChecker.create(false);
     scratch = new Lucene91NeighborArray(Math.max(beamWidth, maxConn + 1));
   }

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnCollector.java
@@ -17,6 +17,8 @@
 
 package org.apache.lucene.search;
 
+import org.apache.lucene.util.FixedBitSet;
+
 /**
  * AbstractKnnCollector is the default implementation for a knn collector used for gathering kNN
  * results and providing topDocs from the gathered neighbors
@@ -26,6 +28,7 @@ public abstract class AbstractKnnCollector implements KnnCollector {
   private long visitedCount;
   private final long visitLimit;
   private final int k;
+  private FixedBitSet visited;
 
   protected AbstractKnnCollector(int k, long visitLimit) {
     this.visitLimit = visitLimit;
@@ -66,4 +69,19 @@ public abstract class AbstractKnnCollector implements KnnCollector {
 
   @Override
   public abstract TopDocs topDocs();
+
+  @Override
+  public void prepareScratchState(int maxDoc) {
+    if (visited == null) {
+      visited = new FixedBitSet(maxDoc + 1);
+    } else {
+      visited = FixedBitSet.ensureCapacity(visited, maxDoc);
+      visited.clear();
+    }
+  }
+
+  @Override
+  public boolean visit(int docId) {
+    return visited != null && visited.getAndSet(docId);
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
@@ -41,9 +41,6 @@ import org.apache.lucene.util.Bits;
  * </ul>
  */
 public class KnnByteVectorQuery extends AbstractKnnVectorQuery {
-
-  private static final TopDocs NO_RESULTS = TopDocsCollector.EMPTY_TOPDOCS;
-
   private final byte[] target;
 
   /**
@@ -75,11 +72,11 @@ public class KnnByteVectorQuery extends AbstractKnnVectorQuery {
   }
 
   @Override
-  protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
-      throws IOException {
-    TopDocs results =
-        context.reader().searchNearestVectors(field, target, k, acceptDocs, visitedLimit);
-    return results != null ? results : NO_RESULTS;
+  protected void approximateSearch(
+      LeafReaderContext context, Bits acceptDocs, KnnCollector collector) throws IOException {
+    if (collector != null) {
+      context.reader().searchNearestVectors(field, target, collector, acceptDocs);
+    }
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/KnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnCollector.java
@@ -85,4 +85,8 @@ public interface KnnCollector {
    * @return The collected top documents
    */
   TopDocs topDocs();
+
+  void prepareScratchState(int maxDoc);
+
+  boolean visit(int docId);
 }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
@@ -42,9 +42,6 @@ import org.apache.lucene.util.VectorUtil;
  * </ul>
  */
 public class KnnFloatVectorQuery extends AbstractKnnVectorQuery {
-
-  private static final TopDocs NO_RESULTS = TopDocsCollector.EMPTY_TOPDOCS;
-
   private final float[] target;
 
   /**
@@ -76,11 +73,11 @@ public class KnnFloatVectorQuery extends AbstractKnnVectorQuery {
   }
 
   @Override
-  protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
-      throws IOException {
-    TopDocs results =
-        context.reader().searchNearestVectors(field, target, k, acceptDocs, visitedLimit);
-    return results != null ? results : NO_RESULTS;
+  protected void approximateSearch(
+      LeafReaderContext context, Bits acceptDocs, KnnCollector collector) throws IOException {
+    if (collector != null) {
+      context.reader().searchNearestVectors(field, target, collector, acceptDocs);
+    }
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswConcurrentMergeBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswConcurrentMergeBuilder.java
@@ -27,7 +27,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.util.BitSet;
-import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.ThreadInterruptedException;
@@ -167,8 +166,7 @@ public class HnswConcurrentMergeBuilder implements HnswBuilder {
           beamWidth,
           seed,
           hnsw,
-          new MergeSearcher(
-              new NeighborQueue(beamWidth, true), new FixedBitSet(hnsw.maxNodeId() + 1)));
+          new MergeSearcher(new NeighborQueue(beamWidth, true)));
       this.workProgress = workProgress;
       this.initializedNodes = initializedNodes;
     }
@@ -217,8 +215,8 @@ public class HnswConcurrentMergeBuilder implements HnswBuilder {
     private int upto;
     private int size;
 
-    private MergeSearcher(NeighborQueue candidates, BitSet visited) {
-      super(candidates, visited);
+    private MergeSearcher(NeighborQueue candidates) {
+      super(candidates);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -109,7 +109,7 @@ public class HnswGraphBuilder implements HnswBuilder {
         beamWidth,
         seed,
         hnsw,
-        new HnswGraphSearcher(new NeighborQueue(beamWidth, true), new FixedBitSet(hnsw.size())));
+        new HnswGraphSearcher(new NeighborQueue(beamWidth, true)));
   }
 
   /**
@@ -452,6 +452,7 @@ public class HnswGraphBuilder implements HnswBuilder {
     private final NeighborQueue queue;
     private final int k;
     private long visitedCount;
+    private FixedBitSet visited;
 
     /**
      * @param k the number of neighbors to collect
@@ -523,6 +524,21 @@ public class HnswGraphBuilder implements HnswBuilder {
     @Override
     public TopDocs topDocs() {
       throw new IllegalArgumentException();
+    }
+
+    @Override
+    public void prepareScratchState(int maxDoc) {
+      if (visited == null) {
+        visited = new FixedBitSet(maxDoc + 1);
+      } else {
+        visited = FixedBitSet.ensureCapacity(visited, maxDoc);
+        visited.clear();
+      }
+    }
+
+    @Override
+    public boolean visit(int docId) {
+      return visited != null && visited.getAndSet(docId);
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OrdinalTranslatedKnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OrdinalTranslatedKnnCollector.java
@@ -80,4 +80,14 @@ public final class OrdinalTranslatedKnnCollector implements KnnCollector {
                 : TotalHits.Relation.EQUAL_TO),
         td.scoreDocs);
   }
+
+  @Override
+  public void prepareScratchState(int maxVector) {
+    in.prepareScratchState(vectorOrdinalToDocId.apply(maxVector));
+  }
+
+  @Override
+  public boolean visit(int vectorId) {
+    return in.visit(vectorOrdinalToDocId.apply(vectorId));
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnByteVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnByteVectorQuery.java
@@ -94,7 +94,8 @@ public class TestKnnByteVectorQuery extends BaseKnnVectorQueryTestCase {
     }
 
     @Override
-    protected TopDocs exactSearch(LeafReaderContext context, DocIdSetIterator acceptIterator) {
+    protected TopDocs exactSearch(
+        LeafReaderContext context, DocIdSetIterator acceptIterator, KnnCollector collector) {
       throw new UnsupportedOperationException("exact search is not supported");
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
@@ -244,7 +244,8 @@ public class TestKnnFloatVectorQuery extends BaseKnnVectorQueryTestCase {
     }
 
     @Override
-    protected TopDocs exactSearch(LeafReaderContext context, DocIdSetIterator acceptIterator) {
+    protected TopDocs exactSearch(
+        LeafReaderContext context, DocIdSetIterator acceptIterator, KnnCollector collector) {
       throw new UnsupportedOperationException("exact search is not supported");
     }
 

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
@@ -19,22 +19,11 @@ package org.apache.lucene.search.join;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
-import org.apache.lucene.index.ByteVectorValues;
-import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.VectorEncoding;
-import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.HitQueue;
 import org.apache.lucene.search.KnnByteVectorQuery;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopDocsCollector;
-import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.BitSet;
-import org.apache.lucene.util.Bits;
 
 /**
  * kNN byte vector query that joins matching children vector documents with their parent doc id. The
@@ -50,8 +39,6 @@ import org.apache.lucene.util.Bits;
  * </pre>
  */
 public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
-  private static final TopDocs NO_RESULTS = TopDocsCollector.EMPTY_TOPDOCS;
-
   private final BitSetProducer parentsFilter;
   private final Query childFilter;
   private final int k;
@@ -76,63 +63,13 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
   }
 
   @Override
-  protected TopDocs exactSearch(LeafReaderContext context, DocIdSetIterator acceptIterator)
+  protected KnnCollector createCollector(LeafReaderContext context, int visitedLimit)
       throws IOException {
-    FieldInfo fi = context.reader().getFieldInfos().fieldInfo(field);
-    if (fi == null || fi.getVectorDimension() == 0) {
-      // The field does not exist or does not index vectors
-      return NO_RESULTS;
-    }
-    if (fi.getVectorEncoding() != VectorEncoding.BYTE) {
+    BitSet parentBitSet = parentsFilter.getBitSet(context);
+    if (parentBitSet == null) {
       return null;
     }
-    BitSet parentBitSet = parentsFilter.getBitSet(context);
-    if (parentBitSet == null) {
-      return NO_RESULTS;
-    }
-    ParentBlockJoinByteVectorScorer vectorScorer =
-        new ParentBlockJoinByteVectorScorer(
-            context.reader().getByteVectorValues(field),
-            acceptIterator,
-            parentBitSet,
-            query,
-            fi.getVectorSimilarityFunction());
-    HitQueue queue = new HitQueue(k, true);
-    ScoreDoc topDoc = queue.top();
-    while (vectorScorer.nextParent() != DocIdSetIterator.NO_MORE_DOCS) {
-      float score = vectorScorer.score();
-      if (score > topDoc.score) {
-        topDoc.score = score;
-        topDoc.doc = vectorScorer.bestChild();
-        topDoc = queue.updateTop();
-      }
-    }
-
-    // Remove any remaining sentinel values
-    while (queue.size() > 0 && queue.top().score < 0) {
-      queue.pop();
-    }
-
-    ScoreDoc[] topScoreDocs = new ScoreDoc[queue.size()];
-    for (int i = topScoreDocs.length - 1; i >= 0; i--) {
-      topScoreDocs[i] = queue.pop();
-    }
-
-    TotalHits totalHits = new TotalHits(acceptIterator.cost(), TotalHits.Relation.EQUAL_TO);
-    return new TopDocs(totalHits, topScoreDocs);
-  }
-
-  @Override
-  protected TopDocs approximateSearch(LeafReaderContext context, Bits acceptDocs, int visitedLimit)
-      throws IOException {
-    BitSet parentBitSet = parentsFilter.getBitSet(context);
-    if (parentBitSet == null) {
-      return NO_RESULTS;
-    }
-    KnnCollector collector =
-        new DiversifyingNearestChildrenKnnCollector(k, visitedLimit, parentBitSet);
-    context.reader().searchNearestVectors(field, query, collector, acceptDocs);
-    return collector.topDocs();
+    return new DiversifyingNearestChildrenKnnCollector(k, visitedLimit, parentBitSet);
   }
 
   @Override
@@ -157,60 +94,5 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
     int result = Objects.hash(super.hashCode(), parentsFilter, childFilter, k);
     result = 31 * result + Arrays.hashCode(query);
     return result;
-  }
-
-  private static class ParentBlockJoinByteVectorScorer {
-    private final byte[] query;
-    private final ByteVectorValues values;
-    private final VectorSimilarityFunction similarity;
-    private final DocIdSetIterator acceptedChildrenIterator;
-    private final BitSet parentBitSet;
-    private int currentParent = -1;
-    private int bestChild = -1;
-    private float currentScore = Float.NEGATIVE_INFINITY;
-
-    protected ParentBlockJoinByteVectorScorer(
-        ByteVectorValues values,
-        DocIdSetIterator acceptedChildrenIterator,
-        BitSet parentBitSet,
-        byte[] query,
-        VectorSimilarityFunction similarity) {
-      this.query = query;
-      this.values = values;
-      this.similarity = similarity;
-      this.acceptedChildrenIterator = acceptedChildrenIterator;
-      this.parentBitSet = parentBitSet;
-    }
-
-    public int bestChild() {
-      return bestChild;
-    }
-
-    public int nextParent() throws IOException {
-      int nextChild = acceptedChildrenIterator.docID();
-      if (nextChild == -1) {
-        nextChild = acceptedChildrenIterator.nextDoc();
-      }
-      if (nextChild == DocIdSetIterator.NO_MORE_DOCS) {
-        currentParent = DocIdSetIterator.NO_MORE_DOCS;
-        return currentParent;
-      }
-      currentScore = Float.NEGATIVE_INFINITY;
-      currentParent = parentBitSet.nextSetBit(nextChild);
-      do {
-        values.advance(nextChild);
-        float score = similarity.compare(query, values.vectorValue());
-        if (score > currentScore) {
-          bestChild = nextChild;
-          currentScore = score;
-        }
-      } while ((nextChild = acceptedChildrenIterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS
-          && nextChild < currentParent);
-      return currentParent;
-    }
-
-    public float score() throws IOException {
-      return currentScore;
-    }
   }
 }


### PR DESCRIPTION
### Description

In KNN queries with a pre-filter, we first perform an approximate graph search and then [fallback](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java#L130-L137) to exact search based on the cost of the filter (if we visit more nodes than what the filter matches, it is cheaper to perform an exact search)

Graph traversal performs some work (like scoring nodes, maintaining the `topK`, etc) which can be re-used from exact search - on the fact that any node which is "visited but not collected" will not be collected from exact search as well..

If we start exact search from the previous state (current `topK` vectors from graph search) - we can ignore vectors already rejected (i.e. visited) from graph traversal, and save on their similarity computations (duplicate work) plus re-use the existing min-max heap from the `KnnCollector`

I performed some benchmarks using `KnnGraphTester` by indexing 100k vectors of 100 dimensions, and ran 10k queries with a `topK` of 1000 with a range of `selectivity` values (denoting what proportion of all documents are accepted by the filter):

#### baseline

```
recall latency   nDoc fanout maxConn beamWidth  topK selectivity     type
0.980	 4.84	100000	0	16	100	1000	1.000	  post-filter
0.988	11.94	100000	0	16	100	1000	0.300	  pre-filter
0.988	14.09	100000	0	16	100	1000	0.250	  pre-filter
0.995	20.01	100000	0	16	100	1000	0.200	  pre-filter
1.000	18.86	100000	0	16	100	1000	0.150	  pre-filter
1.000	12.94	100000	0	16	100	1000	0.100	  pre-filter
```

#### candidate

```
recall latency   nDoc fanout maxConn beamWidth  topK selectivity     type
0.980	 4.86	100000	0	16	100	1000	1.000	  post-filter
0.989	12.16	100000	0	16	100	1000	0.300	  pre-filter
0.989	13.64	100000	0	16	100	1000	0.250	  pre-filter
0.994	19.04	100000	0	16	100	1000	0.200	  pre-filter
1.000	17.24	100000	0	16	100	1000	0.150	  pre-filter
1.000	11.61	100000	0	16	100	1000	0.100	  pre-filter
```

The gains may be beneficial only when `topK` is large and the filter is restrictive (more number of nodes visited -> more chances of falling back to exact search -> more duplicate similarity computations saved)