### PR TITLE
SurroundQuery should pull TermStates during rewrite

### DIFF
--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/BasicQueryFactory.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/BasicQueryFactory.java
@@ -26,6 +26,7 @@ package org.apache.lucene.queryparser.surround.query;
  */
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermStates;
 import org.apache.lucene.queries.spans.SpanTermQuery;
 import org.apache.lucene.search.TermQuery;
 
@@ -70,14 +71,15 @@ public class BasicQueryFactory {
     queriesMade++;
   }
 
-  public TermQuery newTermQuery(Term term) throws TooManyBasicQueries {
+  public TermQuery newTermQuery(Term term, TermStates termStates) throws TooManyBasicQueries {
     checkMax();
-    return new TermQuery(term);
+    return new TermQuery(term, termStates);
   }
 
-  public SpanTermQuery newSpanTermQuery(Term term) throws TooManyBasicQueries {
+  public SpanTermQuery newSpanTermQuery(Term term, TermStates termStates)
+      throws TooManyBasicQueries {
     checkMax();
-    return new SpanTermQuery(term);
+    return new SpanTermQuery(term, termStates);
   }
 
   @Override

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/SimpleTermRewriteQuery.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/SimpleTermRewriteQuery.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermStates;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
@@ -40,8 +41,8 @@ class SimpleTermRewriteQuery extends RewriteQuery<SimpleTerm> {
         fieldName,
         new SimpleTerm.MatchingTermVisitor() {
           @Override
-          public void visitMatchingTerm(Term term) throws IOException {
-            luceneSubQueries.add(qf.newTermQuery(term));
+          public void visitMatchingTerm(Term term, TermStates termStates) throws IOException {
+            luceneSubQueries.add(qf.newTermQuery(term, termStates));
           }
         });
     return (luceneSubQueries.size() == 0)

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/SpanNearClauseFactory.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/SpanNearClauseFactory.java
@@ -57,6 +57,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermStates;
 import org.apache.lucene.queries.spans.SpanOrQuery;
 import org.apache.lucene.queries.spans.SpanQuery;
 import org.apache.lucene.queries.spans.SpanTermQuery;
@@ -104,8 +105,8 @@ public class SpanNearClauseFactory { // FIXME: rename to SpanClauseFactory
     weightBySpanQuery.put(sq, w);
   }
 
-  public void addTermWeighted(Term t, float weight) throws IOException {
-    SpanTermQuery stq = qf.newSpanTermQuery(t);
+  public void addTermWeighted(Term t, float weight, TermStates termStates) throws IOException {
+    SpanTermQuery stq = qf.newSpanTermQuery(t, termStates);
     /* CHECKME: wrap in Hashable...? */
     addSpanQueryWeighted(stq, weight);
   }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/SrndTruncQuery.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/SrndTruncQuery.java
@@ -17,11 +17,10 @@
 package org.apache.lucene.queryparser.surround.query;
 
 import java.io.IOException;
+import java.util.Map;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.index.Terms;
-import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.index.TermStates;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
@@ -56,14 +55,10 @@ public class SrndTruncQuery extends SimpleTerm {
   @Override
   public void visitMatchingTerms(IndexReader reader, String fieldName, MatchingTermVisitor mtv)
       throws IOException {
-    Terms terms = MultiTerms.getTerms(reader, fieldName);
-    if (terms != null) {
-      TermsEnum termsEnum = compiled.getTermsEnum(terms);
-
-      BytesRef br;
-      while ((br = termsEnum.next()) != null) {
-        mtv.visitMatchingTerm(new Term(fieldName, BytesRef.deepCopyOf(br)));
-      }
+    Map<BytesRef, TermStates> termStatesMap =
+        collectTerms(reader, fieldName, compiled::getTermsEnum);
+    for (Map.Entry<BytesRef, TermStates> e : termStatesMap.entrySet()) {
+      mtv.visitMatchingTerm(new Term(fieldName, e.getKey()), e.getValue());
     }
   }
 }


### PR DESCRIPTION
SpanQueries (to which SurroundQuery rewrites) provide the ability to specify TermStates at query construction; but SurroundQuery has not historically leveraged this optimization, instead rewriting to SpanQueries without TermStates information. The SpanQueries then separately pull TermStates info before running, so we can save considerable effort by pulling TermStates directly during the initial SurroundQuery rewrite.