### PR TITLE
Support getMaxScore of ConjunctionScorer for non top level scoring clause

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -202,6 +202,8 @@ Improvements
 
 * GITHUB#12999: Use Automaton for SurroundQuery prefix/pattern matching (Michael Gibney)
 
+* GITHUB#13043: Support getMaxScore of ConjunctionScorer for non top level scoring clause. (Shintaro Murakami)
+
 Optimizations
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/ConjunctionScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ConjunctionScorer.java
@@ -65,21 +65,22 @@ class ConjunctionScorer extends Scorer {
 
   @Override
   public float getMaxScore(int upTo) throws IOException {
-    // This scorer is only used for TOP_SCORES when there is at most one scoring clause
-    switch (scorers.length) {
-      case 0:
-        return 0;
-      case 1:
-        return scorers[0].getMaxScore(upTo);
-      default:
-        return Float.POSITIVE_INFINITY;
+    double maxScore = 0;
+    for (Scorer s : scorers) {
+      if (s.docID() <= upTo) {
+        maxScore += s.getMaxScore(upTo);
+      }
     }
+    return (float) maxScore;
   }
 
   @Override
   public int advanceShallow(int target) throws IOException {
     if (scorers.length == 1) {
       return scorers[0].advanceShallow(target);
+    }
+    for (Scorer scorer : scorers) {
+      scorer.advanceShallow(target);
     }
     return super.advanceShallow(target);
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2ScorerSupplier.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2ScorerSupplier.java
@@ -521,4 +521,20 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     assertTrue(clause1.topLevelScoringClause);
     assertFalse(clause2.topLevelScoringClause);
   }
+
+  public void testMaxScoreNonTopLevelScoringClause() throws Exception {
+    Map<Occur, Collection<ScorerSupplier>> subs = new EnumMap<>(Occur.class);
+    for (Occur occur : Occur.values()) {
+      subs.put(occur, new ArrayList<>());
+    }
+
+    FakeScorerSupplier clause1 = new FakeScorerSupplier(10, 10);
+    subs.get(Occur.MUST).add(clause1);
+    FakeScorerSupplier clause2 = new FakeScorerSupplier(10, 10);
+    subs.get(Occur.MUST).add(clause2);
+
+    Scorer scorer =
+        new Boolean2ScorerSupplier(new FakeWeight(), subs, ScoreMode.TOP_SCORES, 0).get(10);
+    assertEquals(2.0, scorer.getMaxScore(DocIdSetIterator.NO_MORE_DOCS), 0.0);
+  }
 }


### PR DESCRIPTION
### Description
After introducing topLevelScoringClause, ConjunctionScorer with multiple scorers can be used for non top level scoring clause conjunctions instead of BlockMaxConjunctionScorer even requiredScorers is empty. In such case, ConjunctionScorer returns Infinity as maxScore and it ruins some optimizations like parent WANDScorer.
https://github.com/apache/lucene/blob/7d35ae485807147460f63ea58ae495124e972e13/lucene/core/src/java/org/apache/lucene/search/Boolean2ScorerSupplier.java#L218C77-L218C98
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
