### PR TITLE
Improve exception handling for readLongs/readInts/readFloats in ByteBufferIndexInput

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -164,24 +164,24 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     // is no ByteBuffer#getLongs to read multiple longs at once. So we use the
     // below trick in order to be able to leverage LongBuffer#get(long[]) to
     // read multiple longs at once with as little overhead as possible.
-    if (curLongBufferViews == null) {
-      // readLELongs is only used for postings today, so we compute the long
-      // views lazily so that other data-structures don't have to pay for the
-      // associated initialization/memory overhead.
-      curLongBufferViews = new LongBuffer[Long.BYTES];
-      for (int i = 0; i < Long.BYTES; ++i) {
-        // Compute a view for each possible alignment. We cache these views
-        // because #asLongBuffer() has some cost that we don't want to pay on
-        // each invocation of #readLELongs.
-        if (i < curBuf.limit()) {
-          curLongBufferViews[i] =
-              curBuf.duplicate().position(i).order(ByteOrder.LITTLE_ENDIAN).asLongBuffer();
-        } else {
-          curLongBufferViews[i] = EMPTY_LONGBUFFER;
+    try {
+      if (curLongBufferViews == null) {
+        // readLELongs is only used for postings today, so we compute the long
+        // views lazily so that other data-structures don't have to pay for the
+        // associated initialization/memory overhead.
+        curLongBufferViews = new LongBuffer[Long.BYTES];
+        for (int i = 0; i < Long.BYTES; ++i) {
+          // Compute a view for each possible alignment. We cache these views
+          // because #asLongBuffer() has some cost that we don't want to pay on
+          // each invocation of #readLELongs.
+          if (i < curBuf.limit()) {
+            curLongBufferViews[i] =
+                curBuf.duplicate().position(i).order(ByteOrder.LITTLE_ENDIAN).asLongBuffer();
+          } else {
+            curLongBufferViews[i] = EMPTY_LONGBUFFER;
+          }
         }
       }
-    }
-    try {
       final int position = curBuf.position();
       guard.getLongs(
           curLongBufferViews[position & 0x07].position(position >>> 3), dst, offset, length);
@@ -199,18 +199,18 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
   @Override
   public void readInts(int[] dst, int offset, int length) throws IOException {
     // See notes about readLongs above
-    if (curIntBufferViews == null) {
-      curIntBufferViews = new IntBuffer[Integer.BYTES];
-      for (int i = 0; i < Integer.BYTES; ++i) {
-        if (i < curBuf.limit()) {
-          curIntBufferViews[i] =
-              curBuf.duplicate().position(i).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
-        } else {
-          curIntBufferViews[i] = EMPTY_INTBUFFER;
+    try {
+      if (curIntBufferViews == null) {
+        curIntBufferViews = new IntBuffer[Integer.BYTES];
+        for (int i = 0; i < Integer.BYTES; ++i) {
+          if (i < curBuf.limit()) {
+            curIntBufferViews[i] =
+                curBuf.duplicate().position(i).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
+          } else {
+            curIntBufferViews[i] = EMPTY_INTBUFFER;
+          }
         }
       }
-    }
-    try {
       final int position = curBuf.position();
       guard.getInts(
           curIntBufferViews[position & 0x03].position(position >>> 2), dst, offset, length);
@@ -228,20 +228,20 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
   @Override
   public final void readFloats(float[] floats, int offset, int len) throws IOException {
     // See notes about readLongs above
-    if (curFloatBufferViews == null) {
-      curFloatBufferViews = new FloatBuffer[Float.BYTES];
-      for (int i = 0; i < Float.BYTES; ++i) {
-        // Compute a view for each possible alignment.
-        if (i < curBuf.limit()) {
-          ByteBuffer dup = curBuf.duplicate().order(ByteOrder.LITTLE_ENDIAN);
-          dup.position(i);
-          curFloatBufferViews[i] = dup.asFloatBuffer();
-        } else {
-          curFloatBufferViews[i] = EMPTY_FLOATBUFFER;
+    try {
+      if (curFloatBufferViews == null) {
+        curFloatBufferViews = new FloatBuffer[Float.BYTES];
+        for (int i = 0; i < Float.BYTES; ++i) {
+          // Compute a view for each possible alignment.
+          if (i < curBuf.limit()) {
+            ByteBuffer dup = curBuf.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+            dup.position(i);
+            curFloatBufferViews[i] = dup.asFloatBuffer();
+          } else {
+            curFloatBufferViews[i] = EMPTY_FLOATBUFFER;
+          }
         }
       }
-    }
-    try {
       final int position = curBuf.position();
       FloatBuffer floatBuffer = curFloatBufferViews[position & 0x03];
       floatBuffer.position(position >>> 2);
@@ -548,6 +548,7 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     curBufIndex = 0;
     curLongBufferViews = null;
     curIntBufferViews = null;
+    curFloatBufferViews = null;
   }
 
   /** Optimization of ByteBufferIndexInput for when there is only one buffer */

--- a/lucene/core/src/test/org/apache/lucene/store/TestMultiMMap.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMultiMMap.java
@@ -33,6 +33,10 @@ import org.junit.BeforeClass;
  */
 public class TestMultiMMap extends BaseChunkedDirectoryTestCase {
 
+  interface DataReader {
+    void read(IndexInput in) throws IOException;
+  }
+
   @Override
   protected Directory getDirectory(Path path, int maxChunkSize) throws IOException {
     return new MMapDirectory(path, maxChunkSize);
@@ -83,31 +87,43 @@ public class TestMultiMMap extends BaseChunkedDirectoryTestCase {
   // TODO: can we improve ByteBuffersDirectory (without overhead) and move these clone safety tests
   // to the base test case?
 
+  private void assertAlreadyClosed(
+      IndexInput one, IndexInput two, IndexInput three, DataReader reader) throws Exception {
+    expectThrows(
+        AlreadyClosedException.class,
+        () -> {
+          reader.read(one);
+        });
+    expectThrows(
+        AlreadyClosedException.class,
+        () -> {
+          reader.read(two);
+        });
+    expectThrows(
+        AlreadyClosedException.class,
+        () -> {
+          reader.read(three);
+        });
+  }
+
   public void testCloneSafety() throws Exception {
     Directory mmapDir = getDirectory(createTempDir("testCloneSafety"));
     IndexOutput io = mmapDir.createOutput("bytes", newIOContext(random()));
+    long[] longs = new long[2];
+    int[] ints = new int[2];
+    float[] floats = new float[2];
     io.writeVInt(5);
+    io.writeLong(1);
+    io.writeLong(2);
     io.close();
     IndexInput one = mmapDir.openInput("bytes", IOContext.DEFAULT);
     IndexInput two = one.clone();
     IndexInput three = two.clone(); // clone of clone
     one.close();
-    expectThrows(
-        AlreadyClosedException.class,
-        () -> {
-          one.readVInt();
-        });
-    expectThrows(
-        AlreadyClosedException.class,
-        () -> {
-          two.readVInt();
-        });
-    expectThrows(
-        AlreadyClosedException.class,
-        () -> {
-          three.readVInt();
-        });
-
+    assertAlreadyClosed(one, two, three, in -> in.readVInt());
+    assertAlreadyClosed(one, two, three, in -> in.readLongs(longs, 0, 2));
+    assertAlreadyClosed(one, two, three, in -> in.readInts(ints, 0, 2)); // read as int
+    assertAlreadyClosed(one, two, three, in -> in.readFloats(floats, 0, 2)); // read as float
     two.close();
     three.close();
     // test double close of master:

--- a/lucene/core/src/test/org/apache/lucene/store/TestMultiMMap.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMultiMMap.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import org.apache.lucene.tests.store.BaseChunkedDirectoryTestCase;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOConsumer;
 import org.junit.BeforeClass;
 
 /**
@@ -32,10 +33,6 @@ import org.junit.BeforeClass;
  * &gt; Integer.MAX_VALUE in size using multiple byte buffers.
  */
 public class TestMultiMMap extends BaseChunkedDirectoryTestCase {
-
-  interface DataReader {
-    void read(IndexInput in) throws IOException;
-  }
 
   @Override
   protected Directory getDirectory(Path path, int maxChunkSize) throws IOException {
@@ -88,21 +85,21 @@ public class TestMultiMMap extends BaseChunkedDirectoryTestCase {
   // to the base test case?
 
   private void assertAlreadyClosed(
-      IndexInput one, IndexInput two, IndexInput three, DataReader reader) throws Exception {
+      IndexInput one, IndexInput two, IndexInput three, IOConsumer<DataInput> consumer) {
     expectThrows(
         AlreadyClosedException.class,
         () -> {
-          reader.read(one);
+          consumer.accept(one);
         });
     expectThrows(
         AlreadyClosedException.class,
         () -> {
-          reader.read(two);
+          consumer.accept(two);
         });
     expectThrows(
         AlreadyClosedException.class,
         () -> {
-          reader.read(three);
+          consumer.accept(three);
         });
   }
 


### PR DESCRIPTION

Currently, the `readLongs/readInts/readFloats` in `ByteBufferIndexInput` may throws `NullPointerException` when `IndexInput` is closed, The expected should be `AlreadyClosedException`.