### PR TITLE
Fix TestLucene90FieldInfosFormat.testRandom

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseFieldInfoFormatTestCase.java
@@ -278,6 +278,9 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
 
     String parentField = random().nextBoolean() ? TestUtil.randomUnicodeString(random()) : null;
 
+    if (softDeletesField != null && softDeletesField.equals(parentField)) {
+      parentField = null;
+    }
     var builder = INDEX_PACKAGE_ACCESS.newFieldInfosBuilder(softDeletesField, parentField);
 
     for (String field : fieldNames) {


### PR DESCRIPTION
### Description

Failing seed (`E9414A90E55BE2D`) generates empty string with `TestUtil#randomUnicodeString` whereas both field names must not be same as per [this](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java#L399-L405). This fix adds an extra check that prevents this condition.

Test : passes test with failing seed

Closes #13129

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
