### PR TITLE
Fix PayloadFilteredTermIntervalsSource equals

### DIFF
--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/PayloadFilteredTermIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/PayloadFilteredTermIntervalsSource.java
@@ -262,7 +262,7 @@ class PayloadFilteredTermIntervalsSource extends IntervalsSource {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    TermIntervalsSource that = (TermIntervalsSource) o;
+    PayloadFilteredTermIntervalsSource that = (PayloadFilteredTermIntervalsSource) o;
     return Objects.equals(term, that.term);
   }
 

--- a/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestPayloadFilteredInterval.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestPayloadFilteredInterval.java
@@ -89,4 +89,14 @@ public class TestPayloadFilteredInterval extends LuceneTestCase {
     reader.close();
     directory.close();
   }
+
+  public void testPayloadFilteredTermIntervalsSourceEquals() {
+    IntervalsSource interval = Intervals.term("test", (payload) -> true);
+    IntervalsSource sameInterval = Intervals.term("test", (payload) -> true);
+    IntervalsSource differentInterval = Intervals.term("test");
+
+    assertTrue(interval.equals(sameInterval));
+    assertFalse(interval.equals(differentInterval));
+    assertFalse(interval.equals(null));
+  }
 }


### PR DESCRIPTION
### Description

TermIntervalsSource isn't ancestor of PayloadFilteredTermIntervalsSource, so casting to it causes ClassCastException.
Here's a trivial fix and a test.

Because of this bug I wasn't unable to wrap PayloadFilteredTermIntervalsSources into a MinimumShouldMatchIntervalsSource, as it tries to deduplicate wrapped intervals using equals inside UnorderedIntervalsSource.deduplicate() method
