### PR TITLE
Add WrappedCandidateMatcher for composing matchers

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryMatch.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryMatch.java
@@ -48,6 +48,21 @@ public class QueryMatch {
             }
           };
 
+  public static final WrappedMatcherFactory<QueryMatch> SIMPLE_WRAPPED_MATCHER_FACTORY =
+      searcher ->
+          new WrappedCandidateMatcher<QueryMatch>(
+              new CollectingMatcher<QueryMatch>(searcher, ScoreMode.COMPLETE_NO_SCORES) {
+                @Override
+                public QueryMatch resolve(QueryMatch match1, QueryMatch match2) {
+                  return match1;
+                }
+
+                @Override
+                protected QueryMatch doMatch(String queryId, int doc, Scorable scorer) {
+                  return new QueryMatch(queryId);
+                }
+              });
+
   /**
    * Creates a new QueryMatch for a specific query and document
    *

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/WrappedCandidateMatcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/WrappedCandidateMatcher.java
@@ -22,45 +22,92 @@ import java.util.List;
 import java.util.Map;
 import org.apache.lucene.search.Query;
 
-// Wrapper class for an existing candidate matcher exposing finish, matchQuery and reportError
-// for composition of matchers
+/**
+ * Wrapper class for an existing candidate matcher exposing finish, matchQuery and reportError for
+ * composition of matchers
+ */
 public class WrappedCandidateMatcher<T extends QueryMatch> {
 
   private CandidateMatcher<T> delegateTo;
 
+  /**
+   * Creates a new WrappedCandidateMatcher delegating to the supplied CandidateMatcher
+   *
+   * @param wrapThis the CandidateMatcher to which functions should be delegate
+   */
   public WrappedCandidateMatcher(CandidateMatcher<T> wrapThis) {
     delegateTo = wrapThis;
   }
 
+  /**
+   * Runs the supplied query against the delegate CandidateMatcher's set of documents, storing any
+   * resulting match, and recording the query in the presearcher hits
+   *
+   * @param queryId the query id
+   * @param matchQuery the query to run
+   * @param metadata the query metadata
+   * @throws IOException on IO errors
+   */
   public void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata)
       throws IOException {
     delegateTo.matchQuery(queryId, matchQuery, metadata);
   }
 
+  /**
+   * @return the matches from this matcher
+   */
   public MultiMatchingQueries<T> finish(long buildTime, int queryCount) {
     return delegateTo.finish(buildTime, queryCount);
   }
 
+  /**
+   * Record a match into delegate
+   *
+   * @param match a QueryMatch object
+   */
   protected void addMatch(T match, int doc) {
     delegateTo.addMatch(match, doc);
   }
 
+  /**
+   * If two matches from the same query are found (for example, two branches of a disjunction),
+   * combine them using the delegate's resolve function.
+   *
+   * @param match1 the first match found
+   * @param match2 the second match found
+   * @return a Match object that combines the two
+   */
   public T resolve(T match1, T match2) {
     return delegateTo.resolve(match1, match2);
   }
 
+  /** If running a query throws an Exception, this function will add error into delegate */
   public void reportError(String queryId, Exception e) {
     delegateTo.reportError(queryId, e);
   }
 
+  /** Called when all monitoring of a batch of documents is complete */
   protected void doFinish() {
     delegateTo.doFinish();
   }
 
+  /** Copy all matches from another CandidateMatcher */
   protected void copyMatches(CandidateMatcher<T> other) {
     delegateTo.copyMatches(other);
   }
 
