### PR TITLE
Lazily write the FST padding byte

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -550,6 +550,7 @@ public class FSTCompiler<T> {
     }
 
     reverseScratchBytes();
+    // write the padding byte if needed
     if (numBytesWritten == 1) {
       writePaddingByte();
     }
@@ -561,6 +562,7 @@ public class FSTCompiler<T> {
   }
 
   private void writePaddingByte() throws IOException {
+    assert numBytesWritten == 1;
     dataOutput.writeByte((byte) 0);
   }
 
@@ -975,7 +977,6 @@ public class FSTCompiler<T> {
         return null;
       } else {
         // we haven't written the pad byte so far, but the FST is still valid
-        assert numBytesWritten == 1;
         writePaddingByte();
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -164,14 +164,12 @@ public class FSTCompiler<T> {
       boolean allowFixedLengthArcs,
       DataOutput dataOutput,
       float directAddressingMaxOversizingFactor,
-      int version)
-      throws IOException {
+      int version) {
     this.allowFixedLengthArcs = allowFixedLengthArcs;
     this.directAddressingMaxOversizingFactor = directAddressingMaxOversizingFactor;
     this.version = version;
     // pad: ensure no node gets address 0 which is reserved to mean
-    // the stop state w/ no arcs
-    dataOutput.writeByte((byte) 0);
+    // the stop state w/ no arcs. the actual byte will be written lazily
     numBytesWritten++;
     this.dataOutput = dataOutput;
     fst =
@@ -344,7 +342,7 @@ public class FSTCompiler<T> {
     }
 
     /** Creates a new {@link FSTCompiler}. */
-    public FSTCompiler<T> build() throws IOException {
+    public FSTCompiler<T> build() {
       // create a default DataOutput if not specified
       if (dataOutput == null) {
         dataOutput = getOnHeapReaderWriter(15);
@@ -552,6 +550,10 @@ public class FSTCompiler<T> {
     }
 
     reverseScratchBytes();
+    if (numBytesWritten == 1) {
+      // first time, write the padding byte
+      dataOutput.writeByte((byte) 0);
+    }
     scratchBytes.writeTo(dataOutput);
     numBytesWritten += scratchBytes.getPosition();
 

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -551,14 +551,17 @@ public class FSTCompiler<T> {
 
     reverseScratchBytes();
     if (numBytesWritten == 1) {
-      // first time, write the padding byte
-      dataOutput.writeByte((byte) 0);
+      writePaddingByte();
     }
     scratchBytes.writeTo(dataOutput);
     numBytesWritten += scratchBytes.getPosition();
 
     nodeCount++;
     return numBytesWritten - 1;
+  }
+
+  private void writePaddingByte() throws IOException {
+    dataOutput.writeByte((byte) 0);
   }
 
   private void writeLabel(DataOutput out, int v) throws IOException {
@@ -970,6 +973,10 @@ public class FSTCompiler<T> {
     if (root.numArcs == 0) {
       if (fst.metadata.emptyOutput == null) {
         return null;
+      } else {
+        // we haven't written the pad byte so far, but the FST is still valid
+        assert numBytesWritten == 1;
+        writePaddingByte();
       }
     }
 


### PR DESCRIPTION
### Description

Lazily write the FST padding byte, so that in case the FST is empty (no accepted nodes) nothing will be written. This is important for off-heap writing, as we don't want to add that extra byte when the FST would be thrown away. Found while working on https://github.com/apache/lucene/pull/12980