### PR TITLE
Fix intermittently failing TestSortedSetFieldSource

### DIFF
--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestSortedSetFieldSource.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestSortedSetFieldSource.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.queries.function;
 
 import java.util.Collections;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedSetDocValuesField;

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestSortedSetFieldSource.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestSortedSetFieldSource.java
@@ -17,12 +17,15 @@
 package org.apache.lucene.queries.function;
 
 import java.util.Collections;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.queries.function.valuesource.SortedSetFieldSource;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
@@ -31,13 +34,17 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedSetSortField;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
 
 public class TestSortedSetFieldSource extends LuceneTestCase {
   public void testSimple() throws Exception {
     Directory dir = newDirectory();
-    IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig(null));
+    IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+    conf.setMaxBufferedDocs(2); // generate few segments
+    conf.setMergePolicy(NoMergePolicy.INSTANCE); // prevent merges for this test
+    IndexWriter writer = new IndexWriter(dir, conf);
     Document doc = new Document();
     doc.add(new SortedSetDocValuesField("value", new BytesRef("baz")));
     doc.add(newStringField("id", "2", Field.Store.YES));
@@ -47,7 +54,6 @@ public class TestSortedSetFieldSource extends LuceneTestCase {
     doc.add(new SortedSetDocValuesField("value", new BytesRef("bar")));
     doc.add(newStringField("id", "1", Field.Store.YES));
     writer.addDocument(doc);
-    writer.forceMerge(1);
     writer.close();
 
     DirectoryReader ir = DirectoryReader.open(dir);


### PR DESCRIPTION
This commit fixes the intermittently failing TestSortedSetFieldSource.

The test assertions depend on doc order which may be affected by merging. The fix is to trivially avoid merging for the very small index, with just two docs.
