### PR TITLE
Reflow computeCommonPrefixLengthAndBuildHistogram to avoid crash

### DIFF
--- a/gradle/testing/randomization/policies/tests.policy
+++ b/gradle/testing/randomization/policies/tests.policy
@@ -60,6 +60,9 @@ grant {
   permission java.lang.RuntimePermission "getFileStoreAttributes";
   permission java.lang.RuntimePermission "writeFileDescriptor";
 
+  // needed to check if C2 (implied by the presence of the CI env) is enabled
+  permission java.lang.RuntimePermission "getenv.CI";
+
   // TestLockFactoriesMultiJVM opens a random port on 127.0.0.1 (port 0 = ephemeral port range):
   permission java.net.SocketPermission "127.0.0.1:0", "accept,listen,resolve";
 

--- a/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
@@ -214,6 +214,12 @@ public abstract class MSBRadixSorter extends Sorter {
    * @see #buildHistogram
    */
   private int computeCommonPrefixLengthAndBuildHistogram(int from, int to, int k, int[] histogram) {
+    int commonPrefixLength = computeInitialCommonPrefixLength(from, k);
+    return computeCommonPrefixLengthAndBuildHistogramPart1(
+        from, to, k, histogram, commonPrefixLength);
+  }
+
+  private int computeInitialCommonPrefixLength(int from, int k) {
     final int[] commonPrefix = this.commonPrefix;
     int commonPrefixLength = Math.min(commonPrefix.length, maxLength - k);
     for (int j = 0; j < commonPrefixLength; ++j) {
@@ -224,7 +230,12 @@ public abstract class MSBRadixSorter extends Sorter {
         break;
       }
     }
+    return commonPrefixLength;
+  }
 
+  private int computeCommonPrefixLengthAndBuildHistogramPart1(
+      int from, int to, int k, int[] histogram, int commonPrefixLength) {
+    final int[] commonPrefix = this.commonPrefix;
     int i;
     outer:
     for (i = from + 1; i < to; ++i) {
@@ -239,7 +250,12 @@ public abstract class MSBRadixSorter extends Sorter {
         }
       }
     }
+    return computeCommonPrefixLengthAndBuildHistogramPart2(
+        from, to, k, histogram, commonPrefixLength, i);
+  }
 
+  private int computeCommonPrefixLengthAndBuildHistogramPart2(
+      int from, int to, int k, int[] histogram, int commonPrefixLength, int i) {
     if (i < to) {
       // the loop got broken because there is no common prefix
       assert commonPrefixLength == 0;

--- a/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
@@ -213,12 +213,15 @@ public abstract class MSBRadixSorter extends Sorter {
    *
    * @see #buildHistogram
    */
+  // This method, and its namesakes, have been manually split to work around a JVM crash.
+  // See https://github.com/apache/lucene/issues/12898
   private int computeCommonPrefixLengthAndBuildHistogram(int from, int to, int k, int[] histogram) {
     int commonPrefixLength = computeInitialCommonPrefixLength(from, k);
     return computeCommonPrefixLengthAndBuildHistogramPart1(
         from, to, k, histogram, commonPrefixLength);
   }
 
+  // This method, and its namesakes, have been manually split to work around a JVM crash.
   private int computeInitialCommonPrefixLength(int from, int k) {
     final int[] commonPrefix = this.commonPrefix;
     int commonPrefixLength = Math.min(commonPrefix.length, maxLength - k);
@@ -233,6 +236,7 @@ public abstract class MSBRadixSorter extends Sorter {
     return commonPrefixLength;
   }
 
+  // This method, and its namesakes, have been manually split to work around a JVM crash.
   private int computeCommonPrefixLengthAndBuildHistogramPart1(
       int from, int to, int k, int[] histogram, int commonPrefixLength) {
     final int[] commonPrefix = this.commonPrefix;
@@ -254,6 +258,7 @@ public abstract class MSBRadixSorter extends Sorter {
         from, to, k, histogram, commonPrefixLength, i);
   }
 
+  // This method, and its namesakes, have been manually split to work around a JVM crash.
   private int computeCommonPrefixLengthAndBuildHistogramPart2(
       int from, int to, int k, int[] histogram, int commonPrefixLength, int i) {
     if (i < to) {

--- a/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
@@ -199,6 +199,12 @@ public abstract class RadixSelector extends Selector {
    * @see #buildHistogram
    */
   private int computeCommonPrefixLengthAndBuildHistogram(int from, int to, int k, int[] histogram) {
+    int commonPrefixLength = computeInitialCommonPrefixLength(from, k);
+    return computeCommonPrefixLengthAndBuildHistogramPart1(
+        from, to, k, histogram, commonPrefixLength);
+  }
+
+  private int computeInitialCommonPrefixLength(int from, int k) {
     final int[] commonPrefix = this.commonPrefix;
     int commonPrefixLength = Math.min(commonPrefix.length, maxLength - k);
     for (int j = 0; j < commonPrefixLength; ++j) {
@@ -209,7 +215,12 @@ public abstract class RadixSelector extends Selector {
         break;
       }
     }
+    return commonPrefixLength;
+  }
 
+  private int computeCommonPrefixLengthAndBuildHistogramPart1(
+      int from, int to, int k, int[] histogram, int commonPrefixLength) {
+    final int[] commonPrefix = this.commonPrefix;
     int i;
     outer:
     for (i = from + 1; i < to; ++i) {
@@ -226,7 +237,12 @@ public abstract class RadixSelector extends Selector {
         }
       }
     }
+    return computeCommonPrefixLengthAndBuildHistogramPart2(
+        from, to, k, histogram, commonPrefixLength, i);
+  }
 
+  private int computeCommonPrefixLengthAndBuildHistogramPart2(
+      int from, int to, int k, int[] histogram, int commonPrefixLength, int i) {
     if (i < to) {
       // the loop got broken because there is no common prefix
       assert commonPrefixLength == 0;

--- a/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
@@ -198,12 +198,15 @@ public abstract class RadixSelector extends Selector {
    *
    * @see #buildHistogram
    */
+  // This method, and its namesakes, have been manually split to work around a JVM crash.
+  // See https://github.com/apache/lucene/issues/12898
   private int computeCommonPrefixLengthAndBuildHistogram(int from, int to, int k, int[] histogram) {
     int commonPrefixLength = computeInitialCommonPrefixLength(from, k);
     return computeCommonPrefixLengthAndBuildHistogramPart1(
         from, to, k, histogram, commonPrefixLength);
   }
 
+  // This method, and its namesakes, have been manually split to work around a JVM crash.
   private int computeInitialCommonPrefixLength(int from, int k) {
     final int[] commonPrefix = this.commonPrefix;
     int commonPrefixLength = Math.min(commonPrefix.length, maxLength - k);
@@ -218,6 +221,7 @@ public abstract class RadixSelector extends Selector {
     return commonPrefixLength;
   }
 
+  // This method, and its namesakes, have been manually split to work around a JVM crash.
   private int computeCommonPrefixLengthAndBuildHistogramPart1(
       int from, int to, int k, int[] histogram, int commonPrefixLength) {
     final int[] commonPrefix = this.commonPrefix;
@@ -241,6 +245,7 @@ public abstract class RadixSelector extends Selector {
         from, to, k, histogram, commonPrefixLength, i);
   }
 
+  // This method, and its namesakes, have been manually split to work around a JVM crash.
   private int computeCommonPrefixLengthAndBuildHistogramPart2(
       int from, int to, int k, int[] histogram, int commonPrefixLength, int i) {
     if (i < to) {

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -17,6 +17,8 @@
 package org.apache.lucene.util.bkd;
 
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -32,6 +34,7 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.CollectionUtil;
+import org.apache.lucene.util.SuppressForbidden;
 
 public class TestDocIdsWriter extends LuceneTestCase {
 
@@ -155,10 +158,13 @@ public class TestDocIdsWriter extends LuceneTestCase {
     dir.deleteFile("tmp");
   }
 
-  // This simple test tickles a JVM JIT crash on JDK's less than 21.0.1
-  // Needs to be run with C2, so with the environment variable `CI` set
+  // This simple test tickles a JVM C2 JIT crash on JDK's less than 21.0.1
+  // Crashes only when run with C2, so with the environment variable `CI` set
+  // Regardless of whether C2 is enabled or not, the test should never fail.
   public void testCrash() throws IOException {
-    for (int i = 0; i < 100; i++) {
+    assumeTrue("Requires C2, which is only enabled when CI env is set", getCIEnv() != null);
+    int itrs = atLeast(100);
+    for (int i = 0; i < itrs; i++) {
       try (Directory dir = newDirectory();
           IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig(null))) {
         for (int d = 0; d < 20_000; d++) {
@@ -167,5 +173,12 @@ public class TestDocIdsWriter extends LuceneTestCase {
         }
       }
     }
+  }
+
+  @SuppressForbidden(reason = "needed to check if C2 is enabled")
+  @SuppressWarnings("removal")
+  private static String getCIEnv() {
+    PrivilegedAction<String> pa = () -> System.getenv("CI");
+    return AccessController.doPrivileged(pa);
   }
 }


### PR DESCRIPTION
This commit reflows the code in the method body of computeCommonPrefixLengthAndBuildHistogram, so as to avoid a JVM JIT crash. The purpose of this change is to workaround the JVM bug which is somewhat fragile, but the best that we can do for now and appears to be working well. Further details of the JDK issue can be found in https://bugs.openjdk.org/browse/JDK-8321370 and linked issues.

The newly added test fails around 9 out of 10 times for me, before the fix. With the fix the test has not been seen to fail in several hundreds of runs. Though, further test runs are on going.

The JDK issue is already fixed in the currently unreleased JDK 21.0.2 and JDK 22, but we need this workaround to avoid the crash on current released JDKs.

relates https://github.com/apache/lucene/issues/12898