### PR TITLE
Faster prefix sum for bitsPerValue up to 9.

### DIFF
--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ForUtilBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ForUtilBenchmark.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.codecs.lucene99.ForUtil;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.IOUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(
+    value = 5,
+    jvmArgsAppend = {"-Xmx1g", "-Xms1g", "-XX:+AlwaysPreTouch"})
+public class ForUtilBenchmark {
+
+  private Path path;
+  private Directory dir;
+  private IndexInput in;
+  private final ForUtil forUtil = new ForUtil();
+  private final long[] values = new long[128];
+
+  @Param({"6", "7", "8", "9", "10", "11"}) // some of the most common numbers of bits per value
+  public int bpv;
+
+  @Setup(Level.Trial)
+  public void setup() throws Exception {
+    path = Files.createTempDirectory("forUtil");
+    dir = MMapDirectory.open(path);
+    try (IndexOutput out = dir.createOutput("docs", IOContext.DEFAULT)) {
+      Random r = new Random(0);
+      // Write enough random data to not reach EOF while decoding
+      for (int i = 0; i < 100; ++i) {
+        out.writeLong(r.nextLong());
+      }
+    }
+    in = dir.openInput("docs", IOContext.DEFAULT);
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws Exception {
+    if (dir != null) {
+      dir.deleteFile("docs");
+    }
+    IOUtils.close(in, dir);
+    in = null;
+    dir = null;
+    Files.deleteIfExists(path);
+  }
+
+  @Benchmark
+  public void decodeAndPrefixSum(Blackhole bh) throws IOException {
+    in.seek(3); // random unaligned offset
+    forUtil.decodeAndPrefixSum(bpv, in, 100, values);
+    bh.consume(values);
+  }
+}

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ForUtilBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ForUtilBenchmark.java
@@ -59,7 +59,7 @@ public class ForUtilBenchmark {
   private final ForUtil forUtil = new ForUtil();
   private final long[] values = new long[128];
 
-  @Param({"6", "7", "8", "9", "10", "11"}) // some of the most common numbers of bits per value
+  @Param({"2", "16"}) // some of the most common numbers of bits per value
   public int bpv;
 
   @Setup(Level.Trial)

--- a/lucene/core/src/generated/checksums/generateForUtil.json
+++ b/lucene/core/src/generated/checksums/generateForUtil.json
@@ -1,4 +1,4 @@
 {
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java": "679bac572b76b8e6a0cc14ab9c74a56f497a2203",
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/gen_ForUtil.py": "ac1bc462ee4c889dbd24f741abaf64498ae132d6"
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java": "e0c3acef3bca93023611d43502a1e9c40f490701",
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/gen_ForUtil.py": "af6573d06dffd0ae2ecee02708c46a72526fbc8b"
 }

--- a/lucene/core/src/generated/checksums/generateForUtil.json
+++ b/lucene/core/src/generated/checksums/generateForUtil.json
@@ -1,4 +1,4 @@
 {
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java": "1292ad354d255b1272ffd3db684aa2ddb2bc49ec",
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/gen_ForUtil.py": "ab7b63a1b73986cc04e43de1c8f474b97aef5116"
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java": "679bac572b76b8e6a0cc14ab9c74a56f497a2203",
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/gen_ForUtil.py": "ac1bc462ee4c889dbd24f741abaf64498ae132d6"
 }

--- a/lucene/core/src/generated/checksums/generateForUtil.json
+++ b/lucene/core/src/generated/checksums/generateForUtil.json
@@ -1,4 +1,4 @@
 {
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java": "e0c3acef3bca93023611d43502a1e9c40f490701",
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/gen_ForUtil.py": "af6573d06dffd0ae2ecee02708c46a72526fbc8b"
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java": "ad68a0d2be5eef4117086893ea9656e84376dd85",
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene99/gen_ForUtil.py": "d8a9d5fca1d4d02769cc8475bd08cccd1c3f7876"
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java
@@ -140,7 +140,9 @@ public final class ForUtil {
   }
 
   private static void prefixSum16UpTo9BPV(long[] arr, long base) {
-    // When the number of bits per value is 9 or less, we can sum up all values in a block without risking overflowing a 16-bits integer. This allows computing the prefix sum by summing up 4 values at once.
+    // When the number of bits per value is 9 or less, we can sum up all values in a block without
+    // risking overflowing a 16-bits integer. This allows computing the prefix sum by summing up 4
+    // values at once.
     innerPrefixSum16(arr);
     expand16(arr);
     final long l0 = base;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java
@@ -174,6 +174,7 @@ public final class ForUtil {
     }
   }
 
+  // For some reason, unrolling seems to help
   private static void innerPrefixSum16(long[] arr) {
     arr[1] += arr[0];
     arr[2] += arr[1];

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java
@@ -28,6 +28,7 @@ import org.apache.lucene.store.DataOutput;
 // else if bitsPerValue <= 16 we pack 4 ints per long
 // else we pack 2 ints per long
 // public for benchmarking
+/** Logic for packing/unpacking intetgers on a fixed number of bits per value. */
 public final class ForUtil {
 
   static final int BLOCK_SIZE = 128;
@@ -567,7 +568,7 @@ public final class ForUtil {
     }
   }
 
-  /** Delta-decode 128 integers into {@code longs}. */
+  /** Delta-decode 128 integers into {@code longs} and compute their prefix sum in place. */
   public void decodeAndPrefixSum(int bitsPerValue, DataInput in, long base, long[] longs)
       throws IOException {
     switch (bitsPerValue) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java
@@ -28,7 +28,7 @@ import org.apache.lucene.store.DataOutput;
 // else if bitsPerValue <= 16 we pack 4 ints per long
 // else we pack 2 ints per long
 // public for benchmarking
-/** Logic for packing/unpacking intetgers on a fixed number of bits per value. */
+/** Logic for packing/unpacking integers on a fixed number of bits per value. */
 public final class ForUtil {
 
   static final int BLOCK_SIZE = 128;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForUtil.java
@@ -27,10 +27,14 @@ import org.apache.lucene.store.DataOutput;
 // If bitsPerValue <= 8 then we pack 8 ints per long
 // else if bitsPerValue <= 16 we pack 4 ints per long
 // else we pack 2 ints per long
-final class ForUtil {
+// public for benchmarking
+public final class ForUtil {
 
   static final int BLOCK_SIZE = 128;
   private static final int BLOCK_SIZE_LOG2 = 7;
+  private static final int ONE_BLOCK_SIZE_FOURTH = BLOCK_SIZE / 4;
+  private static final int TWO_BLOCK_SIZE_FOURTHS = BLOCK_SIZE / 2;
+  private static final int THREE_BLOCK_SIZE_FOURTHS = 3 * BLOCK_SIZE / 4;
 
   private static long expandMask32(long mask32) {
     return mask32 | (mask32 << 32);
@@ -70,13 +74,11 @@ final class ForUtil {
     }
   }
 
-  private static void expand8To32(long[] arr) {
+  private static void expand8To16(long[] arr) {
     for (int i = 0; i < 16; ++i) {
       long l = arr[i];
-      arr[i] = (l >>> 24) & 0x000000FF000000FFL;
-      arr[16 + i] = (l >>> 16) & 0x000000FF000000FFL;
-      arr[32 + i] = (l >>> 8) & 0x000000FF000000FFL;
-      arr[48 + i] = l & 0x000000FF000000FFL;
+      arr[i] = (l >>> 8) & 0x00FF00FF00FF00FFL;
+      arr[16 + i] = l & 0x00FF00FF00FF00FFL;
     }
   }
 
@@ -133,8 +135,25 @@ final class ForUtil {
   }
 
   private static void prefixSum8(long[] arr, long base) {
-    expand8To32(arr);
-    prefixSum32(arr, base);
+    expand8To16(arr);
+    prefixSum16UpTo9BPV(arr, base);
+  }
+
+  private static void prefixSum16UpTo9BPV(long[] arr, long base) {
+    // When the number of bits per value is 9 or less, we can sum up all values in a block without risking overflowing a 16-bits integer. This allows computing the prefix sum by summing up 4 values at once.
+    innerPrefixSum16(arr);
+    expand16(arr);
+    final long l0 = base;
+    final long l1 = l0 + arr[ONE_BLOCK_SIZE_FOURTH - 1];
+    final long l2 = l1 + arr[TWO_BLOCK_SIZE_FOURTHS - 1];
+    final long l3 = l2 + arr[THREE_BLOCK_SIZE_FOURTHS - 1];
+
+    for (int i = 0; i < ONE_BLOCK_SIZE_FOURTH; ++i) {
+      arr[i] += l0;
+      arr[ONE_BLOCK_SIZE_FOURTH + i] += l1;
+      arr[TWO_BLOCK_SIZE_FOURTHS + i] += l2;
+      arr[THREE_BLOCK_SIZE_FOURTHS + i] += l3;
+    }
   }
 
   private static void prefixSum16(long[] arr, long base) {
@@ -151,6 +170,40 @@ final class ForUtil {
     for (int i = BLOCK_SIZE / 2; i < BLOCK_SIZE; ++i) {
       arr[i] += l;
     }
+  }
+
+  private static void innerPrefixSum16(long[] arr) {
+    arr[1] += arr[0];
+    arr[2] += arr[1];
+    arr[3] += arr[2];
+    arr[4] += arr[3];
+    arr[5] += arr[4];
+    arr[6] += arr[5];
+    arr[7] += arr[6];
+    arr[8] += arr[7];
+    arr[9] += arr[8];
+    arr[10] += arr[9];
+    arr[11] += arr[10];
+    arr[12] += arr[11];
+    arr[13] += arr[12];
+    arr[14] += arr[13];
+    arr[15] += arr[14];
+    arr[16] += arr[15];
+    arr[17] += arr[16];
+    arr[18] += arr[17];
+    arr[19] += arr[18];
+    arr[20] += arr[19];
+    arr[21] += arr[20];
+    arr[22] += arr[21];
+    arr[23] += arr[22];
+    arr[24] += arr[23];
+    arr[25] += arr[24];
+    arr[26] += arr[25];
+    arr[27] += arr[26];
+    arr[28] += arr[27];
+    arr[29] += arr[28];
+    arr[30] += arr[29];
+    arr[31] += arr[30];
   }
 
   // For some reason unrolling seems to help
@@ -512,7 +565,7 @@ final class ForUtil {
   }
 
   /** Delta-decode 128 integers into {@code longs}. */
-  void decodeAndPrefixSum(int bitsPerValue, DataInput in, long base, long[] longs)
+  public void decodeAndPrefixSum(int bitsPerValue, DataInput in, long base, long[] longs)
       throws IOException {
     switch (bitsPerValue) {
       case 1:
@@ -549,7 +602,7 @@ final class ForUtil {
         break;
       case 9:
         decode9(in, tmp, longs);
-        prefixSum16(longs, base);
+        prefixSum16UpTo9BPV(longs, base);
         break;
       case 10:
         decode10(in, tmp, longs);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/gen_ForUtil.py
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/gen_ForUtil.py
@@ -52,6 +52,9 @@ import org.apache.lucene.store.DataOutput;
 // else if bitsPerValue <= 16 we pack 4 ints per long
 // else we pack 2 ints per long
 // public for benchmarking
+/**
+ * Logic for packing/unpacking intetgers on a fixed number of bits per value.
+ */
 public final class ForUtil {
 
   static final int BLOCK_SIZE = 128;
@@ -550,7 +553,7 @@ if __name__ == '__main__':
 
   f.write("""
   /**
-   * Delta-decode 128 integers into {@code longs}.
+   * Delta-decode 128 integers into {@code longs} and compute their prefix sum in place.
    */
   public void decodeAndPrefixSum(int bitsPerValue, DataInput in, long base, long[] longs) throws IOException {
     switch (bitsPerValue) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/gen_ForUtil.py
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/gen_ForUtil.py
@@ -52,9 +52,7 @@ import org.apache.lucene.store.DataOutput;
 // else if bitsPerValue <= 16 we pack 4 ints per long
 // else we pack 2 ints per long
 // public for benchmarking
-/**
- * Logic for packing/unpacking intetgers on a fixed number of bits per value.
- */
+/** Logic for packing/unpacking integers on a fixed number of bits per value. */
 public final class ForUtil {
 
   static final int BLOCK_SIZE = 128;

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestForUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestForUtil.java
@@ -110,7 +110,7 @@ public class TestForUtil extends LuceneTestCase {
           forUtil.decode(bpv, in, expected);
           expected[0] += base;
           for (int i = 1; i < 128; ++i) {
-            expected[i] += expected[i-1];
+            expected[i] += expected[i - 1];
           }
 
           long[] actual = new long[128];


### PR DESCRIPTION
In order to speed up computing prefix sums, we currently pack two deltas in a long and then sum up longs. This allows us to sum up two deltas in a single instruction. We can do better for numbers of bits per value up to 9: since `128 * 2^9 = 2^16`, we can actually compute the prefix sum on only 16 bits per value, summing up 4 deltas at once.