### PR TITLE
Revert the addition of spotless:on/off regions

### DIFF
--- a/gradle/validation/spotless.gradle
+++ b/gradle/validation/spotless.gradle
@@ -28,7 +28,6 @@ configure(project(":lucene").subprojects) { prj ->
 
     spotless {
       java {
-        toggleOffOn() // obviously, only to be used sparingly.
         // TODO: Work out how to support multiple different header files (we have
         // classes in the codebase that have original headers). We currently use
         // Apache RAT to enforce headers so this is of lesser priority.

--- a/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadCheckQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadCheckQuery.java
@@ -269,10 +269,11 @@ public class TestPayloadCheckQuery extends LuceneTestCase {
             MatchOperation.GT);
     checkHits(
         stringGT2,
-        new int[] { // spotless:off
-                 155,  255,  355,  455,  555,  655,  755,  855,  955,
-          1055, 1155, 1255, 1355, 1455, 1555, 1655, 1755, 1855, 1955
-        }); // spotless:on
+        alignedIntArray(
+            """
+                   155,  255,  355,  455,  555,  655,  755,  855,  955,
+            1055, 1155, 1255, 1355, 1455, 1555, 1655, 1755, 1855, 1955
+            """));
     SpanQuery stringGTE2 =
         new SpanPayloadCheckQuery(
             new SpanNearQuery(new SpanQuery[] {termFifty, termFive}, 0, true),
@@ -281,10 +282,11 @@ public class TestPayloadCheckQuery extends LuceneTestCase {
             MatchOperation.GTE);
     checkHits(
         stringGTE2,
-        new int[] { // spotless:off
-            55,  155,  255,  355,  455,  555,  655,  755,  855,  955,
-          1055, 1155, 1255, 1355, 1455, 1555, 1655, 1755, 1855, 1955
-        });  // spotless:on
+        alignedIntArray(
+            """
+              55,  155,  255,  355,  455,  555,  655,  755,  855,  955,
+            1055, 1155, 1255, 1355, 1455, 1555, 1655, 1755, 1855, 1955
+            """));
 
     SpanQuery stringLT2 =
         new SpanPayloadCheckQuery(
@@ -304,6 +306,23 @@ public class TestPayloadCheckQuery extends LuceneTestCase {
     // note: I can imagine support for SpanOrQuery might be interesting but that's for some other
     // time, currently such support is  made intractable by the fact that reset() gets called and
     // sets "upto" back to zero between SpanOrQuery subclauses.
+  }
+
+  /**
+   * Parses a comma-separated array of integers, ignoring white space around them. This allows for
+   * arbitrary alignment of integers in the source string to convey additional information about
+   * their mutual relations. For example:
+   *
+   * <pre>{@code
+   * var ints =
+   * """
+   *   1,  2,  3,
+   *  11, 12, 13
+   * """
+   * }</pre>
+   */
+  private static int[] alignedIntArray(String ints) {
+    return Arrays.stream(ints.split(",")).map(String::trim).mapToInt(Integer::parseInt).toArray();
   }
 
   public void testUnorderedPayloadChecks() throws Exception {


### PR DESCRIPTION
This disables spotless exclusion zones (on/off comments). These comments are only honored by spotless, not by google java format so accidental reformatting is still possible and you can't recover from that. 

This patch also shows one possible alternative that is formatter fool-proof - if you really need to show some alignment in test data.
