### PR TITLE
[draft] Simplify NeighborArray by keeping nodeId and score in a single object

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
+import java.util.Comparator;
+
 import org.apache.lucene.codecs.BufferingKnnVectorsWriter;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.lucene90.IndexedDISI;
@@ -295,10 +297,9 @@ public final class Lucene92HnswVectorsWriter extends BufferingKnnVectorsWriter {
         int size = neighbors.size();
         vectorIndex.writeInt(size);
         // Destructively modify; it's ok we are discarding it after this
-        int[] nnodes = neighbors.nodes();
-        Arrays.sort(nnodes, 0, size);
+        Arrays.sort(neighbors.scoreNodes, 0, size, Comparator.comparingInt(o -> o.node));
         for (int i = 0; i < size; i++) {
-          int nnode = nnodes[i];
+          int nnode = neighbors.scoreNodes[i].node;
           assert nnode < countOnLevel0 : "node too large: " + nnode + ">=" + countOnLevel0;
           vectorIndex.writeInt(nnode);
         }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
@@ -25,7 +25,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Comparator;
-
 import org.apache.lucene.codecs.BufferingKnnVectorsWriter;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.lucene90.IndexedDISI;

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnFieldVectorsWriter;
@@ -357,8 +358,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
     int size = neighbors.size();
     vectorIndex.writeInt(size);
 
-    // Destructively modify; it's ok we are discarding it after this
-    int[] nnodes = neighbors.nodes();
+    int[] nnodes = neighbors.nodesCopy();
     for (int i = 0; i < size; i++) {
       nnodes[i] = oldToNewMap[nnodes[i]];
     }
@@ -482,10 +482,9 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
         int size = neighbors.size();
         vectorIndex.writeInt(size);
         // Destructively modify; it's ok we are discarding it after this
-        int[] nnodes = neighbors.nodes();
-        Arrays.sort(nnodes, 0, size);
+        Arrays.sort(neighbors.scoreNodes, 0, size, Comparator.comparingInt(o -> o.node));
         for (int i = 0; i < size; i++) {
-          int nnode = nnodes[i];
+          int nnode = neighbors.scoreNodes[i].node;
           assert nnode < countOnLevel0 : "node too large: " + nnode + ">=" + countOnLevel0;
           vectorIndex.writeInt(nnode);
         }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -531,7 +531,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
         // information
         for (int i = size - 1; i > 0; --i) {
           assert neighbors.scoreNodes[i].node < countOnLevel0
-            : "node too large: " + neighbors.scoreNodes[i].node + ">=" + countOnLevel0;
+              : "node too large: " + neighbors.scoreNodes[i].node + ">=" + countOnLevel0;
           neighbors.scoreNodes[i].node -= neighbors.scoreNodes[i - 1].node;
         }
         for (int i = 0; i < size; i++) {

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnFieldVectorsWriter;
@@ -382,8 +383,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     int size = neighbors.size();
     vectorIndex.writeVInt(size);
 
-    // Destructively modify; it's ok we are discarding it after this
-    int[] nnodes = neighbors.nodes();
+    int[] nnodes = neighbors.nodesCopy();
     for (int i = 0; i < size; i++) {
       nnodes[i] = oldToNewMap[nnodes[i]];
     }
@@ -526,16 +526,16 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
         long offsetStart = vectorIndex.getFilePointer();
         vectorIndex.writeVInt(size);
         // Destructively modify; it's ok we are discarding it after this
-        int[] nnodes = neighbors.nodes();
-        Arrays.sort(nnodes, 0, size);
+        Arrays.sort(neighbors.scoreNodes, 0, size, Comparator.comparingInt(o -> o.node));
         // Now that we have sorted, do delta encoding to minimize the required bits to store the
         // information
         for (int i = size - 1; i > 0; --i) {
-          assert nnodes[i] < countOnLevel0 : "node too large: " + nnodes[i] + ">=" + countOnLevel0;
-          nnodes[i] -= nnodes[i - 1];
+          assert neighbors.scoreNodes[i].node < countOnLevel0
+            : "node too large: " + neighbors.scoreNodes[i].node + ">=" + countOnLevel0;
+          neighbors.scoreNodes[i].node -= neighbors.scoreNodes[i - 1].node;
         }
         for (int i = 0; i < size; i++) {
-          vectorIndex.writeVInt(nnodes[i]);
+          vectorIndex.writeVInt(neighbors.scoreNodes[i].node);
         }
         offsets[level][nodeOffsetId++] =
             Math.toIntExact(vectorIndex.getFilePointer() - offsetStart);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
@@ -22,6 +22,7 @@ import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DIRECT
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.FlatVectorsWriter;
@@ -318,8 +319,7 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
     int size = neighbors.size();
     vectorIndex.writeVInt(size);
 
-    // Destructively modify; it's ok we are discarding it after this
-    int[] nnodes = neighbors.nodes();
+    int[] nnodes = neighbors.nodesCopy();
     for (int i = 0; i < size; i++) {
       nnodes[i] = oldToNewMap[nnodes[i]];
     }
@@ -408,16 +408,16 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
         long offsetStart = vectorIndex.getFilePointer();
         vectorIndex.writeVInt(size);
         // Destructively modify; it's ok we are discarding it after this
-        int[] nnodes = neighbors.nodes();
-        Arrays.sort(nnodes, 0, size);
+        Arrays.sort(neighbors.scoreNodes, 0, size, Comparator.comparingInt(o -> o.node));
         // Now that we have sorted, do delta encoding to minimize the required bits to store the
         // information
         for (int i = size - 1; i > 0; --i) {
-          assert nnodes[i] < countOnLevel0 : "node too large: " + nnodes[i] + ">=" + countOnLevel0;
-          nnodes[i] -= nnodes[i - 1];
+          assert neighbors.scoreNodes[i].node < countOnLevel0 :
+            "node too large: " + neighbors.scoreNodes[i].node + ">=" + countOnLevel0;
+          neighbors.scoreNodes[i].node -= neighbors.scoreNodes[i - 1].node;
         }
         for (int i = 0; i < size; i++) {
-          vectorIndex.writeVInt(nnodes[i]);
+          vectorIndex.writeVInt(neighbors.scoreNodes[i].node);
         }
         offsets[level][nodeOffsetId++] =
             Math.toIntExact(vectorIndex.getFilePointer() - offsetStart);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
@@ -412,8 +412,8 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
         // Now that we have sorted, do delta encoding to minimize the required bits to store the
         // information
         for (int i = size - 1; i > 0; --i) {
-          assert neighbors.scoreNodes[i].node < countOnLevel0 :
-            "node too large: " + neighbors.scoreNodes[i].node + ">=" + countOnLevel0;
+          assert neighbors.scoreNodes[i].node < countOnLevel0
+              : "node too large: " + neighbors.scoreNodes[i].node + ">=" + countOnLevel0;
           neighbors.scoreNodes[i].node -= neighbors.scoreNodes[i - 1].node;
         }
         for (int i = 0; i < size; i++) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswConcurrentMergeBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswConcurrentMergeBuilder.java
@@ -197,11 +197,10 @@ public class HnswConcurrentMergeBuilder implements HnswBuilder {
       NeighborArray neighborArray = ((OnHeapHnswGraph) graph).getNeighbors(level, targetNode);
       neighborArray.rwlock.readLock().lock();
       try {
-        if (nodeBuffer == null || nodeBuffer.length < neighborArray.size()) {
-          nodeBuffer = new int[neighborArray.size()];
-        }
         size = neighborArray.size();
-        if (size >= 0) System.arraycopy(neighborArray.nodes(), 0, nodeBuffer, 0, size);
+        if (size >= 0) {
+          neighborArray.nodesCopy(nodeBuffer);
+        }
       } finally {
         neighborArray.rwlock.readLock().unlock();
       }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswConcurrentMergeBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswConcurrentMergeBuilder.java
@@ -197,10 +197,11 @@ public class HnswConcurrentMergeBuilder implements HnswBuilder {
       NeighborArray neighborArray = ((OnHeapHnswGraph) graph).getNeighbors(level, targetNode);
       neighborArray.rwlock.readLock().lock();
       try {
-        size = neighborArray.size();
-        if (size >= 0) {
-          neighborArray.nodesCopy(nodeBuffer);
+        if (nodeBuffer == null || nodeBuffer.length < neighborArray.size()) {
+          nodeBuffer = new int[neighborArray.size()];
         }
+        size = neighborArray.size();
+        if (size >= 0) neighborArray.nodesCopy(nodeBuffer);
       } finally {
         neighborArray.rwlock.readLock().unlock();
       }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -310,11 +310,11 @@ public class HnswGraphBuilder implements HnswBuilder {
       if (mask[i] == false) {
         continue;
       }
-      int nbr = candidates.nodes()[i];
+      int nbr = candidates.scoreNodes[i].node;
       NeighborArray nbrsOfNbr = hnsw.getNeighbors(level, nbr);
       nbrsOfNbr.rwlock.writeLock().lock();
       try {
-        nbrsOfNbr.addAndEnsureDiversity(node, candidates.scores()[i], nbr, scorerSupplier);
+        nbrsOfNbr.addAndEnsureDiversity(node, candidates.scoreNodes[i].score, nbr, scorerSupplier);
       } finally {
         nbrsOfNbr.rwlock.writeLock().unlock();
       }
@@ -332,8 +332,8 @@ public class HnswGraphBuilder implements HnswBuilder {
     for (int i = candidates.size() - 1; neighbors.size() < maxConnOnLevel && i >= 0; i--) {
       // compare each neighbor (in distance order) against the closer neighbors selected so far,
       // only adding it if it is closer to the target than to any of the other selected neighbors
-      int cNode = candidates.nodes()[i];
-      float cScore = candidates.scores()[i];
+      int cNode = candidates.scoreNodes[i].node;
+      float cScore = candidates.scoreNodes[i].score;
       assert cNode <= hnsw.maxNodeId();
       if (diversityCheck(cNode, cScore, neighbors)) {
         mask[i] = true;
@@ -367,7 +367,7 @@ public class HnswGraphBuilder implements HnswBuilder {
       throws IOException {
     RandomVectorScorer scorer = scorerSupplier.scorer(candidate);
     for (int i = 0; i < neighbors.size(); i++) {
-      float neighborSimilarity = scorer.score(neighbors.nodes()[i]);
+      float neighborSimilarity = scorer.score(neighbors.scoreNodes[i].node);
       if (neighborSimilarity >= score) {
         return false;
       }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -308,7 +308,7 @@ public class HnswGraphSearcher {
     @Override
     int graphNextNeighbor(HnswGraph graph) {
       if (++upto < cur.size()) {
-        return cur.nodes()[upto];
+        return cur.scoreNodes[upto].node;
       }
       return NO_MORE_DOCS;
     }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -39,21 +39,18 @@ public class NeighborArray {
   private int sortedNodeSize;
   public final ReadWriteLock rwlock = new ReentrantReadWriteLock(true);
 
-  /**
-   * Stores nodeId and its similarity score in a single object
-   */
+  /** Stores nodeId and its similarity score in a single object */
   public static final class ScoreNode {
     public int node;
     public float score;
+
     public ScoreNode(int node, float score) {
       this.node = node;
       this.score = score;
     }
   }
 
-  /**
-   * Comparator used to sort {@link ScoreNode} objects.
-   */
+  /** Comparator used to sort {@link ScoreNode} objects. */
   public static class ScoreNodeComparator implements Comparator<ScoreNode> {
     private final boolean isDescByScore;
     private final RandomVectorScorer scorer;
@@ -178,18 +175,14 @@ public class NeighborArray {
     return size;
   }
 
-  /**
-   * Returns a copy of NeighborArray nodes, for calls that require concurrent modifications
-   */
+  /** Returns a copy of NeighborArray nodes, for calls that require concurrent modifications */
   public int[] nodesCopy() {
-    System.out.println("VIGYA - NODESCOPY WITHOUT BUFFER CALLED");
     int[] nodes = new int[size];
     nodesCopy(nodes);
     return nodes;
   }
 
   public void nodesCopy(int[] target) {
-    System.out.println("VIGYA - NODESCOPY WITH BUFFER CALLED");
     assert target.length >= size;
     for (int i = 0; i < size; i++) {
       target[i] = scoreNodes[i].node;
@@ -249,15 +242,15 @@ public class NeighborArray {
   }
 
   /**
-   * Returns true if the node at candidateIndex is closer to one of the neighbors than it is
-   * to the target node for this NeighborArray.
+   * Returns true if the node at candidateIndex is closer to one of the neighbors than it is to the
+   * target node for this NeighborArray.
    */
   private boolean isWorstNonDiverse(
-    int candidateIndex,
-    ScoreNode[] uncheckedScoreNodes,
-    int uncheckedCursor,
-    RandomVectorScorerSupplier scorerSupplier)
-    throws IOException {
+      int candidateIndex,
+      ScoreNode[] uncheckedScoreNodes,
+      int uncheckedCursor,
+      RandomVectorScorerSupplier scorerSupplier)
+      throws IOException {
     float targetNodeSimilarity = scoreNodes[candidateIndex].score;
     RandomVectorScorer scorer = scorerSupplier.scorer(scoreNodes[candidateIndex].node);
     if (scoreNodes[candidateIndex].node == uncheckedScoreNodes[uncheckedCursor].node) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -35,23 +35,31 @@ public class NeighborArray {
   private final boolean scoresDescOrder;
   private int size;
   private final ScoreNode[] scoreNodes;
-//  private final float[] scores;
-//  private final int[] nodes;
   private int sortedNodeSize;
   public final ReadWriteLock rwlock = new ReentrantReadWriteLock(true);
 
-  private static final class ScoreNode {
-    private final int node;
-    private float score;
+  public static final class ScoreNode {
+    public final int node;
+    public float score;
     public ScoreNode(int node, float score) {
       this.node = node;
       this.score = score;
     }
+
+//    @Override
+//    public boolean equals(Object o) {
+//      if (o == this) {
+//        return true;
+//      }
+//      if (o instanceof ScoreNode == false) {
+//        return false;
+//      }
+//      ScoreNode other = (ScoreNode) o;
+//      return this.node == other.node && this.score == other.score;
+//    }
   }
 
   public NeighborArray(int maxSize, boolean descOrder) {
-//    nodes = new int[maxSize];
-//    scores = new float[maxSize];
     scoreNodes = new ScoreNode[maxSize];
     this.scoresDescOrder = descOrder;
   }
@@ -62,12 +70,10 @@ public class NeighborArray {
    */
   public void addInOrder(int newNode, float newScore) {
     assert size == sortedNodeSize : "cannot call addInOrder after addOutOfOrder";
-//    if (size == nodes.length) {
     if (size == scoreNodes.length) {
       throw new IllegalStateException("No growth is allowed");
     }
     if (size > 0) {
-//      float previousScore = scores[size - 1];
       float previousScore = scoreNodes[size - 1].score;
       assert ((scoresDescOrder && (previousScore >= newScore))
               || (scoresDescOrder == false && (previousScore <= newScore)))
@@ -77,22 +83,17 @@ public class NeighborArray {
               + Arrays.toString(ArrayUtil.copyOfSubArray(scoreNodes, 0, size));
     }
     scoreNodes[size] = new ScoreNode(newNode, newScore);
-//    nodes[size] = newNode;
-//    scores[size] = newScore;
     ++size;
     ++sortedNodeSize;
   }
 
   /** Add node and newScore but do not insert as sorted */
   public void addOutOfOrder(int newNode, float newScore) {
-//    if (size == nodes.length) {
     if (size == scoreNodes.length) {
       throw new IllegalStateException("No growth is allowed");
     }
 
     scoreNodes[size] = new ScoreNode(newNode, newScore);
-//    scores[size] = newScore;
-//    nodes[size] = newNode;
     size++;
   }
 
@@ -124,12 +125,9 @@ public class NeighborArray {
    * @return indexes of newly sorted (unchecked) nodes, in ascending order, or null if the array is
    *     already fully sorted
    */
-//  int[] sort(RandomVectorScorer scorer) throws IOException {
-//  void sort(RandomVectorScorer scorer) throws IOException {
   ScoreNode[] sort(RandomVectorScorer scorer) throws IOException {
     if (size == sortedNodeSize) {
       // all nodes checked and sorted
-//      return;
       return null;
     }
     assert sortedNodeSize < size;
@@ -139,7 +137,7 @@ public class NeighborArray {
     }
 
     // simply sort the entire array
-    Arrays.sort(scoreNodes, (o1, o2) -> {
+    Arrays.sort(scoreNodes, 0, size, (o1, o2) -> {
       try {
         if (Float.isNaN(o1.score)) {
           o1.score = scorer.score(o1.node);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -39,6 +39,9 @@ public class NeighborArray {
   private int sortedNodeSize;
   public final ReadWriteLock rwlock = new ReentrantReadWriteLock(true);
 
+  /**
+   * Stores nodeId and its similarity score in a single object
+   */
   public static final class ScoreNode {
     public int node;
     public float score;
@@ -48,6 +51,9 @@ public class NeighborArray {
     }
   }
 
+  /**
+   * Comparator used to sort {@link ScoreNode} objects.
+   */
   public static class ScoreNodeComparator implements Comparator<ScoreNode> {
     private final boolean isDescByScore;
     private final RandomVectorScorer scorer;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -45,18 +45,6 @@ public class NeighborArray {
       this.node = node;
       this.score = score;
     }
-
-//    @Override
-//    public boolean equals(Object o) {
-//      if (o == this) {
-//        return true;
-//      }
-//      if (o instanceof ScoreNode == false) {
-//        return false;
-//      }
-//      ScoreNode other = (ScoreNode) o;
-//      return this.node == other.node && this.score == other.score;
-//    }
   }
 
   public NeighborArray(int maxSize, boolean descOrder) {
@@ -163,55 +151,12 @@ public class NeighborArray {
       return Float.compare(o2.score, o1.score);
     });
     return uncheckedScoreNodes;
-
-//    int[] uncheckedIndexes = new int[size - sortedNodeSize];
-//    int count = 0;
-//    while (sortedNodeSize != size) {
-//      // TODO: Instead of do an array copy on every insertion, I think we can do better here:
-//      //       Remember the insertion point of each unsorted node and insert them altogether
-//      //       We can save several array copy by doing that
-//      uncheckedIndexes[count] = insertSortedInternal(scorer); // sortedNodeSize is increased inside
-//      for (int i = 0; i < count; i++) {
-//        if (uncheckedIndexes[i] >= uncheckedIndexes[count]) {
-//          // the previous inserted nodes has been shifted
-//          uncheckedIndexes[i]++;
-//        }
-//      }
-//      count++;
-//    }
-//    Arrays.sort(uncheckedIndexes);
-//    return uncheckedIndexes;
   }
-
-//  /** insert the first unsorted node into its sorted position */
-//  private int insertSortedInternal(RandomVectorScorer scorer) throws IOException {
-//    assert sortedNodeSize < size : "Call this method only when there's unsorted node";
-//    int tmpNode = nodes[sortedNodeSize];
-//    float tmpScore = scores[sortedNodeSize];
-//
-//    if (Float.isNaN(tmpScore)) {
-//      tmpScore = scorer.score(tmpNode);
-//    }
-//
-//    int insertionPoint =
-//        scoresDescOrder
-//            ? descSortFindRightMostInsertionPoint(tmpScore, sortedNodeSize)
-//            : ascSortFindRightMostInsertionPoint(tmpScore, sortedNodeSize);
-//    System.arraycopy(
-//        nodes, insertionPoint, nodes, insertionPoint + 1, sortedNodeSize - insertionPoint);
-//    System.arraycopy(
-//        scores, insertionPoint, scores, insertionPoint + 1, sortedNodeSize - insertionPoint);
-//    nodes[insertionPoint] = tmpNode;
-//    scores[insertionPoint] = tmpScore;
-//    ++sortedNodeSize;
-//    return insertionPoint;
-//  }
 
   /** This method is for test only. */
   void insertSorted(int newNode, float newScore) throws IOException {
     addOutOfOrder(newNode, newScore);
     sort(null);
-//    insertSortedInternal(null);
   }
 
   public int size() {
@@ -254,8 +199,6 @@ public class NeighborArray {
       removeLast();
       return;
     }
-//    System.arraycopy(nodes, idx + 1, nodes, idx, size - idx - 1);
-//    System.arraycopy(scores, idx + 1, scores, idx, size - idx - 1);
     System.arraycopy(scoreNodes, idx + 1, scoreNodes, idx, size - idx - 1);
     if (idx < sortedNodeSize) {
       sortedNodeSize--;
@@ -268,32 +211,6 @@ public class NeighborArray {
     return "NeighborArray[" + size + "]";
   }
 
-//  private int ascSortFindRightMostInsertionPoint(float newScore, int bound) {
-//    int insertionPoint = Arrays.binarySearch(scores, 0, bound, newScore);
-//    if (insertionPoint >= 0) {
-//      // find the right most position with the same score
-//      while ((insertionPoint < bound - 1)
-//          && (scores[insertionPoint + 1] == scores[insertionPoint])) {
-//        insertionPoint++;
-//      }
-//      insertionPoint++;
-//    } else {
-//      insertionPoint = -insertionPoint - 1;
-//    }
-//    return insertionPoint;
-//  }
-
-//  private int descSortFindRightMostInsertionPoint(float newScore, int bound) {
-//    int start = 0;
-//    int end = bound - 1;
-//    while (start <= end) {
-//      int mid = (start + end) / 2;
-//      if (scores[mid] < newScore) end = mid - 1;
-//      else start = mid + 1;
-//    }
-//    return start;
-//  }
-
   /**
    * Find first non-diverse neighbour among the list of neighbors starting from the most distant
    * neighbours
@@ -301,18 +218,14 @@ public class NeighborArray {
   private int findWorstNonDiverse(int nodeOrd, RandomVectorScorerSupplier scorerSupplier)
       throws IOException {
     RandomVectorScorer scorer = scorerSupplier.scorer(nodeOrd);
-//    int[] uncheckedIndexes = sort(scorer);
     ScoreNode[] uncheckedScoreNodes = sort(scorer);
-//    assert uncheckedIndexes != null : "We will always have something unchecked";
     assert uncheckedScoreNodes != null : "We will always have something unchecked";
-//    int uncheckedCursor = uncheckedIndexes.length - 1;
     int uncheckedCursor = uncheckedScoreNodes.length - 1;
     for (int i = size - 1; i > 0; i--) {
       if (uncheckedCursor < 0) {
         // no unchecked node left
         break;
       }
-//      if (isWorstNonDiverse(i, uncheckedIndexes, uncheckedCursor, scorerSupplier)) {
       if (isWorstNonDiverse(i, uncheckedScoreNodes, uncheckedCursor, scorerSupplier)) {
         return i;
       }
@@ -355,36 +268,4 @@ public class NeighborArray {
     }
     return false;
   }
-
-//  private boolean isWorstNonDiverse(
-//      int candidateIndex,
-//      int[] uncheckedIndexes,
-//      int uncheckedCursor,
-//      RandomVectorScorerSupplier scorerSupplier)
-//      throws IOException {
-//    float minAcceptedSimilarity = scores[candidateIndex];
-//    RandomVectorScorer scorer = scorerSupplier.scorer(nodes[candidateIndex]);
-//    if (candidateIndex == uncheckedIndexes[uncheckedCursor]) {
-//      // the candidate itself is unchecked
-//      for (int i = candidateIndex - 1; i >= 0; i--) {
-//        float neighborSimilarity = scorer.score(nodes[i]);
-//        // candidate node is too similar to node i given its score relative to the base node
-//        if (neighborSimilarity >= minAcceptedSimilarity) {
-//          return true;
-//        }
-//      }
-//    } else {
-//      // else we just need to make sure candidate does not violate diversity with the (newly
-//      // inserted) unchecked nodes
-//      assert candidateIndex > uncheckedIndexes[uncheckedCursor];
-//      for (int i = uncheckedCursor; i >= 0; i--) {
-//        float neighborSimilarity = scorer.score(nodes[uncheckedIndexes[i]]);
-//        // candidate node is too similar to node i given its score relative to the base node
-//        if (neighborSimilarity >= minAcceptedSimilarity) {
-//          return true;
-//        }
-//      }
-//    }
-//    return false;
-//  }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -34,14 +34,25 @@ import org.apache.lucene.util.ArrayUtil;
 public class NeighborArray {
   private final boolean scoresDescOrder;
   private int size;
-  private final float[] scores;
-  private final int[] nodes;
+  private final ScoreNode[] scoreNodes;
+//  private final float[] scores;
+//  private final int[] nodes;
   private int sortedNodeSize;
   public final ReadWriteLock rwlock = new ReentrantReadWriteLock(true);
 
+  private static final class ScoreNode {
+    private final int node;
+    private float score;
+    public ScoreNode(int node, float score) {
+      this.node = node;
+      this.score = score;
+    }
+  }
+
   public NeighborArray(int maxSize, boolean descOrder) {
-    nodes = new int[maxSize];
-    scores = new float[maxSize];
+//    nodes = new int[maxSize];
+//    scores = new float[maxSize];
+    scoreNodes = new ScoreNode[maxSize];
     this.scoresDescOrder = descOrder;
   }
 
@@ -51,32 +62,37 @@ public class NeighborArray {
    */
   public void addInOrder(int newNode, float newScore) {
     assert size == sortedNodeSize : "cannot call addInOrder after addOutOfOrder";
-    if (size == nodes.length) {
+//    if (size == nodes.length) {
+    if (size == scoreNodes.length) {
       throw new IllegalStateException("No growth is allowed");
     }
     if (size > 0) {
-      float previousScore = scores[size - 1];
+//      float previousScore = scores[size - 1];
+      float previousScore = scoreNodes[size - 1].score;
       assert ((scoresDescOrder && (previousScore >= newScore))
               || (scoresDescOrder == false && (previousScore <= newScore)))
           : "Nodes are added in the incorrect order! Comparing "
               + newScore
               + " to "
-              + Arrays.toString(ArrayUtil.copyOfSubArray(scores, 0, size));
+              + Arrays.toString(ArrayUtil.copyOfSubArray(scoreNodes, 0, size));
     }
-    nodes[size] = newNode;
-    scores[size] = newScore;
+    scoreNodes[size] = new ScoreNode(newNode, newScore);
+//    nodes[size] = newNode;
+//    scores[size] = newScore;
     ++size;
     ++sortedNodeSize;
   }
 
   /** Add node and newScore but do not insert as sorted */
   public void addOutOfOrder(int newNode, float newScore) {
-    if (size == nodes.length) {
+//    if (size == nodes.length) {
+    if (size == scoreNodes.length) {
       throw new IllegalStateException("No growth is allowed");
     }
 
-    scores[size] = newScore;
-    nodes[size] = newNode;
+    scoreNodes[size] = new ScoreNode(newNode, newScore);
+//    scores[size] = newScore;
+//    nodes[size] = newNode;
     size++;
   }
 
@@ -93,12 +109,12 @@ public class NeighborArray {
       int newNode, float newScore, int nodeId, RandomVectorScorerSupplier scorerSupplier)
       throws IOException {
     addOutOfOrder(newNode, newScore);
-    if (size < nodes.length) {
+    if (size < scoreNodes.length) {
       return;
     }
     // we're oversize, need to do diversity check and pop out the least diverse neighbour
     removeIndex(findWorstNonDiverse(nodeId, scorerSupplier));
-    assert size == nodes.length - 1;
+    assert size == scoreNodes.length - 1;
   }
 
   /**
@@ -108,59 +124,96 @@ public class NeighborArray {
    * @return indexes of newly sorted (unchecked) nodes, in ascending order, or null if the array is
    *     already fully sorted
    */
-  int[] sort(RandomVectorScorer scorer) throws IOException {
+//  int[] sort(RandomVectorScorer scorer) throws IOException {
+//  void sort(RandomVectorScorer scorer) throws IOException {
+  ScoreNode[] sort(RandomVectorScorer scorer) throws IOException {
     if (size == sortedNodeSize) {
       // all nodes checked and sorted
+//      return;
       return null;
     }
     assert sortedNodeSize < size;
-    int[] uncheckedIndexes = new int[size - sortedNodeSize];
-    int count = 0;
-    while (sortedNodeSize != size) {
-      // TODO: Instead of do an array copy on every insertion, I think we can do better here:
-      //       Remember the insertion point of each unsorted node and insert them altogether
-      //       We can save several array copy by doing that
-      uncheckedIndexes[count] = insertSortedInternal(scorer); // sortedNodeSize is increased inside
-      for (int i = 0; i < count; i++) {
-        if (uncheckedIndexes[i] >= uncheckedIndexes[count]) {
-          // the previous inserted nodes has been shifted
-          uncheckedIndexes[i]++;
+    ScoreNode[] uncheckedScoreNodes = new ScoreNode[size - sortedNodeSize];
+    for (int i = sortedNodeSize; i < size; i++) {
+      uncheckedScoreNodes[i - sortedNodeSize] = scoreNodes[i];
+    }
+
+    // simply sort the entire array
+    Arrays.sort(scoreNodes, (o1, o2) -> {
+      try {
+        if (Float.isNaN(o1.score)) {
+          o1.score = scorer.score(o1.node);
         }
+        if (Float.isNaN(o2.score)) {
+          o2.score = scorer.score(o2.node);
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
       }
-      count++;
-    }
-    Arrays.sort(uncheckedIndexes);
-    return uncheckedIndexes;
+      if (scoresDescOrder == false) {
+        return Float.compare(o1.score, o2.score);
+      }
+      return Float.compare(o2.score, o1.score);
+    });
+    sortedNodeSize = size;
+
+    // sort the unchecked scoreNodes as well
+    Arrays.sort(uncheckedScoreNodes, (o1, o2) -> {
+      if (scoresDescOrder == false) {
+        return Float.compare(o1.score, o2.score);
+      }
+      return Float.compare(o2.score, o1.score);
+    });
+    return uncheckedScoreNodes;
+
+//    int[] uncheckedIndexes = new int[size - sortedNodeSize];
+//    int count = 0;
+//    while (sortedNodeSize != size) {
+//      // TODO: Instead of do an array copy on every insertion, I think we can do better here:
+//      //       Remember the insertion point of each unsorted node and insert them altogether
+//      //       We can save several array copy by doing that
+//      uncheckedIndexes[count] = insertSortedInternal(scorer); // sortedNodeSize is increased inside
+//      for (int i = 0; i < count; i++) {
+//        if (uncheckedIndexes[i] >= uncheckedIndexes[count]) {
+//          // the previous inserted nodes has been shifted
+//          uncheckedIndexes[i]++;
+//        }
+//      }
+//      count++;
+//    }
+//    Arrays.sort(uncheckedIndexes);
+//    return uncheckedIndexes;
   }
 
-  /** insert the first unsorted node into its sorted position */
-  private int insertSortedInternal(RandomVectorScorer scorer) throws IOException {
-    assert sortedNodeSize < size : "Call this method only when there's unsorted node";
-    int tmpNode = nodes[sortedNodeSize];
-    float tmpScore = scores[sortedNodeSize];
-
-    if (Float.isNaN(tmpScore)) {
-      tmpScore = scorer.score(tmpNode);
-    }
-
-    int insertionPoint =
-        scoresDescOrder
-            ? descSortFindRightMostInsertionPoint(tmpScore, sortedNodeSize)
-            : ascSortFindRightMostInsertionPoint(tmpScore, sortedNodeSize);
-    System.arraycopy(
-        nodes, insertionPoint, nodes, insertionPoint + 1, sortedNodeSize - insertionPoint);
-    System.arraycopy(
-        scores, insertionPoint, scores, insertionPoint + 1, sortedNodeSize - insertionPoint);
-    nodes[insertionPoint] = tmpNode;
-    scores[insertionPoint] = tmpScore;
-    ++sortedNodeSize;
-    return insertionPoint;
-  }
+//  /** insert the first unsorted node into its sorted position */
+//  private int insertSortedInternal(RandomVectorScorer scorer) throws IOException {
+//    assert sortedNodeSize < size : "Call this method only when there's unsorted node";
+//    int tmpNode = nodes[sortedNodeSize];
+//    float tmpScore = scores[sortedNodeSize];
+//
+//    if (Float.isNaN(tmpScore)) {
+//      tmpScore = scorer.score(tmpNode);
+//    }
+//
+//    int insertionPoint =
+//        scoresDescOrder
+//            ? descSortFindRightMostInsertionPoint(tmpScore, sortedNodeSize)
+//            : ascSortFindRightMostInsertionPoint(tmpScore, sortedNodeSize);
+//    System.arraycopy(
+//        nodes, insertionPoint, nodes, insertionPoint + 1, sortedNodeSize - insertionPoint);
+//    System.arraycopy(
+//        scores, insertionPoint, scores, insertionPoint + 1, sortedNodeSize - insertionPoint);
+//    nodes[insertionPoint] = tmpNode;
+//    scores[insertionPoint] = tmpScore;
+//    ++sortedNodeSize;
+//    return insertionPoint;
+//  }
 
   /** This method is for test only. */
   void insertSorted(int newNode, float newScore) throws IOException {
     addOutOfOrder(newNode, newScore);
-    insertSortedInternal(null);
+    sort(null);
+//    insertSortedInternal(null);
   }
 
   public int size() {
@@ -173,10 +226,18 @@ public class NeighborArray {
    * @lucene.internal
    */
   public int[] nodes() {
+    int[] nodes = new int[size];
+    for (int i = 0; i < size; i++) {
+      nodes[i] = scoreNodes[i].node;
+    }
     return nodes;
   }
 
   public float[] scores() {
+    float[] scores = new float[size];
+    for (int i = 0; i < size; i++) {
+      scores[i] = scoreNodes[i].score;
+    }
     return scores;
   }
 
@@ -195,8 +256,9 @@ public class NeighborArray {
       removeLast();
       return;
     }
-    System.arraycopy(nodes, idx + 1, nodes, idx, size - idx - 1);
-    System.arraycopy(scores, idx + 1, scores, idx, size - idx - 1);
+//    System.arraycopy(nodes, idx + 1, nodes, idx, size - idx - 1);
+//    System.arraycopy(scores, idx + 1, scores, idx, size - idx - 1);
+    System.arraycopy(scoreNodes, idx + 1, scoreNodes, idx, size - idx - 1);
     if (idx < sortedNodeSize) {
       sortedNodeSize--;
     }
@@ -208,31 +270,31 @@ public class NeighborArray {
     return "NeighborArray[" + size + "]";
   }
 
-  private int ascSortFindRightMostInsertionPoint(float newScore, int bound) {
-    int insertionPoint = Arrays.binarySearch(scores, 0, bound, newScore);
-    if (insertionPoint >= 0) {
-      // find the right most position with the same score
-      while ((insertionPoint < bound - 1)
-          && (scores[insertionPoint + 1] == scores[insertionPoint])) {
-        insertionPoint++;
-      }
-      insertionPoint++;
-    } else {
-      insertionPoint = -insertionPoint - 1;
-    }
-    return insertionPoint;
-  }
+//  private int ascSortFindRightMostInsertionPoint(float newScore, int bound) {
+//    int insertionPoint = Arrays.binarySearch(scores, 0, bound, newScore);
+//    if (insertionPoint >= 0) {
+//      // find the right most position with the same score
+//      while ((insertionPoint < bound - 1)
+//          && (scores[insertionPoint + 1] == scores[insertionPoint])) {
+//        insertionPoint++;
+//      }
+//      insertionPoint++;
+//    } else {
+//      insertionPoint = -insertionPoint - 1;
+//    }
+//    return insertionPoint;
+//  }
 
-  private int descSortFindRightMostInsertionPoint(float newScore, int bound) {
-    int start = 0;
-    int end = bound - 1;
-    while (start <= end) {
-      int mid = (start + end) / 2;
-      if (scores[mid] < newScore) end = mid - 1;
-      else start = mid + 1;
-    }
-    return start;
-  }
+//  private int descSortFindRightMostInsertionPoint(float newScore, int bound) {
+//    int start = 0;
+//    int end = bound - 1;
+//    while (start <= end) {
+//      int mid = (start + end) / 2;
+//      if (scores[mid] < newScore) end = mid - 1;
+//      else start = mid + 1;
+//    }
+//    return start;
+//  }
 
   /**
    * Find first non-diverse neighbour among the list of neighbors starting from the most distant
@@ -241,53 +303,90 @@ public class NeighborArray {
   private int findWorstNonDiverse(int nodeOrd, RandomVectorScorerSupplier scorerSupplier)
       throws IOException {
     RandomVectorScorer scorer = scorerSupplier.scorer(nodeOrd);
-    int[] uncheckedIndexes = sort(scorer);
-    assert uncheckedIndexes != null : "We will always have something unchecked";
-    int uncheckedCursor = uncheckedIndexes.length - 1;
+//    int[] uncheckedIndexes = sort(scorer);
+    ScoreNode[] uncheckedScoreNodes = sort(scorer);
+//    assert uncheckedIndexes != null : "We will always have something unchecked";
+    assert uncheckedScoreNodes != null : "We will always have something unchecked";
+//    int uncheckedCursor = uncheckedIndexes.length - 1;
+    int uncheckedCursor = uncheckedScoreNodes.length - 1;
     for (int i = size - 1; i > 0; i--) {
       if (uncheckedCursor < 0) {
         // no unchecked node left
         break;
       }
-      if (isWorstNonDiverse(i, uncheckedIndexes, uncheckedCursor, scorerSupplier)) {
+//      if (isWorstNonDiverse(i, uncheckedIndexes, uncheckedCursor, scorerSupplier)) {
+      if (isWorstNonDiverse(i, uncheckedScoreNodes, uncheckedCursor, scorerSupplier)) {
         return i;
       }
-      if (i == uncheckedIndexes[uncheckedCursor]) {
+      if (scoreNodes[i].node == uncheckedScoreNodes[uncheckedCursor].node) {
         uncheckedCursor--;
       }
     }
     return size - 1;
   }
 
+  /**
+   * Returns true if the node at candidateIndex is closer to one of the neighbors than it is
+   * to the target node for this NeighborArray.
+   */
   private boolean isWorstNonDiverse(
-      int candidateIndex,
-      int[] uncheckedIndexes,
-      int uncheckedCursor,
-      RandomVectorScorerSupplier scorerSupplier)
-      throws IOException {
-    float minAcceptedSimilarity = scores[candidateIndex];
-    RandomVectorScorer scorer = scorerSupplier.scorer(nodes[candidateIndex]);
-    if (candidateIndex == uncheckedIndexes[uncheckedCursor]) {
-      // the candidate itself is unchecked
+    int candidateIndex,
+    ScoreNode[] uncheckedScoreNodes,
+    int uncheckedCursor,
+    RandomVectorScorerSupplier scorerSupplier)
+    throws IOException {
+    float targetNodeSimilarity = scoreNodes[candidateIndex].score;
+    RandomVectorScorer scorer = scorerSupplier.scorer(scoreNodes[candidateIndex].node);
+    if (scoreNodes[candidateIndex].node == uncheckedScoreNodes[uncheckedCursor].node) {
+      // if the candidate node is unchecked, compare it against all the neighbor nodes
       for (int i = candidateIndex - 1; i >= 0; i--) {
-        float neighborSimilarity = scorer.score(nodes[i]);
-        // candidate node is too similar to node i given its score relative to the base node
-        if (neighborSimilarity >= minAcceptedSimilarity) {
+        float neighborSimilarity = scorer.score(scoreNodes[i].node);
+        if (neighborSimilarity >= targetNodeSimilarity) {
           return true;
         }
       }
     } else {
-      // else we just need to make sure candidate does not violate diversity with the (newly
-      // inserted) unchecked nodes
-      assert candidateIndex > uncheckedIndexes[uncheckedCursor];
+      // we know that the candidate is non-diverse amongst the checked neighbor nodes,
+      // only need to compare against the unchecked nodes here.
       for (int i = uncheckedCursor; i >= 0; i--) {
-        float neighborSimilarity = scorer.score(nodes[uncheckedIndexes[i]]);
-        // candidate node is too similar to node i given its score relative to the base node
-        if (neighborSimilarity >= minAcceptedSimilarity) {
+        float neighborSimilarity = scorer.score(uncheckedScoreNodes[i].node);
+        if (neighborSimilarity >= targetNodeSimilarity) {
           return true;
         }
       }
     }
     return false;
   }
+
+//  private boolean isWorstNonDiverse(
+//      int candidateIndex,
+//      int[] uncheckedIndexes,
+//      int uncheckedCursor,
+//      RandomVectorScorerSupplier scorerSupplier)
+//      throws IOException {
+//    float minAcceptedSimilarity = scores[candidateIndex];
+//    RandomVectorScorer scorer = scorerSupplier.scorer(nodes[candidateIndex]);
+//    if (candidateIndex == uncheckedIndexes[uncheckedCursor]) {
+//      // the candidate itself is unchecked
+//      for (int i = candidateIndex - 1; i >= 0; i--) {
+//        float neighborSimilarity = scorer.score(nodes[i]);
+//        // candidate node is too similar to node i given its score relative to the base node
+//        if (neighborSimilarity >= minAcceptedSimilarity) {
+//          return true;
+//        }
+//      }
+//    } else {
+//      // else we just need to make sure candidate does not violate diversity with the (newly
+//      // inserted) unchecked nodes
+//      assert candidateIndex > uncheckedIndexes[uncheckedCursor];
+//      for (int i = uncheckedCursor; i >= 0; i--) {
+//        float neighborSimilarity = scorer.score(nodes[uncheckedIndexes[i]]);
+//        // candidate node is too similar to node i given its score relative to the base node
+//        if (neighborSimilarity >= minAcceptedSimilarity) {
+//          return true;
+//        }
+//      }
+//    }
+//    return false;
+//  }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -176,12 +176,14 @@ public class NeighborArray {
    * Returns a copy of NeighborArray nodes, for calls that require concurrent modifications
    */
   public int[] nodesCopy() {
+    System.out.println("VIGYA - NODESCOPY WITHOUT BUFFER CALLED");
     int[] nodes = new int[size];
     nodesCopy(nodes);
     return nodes;
   }
 
   public void nodesCopy(int[] target) {
+    System.out.println("VIGYA - NODESCOPY WITH BUFFER CALLED");
     assert target.length >= size;
     for (int i = 0; i < size; i++) {
       target[i] = scoreNodes[i].node;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -172,12 +172,10 @@ public class NeighborArray {
     return nodes;
   }
 
-  public void nodesCopy(int[] nodeBuffer) {
-    if (nodeBuffer == null || nodeBuffer.length < size) {
-      nodeBuffer = new int[size];
-    }
+  public void nodesCopy(int[] target) {
+    assert target.length >= size;
     for (int i = 0; i < size; i++) {
-      nodeBuffer[i] = scoreNodes[i].node;
+      target[i] = scoreNodes[i].node;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -40,6 +40,7 @@ public class NeighborArray {
   public final ReadWriteLock rwlock = new ReentrantReadWriteLock(true);
 
   /** Stores nodeId and its similarity score in a single object */
+  // noCommit
   public static final class ScoreNode {
     public int node;
     public float score;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -39,7 +39,7 @@ public class NeighborArray {
   public final ReadWriteLock rwlock = new ReentrantReadWriteLock(true);
 
   public static final class ScoreNode {
-    public final int node;
+    public int node;
     public float score;
     public ScoreNode(int node, float score) {
       this.node = node;
@@ -163,26 +163,23 @@ public class NeighborArray {
     return size;
   }
 
-//  /**
-//   * Direct access to the internal list of node ids; provided for efficient writing of the graph
-//   *
-//   * @lucene.internal
-//   */
-//  public int[] nodes() {
-//    int[] nodes = new int[size];
-//    for (int i = 0; i < size; i++) {
-//      nodes[i] = scoreNodes[i].node;
-//    }
-//    return nodes;
-//  }
-//
-//  public float[] scores() {
-//    float[] scores = new float[size];
-//    for (int i = 0; i < size; i++) {
-//      scores[i] = scoreNodes[i].score;
-//    }
-//    return scores;
-//  }
+  /**
+   * Returns a copy of NeighborArray nodes, for calls that require concurrent modifications
+   */
+  public int[] nodesCopy() {
+    int[] nodes = new int[size];
+    nodesCopy(nodes);
+    return nodes;
+  }
+
+  public void nodesCopy(int[] nodeBuffer) {
+    if (nodeBuffer == null || nodeBuffer.length < size) {
+      nodeBuffer = new int[size];
+    }
+    for (int i = 0; i < size; i++) {
+      nodeBuffer[i] = scoreNodes[i].node;
+    }
+  }
 
   public void clear() {
     size = 0;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -34,7 +34,7 @@ import org.apache.lucene.util.ArrayUtil;
 public class NeighborArray {
   private final boolean scoresDescOrder;
   private int size;
-  private final ScoreNode[] scoreNodes;
+  public final ScoreNode[] scoreNodes;
   private int sortedNodeSize;
   public final ReadWriteLock rwlock = new ReentrantReadWriteLock(true);
 
@@ -163,26 +163,26 @@ public class NeighborArray {
     return size;
   }
 
-  /**
-   * Direct access to the internal list of node ids; provided for efficient writing of the graph
-   *
-   * @lucene.internal
-   */
-  public int[] nodes() {
-    int[] nodes = new int[size];
-    for (int i = 0; i < size; i++) {
-      nodes[i] = scoreNodes[i].node;
-    }
-    return nodes;
-  }
-
-  public float[] scores() {
-    float[] scores = new float[size];
-    for (int i = 0; i < size; i++) {
-      scores[i] = scoreNodes[i].score;
-    }
-    return scores;
-  }
+//  /**
+//   * Direct access to the internal list of node ids; provided for efficient writing of the graph
+//   *
+//   * @lucene.internal
+//   */
+//  public int[] nodes() {
+//    int[] nodes = new int[size];
+//    for (int i = 0; i < size; i++) {
+//      nodes[i] = scoreNodes[i].node;
+//    }
+//    return nodes;
+//  }
+//
+//  public float[] scores() {
+//    float[] scores = new float[size];
+//    for (int i = 0; i < size; i++) {
+//      scores[i] = scoreNodes[i].score;
+//    }
+//    return scores;
+//  }
 
   public void clear() {
     size = 0;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -275,16 +275,26 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
 
   @Override
   public long ramBytesUsed() {
+//    long neighborArrayBytes0 =
+//        (long) nsize0 * (Integer.BYTES + Float.BYTES)
+//            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
+//            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
+//            + Integer.BYTES * 3;
+//    long neighborArrayBytes =
+//        (long) nsize * (Integer.BYTES + Float.BYTES)
+//            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
+//            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
+//            + Integer.BYTES * 3;
     long neighborArrayBytes0 =
-        (long) nsize0 * (Integer.BYTES + Float.BYTES)
-            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
-            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
-            + Integer.BYTES * 3;
+      (long) nsize0 * (Integer.BYTES + Float.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
+        + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
+        + RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        + Integer.BYTES * 3;
     long neighborArrayBytes =
-        (long) nsize * (Integer.BYTES + Float.BYTES)
-            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
-            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
-            + Integer.BYTES * 3;
+      (long) nsize * (Integer.BYTES + Float.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
+        + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
+        + RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        + Integer.BYTES * 3;
     long total = 0;
     total +=
         size() * (neighborArrayBytes0 + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER)

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -275,25 +275,15 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
 
   @Override
   public long ramBytesUsed() {
-//    long neighborArrayBytes0 =
-//        (long) nsize0 * (Integer.BYTES + Float.BYTES)
-//            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
-//            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
-//            + Integer.BYTES * 3;
-//    long neighborArrayBytes =
-//        (long) nsize * (Integer.BYTES + Float.BYTES)
-//            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
-//            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
-//            + Integer.BYTES * 3;
     long neighborArrayBytes0 =
       (long) nsize0 * (Integer.BYTES + Float.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
-        + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
-        + RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
+        + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
         + Integer.BYTES * 3;
     long neighborArrayBytes =
       (long) nsize * (Integer.BYTES + Float.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
-        + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
-        + RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
+        + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
         + Integer.BYTES * 3;
     long total = 0;
     total +=

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -164,7 +164,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
   @Override
   public int nextNeighbor() {
     if (++upto < cur.size()) {
-      return cur.nodes()[upto];
+      return cur.scoreNodes[upto].node;
     }
     return NO_MORE_DOCS;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -276,15 +276,15 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
   @Override
   public long ramBytesUsed() {
     long neighborArrayBytes0 =
-      (long) nsize0 * (Integer.BYTES + Float.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
-        + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
-        + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
-        + Integer.BYTES * 3;
+        (long) nsize0 * (Integer.BYTES + Float.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
+            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
+            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
+            + Integer.BYTES * 3;
     long neighborArrayBytes =
-      (long) nsize * (Integer.BYTES + Float.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
-        + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
-        + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
-        + Integer.BYTES * 3;
+        (long) nsize * (Integer.BYTES + Float.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
+            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER * 2L
+            + RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L
+            + Integer.BYTES * 3;
     long total = 0;
     total +=
         size() * (neighborArrayBytes0 + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER)

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -756,6 +756,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     OnHeapHnswGraph hnsw = builder.build(vectors.size());
     long estimated = RamUsageEstimator.sizeOfObject(hnsw);
     long actual = ramUsed(hnsw);
+    System.out.println("estimated = " + estimated + ", actual = " + actual + "delta = " + (double)estimated/actual);
 
     assertEquals((double) actual, (double) estimated, (double) actual * 0.3);
   }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -74,7 +74,6 @@ import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
@@ -756,8 +755,6 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     OnHeapHnswGraph hnsw = builder.build(vectors.size());
     long estimated = RamUsageEstimator.sizeOfObject(hnsw);
     long actual = ramUsed(hnsw);
-    System.out.println("estimated = " + estimated + ", actual = " + actual + "delta = " + (double)estimated/actual);
-
     assertEquals((double) actual, (double) estimated, (double) actual * 0.3);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -485,10 +485,9 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
     for (int i = 0; i < nDoc; i++) {
       NeighborArray neighbors = hnsw.getNeighbors(0, i);
-      int[] nnodes = neighbors.nodes();
       for (int j = 0; j < neighbors.size(); j++) {
         // all neighbors should be valid node ids.
-        assertTrue(nnodes[j] < nDoc);
+        assertTrue(neighbors.scoreNodes[j].node < nDoc);
       }
     }
   }
@@ -882,7 +881,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
   private void assertLevel0Neighbors(OnHeapHnswGraph graph, int node, int... expected) {
     Arrays.sort(expected);
     NeighborArray nn = graph.getNeighbors(0, node);
-    int[] actual = ArrayUtil.copyOfSubArray(nn.nodes(), 0, nn.size());
+    int[] actual = nn.nodesCopy();
     Arrays.sort(actual);
     assertArrayEquals(
         "expected: " + Arrays.toString(expected) + " actual: " + Arrays.toString(actual),

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
@@ -20,6 +20,7 @@ package org.apache.lucene.util.hnsw;
 import java.io.IOException;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.hnsw.NeighborArray.ScoreNode;
 
 public class TestNeighborArray extends LuceneTestCase {
 
@@ -132,8 +133,19 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(7, 8);
     neighbors.addOutOfOrder(6, 7);
     neighbors.addOutOfOrder(4, 5);
-    int[] unchecked = neighbors.sort(null);
-    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
+//    int[] unchecked = neighbors.sort(null);
+//    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
+    ScoreNode[] uncheckedScoreNodes = neighbors.sort(null);
+    ScoreNode[] exp = new ScoreNode[] {
+      new ScoreNode(1, 2),
+      new ScoreNode(2, 3),
+      new ScoreNode(3, 4),
+      new ScoreNode(4, 5),
+      new ScoreNode(5, 6),
+      new ScoreNode(6, 7),
+      new ScoreNode(7, 8)
+    };
+    assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {1, 2, 3, 4, 5, 6, 7}, neighbors);
     assertScoresEqual(new float[] {2, 3, 4, 5, 6, 7, 8}, neighbors);
 
@@ -145,8 +157,16 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors2.addOutOfOrder(6, 7);
     neighbors2.addOutOfOrder(5, 6);
     neighbors2.addOutOfOrder(3, 4);
-    unchecked = neighbors2.sort(null);
-    assertArrayEquals(new int[] {2, 3, 5, 6}, unchecked);
+//    unchecked = neighbors2.sort(null);
+//    assertArrayEquals(new int[] {2, 3, 5, 6}, unchecked);
+    uncheckedScoreNodes = neighbors2.sort(null);
+    exp = new ScoreNode[] {
+      new ScoreNode(2, 3),
+      new ScoreNode(3, 4),
+      new ScoreNode(5, 6),
+      new ScoreNode(6, 7),
+    };
+    assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {0, 1, 2, 3, 4, 5, 6}, neighbors2);
     assertScoresEqual(new float[] {1, 2, 3, 4, 5, 6, 7}, neighbors2);
   }
@@ -162,8 +182,19 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(7, 1);
     neighbors.addOutOfOrder(6, 2);
     neighbors.addOutOfOrder(4, 4);
-    int[] unchecked = neighbors.sort(null);
-    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
+//    int[] unchecked = neighbors.sort(null);
+//    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
+    ScoreNode[] uncheckedScoreNodes = neighbors.sort(null);
+    ScoreNode[] exp = new ScoreNode[] {
+      new ScoreNode(1, 7),
+      new ScoreNode(2, 6),
+      new ScoreNode(3, 5),
+      new ScoreNode(4, 4),
+      new ScoreNode(5, 3),
+      new ScoreNode(6, 2),
+      new ScoreNode(7, 1)
+    };
+    assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {1, 2, 3, 4, 5, 6, 7}, neighbors);
     assertScoresEqual(new float[] {7, 6, 5, 4, 3, 2, 1}, neighbors);
 
@@ -175,8 +206,16 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors2.addOutOfOrder(7, 1);
     neighbors2.addOutOfOrder(6, 2);
     neighbors2.addOutOfOrder(4, 4);
-    unchecked = neighbors2.sort(null);
-    assertArrayEquals(new int[] {2, 3, 5, 6}, unchecked);
+//    unchecked = neighbors2.sort(null);
+//    assertArrayEquals(new int[] {2, 3, 5, 6}, unchecked);
+    uncheckedScoreNodes = neighbors2.sort(null);
+    exp = new ScoreNode[] {
+      new ScoreNode(3, 5),
+      new ScoreNode(4, 4),
+      new ScoreNode(6, 2),
+      new ScoreNode(7, 1),
+    };
+    assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {1, 2, 3, 4, 5, 6, 7}, neighbors2);
     assertScoresEqual(new float[] {7, 6, 5, 4, 3, 2, 1}, neighbors2);
   }
@@ -191,8 +230,19 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(7, Float.NaN);
     neighbors.addOutOfOrder(6, Float.NaN);
     neighbors.addOutOfOrder(4, Float.NaN);
-    int[] unchecked = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 1);
-    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
+//    int[] unchecked = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 1);
+//    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
+    ScoreNode[] uncheckedScoreNodes = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 1);
+    ScoreNode[] exp = new ScoreNode[] {
+      new ScoreNode(1, 7),
+      new ScoreNode(2, 6),
+      new ScoreNode(3, 5),
+      new ScoreNode(4, 4),
+      new ScoreNode(5, 3),
+      new ScoreNode(6, 2),
+      new ScoreNode(7, 1)
+    };
+    assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {1, 2, 3, 4, 5, 6, 7}, neighbors);
     assertScoresEqual(new float[] {7, 6, 5, 4, 3, 2, 1}, neighbors);
   }
@@ -207,10 +257,29 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(17, Float.NaN);
     neighbors.addOutOfOrder(16, Float.NaN);
     neighbors.addOutOfOrder(14, Float.NaN);
-    int[] unchecked = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 11);
-    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
+//    int[] unchecked = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 11);
+//    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
+    ScoreNode[] uncheckedScoreNodes = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 11);
+    ScoreNode[] exp = new ScoreNode[] {
+      new ScoreNode(11, 7),
+      new ScoreNode(12, 6),
+      new ScoreNode(13, 5),
+      new ScoreNode(14, 4),
+      new ScoreNode(15, 3),
+      new ScoreNode(16, 2),
+      new ScoreNode(17, 1)
+    };
+    assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {11, 12, 13, 14, 15, 16, 17}, neighbors);
     assertScoresEqual(new float[] {7, 6, 5, 4, 3, 2, 1}, neighbors);
+  }
+
+  private void assertScoreNodesEqual(ScoreNode[] expected, ScoreNode[] found) {
+    assertEquals(expected.length, found.length);
+    for (int i = 0; i < found.length; i++) {
+      assertEquals(expected[i].node, found[i].node);
+      assertEquals(expected[i].score, found[i].score, 0.01f);
+    }
   }
 
   private void assertScoresEqual(float[] scores, NeighborArray neighbors) {

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
@@ -134,15 +134,16 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(6, 7);
     neighbors.addOutOfOrder(4, 5);
     ScoreNode[] uncheckedScoreNodes = neighbors.sort(null);
-    ScoreNode[] exp = new ScoreNode[] {
-      new ScoreNode(1, 2),
-      new ScoreNode(2, 3),
-      new ScoreNode(3, 4),
-      new ScoreNode(4, 5),
-      new ScoreNode(5, 6),
-      new ScoreNode(6, 7),
-      new ScoreNode(7, 8)
-    };
+    ScoreNode[] exp =
+        new ScoreNode[] {
+          new ScoreNode(1, 2),
+          new ScoreNode(2, 3),
+          new ScoreNode(3, 4),
+          new ScoreNode(4, 5),
+          new ScoreNode(5, 6),
+          new ScoreNode(6, 7),
+          new ScoreNode(7, 8)
+        };
     assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {1, 2, 3, 4, 5, 6, 7}, neighbors);
     assertScoresEqual(new float[] {2, 3, 4, 5, 6, 7, 8}, neighbors);
@@ -156,12 +157,10 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors2.addOutOfOrder(5, 6);
     neighbors2.addOutOfOrder(3, 4);
     uncheckedScoreNodes = neighbors2.sort(null);
-    exp = new ScoreNode[] {
-      new ScoreNode(2, 3),
-      new ScoreNode(3, 4),
-      new ScoreNode(5, 6),
-      new ScoreNode(6, 7),
-    };
+    exp =
+        new ScoreNode[] {
+          new ScoreNode(2, 3), new ScoreNode(3, 4), new ScoreNode(5, 6), new ScoreNode(6, 7),
+        };
     assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {0, 1, 2, 3, 4, 5, 6}, neighbors2);
     assertScoresEqual(new float[] {1, 2, 3, 4, 5, 6, 7}, neighbors2);
@@ -179,15 +178,16 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(6, 2);
     neighbors.addOutOfOrder(4, 4);
     ScoreNode[] uncheckedScoreNodes = neighbors.sort(null);
-    ScoreNode[] exp = new ScoreNode[] {
-      new ScoreNode(1, 7),
-      new ScoreNode(2, 6),
-      new ScoreNode(3, 5),
-      new ScoreNode(4, 4),
-      new ScoreNode(5, 3),
-      new ScoreNode(6, 2),
-      new ScoreNode(7, 1)
-    };
+    ScoreNode[] exp =
+        new ScoreNode[] {
+          new ScoreNode(1, 7),
+          new ScoreNode(2, 6),
+          new ScoreNode(3, 5),
+          new ScoreNode(4, 4),
+          new ScoreNode(5, 3),
+          new ScoreNode(6, 2),
+          new ScoreNode(7, 1)
+        };
     assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {1, 2, 3, 4, 5, 6, 7}, neighbors);
     assertScoresEqual(new float[] {7, 6, 5, 4, 3, 2, 1}, neighbors);
@@ -201,12 +201,10 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors2.addOutOfOrder(6, 2);
     neighbors2.addOutOfOrder(4, 4);
     uncheckedScoreNodes = neighbors2.sort(null);
-    exp = new ScoreNode[] {
-      new ScoreNode(3, 5),
-      new ScoreNode(4, 4),
-      new ScoreNode(6, 2),
-      new ScoreNode(7, 1),
-    };
+    exp =
+        new ScoreNode[] {
+          new ScoreNode(3, 5), new ScoreNode(4, 4), new ScoreNode(6, 2), new ScoreNode(7, 1),
+        };
     assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {1, 2, 3, 4, 5, 6, 7}, neighbors2);
     assertScoresEqual(new float[] {7, 6, 5, 4, 3, 2, 1}, neighbors2);
@@ -222,16 +220,18 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(7, Float.NaN);
     neighbors.addOutOfOrder(6, Float.NaN);
     neighbors.addOutOfOrder(4, Float.NaN);
-    ScoreNode[] uncheckedScoreNodes = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 1);
-    ScoreNode[] exp = new ScoreNode[] {
-      new ScoreNode(1, 7),
-      new ScoreNode(2, 6),
-      new ScoreNode(3, 5),
-      new ScoreNode(4, 4),
-      new ScoreNode(5, 3),
-      new ScoreNode(6, 2),
-      new ScoreNode(7, 1)
-    };
+    ScoreNode[] uncheckedScoreNodes =
+        neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 1);
+    ScoreNode[] exp =
+        new ScoreNode[] {
+          new ScoreNode(1, 7),
+          new ScoreNode(2, 6),
+          new ScoreNode(3, 5),
+          new ScoreNode(4, 4),
+          new ScoreNode(5, 3),
+          new ScoreNode(6, 2),
+          new ScoreNode(7, 1)
+        };
     assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {1, 2, 3, 4, 5, 6, 7}, neighbors);
     assertScoresEqual(new float[] {7, 6, 5, 4, 3, 2, 1}, neighbors);
@@ -247,16 +247,18 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(17, Float.NaN);
     neighbors.addOutOfOrder(16, Float.NaN);
     neighbors.addOutOfOrder(14, Float.NaN);
-    ScoreNode[] uncheckedScoreNodes = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 11);
-    ScoreNode[] exp = new ScoreNode[] {
-      new ScoreNode(11, 7),
-      new ScoreNode(12, 6),
-      new ScoreNode(13, 5),
-      new ScoreNode(14, 4),
-      new ScoreNode(15, 3),
-      new ScoreNode(16, 2),
-      new ScoreNode(17, 1)
-    };
+    ScoreNode[] uncheckedScoreNodes =
+        neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 11);
+    ScoreNode[] exp =
+        new ScoreNode[] {
+          new ScoreNode(11, 7),
+          new ScoreNode(12, 6),
+          new ScoreNode(13, 5),
+          new ScoreNode(14, 4),
+          new ScoreNode(15, 3),
+          new ScoreNode(16, 2),
+          new ScoreNode(17, 1)
+        };
     assertScoreNodesEqual(exp, uncheckedScoreNodes);
     assertNodesEqual(new int[] {11, 12, 13, 14, 15, 16, 17}, neighbors);
     assertScoresEqual(new float[] {7, 6, 5, 4, 3, 2, 1}, neighbors);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
@@ -133,8 +133,6 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(7, 8);
     neighbors.addOutOfOrder(6, 7);
     neighbors.addOutOfOrder(4, 5);
-//    int[] unchecked = neighbors.sort(null);
-//    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
     ScoreNode[] uncheckedScoreNodes = neighbors.sort(null);
     ScoreNode[] exp = new ScoreNode[] {
       new ScoreNode(1, 2),
@@ -157,8 +155,6 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors2.addOutOfOrder(6, 7);
     neighbors2.addOutOfOrder(5, 6);
     neighbors2.addOutOfOrder(3, 4);
-//    unchecked = neighbors2.sort(null);
-//    assertArrayEquals(new int[] {2, 3, 5, 6}, unchecked);
     uncheckedScoreNodes = neighbors2.sort(null);
     exp = new ScoreNode[] {
       new ScoreNode(2, 3),
@@ -182,8 +178,6 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(7, 1);
     neighbors.addOutOfOrder(6, 2);
     neighbors.addOutOfOrder(4, 4);
-//    int[] unchecked = neighbors.sort(null);
-//    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
     ScoreNode[] uncheckedScoreNodes = neighbors.sort(null);
     ScoreNode[] exp = new ScoreNode[] {
       new ScoreNode(1, 7),
@@ -206,8 +200,6 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors2.addOutOfOrder(7, 1);
     neighbors2.addOutOfOrder(6, 2);
     neighbors2.addOutOfOrder(4, 4);
-//    unchecked = neighbors2.sort(null);
-//    assertArrayEquals(new int[] {2, 3, 5, 6}, unchecked);
     uncheckedScoreNodes = neighbors2.sort(null);
     exp = new ScoreNode[] {
       new ScoreNode(3, 5),
@@ -230,8 +222,6 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(7, Float.NaN);
     neighbors.addOutOfOrder(6, Float.NaN);
     neighbors.addOutOfOrder(4, Float.NaN);
-//    int[] unchecked = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 1);
-//    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
     ScoreNode[] uncheckedScoreNodes = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 1);
     ScoreNode[] exp = new ScoreNode[] {
       new ScoreNode(1, 7),
@@ -257,8 +247,6 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(17, Float.NaN);
     neighbors.addOutOfOrder(16, Float.NaN);
     neighbors.addOutOfOrder(14, Float.NaN);
-//    int[] unchecked = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 11);
-//    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6}, unchecked);
     ScoreNode[] uncheckedScoreNodes = neighbors.sort((TestRandomVectorScorer) nodeId -> 7 - nodeId + 11);
     ScoreNode[] exp = new ScoreNode[] {
       new ScoreNode(11, 7),

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
@@ -284,13 +284,13 @@ public class TestNeighborArray extends LuceneTestCase {
 
   private void assertScoresEqual(float[] scores, NeighborArray neighbors) {
     for (int i = 0; i < scores.length; i++) {
-      assertEquals(scores[i], neighbors.scores()[i], 0.01f);
+      assertEquals(scores[i], neighbors.scoreNodes[i].score, 0.01f);
     }
   }
 
   private void assertNodesEqual(int[] nodes, NeighborArray neighbors) {
     for (int i = 0; i < nodes.length; i++) {
-      assertEquals(nodes[i], neighbors.nodes()[i]);
+      assertEquals(nodes[i], neighbors.scoreNodes[i].node);
     }
   }
 


### PR DESCRIPTION
This change stores `node` and `score` into a single `ScoreNode` object instead of maintaining separate arrays. 

I think it simplifies operations like sorting the neighbor nodes when they're added out of order, or finding worst non-diverse nodes to pop out of the neighbor array. We can simply use `Array.sort` instead of searching for insertion points and shifting the entire sub-array for each out of order nodes.

Raising this PR in draft to get feedback on whether this actually simplifies the impl., or ends up making it more complex for the different uses of NeighborArray.

All tests and `precommit` checks passed on my local machine, except the Ram Estimation test, which is intermittently failing. I can use some help in accurately estimating the change in size of NeighborArray object [here](lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java). Will fix it before getting this PR out of draft.