### PR TITLE
Do not place Panama Java 21 class files in MR-JAR section of core.jar file

### DIFF
--- a/gradle/java/core-mrjar.gradle
+++ b/gradle/java/core-mrjar.gradle
@@ -46,15 +46,20 @@ configure(project(":lucene:core")) {
     }
     
     tasks.named('jar').configure {
+      boolean needMRJAR = false;
       mrjarJavaVersions.each { jdkVersion ->
-        into("META-INF/versions/${jdkVersion}") {
+        boolean isBaseVersion = (jdkVersion.toString() == rootProject.minJavaVersion.toString())
+        into(isBaseVersion ? '' : "META-INF/versions/${jdkVersion}") {
           from sourceSets["main${jdkVersion}"].output
         }
+        needMRJAR |= !isBaseVersion
       }
 
-      manifest.attributes(
-        'Multi-Release': 'true'
-      )
+      if (needMRJAR) {
+        manifest.attributes(
+          'Multi-Release': 'true'
+        )
+      }
     }
   }
 }

--- a/gradle/java/core-mrjar.gradle
+++ b/gradle/java/core-mrjar.gradle
@@ -48,6 +48,8 @@ configure(project(":lucene:core")) {
     tasks.named('jar').configure {
       boolean needMRJAR = false;
       mrjarJavaVersions.each { jdkVersion ->
+        // the sourceSet which corresponds to the mininum/base Java version
+        // will copy its output to root of JAR, all other sourceSets will go into MR-JAR folders:
         boolean isBaseVersion = (jdkVersion.toString() == rootProject.minJavaVersion.toString())
         into(isBaseVersion ? '' : "META-INF/versions/${jdkVersion}") {
           from sourceSets["main${jdkVersion}"].output

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -84,8 +84,8 @@ API Changes
   make compile() only return the FSTMetadata. For on-heap (default) use case, please use
   FST.fromFSTReader(fstMetadata, fstCompiler.getFSTReader()) to create the FST. (Anh Dung Bui)
 
-* GITHUB#13146: Remove ByteBufferIndexInput and only use MemorySegment APIs for MMapDirectory.
-  (Uwe Schindler)
+* GITHUB#13146, GITHUB#13148: Remove ByteBufferIndexInput and only use MemorySegment APIs
+  for MMapDirectory.  (Uwe Schindler)
 
 New Features
 ---------------------


### PR DESCRIPTION
This is a followup after: https://github.com/apache/lucene/pull/13146#issuecomment-1971597031

This places the compilation unit for Java 21 MRJAR classes in the main section of JAR file. As we currentlly only have Java 21 classes, the MR-JAR file is then automatically disabled.

It is fully dynamic, so when we add later versions of vector code it will be placed in MRJAR sections again.