### PR TITLE
Adding a getter to FeatureField to allow value access

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/FeatureField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FeatureField.java
@@ -167,8 +167,9 @@ public final class FeatureField extends Field {
   }
 
   /**
-   * This is useful if you have multiple features sharing a name and you want to take action
-   * to deduplicate them.
+   * This is useful if you have multiple features sharing a name and you want to take action to
+   * deduplicate them.
+   *
    * @return the feature value of this field.
    */
   public float getFeatureValue() {

--- a/lucene/core/src/java/org/apache/lucene/document/FeatureField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FeatureField.java
@@ -166,6 +166,15 @@ public final class FeatureField extends Field {
     return stream;
   }
 
+  /**
+   * This is useful if you have multiple features sharing a name and you want to take action
+   * to deduplicate them.
+   * @return the feature value of this field.
+   */
+  public float getFeatureValue() {
+    return featureValue;
+  }
+
   private static final class FeatureTokenStream extends TokenStream {
     private final CharTermAttribute termAttribute = addAttribute(CharTermAttribute.class);
     private final TermFrequencyAttribute freqAttribute = addAttribute(TermFrequencyAttribute.class);


### PR DESCRIPTION
Getting the access of a FeatureField#value is useful for deduplicating. If you have a sparse vector model and you want to handle multiple inputs from them, you want flexibility in how you de-duplicate the feature dimensions.