### PR TITLE
Do not use mock merge policy for TestFuzzyQuery#testFuzziness

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestFuzzyQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFuzzyQuery.java
@@ -67,7 +67,12 @@ public class TestFuzzyQuery extends LuceneTestCase {
 
   public void testFuzziness() throws Exception {
     Directory directory = newDirectory();
-    RandomIndexWriter writer = new RandomIndexWriter(random(), directory);
+    RandomIndexWriter writer =
+        new RandomIndexWriter(
+            random(),
+            directory,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setMergePolicy(newMergePolicy(random(), false)));
     addDoc("aaaaa", writer);
     addDoc("aaaab", writer);
     addDoc("aaabb", writer);


### PR DESCRIPTION
git bisect shows this commit as the perpetrator: f7cab1645017d863331b42900581b67d3591e2da

```
   >     org.junit.ComparisonFailure: expected:<aaaa[b]> but was:<aaaa[a]>
   >         at __randomizedtesting.SeedInfo.seed([7DF2C3FF35FEFFC6:36C7D4343E606C7C]:0)
   >         at org.junit.Assert.assertEquals(Assert.java:117)
   >         at org.junit.Assert.assertEquals(Assert.java:146)
   >         at org.apache.lucene.search.TestFuzzyQuery.testFuzziness(TestFuzzyQuery.java:156)
```

Reproduce command:
```
./gradlew test --tests TestFuzzyQuery.testFuzziness -Dtests.seed=7DF2C3FF35FEFFC6 -Dtests.nightly=true -Dtests.locale=ru-KG -Dtests.timezone=America/Virgin -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```