### PR TITLE
Fix TestKnnByteVectorQuery.testToString

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -442,7 +442,7 @@ abstract class AbstractKnnVectorQuery extends Query {
 
     @Override
     public String toString(String field) {
-      return "DocAndScoreQuery[" + docs[0] + ",...][" + scores[0] + ",...]";
+      return "DocAndScoreQuery[" + docs[0] + ",...][" + scores[0] + ",...]," + maxScore;
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -842,8 +842,8 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
     // The string should contain matching docIds and their score.
     // Since a forceMerge could occur in this test, we must not assert that a specific doc_id is
     // matched
-    // But that instead the string format is expected and that the score is 1.0
-    assertTrue(queryString.matches("DocAndScoreQuery\\[\\d+,...]\\[1.0,...]"));
+    // But that instead the string format is expected and that the max score is 1.0
+    assertTrue(queryString.matches("DocAndScoreQuery\\[\\d+,...]\\[\\d+.\\d+,...],1.0"));
   }
 
   /**


### PR DESCRIPTION
### Description

Fixes the `TestKnnByteVectorQuery.testToString` by removing the assumption in the test that the first doc has the max score whereas in [`AbstractKnnVectorQuery#createRewrittenQuery`](https://github.com/apache/lucene/blob/ca06693a16321eef83617b8e4aabbc7d2f6c5187/lucene/core/src/test/org/apache/lucene/search/TestKnnByteVectorQuery.java#L72) we are sorting the docs based on doc id and not score.

Test : Passes the failing seed

```
./gradlew :lucene:core:test --tests "org.apache.lucene.search.TestKnnByteVectorQuery.testToString" -Ptests.seed=628DBF68334757BB -Ptests.nightly=true
```

Closes #13131

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
