### PR TITLE
Fix test failure for TestDocumentsWriterDeleteQueue.testUpdateDeleteSlices

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterDeleteQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterDeleteQueue.java
@@ -67,7 +67,7 @@ public class TestDocumentsWriterDeleteQueue extends LuceneTestCase {
         assertAllBetween(last2, j, bd2, ids);
         last2 = j + 1;
       }
-      assertEquals(j + 1, queue.numGlobalTermDeletes());
+      assertEquals(uniqueValues.size(), queue.numGlobalTermDeletes());
     }
     assertEquals(uniqueValues, bd1.deleteTerms.keySet());
     assertEquals(uniqueValues, bd2.deleteTerms.keySet());


### PR DESCRIPTION
Some years ago, there was a patch for `TestDocumentsWriterDeleteQueue.testUpdateDeleteSlices` see  https://issues.apache.org/jira/browse/LUCENE-4066, At the time, `DocumentsWriterDeleteQueue#numGlobalTermDeletes` returns the number of deleted terms without deduplication, so the expeced value is `j + 1`, After  https://github.com/apache/lucene/pull/12586 , it will return unique value(with deduplication). In this PR, we use `uniqueValues.size` as expected value. I read the code related to this change, it seems related to test code only, no other issues. cc @gf2121 


```
./gradlew :lucene:core:test --tests "org.apache.lucene.index.TestDocumentsWriterDeleteQueue.testUpdateDeleteSlices" -Ptests.heapsize=32g -Ptests.jvms=6 "-Ptests.jvmargs=-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1" -Ptests.seed=60A190443031BE92 -Ptests.nightly=true -Ptests.gui=false -Ptests.file.encoding=ISO-8859-1 -Ptests.vectorsize=256  -Dtests.multiplier=3
```


```
   >     java.lang.AssertionError: expected:<403> but was:<402>
   >         at __randomizedtesting.SeedInfo.seed([60A190443031BE92:77AEF54BB4FE82A7]:0)
   >         at org.junit.Assert.fail(Assert.java:89)
   >         at org.junit.Assert.failNotEquals(Assert.java:835)
   >         at org.junit.Assert.assertEquals(Assert.java:647)
   >         at org.junit.Assert.assertEquals(Assert.java:633)
   >         at org.apache.lucene.index.TestDocumentsWriterDeleteQueue.testUpdateDeleteSlices(TestDocumentsWriterDeleteQueue.java:70)
   >         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```