### PR TITLE
Deprecate ByteBufferIndexInput and detect MemorySegmentIndexInput correctly in NRTSuggester

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,7 +7,8 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
-(No changes)
+
+* Deprecate ByteBufferIndexInput as it will be removed in Lucene 10.0. (Uwe Schindler)
 
 New Features
 ---------------------
@@ -35,6 +36,8 @@ Bug Fixes
 
 * GITHUB#13105: Fix ByteKnnVectorFieldSource & FloatKnnVectorFieldSource to work correctly when a segment does not contain
   any docs with vectors (hossman)
+
+* Detect MemorySegmentIndexInput correctly in NRTSuggester. (Uwe Schindler)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -8,7 +8,7 @@ http://s.apache.org/luceneversions
 API Changes
 ---------------------
 
-* Deprecate ByteBufferIndexInput as it will be removed in Lucene 10.0. (Uwe Schindler)
+* GITHUB#13145: Deprecate ByteBufferIndexInput as it will be removed in Lucene 10.0. (Uwe Schindler)
 
 New Features
 ---------------------
@@ -37,7 +37,7 @@ Bug Fixes
 * GITHUB#13105: Fix ByteKnnVectorFieldSource & FloatKnnVectorFieldSource to work correctly when a segment does not contain
   any docs with vectors (hossman)
 
-* Detect MemorySegmentIndexInput correctly in NRTSuggester. (Uwe Schindler)
+* GITHUB#13145: Detect MemorySegmentIndexInput correctly in NRTSuggester. (Uwe Schindler)
 
 Other
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -33,7 +33,13 @@ import java.nio.LongBuffer;
  *
  * <p>For efficiency, this class requires that the buffers are a power-of-two (<code>chunkSizePower
  * </code>).
+ *
+ * @deprecated This class was made public for internal reasons ({@code instanceof} checks). In
+ *     {@link MMapDirectory} it was replaced by {@code MemorySegment} based {@link IndexInput}
+ *     implementations and will be no longer required in Lucene 10.
+ * @lucene.internal
  */
+@Deprecated
 public abstract class ByteBufferIndexInput extends IndexInput implements RandomAccessInput {
   private static final FloatBuffer EMPTY_FLOATBUFFER = FloatBuffer.allocate(0);
   private static final LongBuffer EMPTY_LONGBUFFER = LongBuffer.allocate(0);

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDirectory.java
@@ -82,6 +82,13 @@ public final class ByteBuffersDirectory extends BaseDirectory {
   public static final BiFunction<String, ByteBuffersDataOutput, IndexInput> OUTPUT_AS_BYTE_ARRAY =
       OUTPUT_AS_ONE_BUFFER;
 
+  /**
+   * Use {@link ByteBufferIndexInput} for reading, otherwise identical to {@link
+   * #OUTPUT_AS_MANY_BUFFERS}.
+   *
+   * @deprecated Use {@link #OUTPUT_AS_MANY_BUFFERS} instead.
+   */
+  @Deprecated
   public static final BiFunction<String, ByteBuffersDataOutput, IndexInput>
       OUTPUT_AS_MANY_BUFFERS_LUCENE =
           (fileName, output) -> {

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/NRTSuggester.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/NRTSuggester.java
@@ -325,7 +325,10 @@ public final class NRTSuggester implements Accountable {
       case OFF_HEAP:
         return true;
       case AUTO:
-        return input instanceof ByteBufferIndexInput;
+        // TODO: Make this less hacky to maybe expose "off-heap" feature using a marker interface on
+        // the IndexInput
+        return input instanceof ByteBufferIndexInput
+            || input.getClass().getName().contains(".MemorySegmentIndexInput");
       default:
         throw new IllegalStateException("unknown enum constant: " + fstLoadMode);
     }


### PR DESCRIPTION
This is preparation for Lucene 10:
- `ByteBufferIndexInput` was made public for unknown reason (it should have been private). This officially deprecates the class as it will be removed in Lucene 10 (see other PR: TODO)
- There was a bug in `NRTSuggester` which wasn't able to detect `MemorySegmentIndexInput` for loading FST off-heap. This "hack" was already pssoibly the reason why the input was made public.

This PR fixes both issues for Lucene 9.11.