### PR TITLE
join: avoid repeat BytesRefHash.sort() in TermsQuery after TermsIncludingScoreQuery

### DIFF
--- a/lucene/join/src/java/org/apache/lucene/search/join/TermsIncludingScoreQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/TermsIncludingScoreQuery.java
@@ -131,7 +131,7 @@ class TermsIncludingScoreQuery extends Query implements Accountable {
     if (scoreMode.needsScores() == false) {
       // We don't need scores then quickly change the query:
       TermsQuery termsQuery =
-          new TermsQuery(toField, terms, fromField, fromQuery, topReaderContextId);
+          new TermsQuery(toField, terms, ords, fromField, fromQuery, topReaderContextId);
       return searcher
           .rewrite(termsQuery)
           .createWeight(searcher, org.apache.lucene.search.ScoreMode.COMPLETE_NO_SCORES, boost);

--- a/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
@@ -63,9 +63,26 @@ class TermsQuery extends MultiTermQuery implements Accountable {
       String fromField,
       Query fromQuery,
       Object indexReaderContextId) {
+    this(toField, terms, terms.sort(), fromField, fromQuery, indexReaderContextId);
+  }
+
+  /**
+   * @param toField The field that should contain terms that are specified in the next parameter.
+   * @param terms The terms that matching documents should have. The terms must be sorted by natural
+   *     order.
+   * @param indexReaderContextId Refers to the top level index reader used to create the set of
+   *     terms in the previous parameter.
+   */
+  TermsQuery(
+      String toField,
+      BytesRefHash terms,
+      int[] ords,
+      String fromField,
+      Query fromQuery,
+      Object indexReaderContextId) {
     super(toField, CONSTANT_SCORE_BLENDED_REWRITE);
     this.terms = terms;
-    ords = terms.sort();
+    this.ords = ords;
     this.fromField = fromField;
     this.fromQuery = fromQuery;
     this.indexReaderContextId = indexReaderContextId;


### PR DESCRIPTION
naive change for the #13018 issue.

TODOs -- collaboration and pushes to the PR branch welcome
* test coverage
  * edit: still a TODO item
* confirmation that this would solve the `org.apache.solr.search.join.ScoreJoinQParserPlugin` issues
  * edit: done indirectly as per https://github.com/apache/solr/pull/2176#issuecomment-1910399161
* ideas on how callers might workaround the issue using 9.9.1 Lucene
  * edit: no longer applicable