### PR TITLE
Fix BWC test generation after mondernizing LineDocFile

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
@@ -53,7 +53,6 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.FloatDocValuesField;
 import org.apache.lucene.document.FloatPoint;
-import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.LongPoint;
@@ -263,7 +262,8 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
   }
 
   public void testCreateSortedIndexInternal() throws Exception {
-    // this runs without the -Ptests.bwcdir=/tmp/sorted to make sure we can actually index and search the created index
+    // this runs without the -Ptests.bwcdir=/tmp/sorted to make sure we can actually index and
+    // search the created index
     try (Directory dir = newDirectory()) {
       createSortedIndex(dir);
     }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
@@ -282,7 +282,7 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
     conf.setUseCompoundFile(false);
     conf.setIndexSort(new Sort(new SortField("dateDV", SortField.Type.LONG, true)));
     IndexWriter writer = new IndexWriter(dir, conf);
-    LineFileDocs docs = new LineFileDocs(random());
+    LineFileDocs docs = new LineFileDocs(new Random(0));
     SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
     parser.setTimeZone(TimeZone.getTimeZone("UTC"));
     ParsePosition position = new ParsePosition(0);

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
@@ -203,7 +203,7 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
     return Paths.get(path);
   }
 
-  public void testCreateMoreTermsIndex() throws Exception {
+  private void testCreateMoreTermsIndex() throws Exception {
     Path indexDir = getIndexDir().resolve("moreterms");
     Files.deleteIfExists(indexDir);
     try (Directory dir = newFSDirectory(indexDir)) {

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
@@ -203,7 +203,7 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
     return Paths.get(path);
   }
 
-  private void testCreateMoreTermsIndex() throws Exception {
+  public void testCreateMoreTermsIndex() throws Exception {
     Path indexDir = getIndexDir().resolve("moreterms");
     Files.deleteIfExists(indexDir);
     try (Directory dir = newFSDirectory(indexDir)) {
@@ -217,7 +217,7 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
     }
   }
 
-  public void createMoreTermsIndex(Directory dir) throws Exception {
+  private void createMoreTermsIndex(Directory dir) throws Exception {
     LogByteSizeMergePolicy mp = new LogByteSizeMergePolicy();
     mp.setNoCFSRatio(1.0);
     mp.setMaxCFSSegmentSizeMB(Double.POSITIVE_INFINITY);

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
@@ -53,6 +53,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.FloatDocValuesField;
 import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.LongPoint;
@@ -204,11 +205,20 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
   }
 
   public void testCreateMoreTermsIndex() throws Exception {
-
     Path indexDir = getIndexDir().resolve("moreterms");
     Files.deleteIfExists(indexDir);
-    Directory dir = newFSDirectory(indexDir);
+    try (Directory dir = newFSDirectory(indexDir)) {
+      createMoreTermsIndex(dir);
+    }
+  }
 
+  public void testCreateMoreTermsIndexInternal() throws Exception {
+    try (Directory dir = newDirectory()) {
+      createMoreTermsIndex(dir);
+    }
+  }
+
+  public void createMoreTermsIndex(Directory dir) throws Exception {
     LogByteSizeMergePolicy mp = new LogByteSizeMergePolicy();
     mp.setNoCFSRatio(1.0);
     mp.setMaxCFSSegmentSizeMB(Double.POSITIVE_INFINITY);
@@ -219,22 +229,47 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
         new IndexWriterConfig(analyzer).setMergePolicy(mp).setUseCompoundFile(false);
     IndexWriter writer = new IndexWriter(dir, conf);
     LineFileDocs docs = new LineFileDocs(new Random(0));
+    Field docIdDV = null;
+    Field titleDVField = null;
     for (int i = 0; i < 50; i++) {
-      writer.addDocument(docs.nextDoc());
+      Document doc = docs.nextDoc();
+      if (docIdDV == null) {
+        docIdDV = new NumericDocValuesField("docid_intDV", 0);
+        doc.add(docIdDV);
+      }
+      docIdDV.setLongValue(doc.getField("docid_int").numericValue().longValue());
+      if (titleDVField == null) {
+        titleDVField = new SortedDocValuesField("titleDV", new BytesRef());
+        doc.add(titleDVField);
+      }
+      titleDVField.setBytesValue(new BytesRef(doc.getField("title").stringValue()));
+      writer.addDocument(doc);
     }
     docs.close();
     writer.close();
-    dir.close();
+    try (DirectoryReader reader = DirectoryReader.open(dir)) {
+      searchExampleIndex(reader); // make sure we can search it
+    }
   }
 
   // gradlew test -Ptestmethod=testCreateSortedIndex -Ptests.codec=default
   // -Ptests.useSecurityManager=false -Ptests.bwcdir=/tmp/sorted --tests TestBackwardsCompatibility
   public void testCreateSortedIndex() throws Exception {
-
     Path indexDir = getIndexDir().resolve("sorted");
     Files.deleteIfExists(indexDir);
-    Directory dir = newFSDirectory(indexDir);
+    try (Directory dir = newFSDirectory(indexDir)) {
+      createSortedIndex(dir);
+    }
+  }
 
+  public void testCreateSortedIndexInternal() throws Exception {
+    // this runs without the -Ptests.bwcdir=/tmp/sorted to make sure we can actually index and search the created index
+    try (Directory dir = newDirectory()) {
+      createSortedIndex(dir);
+    }
+  }
+
+  public void createSortedIndex(Directory dir) throws Exception {
     LogByteSizeMergePolicy mp = new LogByteSizeMergePolicy();
     mp.setNoCFSRatio(1.0);
     mp.setMaxCFSSegmentSizeMB(Double.POSITIVE_INFINITY);
@@ -251,7 +286,10 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
     SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
     parser.setTimeZone(TimeZone.getTimeZone("UTC"));
     ParsePosition position = new ParsePosition(0);
+    Field docIdDV = null;
     Field dateDVField = null;
+    Field titleDVField = null;
+
     for (int i = 0; i < 50; i++) {
       Document doc = docs.nextDoc();
       String dateString = doc.get("date");
@@ -269,6 +307,17 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
         doc.add(dateDVField);
       }
       dateDVField.setLongValue(date.getTime());
+      if (docIdDV == null) {
+        docIdDV = new NumericDocValuesField("docid_intDV", 0);
+        doc.add(docIdDV);
+      }
+
+      docIdDV.setLongValue(doc.getField("docid_int").numericValue().longValue());
+      if (titleDVField == null) {
+        titleDVField = new SortedDocValuesField("titleDV", new BytesRef());
+        doc.add(titleDVField);
+      }
+      titleDVField.setBytesValue(new BytesRef(doc.getField("title").stringValue()));
       if (i == 250) {
         writer.commit();
       }
@@ -276,7 +325,10 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
     }
     writer.forceMerge(1);
     writer.close();
-    dir.close();
+
+    try (DirectoryReader reader = DirectoryReader.open(dir)) {
+      searchExampleIndex(reader); // make sure we can search it
+    }
   }
 
   private void updateNumeric(IndexWriter writer, String id, String f, String cf, long value)


### PR DESCRIPTION
The changes on #12929 broke the generation code for BWC indices since they are expecting certain fields created by LineDocFile. Yet, this change adds some sanity checks that run with unittest to ensure the bwc generatin is at least readable with the current version.

Relates to #12929