### PR TITLE
Move synonym map off-heap for SynonymGraphFilter

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymFilter.java
@@ -448,7 +448,7 @@ public final class SynonymFilter extends TokenFilter {
   }
 
   // Interleaves all output tokens onto the futureOutputs:
-  private void addOutput(BytesRef bytes, int matchInputLength, int matchEndOffset) {
+  private void addOutput(BytesRef bytes, int matchInputLength, int matchEndOffset) throws IOException {
     bytesReader.reset(bytes.bytes, bytes.offset, bytes.length);
 
     final int code = bytesReader.readVInt();

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymFilter.java
@@ -448,7 +448,8 @@ public final class SynonymFilter extends TokenFilter {
   }
 
   // Interleaves all output tokens onto the futureOutputs:
-  private void addOutput(BytesRef bytes, int matchInputLength, int matchEndOffset) throws IOException {
+  private void addOutput(BytesRef bytes, int matchInputLength, int matchEndOffset)
+      throws IOException {
     bytesReader.reset(bytes.bytes, bytes.offset, bytes.length);
 
     final int code = bytesReader.readVInt();

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymGraphFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymGraphFilter.java
@@ -439,7 +439,7 @@ public final class SynonymGraphFilter extends TokenFilter {
    * Expands the output graph into the necessary tokens, adding synonyms as side paths parallel to
    * the input tokens, and buffers them in the output token buffer.
    */
-  private void bufferOutputTokens(BytesRef bytes, int matchInputLength) {
+  private void bufferOutputTokens(BytesRef bytes, int matchInputLength) throws IOException {
     bytesReader.reset(bytes.bytes, bytes.offset, bytes.length);
 
     final int code = bytesReader.readVInt();

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymGraphFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymGraphFilterFactory.java
@@ -116,7 +116,8 @@ public class SynonymGraphFilterFactory extends TokenFilterFactory implements Res
       }
     }
     String compiledSynonymsPathArg = get(args, "compiledSynonymsPath");
-    compiledSynonymsPath = compiledSynonymsPathArg == null ? null : Path.of(compiledSynonymsPathArg);
+    compiledSynonymsPath =
+        compiledSynonymsPathArg == null ? null : Path.of(compiledSynonymsPathArg);
     if (!args.isEmpty()) {
       throw new IllegalArgumentException("Unknown parameters: " + args);
     }
@@ -178,18 +179,18 @@ public class SynonymGraphFilterFactory extends TokenFilterFactory implements Res
     }
     if (compiledSynonymsDirectory == null || compiledSynonymsDirectory.hasSynonyms() == false) {
       CharsetDecoder decoder =
-              StandardCharsets.UTF_8
-                      .newDecoder()
-                      .onMalformedInput(CodingErrorAction.REPORT)
-                      .onUnmappableCharacter(CodingErrorAction.REPORT);
+          StandardCharsets.UTF_8
+              .newDecoder()
+              .onMalformedInput(CodingErrorAction.REPORT)
+              .onUnmappableCharacter(CodingErrorAction.REPORT);
 
       SynonymMap.Parser parser;
       Class<? extends SynonymMap.Parser> clazz = loader.findClass(cname, SynonymMap.Parser.class);
       try {
         parser =
-                clazz
-                        .getConstructor(boolean.class, boolean.class, Analyzer.class)
-                        .newInstance(dedup, expand, analyzer);
+            clazz
+                .getConstructor(boolean.class, boolean.class, Analyzer.class)
+                .newInstance(dedup, expand, analyzer);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymMap.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymMap.java
@@ -305,7 +305,7 @@ public class SynonymMap {
         fstCompiler.add(Util.toUTF32(input, scratchIntsRef), scratch.toBytesRef());
       }
 
-      FST<BytesRef> fst = FST.fromFSTReader(fstCompiler.compile(), fstCompiler.getFSTReader());
+      FST.FSTMetadata<BytesRef> fstMetaData = fstCompiler.compile();
       if (directory != null) {
         fstOutput.close(); // TODO -- Should fstCompiler.compile take care of this?
         try (SynonymMapDirectory.WordsOutput wordsOutput = directory.wordsOutput()) {
@@ -315,9 +315,10 @@ public class SynonymMap {
             wordsOutput.addWord(scratchRef);
           }
         }
-        directory.writeMetadata(words.size(), maxHorizontalContext, fst);
+        directory.writeMetadata(words.size(), maxHorizontalContext, fstMetaData);
         return directory.readMap();
       }
+      FST<BytesRef> fst = FST.fromFSTReader(fstMetaData, fstCompiler.getFSTReader());
       BytesRefHashLike wordsLike =
           new BytesRefHashLike() {
             @Override

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymMap.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymMap.java
@@ -224,12 +224,15 @@ public class SynonymMap {
       return build(null);
     }
 
-    /** Builds an {@link SynonymMap} and returns it.
-     * If directory is non-null, it will write the compiled SynonymMap to disk and return an off-heap version. */
+    /**
+     * Builds an {@link SynonymMap} and returns it. If directory is non-null, it will write the
+     * compiled SynonymMap to disk and return an off-heap version.
+     */
     public SynonymMap build(SynonymMapDirectory directory) throws IOException {
       ByteSequenceOutputs outputs = ByteSequenceOutputs.getSingleton();
       // TODO: are we using the best sharing options?
-      FSTCompiler.Builder<BytesRef> fstCompilerBuilder = new FSTCompiler.Builder<>(FST.INPUT_TYPE.BYTE4, outputs);
+      FSTCompiler.Builder<BytesRef> fstCompilerBuilder =
+          new FSTCompiler.Builder<>(FST.INPUT_TYPE.BYTE4, outputs);
       IndexOutput fstOutput = null;
       if (directory != null) {
         fstOutput = directory.fstOutput();
@@ -315,17 +318,18 @@ public class SynonymMap {
         directory.writeMetadata(words.size(), maxHorizontalContext, fst);
         return directory.readMap();
       }
-      BytesRefHashLike wordsLike = new BytesRefHashLike() {
-        @Override
-        public void get(int id, BytesRef scratch) {
-          words.get(id, scratch);
-        }
-      };
+      BytesRefHashLike wordsLike =
+          new BytesRefHashLike() {
+            @Override
+            public void get(int id, BytesRef scratch) {
+              words.get(id, scratch);
+            }
+          };
       return new SynonymMap(fst, wordsLike, maxHorizontalContext);
     }
   }
 
-  static abstract class BytesRefHashLike {
+  abstract static class BytesRefHashLike {
     public abstract void get(int id, BytesRef scratch) throws IOException;
   }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymMapDirectory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymMapDirectory.java
@@ -1,0 +1,147 @@
+package org.apache.lucene.analysis.synonym;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.fst.ByteSequenceOutputs;
+import org.apache.lucene.util.fst.FST;
+import org.apache.lucene.util.fst.OffHeapFSTStore;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+public class SynonymMapDirectory implements Closeable {
+    private final SynonymMapFormat synonymMapFormat = new SynonymMapFormat(); // TODO -- Should this be more flexible/codec-like? Less?
+    private final Directory directory;
+    public SynonymMapDirectory(Path path) throws IOException {
+        directory = FSDirectory.open(path);
+    }
+
+    public IndexOutput fstOutput() throws IOException {
+        return synonymMapFormat.getFSTOutput(directory);
+    }
+
+    public WordsOutput wordsOutput() throws IOException {
+        return synonymMapFormat.getWordsOutput(directory);
+    }
+
+    public void writeMetadata(int wordCount, int maxHorizontalContext, FST<BytesRef> fst) throws IOException {
+        synonymMapFormat.writeMetadata(directory, wordCount, maxHorizontalContext, fst);
+    }
+
+    public SynonymMap readMap() throws IOException {
+        return synonymMapFormat.readSynonymMap(directory);
+    }
+
+    public boolean hasSynonyms() throws IOException {
+        // TODO should take the path to the synonyms file to compare file hash against file used to build the directory
+        return directory.listAll().length > 0;
+    }
+
+    @Override
+    public void close() throws IOException {
+        directory.close();
+    }
+
+    public static abstract class WordsOutput  implements Closeable {
+        public abstract void addWord(BytesRef word) throws IOException;
+    }
+
+    private static class SynonymMapFormat {
+        private static final String FST_FILE = "synonyms.fst";
+        private static final String WORDS_FILE = "synonyms.wrd";
+        private static final String METADATA_FILE = "synonyms.mdt";
+
+        public IndexOutput getFSTOutput(Directory directory) throws IOException {
+            return directory.createOutput(FST_FILE, IOContext.DEFAULT);
+        }
+
+        public WordsOutput getWordsOutput(Directory directory)  throws IOException {
+            IndexOutput wordsOutput = directory.createOutput(WORDS_FILE, IOContext.DEFAULT);
+            return new WordsOutput() {
+                @Override
+                public void close() throws IOException {
+                    wordsOutput.close();
+                }
+
+                @Override
+                public void addWord(BytesRef word) throws IOException {
+                    wordsOutput.writeVInt(word.length);
+                    wordsOutput.writeBytes(word.bytes, word.offset, word.length);
+                }
+            };
+        };
+
+        public void writeMetadata(Directory directory, int wordCount, int maxHorizontalContext, FST<BytesRef> fst) throws IOException {
+            try (IndexOutput metadataOutput = directory.createOutput(METADATA_FILE, IOContext.DEFAULT)) {
+                metadataOutput.writeVInt(wordCount);
+                metadataOutput.writeVInt(maxHorizontalContext);
+                fst.saveMetadata(metadataOutput);
+            }
+            directory.sync(List.of(FST_FILE, WORDS_FILE, METADATA_FILE));
+        }
+
+        private SynonymMetadata readMetadata(Directory directory) throws IOException {
+            try (IndexInput metadataInput = directory.openInput(METADATA_FILE, IOContext.READONCE)) {
+                int wordCount = metadataInput.readVInt();
+                int maxHorizontalContext = metadataInput.readVInt();
+                FST.FSTMetadata<BytesRef> fstMetadata = FST.readMetadata(metadataInput, ByteSequenceOutputs.getSingleton());
+                return new SynonymMetadata(wordCount, maxHorizontalContext, fstMetadata);
+            }
+        }
+
+        public SynonymMap readSynonymMap(Directory directory) throws IOException {
+            SynonymMetadata synonymMetadata = readMetadata(directory);
+            FST<BytesRef> fst = new FST<>(synonymMetadata.fstMetadata, directory.openInput(FST_FILE, IOContext.DEFAULT), new OffHeapFSTStore());
+            IndexInput wordsInput = directory.openInput(WORDS_FILE, IOContext.READ);
+            int[] bytesStartArray = new int[synonymMetadata.wordCount];
+            for (int i = 0; i < synonymMetadata.wordCount; i++) {
+                bytesStartArray[i] = Math.toIntExact(wordsInput.getFilePointer());
+                int length = wordsInput.readVInt();
+                wordsInput.seek(wordsInput.getFilePointer() + length);
+            }
+            return new SynonymMap(fst, new OffHeapBytesRefHashLike(bytesStartArray, wordsInput), synonymMetadata.maxHorizontalContext);
+        }
+
+        private static class OffHeapBytesRefHashLike extends SynonymMap.BytesRefHashLike {
+            private final int[] bytesStartArray;
+            private final IndexInput wordsFile;
+
+            public OffHeapBytesRefHashLike(int[] bytesStartArray, IndexInput wordsFile) {
+                this.bytesStartArray = bytesStartArray;
+                this.wordsFile = wordsFile;
+            }
+
+            @Override
+            public void get(int id, BytesRef scratch) throws IOException {
+                wordsFile.seek(bytesStartArray[id]);
+                int length = wordsFile.readVInt();
+                if (scratch.bytes.length < length) {
+                    scratch.bytes = new byte[length];
+                }
+                wordsFile.readBytes(scratch.bytes, 0, length);
+                scratch.offset = 0;
+                scratch.length = length;
+            }
+        }
+
+        private static class SynonymMetadata {
+            final int wordCount;
+            final int maxHorizontalContext;
+            final FST.FSTMetadata<BytesRef> fstMetadata;
+
+            SynonymMetadata(int wordCount, int maxHorizontalContext, FST.FSTMetadata<BytesRef> fstMetadata) {
+                this.wordCount = wordCount;
+                this.maxHorizontalContext = maxHorizontalContext;
+                this.fstMetadata = fstMetadata;
+            }
+        }
+    }
+}

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymMapDirectory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymMapDirectory.java
@@ -1,147 +1,185 @@
-package org.apache.lucene.analysis.synonym;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.FSDirectory;
-import org.apache.lucene.store.IOContext;
-import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.IndexOutput;
-import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.fst.ByteSequenceOutputs;
-import org.apache.lucene.util.fst.FST;
-import org.apache.lucene.util.fst.OffHeapFSTStore;
+package org.apache.lucene.analysis.synonym;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.fst.ByteSequenceOutputs;
+import org.apache.lucene.util.fst.FST;
+import org.apache.lucene.util.fst.OffHeapFSTStore;
 
+/**
+ * Wraps an {@link FSDirectory} to read and write a compiled {@link SynonymMap}. When reading, the
+ * FST and output words are kept off-heap.
+ */
 public class SynonymMapDirectory implements Closeable {
-    private final SynonymMapFormat synonymMapFormat = new SynonymMapFormat(); // TODO -- Should this be more flexible/codec-like? Less?
-    private final Directory directory;
-    public SynonymMapDirectory(Path path) throws IOException {
-        directory = FSDirectory.open(path);
+  private final SynonymMapFormat synonymMapFormat =
+      new SynonymMapFormat(); // TODO -- Should this be more flexible/codec-like? Less?
+  private final Directory directory;
+
+  public SynonymMapDirectory(Path path) throws IOException {
+    directory = FSDirectory.open(path);
+  }
+
+  public IndexOutput fstOutput() throws IOException {
+    return synonymMapFormat.getFSTOutput(directory);
+  }
+
+  public WordsOutput wordsOutput() throws IOException {
+    return synonymMapFormat.getWordsOutput(directory);
+  }
+
+  public void writeMetadata(int wordCount, int maxHorizontalContext, FST<BytesRef> fst)
+      throws IOException {
+    synonymMapFormat.writeMetadata(directory, wordCount, maxHorizontalContext, fst);
+  }
+
+  public SynonymMap readMap() throws IOException {
+    return synonymMapFormat.readSynonymMap(directory);
+  }
+
+  public boolean hasSynonyms() throws IOException {
+    // TODO should take the path to the synonyms file to compare file hash against file used to
+    // build the directory
+    return directory.listAll().length > 0;
+  }
+
+  @Override
+  public void close() throws IOException {
+    directory.close();
+  }
+
+  /**
+   * Abstraction to support writing individual output words to the directory. Should be closed after
+   * the last word is written.
+   */
+  public abstract static class WordsOutput implements Closeable {
+    public abstract void addWord(BytesRef word) throws IOException;
+  }
+
+  private static class SynonymMapFormat {
+    private static final String FST_FILE = "synonyms.fst";
+    private static final String WORDS_FILE = "synonyms.wrd";
+    private static final String METADATA_FILE = "synonyms.mdt";
+
+    public IndexOutput getFSTOutput(Directory directory) throws IOException {
+      return directory.createOutput(FST_FILE, IOContext.DEFAULT);
     }
 
-    public IndexOutput fstOutput() throws IOException {
-        return synonymMapFormat.getFSTOutput(directory);
-    }
-
-    public WordsOutput wordsOutput() throws IOException {
-        return synonymMapFormat.getWordsOutput(directory);
-    }
-
-    public void writeMetadata(int wordCount, int maxHorizontalContext, FST<BytesRef> fst) throws IOException {
-        synonymMapFormat.writeMetadata(directory, wordCount, maxHorizontalContext, fst);
-    }
-
-    public SynonymMap readMap() throws IOException {
-        return synonymMapFormat.readSynonymMap(directory);
-    }
-
-    public boolean hasSynonyms() throws IOException {
-        // TODO should take the path to the synonyms file to compare file hash against file used to build the directory
-        return directory.listAll().length > 0;
-    }
-
-    @Override
-    public void close() throws IOException {
-        directory.close();
-    }
-
-    public static abstract class WordsOutput  implements Closeable {
-        public abstract void addWord(BytesRef word) throws IOException;
-    }
-
-    private static class SynonymMapFormat {
-        private static final String FST_FILE = "synonyms.fst";
-        private static final String WORDS_FILE = "synonyms.wrd";
-        private static final String METADATA_FILE = "synonyms.mdt";
-
-        public IndexOutput getFSTOutput(Directory directory) throws IOException {
-            return directory.createOutput(FST_FILE, IOContext.DEFAULT);
+    public WordsOutput getWordsOutput(Directory directory) throws IOException {
+      IndexOutput wordsOutput = directory.createOutput(WORDS_FILE, IOContext.DEFAULT);
+      return new WordsOutput() {
+        @Override
+        public void close() throws IOException {
+          wordsOutput.close();
         }
 
-        public WordsOutput getWordsOutput(Directory directory)  throws IOException {
-            IndexOutput wordsOutput = directory.createOutput(WORDS_FILE, IOContext.DEFAULT);
-            return new WordsOutput() {
-                @Override
-                public void close() throws IOException {
-                    wordsOutput.close();
-                }
-
-                @Override
-                public void addWord(BytesRef word) throws IOException {
-                    wordsOutput.writeVInt(word.length);
-                    wordsOutput.writeBytes(word.bytes, word.offset, word.length);
-                }
-            };
-        };
-
-        public void writeMetadata(Directory directory, int wordCount, int maxHorizontalContext, FST<BytesRef> fst) throws IOException {
-            try (IndexOutput metadataOutput = directory.createOutput(METADATA_FILE, IOContext.DEFAULT)) {
-                metadataOutput.writeVInt(wordCount);
-                metadataOutput.writeVInt(maxHorizontalContext);
-                fst.saveMetadata(metadataOutput);
-            }
-            directory.sync(List.of(FST_FILE, WORDS_FILE, METADATA_FILE));
+        @Override
+        public void addWord(BytesRef word) throws IOException {
+          wordsOutput.writeVInt(word.length);
+          wordsOutput.writeBytes(word.bytes, word.offset, word.length);
         }
-
-        private SynonymMetadata readMetadata(Directory directory) throws IOException {
-            try (IndexInput metadataInput = directory.openInput(METADATA_FILE, IOContext.READONCE)) {
-                int wordCount = metadataInput.readVInt();
-                int maxHorizontalContext = metadataInput.readVInt();
-                FST.FSTMetadata<BytesRef> fstMetadata = FST.readMetadata(metadataInput, ByteSequenceOutputs.getSingleton());
-                return new SynonymMetadata(wordCount, maxHorizontalContext, fstMetadata);
-            }
-        }
-
-        public SynonymMap readSynonymMap(Directory directory) throws IOException {
-            SynonymMetadata synonymMetadata = readMetadata(directory);
-            FST<BytesRef> fst = new FST<>(synonymMetadata.fstMetadata, directory.openInput(FST_FILE, IOContext.DEFAULT), new OffHeapFSTStore());
-            IndexInput wordsInput = directory.openInput(WORDS_FILE, IOContext.READ);
-            int[] bytesStartArray = new int[synonymMetadata.wordCount];
-            for (int i = 0; i < synonymMetadata.wordCount; i++) {
-                bytesStartArray[i] = Math.toIntExact(wordsInput.getFilePointer());
-                int length = wordsInput.readVInt();
-                wordsInput.seek(wordsInput.getFilePointer() + length);
-            }
-            return new SynonymMap(fst, new OffHeapBytesRefHashLike(bytesStartArray, wordsInput), synonymMetadata.maxHorizontalContext);
-        }
-
-        private static class OffHeapBytesRefHashLike extends SynonymMap.BytesRefHashLike {
-            private final int[] bytesStartArray;
-            private final IndexInput wordsFile;
-
-            public OffHeapBytesRefHashLike(int[] bytesStartArray, IndexInput wordsFile) {
-                this.bytesStartArray = bytesStartArray;
-                this.wordsFile = wordsFile;
-            }
-
-            @Override
-            public void get(int id, BytesRef scratch) throws IOException {
-                wordsFile.seek(bytesStartArray[id]);
-                int length = wordsFile.readVInt();
-                if (scratch.bytes.length < length) {
-                    scratch.bytes = new byte[length];
-                }
-                wordsFile.readBytes(scratch.bytes, 0, length);
-                scratch.offset = 0;
-                scratch.length = length;
-            }
-        }
-
-        private static class SynonymMetadata {
-            final int wordCount;
-            final int maxHorizontalContext;
-            final FST.FSTMetadata<BytesRef> fstMetadata;
-
-            SynonymMetadata(int wordCount, int maxHorizontalContext, FST.FSTMetadata<BytesRef> fstMetadata) {
-                this.wordCount = wordCount;
-                this.maxHorizontalContext = maxHorizontalContext;
-                this.fstMetadata = fstMetadata;
-            }
-        }
+      };
     }
+    ;
+
+    public void writeMetadata(
+        Directory directory, int wordCount, int maxHorizontalContext, FST<BytesRef> fst)
+        throws IOException {
+      try (IndexOutput metadataOutput = directory.createOutput(METADATA_FILE, IOContext.DEFAULT)) {
+        metadataOutput.writeVInt(wordCount);
+        metadataOutput.writeVInt(maxHorizontalContext);
+        fst.saveMetadata(metadataOutput);
+      }
+      directory.sync(List.of(FST_FILE, WORDS_FILE, METADATA_FILE));
+    }
+
+    private SynonymMetadata readMetadata(Directory directory) throws IOException {
+      try (IndexInput metadataInput = directory.openInput(METADATA_FILE, IOContext.READONCE)) {
+        int wordCount = metadataInput.readVInt();
+        int maxHorizontalContext = metadataInput.readVInt();
+        FST.FSTMetadata<BytesRef> fstMetadata =
+            FST.readMetadata(metadataInput, ByteSequenceOutputs.getSingleton());
+        return new SynonymMetadata(wordCount, maxHorizontalContext, fstMetadata);
+      }
+    }
+
+    public SynonymMap readSynonymMap(Directory directory) throws IOException {
+      SynonymMetadata synonymMetadata = readMetadata(directory);
+      FST<BytesRef> fst =
+          new FST<>(
+              synonymMetadata.fstMetadata,
+              directory.openInput(FST_FILE, IOContext.DEFAULT),
+              new OffHeapFSTStore());
+      IndexInput wordsInput = directory.openInput(WORDS_FILE, IOContext.READ);
+      int[] bytesStartArray = new int[synonymMetadata.wordCount];
+      for (int i = 0; i < synonymMetadata.wordCount; i++) {
+        bytesStartArray[i] = Math.toIntExact(wordsInput.getFilePointer());
+        int length = wordsInput.readVInt();
+        wordsInput.seek(wordsInput.getFilePointer() + length);
+      }
+      return new SynonymMap(
+          fst,
+          new OffHeapBytesRefHashLike(bytesStartArray, wordsInput),
+          synonymMetadata.maxHorizontalContext);
+    }
+
+    private static class OffHeapBytesRefHashLike extends SynonymMap.BytesRefHashLike {
+      private final int[] bytesStartArray;
+      private final IndexInput wordsFile;
+
+      public OffHeapBytesRefHashLike(int[] bytesStartArray, IndexInput wordsFile) {
+        this.bytesStartArray = bytesStartArray;
+        this.wordsFile = wordsFile;
+      }
+
+      @Override
+      public void get(int id, BytesRef scratch) throws IOException {
+        wordsFile.seek(bytesStartArray[id]);
+        int length = wordsFile.readVInt();
+        if (scratch.bytes.length < length) {
+          scratch.bytes = new byte[length];
+        }
+        wordsFile.readBytes(scratch.bytes, 0, length);
+        scratch.offset = 0;
+        scratch.length = length;
+      }
+    }
+
+    private static class SynonymMetadata {
+      final int wordCount;
+      final int maxHorizontalContext;
+      final FST.FSTMetadata<BytesRef> fstMetadata;
+
+      SynonymMetadata(
+          int wordCount, int maxHorizontalContext, FST.FSTMetadata<BytesRef> fstMetadata) {
+        this.wordCount = wordCount;
+        this.maxHorizontalContext = maxHorizontalContext;
+        this.fstMetadata = fstMetadata;
+      }
+    }
+  }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/TestSynonymGraphFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/TestSynonymGraphFilter.java
@@ -1274,7 +1274,11 @@ public class TestSynonymGraphFilter extends BaseTokenStreamTestCase {
   }
 
   private Analyzer getAnalyzer(SynonymMap.Builder b, final boolean ignoreCase) throws IOException {
-    final SynonymMap map = b.build();
+    SynonymMapDirectory synonymMapDirectory = null;
+    if (random().nextBoolean()) {
+      synonymMapDirectory = closeAfterTest(new SynonymMapDirectory(createTempDir()));
+    }
+    final SynonymMap map = b.build(synonymMapDirectory);
     return new Analyzer() {
       @Override
       protected TokenStreamComponents createComponents(String fieldName) {


### PR DESCRIPTION
### Description
This stores the synonym map's FST and word lookup off-heap in a separate, configurable directory. 

The initial implementation is rough, but the unit tests pass with this change randomly enabled.

Obvious things that need work are:
1. I tried to do something like a codec, but not really a codec for the synonym map files. For a solution that could evolve over time, we should probably at least write something to the metadata file saying what format was used.
2. Right now it makes no effort to detect changes to the synonym files. I would suggest that SynonymGraphFilterFactory rebuild the directory if a checksum of the input files doesn't match a value recorded in the metadata file.
3. I don't think I like the random seeks in `OffHeapBytesRefHashLike`, but I don't see an alternative (besides moving it on-heap). Given that the original issue was only about moving the FST off-heap, maybe we can keep the word dictionary on-heap.

Fixes #13005

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
