### PR TITLE
Copy collected acc(maxFreqs) into empty acc, rather than merge them.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
@@ -170,7 +170,6 @@ public final class CompetitiveImpactAccumulator {
         it.remove();
       } else {
         // lesser freq but better norm, further entries are not comparable
-        // TODO: further entries may have more lesser freq and greater norms, should we move them?
         break;
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
@@ -38,13 +38,6 @@ public final class CompetitiveImpactAccumulator {
   // encodes norms as bytes.
   private final TreeSet<Impact> otherFreqNormPairs;
 
-  /**
-   * If this is an empty acc, we can copy provided acc into this rather than merge them. There is no
-   * need to modify it in {@link CompetitiveImpactAccumulator#add(int, long)}, because this is a
-   * temp acc only for collecting. Maybe we should rename this field.
-   */
-  private boolean empty = true;
-
   /** Sole constructor. */
   public CompetitiveImpactAccumulator() {
     maxFreqs = new int[256];
@@ -68,7 +61,6 @@ public final class CompetitiveImpactAccumulator {
   public void clear() {
     Arrays.fill(maxFreqs, 0);
     otherFreqNormPairs.clear();
-    empty = true;
     assert assertConsistent();
   }
 
@@ -86,16 +78,7 @@ public final class CompetitiveImpactAccumulator {
     assert assertConsistent();
   }
 
-  /**
-   * Returns {@code true} if this acc contains no elements.
-   *
-   * @return {@code true} if this acc contains no elements
-   */
-  public boolean isEmpty() {
-    return empty;
-  }
-
-  /** Add {@code acc} into this. */
+  /** Merge {@code acc} into this. */
   public void addAll(CompetitiveImpactAccumulator acc) {
     int[] maxFreqs = this.maxFreqs;
     int[] otherMaxFreqs = acc.maxFreqs;
@@ -107,7 +90,6 @@ public final class CompetitiveImpactAccumulator {
       add(entry, otherFreqNormPairs);
     }
 
-    empty = false;
     assert assertConsistent();
   }
 
@@ -120,13 +102,8 @@ public final class CompetitiveImpactAccumulator {
     int[] otherMaxFreqs = acc.maxFreqs;
 
     System.arraycopy(otherMaxFreqs, 0, maxFreqs, 0, maxFreqs.length);
+    otherFreqNormPairs.addAll(acc.otherFreqNormPairs);
 
-    // TODO: optimize add operation for this empty treeset.
-    for (Impact entry : acc.otherFreqNormPairs) {
-      add(entry, otherFreqNormPairs);
-    }
-
-    empty = false;
     assert assertConsistent();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
@@ -93,6 +93,21 @@ public final class CompetitiveImpactAccumulator {
     assert assertConsistent();
   }
 
+  /** Copy {@code acc} into this empty acc. */
+  public void copy(CompetitiveImpactAccumulator acc) {
+    int[] maxFreqs = this.maxFreqs;
+    int[] otherMaxFreqs = acc.maxFreqs;
+    assert Arrays.stream(maxFreqs).sum() == 0;
+
+    System.arraycopy(otherMaxFreqs, 0, maxFreqs, 0, maxFreqs.length);
+
+    for (Impact entry : acc.otherFreqNormPairs) {
+      add(entry, otherFreqNormPairs);
+    }
+
+    assert assertConsistent();
+  }
+
   /** Get the set of competitive freq and norm pairs, ordered by increasing freq and norm. */
   public Collection<Impact> getCompetitiveFreqNormPairs() {
     List<Impact> impacts = new ArrayList<>();

--- a/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
@@ -101,9 +101,7 @@ public final class CompetitiveImpactAccumulator {
 
     System.arraycopy(otherMaxFreqs, 0, maxFreqs, 0, maxFreqs.length);
 
-    for (Impact entry : acc.otherFreqNormPairs) {
-      add(entry, otherFreqNormPairs);
-    }
+    otherFreqNormPairs.addAll(acc.otherFreqNormPairs);
 
     assert assertConsistent();
   }
@@ -154,6 +152,7 @@ public final class CompetitiveImpactAccumulator {
         it.remove();
       } else {
         // lesser freq but better norm, further entries are not comparable
+        // TODO: further entries may have more lesser freq and greater norms, should we move them?
         break;
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
@@ -93,15 +93,13 @@ public final class CompetitiveImpactAccumulator {
     assert assertConsistent();
   }
 
-  /** Copy {@code acc} into this empty acc. */
+  /** Replace the content of this {@code acc} with the provided {@code acc}. */
   public void copy(CompetitiveImpactAccumulator acc) {
-    assert Arrays.stream(maxFreqs).sum() == 0;
-    assert otherFreqNormPairs.isEmpty();
-
     int[] maxFreqs = this.maxFreqs;
     int[] otherMaxFreqs = acc.maxFreqs;
 
     System.arraycopy(otherMaxFreqs, 0, maxFreqs, 0, maxFreqs.length);
+    otherFreqNormPairs.clear();
     otherFreqNormPairs.addAll(acc.otherFreqNormPairs);
 
     assert assertConsistent();

--- a/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
@@ -86,14 +86,13 @@ public final class CompetitiveImpactAccumulator {
     assert assertConsistent();
   }
 
-  /** Merge {@code acc} into this. */
-  public void merge(CompetitiveImpactAccumulator acc) {
-    if (empty) {
-      copy(acc);
-      empty = false;
-    } else {
-      addAll(acc);
-    }
+  /**
+   * Returns {@code true} if this acc contains no elements.
+   *
+   * @return {@code true} if this acc contains no elements
+   */
+  public boolean isEmpty() {
+    return empty;
   }
 
   /** Add {@code acc} into this. */
@@ -108,19 +107,23 @@ public final class CompetitiveImpactAccumulator {
       add(entry, otherFreqNormPairs);
     }
 
+    empty = false;
     assert assertConsistent();
   }
 
   /** Copy {@code acc} into this empty acc. */
   public void copy(CompetitiveImpactAccumulator acc) {
+    assert Arrays.stream(maxFreqs).sum() == 0;
+    assert otherFreqNormPairs.isEmpty();
+
     int[] maxFreqs = this.maxFreqs;
     int[] otherMaxFreqs = acc.maxFreqs;
-    assert Arrays.stream(maxFreqs).sum() == 0;
 
     System.arraycopy(otherMaxFreqs, 0, maxFreqs, 0, maxFreqs.length);
 
     otherFreqNormPairs.addAll(acc.otherFreqNormPairs);
 
+    empty = false;
     assert assertConsistent();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
@@ -121,7 +121,10 @@ public final class CompetitiveImpactAccumulator {
 
     System.arraycopy(otherMaxFreqs, 0, maxFreqs, 0, maxFreqs.length);
 
-    otherFreqNormPairs.addAll(acc.otherFreqNormPairs);
+    // TODO: optimize add operation for this empty treeset.
+    for (Impact entry : acc.otherFreqNormPairs) {
+      add(entry, otherFreqNormPairs);
+    }
 
     empty = false;
     assert assertConsistent();

--- a/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
@@ -38,6 +38,13 @@ public final class CompetitiveImpactAccumulator {
   // encodes norms as bytes.
   private final TreeSet<Impact> otherFreqNormPairs;
 
+  /**
+   * If this is an empty acc, we can copy provided acc into this rather than merge them. There is no
+   * need to modify it in {@link CompetitiveImpactAccumulator#add(int, long)}, because this is a
+   * temp acc only for collecting. Maybe we should rename this field.
+   */
+  private boolean empty = true;
+
   /** Sole constructor. */
   public CompetitiveImpactAccumulator() {
     maxFreqs = new int[256];
@@ -61,6 +68,7 @@ public final class CompetitiveImpactAccumulator {
   public void clear() {
     Arrays.fill(maxFreqs, 0);
     otherFreqNormPairs.clear();
+    empty = true;
     assert assertConsistent();
   }
 
@@ -79,6 +87,16 @@ public final class CompetitiveImpactAccumulator {
   }
 
   /** Merge {@code acc} into this. */
+  public void merge(CompetitiveImpactAccumulator acc) {
+    if (empty) {
+      copy(acc);
+      empty = false;
+    } else {
+      addAll(acc);
+    }
+  }
+
+  /** Add {@code acc} into this. */
   public void addAll(CompetitiveImpactAccumulator acc) {
     int[] maxFreqs = this.maxFreqs;
     int[] otherMaxFreqs = acc.maxFreqs;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99SkipWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99SkipWriter.java
@@ -166,7 +166,7 @@ public final class Lucene99SkipWriter extends MultiLevelSkipListWriter {
     this.curPayPointer = payFP;
     this.curPosBufferUpto = posBufferUpto;
     this.curPayloadByteUpto = payloadByteUpto;
-    this.curCompetitiveFreqNorms[0].merge(competitiveFreqNorms);
+    this.curCompetitiveFreqNorms[0].copy(competitiveFreqNorms);
     bufferSkip(numDocs);
   }
 
@@ -202,7 +202,11 @@ public final class Lucene99SkipWriter extends MultiLevelSkipListWriter {
     CompetitiveImpactAccumulator competitiveFreqNorms = curCompetitiveFreqNorms[level];
     assert competitiveFreqNorms.getCompetitiveFreqNormPairs().size() > 0;
     if (level + 1 < numberOfSkipLevels) {
-      curCompetitiveFreqNorms[level + 1].merge(competitiveFreqNorms);
+      if (curCompetitiveFreqNorms[level + 1].isEmpty()) {
+        curCompetitiveFreqNorms[level + 1].copy(competitiveFreqNorms);
+      } else {
+        curCompetitiveFreqNorms[level + 1].addAll(competitiveFreqNorms);
+      }
     }
     writeImpacts(competitiveFreqNorms, freqNormOut);
     skipBuffer.writeVInt(Math.toIntExact(freqNormOut.size()));

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99SkipWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99SkipWriter.java
@@ -166,7 +166,7 @@ public final class Lucene99SkipWriter extends MultiLevelSkipListWriter {
     this.curPayPointer = payFP;
     this.curPosBufferUpto = posBufferUpto;
     this.curPayloadByteUpto = payloadByteUpto;
-    this.curCompetitiveFreqNorms[0].copy(competitiveFreqNorms);
+    this.curCompetitiveFreqNorms[0].merge(competitiveFreqNorms);
     bufferSkip(numDocs);
   }
 
@@ -202,7 +202,7 @@ public final class Lucene99SkipWriter extends MultiLevelSkipListWriter {
     CompetitiveImpactAccumulator competitiveFreqNorms = curCompetitiveFreqNorms[level];
     assert competitiveFreqNorms.getCompetitiveFreqNormPairs().size() > 0;
     if (level + 1 < numberOfSkipLevels) {
-      curCompetitiveFreqNorms[level + 1].addAll(competitiveFreqNorms);
+      curCompetitiveFreqNorms[level + 1].merge(competitiveFreqNorms);
     }
     writeImpacts(competitiveFreqNorms, freqNormOut);
     skipBuffer.writeVInt(Math.toIntExact(freqNormOut.size()));

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99SkipWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99SkipWriter.java
@@ -166,7 +166,7 @@ public final class Lucene99SkipWriter extends MultiLevelSkipListWriter {
     this.curPayPointer = payFP;
     this.curPosBufferUpto = posBufferUpto;
     this.curPayloadByteUpto = payloadByteUpto;
-    this.curCompetitiveFreqNorms[0].addAll(competitiveFreqNorms);
+    this.curCompetitiveFreqNorms[0].copy(competitiveFreqNorms);
     bufferSkip(numDocs);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99SkipWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99SkipWriter.java
@@ -202,11 +202,7 @@ public final class Lucene99SkipWriter extends MultiLevelSkipListWriter {
     CompetitiveImpactAccumulator competitiveFreqNorms = curCompetitiveFreqNorms[level];
     assert competitiveFreqNorms.getCompetitiveFreqNormPairs().size() > 0;
     if (level + 1 < numberOfSkipLevels) {
-      if (curCompetitiveFreqNorms[level + 1].isEmpty()) {
-        curCompetitiveFreqNorms[level + 1].copy(competitiveFreqNorms);
-      } else {
-        curCompetitiveFreqNorms[level + 1].addAll(competitiveFreqNorms);
-      }
+      curCompetitiveFreqNorms[level + 1].addAll(competitiveFreqNorms);
     }
     writeImpacts(competitiveFreqNorms, freqNormOut);
     skipBuffer.writeVInt(Math.toIntExact(freqNormOut.size()));

--- a/lucene/core/src/test/org/apache/lucene/codecs/TestCompetitiveFreqNormAccumulator.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/TestCompetitiveFreqNormAccumulator.java
@@ -100,7 +100,6 @@ public class TestCompetitiveFreqNormAccumulator extends LuceneTestCase {
         List.copyOf(mergedAcc.getCompetitiveFreqNormPairs()));
 
     acc.add(10, 10000);
-    copiedAcc.clear();
     copiedAcc.copy(acc);
     assertEquals(
         List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
@@ -113,7 +112,6 @@ public class TestCompetitiveFreqNormAccumulator extends LuceneTestCase {
         List.copyOf(mergedAcc.getCompetitiveFreqNormPairs()));
 
     acc.add(5, 200);
-    copiedAcc.clear();
     copiedAcc.copy(acc);
     assertEquals(
         List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
@@ -126,7 +124,6 @@ public class TestCompetitiveFreqNormAccumulator extends LuceneTestCase {
         List.copyOf(mergedAcc.getCompetitiveFreqNormPairs()));
 
     acc.add(20, -100);
-    copiedAcc.clear();
     copiedAcc.copy(acc);
     assertEquals(
         List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
@@ -139,7 +136,6 @@ public class TestCompetitiveFreqNormAccumulator extends LuceneTestCase {
         List.copyOf(mergedAcc.getCompetitiveFreqNormPairs()));
 
     acc.add(30, -3);
-    copiedAcc.clear();
     copiedAcc.copy(acc);
     assertEquals(
         List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),

--- a/lucene/core/src/test/org/apache/lucene/codecs/TestCompetitiveFreqNormAccumulator.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/TestCompetitiveFreqNormAccumulator.java
@@ -83,6 +83,75 @@ public class TestCompetitiveFreqNormAccumulator extends LuceneTestCase {
     assertEquals(List.copyOf(expected), List.copyOf(acc.getCompetitiveFreqNormPairs()));
   }
 
+  public void testCopy() {
+    CompetitiveImpactAccumulator acc = new CompetitiveImpactAccumulator();
+    CompetitiveImpactAccumulator copiedAcc = new CompetitiveImpactAccumulator();
+    CompetitiveImpactAccumulator mergedAcc = new CompetitiveImpactAccumulator();
+
+    acc.add(3, 5);
+    copiedAcc.copy(acc);
+    assertEquals(
+        List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
+        List.copyOf(acc.getCompetitiveFreqNormPairs()));
+
+    mergedAcc.addAll(acc);
+    assertEquals(
+        List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
+        List.copyOf(mergedAcc.getCompetitiveFreqNormPairs()));
+
+    acc.add(10, 10000);
+    copiedAcc.clear();
+    copiedAcc.copy(acc);
+    assertEquals(
+        List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
+        List.copyOf(acc.getCompetitiveFreqNormPairs()));
+
+    mergedAcc.clear();
+    mergedAcc.addAll(acc);
+    assertEquals(
+        List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
+        List.copyOf(mergedAcc.getCompetitiveFreqNormPairs()));
+
+    acc.add(5, 200);
+    copiedAcc.clear();
+    copiedAcc.copy(acc);
+    assertEquals(
+        List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
+        List.copyOf(acc.getCompetitiveFreqNormPairs()));
+
+    mergedAcc.clear();
+    mergedAcc.addAll(acc);
+    assertEquals(
+        List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
+        List.copyOf(mergedAcc.getCompetitiveFreqNormPairs()));
+
+    acc.add(20, -100);
+    copiedAcc.clear();
+    copiedAcc.copy(acc);
+    assertEquals(
+        List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
+        List.copyOf(acc.getCompetitiveFreqNormPairs()));
+
+    mergedAcc.clear();
+    mergedAcc.addAll(acc);
+    assertEquals(
+        List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
+        List.copyOf(mergedAcc.getCompetitiveFreqNormPairs()));
+
+    acc.add(30, -3);
+    copiedAcc.clear();
+    copiedAcc.copy(acc);
+    assertEquals(
+        List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
+        List.copyOf(acc.getCompetitiveFreqNormPairs()));
+
+    mergedAcc.clear();
+    mergedAcc.addAll(acc);
+    assertEquals(
+        List.copyOf(copiedAcc.getCompetitiveFreqNormPairs()),
+        List.copyOf(mergedAcc.getCompetitiveFreqNormPairs()));
+  }
+
   public void testOmitFreqs() {
     CompetitiveImpactAccumulator acc = new CompetitiveImpactAccumulator();
 


### PR DESCRIPTION
We could copy collected acc into buffered acc, rather than merge them, in bufferSkip phase.
Because the target CompetitiveImpactAccumulator is cleared in last writeSkipData phase. 