### PR TITLE
Fix issues with chunked TaxonomyIndexArray

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/TaxonomyIndexArrays.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/TaxonomyIndexArrays.java
@@ -80,7 +80,8 @@ class TaxonomyIndexArrays extends ParallelTaxonomyArrays implements Accountable 
 
   public TaxonomyIndexArrays(IndexReader reader) throws IOException {
     int[][] parentArray = allocateChunkedArray(reader.maxDoc(), 0);
-    if (parentArray.length > 0) {
+    assert parentArray.length > 0;
+    if (parentArray[0].length > 0) {
       initParents(parentArray, reader, 0);
       parentArray[0][0] = TaxonomyReader.INVALID_ORDINAL;
     }
@@ -95,7 +96,8 @@ class TaxonomyIndexArrays extends ParallelTaxonomyArrays implements Accountable 
     // NRT reader was obtained, even though nothing was changed. this is not very likely
     // to happen.
     int[][] parentArray = allocateChunkedArray(reader.maxDoc(), copyFrom.parents.values.length - 1);
-    if (parentArray.length > 0) {
+    assert parentArray.length > 0;
+    if (parentArray[0].length > 0) {
       copyChunkedArray(copyFrom.parents.values, parentArray);
       initParents(parentArray, reader, copyFrom.parents.length());
     }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/TaxonomyIndexArrays.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/TaxonomyIndexArrays.java
@@ -82,7 +82,7 @@ class TaxonomyIndexArrays extends ParallelTaxonomyArrays implements Accountable 
   public TaxonomyIndexArrays(IndexReader reader) throws IOException {
     int[][] parentArray = allocateChunkedArray(reader.maxDoc(), 0);
     assert parentArray.length > 0;
-    if (parentArray[parentArray.length - 1].length > 0) {
+    if (parentArray[0].length > 0) {
       initParents(parentArray, reader, 0);
       parentArray[0][0] = TaxonomyReader.INVALID_ORDINAL;
     }
@@ -98,10 +98,9 @@ class TaxonomyIndexArrays extends ParallelTaxonomyArrays implements Accountable 
     // to happen.
     int[][] parentArray = allocateChunkedArray(reader.maxDoc(), copyFrom.parents.values.length - 1);
     assert parentArray.length > 0;
-    if (parentArray[parentArray.length - 1].length > 0) {
-      copyChunkedArray(copyFrom.parents.values, parentArray);
-      initParents(parentArray, reader, copyFrom.parents.length());
-    }
+
+    copyChunkedArray(copyFrom.parents.values, parentArray);
+    initParents(parentArray, reader, copyFrom.parents.length());
     parents = new ChunkedIntArray(parentArray);
     if (copyFrom.initializedChildren) {
       initChildrenSiblings(copyFrom);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestTaxonomyIndexArrays.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestTaxonomyIndexArrays.java
@@ -17,7 +17,12 @@
  */
 package org.apache.lucene.facet.taxonomy.directory;
 
+import java.io.IOException;
 import org.apache.lucene.facet.taxonomy.TaxonomyReader;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestTaxonomyIndexArrays extends LuceneTestCase {
@@ -58,5 +63,23 @@ public class TestTaxonomyIndexArrays extends LuceneTestCase {
       checkInvariants(oldArray, newArray);
       ordinal = newOrdinal;
     }
+  }
+
+  public void testConstructFromEmptyIndex() throws IOException {
+    Directory dir = newDirectory();
+
+    // Produce empty index
+    new IndexWriter(dir, newIndexWriterConfig(null)).close();
+
+    IndexReader reader = DirectoryReader.open(dir);
+
+    TaxonomyIndexArrays tia = new TaxonomyIndexArrays(reader);
+    assertEquals(0, tia.parents().length());
+
+    tia = new TaxonomyIndexArrays(reader, tia);
+    assertEquals(0, tia.parents().length());
+
+    reader.close();
+    dir.close();
   }
 }


### PR DESCRIPTION
In #12995, we introduced `allocateChunkedArray`, but had a misaligned assumption in the constructor for cases where the allocation size is 0. @msfroh - sorry I missed this check when we refactored `allocateChunkedArray`.

Credit to @Shradha26 for discovering this while applying #12995 to the Amazon fork.
