### PR TITLE
#12932: get monsters tests compiling/running again

### DIFF
--- a/lucene/classification/src/test/org/apache/lucene/classification/Test20NewsgroupsClassification.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/Test20NewsgroupsClassification.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -75,7 +74,7 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
   private static final String CATEGORY_FIELD = "category";
   private static final String BODY_FIELD = "body";
   private static final String SUBJECT_FIELD = "subject";
-  private static final String INDEX_DIR = "/path/to/lucene-solr/lucene/classification/20n";
+  // private static final String INDEX_DIR = "/path/to/lucene-solr/lucene/classification/20n";
 
   private static boolean index = true;
   private static boolean split = true;
@@ -127,7 +126,7 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
         long startIndex = System.nanoTime();
         IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig(analyzer));
 
-        Path indexDir = Paths.get(INDEX_DIR);
+        Path indexDir = createTempDir("Test20NewsgroupsClassification");
         int docsIndexed = buildIndex(indexDir, indexWriter);
 
         long endIndex = System.nanoTime();

--- a/lucene/core/src/test/org/apache/lucene/index/Test2BPoints.java
+++ b/lucene/core/src/test/org/apache/lucene/index/Test2BPoints.java
@@ -143,6 +143,6 @@ public class Test2BPoints extends LuceneTestCase {
   }
 
   private static Codec getCodec() {
-    return Codec.forName("Lucene84");
+    return Codec.getDefault();
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/Test2BSortedDocValuesFixedSorted.java
+++ b/lucene/core/src/test/org/apache/lucene/index/Test2BSortedDocValuesFixedSorted.java
@@ -82,12 +82,12 @@ public class Test2BSortedDocValuesFixedSorted extends LuceneTestCase {
     int expectedValue = 0;
     for (LeafReaderContext context : r.leaves()) {
       LeafReader reader = context.reader();
-      BinaryDocValues dv = DocValues.getBinary(reader, "dv");
+      SortedDocValues dv = DocValues.getSorted(reader, "dv");
       for (int i = 0; i < reader.maxDoc(); i++) {
         assertEquals(i, dv.nextDoc());
         bytes[0] = (byte) (expectedValue >> 8);
         bytes[1] = (byte) expectedValue;
-        final BytesRef term = dv.binaryValue();
+        final BytesRef term = dv.lookupOrd(dv.ordValue());
         assertEquals(data, term);
         expectedValue++;
       }

--- a/lucene/core/src/test/org/apache/lucene/index/Test2BSortedDocValuesOrds.java
+++ b/lucene/core/src/test/org/apache/lucene/index/Test2BSortedDocValuesOrds.java
@@ -84,7 +84,7 @@ public class Test2BSortedDocValuesOrds extends LuceneTestCase {
     int counter = 0;
     for (LeafReaderContext context : r.leaves()) {
       LeafReader reader = context.reader();
-      BinaryDocValues dv = DocValues.getBinary(reader, "dv");
+      SortedDocValues dv = DocValues.getSorted(reader, "dv");
       for (int i = 0; i < reader.maxDoc(); i++) {
         assertEquals(i, dv.nextDoc());
         bytes[0] = (byte) (counter >> 24);
@@ -92,7 +92,7 @@ public class Test2BSortedDocValuesOrds extends LuceneTestCase {
         bytes[2] = (byte) (counter >> 8);
         bytes[3] = (byte) counter;
         counter++;
-        final BytesRef term = dv.binaryValue();
+        final BytesRef term = dv.lookupOrd(dv.ordValue());
         assertEquals(data, term);
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
@@ -40,7 +40,7 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.tests.util.TimeUnits;
 
 @SuppressCodecs({"SimpleText", "Direct"})
-@TimeoutSuite(millis = 8 * TimeUnits.HOUR)
+@TimeoutSuite(millis = 24 * TimeUnits.HOUR)
 public class TestIndexWriterMaxDocs extends LuceneTestCase {
 
   // The two hour time was achieved on a Linux 3.13 system with these specs:


### PR DESCRIPTION
This just fixes a bit of rust on the monster tests so they run again ...

With this change I was able to run all monster tests, except for `Test20NewsgroupsClassification` which now fails with:

```
org.apache.lucene.classification.Test20NewsgroupsClassification > test20Newsgroups FAILED
    java.io.IOException: java.lang.IllegalArgumentException: topNGroups must be >= 1 (got 0)
        at __randomizedtesting.SeedInfo.seed([9C94D9A6FA5F55ED:D92A9B02BDA49C6C]:0)
        at org.apache.lucene.classification.utils.DatasetSplitter.split(DatasetSplitter.java:175)
        at org.apache.lucene.classification.Test20NewsgroupsClassification.test20Newsgroups(Test20NewsgroupsClassification.java:155)
```

I'm not quite sure how to fix this one so I leave it be.