### PR TITLE
Add test that tickles a JVM JIT crash on JDK's less than 21.0.1

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 17
+        java-version: 21
         java-package: jdk
     - name: Prepare caches
       uses: ./.github/actions/gradle-caches

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -25,7 +25,7 @@ jobs:
         # Operating systems to run on.
         os: [ubuntu-latest]
         # Test JVMs.
-        java: [ '17' ]
+        java: [ '21' ]
 
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
         # macos-latest: a tad slower than ubuntu and pretty much the same (?) so leaving out.
         os: [ubuntu-latest]
         # Test JVMs.
-        java: [ '17' ]
+        java: [ '21' ]
 
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}

--- a/.github/workflows/hunspell.yml
+++ b/.github/workflows/hunspell.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 17
+        java-version: 21
         java-package: jdk
 
     - name: Prepare caches

--- a/buildSrc/scriptDepVersions.gradle
+++ b/buildSrc/scriptDepVersions.gradle
@@ -24,7 +24,7 @@ ext {
       "apache-rat": "0.14",
       "asm": "9.6",
       "commons-codec": "1.13",
-      "ecj": "3.30.0",
+      "ecj": "3.36.0",
       "flexmark": "0.61.24",
       "javacc": "7.0.12",
       "jflex": "1.8.2",

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -51,7 +51,7 @@ allprojects {
            includeInReproLine: false
           ],
           [propName: 'tests.jvmargs',
-           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", isCIBuild ? "" : "-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1") },
+           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", "") },
            description: "Arguments passed to each forked JVM."],
           // Other settings.
           [propName: 'tests.neverUpToDate', value: true,

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -163,7 +163,7 @@ public class TestDocIdsWriter extends LuceneTestCase {
           IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig(null))) {
         for (int d = 0; d < 20_000; d++) {
           iw.addDocument(
-              List.of(new IntPoint("foo", 0), new SortedNumericDocValuesField("bar", 0)));
+              List.of(new IntPoint("bar", 0), new SortedNumericDocValuesField("foo", 0)));
         }
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -163,7 +163,7 @@ public class TestDocIdsWriter extends LuceneTestCase {
           IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig(null))) {
         for (int d = 0; d < 20_000; d++) {
           iw.addDocument(
-              List.of(new IntPoint("bar", 0), new SortedNumericDocValuesField("foo", 0)));
+              List.of(new IntPoint("foo", 0), new SortedNumericDocValuesField("bar", 0)));
         }
       }
     }


### PR DESCRIPTION
Add test that tickles a JVM JIT crash on JDK's less than 21.0.1

Work in Progress. Trying to repro a C2 crash, for now 

[This PR is not intended to be commit. At least not as it is.]