### PR TITLE
An improved check for ignoring the c2-crash test if running on a client compiler.

### DIFF
--- a/gradle/testing/randomization/policies/tests.policy
+++ b/gradle/testing/randomization/policies/tests.policy
@@ -60,9 +60,6 @@ grant {
   permission java.lang.RuntimePermission "getFileStoreAttributes";
   permission java.lang.RuntimePermission "writeFileDescriptor";
 
-  // needed to check if C2 (implied by the presence of the CI env) is enabled
-  permission java.lang.RuntimePermission "getenv.CI";
-
   // TestLockFactoriesMultiJVM opens a random port on 127.0.0.1 (port 0 = ephemeral port range):
   permission java.net.SocketPermission "127.0.0.1:0", "accept,listen,resolve";
 

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -34,6 +34,7 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.CollectionUtil;
+import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SuppressForbidden;
 
 public class TestDocIdsWriter extends LuceneTestCase {
@@ -162,7 +163,7 @@ public class TestDocIdsWriter extends LuceneTestCase {
   // Crashes only when run with C2, so with the environment variable `CI` set
   // Regardless of whether C2 is enabled or not, the test should never fail.
   public void testCrash() throws IOException {
-    assumeTrue("Requires C2, which is only enabled when CI env is set", getCIEnv() != null);
+    assumeFalse("Requires C2 compiler (won't work on client VM).", Constants.IS_CLIENT_VM);
     int itrs = atLeast(100);
     for (int i = 0; i < itrs; i++) {
       try (Directory dir = newDirectory();

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -157,7 +157,7 @@ public class TestDocIdsWriter extends LuceneTestCase {
   }
 
   // This simple test tickles a JVM C2 JIT crash on JDK's less than 21.0.1
-  // Crashes only when run with C2, so with the environment variable `CI` set
+  // Crashes only when run with HotSpot C2.
   // Regardless of whether C2 is enabled or not, the test should never fail.
   public void testCrash() throws IOException {
     assumeTrue(

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -17,8 +17,6 @@
 package org.apache.lucene.util.bkd;
 
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -35,7 +33,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.Constants;
-import org.apache.lucene.util.SuppressForbidden;
 
 public class TestDocIdsWriter extends LuceneTestCase {
 
@@ -163,7 +160,9 @@ public class TestDocIdsWriter extends LuceneTestCase {
   // Crashes only when run with C2, so with the environment variable `CI` set
   // Regardless of whether C2 is enabled or not, the test should never fail.
   public void testCrash() throws IOException {
-    assumeFalse("Requires C2 compiler (won't work on client VM).", Constants.IS_CLIENT_VM);
+    assumeTrue(
+        "Requires HotSpot C2 compiler (won't work on client VM).",
+        Constants.IS_HOTSPOT_VM && !Constants.IS_CLIENT_VM);
     int itrs = atLeast(100);
     for (int i = 0; i < itrs; i++) {
       try (Directory dir = newDirectory();
@@ -174,12 +173,5 @@ public class TestDocIdsWriter extends LuceneTestCase {
         }
       }
     }
-  }
-
-  @SuppressForbidden(reason = "needed to check if C2 is enabled")
-  @SuppressWarnings("removal")
-  private static String getCIEnv() {
-    PrivilegedAction<String> pa = () -> System.getenv("CI");
-    return AccessController.doPrivileged(pa);
   }
 }


### PR DESCRIPTION
Follow-up to #12905