### PR TITLE
in BytesRefHash constructor avoid duplicate BytesStartArray.bytesUsed() call

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -79,8 +79,8 @@ public final class BytesRefHash implements Accountable {
     Arrays.fill(ids, -1);
     this.bytesStartArray = bytesStartArray;
     bytesStart = bytesStartArray.init();
-    bytesUsed =
-        bytesStartArray.bytesUsed() == null ? Counter.newCounter() : bytesStartArray.bytesUsed();
+    final Counter bytesUsed = bytesStartArray.bytesUsed();
+    this.bytesUsed = bytesUsed == null ? Counter.newCounter() : bytesUsed;
     bytesUsed.addAndGet(hashSize * (long) Integer.BYTES);
   }
 


### PR DESCRIPTION
Noticed whilst code reading. No issue or CHANGES.txt entry needed I think. For `main` and `branch_9x` branches only.