### PR TITLE
Remove some redundant modifiers from code

### DIFF
--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/TestCompoundWordTokenFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/TestCompoundWordTokenFilter.java
@@ -528,7 +528,7 @@ public class TestCompoundWordTokenFilter extends BaseTokenStreamTestCase {
     assertTokenStreamContents(tf8, new String[] {"fußball"});
   }
 
-  public static interface MockRetainAttribute extends Attribute {
+  public interface MockRetainAttribute extends Attribute {
     void setRetain(boolean attr);
 
     boolean getRetain();

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -3216,7 +3216,7 @@ public final class CheckIndex implements Closeable {
   }
 
   @FunctionalInterface
-  private static interface DocValuesIteratorSupplier {
+  private interface DocValuesIteratorSupplier {
     DocValuesIterator get(FieldInfo fi) throws IOException;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexReader.java
@@ -112,7 +112,7 @@ public abstract sealed class IndexReader implements Closeable permits CompositeR
    *
    * @lucene.experimental
    */
-  public static interface CacheHelper {
+  public interface CacheHelper {
 
     /**
      * Get a key that the resource can be cached on. The given entry can be compared using identity,
@@ -139,7 +139,7 @@ public abstract sealed class IndexReader implements Closeable permits CompositeR
    * @lucene.experimental
    */
   @FunctionalInterface
-  public static interface ClosedListener {
+  public interface ClosedListener {
     /**
      * Invoked when the resource (segment core, or index reader) that is being cached on is closed.
      */

--- a/lucene/core/src/java/org/apache/lucene/index/IndexableField.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexableField.java
@@ -34,10 +34,10 @@ import org.apache.lucene.util.BytesRef;
 public interface IndexableField {
 
   /** Field name */
-  public String name();
+  String name();
 
   /** {@link IndexableFieldType} describing the properties of this field. */
-  public IndexableFieldType fieldType();
+  IndexableFieldType fieldType();
 
   /**
    * Creates the TokenStream used for indexing this field. If appropriate, implementations should
@@ -52,13 +52,13 @@ public interface IndexableField {
    * @return TokenStream value for indexing the document. Should always return a non-null value if
    *     the field is to be indexed
    */
-  public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse);
+  TokenStream tokenStream(Analyzer analyzer, TokenStream reuse);
 
   /** Non-null if this field has a binary value */
-  public BytesRef binaryValue();
+  BytesRef binaryValue();
 
   /** Non-null if this field has a string value */
-  public String stringValue();
+  String stringValue();
 
   /** Non-null if this field has a string value */
   default CharSequence getCharSequenceValue() {
@@ -66,20 +66,20 @@ public interface IndexableField {
   }
 
   /** Non-null if this field has a Reader value */
-  public Reader readerValue();
+  Reader readerValue();
 
   /** Non-null if this field has a numeric value */
-  public Number numericValue();
+  Number numericValue();
 
   /**
    * Stored value. This method is called to populate stored fields and must return a non-null value
    * if the field stored.
    */
-  public StoredValue storedValue();
+  StoredValue storedValue();
 
   /**
    * Describes how this field should be inverted. This must return a non-null value if the field
    * indexes terms and postings.
    */
-  public InvertableType invertableType();
+  InvertableType invertableType();
 }

--- a/lucene/core/src/java/org/apache/lucene/index/TwoPhaseCommit.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TwoPhaseCommit.java
@@ -31,19 +31,19 @@ public interface TwoPhaseCommit {
    * method, but avoid actual committing changes. If the 2-phase commit fails, {@link #rollback()}
    * is called to discard all changes since last successful commit.
    */
-  public long prepareCommit() throws IOException;
+  long prepareCommit() throws IOException;
 
   /**
    * The second phase of a 2-phase commit. Implementations should ideally do very little work in
    * this method (following {@link #prepareCommit()}, and after it returns, the caller can assume
    * that the changes were successfully committed to the underlying storage.
    */
-  public long commit() throws IOException;
+  long commit() throws IOException;
 
   /**
    * Discards any changes that have occurred since the last commit. In a 2-phase commit algorithm,
    * where one of the objects failed to {@link #commit()} or {@link #prepareCommit()}, this method
    * is used to roll all other objects back to their previous state.
    */
-  public void rollback() throws IOException;
+  void rollback() throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/search/similarities/LMSimilarity.java
+++ b/lucene/core/src/java/org/apache/lucene/search/similarities/LMSimilarity.java
@@ -121,12 +121,12 @@ public abstract class LMSimilarity extends SimilarityBase {
   }
 
   /** A strategy for computing the collection language model. */
-  public static interface CollectionModel {
+  public interface CollectionModel {
     /**
      * Computes the probability {@code p(w|C)} according to the language model strategy for the
      * current term.
      */
-    public double computeProbability(BasicStats stats);
+    double computeProbability(BasicStats stats);
 
     /** The name of the collection model strategy. */
     public String getName();

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferGuard.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferGuard.java
@@ -39,7 +39,7 @@ final class ByteBufferGuard {
    * this to allow unmapping of bytebuffers with private Java APIs.
    */
   @FunctionalInterface
-  static interface BufferCleaner {
+  interface BufferCleaner {
     void freeBuffer(String resourceDescription, ByteBuffer b) throws IOException;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -264,7 +264,7 @@ public class MMapDirectory extends FSDirectory {
    */
   public static final String UNMAP_NOT_SUPPORTED_REASON;
 
-  static interface MMapIndexInputProvider {
+  interface MMapIndexInputProvider {
     IndexInput openInput(Path path, IOContext context, int chunkSizePower, boolean preload)
         throws IOException;
 

--- a/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
@@ -26,14 +26,14 @@ import org.apache.lucene.util.BitUtil; // javadocs
 public interface RandomAccessInput {
 
   /** The number of bytes in the file. */
-  public long length();
+  long length();
 
   /**
    * Reads a byte at the given position in the file
    *
    * @see DataInput#readByte
    */
-  public byte readByte(long pos) throws IOException;
+  byte readByte(long pos) throws IOException;
 
   /**
    * Reads a specified number of bytes starting at a given position into an array at the specified
@@ -53,7 +53,7 @@ public interface RandomAccessInput {
    * @see DataInput#readShort
    * @see BitUtil#VH_LE_SHORT
    */
-  public short readShort(long pos) throws IOException;
+  short readShort(long pos) throws IOException;
 
   /**
    * Reads an integer (LE byte order) at the given position in the file
@@ -61,7 +61,7 @@ public interface RandomAccessInput {
    * @see DataInput#readInt
    * @see BitUtil#VH_LE_INT
    */
-  public int readInt(long pos) throws IOException;
+  int readInt(long pos) throws IOException;
 
   /**
    * Reads a long (LE byte order) at the given position in the file
@@ -69,5 +69,5 @@ public interface RandomAccessInput {
    * @see DataInput#readLong
    * @see BitUtil#VH_LE_LONG
    */
-  public long readLong(long pos) throws IOException;
+  long readLong(long pos) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
@@ -714,7 +714,7 @@ public final class ArrayUtil {
 
   /** Comparator for a fixed number of bytes. */
   @FunctionalInterface
-  public static interface ByteArrayComparator {
+  public interface ByteArrayComparator {
 
     /**
      * Compare bytes starting from the given offsets. The return value has the same contract as

--- a/lucene/core/src/java/org/apache/lucene/util/AttributeReflector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/AttributeReflector.java
@@ -30,5 +30,5 @@ public interface AttributeReflector {
    * method once using {@code org.apache.lucene.analysis.tokenattributes.CharTermAttribute.class} as
    * attribute class, {@code "term"} as key and the actual value as a String.
    */
-  public void reflect(Class<? extends Attribute> attClass, String key, Object value);
+  void reflect(Class<? extends Attribute> attClass, String key, Object value);
 }

--- a/lucene/core/src/java/org/apache/lucene/util/ClassLoaderUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ClassLoaderUtils.java
@@ -32,7 +32,7 @@ public interface ClassLoaderUtils {
    * returned (this is fine, because if we get a {@code SecurityException} it is for sure no
    * parent).
    */
-  public static boolean isParentClassLoader(final ClassLoader parent, final ClassLoader child) {
+  static boolean isParentClassLoader(final ClassLoader parent, final ClassLoader child) {
     try {
       ClassLoader cl = child;
       while (cl != null) {

--- a/lucene/core/src/java/org/apache/lucene/util/NamedSPILoader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/NamedSPILoader.java
@@ -127,7 +127,7 @@ public final class NamedSPILoader<S extends NamedSPILoader.NamedSPI> implements 
    *
    * <p>Names must be all ascii alphanumeric, and less than 128 characters in length.
    */
-  public static interface NamedSPI {
+  public interface NamedSPI {
     String getName();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/ResourceLoader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ResourceLoader.java
@@ -23,14 +23,14 @@ import java.io.InputStream;
 public interface ResourceLoader {
 
   /** Opens a named resource */
-  public InputStream openResource(String resource) throws IOException;
+  InputStream openResource(String resource) throws IOException;
 
   /** Finds class of the name and expected type */
-  public <T> Class<? extends T> findClass(String cname, Class<T> expectedType);
+  <T> Class<? extends T> findClass(String cname, Class<T> expectedType);
 
   /** Creates an instance of the name and expected type */
   // TODO: fix exception handling
-  public default <T> T newInstance(String cname, Class<T> expectedType) {
+  default <T> T newInstance(String cname, Class<T> expectedType) {
     Class<? extends T> clazz = findClass(cname, expectedType);
     try {
       return clazz.getConstructor().newInstance();

--- a/lucene/core/src/java/org/apache/lucene/util/RollingBuffer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RollingBuffer.java
@@ -24,8 +24,8 @@ package org.apache.lucene.util;
 public abstract class RollingBuffer<T extends RollingBuffer.Resettable> {
 
   /** Implement to reset an instance */
-  public static interface Resettable {
-    public void reset();
+  public interface Resettable {
+    void reset();
   }
 
   @SuppressWarnings("unchecked")

--- a/lucene/core/src/java/org/apache/lucene/util/Unwrappable.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Unwrappable.java
@@ -29,7 +29,7 @@ public interface Unwrappable<T> {
 
   /** Unwraps all {@code Unwrappable}s around the given object. */
   @SuppressWarnings("unchecked")
-  public static <T> T unwrapAll(T o) {
+  static <T> T unwrapAll(T o) {
     while (o instanceof Unwrappable) {
       o = ((Unwrappable<T>) o).unwrap();
     }

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/AutomatonProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/AutomatonProvider.java
@@ -45,5 +45,5 @@ public interface AutomatonProvider {
    * @return automaton
    * @throws IOException if errors occur
    */
-  public Automaton getAutomaton(String name) throws IOException;
+  Automaton getAutomaton(String name) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDUtil.java
@@ -68,7 +68,7 @@ final class BKDUtil {
 
   /** Predicate for a fixed number of bytes. */
   @FunctionalInterface
-  public static interface ByteArrayPredicate {
+  public interface ByteArrayPredicate {
 
     /** Test bytes starting from the given offsets. */
     boolean test(byte[] a, int aOffset, byte[] b, int bOffset);

--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
@@ -120,7 +120,7 @@ public class PackedInts {
       throw new IllegalArgumentException("Unknown format id: " + id);
     }
 
-    private Format(int id) {
+    Format(int id) {
       this.id = id;
     }
 
@@ -231,7 +231,7 @@ public class PackedInts {
   }
 
   /** A decoder for packed integers. */
-  public static interface Decoder {
+  public interface Decoder {
 
     /**
      * The minimum number of long blocks to encode in a single iteration, when using long encoding.
@@ -299,7 +299,7 @@ public class PackedInts {
   }
 
   /** An encoder for packed integers. */
-  public static interface Encoder {
+  public interface Encoder {
 
     /**
      * The minimum number of long blocks to encode in a single iteration, when using long encoding.
@@ -400,7 +400,7 @@ public class PackedInts {
   }
 
   /** Run-once iterator interface, to decode previously saved PackedInts. */
-  public static interface ReaderIterator {
+  public interface ReaderIterator {
     /** Returns next value */
     long next() throws IOException;
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
@@ -221,7 +221,7 @@ public class TestBoolean2 extends LuceneTestCase {
     bigSearcher = null;
   }
 
-  private static String[] docFields = {
+  private static final String[] docFields = {
     "w1 w2 w3 w4 w5", "w1 w3 w2 w3", "w1 xx w2 yy w3", "w1 w3 xx w2 yy mm"
   };
 
@@ -423,8 +423,8 @@ public class TestBoolean2 extends LuceneTestCase {
 
   // used to set properties or change every BooleanQuery
   // generated from randBoolQuery.
-  public static interface Callback {
-    public void postCreate(BooleanQuery.Builder q);
+  public interface Callback {
+    void postCreate(BooleanQuery.Builder q);
   }
 
   // Random rnd is passed in so that the exact same random query may be created

--- a/lucene/join/src/java/org/apache/lucene/search/join/DocValuesTermsCollector.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DocValuesTermsCollector.java
@@ -27,7 +27,7 @@ import org.apache.lucene.search.SimpleCollector;
 abstract class DocValuesTermsCollector<DV> extends SimpleCollector {
 
   @FunctionalInterface
-  static interface Function<R> {
+  interface Function<R> {
     R apply(LeafReader t) throws IOException;
   }
 

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/core/builders/TestQueryTreeBuilder.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/core/builders/TestQueryTreeBuilder.java
@@ -41,7 +41,7 @@ public class TestQueryTreeBuilder extends LuceneTestCase {
     assertEquals("OK", result);
   }
 
-  private static interface DummyQueryNodeInterface extends QueryNode {}
+  private interface DummyQueryNodeInterface extends QueryNode {}
 
   private abstract static class AbstractDummyQueryNode extends QueryNodeImpl
       implements DummyQueryNodeInterface {}

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/NumberRangePrefixTree.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/NumberRangePrefixTree.java
@@ -80,17 +80,17 @@ public abstract class NumberRangePrefixTree extends SpatialPrefixTree {
    *
    * @lucene.experimental
    */
-  public static interface NRShape extends Shape, Cloneable {
+  public interface NRShape extends Shape, Cloneable {
     /** The result should be parseable by {@link #parseShape(String)}. */
     @Override
-    abstract String toString();
+    String toString();
 
     /**
      * Returns this shape rounded to the target level. If we are already more course than the level
      * then the shape is simply returned. The result may refer to internal state of the argument so
      * you may want to clone it.
      */
-    public NRShape roundToLevel(int targetLevel);
+    NRShape roundToLevel(int targetLevel);
   }
 
   //
@@ -234,7 +234,7 @@ public abstract class NumberRangePrefixTree extends SpatialPrefixTree {
    *
    * @lucene.experimental
    */
-  public static interface UnitNRShape extends NRShape, Comparable<UnitNRShape> {
+  public interface UnitNRShape extends NRShape, Comparable<UnitNRShape> {
     // note: formerly known as LevelledValue; thus some variables still use 'lv'
 
     /** Get the prefix tree level, the higher the more precise. 0 means the world (universe). */

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoComplexPolygon.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoComplexPolygon.java
@@ -1120,12 +1120,12 @@ class GeoComplexPolygon extends GeoBasePolygon {
    * into the traversal method of a tree, and each edge that matches will cause this object to be
    * called.
    */
-  private static interface EdgeIterator {
+  private interface EdgeIterator {
     /**
      * @param edge is the edge that matched.
      * @return true if the iteration should continue, false otherwise.
      */
-    public boolean matches(final Edge edge);
+    boolean matches(final Edge edge);
   }
 
   /**
@@ -1133,16 +1133,16 @@ class GeoComplexPolygon extends GeoBasePolygon {
    * implementing this interface into the traversal method of a tree, and each edge that matches
    * will cause this object to be called.
    */
-  private static interface CountingEdgeIterator extends EdgeIterator {
+  private interface CountingEdgeIterator extends EdgeIterator {
     /**
      * @return the number of edges that were crossed.
      */
-    public int getCrossingCount();
+    int getCrossingCount();
 
     /**
      * @return true if the endpoint was on an edge.
      */
-    public boolean isOnEdge();
+    boolean isOnEdge();
   }
 
   /**

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/SuggestRebuildTestUtil.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/SuggestRebuildTestUtil.java
@@ -100,8 +100,8 @@ public final class SuggestRebuildTestUtil {
    * Simple marker interface to allow {@link #testLookupsDuringReBuild} callbacks to throw
    * Exceptions
    */
-  public static interface ExceptionalCallback {
-    public void check(final Lookup suggester) throws Exception;
+  public interface ExceptionalCallback {
+    void check(final Lookup suggester) throws Exception;
   }
 
   /**

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/BaseTokenStreamTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/BaseTokenStreamTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
    * Attribute that records if it was cleared or not. This is used for testing that
    * clearAttributes() was called correctly.
    */
-  public static interface CheckClearAttributesAttribute extends Attribute {
+  public interface CheckClearAttributesAttribute extends Attribute {
     boolean getAndResetClearCalled();
   }
 
@@ -129,7 +129,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
 
     @Override
     public void copyTo(AttributeImpl target) {
-      ((CheckClearAttributesAttributeImpl) target).clear();
+      target.clear();
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleIgnoreTestSuites.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleIgnoreTestSuites.java
@@ -30,7 +30,7 @@ import org.junit.runners.model.Statement;
  */
 public final class TestRuleIgnoreTestSuites implements TestRule {
   /** Marker interface for nested suites that should be ignored if executed in stand-alone mode. */
-  public static interface NestedTestSuite {}
+  public interface NestedTestSuite {}
 
   /** A boolean system property indicating nested suites should be executed normally. */
   public static final String PROPERTY_RUN_NESTED = "tests.runnested";

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleLimitSysouts.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleLimitSysouts.java
@@ -140,7 +140,7 @@ public class TestRuleLimitSysouts extends TestRuleAdapter {
   /** Test failures from any tests or rules before. */
   private final TestRuleMarkFailure failureMarker;
 
-  static interface LimitPredicate {
+  interface LimitPredicate {
     void check(long before, long after) throws IOException;
   }
 


### PR DESCRIPTION
### Description

This PR removes(or cleans up) some of the redundant modifiers from the code. Addresses the below warning in my IDE :

- Modifier ‘static’ is redundant for inner interfaces
- Modifier ‘public’ is redundant for interface members
- Modifier 'abstract' is redundant for interface methods
- Modifier ‘private’ is redundant for enum constructors

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
