### PR TITLE
Use String.isEmpty() instead of equals("")

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/geo/SimpleGeoJSONPolygonParser.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/SimpleGeoJSONPolygonParser.java
@@ -194,7 +194,7 @@ class SimpleGeoJSONPolygonParser {
         } else if (type.equals("MultiPolygon") && isValidGeometryPath(path)) {
           polyType = "MultiPolygon";
         } else if ((type.equals("FeatureCollection") || type.equals("Feature"))
-            && (path.equals("features.[]") || path.equals(""))) {
+            && (path.equals("features.[]") || path.isEmpty())) {
           // OK, we recurse
         } else {
           upto = uptoStart;
@@ -220,7 +220,7 @@ class SimpleGeoJSONPolygonParser {
 
   /** Returns true if the object path is a valid location to see a Multi/Polygon geometry */
   private boolean isValidGeometryPath(String path) {
-    return path.equals("") || path.equals("geometry") || path.equals("features.[].geometry");
+    return path.isEmpty() || path.equals("geometry") || path.equals("features.[].geometry");
   }
 
   private Polygon parsePolygon(List<Object> coordinates) throws ParseException {

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentReader.java
@@ -99,12 +99,12 @@ public class TestSegmentReader extends LuceneTestCase {
 
     assertTrue(allFieldNames.size() == DocHelper.all.size());
     for (String s : allFieldNames) {
-      assertTrue(DocHelper.nameValues.containsKey(s) == true || s.equals(""));
+      assertTrue(DocHelper.nameValues.containsKey(s) == true || s.isEmpty());
     }
 
     assertTrue(indexedFieldNames.size() == DocHelper.indexed.size());
     for (String s : indexedFieldNames) {
-      assertTrue(DocHelper.indexed.containsKey(s) == true || s.equals(""));
+      assertTrue(DocHelper.indexed.containsKey(s) == true || s.isEmpty());
     }
 
     assertTrue(notIndexedFieldNames.size() == DocHelper.unindexed.size());

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/AbstractGroupingTestCase.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/AbstractGroupingTestCase.java
@@ -40,7 +40,7 @@ public abstract class AbstractGroupingTestCase extends LuceneTestCase {
       // groups.
       randomValue = TestUtil.randomRealisticUnicodeString(random());
       // randomValue = _TestUtil.randomSimpleString(random());
-    } while ("".equals(randomValue));
+    } while (randomValue.isEmpty());
     return randomValue;
   }
 

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -712,7 +712,7 @@ public class TestGrouping extends LuceneTestCase {
           // groups.
           randomValue = TestUtil.randomRealisticUnicodeString(random());
           // randomValue = TestUtil.randomSimpleString(random());
-        } while ("".equals(randomValue));
+        } while (randomValue.isEmpty());
 
         groups.add(new BytesRef(randomValue));
       }

