### PR TITLE
Fix NPE in TestReqOptSumScorer.testFilterRandomRareOpt

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
@@ -733,6 +733,9 @@ public class CheckHits {
         assertTrue(s2 == null || s2.iterator().nextDoc() == DocIdSetIterator.NO_MORE_DOCS);
         continue;
       }
+      if (s2 == null) {
+        continue;
+      }
       TwoPhaseIterator twoPhase1 = s1.twoPhaseIterator();
       TwoPhaseIterator twoPhase2 = s2.twoPhaseIterator();
       DocIdSetIterator approx1 = twoPhase1 == null ? s1.iterator() : twoPhase1.approximation();


### PR DESCRIPTION
The value `C` of field `f` may not appear in all segments.


```
   >     java.lang.NullPointerException: Cannot invoke "org.apache.lucene.search.Scorer.twoPhaseIterator()" because "s2" is null
   >         at __randomizedtesting.SeedInfo.seed([E000CB24BEEF3CDA:634D0259C7E92DEB]:0)
   >         at org.apache.lucene.tests.search.CheckHits.doCheckMaxScores(CheckHits.java:738)
   >         at org.apache.lucene.tests.search.CheckHits.checkTopScores(CheckHits.java:698)
   >         at org.apache.lucene.search.TestReqOptSumScorer.doTestRandom(TestReqOptSumScorer.java:379)
   >         at org.apache.lucene.search.TestReqOptSumScorer.testFilterRandomRareOpt(TestReqOptSumScorer.java:267)
```

It cannot be reproduced stably, but there is a high probability.

```
./gradlew test --tests TestReqOptSumScorer.testFilterRandomRareOpt -Dtests.seed=E000CB24BEEF3CDA -Dtests.nightly=true -Dtests.locale=hsb-DE -Dtests.timezone=Africa/Djibouti -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```

