### PR TITLE
Fix test failure for TestTopFieldCollector.testTotalHits

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -26,6 +26,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.NoMergePolicy;
@@ -300,7 +301,11 @@ public class TestTopDocsCollector extends LuceneTestCase {
   public void testSetMinCompetitiveScore() throws Exception {
     Directory dir = newDirectory();
     IndexWriter w =
-        new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig()
+                .setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .setMergePolicy(NoMergePolicy.INSTANCE));
     Document doc = new Document();
     w.addDocuments(Arrays.asList(doc, doc, doc, doc));
     w.flush();
@@ -362,7 +367,11 @@ public class TestTopDocsCollector extends LuceneTestCase {
     Query q = new MatchAllDocsQuery();
     Directory dir = newDirectory();
     IndexWriter w =
-        new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig()
+                .setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .setMergePolicy(NoMergePolicy.INSTANCE));
     Document doc = new Document();
     w.addDocuments(Arrays.asList(doc, doc, doc, doc));
     w.flush();
@@ -384,7 +393,11 @@ public class TestTopDocsCollector extends LuceneTestCase {
   public void testTotalHits() throws Exception {
     Directory dir = newDirectory();
     IndexWriter w =
-        new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig()
+                .setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .setMergePolicy(NoMergePolicy.INSTANCE));
     Document doc = new Document();
     w.addDocuments(Arrays.asList(doc, doc, doc, doc));
     w.flush();
@@ -468,7 +481,11 @@ public class TestTopDocsCollector extends LuceneTestCase {
   public void testConcurrentMinScore() throws Exception {
     Directory dir = newDirectory();
     IndexWriter w =
-        new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig()
+                .setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .setMergePolicy(NoMergePolicy.INSTANCE));
     Document doc = new Document();
     w.addDocuments(Arrays.asList(doc, doc, doc, doc, doc));
     w.flush();

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -31,6 +31,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
@@ -180,7 +181,11 @@ public class TestTopFieldCollector extends LuceneTestCase {
     Sort sort = new Sort(new SortField("foo", SortField.Type.LONG));
     IndexWriter w =
         new IndexWriter(
-            dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE).setIndexSort(sort));
+            dir,
+            newIndexWriterConfig()
+                .setMergePolicy(NoMergePolicy.INSTANCE)
+                .setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .setIndexSort(sort));
     Document doc = new Document();
     doc.add(new NumericDocValuesField("foo", 3));
     for (Document d : Arrays.asList(doc, doc, doc, doc)) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -267,7 +267,11 @@ public class TestTopFieldCollector extends LuceneTestCase {
   public void testSetMinCompetitiveScore() throws Exception {
     Directory dir = newDirectory();
     IndexWriter w =
-        new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig()
+                .setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .setMergePolicy(NoMergePolicy.INSTANCE));
     Document doc = new Document();
     w.addDocuments(Arrays.asList(doc, doc, doc, doc));
     w.flush();
@@ -328,7 +332,11 @@ public class TestTopFieldCollector extends LuceneTestCase {
   public void testTotalHitsWithScore() throws Exception {
     Directory dir = newDirectory();
     IndexWriter w =
-        new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig()
+                .setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .setMergePolicy(NoMergePolicy.INSTANCE));
     Document doc = new Document();
     w.addDocuments(Arrays.asList(doc, doc, doc, doc));
     w.flush();
@@ -544,7 +552,11 @@ public class TestTopFieldCollector extends LuceneTestCase {
   public void testConcurrentMinScore() throws Exception {
     Directory dir = newDirectory();
     IndexWriter w =
-        new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig()
+                .setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .setMergePolicy(NoMergePolicy.INSTANCE));
     Document doc = new Document();
     w.addDocuments(Arrays.asList(doc, doc, doc, doc, doc));
     w.flush();


### PR DESCRIPTION
Gradle command to reproduce:

```
./gradlew :lucene:core:test --tests "org.apache.lucene.search.TestTopFieldCollector.testTotalHits" -Ptests.heapsize=2g -Ptests.jvms=6 "-Ptests.jvmargs=-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1" -Ptests.seed=334CDB6B7D196089 -Ptests.nightly=true -Ptests.gui=false -Ptests.file.encoding=ISO-8859-1 -Ptests.vectorsize=256
```

Error message:

```
   >     java.lang.AssertionError: expected:<2> but was:<3>
   >         at __randomizedtesting.SeedInfo.seed([334CDB6B7D196089:193C89DD7C8E120E]:0)
   >         at org.junit.Assert.fail(Assert.java:89)
   >         at org.junit.Assert.failNotEquals(Assert.java:835)
   >         at org.junit.Assert.assertEquals(Assert.java:647)
   >         at org.junit.Assert.assertEquals(Assert.java:633)
   >         at org.apache.lucene.search.TestTopFieldCollector.testTotalHits(TestTopFieldCollector.java:195)


```   
The `newIndexWriterConfig` will `setMaxBufferedDocs` using a random value of 2-15 or 16-1000, which maybe cause the `AssertionError` in this test.