### PR TITLE
Use String.replace() instead of replaceAll()

### DIFF
--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/charfilter/TestHTMLStripCharFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/charfilter/TestHTMLStripCharFilter.java
@@ -478,14 +478,14 @@ public class TestHTMLStripCharFilter extends BaseTokenStreamTestCase {
         // ">"
         =
             TestUtil.randomHtmlishString(random(), maxNumElems)
-                .replaceAll(">", " ")
+                .replace('>', ' ')
                 .replaceFirst("^--", "__");
     String closedAngleBangNonCDATA = "<!" + randomHtmlishString1 + "-[CDATA[&]]>";
 
     // Don't create a comment (disallow "<!--") and don't include a closing ">"
     String randomHtmlishString2 =
         TestUtil.randomHtmlishString(random(), maxNumElems)
-            .replaceAll(">", " ")
+            .replace('>', ' ')
             .replaceFirst("^--", "__");
     String unclosedAngleBangNonCDATA = "<!" + randomHtmlishString2 + "-[CDATA[";
 

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/RepAllTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/RepAllTask.java
@@ -64,7 +64,7 @@ public class RepAllTask extends ReportTask {
         String line = taskReportLine(longestOp, stat);
         reported++;
         if (taskStats.size() > 2 && reported % 2 == 0) {
-          line = line.replaceAll("   ", " - ");
+          line = line.replace("   ", " - ");
         }
         sb.append(line);
       }

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/RepSelectByPrefTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/RepSelectByPrefTask.java
@@ -69,7 +69,7 @@ public class RepSelectByPrefTask extends RepSumByPrefTask {
         first = false;
         String line = taskReportLine(longestOp, stat);
         if (taskStats.size() > 2 && reported % 2 == 0) {
-          line = line.replaceAll("   ", " - ");
+          line = line.replace("   ", " - ");
         }
         sb.append(line);
       }

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/ReportTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/ReportTask.java
@@ -140,7 +140,7 @@ public abstract class ReportTask extends PerfTask {
       String line = taskReportLine(longetOp, stat);
       lineNum++;
       if (partOfTasks.size() > 2 && lineNum % 2 == 0) {
-        line = line.replaceAll("   ", " - ");
+        line = line.replace("   ", " - ");
       }
       sb.append(line);
       int[] byTime = stat.getCountsByTime();

--- a/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/TestPerfTasksLogic.java
+++ b/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/TestPerfTasksLogic.java
@@ -961,12 +961,11 @@ public class TestPerfTasksLogic extends BenchmarkTestCase {
   }
 
   private String[] getAnalyzerFactoryConfig(String name, String params) {
-    final String singleQuoteEscapedName = name.replaceAll("'", "\\\\'");
+    final String singleQuoteEscapedName = name.replace("'", "\\'");
     String[] algLines = {
       "content.source=org.apache.lucene.benchmark.byTask.feeds.LineDocSource",
       "docs.file=" + getReuters20LinesFile(),
-      "work.dir="
-          + getWorkDir().toAbsolutePath().toString().replaceAll("\\\\", "/"), // Fix Windows path
+      "work.dir=" + getWorkDir().toAbsolutePath().toString().replace('\\', '/'), // Fix Windows path
       "content.source.forever=false",
       "directory=ByteBuffersDirectory",
       "AnalyzerFactory(name:'" + singleQuoteEscapedName + "', " + params + ")",

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
@@ -142,11 +142,11 @@ public class TestRegExp extends LuceneTestCase {
         break;
       case 3:
         // Star-replace all ab sequences.
-        result.append(replacementPart.replaceAll("ab", ".*"));
+        result.append(replacementPart.replace("ab", ".*"));
         break;
       case 4:
         // .-replace all b chars
-        result.append(replacementPart.replaceAll("b", "."));
+        result.append(replacementPart.replace("b", "."));
         break;
       case 5:
         // length-limited stars {1,2}
@@ -165,7 +165,7 @@ public class TestRegExp extends LuceneTestCase {
         break;
       case 8:
         // NOT a character - replace all b's with "not a"
-        result.append(replacementPart.replaceAll("b", "[^a]"));
+        result.append(replacementPart.replace("b", "[^a]"));
         break;
       case 9:
         // Make whole part repeatable 1 or more times


### PR DESCRIPTION
When arguments do not make use of regexp features `replace()` is a more efficient option, especially the `char`-variant.