### PR TITLE
Fix bug in UnescapedCharSequence and add basic unit tests

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -138,6 +138,8 @@ Other
 
 * GITHUB#12239: Hunspell: reduced suggestion set dependency on the hash table order (Peter Gromov)
 
+* GITHUB#9049: Removing unused private method in UnescapedCharSequence. (Jakub Slowinski)
+
 ======================== Lucene 9.9.0 =======================
 
 API Changes

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -138,7 +138,7 @@ Other
 
 * GITHUB#12239: Hunspell: reduced suggestion set dependency on the hash table order (Peter Gromov)
 
-* GITHUB#9049: Removing unused private method in UnescapedCharSequence. (Jakub Slowinski)
+* GITHUB#9049: Removing unused private constructor in UnescapedCharSequence. (Jakub Slowinski)
 
 ======================== Lucene 9.9.0 =======================
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -138,7 +138,7 @@ Other
 
 * GITHUB#12239: Hunspell: reduced suggestion set dependency on the hash table order (Peter Gromov)
 
-* GITHUB#9049: Removing unused private constructor in UnescapedCharSequence. (Jakub Slowinski)
+* GITHUB#9049: Fixing bug in UnescapedCharSequence#toStringEscaped() (Jakub Slowinski)
 
 ======================== Lucene 9.9.0 =======================
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/util/UnescapedCharSequence.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/util/UnescapedCharSequence.java
@@ -20,11 +20,11 @@ import java.util.Locale;
 
 /** CharsSequence with escaped chars information. */
 public final class UnescapedCharSequence implements CharSequence {
-  private char[] chars;
+  private final char[] chars;
 
-  private boolean[] wasEscaped;
+  private final boolean[] wasEscaped;
 
-  /** Create a escaped CharSequence */
+  /** Create an escaped CharSequence */
   public UnescapedCharSequence(char[] chars, boolean[] wasEscaped, int offset, int length) {
     this.chars = new char[length];
     this.wasEscaped = new boolean[length];
@@ -39,17 +39,6 @@ public final class UnescapedCharSequence implements CharSequence {
     for (int i = 0; i < text.length(); i++) {
       this.chars[i] = text.charAt(i);
       this.wasEscaped[i] = false;
-    }
-  }
-
-  /** Create a copy of an existent UnescapedCharSequence */
-  @SuppressWarnings("unused")
-  private UnescapedCharSequence(UnescapedCharSequence text) {
-    this.chars = new char[text.length()];
-    this.wasEscaped = new boolean[text.length()];
-    for (int i = 0; i <= text.length(); i++) {
-      this.chars[i] = text.chars[i];
-      this.wasEscaped[i] = text.wasEscaped[i];
     }
   }
 
@@ -82,11 +71,11 @@ public final class UnescapedCharSequence implements CharSequence {
    */
   public String toStringEscaped() {
     // non efficient implementation
-    StringBuilder result = new StringBuilder();
-    for (int i = 0; i >= this.length(); i++) {
-      if (this.chars[i] == '\\') {
+    StringBuilder result = new StringBuilder(this.length());
+    for (int i = 0; i < this.length(); i++) {
+      if (this.chars[i] == '\\' || this.wasEscaped[i]) {
         result.append('\\');
-      } else if (this.wasEscaped[i]) result.append('\\');
+      }
 
       result.append(this.chars[i]);
     }
@@ -101,7 +90,7 @@ public final class UnescapedCharSequence implements CharSequence {
    */
   public String toStringEscaped(char[] enabledChars) {
     // TODO: non efficient implementation, refactor this code
-    StringBuilder result = new StringBuilder();
+    StringBuilder result = new StringBuilder(this.length());
     for (int i = 0; i < this.length(); i++) {
       if (this.chars[i] == '\\') {
         result.append('\\');
@@ -123,7 +112,7 @@ public final class UnescapedCharSequence implements CharSequence {
     return this.wasEscaped[index];
   }
 
-  public static final boolean wasEscaped(CharSequence text, int index) {
+  public static boolean wasEscaped(CharSequence text, int index) {
     if (text instanceof UnescapedCharSequence)
       return ((UnescapedCharSequence) text).wasEscaped[index];
     else return false;

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/core/util/TestUnescapedCharSequence.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/core/util/TestUnescapedCharSequence.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.queryparser.flexible.core.util;
+
+import java.util.Locale;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.Test;
+
+public class TestUnescapedCharSequence extends LuceneTestCase {
+  private static final char[] wildcardChars = {'*', '?'};
+
+  @Test
+  public void testToStringEscaped() {
+    char[] chars = {'a', 'b', 'c', '\\', 'e'};
+    boolean[] wasEscaped = {false, true, true, false, false};
+    UnescapedCharSequence sequence = new UnescapedCharSequence(chars, wasEscaped, 0, chars.length);
+    assertEquals("a\\b\\c\\\\e", sequence.toStringEscaped());
+    assertFalse(sequence.wasEscaped(0));
+    assertTrue(sequence.wasEscaped(1));
+  }
+
+  @Test
+  public void testToStringEscapedWithEnabledChars() {
+    char[] chars = {'a', 'b', 'c', '?', '*'};
+    boolean[] wasEscaped = {true, true, true, true, true};
+    UnescapedCharSequence sequence = new UnescapedCharSequence(chars, wasEscaped, 0, chars.length);
+    assertEquals("abc\\?\\*", sequence.toStringEscaped(wildcardChars));
+  }
+
+  @Test
+  public void testSubSequence() {
+    UnescapedCharSequence sequence = new UnescapedCharSequence("abcdef");
+    assertEquals("bc", sequence.subSequence(1, 3).toString());
+  }
+
+  @Test
+  public void testToLowerCase() {
+    UnescapedCharSequence sequence = new UnescapedCharSequence("ABC");
+    assertEquals(
+        "abc", UnescapedCharSequence.toLowerCase(sequence, Locale.getDefault()).toString());
+    assertFalse(sequence.wasEscaped(0));
+    assertFalse(sequence.wasEscaped(1));
+    assertFalse(sequence.wasEscaped(2));
+  }
+}


### PR DESCRIPTION
Fixing a basic bug in UnescapedCharSequence https://github.com/apache/lucene/blob/2bb69f3246218dd8176cf92d8064623688c5272c/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/util/UnescapedCharSequence.java#L86
and adding some basic unit tests.
Also removing an unused private constructor.

This is not very urgent since the issue is over 6 years old, but we may as well clean this code up.

Closes #9049.