### PR TITLE
Fix NPE on off-heap test and FST is null

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/fst/FSTTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/fst/FSTTester.java
@@ -284,24 +284,26 @@ public class FSTTester<T> {
     }
     FST<T> fst = fstCompiler.compile();
 
-    if (fst != null) {
-      if (useOffHeap) {
-        indexOutput.close();
+    if (useOffHeap) {
+      indexOutput.close();
+      if (fst == null) {
+        dir.deleteFile("fstOffHeap.bin");
+      } else {
         try (IndexInput in = dir.openInput("fstOffHeap.bin", IOContext.DEFAULT)) {
           fst = new FST<>(fst.getMetadata(), in);
         } finally {
           dir.deleteFile("fstOffHeap.bin");
         }
-      } else if (random.nextBoolean()) {
-        IOContext context = LuceneTestCase.newIOContext(random);
-        try (IndexOutput out = dir.createOutput("fst.bin", context)) {
-          fst.save(out, out);
-        }
-        try (IndexInput in = dir.openInput("fst.bin", context)) {
-          fst = new FST<>(FST.readMetadata(in, outputs), in);
-        } finally {
-          dir.deleteFile("fst.bin");
-        }
+      }
+    } else if (random.nextBoolean() && fst != null) {
+      IOContext context = LuceneTestCase.newIOContext(random);
+      try (IndexOutput out = dir.createOutput("fst.bin", context)) {
+        fst.save(out, out);
+      }
+      try (IndexInput in = dir.openInput("fst.bin", context)) {
+        fst = new FST<>(FST.readMetadata(in, outputs), in);
+      } finally {
+        dir.deleteFile("fst.bin");
       }
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/fst/FSTTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/fst/FSTTester.java
@@ -283,24 +283,25 @@ public class FSTTester<T> {
       }
     }
     FST<T> fst = fstCompiler.compile();
-    ;
 
-    if (useOffHeap) {
-      indexOutput.close();
-      try (IndexInput in = dir.openInput("fstOffHeap.bin", IOContext.DEFAULT)) {
-        fst = new FST<>(fst.getMetadata(), in);
-      } finally {
-        dir.deleteFile("fstOffHeap.bin");
-      }
-    } else if (random.nextBoolean() && fst != null) {
-      IOContext context = LuceneTestCase.newIOContext(random);
-      try (IndexOutput out = dir.createOutput("fst.bin", context)) {
-        fst.save(out, out);
-      }
-      try (IndexInput in = dir.openInput("fst.bin", context)) {
-        fst = new FST<>(FST.readMetadata(in, outputs), in);
-      } finally {
-        dir.deleteFile("fst.bin");
+    if (fst != null) {
+      if (useOffHeap) {
+        indexOutput.close();
+        try (IndexInput in = dir.openInput("fstOffHeap.bin", IOContext.DEFAULT)) {
+          fst = new FST<>(fst.getMetadata(), in);
+        } finally {
+          dir.deleteFile("fstOffHeap.bin");
+        }
+      } else if (random.nextBoolean()) {
+        IOContext context = LuceneTestCase.newIOContext(random);
+        try (IndexOutput out = dir.createOutput("fst.bin", context)) {
+          fst.save(out, out);
+        }
+        try (IndexInput in = dir.openInput("fst.bin", context)) {
+          fst = new FST<>(FST.readMetadata(in, outputs), in);
+        } finally {
+          dir.deleteFile("fst.bin");
+        }
       }
     }
 


### PR DESCRIPTION
### Description

The test can throw a NPE when it's using off-heap mode and no nodes are accepted. I haven't been able to reproduce, but theoretically this could happen.