### PR TITLE
Backport #12829 to 9.x

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -24,6 +24,12 @@ New Features
   better-scoring nodes are available, or the best candidate is below a score of `traversalSimilarity` in the lowest
   level. (Aditya Prakash, Kaival Parikh)
 
+* GITHUB#12829: For indices newly created as of 9.10.0 onwards, IndexWriter preserves document blocks indexed via
+  IndexWriter#addDocuments or IndexWriter#updateDocuments also when index sorting is configured. Document blocks are
+  maintained alongside their parent documents during sort and merge. IndexWriterConfig accepts a parent field that is used
+  to maintain block orders if index sorting is used. Note, this is fully optional in Lucene 9.x while will be mandatory for
+  indices that use document blocks together with index sorting as of 10.0.0. (Simon Willnauer)
+
 Improvements
 ---------------------
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene60/Lucene60FieldInfosFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene60/Lucene60FieldInfosFormat.java
@@ -217,7 +217,8 @@ public final class Lucene60FieldInfosFormat extends FieldInfosFormat {
                 0,
                 VectorEncoding.FLOAT32,
                 VectorSimilarityFunction.EUCLIDEAN,
-                isSoftDeletesField);
+                isSoftDeletesField,
+                false);
       } catch (IllegalStateException e) {
         throw new CorruptIndexException(
             "invalid fieldinfo for field: " + name + ", fieldNumber=" + fieldNumber, input, e);

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90FieldInfosFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90FieldInfosFormat.java
@@ -194,7 +194,8 @@ public final class Lucene90FieldInfosFormat extends FieldInfosFormat {
                     vectorDimension,
                     VectorEncoding.FLOAT32,
                     vectorDistFunc,
-                    isSoftDeletesField);
+                    isSoftDeletesField,
+                    false);
             infos[i].checkConsistency();
           } catch (IllegalStateException e) {
             throw new CorruptIndexException(

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene70/TestLucene70SegmentInfoFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene70/TestLucene70SegmentInfoFormat.java
@@ -34,4 +34,9 @@ public class TestLucene70SegmentInfoFormat extends BaseSegmentInfoFormatTestCase
   protected Codec getCodec() {
     return new Lucene84RWCodec();
   }
+
+  @Override
+  protected boolean supportsHasBlocks() {
+    return false;
+  }
 }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene86/TestLucene86SegmentInfoFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene86/TestLucene86SegmentInfoFormat.java
@@ -34,4 +34,9 @@ public class TestLucene86SegmentInfoFormat extends BaseSegmentInfoFormatTestCase
   protected Codec getCodec() {
     return new Lucene87RWCodec();
   }
+
+  @Override
+  protected boolean supportsHasBlocks() {
+    return false;
+  }
 }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/TestLucene90SegmentInfoFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/TestLucene90SegmentInfoFormat.java
@@ -32,4 +32,9 @@ public class TestLucene90SegmentInfoFormat extends BaseSegmentInfoFormatTestCase
   protected Codec getCodec() {
     return new Lucene90RWCodec();
   }
+
+  @Override
+  protected boolean supportsHasBlocks() {
+    return false;
+  }
 }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldInfosFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldInfosFormat.java
@@ -72,6 +72,7 @@ public class SimpleTextFieldInfosFormat extends FieldInfosFormat {
   static final BytesRef VECTOR_ENCODING = new BytesRef("  vector encoding ");
   static final BytesRef VECTOR_SIMILARITY = new BytesRef("  vector similarity ");
   static final BytesRef SOFT_DELETES = new BytesRef("  soft-deletes ");
+  static final BytesRef PARENT = new BytesRef("  parent ");
 
   @Override
   public FieldInfos read(
@@ -170,6 +171,9 @@ public class SimpleTextFieldInfosFormat extends FieldInfosFormat {
         SimpleTextUtil.readLine(input, scratch);
         assert StringHelper.startsWith(scratch.get(), SOFT_DELETES);
         boolean isSoftDeletesField = Boolean.parseBoolean(readString(SOFT_DELETES.length, scratch));
+        SimpleTextUtil.readLine(input, scratch);
+        assert StringHelper.startsWith(scratch.get(), PARENT);
+        boolean isParentField = Boolean.parseBoolean(readString(PARENT.length, scratch));
 
         infos[i] =
             new FieldInfo(
@@ -188,7 +192,8 @@ public class SimpleTextFieldInfosFormat extends FieldInfosFormat {
                 vectorNumDimensions,
                 vectorEncoding,
                 vectorDistFunc,
-                isSoftDeletesField);
+                isSoftDeletesField,
+                isParentField);
       }
 
       SimpleTextUtil.checkFooter(input);
@@ -319,6 +324,10 @@ public class SimpleTextFieldInfosFormat extends FieldInfosFormat {
 
         SimpleTextUtil.write(out, SOFT_DELETES);
         SimpleTextUtil.write(out, Boolean.toString(fi.isSoftDeletesField()), scratch);
+        SimpleTextUtil.writeNewline(out);
+
+        SimpleTextUtil.write(out, PARENT);
+        SimpleTextUtil.write(out, Boolean.toString(fi.isParentField()), scratch);
         SimpleTextUtil.writeNewline(out);
       }
       SimpleTextUtil.writeChecksum(out, scratch);

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSegmentInfoFormat.java
@@ -196,7 +196,13 @@ public class SimpleTextSegmentInfoFormat extends SegmentInfoFormat {
         sortField[i] = SortFieldProvider.forName(provider).readSortField(bytes);
         assert bytes.eof();
       }
-      Sort indexSort = sortField.length == 0 ? null : new Sort(sortField);
+
+      final Sort indexSort;
+      if (sortField.length == 0) {
+        indexSort = null;
+      } else {
+        indexSort = new Sort(sortField);
+      }
 
       SimpleTextUtil.checkFooter(input);
 
@@ -335,7 +341,6 @@ public class SimpleTextSegmentInfoFormat extends SegmentInfoFormat {
         SimpleTextUtil.write(output, b.bytes.get().toString(), scratch);
         SimpleTextUtil.writeNewline(output);
       }
-
       SimpleTextUtil.writeChecksum(output, scratch);
     }
   }

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/TestBlockWriter.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/TestBlockWriter.java
@@ -119,6 +119,7 @@ public class TestBlockWriter extends LuceneTestCase {
         0,
         VectorEncoding.FLOAT32,
         VectorSimilarityFunction.EUCLIDEAN,
-        true);
+        true,
+        false);
   }
 }

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/sharedterms/TestSTBlockReader.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/sharedterms/TestSTBlockReader.java
@@ -206,6 +206,7 @@ public class TestSTBlockReader extends LuceneTestCase {
         0,
         VectorEncoding.FLOAT32,
         VectorSimilarityFunction.EUCLIDEAN,
+        false,
         false);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene94/Lucene94FieldInfosFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene94/Lucene94FieldInfosFormat.java
