### PR TITLE
Make TestDrillSideways#testCollectionTerminated less strict

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -195,6 +195,9 @@ Bug Fixes
 * GITHUB#12558: Ensure #finish is called on all drill-sideways FacetsCollectors even when no hits are scored.
   (Greg Miller)
 
+* GITHUB#12920: Address bug in TestDrillSideways#testCollectionTerminated that could occasionally cause the test to
+  fail with certain random seeds. (Greg Miller)
+
 Other
 ---------------------
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -326,10 +326,6 @@ public class TestDrillSideways extends FacetTestCase {
         // termination occurs (i.e., #finish is properly called in that scenario):
         assertEquals(1, baseFC.getMatchingDocs().size());
         assertEquals(1, dimFC.getMatchingDocs().size());
-        FacetsCollector.MatchingDocs baseMD = baseFC.getMatchingDocs().get(0);
-        FacetsCollector.MatchingDocs dimMD = dimFC.getMatchingDocs().get(0);
-        assertEquals(1, baseMD.totalHits);
-        assertEquals(1, dimMD.totalHits);
       }
     }
   }


### PR DESCRIPTION
This test is really about confirming that #finish is called, so we don't really need to check the hit counts on early termination. The problem with checking the hit counts is that it depends on doc ordering and segment geometry in the index, which is unreliable with the randomized writer.