### PR TITLE
Change `set.removeAll(list)` to `list.forEach(set::remove)`

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -228,6 +228,8 @@ Optimizations
   this will help boolean queries that consist of a mix OF FILTER clauses and
   SHOULD clauses. (Adrien Grand)
 
+* GITHUB#13052: Avoid set.removeAll(list) O(n^2) performance trap in the UpgradeIndexMergePolicy (Dmitry Cherniachenko)
+
 Bug Fixes
 ---------------------
 * GITHUB#12866: Prevent extra similarity computation for single-level HNSW graphs. (Kaival Parikh)

--- a/lucene/core/src/java/org/apache/lucene/index/UpgradeIndexMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/UpgradeIndexMergePolicy.java
@@ -106,6 +106,10 @@ public class UpgradeIndexMergePolicy extends FilterMergePolicy {
       // the resulting set contains all segments that are left over
       // and will be merged to one additional segment:
       for (final OneMerge om : spec.merges) {
+        // om.segments.forEach(::remove) is used here instead of oldSegments.keySet().removeAll()
+        // for performance reasons; om.segments size is always greater than oldSegments size, and
+        // then the AbstractSet#removeAll() implementation will iterate the set elements calling
+        // list.contains() for each of them, resulting in O(n^2) performance
         om.segments.forEach(oldSegments::remove);
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/UpgradeIndexMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/UpgradeIndexMergePolicy.java
@@ -106,7 +106,7 @@ public class UpgradeIndexMergePolicy extends FilterMergePolicy {
       // the resulting set contains all segments that are left over
       // and will be merged to one additional segment:
       for (final OneMerge om : spec.merges) {
-        oldSegments.keySet().removeAll(om.segments);
+        om.segments.forEach(oldSegments::remove);
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/UpgradeIndexMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/UpgradeIndexMergePolicy.java
@@ -107,9 +107,9 @@ public class UpgradeIndexMergePolicy extends FilterMergePolicy {
       // and will be merged to one additional segment:
       for (final OneMerge om : spec.merges) {
         // om.segments.forEach(::remove) is used here instead of oldSegments.keySet().removeAll()
-        // for performance reasons; om.segments size is always greater than oldSegments size, and
-        // then the AbstractSet#removeAll() implementation will iterate the set elements calling
-        // list.contains() for each of them, resulting in O(n^2) performance
+        // for performance reasons; when om.segments.size() == oldSegments.size()
+        // the AbstractSet#removeAll() implementation will iterate the set elements
+        // calling list.contains() for each of them, resulting in O(n^2) performance
         om.segments.forEach(oldSegments::remove);
       }
     }


### PR DESCRIPTION
When list size is greater than set size, `list.contains()` will be called for each set element resulting in O(n^2) complexity.
When list size is smaller the default `removeAll()` implementation will iterate the list anyway.