### PR TITLE
Fix failing BaseVectorSimilarityQueryTestCase#testApproximate

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java
@@ -255,6 +255,11 @@ abstract class AbstractVectorSimilarityQuery extends Query {
           new FilteredDocIdSetIterator(acceptDocs) {
             @Override
             protected boolean match(int doc) throws IOException {
+              // Advance the scorer
+              if (!scorer.advanceExact(doc)) {
+                return false;
+              }
+
               // Compute the dot product
               float score = scorer.score();
               cachedScore[0] = score * boost;

--- a/lucene/core/src/java/org/apache/lucene/search/VectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/VectorScorer.java
@@ -87,6 +87,7 @@ abstract class VectorScorer {
 
     @Override
     public float score() throws IOException {
+      assert values.docID() != -1 : getClass().getSimpleName() + " is not positioned";
       return similarity.compare(query, values.vectorValue());
     }
   }
@@ -117,6 +118,7 @@ abstract class VectorScorer {
 
     @Override
     public float score() throws IOException {
+      assert values.docID() != -1 : getClass().getSimpleName() + " is not positioned";
       return similarity.compare(query, values.vectorValue());
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
@@ -433,8 +433,8 @@ abstract class BaseVectorSimilarityQueryTestCase<
 
   public void testApproximate() throws IOException {
     // Non-restrictive filter, along with similarity to visit a small number of nodes
-    int numFiltered = random().nextInt((numDocs * 4) / 5, numDocs);
-    int targetVisited = random().nextInt(numFiltered / 10, numFiltered / 8);
+    int numFiltered = numDocs - 1;
+    int targetVisited = random().nextInt(1, numFiltered / 10);
 
     V[] vectors = getRandomVectors(numDocs, dim);
     V queryVector = getRandomVector(dim);


### PR DESCRIPTION
Discovered in #12921, and introduced in #12679 

The first issue is that we weren't advancing the `VectorScorer` [here](https://github.com/apache/lucene/blob/cf13a9295052288b748ed8f279f05ee26f3bfd5f/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java#L257-L262) -- so it was still un-positioned while trying to compute the similarity score

Earlier in the PR, the underlying delegate of the `FilteredDocIdSetIterator` was `scorer.iterator()` (see [here](https://github.com/apache/lucene/blob/cad565439be512ac6e95a698007b1fc971173f00/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java#L107)) -- so we didn't need to explicitly advance it

Later, we decided to maintain parity to `AbstractKnnVectorQuery` and introduce filtering in `AbstractVectorSimilarityQuery` (see [this commit](https://github.com/apache/lucene/commit/5096790f281e477c529a7c8311aeb353ccdffdeb)) to determine the `visitLimit` of approximate search -- after which the underlying iterator changed to the accepted docs (see [here](https://github.com/apache/lucene/blob/5096790f281e477c529a7c8311aeb353ccdffdeb/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java#L255)) and I missed advancing the `VectorScorer` explicitly..

After doing so, we no longer get the original `java.lang.ArrayIndexOutOfBoundsException` -- but the `BaseVectorSimilarityQueryTestCase#testApproximate` starts failing because it falls back to exact search, as the limit of the prefilter is met during graph search

Relaxed the parameters of the test to fix this (making the filter less restrictive, and trying to visit a fewer number of nodes so that approximate search completes without hitting its limit)

Sorry for missing this earlier!