+  /**
+   * Build a MultiMatchingQueries
+   *
+   * @param matches the matches to include, mapping from queryId to match
+   * @param errors any errors thrown while evaluating matches
+   * @param queryBuildTime how long (in ns) it took to build the Presearcher query for the matcher
+   *     run
+   * @param searchTime how long (in ms) it took to run the selected queries
+   * @param queriesRun the number of queries passed to this CandidateMatcher during the matcher run
+   * @param batchSize the number of documents in the batch
+   * @return a MultiMatchingQueries object with the results of matching a batch of Documents
+   */
   public static <T1 extends QueryMatch> MultiMatchingQueries<T1> buildMultiMatchingQueries(
       List<Map<String, T1>> matches,
       Map<String, Exception> errors,

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/WrappedCandidateMatcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/WrappedCandidateMatcher.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.monitor;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.lucene.search.Query;
+
+// Wrapper class for an existing candidate matcher exposing finish, matchQuery and reportError
+// for composition of matchers
+public class WrappedCandidateMatcher<T extends QueryMatch> {
+
+  private CandidateMatcher<T> delegateTo;
+
+  public WrappedCandidateMatcher(CandidateMatcher<T> wrapThis) {
+    delegateTo = wrapThis;
+  }
+
+  public void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata)
+      throws IOException {
+    delegateTo.matchQuery(queryId, matchQuery, metadata);
+  }
+
+  public MultiMatchingQueries<T> finish(long buildTime, int queryCount) {
+    return delegateTo.finish(buildTime, queryCount);
+  }
+
+  protected void addMatch(T match, int doc) {
+    delegateTo.addMatch(match, doc);
+  }
+
+  public T resolve(T match1, T match2) {
+    return delegateTo.resolve(match1, match2);
+  }
+
+  public void reportError(String queryId, Exception e) {
+    delegateTo.reportError(queryId, e);
+  }
+
+  protected void doFinish() {
+    delegateTo.doFinish();
+  }
+
+  protected void copyMatches(CandidateMatcher<T> other) {
+    delegateTo.copyMatches(other);
+  }
+
+  public static <T1 extends QueryMatch> MultiMatchingQueries<T1> buildMultiMatchingQueries(
+      List<Map<String, T1>> matches,
+      Map<String, Exception> errors,
+      long queryBuildTime,
+      long searchTime,
+      int queriesRun,
+      int batchSize) {
+    return new MultiMatchingQueries<>(
+        matches, errors, queryBuildTime, searchTime, queriesRun, batchSize);
+  }
+}

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/WrappedMatcherFactory.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/WrappedMatcherFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.monitor;
+
+import org.apache.lucene.search.IndexSearcher;
+
+public interface WrappedMatcherFactory<T extends QueryMatch> {
+
+  WrappedCandidateMatcher<T> createWrappedMatcher(IndexSearcher searcher);
+}

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/WrappedMatcherFactory.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/WrappedMatcherFactory.java
@@ -19,7 +19,16 @@ package org.apache.lucene.monitor;
 
 import org.apache.lucene.search.IndexSearcher;
 
+/**
+ * Interface for the creation of new WrappedCandidateMatcher objects
+ *
+ * @param <T> a subclass of {@link CandidateMatcher}
+ */
 public interface WrappedMatcherFactory<T extends QueryMatch> {
 
+  /**
+   * Create a new {@link WrappedCandidateMatcher} object, to be used to select queries to match
+   * against the passed-in IndexSearcher
+   */
   WrappedCandidateMatcher<T> createWrappedMatcher(IndexSearcher searcher);
 }


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

Create a `WrappedCandidateMatcher`, along with a factory for creating these objects and a default implementation of the factory, to assist users in creating their own composite matchers.

### Problem

The current access protections on `CandidateMatcher` make it infeasible for a user of the Lucene Monitor library to create their own composite `CandidateMatcher` (for example, an alternate version of `ParallelMatcher`) on top of existing `CandidateMatcher` instances if they are outside the package.

As an example, the existing implementation of `ParallelMatcher` makes use of delegate `CandidateMatcher` instances, but a user would not be able to write their own version of this in their own package, because `matchQuery()`, `finish()` and `reportError()` all have package-private access ([see this gist](https://gist.github.com/bjacobowitz/be9a54663217c46cc239cc9f9f580de8#file-parallelmatcher-java), comments labeled "PROBLEM").

### Solution

The simplest solution to this problem would be to increase the visibility of those functions in `CandidateMatcher` (either to `protected` or `public`), but it runs the risk of violating encapsulation, so I've tried to avoid that here.

The solution I've put together here introduces a `WrappedCandidateMatcher`, which can be used to increase visibility when creating a composite matcher. `WrappedCandidateMatcher` does **NOT** extend from `CandidateMatcher` but has nearly the same interface, with increased visibility on `matchQuery()`, `finish()` and `reportError()`. A user building a new `CandidateMatcher` by composing existing `CandidateMatcher` instances could make full use of those `CandidateMatchers` by wrapping them with `WrappedCandidateMatcher`, allowing them to be used internally to the composite matcher ([see this gist](https://gist.github.com/bjacobowitz/be9a54663217c46cc239cc9f9f580de8#file-parallelmatcherusingwrapped-java), comments labeled "SOLUTION").

On a certain level, this solution also violates existing encapsulation, but it requires the user to jump through a few hoops to get there, so it would limit the potential for misuse of a `CandidateMatcher`. If we would instead prefer to increase the visibility on `CandidateMatcher`, let me know and I can do that instead.

### Merge Request

If this PR gets merged, can you please use my `bjacobowitz1@bloomberg.net` email address for the squash+merge. Thank you.