### PR TITLE
Replace `new HashSet<>(Arrays.asList())` with `EnumSet.of()`

### DIFF
--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanPartOfSpeechStopFilter.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanPartOfSpeechStopFilter.java
@@ -16,8 +16,7 @@
  */
 package org.apache.lucene.analysis.ko;
 
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Set;
 import org.apache.lucene.analysis.FilteringTokenFilter;
 import org.apache.lucene.analysis.TokenStream;
@@ -34,38 +33,37 @@ public final class KoreanPartOfSpeechStopFilter extends FilteringTokenFilter {
 
   /** Default list of tags to filter. */
   public static final Set<POS.Tag> DEFAULT_STOP_TAGS =
-      new HashSet<>(
-          Arrays.asList(
-              POS.Tag.EP,
-              POS.Tag.EF,
-              POS.Tag.EC,
-              POS.Tag.ETN,
-              POS.Tag.ETM,
-              POS.Tag.IC,
-              POS.Tag.JKS,
-              POS.Tag.JKC,
-              POS.Tag.JKG,
-              POS.Tag.JKO,
-              POS.Tag.JKB,
-              POS.Tag.JKV,
-              POS.Tag.JKQ,
-              POS.Tag.JX,
-              POS.Tag.JC,
-              POS.Tag.MAG,
-              POS.Tag.MAJ,
-              POS.Tag.MM,
-              POS.Tag.SP,
-              POS.Tag.SSC,
-              POS.Tag.SSO,
-              POS.Tag.SC,
-              POS.Tag.SE,
-              POS.Tag.XPN,
-              POS.Tag.XSA,
-              POS.Tag.XSN,
-              POS.Tag.XSV,
-              POS.Tag.UNA,
-              POS.Tag.NA,
-              POS.Tag.VSV));
+      EnumSet.of(
+          POS.Tag.EP,
+          POS.Tag.EF,
+          POS.Tag.EC,
+          POS.Tag.ETN,
+          POS.Tag.ETM,
+          POS.Tag.IC,
+          POS.Tag.JKS,
+          POS.Tag.JKC,
+          POS.Tag.JKG,
+          POS.Tag.JKO,
+          POS.Tag.JKB,
+          POS.Tag.JKV,
+          POS.Tag.JKQ,
+          POS.Tag.JX,
+          POS.Tag.JC,
+          POS.Tag.MAG,
+          POS.Tag.MAJ,
+          POS.Tag.MM,
+          POS.Tag.SP,
+          POS.Tag.SSC,
+          POS.Tag.SSO,
+          POS.Tag.SC,
+          POS.Tag.SE,
+          POS.Tag.XPN,
+          POS.Tag.XSA,
+          POS.Tag.XSN,
+          POS.Tag.XSV,
+          POS.Tag.UNA,
+          POS.Tag.NA,
+          POS.Tag.VSV);
 
   /**
    * Create a new {@link KoreanPartOfSpeechStopFilter} with the default list of stop tags {@link

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanAnalyzer.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanAnalyzer.java
@@ -17,8 +17,7 @@
 package org.apache.lucene.analysis.ko;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Random;
 import java.util.Set;
 import org.apache.lucene.analysis.Analyzer;
@@ -39,7 +38,7 @@ public class TestKoreanAnalyzer extends BaseTokenStreamTestCase {
   }
 
   public void testStopTags() throws IOException {
-    Set<POS.Tag> stopTags = new HashSet<>(Arrays.asList(POS.Tag.NNP, POS.Tag.NNG));
+    Set<POS.Tag> stopTags = EnumSet.of(POS.Tag.NNP, POS.Tag.NNG);
     Analyzer a = new KoreanAnalyzer(null, KoreanTokenizer.DecompoundMode.DISCARD, stopTags, false);
     assertAnalyzesTo(
         a,

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanNumberFilter.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanNumberFilter.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Set;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -62,8 +62,7 @@ public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
   public void setUp() throws Exception {
     super.setUp();
     UserDictionary userDictionary = readDict();
-    Set<POS.Tag> stopTags = new HashSet<>();
-    stopTags.add(POS.Tag.SP);
+    Set<POS.Tag> stopTags = EnumSet.of(POS.Tag.SP);
     analyzer =
         new Analyzer() {
           @Override
@@ -205,8 +204,7 @@ public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
             CharArraySet set = new CharArraySet(1, false);
             set.add("경일");
             UserDictionary userDictionary = readDict();
-            Set<POS.Tag> stopTags = new HashSet<>();
-            stopTags.add(POS.Tag.SP);
+            Set<POS.Tag> stopTags = EnumSet.of(POS.Tag.SP);
             Tokenizer tokenizer =
                 new KoreanTokenizer(
                     newAttributeFactory(),
@@ -303,8 +301,7 @@ public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
           @Override
           protected TokenStreamComponents createComponents(String fieldName) {
             UserDictionary userDictionary = readDict();
-            Set<POS.Tag> stopTags = new HashSet<>();
-            stopTags.add(POS.Tag.SP);
+            Set<POS.Tag> stopTags = EnumSet.of(POS.Tag.SP);
             Tokenizer tokenizer =
                 new KoreanTokenizer(
                     newAttributeFactory(),


### PR DESCRIPTION
For sets with enum values `EnumSet` provides a more efficient implementation.
Besides, `EnumSet.of()` results in a shorter, easier to understand code than `new HashSet<>(Arrays.asList())`.