### PR TITLE
Removing @lucene.experimental tags in testXXX methods in CheckIndex

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -181,6 +181,8 @@ Other
 
 * GITHUB#11023: Removing some dead code in CheckIndex. (Jakub Slowinski)
 
+* GITHUB#11023: Removing @lucene.experimental tags in testXXX methods in CheckIndex. (Jakub Slowinski)
+
 ======================== Lucene 9.9.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -1149,11 +1149,7 @@ public final class CheckIndex implements Closeable {
     return segInfoStat;
   }
 
-  /**
-   * Tests index sort order.
-   *
-   * @lucene.experimental
-   */
+  /** Tests index sort order. */
   public static Status.IndexSortStatus testSort(
       CodecReader reader, Sort sort, PrintStream infoStream, boolean failFast) throws IOException {
     // This segment claims its documents are sorted according to the incoming sort ... let's make
@@ -1226,11 +1222,7 @@ public final class CheckIndex implements Closeable {
     return status;
   }
 
-  /**
-   * Test live docs.
-   *
-   * @lucene.experimental
-   */
+  /** Test live docs. */
   public static Status.LiveDocStatus testLiveDocs(
       CodecReader reader, PrintStream infoStream, boolean failFast) throws IOException {
     long startNS = System.nanoTime();
@@ -1295,11 +1287,7 @@ public final class CheckIndex implements Closeable {
     return status;
   }
 
-  /**
-   * Test field infos.
-   *
-   * @lucene.experimental
-   */
+  /** Test field infos. */
   public static Status.FieldInfoStatus testFieldInfos(
       CodecReader reader, PrintStream infoStream, boolean failFast) throws IOException {
     long startNS = System.nanoTime();
@@ -1336,11 +1324,7 @@ public final class CheckIndex implements Closeable {
     return status;
   }
 
-  /**
-   * Test field norms.
-   *
-   * @lucene.experimental
-   */
+  /** Test field norms. */
   public static Status.FieldNormStatus testFieldNorms(
       CodecReader reader, PrintStream infoStream, boolean failFast) throws IOException {
     long startNS = System.nanoTime();
@@ -2443,21 +2427,13 @@ public final class CheckIndex implements Closeable {
     }
   }
 
-  /**
-   * Test the term index.
-   *
-   * @lucene.experimental
-   */
+  /** Test the term index. */
   public static Status.TermIndexStatus testPostings(CodecReader reader, PrintStream infoStream)
       throws IOException {
     return testPostings(reader, infoStream, false, Level.MIN_LEVEL_FOR_SLOW_CHECKS, false);
   }
 
-  /**
-   * Test the term index.
-   *
-   * @lucene.experimental
-   */
+  /** Test the term index. */
   public static Status.TermIndexStatus testPostings(
       CodecReader reader, PrintStream infoStream, boolean verbose, int level, boolean failFast)
       throws IOException {
@@ -2510,11 +2486,7 @@ public final class CheckIndex implements Closeable {
     return status;
   }
 
-  /**
-   * Test the points index
-   *
-   * @lucene.experimental
-   */
+  /** Test the points index. */
   public static Status.PointsStatus testPoints(
       CodecReader reader, PrintStream infoStream, boolean failFast) throws IOException {
     if (infoStream != null) {
@@ -2617,11 +2589,7 @@ public final class CheckIndex implements Closeable {
     return status;
   }
 
-  /**
-   * Test the vectors index
-   *
-   * @lucene.experimental
-   */
+  /** Test the vectors index. */
   public static Status.VectorValuesStatus testVectors(
       CodecReader reader, PrintStream infoStream, boolean failFast) throws IOException {
     if (infoStream != null) {
@@ -3104,11 +3072,7 @@ public final class CheckIndex implements Closeable {
     }
   }
 
-  /**
-   * Test stored fields.
-   *
-   * @lucene.experimental
-   */
+  /** Test stored fields. */
   public static Status.StoredFieldStatus testStoredFields(
       CodecReader reader, PrintStream infoStream, boolean failFast) throws IOException {
     long startNS = System.nanoTime();
@@ -3162,11 +3126,7 @@ public final class CheckIndex implements Closeable {
     return status;
   }
 
-  /**
-   * Test docvalues.
-   *
-   * @lucene.experimental
-   */
+  /** Test docvalues. */
   public static Status.DocValuesStatus testDocValues(
       CodecReader reader, PrintStream infoStream, boolean failFast) throws IOException {
     long startNS = System.nanoTime();
@@ -3623,21 +3583,13 @@ public final class CheckIndex implements Closeable {
     }
   }
 
-  /**
-   * Test term vectors.
-   *
-   * @lucene.experimental
-   */
+  /** Test term vectors. */
   public static Status.TermVectorStatus testTermVectors(CodecReader reader, PrintStream infoStream)
       throws IOException {
     return testTermVectors(reader, infoStream, false, Level.MIN_LEVEL_FOR_INTEGRITY_CHECKS, false);
   }
 
-  /**
-   * Test term vectors.
-   *
-   * @lucene.experimental
-   */
+  /** Test term vectors. */
   public static Status.TermVectorStatus testTermVectors(
       CodecReader reader, PrintStream infoStream, boolean verbose, int level, boolean failFast)
       throws IOException {


### PR DESCRIPTION
Following up on @mikemccand's comment in previous CheckIndex PR:https://github.com/apache/lucene/pull/12876 related to my question of cleaning up the >10 year old @lucene.experimental tags in CheckIndex.

>  I do think some of these tags in CheckIndex.java could be removed, e.g. on each of the testXXX methods? But likely we should leave it on each of the XXXStatus returned classes, so we are free to break/change what metadata these classes return? And let's do it separately -- this PR looks like a great cleanup already. Progress not perfection!

Targetting Lucene 9.10.