### PR TITLE
Fix TestTopFieldCollector.testTotalHits #13080

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -31,6 +31,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
@@ -180,7 +181,12 @@ public class TestTopFieldCollector extends LuceneTestCase {
     Sort sort = new Sort(new SortField("foo", SortField.Type.LONG));
     IndexWriter w =
         new IndexWriter(
-            dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE).setIndexSort(sort));
+            dir,
+            newIndexWriterConfig()
+                .setMergePolicy(NoMergePolicy.INSTANCE)
+                .setIndexSort(sort)
+                .setMaxBufferedDocs(7)
+                .setRAMBufferSizeMB(IndexWriterConfig.DISABLE_AUTO_FLUSH));
     Document doc = new Document();
     doc.add(new NumericDocValuesField("foo", 3));
     for (Document d : Arrays.asList(doc, doc, doc, doc)) {


### PR DESCRIPTION
The failure is due to the randomized flushing and the later assertion there are two leaves only. When switching from `w.addDocuments` to `w.addDocument` the test infra now has an opportunity to randomly flush. 

This commit disables auto-flush for this test.

closes https://github.com/apache/lucene/issues/13080