### PR TITLE
Ensure Nori/Kuromoji shipped binary FST is the latest version

### DIFF
--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/dict/TokenInfoDictionary.java
@@ -111,7 +111,7 @@ public final class TokenInfoDictionary extends BinaryDictionary<TokenInfoMorphDa
     this.fst = new TokenInfoFST(fst, true);
   }
 
-  private static InputStream getClassResource(String suffix) throws IOException {
+  static InputStream getClassResource(String suffix) throws IOException {
     final String resourcePath = TokenInfoDictionary.class.getSimpleName() + suffix;
     return IOUtils.requireResourceNonNull(
         TokenInfoDictionary.class.getResourceAsStream(resourcePath), resourcePath);

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestTokenInfoDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestTokenInfoDictionary.java
@@ -198,7 +198,7 @@ public class TestTokenInfoDictionary extends LuceneTestCase {
               + FST.VERSION_CURRENT
               + " but got: "
               + actualVersion
-              + "; run \"./gradlew regenerate\" to regenerate this FST and all other resources",
+              + "; run \"./gradlew :lucene:analysis:kuromoji:regenerate\" to regenerate this FST",
           FST.VERSION_CURRENT,
           actualVersion);
     }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestTokenInfoDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestTokenInfoDictionary.java
@@ -21,18 +21,22 @@ import static org.apache.lucene.analysis.morph.BinaryDictionary.DICT_FILENAME_SU
 import static org.apache.lucene.analysis.morph.BinaryDictionary.POSDICT_FILENAME_SUFFIX;
 import static org.apache.lucene.analysis.morph.BinaryDictionary.TARGETMAP_FILENAME_SUFFIX;
 
+import java.io.BufferedInputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.apache.lucene.store.InputStreamDataInput;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.IntsRefBuilder;
 import org.apache.lucene.util.UnicodeUtil;
 import org.apache.lucene.util.fst.FST;
 import org.apache.lucene.util.fst.IntsRefFSTEnum;
+import org.apache.lucene.util.fst.PositiveIntOutputs;
 
 /** Tests of TokenInfoDictionary build tools; run using ant test-tools */
 public class TestTokenInfoDictionary extends LuceneTestCase {
@@ -176,6 +180,27 @@ public class TestTokenInfoDictionary extends LuceneTestCase {
     }
     if (VERBOSE) {
       System.out.println("checked " + numTerms + " terms, " + numWords + " words.");
+    }
+  }
+
+  // #12911: make sure our shipped binary FST for TokenInfoDictionary is the latest & greatest
+  // format
+  public void testBinaryFSTIsLatestFormat() throws Exception {
+    try (InputStream is =
+        new BufferedInputStream(
+            TokenInfoDictionary.getClassResource(TokenInfoDictionary.FST_FILENAME_SUFFIX))) {
+      // we only need to load the FSTMetadata to check version:
+      int actualVersion =
+          FST.readMetadata(new InputStreamDataInput(is), PositiveIntOutputs.getSingleton())
+              .getVersion();
+      assertEquals(
+          "TokenInfoDictionary's FST is not the latest version: expected "
+              + FST.VERSION_CURRENT
+              + " but got: "
+              + actualVersion
+              + "; run \"./gradlew regenerate\" to regenerate this FST and all other resources",
+          FST.VERSION_CURRENT,
+          actualVersion);
     }
   }
 }

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/TokenInfoDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/TokenInfoDictionary.java
@@ -109,7 +109,7 @@ public final class TokenInfoDictionary extends BinaryDictionary<TokenInfoMorphDa
     this.fst = new TokenInfoFST(fst);
   }
 
