### PR TITLE
Remove unnecessary comment

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -107,7 +107,6 @@ public final class TaskExecutor {
     }
 
     RunnableFuture<T> createTask(Callable<T> callable) {
-      // -1: cancelled; 0: not yet started; 1: started
       AtomicBoolean startedOrCancelled = new AtomicBoolean(false);
       return new FutureTask<>(
           () -> {


### PR DESCRIPTION
### Description

A [previous iteration][1] of this code used an AtomicInteger and required this comment. The committed version uses a self-documenting boolean and the comment is not needed.

[1]: https://github.com/apache/lucene/pull/12689/commits/5c847a0a3b2312414c8a4623d288d8fe96d52ff8


<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
