### PR TITLE
Make Hnsw99Codecs Extensible

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswScalarQuantizedVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswScalarQuantizedVectorsFormat.java
@@ -42,7 +42,7 @@ import org.apache.lucene.util.hnsw.HnswGraph;
  *
  * @lucene.experimental
  */
-public final class Lucene99HnswScalarQuantizedVectorsFormat extends KnnVectorsFormat {
+public class Lucene99HnswScalarQuantizedVectorsFormat extends KnnVectorsFormat {
 
   /**
    * Controls how many of the nearest neighbor candidates are connected to the new node. Defaults to

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsFormat.java
@@ -83,7 +83,7 @@ import org.apache.lucene.util.hnsw.HnswGraph;
  *
  * @lucene.experimental
  */
-public final class Lucene99HnswVectorsFormat extends KnnVectorsFormat {
+public class Lucene99HnswVectorsFormat extends KnnVectorsFormat {
 
   static final String META_CODEC_NAME = "Lucene99HnswVectorsFormatMeta";
   static final String VECTOR_INDEX_CODEC_NAME = "Lucene99HnswVectorsFormatIndex";


### PR DESCRIPTION
### Description
Lucene99HnswVectorsFormat and Lucene99HnswScalarQuantizedVectorsFormat are not extensible. With the new changes to how max vector dimension is set in the codec, users should be able to extend these classes to override the `getMaxDimensions` method. The current alternative is to make a delegating class that extends from KnnVectorsFormat which isn't the nicest UX.