### PR TITLE
Mark DrillSideways#createDrillDownFacetsCollector as @Deprecated

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -10,6 +10,8 @@ API Changes
 * GITHUB#12243: Mark TermInSetQuery ctors with varargs terms as @Deprecated. SortedSetDocValuesField#newSlowSetQuery,
   SortedDocValuesField#newSlowSetQuery, KeywordField#newSetQuery now take a collection of terms as a param. (Jakub Slowinski)
 
+* GITHUB#12854: Mark DrillSideways#createDrillDownFacetsCollector as @Deprecated. (Greg Miller)
+
 New Features
 ---------------------
 (No changes)
@@ -28,7 +30,6 @@ Bug Fixes
 
 Other
 ---------------------
-
 * GITHUB#11023: Removing some dead code in CheckIndex. (Jakub Slowinski)
 
 ======================== Lucene 9.9.0 =======================

--- a/lucene/facet/src/java/org/apache/lucene/facet/DrillSideways.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/DrillSideways.java
@@ -133,7 +133,12 @@ public class DrillSideways {
   /**
    * Subclass can override to customize drill down facets collector. Returning {@code null} is valid
    * if no drill down facet collection is needed.
+   *
+   * @deprecated This is only used by the deprecated {@link #search(DrillDownQuery, Collector)}
+   *     entry-point. Please use {@link #search(DrillDownQuery, CollectorManager)} instead, and
+   *     leverage {@link #createDrillDownFacetsCollectorManager()} as necessary
    */
+  @Deprecated
   protected FacetsCollector createDrillDownFacetsCollector() {
     return new FacetsCollector();
   }


### PR DESCRIPTION
This extension hook is only referenced by the also-deprecated `DrillSideways#search(DrillDownQuery, Collector)`, so let's mark it deprecated as well and remove it on main.