### PR TITLE
Change the links to Lucene's homepage in the DOAP file to https://

### DIFF
--- a/dev-tools/doap/lucene.rdf
+++ b/dev-tools/doap/lucene.rdf
@@ -23,23 +23,23 @@
          xmlns:asfext="http://projects.apache.org/ns/asfext#"
          xmlns:foaf="http://xmlns.com/foaf/0.1/">
 <!--
-  This file's canonical URL is: http://lucene.apache.org/core/doap.rdf
+  This file's canonical URL is: https://lucene.apache.org/core/doap.rdf
 
   Note that the canonical URL may redirect to other non-canonical locations.
 -->
-  <Project rdf:about="http://lucene.apache.org/core/">
+  <Project rdf:about="https://lucene.apache.org/core/">
     <created>2001-09-01</created>
     <license rdf:resource="http://www.apache.org/licenses/LICENSE-2.0"/>
     <name>Apache Lucene Core</name>
-    <homepage rdf:resource="http://lucene.apache.org/core/" />
-    <asfext:pmc rdf:resource="http://lucene.apache.org" />
+    <homepage rdf:resource="https://lucene.apache.org/core/" />
+    <asfext:pmc rdf:resource="https://lucene.apache.org" />
 
     <shortdesc>Apache Lucene is a high-performance, full-featured text search engine library</shortdesc>
     <description>Apache Lucene is a high-performance, full-featured text search engine library written entirely in Java. It is a technology suitable for nearly any application that requires full-text search, especially cross-platform.
     </description>
     <bug-database rdf:resource="https://github.com/apache/lucene/issues" />
-    <mailing-list rdf:resource="http://lucene.apache.org/core/discussion.html" />
-    <download-page rdf:resource="http://lucene.apache.org/core/downloads.html" />
+    <mailing-list rdf:resource="https://lucene.apache.org/core/discussion.html" />
+    <download-page rdf:resource="https://lucene.apache.org/core/downloads.html" />
     <programming-language>Java</programming-language>
 
     <!--


### PR DESCRIPTION
This PR changes all references to the Lucene homepage from the DOAP file to use the canonic HTTPS link.

P.S.: This cannot change the namespace links as they are identifiers in XML world. Also the official Apache License URL is without https at moment.