### PR TITLE
Upgrade ECJ to 3.36.0

### DIFF
--- a/buildSrc/scriptDepVersions.gradle
+++ b/buildSrc/scriptDepVersions.gradle
@@ -24,7 +24,7 @@ ext {
       "apache-rat": "0.14",
       "asm": "9.6",
       "commons-codec": "1.13",
-      "ecj": "3.30.0",
+      "ecj": "3.36.0",
       "flexmark": "0.61.24",
       "javacc": "7.0.12",
       "jflex": "1.8.2",


### PR DESCRIPTION
This commit upgrades ECJ to 3.36.0, as it has support for more recent Java versions, like Java 21.

The motivation for this change is to better allow build and testing with more recent JDK.s