### PR TITLE
Fix test failure in TestIndexWriterOnDiskFull.testAddIndexOnDiskFull

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import org.apache.lucene.codecs.LiveDocsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -84,7 +85,7 @@ public class TestIndexWriterOnDiskFull extends LuceneTestCase {
             // depending on when it happens.
             writer.commit();
             indexExists = true;
-          } catch (IOException | IllegalStateException e) {
+          } catch (IOException | IllegalStateException | UncheckedIOException e) {
             if (VERBOSE) {
               System.out.println("TEST: exception on commit");
               e.printStackTrace(System.out);
@@ -364,7 +365,10 @@ public class TestIndexWriterOnDiskFull extends LuceneTestCase {
               done = true;
             }
 
-          } catch (IllegalStateException | IOException | MergePolicy.MergeException e) {
+          } catch (IllegalStateException
+              | IOException
+              | MergePolicy.MergeException
+              | UncheckedIOException e) {
             success = false;
             err = e;
             if (VERBOSE) {


### PR DESCRIPTION
From https://github.com/apache/lucene/issues/13116

```
gradlew test --tests TestIndexWriterOnDiskFull.testAddIndexOnDiskFull -Dtests.seed=D7C2553CB8A4ADB5 -Dtests.nightly=true -Dtests.locale=fr-MQ -Dtests.timezone=Indian/Chagos -Dtests.asser\
ts=true -Dtests.file.encoding=UTF-8
```

This test failure reproducible in branch_9x, file size change will make seed-shifting which affects whether failures can be reproduced.
