### PR TITLE
Replace Collections.synchronizedSet() with ConcurrentHashMap.newKeySet()

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -204,6 +204,8 @@ Optimizations
 
 * GITHUB#13085: Remove unnecessary toString() / substring() calls to save some String allocations (Dmitry Cherniachenko)
 
+* GITHUB#13142: Replace Collections.synchronizedSet() with ConcurrentHashMap.newKeySet() (Dmitry Cherniachenko)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/store/NativeFSLockFactory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NativeFSLockFactory.java
@@ -24,9 +24,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.lucene.util.IOUtils;
 
 /**
@@ -65,7 +64,7 @@ public final class NativeFSLockFactory extends FSLockFactory {
   /** Singleton instance */
   public static final NativeFSLockFactory INSTANCE = new NativeFSLockFactory();
 
-  private static final Set<String> LOCK_HELD = Collections.synchronizedSet(new HashSet<String>());
+  private static final Set<String> LOCK_HELD = ConcurrentHashMap.newKeySet();
 
   private NativeFSLockFactory() {}
 
@@ -127,7 +126,7 @@ public final class NativeFSLockFactory extends FSLockFactory {
     }
   }
 
-  private static final void clearLockHeld(Path path) throws IOException {
+  private static void clearLockHeld(Path path) throws IOException {
     boolean remove = LOCK_HELD.remove(path.toString());
     if (remove == false) {
       throw new AlreadyClosedException("Lock path was cleared but never marked as held: " + path);

--- a/lucene/core/src/java/org/apache/lucene/store/TrackingDirectoryWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/store/TrackingDirectoryWrapper.java
@@ -17,14 +17,14 @@
 package org.apache.lucene.store;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /** A delegating Directory that records which files were written to and deleted. */
 public final class TrackingDirectoryWrapper extends FilterDirectory {
 
-  private final Set<String> createdFileNames = Collections.synchronizedSet(new HashSet<String>());
+  private final Set<String> createdFileNames = ConcurrentHashMap.newKeySet();
 
   public TrackingDirectoryWrapper(Directory in) {
     super(in);
@@ -61,10 +61,8 @@ public final class TrackingDirectoryWrapper extends FilterDirectory {
   @Override
   public void rename(String source, String dest) throws IOException {
     in.rename(source, dest);
-    synchronized (createdFileNames) {
-      createdFileNames.add(dest);
-      createdFileNames.remove(source);
-    }
+    createdFileNames.add(dest);
+    createdFileNames.remove(source);
   }
 
   /** NOTE: returns a copy of the created files. */

--- a/lucene/core/src/java/org/apache/lucene/util/VirtualMethod.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VirtualMethod.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * A utility for keeping backwards compatibility on previously abstract methods (or similar
  * replacements).
  *
- * <p>Before the replacement method can be made abstract, the old method must kept deprecated. If
+ * <p>Before the replacement method can be made abstract, the old method must be kept deprecated. If
  * somebody still overrides the deprecated method in a non-final class, you must keep track, of this
  * and maybe delegate to the old method in the subclass. The cost of reflection is minimized by the
  * following usage of this class:

--- a/lucene/core/src/java/org/apache/lucene/util/VirtualMethod.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VirtualMethod.java
@@ -19,9 +19,8 @@ package org.apache.lucene.util;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A utility for keeping backwards compatibility on previously abstract methods (or similar
@@ -74,8 +73,7 @@ import java.util.Set;
  */
 public final class VirtualMethod<C> {
 
-  private static final Set<Method> singletonSet =
-      Collections.synchronizedSet(new HashSet<Method>());
+  private static final Set<Method> singletonSet = ConcurrentHashMap.newKeySet();
 
   private final Class<C> baseClass;
   private final String method;
@@ -100,7 +98,7 @@ public final class VirtualMethod<C> {
     this.method = method;
     this.parameters = parameters;
     try {
-      if (!singletonSet.add(baseClass.getDeclaredMethod(method, parameters)))
+      if (singletonSet.add(baseClass.getDeclaredMethod(method, parameters)) == false)
         throw new UnsupportedOperationException(
             "VirtualMethod instances must be singletons and therefore "
                 + "assigned to static final members in the same class, they use as baseClass ctor param.");

--- a/lucene/core/src/test/org/apache/lucene/index/TestDirectoryReaderReopen.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDirectoryReaderReopen.java
@@ -21,11 +21,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DocumentStoredFieldVisitor;
 import org.apache.lucene.document.Field;
@@ -240,8 +240,7 @@ public class TestDirectoryReaderReopen extends LuceneTestCase {
     DirectoryReader reader = firstReader;
 
     ReaderThread[] threads = new ReaderThread[n];
-    final Set<DirectoryReader> readersToClose =
-        Collections.synchronizedSet(new HashSet<DirectoryReader>());
+    final Set<DirectoryReader> readersToClose = ConcurrentHashMap.newKeySet();
 
     for (int i = 0; i < n; i++) {
       if (i % 2 == 0) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -3348,7 +3349,7 @@ public class TestIndexWriter extends LuceneTestCase {
 
   public void testCheckPendingFlushPostUpdate() throws IOException, InterruptedException {
     MockDirectoryWrapper dir = newMockDirectory();
-    Set<String> flushingThreads = Collections.synchronizedSet(new HashSet<>());
+    Set<String> flushingThreads = ConcurrentHashMap.newKeySet();
     dir.failOn(
         new MockDirectoryWrapper.Failure() {
           @Override
@@ -3594,7 +3595,7 @@ public class TestIndexWriter extends LuceneTestCase {
     CountDownLatch startLatch = new CountDownLatch(1);
     CountDownLatch started = new CountDownLatch(threads.length);
     boolean updateSeveralDocs = random().nextBoolean();
-    Set<String> ids = Collections.synchronizedSet(new HashSet<>());
+    Set<String> ids = ConcurrentHashMap.newKeySet();
     for (int i = 0; i < threads.length; i++) {
       threads[i] =
           new Thread(

--- a/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesRetentionMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesRetentionMergePolicy.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -292,7 +293,7 @@ public class TestSoftDeletesRetentionMergePolicy extends LuceneTestCase {
     CountDownLatch startLatch = new CountDownLatch(1);
     CountDownLatch started = new CountDownLatch(threads.length);
     boolean updateSeveralDocs = random().nextBoolean();
-    Set<String> ids = Collections.synchronizedSet(new HashSet<>());
+    Set<String> ids = ConcurrentHashMap.newKeySet();
     for (int i = 0; i < threads.length; i++) {
       threads[i] =
           new Thread(

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/PrimaryNode.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/PrimaryNode.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.SegmentCommitInfo;
@@ -67,7 +67,7 @@ public abstract class PrimaryNode extends Node {
    * Contains merged segments that have been copied to all running replicas (as of when that merge
    * started warming).
    */
-  final Set<String> finishedMergedFiles = Collections.synchronizedSet(new HashSet<String>());
+  final Set<String> finishedMergedFiles = ConcurrentHashMap.newKeySet();
 
   private final AtomicInteger copyingCount = new AtomicInteger();
 
@@ -158,10 +158,7 @@ public abstract class PrimaryNode extends Node {
    */
   public boolean flushAndRefresh() throws IOException {
     message("top: now flushAndRefresh");
-    Set<String> completedMergeFiles;
-    synchronized (finishedMergedFiles) {
-      completedMergeFiles = Set.copyOf(finishedMergedFiles);
-    }
+    Set<String> completedMergeFiles = Set.copyOf(finishedMergedFiles);
     mgr.maybeRefreshBlocking();
     boolean result = setCurrentInfos(completedMergeFiles);
     if (result) {

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimplePrimaryNode.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimplePrimaryNode.java
@@ -27,13 +27,13 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.lucene.document.Document;
@@ -81,7 +81,7 @@ class SimplePrimaryNode extends PrimaryNode {
   int[] replicaIDs = new int[0];
 
   // So we only flip a bit once per file name:
-  final Set<String> bitFlipped = Collections.synchronizedSet(new HashSet<>());
+  final Set<String> bitFlipped = ConcurrentHashMap.newKeySet();
 
   final List<MergePreCopy> warmingSegments = Collections.synchronizedList(new ArrayList<>());
 

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestSimpleServer.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestSimpleServer.java
@@ -29,12 +29,12 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
@@ -61,7 +61,7 @@ import org.junit.BeforeClass;
 @SuppressForbidden(reason = "We need Unsafe to actually crush :-)")
 public class TestSimpleServer extends LuceneTestCase {
 
-  static final Set<Thread> clientThreads = Collections.synchronizedSet(new HashSet<>());
+  static final Set<Thread> clientThreads = ConcurrentHashMap.newKeySet();
   static final AtomicBoolean stop = new AtomicBoolean();
 
   /** Handles one client connection */

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestStressNRTReplication.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestStressNRTReplication.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -185,7 +184,7 @@ public class TestStressNRTReplication extends LuceneTestCase {
 
   final AtomicLong nodeStartCounter = new AtomicLong();
 
-  final Set<Integer> crashingNodes = Collections.synchronizedSet(new HashSet<>());
+  final Set<Integer> crashingNodes = ConcurrentHashMap.newKeySet();
 
   @Nightly
   @SuppressForbidden(reason = "Thread sleep")

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/ThreadedIndexingAndSearchingTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/ThreadedIndexingAndSearchingTestCase.java
@@ -19,12 +19,12 @@ package org.apache.lucene.tests.index;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -573,8 +573,8 @@ public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCas
 
     final int MAX_ITERATIONS = LuceneTestCase.TEST_NIGHTLY ? 200 : 10 * RANDOM_MULTIPLIER;
 
-    final Set<String> delIDs = Collections.synchronizedSet(new HashSet<String>());
-    final Set<String> delPackIDs = Collections.synchronizedSet(new HashSet<String>());
+    final Set<String> delIDs = ConcurrentHashMap.newKeySet();
+    final Set<String> delPackIDs = ConcurrentHashMap.newKeySet();
     final List<SubDocs> allSubDocs = Collections.synchronizedList(new ArrayList<SubDocs>());
 
     final Thread[] indexThreads =


### PR DESCRIPTION
`ConcurrentHashMap.newKeySet()` provides better multi-threaded performance thanks to judicious use of synchronization.
Also it does not require "external" synchronization for iteration.
