### PR TITLE
[Minor] Shorten getOrdinal synchronized loop

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -165,7 +165,8 @@ New Features
 
 Improvements
 ---------------------
-(No changes)
+
+* GITHUB#12870: Tighten synchronized loop in DirectoryTaxonomyReader#getOrdinal. (Stefan Vodita)
 
 Optimizations
 ---------------------

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/DirectoryTaxonomyReader.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/DirectoryTaxonomyReader.java
@@ -279,21 +279,22 @@ public class DirectoryTaxonomyReader extends TaxonomyReader implements Accountab
     }
 
     // First try to find the answer in the LRU cache:
+    Integer res;
     synchronized (ordinalCache) {
-      Integer res = ordinalCache.get(cp);
-      if (res != null) {
-        if (res < indexReader.maxDoc()) {
-          // Since the cache is shared with DTR instances allocated from
-          // doOpenIfChanged, we need to ensure that the ordinal is one that
-          // this DTR instance recognizes.
-          return res;
-        } else {
-          // if we get here, it means that the category was found in the cache,
-          // but is not recognized by this TR instance. Therefore, there's no
-          // need to continue search for the path on disk, because we won't find
-          // it there too.
-          return TaxonomyReader.INVALID_ORDINAL;
-        }
+      res = ordinalCache.get(cp);
+    }
+    if (res != null) {
+      if (res < indexReader.maxDoc()) {
+        // Since the cache is shared with DTR instances allocated from
+        // doOpenIfChanged, we need to ensure that the ordinal is one that
+        // this DTR instance recognizes.
+        return res;
+      } else {
+        // if we get here, it means that the category was found in the cache,
+        // but is not recognized by this TR instance. Therefore, there's no
+        // need to continue search for the path on disk, because we won't find
+        // it there too.
+        return TaxonomyReader.INVALID_ORDINAL;
       }
     }
 


### PR DESCRIPTION
### Description

`DirectoryTaxonomyReader.getOrdinal` seems to have a wider synchronized loop than needed when checking if the label we've asked about exists in the cache. `getBulkOrdinal` already has a [smaller corresponding synchronized loop](https://github.com/apache/lucene/blob/65d30ca1af15ecbec28618338aebe097e5516afc/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/DirectoryTaxonomyReader.java#L336).
