### PR TITLE
Report the time it took for building the FST in Test2BFST

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -83,6 +83,8 @@ Improvements
 
 * GITHUB#12447: Hunspell: speed up the dictionary enumeration on suggestion (Peter Gromov)
 
+* GITHUB#12847: Test2BFST now reports the time it took to build the FST and the real FST size (Anh Dung Bui)
+
 Optimizations
 ---------------------
 
@@ -171,6 +173,9 @@ API Changes
 * GITHUB#12799: Make TaskExecutor constructor public and use TaskExecutor for concurrent
   HNSW graph build. (Shubham Chaudhary)
 
+* GITHUB#12758, GITHUB#12803: Remove FST constructor with DataInput for metadata. Please
+  use the constructor with FSTMetadata instead. (Anh Dung Bui)
+
 New Features
 ---------------------
 
@@ -238,6 +243,8 @@ Improvements
   Double.POSITIVE_INFINITY to use as much RAM as is needed to create a purely
   minimal FST.  Inspired by this Rust FST implemention:
   https://blog.burntsushi.net/transducers (Mike McCandless)
+
+* GITHUB#12738: NodeHash now stores the FST nodes data instead of just node addresses (Anh Dung Bui)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -867,6 +867,10 @@ public class FSTCompiler<T> {
     return fst.ramBytesUsed();
   }
 
