### PR TITLE
Fix test failure in #13057

### DIFF
--- a/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
@@ -208,21 +211,23 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
         IndexSearcher searcher = new IndexSearcher(reader);
         BitSetProducer parentFilter = parentFilter(searcher.getIndexReader());
         Query query = getParentJoinKnnQuery("field", new float[] {2, 2}, null, 3, parentFilter);
-        assertScorerResults(searcher, query, new float[] {1f, 1f / 51f}, new String[] {"2", "7"});
+        assertScorerResults(
+            searcher, query, new float[] {1f, 1f / 51f}, new String[] {"2", "7"}, 2);
 
         query = getParentJoinKnnQuery("field", new float[] {6, 6}, null, 3, parentFilter);
         assertScorerResults(
-            searcher, query, new float[] {1f / 3f, 1f / 3f}, new String[] {"5", "7"});
+            searcher, query, new float[] {1f / 3f, 1f / 3f}, new String[] {"5", "7"}, 2);
         query =
             getParentJoinKnnQuery(
                 "field", new float[] {6, 6}, new MatchAllDocsQuery(), 20, parentFilter);
         assertScorerResults(
-            searcher, query, new float[] {1f / 3f, 1f / 3f}, new String[] {"5", "7"});
+            searcher, query, new float[] {1f / 3f, 1f / 3f}, new String[] {"5", "7"}, 2);
 
         query =
             getParentJoinKnnQuery(
                 "field", new float[] {6, 6}, new MatchAllDocsQuery(), 1, parentFilter);
-        assertScorerResults(searcher, query, new float[] {1f / 3f}, new String[] {"5"});
+        assertScorerResults(
+            searcher, query, new float[] {1f / 3f, 1f / 3f}, new String[] {"5", "7"}, 1);
       }
     }
   }
@@ -324,7 +329,8 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
     assertEquals(expectedId, actualId);
   }
 
-  void assertScorerResults(IndexSearcher searcher, Query query, float[] scores, String[] ids)
+  void assertScorerResults(
+      IndexSearcher searcher, Query query, float[] possibleScores, String[] possibleIds, int count)
       throws IOException {
     IndexReader reader = searcher.getIndexReader();
     Query rewritten = query.rewrite(searcher);
@@ -334,11 +340,16 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
     assertEquals(-1, scorer.docID());
     expectThrows(ArrayIndexOutOfBoundsException.class, scorer::score);
     DocIdSetIterator it = scorer.iterator();
-    for (int i = 0; i < scores.length; i++) {
+    Map<String, Float> idToScore =
+        IntStream.range(0, possibleIds.length)
+            .boxed()
+            .collect(Collectors.toMap(i -> possibleIds[i], i -> possibleScores[i]));
+    for (int i = 0; i < count; i++) {
       int docId = it.nextDoc();
       assertNotEquals(NO_MORE_DOCS, docId);
-      assertEquals(scores[i], scorer.score(), 0.0001);
-      assertIdMatches(reader, ids[i], docId);
+      String actualId = reader.storedFields().document(docId).get("id");
+      assertTrue(idToScore.containsKey(actualId));
+      assertEquals(idToScore.get(actualId), scorer.score(), 0.0001);
     }
   }
 }

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
@@ -81,7 +81,8 @@ public class TestParentBlockJoinFloatKnnVectorQuery extends ParentBlockJoinKnnVe
         float score1 =
             (float) ((1 + (2 * 2 + 3 * 4) / Math.sqrt((2 * 2 + 3 * 3) * (2 * 2 + 4 * 4))) / 2);
 
-        assertScorerResults(searcher, query, new float[] {score0, score1}, new String[] {"1", "2"});
+        assertScorerResults(
+            searcher, query, new float[] {score0, score1}, new String[] {"1", "2"}, 2);
       }
     }
   }


### PR DESCRIPTION
The original tests assume particular document orders & scores. To make the test more resilient to random flushes & merges, I adjusted the assertion conditions. Particularly, we verify matching ids -> score instead of relying on docIds.

closes: https://github.com/apache/lucene/issues/13057