### PR TITLE
Avoid null PointValues when merging points in SlowCompositeCodecReaderWrapper

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
@@ -558,7 +558,7 @@ final class SlowCompositeCodecReaderWrapper extends CodecReader {
     private final int docBase;
 
     PointValuesSub(PointValues sub, int docBase) {
-      this.sub = sub;
+      this.sub = Objects.requireNonNull(sub);
       this.docBase = docBase;
     }
   }
@@ -599,7 +599,11 @@ final class SlowCompositeCodecReaderWrapper extends CodecReader {
         FieldInfo fi = codecReaders[i].getFieldInfos().fieldInfo(field);
         if (fi != null && fi.getPointDimensionCount() > 0) {
           PointValues v = readers[i].getValues(field);
-          values.add(new PointValuesSub(v, docStarts[i]));
+          if (v != null) {
+            // Apparently FieldInfo can claim a field has points, yet the returned
+            // PointValues is null
+            values.add(new PointValuesSub(v, docStarts[i]));
+          }
         }
       }
       if (values.isEmpty()) {

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.KnnVectorsReader;
@@ -77,7 +78,7 @@ public final class SortingCodecReader extends FilterCodecReader {
     private final Sorter.DocMap docMap;
 
     SortingPointValues(final PointValues in, Sorter.DocMap docMap) {
-      this.in = in;
+      this.in = Objects.requireNonNull(in);
       this.docMap = docMap;
     }
 
@@ -472,6 +473,10 @@ public final class SortingCodecReader extends FilterCodecReader {
 
       @Override
       public PointValues getValues(String field) throws IOException {
+        var values = delegate.getValues(field);
+        if (values == null) {
+          return null;
+        }
         return new SortingPointValues(delegate.getValues(field), docMap);
       }
 


### PR DESCRIPTION
Just adds a null check when gathering the sub-`PointValues` in `SlowCompositePointsReaderWrapper.getValues`.

This is a disagreement in what the `FieldInfo` says (that this field has points) versus what the underlying `AssertingPointsReader` (in this case) `getValues` returns for this field (`null`).

Closes #12858.