@@ -131,13 +131,14 @@ public final class Lucene94FieldInfosFormat extends FieldInfosFormat {
       Throwable priorE = null;
       FieldInfo[] infos = null;
       try {
-        CodecUtil.checkIndexHeader(
-            input,
-            Lucene94FieldInfosFormat.CODEC_NAME,
-            Lucene94FieldInfosFormat.FORMAT_START,
-            Lucene94FieldInfosFormat.FORMAT_CURRENT,
-            segmentInfo.getId(),
-            segmentSuffix);
+        int format =
+            CodecUtil.checkIndexHeader(
+                input,
+                Lucene94FieldInfosFormat.CODEC_NAME,
+                Lucene94FieldInfosFormat.FORMAT_START,
+                Lucene94FieldInfosFormat.FORMAT_CURRENT,
+                segmentInfo.getId(),
+                segmentSuffix);
 
         final int size = input.readVInt(); // read in the size
         infos = new FieldInfo[size];
@@ -157,6 +158,18 @@ public final class Lucene94FieldInfosFormat extends FieldInfosFormat {
           boolean omitNorms = (bits & OMIT_NORMS) != 0;
           boolean storePayloads = (bits & STORE_PAYLOADS) != 0;
           boolean isSoftDeletesField = (bits & SOFT_DELETES_FIELD) != 0;
+          boolean isParentField =
+              format >= FORMAT_PARENT_FIELD ? (bits & PARENT_FIELD_FIELD) != 0 : false;
+
+          if ((bits & 0xE0) != 0) {
+            throw new CorruptIndexException(
+                "unused bits are set \"" + Integer.toBinaryString(bits) + "\"", input);
+          }
+          if (format < FORMAT_PARENT_FIELD && (bits & 0xF0) != 0) {
+            throw new CorruptIndexException(
+                "parent field bit is set but shouldn't \"" + Integer.toBinaryString(bits) + "\"",
+                input);
+          }
 
           final IndexOptions indexOptions = getIndexOptions(input, input.readByte());
 
@@ -200,7 +213,8 @@ public final class Lucene94FieldInfosFormat extends FieldInfosFormat {
                     vectorDimension,
                     vectorEncoding,
                     vectorDistFunc,
-                    isSoftDeletesField);
+                    isSoftDeletesField,
+                    isParentField);
             infos[i].checkConsistency();
           } catch (IllegalStateException e) {
             throw new CorruptIndexException(
@@ -348,6 +362,7 @@ public final class Lucene94FieldInfosFormat extends FieldInfosFormat {
         if (fi.omitsNorms()) bits |= OMIT_NORMS;
         if (fi.hasPayloads()) bits |= STORE_PAYLOADS;
         if (fi.isSoftDeletesField()) bits |= SOFT_DELETES_FIELD;
+        if (fi.isParentField()) bits |= PARENT_FIELD_FIELD;
         output.writeByte(bits);
 
         output.writeByte(indexOptionsByte(fi.getIndexOptions()));
@@ -375,11 +390,14 @@ public final class Lucene94FieldInfosFormat extends FieldInfosFormat {
   // Codec header
   static final String CODEC_NAME = "Lucene94FieldInfos";
   static final int FORMAT_START = 0;
-  static final int FORMAT_CURRENT = FORMAT_START;
+  // this doesn't actually change the file format but uses up one more bit an existing bit pattern
+  static final int FORMAT_PARENT_FIELD = 1;
+  static final int FORMAT_CURRENT = FORMAT_PARENT_FIELD;
 
   // Field flags
   static final byte STORE_TERMVECTOR = 0x1;
   static final byte OMIT_NORMS = 0x2;
   static final byte STORE_PAYLOADS = 0x4;
   static final byte SOFT_DELETES_FIELD = 0x8;
+  static final byte PARENT_FIELD_FIELD = 0x10;
 }

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
@@ -63,6 +63,8 @@ public final class FieldInfo {
   // whether this field is used as the soft-deletes field
   private final boolean softDeletesField;
 
+  private final boolean isParentField;
+
   /**
    * Sole constructor.
    *
@@ -84,7 +86,8 @@ public final class FieldInfo {
       int vectorDimension,
       VectorEncoding vectorEncoding,
       VectorSimilarityFunction vectorSimilarityFunction,
-      boolean softDeletesField) {
+      boolean softDeletesField,
+      boolean isParentField) {
     this.name = Objects.requireNonNull(name);
     this.number = number;
     this.docValuesType =
@@ -111,6 +114,7 @@ public final class FieldInfo {
     this.vectorEncoding = vectorEncoding;
     this.vectorSimilarityFunction = vectorSimilarityFunction;
     this.softDeletesField = softDeletesField;
+    this.isParentField = isParentField;
     this.checkConsistency();
   }
 
@@ -205,6 +209,13 @@ public final class FieldInfo {
     if (vectorDimension < 0) {
       throw new IllegalArgumentException(
           "vectorDimension must be >=0; got " + vectorDimension + " (field: '" + name + "')");
+    }
+
+    if (softDeletesField && isParentField) {
+      throw new IllegalArgumentException(
+          "field can't be used as soft-deletes field and parent document field (field: '"
+              + name
+              + "')");
     }
   }
 
@@ -542,7 +553,8 @@ public final class FieldInfo {
         this.vectorDimension,
         this.vectorEncoding,
         this.vectorSimilarityFunction,
-        this.softDeletesField);
+        this.softDeletesField,
+        this.isParentField);
   }
 
   /**
@@ -800,5 +812,13 @@ public final class FieldInfo {
    */
   public boolean isSoftDeletesField() {
     return softDeletesField;
+  }
+
+  /**
+   * Returns true if this field is configured and used as the parent document field field. See
+   * {@link IndexWriterConfig#setParentField(String)}
+   */
+  public boolean isParentField() {
+    return isParentField;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1262,8 +1262,10 @@ public class IndexWriter
    */
   private FieldNumbers getFieldNumberMap() throws IOException {
     final FieldNumbers map =
-        new FieldNumbers(config.softDeletesField, segmentInfos.getIndexCreatedVersionMajor());
-
+        new FieldNumbers(
+            config.softDeletesField,
+            config.getParentField(),
+            segmentInfos.getIndexCreatedVersionMajor());
     for (SegmentCommitInfo info : segmentInfos) {
       FieldInfos fis = readFieldInfos(info);
       for (FieldInfo fi : fis) {
@@ -6615,11 +6617,13 @@ public class IndexWriter
           }
 
           @Override
-          public FieldInfosBuilder newFieldInfosBuilder(String softDeletesFieldName) {
+          public FieldInfosBuilder newFieldInfosBuilder(
+              String softDeletesFieldName, String parentFieldName) {
             return new FieldInfosBuilder() {
               private FieldInfos.Builder builder =
                   new FieldInfos.Builder(
-                      new FieldInfos.FieldNumbers(softDeletesFieldName, Version.LATEST.major));
+                      new FieldInfos.FieldNumbers(
+                          softDeletesFieldName, parentFieldName, Version.LATEST.major));
 
               @Override
               public FieldInfosBuilder add(FieldInfo fi) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
@@ -545,4 +545,20 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
     this.eventListener = eventListener;
     return this;
   }
+
+  /**
+   * Sets the parent document field. If this optional property is set, IndexWriter will add an
+   * internal field to every root document added to the index writer. A document is considered a
+   * parent document if it's the last document in a document block indexed via {@link
+   * IndexWriter#addDocuments(Iterable)} or {@link IndexWriter#updateDocuments(Term, Iterable)} and
+   * its relatives. Additionally, all individual documents added via the single document methods
+   * ({@link IndexWriter#addDocuments(Iterable)} etc.) are also considered parent documents. This
+   * property is optional for all indices that don't use document blocks in combination with index
+   * sorting. In order to maintain the API guarantee that the document order of a block is not
+   * altered by the {@link IndexWriter} a marker for parent documents is required.
+   */
+  public IndexWriterConfig setParentField(String parentField) {
+    this.parentField = parentField;
+    return this;
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.codecs.DocValuesConsumer;
@@ -38,6 +40,7 @@ import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsFormat;
 import org.apache.lucene.codecs.PointsWriter;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.InvertableType;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.StoredValue;
@@ -49,6 +52,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.ByteBlockPool;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefHash.MaxBytesLengthExceededException;
@@ -219,7 +223,23 @@ final class IndexingChain implements Accountable {
     }
 
     LeafReader docValuesReader = getDocValuesLeafReader();
+    Function<IndexSorter.DocComparator, IndexSorter.DocComparator> comparatorWrapper =
+        Function.identity();
 
+    if (state.segmentInfo.getHasBlocks() && state.fieldInfos.getParentField() != null) {
+      final DocIdSetIterator readerValues =
+          docValuesReader.getNumericDocValues(state.fieldInfos.getParentField());
+      if (readerValues == null) {
+        throw new CorruptIndexException(
+            "missing doc values for parent field \"" + state.fieldInfos.getParentField() + "\"",
+            "IndexingChain");
+      }
+      BitSet parents = BitSet.of(readerValues, state.segmentInfo.maxDoc());
+      comparatorWrapper =
+          in ->
+              (docID1, docID2) ->
+                  in.compare(parents.nextSetBit(docID1), parents.nextSetBit(docID2));
+    }
     List<IndexSorter.DocComparator> comparators = new ArrayList<>();
     for (int i = 0; i < indexSort.getSort().length; i++) {
       SortField sortField = indexSort.getSort()[i];
@@ -227,7 +247,10 @@ final class IndexingChain implements Accountable {
       if (sorter == null) {
         throw new UnsupportedOperationException("Cannot sort index using sort field " + sortField);
       }
-      comparators.add(sorter.getDocComparator(docValuesReader, state.segmentInfo.maxDoc()));
+
+      IndexSorter.DocComparator docComparator =
+          sorter.getDocComparator(docValuesReader, state.segmentInfo.maxDoc());
+      comparators.add(comparatorWrapper.apply(docComparator));
     }
     Sorter sorter = new Sorter(indexSort);
     // returns null if the documents are already sorted
@@ -546,7 +569,17 @@ final class IndexingChain implements Accountable {
       // build schema for each unique doc field
       for (IndexableField field : document) {
         IndexableFieldType fieldType = field.fieldType();
-        PerField pf = getOrAddPerField(field.name());
+        final boolean isReserved = field.getClass() == ReservedField.class;
+        PerField pf =
+            getOrAddPerField(
+                field.name(), false
+                /* we never add reserved fields during indexing should be done during DWPT setup*/ );
+        if (pf.reserved != isReserved) {
+          throw new IllegalArgumentException(
+              "\""
+                  + field.name()
+                  + "\" is a reserved field and should not be added to any document");
+        }
         if (pf.fieldGen != fieldGen) { // first time we see this field in this document
           fields[fieldCount++] = pf;
           pf.fieldGen = fieldGen;
@@ -556,7 +589,7 @@ final class IndexingChain implements Accountable {
         docFields[docFieldIdx++] = pf;
         updateDocFieldSchema(field.name(), pf.schema, fieldType);
       }
-      // For each field, if it the first time we see this field in this segment,
+      // For each field, if it's the first time we see this field in this segment,
       // initialize its FieldInfo.
       // If we have already seen this field, verify that its schema
       // within the current doc matches its schema in the index.
@@ -646,7 +679,8 @@ final class IndexingChain implements Accountable {
                 s.vectorDimension,
                 s.vectorEncoding,
                 s.vectorSimilarityFunction,
-                pf.fieldName.equals(fieldInfos.getSoftDeletesFieldName())));
+                pf.fieldName.equals(fieldInfos.getSoftDeletesFieldName()),
+                pf.fieldName.equals(fieldInfos.getParentFieldName())));
     pf.setFieldInfo(fi);
     if (fi.getIndexOptions() != IndexOptions.NONE) {
       pf.setInvertState();
@@ -741,7 +775,7 @@ final class IndexingChain implements Accountable {
    * Returns a previously created {@link PerField}, absorbing the type information from {@link
    * FieldType}, and creates a new {@link PerField} if this field name wasn't seen yet.
    */
-  private PerField getOrAddPerField(String fieldName) {
+  private PerField getOrAddPerField(String fieldName, boolean reserved) {
     final int hashPos = fieldName.hashCode() & hashMask;
     PerField pf = fieldHash[hashPos];
     while (pf != null && pf.fieldName.equals(fieldName) == false) {
@@ -757,7 +791,8 @@ final class IndexingChain implements Accountable {
               schema,
               indexWriterConfig.getSimilarity(),
               indexWriterConfig.getInfoStream(),
-              indexWriterConfig.getAnalyzer());
+              indexWriterConfig.getAnalyzer(),
+              reserved);
       pf.next = fieldHash[hashPos];
       fieldHash[hashPos] = pf;
       totalFieldCount++;
@@ -1028,6 +1063,7 @@ final class IndexingChain implements Accountable {
     final String fieldName;
     final int indexCreatedVersionMajor;
     final FieldSchema schema;
+    final boolean reserved;
     FieldInfo fieldInfo;
     final Similarity similarity;
 
@@ -1065,13 +1101,15 @@ final class IndexingChain implements Accountable {
         FieldSchema schema,
         Similarity similarity,
         InfoStream infoStream,
-        Analyzer analyzer) {
+        Analyzer analyzer,
+        boolean reserved) {
       this.fieldName = fieldName;
       this.indexCreatedVersionMajor = indexCreatedVersionMajor;
       this.schema = schema;
       this.similarity = similarity;
       this.infoStream = infoStream;
       this.analyzer = analyzer;
+      this.reserved = reserved;
     }
 
     void reset(int docId) {
@@ -1516,6 +1554,79 @@ final class IndexingChain implements Accountable {
       assertSame(
           "point index dimension", fi.getPointIndexDimensionCount(), pointIndexDimensionCount);
       assertSame("point num bytes", fi.getPointNumBytes(), pointNumBytes);
+    }
+  }
+
+  /**
+   * Wraps the given field in a reserved field and registers it as reserved. Only DWPT should do
+   * this to mark fields as private / reserved to prevent this fieldname to be used from the outside
+   * of the IW / DWPT eco-system
+   */
+  <T extends IndexableField> ReservedField<T> markAsReserved(T field) {
+    getOrAddPerField(field.name(), true);
+    return new ReservedField<T>(field);
+  }
+
+  static final class ReservedField<T extends IndexableField> implements IndexableField {
+
+    private final T delegate;
+
+    private ReservedField(T delegate) {
+      this.delegate = delegate;
+    }
+
+    T getDelegate() {
+      return delegate;
+    }
+
+    @Override
+    public String name() {
+      return delegate.name();
+    }
+
+    @Override
+    public IndexableFieldType fieldType() {
+      return delegate.fieldType();
+    }
+
+    @Override
+    public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse) {
+      return delegate.tokenStream(analyzer, reuse);
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+      return delegate.binaryValue();
+    }
+
+    @Override
+    public String stringValue() {
+      return delegate.stringValue();
+    }
+
+    @Override
+    public CharSequence getCharSequenceValue() {
+      return delegate.getCharSequenceValue();
+    }
+
+    @Override
+    public Reader readerValue() {
+      return delegate.readerValue();
+    }
+
+    @Override
+    public Number numericValue() {
+      return delegate.numericValue();
+    }
+
+    @Override
+    public StoredValue storedValue() {
+      return delegate.storedValue();
+    }
+
+    @Override
+    public InvertableType invertableType() {
+      return delegate.invertableType();
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
@@ -98,6 +98,9 @@ public class LiveIndexWriterConfig {
   /** The field names involved in the index sort */
   protected Set<String> indexSortFields = Collections.emptySet();
 
+  /** parent document field */
+  protected String parentField = null;
+
   /**
    * if an indexing thread should check for pending flushes on update in order to help out on a full
    * flush
@@ -458,6 +461,11 @@ public class LiveIndexWriterConfig {
     return eventListener;
   }
 
+  /** Returns the parent document field name if configured. */
+  public String getParentField() {
+    return parentField;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -486,6 +494,7 @@ public class LiveIndexWriterConfig {
     sb.append("maxFullFlushMergeWaitMillis=").append(getMaxFullFlushMergeWaitMillis()).append("\n");
     sb.append("leafSorter=").append(getLeafSorter()).append("\n");
     sb.append("eventListener=").append(getIndexWriterEventListener()).append("\n");
+    sb.append("parentField=").append(getParentField()).append("\n");
     return sb.toString();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -111,6 +111,12 @@ public class ParallelLeafReader extends LeafReader {
             .filter(Objects::nonNull)
             .findAny()
             .orElse(null);
+    final String parentField =
+        completeReaderSet.stream()
+            .map(r -> r.getFieldInfos().getParentField())
+            .filter(Objects::nonNull)
+            .findAny()
+            .orElse(null);
     // TODO: make this read-only in a cleaner way?
     final int indexCreatedVersionMajor =
         completeReaderSet.stream()
@@ -121,8 +127,7 @@ public class ParallelLeafReader extends LeafReader {
             .orElse(Version.LATEST.major);
     FieldInfos.Builder builder =
         new FieldInfos.Builder(
-            new FieldInfos.FieldNumbers(softDeletesField, indexCreatedVersionMajor));
-
+            new FieldInfos.FieldNumbers(softDeletesField, parentField, indexCreatedVersionMajor));
     Sort indexSort = null;
     int createdVersionMajor = -1;
 

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -720,7 +720,8 @@ final class ReadersAndUpdates {
         fi.getVectorDimension(),
         fi.getVectorEncoding(),
         fi.getVectorSimilarityFunction(),
-        fi.isSoftDeletesField());
+        fi.isSoftDeletesField(),
+        fi.isParentField());
   }
 
   private SegmentReader createNewReaderWithLatestLiveDocs(SegmentReader reader) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/index/Sorter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Sorter.java
@@ -17,8 +17,10 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.util.function.Function;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.TimSorter;
 import org.apache.lucene.util.packed.PackedInts;
 import org.apache.lucene.util.packed.PackedLongValues;
@@ -206,13 +208,25 @@ public final class Sorter {
     SortField[] fields = sort.getSort();
     final IndexSorter.DocComparator[] comparators = new IndexSorter.DocComparator[fields.length];
 
+    Function<IndexSorter.DocComparator, IndexSorter.DocComparator> comparatorWrapper = in -> in;
+    LeafMetaData metaData = reader.getMetaData();
+    FieldInfos fieldInfos = reader.getFieldInfos();
+    if (metaData.hasBlocks() && fieldInfos.getParentField() != null) {
+      BitSet parents =
+          BitSet.of(reader.getNumericDocValues(fieldInfos.getParentField()), reader.maxDoc());
+      comparatorWrapper =
+          in ->
+              (docID1, docID2) ->
+                  in.compare(parents.nextSetBit(docID1), parents.nextSetBit(docID2));
+    }
+
     for (int i = 0; i < fields.length; i++) {
       IndexSorter sorter = fields[i].getIndexSorter();
       if (sorter == null) {
         throw new IllegalArgumentException(
             "Cannot use sortfield + " + fields[i] + " to sort indexes");
       }
-      comparators[i] = sorter.getDocComparator(reader, reader.maxDoc());
+      comparators[i] = comparatorWrapper.apply(sorter.getDocComparator(reader, reader.maxDoc()));
     }
     return sort(reader.maxDoc(), comparators);
   }

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/IndexPackageAccess.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/IndexPackageAccess.java
@@ -31,7 +31,7 @@ public interface IndexPackageAccess {
 
   void setIndexWriterMaxDocs(int limit);
 
-  FieldInfosBuilder newFieldInfosBuilder(String softDeletesFieldName);
+  FieldInfosBuilder newFieldInfosBuilder(String softDeletesFieldName, String parentFieldName);
 
   void checkImpacts(Impacts impacts, int max);
 

--- a/lucene/core/src/java/org/apache/lucene/search/Sort.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Sort.java
@@ -85,7 +85,6 @@ public final class Sort {
    */
   public Sort rewrite(IndexSearcher searcher) throws IOException {
     boolean changed = false;
-
     SortField[] rewrittenSortFields = new SortField[fields.length];
     for (int i = 0; i < fields.length; i++) {
       rewrittenSortFields[i] = fields[i].rewrite(searcher);
@@ -100,7 +99,6 @@ public final class Sort {
   @Override
   public String toString() {
     StringBuilder buffer = new StringBuilder();
-
     for (int i = 0; i < fields.length; i++) {
       buffer.append(fields[i].toString());
       if ((i + 1) < fields.length) buffer.append(',');

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -1937,4 +1937,97 @@ public class TestAddIndexes extends LuceneTestCase {
     targetDir.close();
     sourceDir.close();
   }
+
+  public void testIllegalParentDocChange() throws Exception {
+    Directory dir1 = newDirectory();
+    IndexWriterConfig iwc1 = newIndexWriterConfig(new MockAnalyzer(random()));
+    iwc1.setParentField("foobar");
+    RandomIndexWriter w1 = new RandomIndexWriter(random(), dir1, iwc1);
+    Document parent = new Document();
+    w1.addDocuments(Arrays.asList(new Document(), new Document(), parent));
+    w1.commit();
+    w1.addDocuments(Arrays.asList(new Document(), new Document(), parent));
+    w1.commit();
+    // so the index sort is in fact burned into the index:
+    w1.forceMerge(1);
+    w1.close();
+
+    Directory dir2 = newDirectory();
+    IndexWriterConfig iwc2 = newIndexWriterConfig(new MockAnalyzer(random()));
+    iwc2.setParentField("foo");
+    RandomIndexWriter w2 = new RandomIndexWriter(random(), dir2, iwc2);
+
+    IndexReader r1 = DirectoryReader.open(dir1);
+    String message =
+        expectThrows(
+                IllegalArgumentException.class,
+                () -> {
+                  w2.addIndexes((SegmentReader) getOnlyLeafReader(r1));
+                })
+            .getMessage();
+    assertEquals(
+        "can't add field [foobar] as parent document field; this IndexWriter is configured with [foo] as parent document field",
+        message);
+
+    message =
+        expectThrows(
+                IllegalArgumentException.class,
+                () -> {
+                  w2.addIndexes(dir1);
+                })
+            .getMessage();
+    assertEquals(
+        "can't add field [foobar] as parent document field; this IndexWriter is configured with [foo] as parent document field",
+        message);
+
+    Directory dir3 = newDirectory();
+    IndexWriterConfig iwc3 = newIndexWriterConfig(new MockAnalyzer(random()));
+    iwc3.setParentField("foobar");
+    RandomIndexWriter w3 = new RandomIndexWriter(random(), dir3, iwc3);
+
+    w3.addIndexes((SegmentReader) getOnlyLeafReader(r1));
+    w3.addIndexes(dir1);
+
+    IOUtils.close(r1, dir1, w2, dir2, w3, dir3);
+  }
+
+  public void testIllegalNonParentField() throws IOException {
+    Directory dir1 = newDirectory();
+    IndexWriterConfig iwc1 = newIndexWriterConfig(new MockAnalyzer(random()));
+    RandomIndexWriter w1 = new RandomIndexWriter(random(), dir1, iwc1);
+    Document parent = new Document();
+    parent.add(new StringField("foo", "XXX", Field.Store.NO));
+    w1.addDocument(parent);
+    w1.close();
+
+    Directory dir2 = newDirectory();
+    IndexWriterConfig iwc2 = newIndexWriterConfig(new MockAnalyzer(random()));
+    iwc2.setParentField("foo");
+    RandomIndexWriter w2 = new RandomIndexWriter(random(), dir2, iwc2);
+
+    IndexReader r1 = DirectoryReader.open(dir1);
+    String message =
+        expectThrows(
+                IllegalArgumentException.class,
+                () -> {
+                  w2.addIndexes((SegmentReader) getOnlyLeafReader(r1));
+                })
+            .getMessage();
+    assertEquals(
+        "can't add [foo] as non parent document field; this IndexWriter is configured with [foo] as parent document field",
+        message);
+
+    message =
+        expectThrows(
+                IllegalArgumentException.class,
+                () -> {
+                  w2.addIndexes(dir1);
+                })
+            .getMessage();
+    assertEquals(
+        "can't add [foo] as non parent document field; this IndexWriter is configured with [foo] as parent document field",
+        message);
+
+    IOUtils.close(r1, dir1, w2, dir2);
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
@@ -114,6 +114,7 @@ public class TestCodecs extends LuceneTestCase {
                     0,
                     VectorEncoding.FLOAT32,
                     VectorSimilarityFunction.EUCLIDEAN,
+                    false,
                     false));
       }
       this.terms = terms;
@@ -230,8 +231,7 @@ public class TestCodecs extends LuceneTestCase {
     }
 
     final FieldInfos.Builder builder =
-        new FieldInfos.Builder(new FieldInfos.FieldNumbers(null, Version.LATEST.major));
-
+        new FieldInfos.Builder(new FieldInfos.FieldNumbers(null, null, Version.LATEST.major));
     final FieldData field = new FieldData("field", builder, terms, true, false);
     final FieldData[] fields = new FieldData[] {field};
     final FieldInfos fieldInfos = builder.finish();
@@ -294,8 +294,7 @@ public class TestCodecs extends LuceneTestCase {
 
   public void testRandomPostings() throws Throwable {
     final FieldInfos.Builder builder =
-        new FieldInfos.Builder(new FieldInfos.FieldNumbers(null, Version.LATEST.major));
-
+        new FieldInfos.Builder(new FieldInfos.FieldNumbers(null, null, Version.LATEST.major));
     final FieldData[] fields = new FieldData[NUM_FIELDS];
     for (int i = 0; i < NUM_FIELDS; i++) {
       final boolean omitTF = 0 == (i % 3);

--- a/lucene/core/src/test/org/apache/lucene/index/TestDoc.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDoc.java
@@ -236,7 +236,7 @@ public class TestDoc extends LuceneTestCase {
             si,
             InfoStream.getDefault(),
             trackingDir,
-            new FieldInfos.FieldNumbers(null, Version.LATEST.major),
+            new FieldInfos.FieldNumbers(null, null, Version.LATEST.major),
             context);
 
     merger.merge();

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldInfo.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldInfo.java
@@ -224,6 +224,8 @@ public class TestFieldInfo extends LuceneTestCase {
     VectorSimilarityFunction vectorSimilarityFunction = VectorSimilarityFunction.EUCLIDEAN;
     boolean softDeletesField = false;
 
+    boolean isParentField = false;
+
     FieldInfo get() {
       return new FieldInfo(
           name,
@@ -241,7 +243,8 @@ public class TestFieldInfo extends LuceneTestCase {
           vectorDimension,
           vectorEncoding,
           vectorSimilarityFunction,
-          softDeletesField);
+          softDeletesField,
+          isParentField);
     }
 
     public FieldInfoTestBuilder setStoreTermVector(boolean storeTermVector) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
@@ -249,7 +249,7 @@ public class TestFieldInfos extends LuceneTestCase {
 
   public void testFieldNumbersAutoIncrement() {
     FieldInfos.FieldNumbers fieldNumbers =
-        new FieldInfos.FieldNumbers("softDeletes", Version.LATEST.major);
+        new FieldInfos.FieldNumbers("softDeletes", "parentDoc", Version.LATEST.major);
     for (int i = 0; i < 10; i++) {
       fieldNumbers.addOrGet(
           new FieldInfo(
@@ -268,6 +268,7 @@ public class TestFieldInfos extends LuceneTestCase {
               0,
               VectorEncoding.FLOAT32,
               VectorSimilarityFunction.EUCLIDEAN,
+              false,
               false));
     }
     int idx =
@@ -288,6 +289,7 @@ public class TestFieldInfos extends LuceneTestCase {
                 0,
                 VectorEncoding.FLOAT32,
                 VectorSimilarityFunction.EUCLIDEAN,
+                false,
                 false));
     assertEquals("Field numbers 0 through 9 were allocated", 10, idx);
 
@@ -310,6 +312,7 @@ public class TestFieldInfos extends LuceneTestCase {
                 0,
                 VectorEncoding.FLOAT32,
                 VectorSimilarityFunction.EUCLIDEAN,
+                false,
                 false));
     assertEquals("Field numbers should reset after clear()", 0, idx);
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldsReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldsReader.java
@@ -46,10 +46,8 @@ public class TestFieldsReader extends LuceneTestCase {
   @BeforeClass
   public static void beforeClass() throws Exception {
     testDoc = new Document();
-    final String softDeletesFieldName = null;
     fieldInfos =
-        new FieldInfos.Builder(
-            new FieldInfos.FieldNumbers(softDeletesFieldName, Version.LATEST.major));
+        new FieldInfos.Builder(new FieldInfos.FieldNumbers(null, null, Version.LATEST.major));
     DocHelper.setupDoc(testDoc);
     for (IndexableField field : testDoc.getFields()) {
       IndexableFieldType ift = field.fieldType();
@@ -70,7 +68,8 @@ public class TestFieldsReader extends LuceneTestCase {
               0,
               VectorEncoding.FLOAT32,
               VectorSimilarityFunction.EUCLIDEAN,
-              field.name().equals(softDeletesFieldName)));
+              false,
+              false));
     }
     dir = newDirectory();
     IndexWriterConfig conf =

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
@@ -2121,6 +2121,10 @@ public class TestIndexSorting extends LuceneTestCase {
   public void testAddIndexes(boolean withDeletes, boolean useReaders) throws Exception {
     Directory dir = newDirectory();
     IndexWriterConfig iwc1 = newIndexWriterConfig();
+    boolean useParent = rarely();
+    if (useParent) {
+      iwc1.setParentField("___parent");
+    }
     Sort indexSort =
         new Sort(
             new SortField("foo", SortField.Type.LONG), new SortField("bar", SortField.Type.LONG));
@@ -2152,6 +2156,9 @@ public class TestIndexSorting extends LuceneTestCase {
       iwc.setIndexSort(new Sort(new SortField("foo", SortField.Type.LONG)));
     } else {
       iwc.setIndexSort(indexSort);
+    }
+    if (useParent) {
+      iwc.setParentField("___parent");
     }
     IndexWriter w2 = new IndexWriter(dir2, iwc);
 
@@ -3170,5 +3177,259 @@ public class TestIndexSorting extends LuceneTestCase {
     assertNull(fieldTerms.next());
     reader.close();
     dir.close();
+  }
+
+  public void testBlockContainsParentField() throws IOException {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
+      String parentField = "parent";
+      iwc.setParentField(parentField);
+      Sort indexSort = new Sort(new SortField("foo", SortField.Type.INT));
+      iwc.setIndexSort(indexSort);
+      try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+        List<Runnable> runnabels =
+            Arrays.asList(
+                () -> {
+                  IllegalArgumentException ex =
+                      expectThrows(
+                          IllegalArgumentException.class,
+                          () -> {
+                            Document doc = new Document();
+                            doc.add(new NumericDocValuesField("parent", 0));
+                            writer.addDocuments(Arrays.asList(doc, new Document()));
+                          });
+                  assertEquals(
+                      "\"parent\" is a reserved field and should not be added to any document",
+                      ex.getMessage());
+                },
+                () -> {
+                  IllegalArgumentException ex =
+                      expectThrows(
+                          IllegalArgumentException.class,
+                          () -> {
+                            Document doc = new Document();
+                            doc.add(new NumericDocValuesField("parent", 0));
+                            writer.addDocuments(Arrays.asList(new Document(), doc));
+                          });
+                  assertEquals(
+                      "\"parent\" is a reserved field and should not be added to any document",
+                      ex.getMessage());
+                });
+        Collections.shuffle(runnabels, random());
+        for (Runnable runnable : runnabels) {
+          runnable.run();
+        }
+      }
+    }
+  }
+
+  public void testIndexSortWithBlocks() throws IOException {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
+      AssertingNeedsIndexSortCodec codec = new AssertingNeedsIndexSortCodec();
+      iwc.setCodec(codec);
+      String parentField = "parent";
+      Sort indexSort = new Sort(new SortField("foo", SortField.Type.INT));
+      iwc.setIndexSort(indexSort);
+      iwc.setParentField(parentField);
+      LogMergePolicy policy = newLogMergePolicy();
+      // make sure that merge factor is always > 2
+      if (policy.getMergeFactor() <= 2) {
+        policy.setMergeFactor(3);
+      }
+      iwc.setMergePolicy(policy);
+
+      // add already sorted documents
+      codec.numCalls = 0;
+      codec.needsIndexSort = false;
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        int numDocs = 50 + random().nextInt(50);
+        for (int i = 0; i < numDocs; i++) {
+          Document child1 = new Document();
+          child1.add(new StringField("id", Integer.toString(i), Store.YES));
+          child1.add(new NumericDocValuesField("id", i));
+          child1.add(new NumericDocValuesField("child", 1));
+          child1.add(new NumericDocValuesField("foo", random().nextInt()));
+          Document child2 = new Document();
+          child2.add(new StringField("id", Integer.toString(i), Store.YES));
+          child2.add(new NumericDocValuesField("id", i));
+          child2.add(new NumericDocValuesField("child", 2));
+          child2.add(new NumericDocValuesField("foo", random().nextInt()));
+          Document parent = new Document();
+          parent.add(new StringField("id", Integer.toString(i), Store.YES));
+          parent.add(new NumericDocValuesField("id", i));
+          parent.add(new NumericDocValuesField("foo", random().nextInt()));
+          w.addDocuments(Arrays.asList(child1, child2, parent));
+          if (rarely()) {
+            w.commit();
+          }
+        }
+        w.commit();
+        if (random().nextBoolean()) {
+          w.forceMerge(1, true);
+        }
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        for (LeafReaderContext ctx : reader.leaves()) {
+          LeafReader leaf = ctx.reader();
+          NumericDocValues parentDISI = leaf.getNumericDocValues(parentField);
+          NumericDocValues ids = leaf.getNumericDocValues("id");
+          NumericDocValues children = leaf.getNumericDocValues("child");
+          int doc;
+          int expectedDocID = 2;
+          while ((doc = parentDISI.nextDoc()) != NO_MORE_DOCS) {
+            assertEquals(-1, parentDISI.longValue());
+            assertEquals(expectedDocID, doc);
+            int id = ids.nextDoc();
+            long child1ID = ids.longValue();
+            assertEquals(id, children.nextDoc());
+            long child1 = children.longValue();
+            assertEquals(1, child1);
+
+            id = ids.nextDoc();
+            long child2ID = ids.longValue();
+            assertEquals(id, children.nextDoc());
+            long child2 = children.longValue();
+            assertEquals(2, child2);
+
+            int idParent = ids.nextDoc();
+            assertEquals(id + 1, idParent);
+            long parent = ids.longValue();
+            assertEquals(child1ID, parent);
+            assertEquals(child2ID, parent);
+            expectedDocID += 3;
+          }
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings("fallthrough")
+  public void testMixRandomDocumentsWithBlocks() throws IOException {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
+      AssertingNeedsIndexSortCodec codec = new AssertingNeedsIndexSortCodec();
+      iwc.setCodec(codec);
+      String parentField = "parent";
+      Sort indexSort = new Sort(new SortField("foo", SortField.Type.INT));
+      iwc.setIndexSort(indexSort);
+      iwc.setParentField(parentField);
+      RandomIndexWriter randomIndexWriter = new RandomIndexWriter(random(), dir, iwc);
+      int numDocs = 100 + random().nextInt(900);
+      for (int i = 0; i < numDocs; i++) {
+        if (rarely()) {
+          randomIndexWriter.deleteDocuments(new Term("id", "" + random().nextInt(i + 1)));
+        }
+        List<Document> docs = new ArrayList<>();
+        switch (random().nextInt(100) % 5) {
+          case 4:
+            Document child3 = new Document();
+            child3.add(new StringField("id", Integer.toString(i), Store.YES));
+            child3.add(new NumericDocValuesField("type", 2));
+            child3.add(new NumericDocValuesField("child_ord", 3));
+            child3.add(new NumericDocValuesField("foo", random().nextInt()));
+            docs.add(child3);
+          case 3:
+            Document child2 = new Document();
+            child2.add(new StringField("id", Integer.toString(i), Store.YES));
+            child2.add(new NumericDocValuesField("type", 2));
+            child2.add(new NumericDocValuesField("child_ord", 2));
+            child2.add(new NumericDocValuesField("foo", random().nextInt()));
+            docs.add(child2);
+          case 2:
+            Document child1 = new Document();
+            child1.add(new StringField("id", Integer.toString(i), Store.YES));
+            child1.add(new NumericDocValuesField("type", 2));
+            child1.add(new NumericDocValuesField("child_ord", 1));
+            child1.add(new NumericDocValuesField("foo", random().nextInt()));
+            docs.add(child1);
+          case 1:
+            Document root = new Document();
+            root.add(new StringField("id", Integer.toString(i), Store.YES));
+            root.add(new NumericDocValuesField("type", 1));
+            root.add(new NumericDocValuesField("num_children", docs.size()));
+            root.add(new NumericDocValuesField("foo", random().nextInt()));
+            docs.add(root);
+            randomIndexWriter.addDocuments(docs);
+            break;
+          case 0:
+            Document single = new Document();
+            single.add(new StringField("id", Integer.toString(i), Store.YES));
+            single.add(new NumericDocValuesField("type", 0));
+            single.add(new NumericDocValuesField("foo", random().nextInt()));
+            randomIndexWriter.addDocument(single);
+        }
+        if (rarely()) {
+          randomIndexWriter.forceMerge(1);
+        }
+        randomIndexWriter.commit();
+      }
+
+      randomIndexWriter.close();
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        for (LeafReaderContext ctx : reader.leaves()) {
+          LeafReader leaf = ctx.reader();
+          NumericDocValues parentDISI = leaf.getNumericDocValues(parentField);
+          assertNotNull(parentDISI);
+          NumericDocValues type = leaf.getNumericDocValues("type");
+          NumericDocValues childOrd = leaf.getNumericDocValues("child_ord");
+          NumericDocValues numChildren = leaf.getNumericDocValues("num_children");
+          int numCurrentChildren = 0;
+          int totalPendingChildren = 0;
+          String childId = null;
+          for (int i = 0; i < leaf.maxDoc(); i++) {
+            if (leaf.getLiveDocs() == null || leaf.getLiveDocs().get(i)) {
+              assertTrue(type.advanceExact(i));
+              int typeValue = (int) type.longValue();
+              switch (typeValue) {
+                case 2:
+                  assertFalse(parentDISI.advanceExact(i));
+                  assertTrue(childOrd.advanceExact(i));
+                  if (numCurrentChildren == 0) { // first child
+                    childId = leaf.storedFields().document(i).get("id");
+                    totalPendingChildren = (int) childOrd.longValue() - 1;
+                  } else {
+                    assertNotNull(childId);
+                    assertEquals(totalPendingChildren--, childOrd.longValue());
+                    assertEquals(childId, leaf.storedFields().document(i).get("id"));
+                  }
+                  numCurrentChildren++;
+                  break;
+                case 1:
+                  assertTrue(parentDISI.advanceExact(i));
+                  assertEquals(-1, parentDISI.longValue());
+                  if (childOrd != null) {
+                    assertFalse(childOrd.advanceExact(i));
+                  }
+                  assertTrue(numChildren.advanceExact(i));
+                  assertEquals(0, totalPendingChildren);
+                  assertEquals(numCurrentChildren, numChildren.longValue());
+                  if (numCurrentChildren > 0) {
+                    assertEquals(childId, leaf.storedFields().document(i).get("id"));
+                  } else {
+                    assertNull(childId);
+                  }
+                  numCurrentChildren = 0;
+                  childId = null;
+                  break;
+                case 0:
+                  assertEquals(-1, parentDISI.longValue());
+                  assertTrue(parentDISI.advanceExact(i));
+                  if (childOrd != null) {
+                    assertFalse(childOrd.advanceExact(i));
+                  }
+                  if (numChildren != null) {
+                    assertFalse(numChildren.advanceExact(i));
+                  }
+                  break;
+                default:
+                  fail();
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestPendingSoftDeletes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPendingSoftDeletes.java
@@ -199,7 +199,8 @@ public class TestPendingSoftDeletes extends TestPendingDeletes {
             0,
             VectorEncoding.FLOAT32,
             VectorSimilarityFunction.EUCLIDEAN,
-            true);
+            true,
+            false);
     List<Integer> docsDeleted = Arrays.asList(1, 3, 7, 8, DocIdSetIterator.NO_MORE_DOCS);
     List<DocValuesFieldUpdates> updates = Arrays.asList(singleUpdate(docsDeleted, 10, true));
     for (DocValuesFieldUpdates update : updates) {
@@ -237,7 +238,8 @@ public class TestPendingSoftDeletes extends TestPendingDeletes {
             0,
             VectorEncoding.FLOAT32,
             VectorSimilarityFunction.EUCLIDEAN,
-            true);
+            true,
+            false);
     for (DocValuesFieldUpdates update : updates) {
       deletes.onDocValuesUpdate(fieldInfo, update.iterator());
     }
@@ -301,7 +303,8 @@ public class TestPendingSoftDeletes extends TestPendingDeletes {
             0,
             VectorEncoding.FLOAT32,
             VectorSimilarityFunction.EUCLIDEAN,
-            true);
+            true,
+            false);
     List<Integer> docsDeleted = Arrays.asList(1, DocIdSetIterator.NO_MORE_DOCS);
     List<DocValuesFieldUpdates> updates = Arrays.asList(singleUpdate(docsDeleted, 3, true));
     for (DocValuesFieldUpdates update : updates) {
@@ -370,7 +373,8 @@ public class TestPendingSoftDeletes extends TestPendingDeletes {
             0,
             VectorEncoding.FLOAT32,
             VectorSimilarityFunction.EUCLIDEAN,
-            true);
+            true,
+            false);
     List<DocValuesFieldUpdates> updates =
         Arrays.asList(singleUpdate(Arrays.asList(0, 1, DocIdSetIterator.NO_MORE_DOCS), 3, false));
     for (DocValuesFieldUpdates update : updates) {
@@ -407,7 +411,8 @@ public class TestPendingSoftDeletes extends TestPendingDeletes {
             0,
             VectorEncoding.FLOAT32,
             VectorSimilarityFunction.EUCLIDEAN,
-            true);
+            true,
+            false);
     updates = Arrays.asList(singleUpdate(Arrays.asList(1, DocIdSetIterator.NO_MORE_DOCS), 3, true));
     for (DocValuesFieldUpdates update : updates) {
       deletes.onDocValuesUpdate(fieldInfo, update.iterator());

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentMerger.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentMerger.java
@@ -104,7 +104,7 @@ public class TestSegmentMerger extends LuceneTestCase {
             si,
             InfoStream.getDefault(),
             mergedDir,
-            new FieldInfos.FieldNumbers(null, Version.LATEST.major),
+            new FieldInfos.FieldNumbers(null, null, Version.LATEST.major),
             newIOContext(random(), new IOContext(new MergeInfo(-1, -1, false, -1))));
     MergeState mergeState = merger.merge();
     int docsMerged = mergeState.segmentInfo.maxDoc();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -1297,7 +1297,8 @@ public class TestSortOptimization extends LuceneTestCase {
                 0,
                 VectorEncoding.FLOAT32,
                 VectorSimilarityFunction.DOT_PRODUCT,
-                fi.isSoftDeletesField());
+                fi.isSoftDeletesField(),
+                fi.isParentField());
         newInfos[i] = noIndexFI;
         i++;
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -182,9 +182,13 @@ public class TestTopFieldCollector extends LuceneTestCase {
             dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE).setIndexSort(sort));
     Document doc = new Document();
     doc.add(new NumericDocValuesField("foo", 3));
-    w.addDocuments(Arrays.asList(doc, doc, doc, doc));
+    for (Document d : Arrays.asList(doc, doc, doc, doc)) {
+      w.addDocument(d);
+    }
     w.flush();
-    w.addDocuments(Arrays.asList(doc, doc, doc, doc, doc, doc));
+    for (Document d : Arrays.asList(doc, doc, doc, doc, doc, doc)) {
+      w.addDocument(d);
+    }
     w.flush();
     IndexReader reader = DirectoryReader.open(w);
     assertEquals(2, reader.leaves().size());

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
@@ -103,6 +103,7 @@ public class TermVectorLeafReader extends LeafReader {
             0,
             VectorEncoding.FLOAT32,
             VectorSimilarityFunction.EUCLIDEAN,
+            false,
             false);
     fieldInfos = new FieldInfos(new FieldInfo[] {fieldInfo});
   }

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -736,6 +736,7 @@ public class MemoryIndex {
         fieldType.vectorDimension(),
         fieldType.vectorEncoding(),
         fieldType.vectorSimilarityFunction(),
+        false,
         false);
   }
 
@@ -789,7 +790,8 @@ public class MemoryIndex {
               info.fieldInfo.getVectorDimension(),
               info.fieldInfo.getVectorEncoding(),
               info.fieldInfo.getVectorSimilarityFunction(),
-              info.fieldInfo.isSoftDeletesField());
+              info.fieldInfo.isSoftDeletesField(),
+              info.fieldInfo.isParentField());
     } else if (existingDocValuesType != docValuesType) {
       throw new IllegalArgumentException(
           "Can't add ["

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/compressing/dummy/DummyCompressingCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/compressing/dummy/DummyCompressingCodec.java
@@ -78,7 +78,7 @@ public class DummyCompressingCodec extends CompressingCodec {
 
         @Override
         public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-          out.copyBytes(buffersInput, buffersInput.size());
+          out.copyBytes(buffersInput, buffersInput.length());
         }
 
         @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
@@ -68,7 +68,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     FieldInfo fi = createFieldInfo();
     addAttributes(fi);
 
-    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null, null).add(fi).finish();
 
     codec.fieldInfosFormat().write(dir, segmentInfo, "", infos, IOContext.DEFAULT);
 
@@ -96,7 +96,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     fi.putAttribute("foo", "bar");
     fi.putAttribute("bar", "baz");
 
-    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null, null).add(fi).finish();
 
     codec.fieldInfosFormat().write(dir, segmentInfo, "", infos, IOContext.DEFAULT);
 
@@ -136,7 +136,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     FieldInfo fi = createFieldInfo();
     addAttributes(fi);
 
-    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null, null).add(fi).finish();
 
     fail.setDoFail();
     expectThrows(
@@ -171,7 +171,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     FieldInfo fi = createFieldInfo();
     addAttributes(fi);
 
-    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null, null).add(fi).finish();
 
     fail.setDoFail();
     expectThrows(
@@ -206,7 +206,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     FieldInfo fi = createFieldInfo();
     addAttributes(fi);
 
-    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null, null).add(fi).finish();
 
     codec.fieldInfosFormat().write(dir, segmentInfo, "", infos, IOContext.DEFAULT);
 
@@ -243,7 +243,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     FieldInfo fi = createFieldInfo();
     addAttributes(fi);
 
-    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null).add(fi).finish();
+    FieldInfos infos = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(null, null).add(fi).finish();
 
     codec.fieldInfosFormat().write(dir, segmentInfo, "", infos, IOContext.DEFAULT);
 
@@ -276,7 +276,9 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     String softDeletesField =
         random().nextBoolean() ? TestUtil.randomUnicodeString(random()) : null;
 
-    var builder = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(softDeletesField);
+    String parentField = random().nextBoolean() ? TestUtil.randomUnicodeString(random()) : null;
+
+    var builder = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(softDeletesField, parentField);
 
     for (String field : fieldNames) {
       IndexableFieldType fieldType = randomFieldType(random(), field);
@@ -307,7 +309,8 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
               fieldType.vectorDimension(),
               fieldType.vectorEncoding(),
               fieldType.vectorSimilarityFunction(),
-              field.equals(softDeletesField));
+              field.equals(softDeletesField),
+              field.equals(parentField));
       addAttributes(fi);
       builder.add(fi);
     }
@@ -431,6 +434,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
         0,
         VectorEncoding.FLOAT32,
         VectorSimilarityFunction.EUCLIDEAN,
+        false,
         false);
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
@@ -365,7 +365,8 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
             proto.getVectorDimension(),
             proto.getVectorEncoding(),
             proto.getVectorSimilarityFunction(),
-            proto.isSoftDeletesField());
+            proto.isSoftDeletesField(),
+            proto.isParentField());
 
     FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] {field});
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseSegmentInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseSegmentInfoFormatTestCase.java
@@ -80,6 +80,33 @@ public abstract class BaseSegmentInfoFormatTestCase extends BaseIndexFileFormatT
     dir.close();
   }
 
+  public void testHasBlocks() throws IOException {
+    assumeTrue("test requires a codec that can read/write hasBlocks", supportsHasBlocks());
+
+    Directory dir = newDirectory();
+    Codec codec = getCodec();
+    byte[] id = StringHelper.randomId();
+    SegmentInfo info =
+        new SegmentInfo(
+            dir,
+            getVersions()[0],
+            getVersions()[0],
+            "_123",
+            1,
+            false,
+            random().nextBoolean(),
+            codec,
+            Collections.emptyMap(),
+            id,
+            Collections.emptyMap(),
+            null);
+    info.setFiles(Collections.<String>emptySet());
+    codec.segmentInfoFormat().write(dir, info, IOContext.DEFAULT);
+    SegmentInfo info2 = codec.segmentInfoFormat().read(dir, "_123", id, IOContext.DEFAULT);
+    assertEquals(info.getHasBlocks(), info2.getHasBlocks());
+    dir.close();
+  }
+
   /** Tests SI writer adds itself to files... */
   public void testAddsSelfToFiles() throws Exception {
     Directory dir = newDirectory();
@@ -260,6 +287,10 @@ public abstract class BaseSegmentInfoFormatTestCase extends BaseIndexFileFormatT
     return true;
   }
 
+  protected boolean supportsHasBlocks() {
+    return true;
+  }
+
   private SortField randomIndexSortField() {
     boolean reversed = random().nextBoolean();
     SortField sortField;
@@ -360,7 +391,11 @@ public abstract class BaseSegmentInfoFormatTestCase extends BaseIndexFileFormatT
         for (int j = 0; j < numSortFields; ++j) {
           sortFields[j] = randomIndexSortField();
         }
-        sort = new Sort(sortFields);
+        if (supportsHasBlocks()) {
+          sort = new Sort(sortFields);
+        } else {
+          sort = new Sort(sortFields);
+        }
       }
 
       Directory dir = newDirectory();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MismatchedLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MismatchedLeafReader.java
@@ -117,7 +117,8 @@ public class MismatchedLeafReader extends FilterLeafReader {
               oldInfo.getVectorEncoding(), // numeric type of vector samples
               // distance function for calculating similarity of the field's vector
               oldInfo.getVectorSimilarityFunction(),
-              oldInfo.isSoftDeletesField()); // used as soft-deletes field
+              oldInfo.isSoftDeletesField(), // used as soft-deletes field
+              oldInfo.isParentField());
       shuffled.set(i, newInfo);
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomIndexWriter.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomIndexWriter.java
@@ -158,6 +158,7 @@ public class RandomIndexWriter implements Closeable {
     } else {
       softDeletesRatio = 0d;
     }
+
     w = mockIndexWriter(dir, c, r);
     config = w.getConfig();
     flushAt = TestUtil.nextInt(r, 10, 1000);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
@@ -165,6 +165,7 @@ public class RandomPostingsTester {
               0,
               VectorEncoding.FLOAT32,
               VectorSimilarityFunction.EUCLIDEAN,
+              false,
               false);
       fieldUpto++;
 
@@ -738,6 +739,7 @@ public class RandomPostingsTester {
               0,
               VectorEncoding.FLOAT32,
               VectorSimilarityFunction.EUCLIDEAN,
+              false,
               false);
     }
 


### PR DESCRIPTION
This is a backport PR for #12829. It add the optional ability to index parent fields in 9.x. While 9.x can still use index sorting with doc blocks without using a parent field this allows users to migrate to this mandatory feature earlier than 10.x. Only indices with min segment version 9.9 and older will be able to be configured with a parent field. These versions record if the index already has blocks which makes it safe to add the parent field after the fact. 
