### PR TITLE
Fix NPE for TestRandomChains.testRandomChainsWithLargeStrings

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/shingle/ShingleFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/shingle/ShingleFilter.java
@@ -19,6 +19,7 @@ package org.apache.lucene.analysis.shingle;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.Objects;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -166,6 +167,7 @@ public final class ShingleFilter extends TokenFilter {
    */
   public ShingleFilter(TokenStream input, String tokenType) {
     this(input, DEFAULT_MIN_SHINGLE_SIZE, DEFAULT_MAX_SHINGLE_SIZE);
+    this.tokenType = Objects.requireNonNull(tokenType, "tokenType");
     setTokenType(tokenType);
   }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/shingle/ShingleFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/shingle/ShingleFilter.java
@@ -167,7 +167,6 @@ public final class ShingleFilter extends TokenFilter {
    */
   public ShingleFilter(TokenStream input, String tokenType) {
     this(input, DEFAULT_MIN_SHINGLE_SIZE, DEFAULT_MAX_SHINGLE_SIZE);
-    this.tokenType = Objects.requireNonNull(tokenType, "tokenType");
     setTokenType(tokenType);
   }
 
@@ -177,7 +176,7 @@ public final class ShingleFilter extends TokenFilter {
    * @param tokenType token tokenType
    */
   public void setTokenType(String tokenType) {
-    this.tokenType = tokenType;
+    this.tokenType = Objects.requireNonNull(tokenType, "tokenType");
   }
 
   /**


### PR DESCRIPTION
Related to LUCENE-10353
```
./gradlew test --tests TestRandomChains.testRandomChainsWithLargeStrings -Dtests.seed=1B915D6C476F9BFE -Dtests.nightly=true -Dtests.locale=mn -Dtests.timezone=Canada/Mountain -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```


```
org.apache.lucene.analysis.tests.TestRandomChains > testRandomChainsWithLargeStrings FAILED
    java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because the return value of "org.apache.lucene.analysis.tokenattributes.TypeAttribute.type()" is null
        at __randomizedtesting.SeedInfo.seed([1B915D6C476F9BFE:71CAE27D1E21BB0D]:0)
        at org.apache.lucene.analysis.common@10.0.0-SNAPSHOT/org.apache.lucene.analysis.payloads.NumericPayloadTokenFilter.incrementToken(NumericPayloadTokenFilter.java:49)
        at org.apache.lucene.analysis.common@10.0.0-SNAPSHOT/org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilter.incrementToken(ConditionalTokenFilter.java:185)
        at org.apache.lucene.test_framework@10.0.0-SNAPSHOT/org.apache.lucene.tests.analysis.ValidatingTokenFilter.incrementToken(ValidatingTokenFilter.java:81)
        at org.apache.lucene.analysis.common@10.0.0-SNAPSHOT/org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilter$OneTimeWrapper.incrementToken(ConditionalTokenFilter.java:65)
        at org.apache.lucene.analysis.icu@10.0.0-SNAPSHOT/org.apache.lucene.analysis.icu.ICUNormalizer2Filter.incrementToken(ICUNormalizer2Filter.java:80)
        at org.apache.lucene.analysis.common@10.0.0-SNAPSHOT/org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilter.incrementToken(ConditionalTokenFilter.java:203)
        at org.apache.lucene.test_framework@10.0.0-SNAPSHOT/org.apache.lucene.tests.analysis.ValidatingTokenFilter.incrementToken(ValidatingTokenFilter.java:81)
        at org.apache.lucene.test_framework@10.0.0-SNAPSHOT/org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.checkResetException(BaseTokenStreamTestCase.java:926)
        at org.apache.lucene.test_framework@10.0.0-SNAPSHOT/org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.checkRandomData(BaseTokenStreamTestCase.java:1068)
        at org.apache.lucene.analysis.tests@10.0.0-SNAPSHOT/org.apache.lucene.analysis.tests.TestRandomChains.testRandomChainsWithLargeStrings(TestRandomChains.java:978)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```