### PR TITLE
[Minor] Fix the only use of java.lang.String#toLowerCase() with no Locale

### DIFF
--- a/buildSrc/src/main/java/org/apache/lucene/gradle/Checksum.java
+++ b/buildSrc/src/main/java/org/apache/lucene/gradle/Checksum.java
@@ -190,6 +190,6 @@ public class Checksum extends DefaultTask {
 
   private FileCollection filesFor(final Algorithm algo) {
     return getProject()
-        .fileTree(getOutputDir(), files -> files.include("**/*." + algo.toString().toLowerCase()));
+        .fileTree(getOutputDir(), files -> files.include("**/*." + algo.toString().toLowerCase(Locale.ROOT)));
   }
 }


### PR DESCRIPTION
I was looking at this old issue: https://github.com/apache/lucene/issues/4390 `Flexible Queryparser has some Locale violation with lowercasing`, which was already fixed with the work done in https://github.com/apache/lucene/issues/5271. But I came across this single use of `.toLowerCase()` with no Locale in Checksum.java.

TIL: forbidden apis doesn't run against the `package org.apache.lucene.gradle`.

