### PR TITLE
Fix intermittently failing TestParallelLeafReader

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestParallelLeafReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestParallelLeafReader.java
@@ -301,7 +301,11 @@ public class TestParallelLeafReader extends LuceneTestCase {
 
   private Directory getDir1(Random random) throws IOException {
     Directory dir1 = newDirectory();
-    IndexWriter w1 = new IndexWriter(dir1, newIndexWriterConfig(new MockAnalyzer(random)));
+    IndexWriterConfig conf =
+        newIndexWriterConfig(new MockAnalyzer(random()))
+            .setMaxBufferedDocs(2) // generate few segments
+            .setMergePolicy(NoMergePolicy.INSTANCE); // prevent merges for this test
+    IndexWriter w1 = new IndexWriter(dir1, conf);
     Document d1 = new Document();
     d1.add(newTextField("f1", "v1", Field.Store.YES));
     d1.add(newTextField("f2", "v1", Field.Store.YES));
@@ -310,14 +314,17 @@ public class TestParallelLeafReader extends LuceneTestCase {
     d2.add(newTextField("f1", "v2", Field.Store.YES));
     d2.add(newTextField("f2", "v2", Field.Store.YES));
     w1.addDocument(d2);
-    w1.forceMerge(1);
     w1.close();
     return dir1;
   }
 
   private Directory getDir2(Random random) throws IOException {
     Directory dir2 = newDirectory();
-    IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig(new MockAnalyzer(random)));
+    IndexWriterConfig conf =
+        newIndexWriterConfig(new MockAnalyzer(random()))
+            .setMaxBufferedDocs(2) // generate few segments
+            .setMergePolicy(NoMergePolicy.INSTANCE); // prevent merges for this test
+    IndexWriter w2 = new IndexWriter(dir2, conf);
     Document d3 = new Document();
     d3.add(newTextField("f3", "v1", Field.Store.YES));
     d3.add(newTextField("f4", "v1", Field.Store.YES));
@@ -326,7 +333,6 @@ public class TestParallelLeafReader extends LuceneTestCase {
     d4.add(newTextField("f3", "v2", Field.Store.YES));
     d4.add(newTextField("f4", "v2", Field.Store.YES));
     w2.addDocument(d4);
-    w2.forceMerge(1);
     w2.close();
     return dir2;
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestParallelLeafReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestParallelLeafReader.java
@@ -302,8 +302,7 @@ public class TestParallelLeafReader extends LuceneTestCase {
   private Directory getDir1(Random random) throws IOException {
     Directory dir1 = newDirectory();
     IndexWriterConfig conf =
-        newIndexWriterConfig(new MockAnalyzer(random()))
-            .setMergePolicy(new LogDocMergePolicy());
+        newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(new LogDocMergePolicy());
     IndexWriter w1 = new IndexWriter(dir1, conf);
     Document d1 = new Document();
     d1.add(newTextField("f1", "v1", Field.Store.YES));
@@ -321,8 +320,7 @@ public class TestParallelLeafReader extends LuceneTestCase {
   private Directory getDir2(Random random) throws IOException {
     Directory dir2 = newDirectory();
     IndexWriterConfig conf =
-        newIndexWriterConfig(new MockAnalyzer(random()))
-            .setMergePolicy(new LogDocMergePolicy());
+        newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(new LogDocMergePolicy());
     IndexWriter w2 = new IndexWriter(dir2, conf);
     Document d3 = new Document();
     d3.add(newTextField("f3", "v1", Field.Store.YES));

--- a/lucene/core/src/test/org/apache/lucene/index/TestParallelLeafReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestParallelLeafReader.java
@@ -303,8 +303,7 @@ public class TestParallelLeafReader extends LuceneTestCase {
     Directory dir1 = newDirectory();
     IndexWriterConfig conf =
         newIndexWriterConfig(new MockAnalyzer(random()))
-            .setMaxBufferedDocs(2) // generate few segments
-            .setMergePolicy(NoMergePolicy.INSTANCE); // prevent merges for this test
+            .setMergePolicy(new LogDocMergePolicy());
     IndexWriter w1 = new IndexWriter(dir1, conf);
     Document d1 = new Document();
     d1.add(newTextField("f1", "v1", Field.Store.YES));
@@ -314,6 +313,7 @@ public class TestParallelLeafReader extends LuceneTestCase {
     d2.add(newTextField("f1", "v2", Field.Store.YES));
     d2.add(newTextField("f2", "v2", Field.Store.YES));
     w1.addDocument(d2);
+    w1.forceMerge(1);
     w1.close();
     return dir1;
   }
@@ -322,8 +322,7 @@ public class TestParallelLeafReader extends LuceneTestCase {
     Directory dir2 = newDirectory();
     IndexWriterConfig conf =
         newIndexWriterConfig(new MockAnalyzer(random()))
-            .setMaxBufferedDocs(2) // generate few segments
-            .setMergePolicy(NoMergePolicy.INSTANCE); // prevent merges for this test
+            .setMergePolicy(new LogDocMergePolicy());
     IndexWriter w2 = new IndexWriter(dir2, conf);
     Document d3 = new Document();
     d3.add(newTextField("f3", "v1", Field.Store.YES));
@@ -333,6 +332,7 @@ public class TestParallelLeafReader extends LuceneTestCase {
     d4.add(newTextField("f3", "v2", Field.Store.YES));
     d4.add(newTextField("f4", "v2", Field.Store.YES));
     w2.addDocument(d4);
+    w2.forceMerge(1);
     w2.close();
     return dir2;
   }


### PR DESCRIPTION
This commit fixes the intermittently failing TestParallelLeafReader.

The ParallelLeafReader requires the document order to be consistent across indexes - each document contains the union of the fields of all documents with the same document number. The test asserts this. But now, with MockRandomMergePolicy potentially reversing the doc ID order while merging, this invalidates the assumption of the test indexes and assertions. The solution is to just ensure that no merging actually happens in these tiny test indexes.

Similar root cause as #12850.