### PR TITLE
Add GrowableByteArrayDataOutput

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/GrowableByteArrayDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/GrowableByteArrayDataOutput.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.store;
+
+import java.io.IOException;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.RamUsageEstimator;
+
+/**
+ * A {@link DataOutput} backed by a growable byte[]. The byte[] will only grow, never shrinks.
+ *
+ * @lucene.experimental
+ */
+public final class GrowableByteArrayDataOutput extends DataOutput implements Accountable {
+
+  private static final long BASE_RAM_BYTES_USED =
+      RamUsageEstimator.shallowSizeOfInstance(GrowableByteArrayDataOutput.class);
+
+  private byte[] bytes;
+
+  private int nextWrite;
+
+  public GrowableByteArrayDataOutput(int initialSize) {
+    bytes = new byte[initialSize];
+  }
+
+  @Override
+  public void writeByte(byte b) {
+    ensureCapacity(1);
+    bytes[nextWrite++] = b;
+  }
+
+  @Override
+  public void writeBytes(byte[] b, int offset, int len) {
+    ensureCapacity(len);
+    System.arraycopy(b, offset, bytes, nextWrite, len);
+    nextWrite += len;
+  }
+
+  /**
+   * @return the current position of this DataOutput
+   */
+  public int getPosition() {
+    return nextWrite;
+  }
+
+  /**
+   * @return the internal byte[]
+   */
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  /**
+   * Set the position of the byte[], increasing the capacity if needed.
+   *
+   * @param position the new position
+   */
+  public void setPosition(int position) {
+    assert position >= 0;
+    if (position > nextWrite) {
+      ensureCapacity(position - nextWrite);
+    }
+    nextWrite = position;
+  }
+
+  /**
+   * Ensure we can write additional bytesToWrite bytes.
+   *
+   * @param bytesToWrite the additional bytes to write
+   */
+  private void ensureCapacity(int bytesToWrite) {
+    bytes = ArrayUtil.grow(bytes, nextWrite + bytesToWrite);
+  }
+
+  /**
+   * Writes all of our bytes to the target {@link DataOutput}.
+   *
+   * @param out the DataOutput to write to
+   */
+  public void writeTo(DataOutput out) throws IOException {
+    out.writeBytes(bytes, 0, nextWrite);
+  }
+
+  /**
+   * Copy a portion of the written bytes to a target byte[]
+   *
+   * @param srcOffset the offset of the internal byte[] to copy
+   * @param dest the target byte[] to write to
+   * @param destOffset the offset in the target byte[]
+   * @param len the number of bytes to write
+   */
+  public void writeTo(int srcOffset, byte[] dest, int destOffset, int len) {
+    assert srcOffset + len <= nextWrite;
+    System.arraycopy(bytes, srcOffset, dest, destOffset, len);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(bytes);
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/store/TestGrowableByteArrayDataOutput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestGrowableByteArrayDataOutput.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.store;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.ArrayUtil;
+
+public class TestGrowableByteArrayDataOutput extends LuceneTestCase {
+
+  public void testRandom() throws Exception {
+
+    final int iters = atLeast(10);
+    final int maxBytes = TEST_NIGHTLY ? 200000 : 20000;
+    for (int iter = 0; iter < iters; iter++) {
+      final int numBytes = TestUtil.nextInt(random(), 1, maxBytes);
+      final byte[] expected = new byte[numBytes];
+      final GrowableByteArrayDataOutput bytes = new GrowableByteArrayDataOutput(8);
+      if (VERBOSE) {
+        System.out.println("TEST: iter=" + iter + " numBytes=" + numBytes);
+      }
+
+      int pos = 0;
+      while (pos < numBytes) {
+        int op = random().nextInt(2);
+        if (VERBOSE) {
+          System.out.println("  cycle pos=" + pos);
+        }
+        switch (op) {
+          case 0:
+            {
+              // write random byte
+              byte b = (byte) random().nextInt(256);
+              if (VERBOSE) {
+                System.out.println("    writeByte b=" + b);
+              }
+
+              expected[pos++] = b;
+              bytes.writeByte(b);
+            }
+            break;
+
+          case 1:
+            {
+              // write random byte[]
+              int len = random().nextInt(Math.min(numBytes - pos, 100));
+              byte[] temp = new byte[len];
+              random().nextBytes(temp);
+              if (VERBOSE) {
+                System.out.println("    writeBytes len=" + len + " bytes=" + Arrays.toString(temp));
+              }
+              System.arraycopy(temp, 0, expected, pos, temp.length);
+              bytes.writeBytes(temp, 0, temp.length);
+              pos += len;
+            }
+            break;
+        }
+
+        assertEquals(pos, bytes.getPosition());
+
+        if (pos > 0 && random().nextInt(50) == 17) {
+          // truncate
+          int len = TestUtil.nextInt(random(), 1, Math.min(pos, 100));
+          bytes.setPosition(pos - len);
+          pos -= len;
+          Arrays.fill(expected, pos, pos + len, (byte) 0);
+          if (VERBOSE) {
+            System.out.println("    truncate len=" + len + " newPos=" + pos);
+          }
+        }
+
+        if ((pos > 0 && random().nextInt(200) == 17)) {
+          verify(bytes, expected, pos);
+        }
+      }
+
+      GrowableByteArrayDataOutput bytesToVerify;
+
+      if (random().nextBoolean()) {
+        if (VERBOSE) {
+          System.out.println("TEST: save/load final bytes");
+        }
+        Directory dir = newDirectory();
+        IndexOutput out = dir.createOutput("bytes", IOContext.DEFAULT);
+        bytes.writeTo(out);
+        out.close();
+        IndexInput in = dir.openInput("bytes", IOContext.DEFAULT);
+        bytesToVerify = new GrowableByteArrayDataOutput(8);
+        bytesToVerify.copyBytes(in, numBytes);
+        in.close();
+        dir.close();
+      } else {
+        bytesToVerify = bytes;
+      }
+
+      verify(bytesToVerify, expected, numBytes);
+    }
+  }
+
+  public void testCopyBytesOnByteStore() throws IOException {
+    byte[] bytes = new byte[1024 * 8 + 10];
+    byte[] bytesout = new byte[bytes.length];
+    random().nextBytes(bytes);
+    int offset = TestUtil.nextInt(random(), 0, 100);
+    int len = bytes.length - offset;
+    ByteArrayDataInput in = new ByteArrayDataInput(bytes, offset, len);
+    final GrowableByteArrayDataOutput o = new GrowableByteArrayDataOutput(8);
+    o.copyBytes(in, len);
+    o.writeTo(0, bytesout, 0, len);
+    assertArrayEquals(
+        ArrayUtil.copyOfSubArray(bytesout, 0, len),
+        ArrayUtil.copyOfSubArray(bytes, offset, offset + len));
+  }
+
+  private void verify(GrowableByteArrayDataOutput bytes, byte[] expected, int totalLength)
+      throws Exception {
+    assertEquals(totalLength, bytes.getPosition());
+    if (totalLength == 0) {
+      return;
+    }
+    if (VERBOSE) {
+      System.out.println("  verify...");
+    }
+
+    // First verify whole thing in one blast:
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    bytes.writeTo(new OutputStreamDataOutput(baos));
+    byte[] actual = baos.toByteArray();
+
+    assertEquals(totalLength, actual.length);
+
+    for (int i = 0; i < totalLength; i++) {
+      assertEquals("byte @ index=" + i, expected[i], actual[i]);
+    }
+  }
+}


### PR DESCRIPTION
### Description

Spawn out of #12624 

This DataOutput is meant to replace BytesStore. I wasn't sure if it could be useful outside of FST, but as it's only a general purpose DataOutput backed by a growable byte[], I'm putting it as a separate PR to gather feedbacks.

Also putting `@lucene.experimental` so that we are free to change it later