### PR TITLE
Made the UnifiedHighlighter's hasUnrecognizedQuery function processes FunctionQuery the same way as MatchAllDocsQuery and MatchNoDocsQuery queries for performance reasons.

### DIFF
--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -49,6 +49,7 @@ import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermVectors;
+import org.apache.lucene.queries.function.FunctionQuery;
 import org.apache.lucene.queries.spans.SpanQuery;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
@@ -1130,7 +1131,7 @@ public class UnifiedHighlighter {
           @Override
           public void visitLeaf(Query query) {
             if (MultiTermHighlighting.canExtractAutomataFromLeafQuery(query) == false) {
-              if (!(query instanceof MatchAllDocsQuery || query instanceof MatchNoDocsQuery)) {
+              if (!(query instanceof MatchAllDocsQuery || query instanceof MatchNoDocsQuery || query instanceof FunctionQuery)) {
                 hasUnknownLeaf[0] = true;
               }
             }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -1131,7 +1131,9 @@ public class UnifiedHighlighter {
           @Override
           public void visitLeaf(Query query) {
             if (MultiTermHighlighting.canExtractAutomataFromLeafQuery(query) == false) {
-              if (!(query instanceof MatchAllDocsQuery || query instanceof MatchNoDocsQuery || query instanceof FunctionQuery)) {
+              if (!(query instanceof MatchAllDocsQuery
+                  || query instanceof MatchNoDocsQuery
+                  || query instanceof FunctionQuery)) {
                 hasUnknownLeaf[0] = true;
               }
             }


### PR DESCRIPTION
### Description

At [Lexum](https://lexum.com/en/), we deploy Solr with a slightly modified version of the UnifiedHighlighter: the `FunctionQuery` type is added as a knownLeaf to the `QueryVisitor` of the `hasUnrecognizedQuery` function (next to both `MatchAllDocsQuery` and `MatchNoDocsQuery` types). I wasn't there when the change was identified but it seems necessary for performance reasons. I propose the change, hoping that we don't need to maintain a slighty modified version of that class in our code base. 


