### PR TITLE
Reduce number of dimensions for Test[Byte|Float]VectorSimilarityQuery

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestByteVectorSimilarityQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestByteVectorSimilarityQuery.java
@@ -33,7 +33,7 @@ public class TestByteVectorSimilarityQuery
     idField = getClass().getSimpleName() + ":IdField";
     function = VectorSimilarityFunction.EUCLIDEAN;
     numDocs = atLeast(100);
-    dim = atLeast(50);
+    dim = atLeast(5);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestFloatVectorSimilarityQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFloatVectorSimilarityQuery.java
@@ -33,7 +33,7 @@ public class TestFloatVectorSimilarityQuery
     idField = getClass().getSimpleName() + ":IdField";
     function = VectorSimilarityFunction.EUCLIDEAN;
     numDocs = atLeast(100);
-    dim = atLeast(50);
+    dim = atLeast(5);
   }
 
   @Override


### PR DESCRIPTION
### Description

Identified in #12955, where `TestFloatVectorSimilarityQuery.testVectorsAboveSimilarity` fails because of a disconnected HNSW graph

This is a bigger issue, but we can reduce intermittent failures by keeping the number of docs and dimensions same as [`BaseKnnVectorQueryTestCase.testRandom`](https://github.com/apache/lucene/blob/dc9f154aa574e8cd0e60070a1814c1d221fbec5d/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java#L470) (similar test for KNN with random vectors)

### Command to reproduce

```
./gradlew :lucene:core:test --tests "org.apache.lucene.search.TestFloatVectorSimilarityQuery.testVectorsAboveSimilarity" -Ptests.jvms=12 -Ptests.jvmargs= -Ptests.seed=1A1CDC0974AF361
```