### PR TITLE
Remove DrillSideways#createDrillDownFacetsCollector in favor of the manager-based hook

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -167,6 +167,8 @@ API Changes
   IndexSearcher#search(Query, CollectorManager) for TopFieldCollectorManager
   and TopScoreDocCollectorManager. (Zach Chen, Adrien Grand, Michael McCandless, Greg Miller, Luca Cavanna)
 
+* GITHUB#12854: Mark DrillSideways#createDrillDownFacetsCollector as @Deprecated. (Greg Miller)
+
 New Features
 ---------------------
 (No changes)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -75,6 +75,8 @@ API Changes
   (allows handling long fields with lots of hits more gracefully). MatchRegionRetriever utilizes IndexSearcher's
   executor to extract hit offsets concurrently. (Dawid Weiss)
 
+* GITHUB#12855: Remove deprecated DrillSideways#createDrillDownFacetsCollector extension method. (Greg Miller)
+
 New Features
 ---------------------
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/DrillSideways.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/DrillSideways.java
@@ -133,14 +133,6 @@ public class DrillSideways {
    * Subclass can override to customize drill down facets collector. Returning {@code null} is valid
    * if no drill down facet collection is needed.
    */
-  protected FacetsCollector createDrillDownFacetsCollector() {
-    return new FacetsCollector();
-  }
-
-  /**
-   * Subclass can override to customize drill down facets collector. Returning {@code null} is valid
-   * if no drill down facet collection is needed.
-   */
   protected FacetsCollectorManager createDrillDownFacetsCollectorManager() {
     return new FacetsCollectorManager();
   }

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -1984,11 +1984,6 @@ public class TestDrillSideways extends FacetTestCase {
     DrillSideways ds =
         new DrillSideways(searcher, config, taxoReader, null, executorService) {
           @Override
-          protected FacetsCollector createDrillDownFacetsCollector() {
-            return null;
-          }
-
-          @Override
           protected FacetsCollectorManager createDrillDownFacetsCollectorManager() {
             return null;
           }


### PR DESCRIPTION
This extension hook is no longer used on the main branch, so let's remove it. Opened a corresponding PR to mark this deprecated on 9x (#12854)

More specifically, the `DrillSideways` class used to delegate to this method for creating the drill-down collector, but a while back was switched over to delegating to `createDrillDownFacetsCollectorManager` instead (doing "manger-based" collection instead). So users can still override the drill-down collection behavior, but they have to use `createDrillDownFacetsCollectorManager`, not `createDrillDownFacetsCollector`. Since nothing actually delegates to `createDrillDownFacetsCollector`, this is really trappy for users.