### PR TITLE
Fix flaky tests that are caused by small float vectors

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -100,22 +100,18 @@ public class TestKnnGraph extends LuceneTestCase {
           }
         };
 
-    if (vectorEncoding == VectorEncoding.FLOAT32) {
-      float32Codec = codec;
-    } else {
-      float32Codec =
-          new FilterCodec(TestUtil.getDefaultCodec().getName(), TestUtil.getDefaultCodec()) {
-            @Override
-            public KnnVectorsFormat knnVectorsFormat() {
-              return new PerFieldKnnVectorsFormat() {
-                @Override
-                public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-                  return new Lucene99HnswVectorsFormat(M, HnswGraphBuilder.DEFAULT_BEAM_WIDTH);
-                }
-              };
-            }
-          };
-    }
+    float32Codec =
+        new FilterCodec(TestUtil.getDefaultCodec().getName(), TestUtil.getDefaultCodec()) {
+          @Override
+          public KnnVectorsFormat knnVectorsFormat() {
+            return new PerFieldKnnVectorsFormat() {
+              @Override
+              public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                return new Lucene99HnswVectorsFormat(M, HnswGraphBuilder.DEFAULT_BEAM_WIDTH);
+              }
+            };
+          }
+        };
   }
 
   private VectorEncoding randomVectorEncoding() {


### PR DESCRIPTION
While quantization generally works well, when the number of dimensions is tiny (just two like in our tests), and we are indexing a circle, and we have random merge policies, we can end up getting unexpected ordering on the resulting vectors.

closes: https://github.com/apache/lucene/issues/12940