--- a/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestSimpleFragmentsBuilder.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestSimpleFragmentsBuilder.java
@@ -235,7 +235,7 @@ public class TestSimpleFragmentsBuilder extends AbstractTestCase {
       String randomValue;
       do {
         randomValue = TestUtil.randomSimpleString(random());
-      } while ("".equals(randomValue));
+      } while (randomValue.isEmpty());
       randomValues[i] = randomValue;
     }
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/EditParamsDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/EditParamsDialogFactory.java
@@ -150,9 +150,9 @@ public final class EditParamsDialogFactory implements DialogOpener.DialogFactory
                 (String) paramsTable.getValueAt(i, ParamsTableModel.Column.VALUE.getIndex());
             if (deleted
                 || Objects.isNull(name)
-                || name.equals("")
+                || name.isEmpty()
                 || Objects.isNull(value)
-                || value.equals("")) {
+                || value.isEmpty()) {
               continue;
             }
             params.put(name, value);

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/StringUtils.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/StringUtils.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 public class StringUtils {
 
   public static boolean isNullOrEmpty(String s) {
-    return Objects.isNull(s) || s.equals("");
+    return Objects.isNull(s) || s.isEmpty();
   }
 
   private StringUtils() {}

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/inifile/SimpleIniFile.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/inifile/SimpleIniFile.java
@@ -75,7 +75,7 @@ public class SimpleIniFile implements IniFile {
   }
 
   private boolean checkString(String s) {
-    return Objects.nonNull(s) && !s.equals("");
+    return Objects.nonNull(s) && !s.isEmpty();
   }
 
   Map<String, OptionMap> getSections() {

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/inifile/SimpleIniFileReader.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/inifile/SimpleIniFileReader.java
@@ -44,10 +44,10 @@ public class SimpleIniFileReader implements IniFileReader {
                   // set section if this is a valid section string
                   currentSection = line.substring(1, line.length() - 1);
                   sections.putIfAbsent(currentSection, new OptionMap());
-                } else if (!currentSection.equals("")) {
+                } else if (!currentSection.isEmpty()) {
                   // put option if this is a valid option string
                   String[] ary = line.split("=", 2);
-                  if (ary.length == 2 && !ary[0].trim().equals("") && !ary[1].trim().equals("")) {
+                  if (ary.length == 2 && !ary[0].trim().isEmpty() && !ary[1].trim().isEmpty()) {
                     sections.get(currentSection).put(ary[0].trim(), ary[1].trim());
                   }
                 }

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/util/twentynewsgroups/MessageFilesParser.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/util/twentynewsgroups/MessageFilesParser.java
@@ -68,7 +68,7 @@ public class MessageFilesParser extends SimpleFileVisitor<Path> {
       String line = br.readLine();
 
       Message message = new Message();
-      while (!line.equals("")) {
+      while (!line.isEmpty()) {
         String[] ary = line.split(":", 2);
         if (ary.length < 2) {
           line = br.readLine();

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/simple/SimpleQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/simple/SimpleQueryParser.java
@@ -514,7 +514,7 @@ public class SimpleQueryParser extends QueryBuilder {
       int fuzziness = 0;
       try {
         String fuzzyString = new String(slopText, 0, slopLength);
-        if ("".equals(fuzzyString)) {
+        if (fuzzyString.isEmpty()) {
           // Use automatic fuzziness, ~2
           fuzziness = 2;
         } else {

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/DOMUtils.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/DOMUtils.java
@@ -86,7 +86,7 @@ public class DOMUtils {
    */
   public static String getAttributeWithInheritance(Element element, String attributeName) {
     String result = element.getAttribute(attributeName);
-    if ((result == null) || ("".equals(result))) {
+    if ((result == null) || (result.isEmpty())) {
       Node n = element.getParentNode();
       if ((n == element) || (n == null)) {
         return null;
@@ -118,22 +118,22 @@ public class DOMUtils {
 
   public static String getAttribute(Element element, String attributeName, String deflt) {
     String result = element.getAttribute(attributeName);
-    return (result == null) || ("".equals(result)) ? deflt : result;
+    return (result == null) || (result.isEmpty()) ? deflt : result;
   }
 
   public static float getAttribute(Element element, String attributeName, float deflt) {
     String result = element.getAttribute(attributeName);
-    return (result == null) || ("".equals(result)) ? deflt : Float.parseFloat(result);
+    return (result == null) || (result.isEmpty()) ? deflt : Float.parseFloat(result);
   }
 
   public static int getAttribute(Element element, String attributeName, int deflt) {
     String result = element.getAttribute(attributeName);
-    return (result == null) || ("".equals(result)) ? deflt : Integer.parseInt(result);
+    return (result == null) || (result.isEmpty()) ? deflt : Integer.parseInt(result);
   }
 
   public static boolean getAttribute(Element element, String attributeName, boolean deflt) {
     String result = element.getAttribute(attributeName);
-    return (result == null) || ("".equals(result)) ? deflt : Boolean.valueOf(result);
+    return (result == null) || (result.isEmpty()) ? deflt : Boolean.valueOf(result);
   }
 
   /* Returns text of node and all child nodes - without markup */


### PR DESCRIPTION
`isEmpty()` is a simpler more efficient method without the overhead of extra parameter, additional `instanceof` check, calling the coder to actually do the comparison, etc.
Besides, it aligns nicely with the approach used for collections: `list == null || list.isEmpty()`.