### PR TITLE
Replace usage of deprecated size() with length() in ByteBuffersDataInput

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
@@ -157,7 +157,7 @@ public abstract class CompressionMode {
 
     @Override
     public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-      final int len = (int) buffersInput.size();
+      final int len = (int) buffersInput.length();
       byte[] bytes = new byte[len];
       buffersInput.readBytes(bytes, 0, len);
       LZ4.compress(bytes, 0, len, out, ht);
@@ -179,7 +179,7 @@ public abstract class CompressionMode {
 
     @Override
     public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-      final int len = (int) buffersInput.size();
+      final int len = (int) buffersInput.length();
       byte[] bytes = new byte[len];
       buffersInput.readBytes(bytes, 0, len);
       LZ4.compress(bytes, 0, len, out, ht);
@@ -265,7 +265,7 @@ public abstract class CompressionMode {
 
     @Override
     public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-      final int len = (int) buffersInput.size();
+      final int len = (int) buffersInput.length();
 
       byte[] bytes = new byte[len];
       buffersInput.readBytes(bytes, 0, len);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
@@ -202,7 +202,7 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
 
     @Override
     public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-      final int len = (int) (buffersInput.size() - buffersInput.position());
+      final int len = (int) (buffersInput.length() - buffersInput.position());
       final int dictLength = len / (NUM_SUB_BLOCKS * DICT_SIZE_FACTOR);
       final int blockLength = (len - dictLength + NUM_SUB_BLOCKS - 1) / NUM_SUB_BLOCKS;
       out.writeVInt(dictLength);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -169,7 +169,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
 
     @Override
     public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-      final int len = (int) (buffersInput.size() - buffersInput.position());
+      final int len = (int) (buffersInput.length() - buffersInput.position());
       final int dictLength = Math.min(LZ4.MAX_DISTANCE, len / (NUM_SUB_BLOCKS * DICT_SIZE_FACTOR));
       final int blockLength = (len - dictLength + NUM_SUB_BLOCKS - 1) / NUM_SUB_BLOCKS;
       buffer = ArrayUtil.growNoCopy(buffer, dictLength + blockLength);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
@@ -253,7 +253,7 @@ public final class Lucene90CompressingStoredFieldsWriter extends StoredFieldsWri
     // compress stored fields to fieldsStream.
     if (sliced) {
       // big chunk, slice it, using ByteBuffersDataInput ignore memory copy
-      final int capacity = (int) bytebuffers.size();
+      final int capacity = (int) bytebuffers.length();
       for (int compressed = 0; compressed < capacity; compressed += chunkSize) {
         int l = Math.min(chunkSize, capacity - compressed);
         ByteBuffersDataInput bbdi = bytebuffers.slice(compressed, l);

--- a/lucene/core/src/java/org/apache/lucene/index/PrefixCodedTerms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PrefixCodedTerms.java
@@ -115,7 +115,7 @@ public class PrefixCodedTerms implements Accountable {
 
     private TermIterator(long delGen, ByteBuffersDataInput input) {
       this.input = input;
-      end = input.size();
+      end = input.length();
       this.delGen = delGen;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
@@ -49,7 +49,7 @@ final class SortingStoredFieldsConsumer extends StoredFieldsConsumer {
             @Override
             public void compress(ByteBuffersDataInput buffersInput, DataOutput out)
                 throws IOException {
-              out.copyBytes(buffersInput, buffersInput.size());
+              out.copyBytes(buffersInput, buffersInput.length());
             }
           };
         }

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersIndexInput.java
@@ -53,7 +53,7 @@ public final class ByteBuffersIndexInput extends IndexInput implements RandomAcc
   @Override
   public long length() {
     ensureOpen();
-    return in.size();
+    return in.length();
   }
 
   @Override
@@ -209,7 +209,7 @@ public final class ByteBuffersIndexInput extends IndexInput implements RandomAcc
   public IndexInput clone() {
     ensureOpen();
     ByteBuffersIndexInput cloned =
-        new ByteBuffersIndexInput(in.slice(0, in.size()), "(clone of) " + toString());
+        new ByteBuffersIndexInput(in.slice(0, in.length()), "(clone of) " + toString());
     try {
       cloned.seek(getFilePointer());
     } catch (IOException e) {

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataInput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataInput.java
@@ -37,7 +37,7 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
   public void testSanity() throws IOException {
     ByteBuffersDataOutput out = new ByteBuffersDataOutput();
     ByteBuffersDataInput o1 = out.toDataInput();
-    assertEquals(0, o1.size());
+    assertEquals(0, o1.length());
     LuceneTestCase.expectThrows(
         EOFException.class,
         () -> {
@@ -47,9 +47,9 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
     out.writeByte((byte) 1);
 
     ByteBuffersDataInput o2 = out.toDataInput();
-    assertEquals(1, o2.size());
+    assertEquals(1, o2.length());
     assertEquals(0, o2.position());
-    assertEquals(0, o1.size());
+    assertEquals(0, o1.length());
 
     assertTrue(o2.ramBytesUsed() > 0);
     assertEquals(1, o2.readByte());
@@ -106,7 +106,7 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
           dst.toDataInput().slice(prefix.length, dst.size() - prefix.length - suffix.length);
 
       assertEquals(0, src.position());
-      assertEquals(dst.size() - prefix.length - suffix.length, src.size());
+      assertEquals(dst.size() - prefix.length - suffix.length, src.length());
       for (IOConsumer<DataInput> c : reply) {
         c.accept(src);
       }
@@ -190,8 +190,8 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
         curr = skipTo + 1; // +1 for read byte
       }
 
-      in.seek(in.size());
-      assertEquals(in.size(), in.position());
+      in.seek(in.length());
+      assertEquals(in.length(), in.position());
       LuceneTestCase.expectThrows(
           EOFException.class,
           () -> {
@@ -203,18 +203,18 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
   @Test
   public void testSlicingWindow() throws Exception {
     ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
-    assertEquals(0, dst.toDataInput().slice(0, 0).size());
+    assertEquals(0, dst.toDataInput().slice(0, 0).length());
 
     dst.writeBytes(randomBytesOfLength(1024 * 8));
     ByteBuffersDataInput in = dst.toDataInput();
     for (int offset = 0, max = (int) dst.size(); offset < max; offset++) {
-      assertEquals(0, in.slice(offset, 0).size());
-      assertEquals(1, in.slice(offset, 1).size());
+      assertEquals(0, in.slice(offset, 0).length());
+      assertEquals(1, in.slice(offset, 1).length());
 
       int window = Math.min(max - offset, 1024);
-      assertEquals(window, in.slice(offset, window).size());
+      assertEquals(window, in.slice(offset, window).length());
     }
-    assertEquals(0, in.slice((int) dst.size(), 0).size());
+    assertEquals(0, in.slice((int) dst.size(), 0).length());
   }
 
   @Test
@@ -265,17 +265,17 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
     buffers.get(0).position(shift);
 
     ByteBuffersDataInput dst = new ByteBuffersDataInput(buffers);
-    assertEquals(simulatedLength, dst.size());
+    assertEquals(simulatedLength, dst.length());
 
-    final long max = dst.size();
+    final long max = dst.length();
     long offset = 0;
     for (; offset < max; offset += randomIntBetween(MB, 4 * MB)) {
-      assertEquals(0, dst.slice(offset, 0).size());
-      assertEquals(1, dst.slice(offset, 1).size());
+      assertEquals(0, dst.slice(offset, 0).length());
+      assertEquals(1, dst.slice(offset, 1).length());
 
       long window = Math.min(max - offset, 1024);
       ByteBuffersDataInput slice = dst.slice(offset, window);
-      assertEquals(window, slice.size());
+      assertEquals(window, slice.length());
 
       // Sanity check of the content against original pages.
       for (int i = 0; i < window; i++) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/compressing/dummy/DummyCompressingCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/compressing/dummy/DummyCompressingCodec.java
@@ -78,7 +78,7 @@ public class DummyCompressingCodec extends CompressingCodec {
 
         @Override
         public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-          out.copyBytes(buffersInput, buffersInput.size());
+          out.copyBytes(buffersInput, buffersInput.length());
         }
 
         @Override


### PR DESCRIPTION
In https://github.com/apache/lucene/pull/12594, we mark `ByteBuffersDataInput#size()`  as `Deprecated`. For simplicity, maybe we should replace the usage of deprecated `size()` with `length()` ? 