-  private static InputStream getClassResource(String suffix) throws IOException {
+  static InputStream getClassResource(String suffix) throws IOException {
     final String resourcePath = TokenInfoDictionary.class.getSimpleName() + suffix;
     return IOUtils.requireResourceNonNull(
         TokenInfoDictionary.class.getResourceAsStream(resourcePath), resourcePath);

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestTokenInfoDictionary.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestTokenInfoDictionary.java
@@ -21,6 +21,8 @@ import static org.apache.lucene.analysis.morph.BinaryDictionary.DICT_FILENAME_SU
 import static org.apache.lucene.analysis.morph.BinaryDictionary.POSDICT_FILENAME_SUFFIX;
 import static org.apache.lucene.analysis.morph.BinaryDictionary.TARGETMAP_FILENAME_SUFFIX;
 
+import java.io.BufferedInputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -28,12 +30,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.apache.lucene.analysis.ko.POS;
+import org.apache.lucene.store.InputStreamDataInput;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.IntsRefBuilder;
 import org.apache.lucene.util.UnicodeUtil;
 import org.apache.lucene.util.fst.FST;
 import org.apache.lucene.util.fst.IntsRefFSTEnum;
+import org.apache.lucene.util.fst.PositiveIntOutputs;
 
 /** Tests of TokenInfoDictionary build tools; run using ant test-tools */
 public class TestTokenInfoDictionary extends LuceneTestCase {
@@ -183,6 +187,27 @@ public class TestTokenInfoDictionary extends LuceneTestCase {
     }
     if (VERBOSE) {
       System.out.println("checked " + numTerms + " terms, " + numWords + " words.");
+    }
+  }
+
+  // #12911: make sure our shipped binary FST for TokenInfoDictionary is the latest & greatest
+  // format
+  public void testBinaryFSTIsLatestFormat() throws Exception {
+    try (InputStream is =
+        new BufferedInputStream(
+            TokenInfoDictionary.getClassResource(TokenInfoDictionary.FST_FILENAME_SUFFIX))) {
+      // we only need to load the FSTMetadata to check version:
+      int actualVersion =
+          FST.readMetadata(new InputStreamDataInput(is), PositiveIntOutputs.getSingleton())
+              .getVersion();
+      assertEquals(
+          "TokenInfoDictionary's FST is not the latest version: expected "
+              + FST.VERSION_CURRENT
+              + " but got: "
+              + actualVersion
+              + "; run \"./gradlew regenerate\" to regenerate this FST and all other resources",
+          FST.VERSION_CURRENT,
+          actualVersion);
     }
   }
 }

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestTokenInfoDictionary.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestTokenInfoDictionary.java
@@ -205,7 +205,7 @@ public class TestTokenInfoDictionary extends LuceneTestCase {
               + FST.VERSION_CURRENT
               + " but got: "
               + actualVersion
-              + "; run \"./gradlew regenerate\" to regenerate this FST and all other resources",
+              + "; run \"./gradlew :lucene:analysis:nori:regenerate\" to regenerate this FST",
           FST.VERSION_CURRENT,
           actualVersion);
     }

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -1236,5 +1236,9 @@ public final class FST<T> implements Accountable {
       this.version = version;
       this.numBytes = numBytes;
     }
+
+    public int getVersion() {
+      return version;
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -1208,7 +1208,7 @@ public final class FST<T> implements Accountable {
   }
 
   /**
-   * Represent the FST metadata
+   * Represents the FST metadata.
    *
    * @param <T> the FST output type
    */
@@ -1237,6 +1237,11 @@ public final class FST<T> implements Accountable {
       this.numBytes = numBytes;
     }
 
+    /**
+     * Returns the version constant of the binary format this FST was written in. See the {@code
+     * static final int VERSION} constants in FST's javadoc, e.g. {@link
+     * FST#VERSION_CONTINUOUS_ARCS}.
+     */
     public int getVersion() {
       return version;
     }


### PR DESCRIPTION
Closes #12911

This just adds specific unit tests for the binary FST for Nori's and Kuromoji's `TokenInfoDictionary`.  I had to promote some APIs from private -> package private for test visibility.

I backed out this AM's FST upgrade confirmed the tests fail, with something like this:

```
    java.lang.AssertionError: TokenInfoDictionary's FST is not the latest version: expected 9 but got: 8; run "./gradlew regenerate" to regenerate this FST and all other resources expected:<9> but was:<8>
        at __randomizedtesting.SeedInfo.seed([32EBD74005BEF4E1:C57DC409B3CCC027]:0)
        at junit@4.13.1/org.junit.Assert.fail(Assert.java:89)
        at junit@4.13.1/org.junit.Assert.failNotEquals(Assert.java:835)
        at junit@4.13.1/org.junit.Assert.assertEquals(Assert.java:647)
        at org.apache.lucene.analysis.ja.dict.TestTokenInfoDictionary.testBinaryFSTIsLatestFormat(TestTokenInfoDictionary.java:192)
```