### PR TITLE
Optimize counts on two clause term disjunctions

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -232,6 +232,8 @@ Optimizations
 
 * GITHUB#13052: Avoid set.removeAll(list) O(n^2) performance trap in the UpgradeIndexMergePolicy (Dmitry Cherniachenko)
 
+* GITHUB#:13036 Optimize counts on two clause term disjunctions. (Adrien Grand, Johannes Fredén)
+
 Bug Fixes
 ---------------------
 * GITHUB#12866: Prevent extra similarity computation for single-level HNSW graphs. (Kaival Parikh)

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -198,6 +198,8 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
     Query[] queries = new Query[3];
     for (int i = 0; i < clauses.size(); i++) {
       TermQuery termQuery = (TermQuery) clauses.get(i).getQuery();
+      // Optimization will count term query several times so use cache to avoid multiple terms
+      // dictionary lookups
       if (termQuery.getTermStates() == null) {
         termQuery =
             new TermQuery(

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -182,8 +182,7 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
   /** Whether this query is a two clause disjunction with two term query clauses. */
   boolean isTwoClauseDisjunctionWithTerms() {
     return clauses.size() == 2
-        && getClauses(Occur.SHOULD).size() == 2
-        && minimumNumberShouldMatch == 1
+        && isPureDisjunction()
         && clauses.get(0).getQuery() instanceof TermQuery
         && clauses.get(1).getQuery() instanceof TermQuery;
   }

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -201,7 +201,7 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
       if (termQuery.getTermStates() == null) {
         termQuery =
             new TermQuery(
-                termQuery.getTerm(), TermStates.build(indexSearcher, termQuery.getTerm(), true));
+                termQuery.getTerm(), TermStates.build(indexSearcher, termQuery.getTerm(), false));
       }
       newQuery.add(termQuery, Occur.MUST);
       queries[i] = termQuery;

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -179,6 +179,15 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
     return clauses.size() == getClauses(Occur.SHOULD).size() && minimumNumberShouldMatch <= 1;
   }
 
+  /** Whether this query is a two clause disjunction with two term query clauses. */
+  boolean isTwoClauseDisjunctionWithTerms() {
+    return clauses.size() == 2
+        && getClauses(Occur.SHOULD).size() == 2
+        && minimumNumberShouldMatch == 1
+        && clauses.get(0).getQuery() instanceof TermQuery
+        && clauses.get(1).getQuery() instanceof TermQuery;
+  }
+
   /**
    * Returns an iterator on the clauses in this query. It implements the {@link Iterable} interface
    * to make it possible to do:

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -189,6 +189,21 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
   }
 
   /**
+   * Rewrite a single two clause disjunction query with terms to two term queries and a conjunction
+   * query using the inclusion–exclusion principle.
+   */
+  Query[] rewriteTwoClauseDisjunctionWithTermsForCount() {
+    BooleanQuery.Builder newQuery = new BooleanQuery.Builder();
+    Query[] queries = new Query[3];
+    for (int i = 0; i < clauses.size(); i++) {
+      newQuery.add(clauses.get(i).getQuery(), Occur.MUST);
+      queries[i] = clauses.get(i).getQuery();
+    }
+    queries[2] = newQuery.build();
+    return queries;
+  }
+
+  /**
    * Returns an iterator on the clauses in this query. It implements the {@link Iterable} interface
    * to make it possible to do:
    *

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
@@ -249,72 +249,8 @@ final class BooleanWeight extends Weight {
       return optional.get(0);
     }
 
-    // Calculate count(clause1 OR clause2) as count(clause1) + count(clause2) - count(clause1 AND
-    // clause2)
-    if (scoreMode == ScoreMode.COMPLETE_NO_SCORES
-        && context.reader().hasDeletions() == false
-        && query.isTwoClauseDisjunctionWithTerms()) {
-      return twoClauseTermDisjunctionOptimizedScorer(context);
-    }
-
     return new BooleanScorer(
         this, optional, Math.max(1, query.getMinimumNumberShouldMatch()), scoreMode.needsScores());
-  }
-
-  private BulkScorer twoClauseTermDisjunctionOptimizedScorer(LeafReaderContext context)
-      throws IOException {
-    List<Scorer> optionalScorers = new ArrayList<>();
-    final int[] clauseDocFreqSum = new int[1];
-    for (WeightedBooleanClause wc : weightedClauses) {
-      clauseDocFreqSum[0] += wc.weight.count(context);
-      ScorerSupplier scorerSupplier = wc.weight.scorerSupplier(context);
-      if (scorerSupplier != null) {
-        optionalScorers.add(scorerSupplier.get(Long.MAX_VALUE));
-      }
-    }
-
-    final ConjunctionBulkScorer conjunctionBulkScorer =
-        optionalScorers.size() == 2 ? new ConjunctionBulkScorer(List.of(), optionalScorers) : null;
-    return new BulkScorer() {
-      @Override
-      public int score(LeafCollector collector, Bits acceptDocs, int min, int max)
-          throws IOException {
-        final int[] intersectionScore = new int[1];
-        LeafCollector intersectionCollector =
-            new LeafCollector() {
-              @Override
-              public void setScorer(Scorable scorer) {}
-
-              @Override
-              public void collect(int doc) {
-                intersectionScore[0]++;
-              }
-
-              @Override
-              public void collect(DocIdStream stream) throws IOException {
-                intersectionScore[0] += stream.count();
-              }
-            };
-
-        int leadDocId = 0;
-        if (conjunctionBulkScorer != null) {
-          leadDocId = conjunctionBulkScorer.score(intersectionCollector, acceptDocs, min, max);
-        }
-
-        for (int i = 1; i <= clauseDocFreqSum[0] - intersectionScore[0]; i++) {
-          collector.collect(i);
-        }
-        return leadDocId;
-      }
-
-      @Override
-      public long cost() {
-        if (conjunctionBulkScorer == null) {
-          return 0;
-        }
-        return conjunctionBulkScorer.cost();
-      }
-    };
   }
 
   // Return a BulkScorer for the required clauses only

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -429,8 +429,8 @@ public class IndexSearcher {
     // Check if two clause disjunction optimization applies
     if (query instanceof BooleanQuery booleanQuery
         && this.reader.hasDeletions() == false
-        && booleanQuery.isTwoClauseDisjunctionWithTerms()) {
-      Query[] queries = booleanQuery.rewriteTwoClauseDisjunctionWithTermsForCount();
+        && booleanQuery.isTwoClausePureDisjunctionWithTerms()) {
+      Query[] queries = booleanQuery.rewriteTwoClauseDisjunctionWithTermsForCount(this);
       int countTerm1 = count(queries[0]);
       int countTerm2 = count(queries[1]);
       // Only apply optimization if the intersection is significantly smaller than the union

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -420,6 +420,13 @@ public class IndexSearcher {
    * possible.
    */
   public int count(Query query) throws IOException {
+    // Rewrite query before optimization check
+    query = rewrite(new ConstantScoreQuery(query));
+    if (query instanceof ConstantScoreQuery csq) {
+      query = csq.getQuery();
+    }
+
+    // Check if two clause disjunction optimization applies
     if (query instanceof BooleanQuery booleanQuery
         && this.reader.hasDeletions() == false
         && booleanQuery.isTwoClauseDisjunctionWithTerms()) {

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -420,6 +420,12 @@ public class IndexSearcher {
    * possible.
    */
   public int count(Query query) throws IOException {
+    if (query instanceof BooleanQuery booleanQuery
+        && this.reader.hasDeletions() == false
+        && booleanQuery.isTwoClauseDisjunctionWithTerms()) {
+      Query[] queries = booleanQuery.rewriteTwoClauseDisjunctionWithTermsForCount();
+      return count(queries[0]) + count(queries[1]) - count(queries[2]);
+    }
     return search(new ConstantScoreQuery(query), new TotalHitCountCollectorManager());
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -433,8 +433,11 @@ public class IndexSearcher {
       Query[] queries = booleanQuery.rewriteTwoClauseDisjunctionWithTermsForCount(this);
       int countTerm1 = count(queries[0]);
       int countTerm2 = count(queries[1]);
-      // Only apply optimization if the intersection is significantly smaller than the union
-      if ((double) Math.min(countTerm1, countTerm2) / Math.max(countTerm1, countTerm2) < 0.1) {
+      if (countTerm1 == 0 || countTerm2 == 0) {
+        return Math.max(countTerm1, countTerm2);
+        // Only apply optimization if the intersection is significantly smaller than the union
+      } else if ((double) Math.min(countTerm1, countTerm2) / Math.max(countTerm1, countTerm2)
+          < 0.1) {
         return countTerm1 + countTerm2 - count(queries[2]);
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -431,7 +431,12 @@ public class IndexSearcher {
         && this.reader.hasDeletions() == false
         && booleanQuery.isTwoClauseDisjunctionWithTerms()) {
       Query[] queries = booleanQuery.rewriteTwoClauseDisjunctionWithTermsForCount();
-      return count(queries[0]) + count(queries[1]) - count(queries[2]);
+      int countTerm1 = count(queries[0]);
+      int countTerm2 = count(queries[1]);
+      // Only apply optimization if the intersection is significantly smaller than the union
+      if ((double) Math.min(countTerm1, countTerm2) / Math.max(countTerm1, countTerm2) < 0.1) {
+        return countTerm1 + countTerm2 - count(queries[2]);
+      }
     }
     return search(new ConstantScoreQuery(query), new TotalHitCountCollectorManager());
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -962,8 +962,7 @@ public class TestBooleanQuery extends LuceneTestCase {
     dir.close();
   }
 
-  // test twoClauseTermDisjunctionOptimizedScorer
-  public void testTwoClauseTermDisjunctionOptimizedScorer() throws Exception {
+  public void testTwoClauseTermDisjunctionCountOptimization() throws Exception {
     List<String[]> docContent =
         Arrays.asList(
             new String[] {"A", "B"},


### PR DESCRIPTION
Calculate `count(clause1 OR clause2)` as `count(clause1) + count(clause2) - count(clause1 AND clause2)`  as discussed in https://github.com/apache/lucene/issues/12644. 

**Todo:** 
- Update nightly benchmarks to either have deletes or add tasks on disjunctions of 3 terms or more to retain coverage on actual disjunction counts