### PR TITLE
Use String.indexOf(char) where possible

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/CheckCompoundPattern.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/CheckCompoundPattern.java
@@ -34,11 +34,11 @@ class CheckCompoundPattern {
       throw new IllegalArgumentException("Invalid pattern: " + unparsed);
     }
 
-    int flagSep = parts[1].indexOf("/");
+    int flagSep = parts[1].indexOf('/');
     endChars = flagSep < 0 ? parts[1] : parts[1].substring(0, flagSep);
     endFlags = flagSep < 0 ? new char[0] : strategy.parseFlags(parts[1].substring(flagSep + 1));
 
-    flagSep = parts[2].indexOf("/");
+    flagSep = parts[2].indexOf('/');
     beginChars = flagSep < 0 ? parts[2] : parts[2].substring(0, flagSep);
     beginFlags = flagSep < 0 ? new char[0] : strategy.parseFlags(parts[2].substring(flagSep + 1));
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/CompoundRule.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/CompoundRule.java
@@ -28,7 +28,7 @@ class CompoundRule {
     StringBuilder parsedFlags = new StringBuilder();
     int pos = 0;
     while (pos < rule.length()) {
-      int lParen = rule.indexOf("(", pos);
+      int lParen = rule.indexOf('(', pos);
       if (lParen < 0) {
         parsedFlags.append(dictionary.flagParsingStrategy.parseFlags(rule.substring(pos)));
         break;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
@@ -585,7 +585,7 @@ public class Dictionary {
   }
 
   static String extractLanguageCode(String isoCode) {
-    int underscore = isoCode.indexOf("_");
+    int underscore = isoCode.indexOf('_');
     return underscore < 0 ? isoCode : isoCode.substring(0, underscore);
   }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternTypingFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternTypingFilterFactory.java
@@ -97,7 +97,7 @@ public class PatternTypingFilterFactory extends TokenFilterFactory implements Re
     // eg: 2 (\d+\(?([a-z])\)?\(?(\d+)\)? ::: legal3_$1_$2_3
     // which yields legal3_501_c_3 for 501(c)(3) or 501c3 and sets the second lowest bit in flags
     for (String line : lines) {
-      int firstSpace = line.indexOf(" "); // no leading spaces allowed
+      int firstSpace = line.indexOf(' '); // no leading spaces allowed
       int flagsVal = Integer.parseInt(line.substring(0, firstSpace));
       line = line.substring(firstSpace + 1);
       String[] split =

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SolrSynonymParser.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SolrSynonymParser.java
@@ -170,7 +170,7 @@ public class SolrSynonymParser extends SynonymMap.Parser {
   }
 
   private String unescape(String s) {
-    if (s.indexOf("\\") >= 0) {
+    if (s.indexOf('\\') >= 0) {
       StringBuilder sb = new StringBuilder();
       for (int i = 0; i < s.length(); i++) {
         char ch = s.charAt(i);

--- a/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/segmentation/ICUTokenizerFactory.java
+++ b/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/segmentation/ICUTokenizerFactory.java
@@ -87,7 +87,7 @@ public class ICUTokenizerFactory extends TokenizerFactory implements ResourceLoa
     if (rulefilesArg != null) {
       List<String> scriptAndResourcePaths = splitFileNames(rulefilesArg);
       for (String scriptAndResourcePath : scriptAndResourcePaths) {
-        int colonPos = scriptAndResourcePath.indexOf(":");
+        int colonPos = scriptAndResourcePath.indexOf(':');
         String scriptCode = scriptAndResourcePath.substring(0, colonPos).trim();
         String resourcePath = scriptAndResourcePath.substring(colonPos + 1).trim();
         tailored.put(UCharacter.getPropertyValueEnum(UProperty.SCRIPT, scriptCode), resourcePath);

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchWithSortTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchWithSortTask.java
@@ -54,7 +54,7 @@ public class SearchWithSortTask extends ReadTask {
       } else if (field.equals("score")) {
         sortField0 = SortField.FIELD_SCORE;
       } else {
-        int index = field.lastIndexOf(":");
+        int index = field.lastIndexOf(':');
         String fieldName;
         String typeString;
         if (index != -1) {

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SetPropTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SetPropTask.java
@@ -54,7 +54,7 @@ public class SetPropTask extends PerfTask {
   @Override
   public void setParams(String params) {
     super.setParams(params);
-    int k = params.indexOf(",");
+    int k = params.indexOf(',');
     name = params.substring(0, k).trim();
     value = params.substring(k + 1).trim();
   }

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Config.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Config.java
@@ -150,7 +150,7 @@ public class Config {
     if (sval == null) {
       return null;
     }
-    if (sval.indexOf(":") < 0) {
+    if (sval.indexOf(':') < 0) {
       return sval;
     } else if (sval.indexOf(":\\") >= 0 || sval.indexOf(":/") >= 0) {
       // this previously messed up absolute path names on Windows. Assuming
@@ -158,7 +158,7 @@ public class Config {
       return sval;
     }
     // first time this prop is extracted by round
-    int k = sval.indexOf(":");
+    int k = sval.indexOf(':');
     String colName = sval.substring(0, k);
     sval = sval.substring(k + 1);
     colForValByRound.put(name, colName);
@@ -197,11 +197,11 @@ public class Config {
     }
     // done if not by round
     String sval = props.getProperty(name, "" + dflt);
-    if (sval.indexOf(":") < 0) {
+    if (sval.indexOf(':') < 0) {
       return Integer.parseInt(sval);
     }
     // first time this prop is extracted by round
-    int k = sval.indexOf(":");
+    int k = sval.indexOf(':');
     String colName = sval.substring(0, k);
     sval = sval.substring(k + 1);
     colForValByRound.put(name, colName);
@@ -227,11 +227,11 @@ public class Config {
     }
     // done if not by round
     String sval = props.getProperty(name, "" + dflt);
-    if (sval.indexOf(":") < 0) {
+    if (sval.indexOf(':') < 0) {
       return Double.parseDouble(sval);
     }
     // first time this prop is extracted by round
-    int k = sval.indexOf(":");
+    int k = sval.indexOf(':');
     String colName = sval.substring(0, k);
     sval = sval.substring(k + 1);
     colForValByRound.put(name, colName);
@@ -257,11 +257,11 @@ public class Config {
     }
     // done if not by round
     String sval = props.getProperty(name, "" + dflt);
-    if (sval.indexOf(":") < 0) {
+    if (sval.indexOf(':') < 0) {
       return Boolean.valueOf(sval).booleanValue();
     }
     // first time this prop is extracted by round
-    int k = sval.indexOf(":");
+    int k = sval.indexOf(':');
     String colName = sval.substring(0, k);
     sval = sval.substring(k + 1);
     colForValByRound.put(name, colName);
@@ -319,7 +319,7 @@ public class Config {
   }
 
   private String[] propToStringArray(String s) {
-    if (s.indexOf(":") < 0) {
+    if (s.indexOf(':') < 0) {
       return new String[] {s};
     }
 
@@ -334,7 +334,7 @@ public class Config {
 
   // extract properties to array, e.g. for "10:100:5" return int[]{10,100,5}.
   private int[] propToIntArray(String s) {
-    if (s.indexOf(":") < 0) {
+    if (s.indexOf(':') < 0) {
       return new int[] {Integer.parseInt(s)};
     }
 
@@ -353,7 +353,7 @@ public class Config {
 
   // extract properties to array, e.g. for "10.7:100.4:-2.3" return int[]{10.7,100.4,-2.3}.
   private double[] propToDoubleArray(String s) {
-    if (s.indexOf(":") < 0) {
+    if (s.indexOf(':') < 0) {
       return new double[] {Double.parseDouble(s)};
     }
 
@@ -372,7 +372,7 @@ public class Config {
 
   // extract properties to array, e.g. for "true:true:false" return boolean[]{true,false,false}.
   private boolean[] propToBooleanArray(String s) {
-    if (s.indexOf(":") < 0) {
+    if (s.indexOf(':') < 0) {
       return new boolean[] {Boolean.valueOf(s).booleanValue()};
     }
 

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/quality/trec/Trec1MQReader.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/quality/trec/Trec1MQReader.java
@@ -67,7 +67,7 @@ public class Trec1MQReader {
           continue;
         }
         // id
-        int k = line.indexOf(":");
+        int k = line.indexOf(':');
         String id = line.substring(0, k).trim();
         // qtext
         String qtext = line.substring(k + 1).trim();

--- a/lucene/core/src/java/org/apache/lucene/util/CommandLineUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/CommandLineUtil.java
@@ -98,7 +98,7 @@ public final class CommandLineUtil {
           "The " + FSDirectory.class.getSimpleName() + " implementation must not be null or empty");
     }
 
-    if (clazzName.indexOf(".") == -1) { // if not fully qualified, assume .store
+    if (clazzName.indexOf('.') == -1) { // if not fully qualified, assume .store
       clazzName = Directory.class.getPackage().getName() + "." + clazzName;
     }
     return clazzName;

--- a/lucene/core/src/test/org/apache/lucene/index/TestTransactionRollback.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTransactionRollback.java
@@ -177,7 +177,7 @@ public class TestTransactionRollback extends LuceneTestCase {
           // This code reads the last id ("30" in this example) and deletes it
           // if it is after the desired rollback point
           String x = userData.get("index");
-          String lastVal = x.substring(x.lastIndexOf("-") + 1);
+          String lastVal = x.substring(x.lastIndexOf('-') + 1);
           int last = Integer.parseInt(lastVal);
           if (last > rollbackPoint) {
             /*

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestDefaultPassageFormatter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestDefaultPassageFormatter.java
@@ -27,10 +27,10 @@ public class TestDefaultPassageFormatter extends LuceneTestCase {
     Passage[] passages = new Passage[2];
     passages[0] = new Passage();
     passages[0].setStartOffset(0);
-    passages[0].setEndOffset(text.indexOf(".") + 1);
+    passages[0].setEndOffset(text.indexOf('.') + 1);
     passages[0].addMatch(text.indexOf("very"), text.indexOf("very") + 4, null, 2);
     passages[1] = new Passage();
-    passages[1].setStartOffset(text.indexOf(".", passages[0].getEndOffset() + 1) + 2);
+    passages[1].setStartOffset(text.indexOf('.', passages[0].getEndOffset() + 1) + 2);
     passages[1].setEndOffset(text.length());
     passages[1].addMatch(
         text.indexOf("very", passages[0].getEndOffset()),

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/RegexpQueryHandler.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/RegexpQueryHandler.java
@@ -127,9 +127,9 @@ public class RegexpQueryHandler implements CustomQueryHandler {
   }
 
   private static String parseOutRegexp(String rep) {
-    int fieldSepPos = rep.indexOf(":");
-    int firstSlash = rep.indexOf("/", fieldSepPos);
-    int lastSlash = rep.lastIndexOf("/");
+    int fieldSepPos = rep.indexOf(':');
+    int firstSlash = rep.indexOf('/', fieldSepPos);
+    int lastSlash = rep.lastIndexOf('/');
     return rep.substring(firstSlash + 1, lastSlash);
   }
 

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
@@ -654,7 +654,7 @@ public abstract class QueryParserTestBase extends LuceneTestCase {
   }
 
   private String escapeDateString(String s) {
-    if (s.indexOf(" ") > -1) {
+    if (s.indexOf(' ') > -1) {
       return "\"" + s + "\"";
     } else {
       return s;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
@@ -444,7 +444,7 @@ public class CheckHits {
           int k1 = descr.indexOf("max plus ");
           if (k1 >= 0) {
             k1 += "max plus ".length();
-            int k2 = descr.indexOf(" ", k1);
+            int k2 = descr.indexOf(' ', k1);
             try {
               x = Float.parseFloat(descr.substring(k1, k2).trim());
               if (descr.substring(k2).trim().equals("times others of:")) {


### PR DESCRIPTION
`indexOf(char)` runs faster than searching for the same one-character string.
It makes sense to use `indexOf('x')` instead of any `indexOf("x")`.