### PR TITLE
[Minor] Document operation costs for stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,5 +33,18 @@ jobs:
           If the PR is waiting for review, notify the dev@lucene.apache.org list.
           Thank you for your contribution!
 
-        operations-per-run: 500       # operations budget
         debug-only: false             # turn on to run the action without applying changes
+        operations-per-run: 500       # operations budget
+
+# The table shows the cost in operations of all combinations of stale / not-stale for a PR.
+# Processing a non-PR issue takes 0 operations, since we don't perform any action on it.
+#
+#                            +-----------------------+
+#            number of       |  state after workflow |
+#           operations       +-----------+-----------+
+#                            |   stale   | not stale |
+#     +----------+-----------+-----------+-----------+
+#     |  state   |   stale   |     3     |     4     |
+#     |  before  +-----------+-----------+-----------+
+#     | workflow | not stale |     5     |     1     |
+#     +----------+-----------+-----------+-----------+


### PR DESCRIPTION
Documenting the operation costs from the [latest stale workflow run](https://github.com/apache/lucene/actions/runs/7454785611/job/20282760199) for posterity.