### PR TITLE
Made DocIdsWriter use DISI when reading documents with an IntersectVisitor

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -134,6 +134,9 @@ Optimizations
 
 * GITHUB#12552: Make FSTPostingsFormat load FSTs off-heap. (Tony X)
 
+* GITHUB#13149: Made PointRangeQuery faster, for some segment sizes, by reducing the amount of virtual calls to
+  IntersectVisitor::visit(int). (Anton Hägerstrand)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/PointValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValues.java
@@ -31,6 +31,7 @@ import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.ArrayUtil.ByteArrayComparator;
+import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.bkd.BKDConfig;
 
 /**
@@ -295,6 +296,17 @@ public abstract class PointValues {
       int docID;
       while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
         visit(docID);
+      }
+    }
+
+    /**
+     * Similar to {@link IntersectVisitor#visit(int)}, but a bulk visit and implements may have
+     * their optimizations. Even if the implementation does the same thing, this can be a speed
+     * improvement due to fewer virtual calls.
+     */
+    default void visit(IntsRef ref) throws IOException {
+      for (int i = ref.offset; i < ref.length + ref.offset; i++) {
+        visit(ref.ints[i]);
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/PointValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValues.java
@@ -289,7 +289,7 @@ public abstract class PointValues {
     void visit(int docID) throws IOException;
 
     /**
-     * Similar to {@link IntersectVisitor#visit(int)}, but a bulk visit and implements may have
+     * Similar to {@link IntersectVisitor#visit(int)}, but a bulk visit and implementations may have
      * their optimizations.
      */
     default void visit(DocIdSetIterator iterator) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/index/PointValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValues.java
@@ -301,8 +301,8 @@ public abstract class PointValues {
 
     /**
      * Similar to {@link IntersectVisitor#visit(int)}, but a bulk visit and implements may have
-     * their optimizations. Even if the implementation does the same thing, this can be a speed
-     * improvement due to fewer virtual calls.
+     * their optimizations. Even if the implementation does the same thing this method, this may be
+     * a speed improvement due to fewer virtual calls.
      */
     default void visit(IntsRef ref) throws IOException {
       for (int i = ref.offset; i < ref.length + ref.offset; i++) {

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -231,11 +231,11 @@ public abstract class PointRangeQuery extends Query {
           }
 
           @Override
-          public void visit(IntsRef ref) throws IOException {
+          public void visit(IntsRef ref) {
             for (int i = ref.offset; i < ref.offset + ref.length; i++) {
               result.clear(ref.ints[i]);
-              cost[0]--;
             }
+            cost[0] -= ref.length;
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -32,6 +32,7 @@ import org.apache.lucene.util.ArrayUtil.ByteArrayComparator;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IntsRef;
 
 /**
  * Abstract class for range queries against single or multidimensional points such as {@link
@@ -186,6 +187,13 @@ public abstract class PointRangeQuery extends Query {
           }
 
           @Override
+          public void visit(IntsRef ref) {
+            for (int i = ref.offset; i < ref.offset + ref.length; i++) {
+              adder.add(ref.ints[i]);
+            }
+          }
+
+          @Override
           public void visit(int docID, byte[] packedValue) {
             if (matches(packedValue)) {
               visit(docID);
@@ -220,6 +228,14 @@ public abstract class PointRangeQuery extends Query {
           public void visit(DocIdSetIterator iterator) throws IOException {
             result.andNot(iterator);
             cost[0] = Math.max(0, cost[0] - iterator.cost());
+          }
+
+          @Override
+          public void visit(IntsRef ref) throws IOException {
+            for (int i = ref.offset; i < ref.offset + ref.length; i++) {
+              result.clear(ref.ints[i]);
+              cost[0]--;
+            }
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
@@ -39,13 +39,14 @@ final class DocIdsWriter {
   private final ScratchDocIdSetIterator scratchDocIdSetIterator = new ScratchDocIdSetIterator();
 
   /**
-   DocIdSetIterator to be used to iterate over the scratch buffer. A single instance is reused to avoid
-   re-allocating the object. The reset method should be called before each use with the count.
-
-   The main reason for existing is to be able to call the {@link IntersectVisitor#visit(DocIdSetIterator)} method
-   rather than the {@link IntersectVisitor#visit(int)} method. This seems to make a difference in performance,
-   probably due to fewer virtual calls then happening (once per read call rather than once per doc).
-
+   * DocIdSetIterator to be used to iterate over the scratch buffer. A single instance is reused to
+   * avoid re-allocating the object. The reset method should be called before each use with the
+   * count.
+   *
+   * <p>The main reason for existing is to be able to call the {@link
+   * IntersectVisitor#visit(DocIdSetIterator)} method rather than the {@link
+   * IntersectVisitor#visit(int)} method. This seems to make a difference in performance, probably
+   * due to fewer virtual calls then happening (once per read call rather than once per doc).
    */
   private class ScratchDocIdSetIterator extends DocIdSetIterator {
 

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/DocIdsWriter.java
@@ -23,6 +23,7 @@ import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.DocBaseBitSetIterator;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IntsRef;
 
 final class DocIdsWriter {
 
@@ -36,64 +37,20 @@ final class DocIdsWriter {
 
   private final int[] scratch;
 
-  private final ScratchDocIdSetIterator scratchDocIdSetIterator = new ScratchDocIdSetIterator();
-
   /**
-   * DocIdSetIterator to be used to iterate over the scratch buffer. A single instance is reused to
-   * avoid re-allocating the object. The reset method should be called before each use with the
-   * count.
+   * IntsRef to be used to iterate over the scratch buffer. A single instance is reused to avoid
+   * re-allocating the object. The ints and length fields need to be reset each use.
    *
    * <p>The main reason for existing is to be able to call the {@link
-   * IntersectVisitor#visit(DocIdSetIterator)} method rather than the {@link
-   * IntersectVisitor#visit(int)} method. This seems to make a difference in performance, probably
-   * due to fewer virtual calls then happening (once per read call rather than once per doc).
+   * IntersectVisitor#visit(IntsRef)} method rather than the {@link IntersectVisitor#visit(int)}
+   * method. This seems to make a difference in performance, probably due to fewer virtual calls
+   * then happening (once per read call rather than once per doc).
    */
-  private class ScratchDocIdSetIterator extends DocIdSetIterator {
+  private final IntsRef scratchIntsRef = new IntsRef();
 
-    private int index = -1;
-    private int count = -1;
-
-    @Override
-    public int docID() {
-      if (index < 0) {
-        return -1;
-      }
-      if (index >= count) {
-        return NO_MORE_DOCS;
-      }
-      return scratch[index];
-    }
-
-    @Override
-    public int nextDoc() throws IOException {
-      index++;
-      if (index >= count) {
-        return NO_MORE_DOCS;
-      }
-      return scratch[index];
-    }
-
-    @Override
-    public int advance(int target) throws IOException {
-      while (index < count && scratch[index] < target) {
-        index++;
-      }
-      if (index >= count) {
-        return NO_MORE_DOCS;
-      } else {
-        return scratch[index];
-      }
-    }
-
-    @Override
-    public long cost() {
-      return count;
-    }
-
-    void reset(int count) {
-      this.count = count;
-      this.index = -1;
-    }
+  {
+    // This is here to not rely on the default constructor of IntsRef to set offset to 0
+    scratchIntsRef.offset = 0;
   }
 
   DocIdsWriter(int maxPointsInLeaf) {
@@ -378,8 +335,9 @@ final class DocIdsWriter {
 
   private void readDelta16(IndexInput in, int count, IntersectVisitor visitor) throws IOException {
     readDelta16(in, count, scratch);
-    scratchDocIdSetIterator.reset(count);
-    visitor.visit(scratchDocIdSetIterator);
+    scratchIntsRef.ints = scratch;
+    scratchIntsRef.length = count;
+    visitor.visit(scratchIntsRef);
   }
 
   private static void readInts24(IndexInput in, int count, IntersectVisitor visitor)
@@ -405,7 +363,8 @@ final class DocIdsWriter {
 
   private void readInts32(IndexInput in, int count, IntersectVisitor visitor) throws IOException {
     in.readInts(scratch, 0, count);
-    scratchDocIdSetIterator.reset(count);
-    visitor.visit(scratchDocIdSetIterator);
+    scratchIntsRef.ints = scratch;
+    scratchIntsRef.length = count;
+    visitor.visit(scratchIntsRef);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
@@ -374,6 +374,10 @@ public class TestPointQueries extends LuceneTestCase {
     doTestRandomLongs(1000);
   }
 
+  public void testRandomLongsBig() throws Exception {
+    doTestRandomLongs(20_000);
+  }
+
   private void doTestRandomLongs(int count) throws Exception {
 
     int numValues = TestUtil.nextInt(random(), count, count * 2);
@@ -434,7 +438,13 @@ public class TestPointQueries extends LuceneTestCase {
       dir = newMaybeVirusCheckingDirectory();
     }
 
-    int missingPct = random().nextInt(100);
+    /*
+    The point range query chooses only considers using an inverse BKD visitor if
+    there is exactly one value per document. If any document misses a value that
+    code is not exercised. Using a nextBoolean() here increases the likelihood
+    that there is no missing values, making the test more likely to test that code.
+    */
+    int missingPct = random().nextBoolean() ? 0 : random().nextInt(100);
     int deletedPct = random().nextInt(100);
     if (VERBOSE) {
       System.out.println("  missingPct=" + missingPct);


### PR DESCRIPTION
Instead of calling `IntersectVisitor.visit` for each doc in the `readDelta16` and `readInts32` methods, create a `DocIdSetIterator` and call `IntersectVisitor.visit(DocIdSetIterator)` instead.

This seems to make Lucene faster at some sorting and range querying tasks - I saw **35-45% reduction in execution time**. In learnt this through running this benchmark setup by Elastic: https://github.com/elastic/elasticsearch-opensearch-benchmark. 

The hypothesis is that this is due to fewer virtual calls being made - once per BKD leaf, instead of once per document. Note that this is only measurable if the readInts methods have been called with at least 3 implementation of the IntersectVisitor interface - otherwise the JIT inlining takes away the virtual call. In real life Lucene deployments, I would judge that it is very likely that at least 3 implementations are used. For more details on method etc, there are details in this blog post: https://blunders.io/posts/es-benchmark-4-inlining

I tried benchmarking this with luceneutil, but did not see any significant change with the default benchmark - I suspect that I'm using the wrong luceneutil tasks to see any major difference. Which luceneutils benchmarks should I be using for these changes?
