### PR TITLE
Fix too many open files Exception for some tests

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
@@ -152,10 +152,8 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
     mp.setMinMergeDocs(1000);
     IndexWriter writer =
         new IndexWriter(
-            directory,
-            newIndexWriterConfig(new MockAnalyzer(random()))
-                .setMaxBufferedDocs(50)
-                .setMergePolicy(mp));
+            directory, newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(mp));
+    TestUtil.reduceOpenFiles(writer);
 
     Document doc = new Document();
     Field idField = newStringField("id", "", Field.Store.YES);
@@ -778,7 +776,8 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
 
     IndexWriterConfig iwc = newIndexWriterConfig(new MockAnalyzer(random()));
     iwc.setMergePolicy(NoMergePolicy.INSTANCE);
-    iwc.setMaxBufferedDocs(20);
+    iwc.setMaxBufferedDocs(2);
+    iwc.setUseCompoundFile(true); // reduce open files
     IndexWriter w = new IndexWriter(dir, iwc);
     int numDocs = TEST_NIGHTLY ? 1000 : 100;
     for (int i = 0; i < numDocs; i++) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
@@ -43,8 +43,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.InfoStream;
 
-// the testNoStallMergeThreads method will create many files
-@LuceneTestCase.SuppressFileSystems("HandleLimitFS")
 public class TestConcurrentMergeScheduler extends LuceneTestCase {
 
   private class FailOnlyOnFlush extends MockDirectoryWrapper.Failure {
@@ -154,7 +152,10 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
     mp.setMinMergeDocs(1000);
     IndexWriter writer =
         new IndexWriter(
-            directory, newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(mp));
+            directory,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setMaxBufferedDocs(50)
+                .setMergePolicy(mp));
 
     Document doc = new Document();
     Field idField = newStringField("id", "", Field.Store.YES);
@@ -777,7 +778,7 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
 
     IndexWriterConfig iwc = newIndexWriterConfig(new MockAnalyzer(random()));
     iwc.setMergePolicy(NoMergePolicy.INSTANCE);
-    iwc.setMaxBufferedDocs(2);
+    iwc.setMaxBufferedDocs(20);
     IndexWriter w = new IndexWriter(dir, iwc);
     int numDocs = TEST_NIGHTLY ? 1000 : 100;
     for (int i = 0; i < numDocs; i++) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
@@ -43,6 +43,8 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.InfoStream;
 
+// the testNoStallMergeThreads method will create many files
+@LuceneTestCase.SuppressFileSystems("HandleLimitFS")
 public class TestConcurrentMergeScheduler extends LuceneTestCase {
 
   private class FailOnlyOnFlush extends MockDirectoryWrapper.Failure {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterThreadsToSegments.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterThreadsToSegments.java
@@ -256,6 +256,7 @@ public class TestIndexWriterThreadsToSegments extends LuceneTestCase {
     IndexWriterConfig iwc = newIndexWriterConfig(r, new MockAnalyzer(r));
     iwc.setCommitOnClose(false);
     final RandomIndexWriter w = new RandomIndexWriter(r, dir, iwc);
+    TestUtil.reduceOpenFiles(w.w);
     w.setDoRandomForceMerge(false);
     Thread[] threads = new Thread[TestUtil.nextInt(random(), 4, 30)];
     final CountDownLatch startingGun = new CountDownLatch(1);


### PR DESCRIPTION
```
./gradlew :lucene:core:test --tests "org.apache.lucene.index.TestConcurrentMergeScheduler.testNoStallMergeThreads" -Ptests.jvms=6 "-Ptests.jvmargs=-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1" -Ptests.seed=13FCF0E4FD5ABF60 -Ptests.nightly=true -Ptests.gui=false -Ptests.file.encoding=US-ASCII -Ptests.vectorsize=128
```


```
  2> org.apache.lucene.index.MergePolicy$MergeException: java.nio.file.FileSystemException: /Users/zhangchao-so/Develop/git/fork/lucene/lucene/core/build/tmp/tests-tmp/lucene.index.TestConcurrentMergeScheduler_13FCF0E4FD5ABF60-008/index-NIOFSDirectory-001/_cr_Lucene99_0.tip: Too many open files
  2>    at __randomizedtesting.SeedInfo.seed([13FCF0E4FD5ABF60]:0)
  2>    at org.apache.lucene.index.ConcurrentMergeScheduler.handleMergeException(ConcurrentMergeScheduler.java:735)
  2>    at org.apache.lucene.index.ConcurrentMergeScheduler$MergeThread.run(ConcurrentMergeScheduler.java:727)
  2> Caused by: java.nio.file.FileSystemException: /Users/zhangchao-so/Develop/git/fork/lucene/lucene/core/build/tmp/tests-tmp/lucene.index.TestConcurrentMergeScheduler_13FCF0E4FD5ABF60-008/index-NIOFSDirectory-001/_cr_Lucene99_0.tip: Too many open files
  2>    at org.apache.lucene.tests.mockfile.HandleLimitFS.onOpen(HandleLimitFS.java:67)
  2>    at org.apache.lucene.tests.mockfile.HandleTrackingFS.callOpenHook(HandleTrackingFS.java:82)
  2>    at org.apache.lucene.tests.mockfile.HandleTrackingFS.newFileChannel(HandleTrackingFS.java:202)
  2>    at org.apache.lucene.tests.mockfile.FilterFileSystemProvider.newFileChannel(FilterFileSystemProvider.java:206)
  2>    at java.base/java.nio.channels.FileChannel.open(FileChannel.java:298)
```

git bisect shows this commit as the perpetrator: d6836d3d0e5d33a98b35c0885b9787f46c4be47e

