### PR TITLE
Fix test failure in TestReqOptSumScorer.testFilterRandomRareOpt

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
@@ -793,6 +793,10 @@ public class CheckHits {
         assertTrue(s2 == null || s2.iterator().nextDoc() == DocIdSetIterator.NO_MORE_DOCS);
         continue;
       }
+      if (s2 == null) {
+        assertTrue(s1.iterator().nextDoc() == DocIdSetIterator.NO_MORE_DOCS);
+        continue;
+      }
       TwoPhaseIterator twoPhase1 = s1.twoPhaseIterator();
       TwoPhaseIterator twoPhase2 = s2.twoPhaseIterator();
       DocIdSetIterator approx1 = twoPhase1 == null ? s1.iterator() : twoPhase1.approximation();


### PR DESCRIPTION
closes: https://github.com/apache/lucene/issues/13120

This is a similar issue like https://github.com/apache/lucene/pull/13069, This exception was not thrown in the previous PR, because `s1` might be `null` in the second loop, then `s2` will not be read.