### PR TITLE
Move MergeState.DocMap to a FunctionalInterface

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -5199,12 +5199,9 @@ public class IndexWriter
           for (CodecReader reader : mergeReaders) {
             final int currentDocBase = docBase;
             reorderDocMaps[i] =
-                new MergeState.DocMap() {
-                  @Override
-                  public int get(int docID) {
-                    Objects.checkIndex(docID, reader.maxDoc());
-                    return docMap.oldToNew(currentDocBase + docID);
-                  }
+                docID -> {
+                  Objects.checkIndex(docID, reader.maxDoc());
+                  return docMap.oldToNew(currentDocBase + docID);
                 };
             i++;
             docBase += reader.maxDoc();
@@ -5237,13 +5234,10 @@ public class IndexWriter
         for (int i = 0; i < docMaps.length; ++i) {
           MergeState.DocMap reorderDocMap = reorderDocMaps[i];
           docMaps[i] =
-              new MergeState.DocMap() {
-                @Override
-                public int get(int docID) {
-                  int reorderedDocId = reorderDocMap.get(docID);
-                  int compactedDocId = compactionDocMap.get(reorderedDocId);
-                  return compactedDocId;
-                }
+              docID -> {
+                int reorderedDocId = reorderDocMap.get(docID);
+                int compactedDocId = compactionDocMap.get(reorderedDocId);
+                return compactedDocId;
               };
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -5233,12 +5233,7 @@ public class IndexWriter
         docMaps = new MergeState.DocMap[reorderDocMaps.length];
         for (int i = 0; i < docMaps.length; ++i) {
           MergeState.DocMap reorderDocMap = reorderDocMaps[i];
-          docMaps[i] =
-              docID -> {
-                int reorderedDocId = reorderDocMap.get(docID);
-                int compactedDocId = compactionDocMap.get(reorderedDocId);
-                return compactedDocId;
-              };
+          docMaps[i] = docID -> compactionDocMap.get(reorderDocMap.get(docID));
         }
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -177,16 +177,13 @@ public class MergeState {
 
       final int docBase = totalDocs;
       docMaps[i] =
-          new DocMap() {
-            @Override
-            public int get(int docID) {
-              if (liveDocs == null) {
-                return docBase + docID;
-              } else if (liveDocs.get(docID)) {
-                return docBase + (int) delDocMap.get(docID);
-              } else {
-                return -1;
-              }
+          docID -> {
+            if (liveDocs == null) {
+              return docBase + docID;
+            } else if (liveDocs.get(docID)) {
+              return docBase + (int) delDocMap.get(docID);
+            } else {
+              return -1;
             }
           };
       totalDocs += reader.numDocs();
@@ -242,13 +239,10 @@ public class MergeState {
   }
 
   /** A map of doc IDs. */
-  public abstract static class DocMap {
-    /** Sole constructor. (For invocation by subclass constructors, typically implicit.) */
-    // Explicitly declared so that we have non-empty javadoc
-    protected DocMap() {}
-
+  @FunctionalInterface
+  public interface DocMap {
     /** Return the mapped docID or -1 if the given doc is not mapped. */
-    public abstract int get(int docID);
+    int get(int docID);
   }
 
   static PackedLongValues removeDeletes(final int maxDoc, final Bits liveDocs) {

--- a/lucene/core/src/java/org/apache/lucene/index/MultiSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiSorter.java
@@ -122,14 +122,11 @@ final class MultiSorter {
       final PackedLongValues remapped = builders[i].build();
       final Bits liveDocs = readers.get(i).getLiveDocs();
       docMaps[i] =
-          new MergeState.DocMap() {
-            @Override
-            public int get(int docID) {
-              if (liveDocs == null || liveDocs.get(docID)) {
-                return (int) remapped.get(docID);
-              } else {
-                return -1;
-              }
+          docID -> {
+            if (liveDocs == null || liveDocs.get(docID)) {
+              return (int) remapped.get(docID);
+            } else {
+              return -1;
             }
           };
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocIDMerger.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocIDMerger.java
@@ -60,16 +60,7 @@ public class TestDocIDMerger extends LuceneTestCase {
     for (int i = 0; i < subCount; i++) {
       int maxDoc = TestUtil.nextInt(random(), 1, 1000);
       final int docBase = valueStart;
-      subs.add(
-          new TestSubUnsorted(
-              new MergeState.DocMap() {
-                @Override
-                public int get(int docID) {
-                  return docBase + docID;
-                }
-              },
-              maxDoc,
-              valueStart));
+      subs.add(new TestSubUnsorted(docID -> docBase + docID, maxDoc, valueStart));
       valueStart += maxDoc;
     }
 
@@ -167,15 +158,12 @@ public class TestDocIDMerger extends LuceneTestCase {
       final int[] docMap = completedSubs.get(i);
       subs.add(
           new TestSubSorted(
-              new MergeState.DocMap() {
-                @Override
-                public int get(int docID) {
-                  int mapped = docMap[docID];
-                  if (liveDocs == null || liveDocs.get(mapped)) {
-                    return mapped;
-                  } else {
-                    return -1;
-                  }
+              docID -> {
+                int mapped = docMap[docID];
+                if (liveDocs == null || liveDocs.get(mapped)) {
+                  return mapped;
+                } else {
+                  return -1;
                 }
               },
               docMap.length,

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
@@ -734,13 +734,7 @@ public class TestBKD extends LuceneTestCase {
             docMaps = new ArrayList<>();
           }
           final int curDocIDBase = lastDocIDBase;
-          docMaps.add(
-              new MergeState.DocMap() {
-                @Override
-                public int get(int docID) {
-                  return curDocIDBase + docID;
-                }
-              });
+          docMaps.add(docID1 -> curDocIDBase + docID1);
           Runnable finalizer = w.finish(out, out, out);
           toMerge.add(out.getFilePointer());
           finalizer.run();
@@ -770,13 +764,7 @@ public class TestBKD extends LuceneTestCase {
           toMerge.add(out.getFilePointer());
           finalizer.run();
           final int curDocIDBase = lastDocIDBase;
-          docMaps.add(
-              new MergeState.DocMap() {
-                @Override
-                public int get(int docID) {
-                  return curDocIDBase + docID;
-                }
-              });
+          docMaps.add(docID -> curDocIDBase + docID);
         }
         out.close();
         in = dir.openInput("bkd", IOContext.DEFAULT);


### PR DESCRIPTION
This change converts MergeState to an interface to make use of lambda expressions. 
