### PR TITLE
Make FSTCompiler.Builder build() throw IOException

### DIFF
--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsWriter.java
@@ -251,7 +251,7 @@ public class FSTTermsWriter extends FieldsConsumer {
     private final IntsRefBuilder scratchTerm = new IntsRefBuilder();
     private final ByteBuffersDataOutput metaWriter = ByteBuffersDataOutput.newResettableInstance();
 
-    TermsWriter(FieldInfo fieldInfo) {
+    TermsWriter(FieldInfo fieldInfo) throws IOException {
       this.numTerms = 0;
       this.fieldInfo = fieldInfo;
       postingsWriter.setField(fieldInfo);

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/uniformsplit/FSTDictionary.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/uniformsplit/FSTDictionary.java
@@ -171,7 +171,7 @@ public class FSTDictionary implements IndexDictionary {
     protected final FSTCompiler<Long> fstCompiler;
     protected final IntsRefBuilder scratchInts;
 
-    public Builder() {
+    public Builder() throws IOException {
       PositiveIntOutputs outputs = PositiveIntOutputs.getSingleton();
       fstCompiler = new FSTCompiler.Builder<>(FST.INPUT_TYPE.BYTE1, outputs).build();
       scratchInts = new IntsRefBuilder();

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -247,16 +247,14 @@ public class FSTCompiler<T> {
     }
 
     /** Creates a new {@link FSTCompiler}. */
-    public FSTCompiler<T> build() {
-      FSTCompiler<T> fstCompiler =
-          new FSTCompiler<>(
-              inputType,
-              suffixRAMLimitMB,
-              outputs,
-              allowFixedLengthArcs,
-              bytesPageBits,
-              directAddressingMaxOversizingFactor);
-      return fstCompiler;
+    public FSTCompiler<T> build() throws IOException {
+      return new FSTCompiler<>(
+          inputType,
+          suffixRAMLimitMB,
+          outputs,
+          allowFixedLengthArcs,
+          bytesPageBits,
+          directAddressingMaxOversizingFactor);
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTDirectAddressing.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTDirectAddressing.java
@@ -172,7 +172,8 @@ public class TestFSTDirectAddressing extends LuceneTestCase {
                 ((double) (fstCompiler.continuousNodeCount) / fixedLengthArcNodeCount * 100)));
   }
 
-  private static FSTCompiler<Object> createFSTCompiler(float directAddressingMaxOversizingFactor) {
+  private static FSTCompiler<Object> createFSTCompiler(float directAddressingMaxOversizingFactor)
+      throws IOException {
     return new FSTCompiler.Builder<>(FST.INPUT_TYPE.BYTE1, NoOutputs.getSingleton())
         .directAddressingMaxOversizingFactor(directAddressingMaxOversizingFactor)
         .build();

--- a/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
@@ -521,7 +521,8 @@ public class TestFSTs extends LuceneTestCase {
     private final FSTCompiler<T> fstCompiler;
 
     public VisitTerms(
-        Path dirOut, Path wordsFileIn, int inputMode, Outputs<T> outputs, boolean noArcArrays) {
+        Path dirOut, Path wordsFileIn, int inputMode, Outputs<T> outputs, boolean noArcArrays)
+        throws IOException {
       this.dirOut = dirOut;
       this.wordsFileIn = wordsFileIn;
       this.inputMode = inputMode;

--- a/lucene/demo/src/java/org/apache/lucene/demo/knn/KnnVectorDict.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/knn/KnnVectorDict.java
@@ -133,12 +133,17 @@ public class KnnVectorDict implements Closeable {
     private static final Pattern SPACE_RE = Pattern.compile(" ");
 
     private final IntsRefBuilder intsRefBuilder = new IntsRefBuilder();
-    private final FSTCompiler<Long> fstCompiler =
-        new FSTCompiler.Builder<>(FST.INPUT_TYPE.BYTE1, PositiveIntOutputs.getSingleton()).build();
+    private final FSTCompiler<Long> fstCompiler;
     private float[] scratch;
     private ByteBuffer byteBuffer;
     private long ordinal = 1;
     private int numFields;
+
+    Builder() throws IOException {
+      fstCompiler =
+          new FSTCompiler.Builder<>(FST.INPUT_TYPE.BYTE1, PositiveIntOutputs.getSingleton())
+              .build();
+    }
 
     void build(Path gloveInput, Directory directory, String dictName) throws IOException {
       try (BufferedReader in = Files.newBufferedReader(gloveInput);

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionFieldsConsumer.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionFieldsConsumer.java
@@ -190,7 +190,7 @@ final class CompletionFieldsConsumer extends FieldsConsumer {
     private final BytesRefBuilder scratch = new BytesRefBuilder();
     private final NRTSuggesterBuilder builder;
 
-    public CompletionTermWriter() {
+    public CompletionTermWriter() throws IOException {
       builder = new NRTSuggesterBuilder();
       first = true;
     }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/NRTSuggesterBuilder.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/NRTSuggesterBuilder.java
@@ -53,7 +53,7 @@ final class NRTSuggesterBuilder {
   private int maxAnalyzedPathsPerOutput = 0;
 
   /** Create a builder for {@link NRTSuggester} */
-  public NRTSuggesterBuilder() {
+  public NRTSuggesterBuilder() throws IOException {
     this.payloadSep = PAYLOAD_SEP;
     this.endByte = END_BYTE;
     this.outputs =


### PR DESCRIPTION
### Description

Spawn out of #12624 . This PR make FSTCompiler.Builder to throw IOException as required by the other PR and avoid large/irrelevant diffs. These 2 PRs can be merged in any order.