### PR TITLE
Only track released versions in `oldVersions`.

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/BackwardsCompatibilityTestBase.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/BackwardsCompatibilityTestBase.java
@@ -75,8 +75,8 @@ public abstract class BackwardsCompatibilityTestBase extends LuceneTestCase {
         throw new RuntimeException(ex);
       }
     }
-    List<Version> allCurrentVersions = getAllCurrentVersions();
-    for (Version version : allCurrentVersions) {
+
+    for (Version version : getAllCurrentReleasedVersions()) {
       // make sure we never miss a version.
       assertTrue("Version: " + version + " missing", binaryVersions.remove(version));
     }
@@ -181,19 +181,22 @@ public abstract class BackwardsCompatibilityTestBase extends LuceneTestCase {
     return versions;
   }
 
+  public static List<Version> getAllCurrentReleasedVersions() {
+    List<Version> currentReleasedVersions = getAllCurrentVersions();
+    assertTrue(currentReleasedVersions.remove(LATEST_PREVIOUS_MAJOR));
+    return currentReleasedVersions;
+  }
+
   public static Iterable<Object[]> allVersion(String name, String... suffixes) {
     List<Object> patterns = new ArrayList<>();
     for (String suffix : suffixes) {
       patterns.add(createPattern(name, suffix));
     }
     List<Object[]> versionAndPatterns = new ArrayList<>();
-    List<Version> versionList = getAllCurrentVersions();
+    List<Version> versionList = getAllCurrentReleasedVersions();
     for (Version v : versionList) {
-      if (v.equals(LATEST_PREVIOUS_MAJOR)
-          == false) { // the latest prev-major has not yet been released
-        for (Object p : patterns) {
-          versionAndPatterns.add(new Object[] {v, p});
-        }
+      for (Object p : patterns) {
+        versionAndPatterns.add(new Object[] {v, p});
       }
     }
     return versionAndPatterns;

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/BackwardsCompatibilityTestBase.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/BackwardsCompatibilityTestBase.java
@@ -62,8 +62,7 @@ public abstract class BackwardsCompatibilityTestBase extends LuceneTestCase {
           "8.7.0", "8.7.0", "8.8.0", "8.8.0", "8.8.1", "8.8.1", "8.8.2", "8.8.2", "8.9.0", "8.9.0",
           "8.10.0", "8.10.0", "8.10.1", "8.10.1", "8.11.0", "8.11.0", "8.11.1", "8.11.1", "8.11.2",
           "8.11.2", "8.11.3", "8.11.3", "9.0.0", "9.1.0", "9.2.0", "9.3.0", "9.4.0", "9.4.1",
-          "9.4.2", "9.5.0", "9.6.0", "9.7.0", "9.8.0", "9.9.0", "9.9.1", "9.9.2", "9.10.0",
-          "10.0.0",
+          "9.4.2", "9.5.0", "9.6.0", "9.7.0", "9.8.0", "9.9.0", "9.9.1", "9.9.2"
         };
 
     Set<Version> binaryVersions = new HashSet<>();
@@ -182,7 +181,7 @@ public abstract class BackwardsCompatibilityTestBase extends LuceneTestCase {
     return versions;
   }
 
-  public static List<Version> getAllCurrentReleasedVersions() {
+  private static List<Version> getAllCurrentReleasedVersions() {
     List<Version> currentReleasedVersions = getAllCurrentVersions();
 
     // The latest version from the current major is always under development.
@@ -213,13 +212,20 @@ public abstract class BackwardsCompatibilityTestBase extends LuceneTestCase {
     return currentReleasedVersions;
   }
 
+  /** Get all versions that are released, plus the latest version which is unreleased. */
+  public static List<Version> getAllCurrentReleasedVersionsAndCurrent() {
+    List<Version> versions = new ArrayList<>(getAllCurrentReleasedVersions());
+    versions.add(Version.LATEST);
+    return versions;
+  }
+
   public static Iterable<Object[]> allVersion(String name, String... suffixes) {
     List<Object> patterns = new ArrayList<>();
     for (String suffix : suffixes) {
       patterns.add(createPattern(name, suffix));
     }
     List<Object[]> versionAndPatterns = new ArrayList<>();
-    List<Version> versionList = getAllCurrentReleasedVersions();
+    List<Version> versionList = getAllCurrentReleasedVersionsAndCurrent();
     for (Version v : versionList) {
       for (Object p : patterns) {
         versionAndPatterns.add(new Object[] {v, p});


### PR DESCRIPTION
This would avoid test failures when a release is in progress.