+  public long fstSize() {
+    return bytes.getPosition();
+  }
+
   static final class CompiledNode implements Node {
     long node;
 

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -867,7 +867,7 @@ public class FSTCompiler<T> {
     return fst.ramBytesUsed();
   }
 
-  public long fstSize() {
+  public long fstSizeInBytes() {
     return bytes.getPosition();
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFST.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFST.java
@@ -108,9 +108,11 @@ public class Test2BFST extends LuceneTestCase {
           Arrays.fill(ints2, 0);
           r = new Random(seed);
 
+          startTime = System.nanoTime();
           for (int i = 0; i < count; i++) {
             if (i % 1000000 == 0) {
-              System.out.println(i + "...: ");
+              System.out.println(
+                  i + "...: took " + (long) ((System.nanoTime() - startTime) / 1e9) + " seconds");
             }
             for (int j = 10; j < ints2.length; j++) {
               ints2[j] = r.nextInt(256);
@@ -199,9 +201,12 @@ public class Test2BFST extends LuceneTestCase {
           r = new Random(seed);
           Arrays.fill(ints, 0);
 
+          long startTime = System.nanoTime();
+
           for (int i = 0; i < count; i++) {
             if (i % 1000000 == 0) {
-              System.out.println(i + "...: ");
+              System.out.println(
+                  i + "...: took " + (long) ((System.nanoTime() - startTime) / 1e9) + " seconds");
             }
             r.nextBytes(outputBytes);
             assertEquals(output, Util.get(fst, input));
@@ -288,9 +293,11 @@ public class Test2BFST extends LuceneTestCase {
 
           output = 1;
           r = new Random(seed);
+          long startTime = System.nanoTime();
           for (int i = 0; i < count; i++) {
             if (i % 1000000 == 0) {
-              System.out.println(i + "...: ");
+              System.out.println(
+                  i + "...: took " + (long) ((System.nanoTime() - startTime) / 1e9) + " seconds");
             }
 
             assertEquals(output, Util.get(fst, input).longValue());

--- a/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFST.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFST.java
@@ -80,7 +80,7 @@ public class Test2BFST extends LuceneTestCase {
                     + ": "
                     + fstCompiler.fstRamBytesUsed()
                     + " RAM bytes used; "
-                    + fstCompiler.fstSize()
+                    + fstCompiler.fstSizeInBytes()
                     + " FST bytes; "
                     + fstCompiler.getNodeCount()
                     + " nodes; took "
@@ -175,7 +175,7 @@ public class Test2BFST extends LuceneTestCase {
           fstCompiler.add(input, BytesRef.deepCopyOf(output));
           count++;
           if (count % 10000 == 0) {
-            long size = fstCompiler.fstSize();
+            long size = fstCompiler.fstSizeInBytes();
             if (count % 1000000 == 0) {
               System.out.println(count + "...: " + size + " bytes");
             }
@@ -265,7 +265,7 @@ public class Test2BFST extends LuceneTestCase {
           output += 1 + r.nextInt(10);
           count++;
           if (count % 10000 == 0) {
-            long size = fstCompiler.fstSize();
+            long size = fstCompiler.fstSizeInBytes();
             if (count % 1000000 == 0) {
               System.out.println(count + "...: " + size + " bytes");
             }

--- a/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFST.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFST.java
@@ -98,7 +98,7 @@ public class Test2BFST extends LuceneTestCase {
         for (int verify = 0; verify < 2; verify++) {
           System.out.println(
               "\nTEST: now verify [fst size="
-                  + fst.ramBytesUsed()
+                  + fst.numBytes()
                   + "; nodeCount="
                   + fstCompiler.getNodeCount()
                   + "; arcCount="
@@ -173,7 +173,7 @@ public class Test2BFST extends LuceneTestCase {
           fstCompiler.add(input, BytesRef.deepCopyOf(output));
           count++;
           if (count % 10000 == 0) {
-            long size = fstCompiler.fstRamBytesUsed();
+            long size = fstCompiler.fstSize();
             if (count % 1000000 == 0) {
               System.out.println(count + "...: " + size + " bytes");
             }
@@ -189,7 +189,7 @@ public class Test2BFST extends LuceneTestCase {
 
           System.out.println(
               "\nTEST: now verify [fst size="
-                  + fst.ramBytesUsed()
+                  + fst.numBytes()
                   + "; nodeCount="
                   + fstCompiler.getNodeCount()
                   + "; arcCount="
@@ -260,7 +260,7 @@ public class Test2BFST extends LuceneTestCase {
           output += 1 + r.nextInt(10);
           count++;
           if (count % 10000 == 0) {
-            long size = fstCompiler.fstRamBytesUsed();
+            long size = fstCompiler.fstSize();
             if (count % 1000000 == 0) {
               System.out.println(count + "...: " + size + " bytes");
             }
@@ -277,7 +277,7 @@ public class Test2BFST extends LuceneTestCase {
 
           System.out.println(
               "\nTEST: now verify [fst size="
-                  + fst.ramBytesUsed()
+                  + fst.numBytes()
                   + "; nodeCount="
                   + fstCompiler.getNodeCount()
                   + "; arcCount="

--- a/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFST.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFST.java
@@ -66,6 +66,7 @@ public class Test2BFST extends LuceneTestCase {
         Random r = new Random(seed);
         int[] ints2 = new int[200];
         IntsRef input2 = new IntsRef(ints2, 0, ints2.length);
+        long startTime = System.nanoTime();
         while (true) {
           // System.out.println("add: " + input + " -> " + output);
           for (int i = 10; i < ints2.length; i++) {
@@ -78,9 +79,13 @@ public class Test2BFST extends LuceneTestCase {
                 count
                     + ": "
                     + fstCompiler.fstRamBytesUsed()
-                    + " bytes; "
+                    + " RAM bytes used; "
+                    + fstCompiler.fstSize()
+                    + " FST bytes; "
                     + fstCompiler.getNodeCount()
-                    + " nodes");
+                    + " nodes; took "
+                    + (long) ((System.nanoTime() - startTime) / 1e9)
+                    + " seconds");
           }
           if (fstCompiler.getNodeCount() > Integer.MAX_VALUE + 100L * 1024 * 1024) {
             break;


### PR DESCRIPTION
### Description

- Report the time it took for building the FST
- Report the FST actual size, as it can differ from the RAM bytes used once the test is moved to off-heap

```
100000: 39308104 RAM bytes used; 39256528 FST bytes; 19189166 nodes; took 25 seconds
200000: 78583336 RAM bytes used; 78520655 FST bytes; 38378178 nodes; took 49 seconds
300000: 117858568 RAM bytes used; 117784024 FST bytes; 57567011 nodes; took 75 seconds
400000: 157133800 RAM bytes used; 157048270 FST bytes; 76756271 nodes; took 101 seconds
```