### PR TITLE
Add simple tool to diff entries in lucene's CHANGES.txt that should be identical

### DIFF
--- a/dev-tools/scripts/diff_lucene_changes.py
+++ b/dev-tools/scripts/diff_lucene_changes.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.request
+
+'''
+A simple tool to see diffs between main's version of CHANGES.txt entries for
+a given release vs the stable branch's version.  It's best to keep these 1)
+identical and 2) matching what changes were actually backported to be honest
+to users and avoid future annoying conflicts on backport.
+'''
+
+# e.g. python3 -u diff_lucene_changes.py branch_9_9 main 9.9.0
+
+#
+
+def get_changes_url(branch_name):
+  if os.path.isdir(branch_name):
+    url = f'file://{branch_name}/lucene/CHANGES.txt'
+  else:
+    url = f'https://raw.githubusercontent.com/apache/lucene/{branch_name}/lucene/CHANGES.txt'
+  print(f'NOTE: resolving {branch_name} --> {url}')
+  return url
+
+def extract_release_section(changes_txt, release_name):
+  open('/x/tmp/foo.txt', 'wb').write(changes_txt)
+  return re.search(f'=======+ Lucene {re.escape(release_name)} =======+(.*?)=======+ Lucene .*? =======+$',
+                   changes_txt.decode('utf-8'), re.MULTILINE | re.DOTALL).group(1).encode('utf-8')
+
+def main():
+  if len(sys.argv) < 3 or len(sys.argv) > 5:
+    print('\nUsage: python3 -u dev-tools/scripts/diff_lucene_changes.py <branch1-or-local-clone> <branch2-or-local-clone> <release-name> [diff-commandline-extras]\n')
+    print('  e.g.: python3 -u dev-tools/scripts/diff_lucene_changes.py branch_9_9 /l/trunk 9.9.0 "-w"\n')
+    sys.exit(1)
+
+  branch1 = sys.argv[1]
+  branch2 = sys.argv[2]
+  release_name = sys.argv[3]
+
+  if len(sys.argv) > 4:
+    diff_cl_extras = [sys.argv[4]]
+  else:
+    diff_cl_extras = []
+
+  branch1_changes = extract_release_section(urllib.request.urlopen(get_changes_url(branch1)).read(),
+                                            release_name)
+  branch2_changes = extract_release_section(urllib.request.urlopen(get_changes_url(branch2)).read(),
+                                            release_name)
+
+  with tempfile.NamedTemporaryFile() as f1, tempfile.NamedTemporaryFile() as f2:
+    f1.write(branch1_changes)
+    f2.write(branch2_changes)
+
+    command = ['diff'] + diff_cl_extras + [f1.name, f2.name]
+
+    # diff returns non-zero exit status when there are diffs, so don't pass check=True
+    print(subprocess.run(command, check=False, capture_output=True).stdout.decode('utf-8'))
+
+if __name__ == '__main__':
+  main()

--- a/dev-tools/scripts/diff_lucene_changes.py
+++ b/dev-tools/scripts/diff_lucene_changes.py
@@ -42,7 +42,6 @@ def get_changes_url(branch_name):
   return url
 
 def extract_release_section(changes_txt, release_name):
-  open('/x/tmp/foo.txt', 'wb').write(changes_txt)
   return re.search(f'=======+ Lucene {re.escape(release_name)} =======+(.*?)=======+ Lucene .*? =======+$',
                    changes_txt.decode('utf-8'), re.MULTILINE | re.DOTALL).group(1).encode('utf-8')
 


### PR DESCRIPTION
I had thought we had some tooling around this already but couldn't find it so I wrote it (again maybe!).

It's a simple tool: you pass in two branches to compare.  The branch can be a branch name from git, or a path in your local filesystem to a `lucene` clone, and the version name you are checking.  The tool extracts the section of each `CHANGES.txt` matching that version name and runs the local `diff` command.  You can also pass extra `diff` command-line args (I find `-w` helpful).

E.g. for release 9.9.0 underway now, I run this:

```
raptorlake:trunk[diff_lucene_changes]$ python3 -u dev-tools/scripts/diff_lucene_changes.py branch_9_9 main 9.9.0 "-w"
```

And it finds these differences:

```
NOTE: resolving branch_9_9 --> https://raw.githubusercontent.com/apache/lucene/branch_9_9/lucene/CHANGES.txt
NOTE: resolving main --> https://raw.githubusercontent.com/apache/lucene/main/lucene/CHANGES.txt
15a16,18
> * GITHUB#12646, GITHUB#12690: Move FST#addNode to FSTCompiler to avoid a circular dependency
>   between FST and FSTCompiler (Anh Dung Bui)
>
27,30c30
< * GITHUB#12646, GITHUB#12690: Move FST#addNode to FSTCompiler to avoid a circular dependency
<   between FST and FSTCompiler (Anh Dung Bui)
<
< * GITHUB#12709 Consolidate FSTStore and BytesStore in FST. Created FSTReader which contains the common methods
---
> * GITHUB#12709: Consolidate FSTStore and BytesStore in FST. Created FSTReader which contains the common methods
33,34d32
< * GITHUB#12735: Remove FSTCompiler#getTermCount() and FSTCompiler.UnCompiledNode#inputCount (Anh Dung Bui)
<
37a36,37
> * GITHUB#12735: Remove FSTCompiler#getTermCount() and FSTCompiler.UnCompiledNode#inputCount (Anh Dung Bui)
>
166a167,168
> * GITHUB#12748: Specialize arc store for continuous label in FST. (Guo Feng, Zhang Chao)
>
173,177d174
< * GITHUB#12748: Specialize arc store for continuous label in FST. (Guo Feng, Chao Zhang)
<
< * GITHUB#12825, GITHUB#12834: Hunspell: improved dictionary loading performance, allowed in-memory entry sorting.
<   (Peter Gromov)
<
185,186d181
<
< * GITHUB#12552: Make FSTPostingsFormat load FSTs off-heap. (Tony X)
```

I think these are mostly minor and @ChrisHegarty you can copy the 9.9.x CHANGES.txt entry for Lucene 9.9.0 over onto `main` so they are in sync again.

The one minor issue I see is a missing `:` in this line on 9.9.x:

```
* GITHUB#12709 Consolidate FSTStore and BytesStore in FST. Created FSTReader which contains the common methods
```

I'm not sure whether our changesToHTML cares about that missing `:`?