### PR TITLE
Rollback the tmp storage of BytesRefHash to -1 after sort

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -214,6 +214,7 @@ public final class BytesRefHash implements Accountable {
         pool.fillBytesRef(result, bytesStart[compact[i]]);
       }
     }.sort(0, count);
+    Arrays.fill(compact, tmpOffset, compact.length, -1);
     return compact;
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestBytesRefHash.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestBytesRefHash.java
@@ -176,13 +176,17 @@ public class TestBytesRefHash extends LuceneTestCase {
         hash.add(ref.get());
         strings.add(str);
       }
-      int[] sort = hash.sort();
-      assertTrue(strings.size() < sort.length);
-      int i = 0;
-      BytesRef scratch = new BytesRef();
-      for (String string : strings) {
-        ref.copyChars(string);
-        assertEquals(ref.get(), hash.get(sort[i++], scratch));
+      for (int iter = 0; iter < 3; iter++) {
+        // Test duplicate sort on a BytesRefHash instance work well. This makes no sense but some
+        // users need that.
+        int[] sort = hash.sort();
+        assertTrue(strings.size() < sort.length);
+        int i = 0;
+        BytesRef scratch = new BytesRef();
+        for (String string : strings) {
+          ref.copyChars(string);
+          assertEquals(ref.get(), hash.get(sort[i++], scratch));
+        }
       }
       hash.clear();
       assertEquals(0, hash.size());


### PR DESCRIPTION
In #12784 we cache buckets into extra slots in `BytesRefHash` to speed up `BytesRefHash#sort`. This causes an [AssertError](https://lists.apache.org/thread/lxk2lm88twfzdl549974vov1984kj995) for [`TermsQuery`](https://github.com/apache/lucene/blob/c746bea233fd14fe81d9805633fcce0f7b9681b6/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java#L68) because it could call `sort` more than once on a `BytesRefHash` instance. Not sure if any other users were relying on this but it would be great to keep consistent with before.
