### PR TITLE
Remove hardcoded "--release" from renderJavadoc task

### DIFF
--- a/gradle/documentation/render-javadoc.gradle
+++ b/gradle/documentation/render-javadoc.gradle
@@ -73,6 +73,7 @@ allprojects {
         dependsOn sourceSets.main.compileClasspath
         classpath = sourceSets.main.compileClasspath
         srcDirSet = sourceSets.main.java
+        releaseVersion = rootProject.minJavaVersion
 
         relativeProjectLinks = true
 

--- a/gradle/documentation/render-javadoc.gradle
+++ b/gradle/documentation/render-javadoc.gradle
@@ -53,6 +53,7 @@ allprojects {
       dependsOn sourceSets.main.compileClasspath
       classpath = sourceSets.main.compileClasspath
       srcDirSet = sourceSets.main.java
+      releaseVersion = rootProject.minJavaVersion
 
       outputDir = project.javadoc.destinationDir
     }
@@ -280,6 +281,9 @@ class RenderJavadocTask extends DefaultTask {
   @Input
   boolean relativeProjectLinks = false
 
+  @Input
+  JavaVersion releaseVersion
+
   @Internal
   Map<String, File> offlineLinks = [:]
 
@@ -423,7 +427,7 @@ class RenderJavadocTask extends DefaultTask {
       opts << [ '-linkoffline', url, dir ]
     }
 
-    opts << [ '--release', 17 ]
+    opts << [ '--release', releaseVersion.toString() ]
     opts << '-Xdoclint:all,-missing'
 
     // Increase Javadoc's heap.


### PR DESCRIPTION
I noticed this while reviwing #12753. The Java version in the renderJavadoc task is hardcoded and does not use the global setting.