### PR TITLE
Remove concatenation in String.format() calls

### DIFF
--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/PreCopyMergedSegmentWarmer.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/PreCopyMergedSegmentWarmer.java
@@ -60,7 +60,8 @@ class PreCopyMergedSegmentWarmer implements IndexReaderWarmer {
     primary.message(
         String.format(
             Locale.ROOT,
-            "top: done warm merge " + info + ": took %.3f sec, %.1f MB",
+            "top: done warm merge %s: took %.3f sec, %.1f MB",
+            info,
             (System.nanoTime() - startNS) / (double) TimeUnit.SECONDS.toNanos(1),
             info.sizeInBytes() / 1024. / 1024.));
     primary.finishedMergedFiles.addAll(filesMetaData.keySet());

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimplePrimaryNode.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimplePrimaryNode.java
@@ -242,11 +242,9 @@ class SimplePrimaryNode extends PrimaryNode {
           message(
               String.format(
                   Locale.ROOT,
-                  "top: warning: still warming merge "
-                      + info
-                      + " to "
-                      + preCopy.connections.size()
-                      + " replicas for %.1f sec...",
+                  "top: warning: still warming merge %s to %d replicas for %.1f sec...",
+                  info,
+                  preCopy.connections.size(),
                   (ns - startNS) / (double) TimeUnit.SECONDS.toNanos(1)));
           lastWarnNS = ns;
         }


### PR DESCRIPTION
Using concatenation in the format string like this:
```
              String.format(
                  Locale.ROOT,
                  "top: warning: still warming merge "
                      + info
                      + " to "
                      + preCopy.connections.size()
                      + " replicas for %.1f sec...",
```

- is inconsistent
- is error prone (the `info.toString()` result above might happen to contain some `100%s`)
- results in longer code
- that is more difficult to modify

Replacing the concatenation with the format placeholders results in a cleaner more compact code:
```
              String.format(
                  Locale.ROOT,
                  "top: warning: still warming merge %s to %d replicas for %.1f sec...",
                  info,
                  preCopy.connections.size(),
```