### PR TITLE
Bump Yetus version to 0.15.0

### DIFF
--- a/dev-tools/test-patch/jenkins-precommit-script.sh
+++ b/dev-tools/test-patch/jenkins-precommit-script.sh
@@ -39,7 +39,7 @@ mkdir -p "${ARTIFACTS}"
 
 PIDMAX=10000 # Arbitrary limit; may need to revisit
 
-YETUS_RELEASE=0.7.0
+YETUS_RELEASE=0.15.0
 YETUS_TARBALL="yetus-${YETUS_RELEASE}.tar.gz"
 echo "Downloading Yetus ${YETUS_RELEASE}"
 curl -L "https://api.github.com/repos/apache/yetus/tarball/rel/${YETUS_RELEASE}" -o "${YETUS_TARBALL}"


### PR DESCRIPTION
### Description

Refer to https://github.com/apache/lucene/issues/9561

Latest Yetus version is 0.15.0 which is released at 2023/12/02.

https://github.com/apache/yetus/releases/tag/rel%2F0.15.0


<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
