### PR TITLE
gh-13147: use dense bit-encoding for frequent terms

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/DenseUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/DenseUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene99;
+
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.FixedBitSet;
+
+/** Utility class to encode 128 bits ha ha */
+final class DenseUtil {
+
+  /**
+   * Encode 128 integer deltas from {@code longs} into {@code out} as a bitset.
+   *
+   * @param numBits indicates the delta between the first and last encoded docid, which is the
+   *     number of bits required
+   */
+  static void encodeDeltas(long[] longs, int numBits, DataOutput out) throws IOException {
+    FixedBitSet bits = new FixedBitSet(numBits);
+    int lastSetBit = 0;
+    for (long l : longs) {
+      lastSetBit += l;
+      bits.set(lastSetBit);
+    }
+    int numLongs = bits.getBits().length;
+    // the encoding format uses this bit
+    assert numLongs < 0x80;
+    // nocommit: we are wastefully writing full longs when we could skip the trailing zero bytes
+    // instead we should write only the bytes we need and write that number rather than numLongs
+    // when we read we will have to reconstruct the trailiing partial long
+    out.writeByte((byte) (0x80 | numLongs));
+    assert numBits == lastSetBit + 1;
+    // out.writeByte((byte) (nBytes & 0xff));
+    for (long l : bits.getBits()) {
+      out.writeLong(l);
+    }
+  }
+
+  public static void readBlock(int bitsPerValue, DataInput in, FixedBitSet bits)
+      throws IOException {
+    int numLongs = bitsPerValue & 0x7f;
+    long[] longs = bits.getBits();
+    in.readLongs(longs, 0, numLongs);
+    // empty out the "ghost bits" so FixedBitSet doesn't get upset
+    Arrays.fill(longs, numLongs, longs.length, 0);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/DenseUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/DenseUtil.java
@@ -58,6 +58,15 @@ final class DenseUtil {
     long[] longs = bits.getBits();
     in.readLongs(longs, 0, numLongs);
     // empty out the "ghost bits" so FixedBitSet doesn't get upset
-    Arrays.fill(longs, numLongs, longs.length, 0);
+    // but this is not really required since the trailing longs are
+    // never seen by FixedBitSet -- the methods we use are all restricted by
+    // numLongs. In fact we could relax FixedBitSet verification.
+    // Arrays.fill(longs, numLongs, longs.length, 0);
+    assert clear(bits);
+  }
+
+  private static boolean clear(FixedBitSet bits) {
+    Arrays.fill(bits.getBits(), 0);
+    return true;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForDeltaUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForDeltaUtil.java
@@ -64,7 +64,7 @@ public class ForDeltaUtil {
       }
       assert or != 0;
       final int bitsPerValue = PackedInts.bitsRequired(or);
-      // nocommit tune me
+      // TODO: tune me
       if (longs.length * bitsPerValue >= (int) sum && sum <= 31 * Long.BYTES) {
         //
         // sum = bits required in dense bitset;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForDeltaUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/ForDeltaUtil.java
@@ -64,7 +64,7 @@ public class ForDeltaUtil {
       assert or != 0;
       final int bitsPerValue = PackedInts.bitsRequired(or);
       // nocommit tune me
-      if (longs.length * bitsPerValue >= sum) {
+      if (longs.length * bitsPerValue >= (int) sum) {
         // sum = bits required in dense bitset;
         // len (block_size=128) * bitsPerValue = number of bits required in packed encoding
         DenseUtil.encodeDeltas(longs, (int) sum, out);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsFormat.java
@@ -359,6 +359,11 @@ public final class Lucene99PostingsFormat extends PostingsFormat {
   /** Size of blocks. */
   public static final int BLOCK_SIZE = ForUtil.BLOCK_SIZE;
 
+  // We check if total bits required for packed encoding a block exceeds bits required for dense
+  // encoding in order to decide which encoding to use. When this factor is 1 we pick whichever
+  // that takes less space. TODO: how to control this?
+  // static final int DENSE_ENCODING_FACTOR = 1;
+
   /**
    * Expert: The maximum number of skip levels. Smaller values result in slightly smaller indexes,
    * but slower skipping in big posting lists.

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
@@ -594,6 +594,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         int next = checkNextSetBit(denseDocs, target - denseBlockBaseDoc);
         if (next == NO_MORE_DOCS) {
           this.doc = NO_MORE_DOCS;
+          docBufferUpto = BLOCK_SIZE;
         } else {
           this.doc = denseBlockBaseDoc + next;
           // count all the set bits between here and there
@@ -995,6 +996,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         int next = checkNextSetBit(denseDocs, target - denseBlockBaseDoc);
         if (next == NO_MORE_DOCS) {
           this.doc = NO_MORE_DOCS;
+          docBufferUpto = BLOCK_SIZE;
         } else {
           this.doc = denseBlockBaseDoc + next;
           // count bits to know how many docs in this block we advanced
@@ -1354,6 +1356,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         int next = checkNextSetBit(denseDocs, target - denseBlockBaseDoc);
         if (next == NO_MORE_DOCS) {
           doc = NO_MORE_DOCS;
+          docBufferUpto = BLOCK_SIZE;
         } else {
           doc = denseBlockBaseDoc + next;
           docBufferUpto += denseDocs.count(bitIndex + 1, next) + 1;
@@ -1611,13 +1614,16 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         int next = checkNextSetBit(denseDocs, target - denseBlockBaseDoc);
         if (next == NO_MORE_DOCS) {
           this.doc = NO_MORE_DOCS;
+          docBufferUpto = BLOCK_SIZE;
         } else {
           this.doc = denseBlockBaseDoc + next;
-          int advanceTo = docBufferUpto + denseDocs.count(bitIndex + 1, next);
+          int numAdvance = denseDocs.count(bitIndex + 1, next);
+          int advanceTo = docBufferUpto + numAdvance;
           while (docBufferUpto <= advanceTo) {
             freq = (int) freqBuffer[docBufferUpto++];
             posPendingCount += freq;
           }
+          docUpto += numAdvance;
           position = 0;
           bitIndex = next;
         }
@@ -2083,11 +2089,16 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         int next = checkNextSetBit(denseDocs, target - denseBlockBaseDoc);
         if (next == NO_MORE_DOCS) {
           this.doc = NO_MORE_DOCS;
+          docBufferUpto = BLOCK_SIZE;
         } else {
           this.doc = denseBlockBaseDoc + next;
-          docBufferUpto += denseDocs.count(bitIndex + 1, next) + 1;
+          int numAdvanced = denseDocs.count(bitIndex + 1, next) + 1;
+          docBufferUpto += numAdvanced;
+          docUpto += numAdvanced;
           bitIndex = next;
         }
+        position = 0;
+        lastStartOffset = 0;
         return this.doc;
       } else {
         // Now scan:

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
@@ -24,7 +24,6 @@ import static org.apache.lucene.codecs.lucene99.Lucene99PostingsFormat.POS_CODEC
 import static org.apache.lucene.codecs.lucene99.Lucene99PostingsFormat.TERMS_CODEC;
 import static org.apache.lucene.codecs.lucene99.Lucene99PostingsFormat.VERSION_CURRENT;
 import static org.apache.lucene.codecs.lucene99.Lucene99PostingsFormat.VERSION_START;
-import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -53,11 +52,6 @@ import org.apache.lucene.util.IOUtils;
  * @lucene.experimental
  */
 public final class Lucene99PostingsReader extends PostingsReaderBase {
-
-  // nocommit this seems absurdly large - it's unlikely we would ever use this much in practice
-  // maybe we should put an arbitrary maximum in place so that even if this would use fewer
-  // bits than packed encoding we only use it if the bitmap is < that maximum size...
-  static final int DENSE_BITSET_SIZE = BLOCK_SIZE * Long.SIZE;
 
   private final IndexInput docIn;
   private final IndexInput posIn;
@@ -345,7 +339,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
     // docID of first doc in the block; only used/valid when blockFormat is dense
     private int denseBlockBaseDoc;
     private int bitIndex; // tracks nextDoc() iteration through dense bits
-    private final PostingBits denseDocs = new PostingBits(8);
+    private final PostingBits denseDocs = new PostingBits();
 
     // Where this term's postings start in the .doc file:
     private long docTermStartFP;
@@ -656,7 +650,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
     // docID of first doc in the block; only used/valid when blockFormat is dense
     private int denseBlockBaseDoc;
     private int bitIndex; // tracks nextDoc() iteration through dense bits
-    private final PostingBits denseDocs = new PostingBits(8);
+    private final PostingBits denseDocs = new PostingBits();
 
     private Lucene99SkipReader skipper;
     private boolean skipped;
@@ -1182,7 +1176,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
     // docID of first doc in the block; only used/valid when blockFormat is dense
     private int denseBlockBaseDoc;
     private int bitIndex; // tracks nextDoc() iteration through dense bits
-    private final PostingBits denseDocs = new PostingBits(8);
+    private final PostingBits denseDocs = new PostingBits();
 
     private final Lucene99ScoreSkipReader skipper;
 
@@ -1419,7 +1413,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
     // docID of first doc in the block; only used/valid when blockFormat is dense
     private int denseBlockBaseDoc;
     private int bitIndex; // tracks nextDoc() iteration through dense bits
-    private final PostingBits denseDocs = new PostingBits(DENSE_BITSET_SIZE);
+    private final PostingBits denseDocs = new PostingBits();
     private final Lucene99ScoreSkipReader skipper;
 
     final IndexInput docIn;
@@ -1753,7 +1747,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
     // docID of first doc in the block; only used/valid when blockFormat is dense
     private int denseBlockBaseDoc;
     private int bitIndex; // tracks nextDoc() iteration through dense bits
-    private final PostingBits denseDocs = new PostingBits(DENSE_BITSET_SIZE);
+    private final PostingBits denseDocs = new PostingBits();
 
     private final Lucene99ScoreSkipReader skipper;
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
@@ -24,6 +24,7 @@ import static org.apache.lucene.codecs.lucene99.Lucene99PostingsFormat.POS_CODEC
 import static org.apache.lucene.codecs.lucene99.Lucene99PostingsFormat.TERMS_CODEC;
 import static org.apache.lucene.codecs.lucene99.Lucene99PostingsFormat.VERSION_CURRENT;
 import static org.apache.lucene.codecs.lucene99.Lucene99PostingsFormat.VERSION_START;
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -44,6 +45,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 
 /**
@@ -52,6 +54,11 @@ import org.apache.lucene.util.IOUtils;
  * @lucene.experimental
  */
 public final class Lucene99PostingsReader extends PostingsReaderBase {
+
+  // nocommit this seems absurdly large - it's unlikely we would ever use this much in practice
+  // maybe we should put an arbitrary maximum in place so that even if this would use fewer
+  // bits than packed encoding we only use it if the bitmap is < that maximum size...
+  static final int DENSE_BITSET_SIZE = BLOCK_SIZE * Long.SIZE;
 
   private final IndexInput docIn;
   private final IndexInput posIn;
@@ -336,6 +343,11 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
     private int doc; // doc we last read
     private long accum; // accumulator for doc deltas
 
+    // docID of first doc in the block; only used/valid when blockFormat is dense
+    private int denseBlockBaseDoc;
+    private int bitIndex; // tracks nextDoc() iteration through dense bits
+    private final FixedBitSet denseDocs = new FixedBitSet(DENSE_BITSET_SIZE);
+
     // Where this term's postings start in the .doc file:
     private long docTermStartFP;
 
@@ -409,6 +421,8 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
       nextSkipDoc = BLOCK_SIZE - 1; // we won't skip if target is found in first block
       docBufferUpto = BLOCK_SIZE;
       skipped = false;
+      bitIndex = -1;
+      denseBlockBaseDoc = -1;
       return this;
     }
 
@@ -418,6 +432,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         pforUtil.decode(docIn, freqBuffer); // read freqBuffer for this block
         isFreqsRead = true;
       }
+      // System.out.println(" freq(" + docBufferUpto + " - 1) = " + freqBuffer[docBufferUpto - 1]);
       return (int) freqBuffer[docBufferUpto - 1];
     }
 
@@ -456,10 +471,17 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
 
       final int left = docFreq - blockUpto;
       assert left >= 0;
-
+      denseBlockBaseDoc = -1;
+      // System.out.println(getClass().getSimpleName() + "refillDocs");
       if (left >= BLOCK_SIZE) {
-        forDeltaUtil.decodeAndPrefixSum(docIn, accum, docBuffer);
-
+        int headerByte = forDeltaUtil.decodeAndPrefixSum(docIn, accum, docBuffer, denseDocs);
+        // System.out.println(getClass().getSimpleName() + " refillDocs " + ((headerByte & 0x80) !=
+        // 0 ? "dense " : "packed ") + (headerByte & 0x7f));
+        if ((headerByte & 0x80) != 0) {
+          bitIndex = -1;
+          // the docid of the first doc position in a dense block
+          denseBlockBaseDoc = (int) accum;
+        }
         if (indexHasFreq) {
           if (needsFreq) {
             isFreqsRead = false;
@@ -480,20 +502,42 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         docBuffer[left] = NO_MORE_DOCS;
         blockUpto += left;
       }
-      accum = docBuffer[BLOCK_SIZE - 1];
-      docBufferUpto = 0;
+      if (denseBlockBaseDoc >= 0) {
+        // what docid range is encoded?
+        accum += denseDocs.prevSetBit(denseDocs.length() - 1);
+      } else {
+        accum = docBuffer[BLOCK_SIZE - 1];
+        bitIndex = -1; // not really needed?, but helps with assertions
+      }
       assert docBuffer[BLOCK_SIZE] == NO_MORE_DOCS;
+      docBufferUpto = 0;
     }
+
+    // refill is controlled by docBufferUpto -- once we have read BLOCK_SIZE docs we must refill
+    // it's not necessary to advance the bit pointer beyond the current doc because
+    // nextDoc will always succeed in finding another bit so long as docBufferUpto < BLOCK_SIZE.
+    // so -- after reading the first doc, docBufferUpto will be set to 1 and the bitIndex
+    // (should we rename it to currentBit) will be at bit position (docid - base).
+    //
+    // However advance may advance beyond the current block .. therefore we must be prepared to
+    // refill *after* failing to get a next bit in advance. We also must correctly set docBufferUpto
+    // in advance
 
     @Override
     public int nextDoc() throws IOException {
+      // System.out.println("  enter nextDoc i=" + bitIndex + " [" + docBufferUpto + "]");
       if (docBufferUpto == BLOCK_SIZE) {
         refillDocs(); // we don't need to load freqBuffer for now (will be loaded later if
         // necessary)
       }
-
-      doc = (int) docBuffer[docBufferUpto];
+      if (denseBlockBaseDoc >= 0) {
+        bitIndex = denseDocs.nextSetBit(bitIndex + 1);
+        doc = denseBlockBaseDoc + bitIndex;
+      } else {
+        doc = (int) docBuffer[docBufferUpto];
+      }
       docBufferUpto++;
+      // System.out.println("  exit nextDoc " + doc + " [" + docBufferUpto + "]");
       return doc;
     }
 
@@ -543,21 +587,38 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
       if (docBufferUpto == BLOCK_SIZE) {
         refillDocs();
       }
-
-      // Now scan... this is an inlined/pared down version
-      // of nextDoc():
-      long doc;
-      while (true) {
-        doc = docBuffer[docBufferUpto];
-
-        if (doc >= target) {
-          break;
+      if (denseBlockBaseDoc >= 0) {
+        // NOTE: the loop below encodes the assumption that this block has docids
+        // >= target; otherwise we would have skipped ahead already. So we don't
+        // need to check for overflow here
+        int next = checkNextSetBit(denseDocs, target - denseBlockBaseDoc);
+        if (next == NO_MORE_DOCS) {
+          this.doc = NO_MORE_DOCS;
+        } else {
+          this.doc = denseBlockBaseDoc + next;
+          // count all the set bits between here and there
+          // TODO: could we combine this with nextSetBit??
+          docBufferUpto += denseDocs.count(bitIndex + 1, next) + 1;
+          bitIndex = next;
         }
-        ++docBufferUpto;
-      }
+        // System.out.println("  advance " + target + "->" + doc + " [" + docBufferUpto + "]");
+        return doc;
+      } else {
+        // Now scan... this is an inlined/pared down version
+        // of nextDoc():
+        long doc;
+        while (true) {
+          doc = docBuffer[docBufferUpto];
 
-      docBufferUpto++;
-      return this.doc = (int) doc;
+          if (doc >= target) {
+            break;
+          }
+          ++docBufferUpto;
+        }
+
+        docBufferUpto++;
+        return this.doc = (int) doc;
+      }
     }
 
     @Override
@@ -591,6 +652,11 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
 
     private int docBufferUpto;
     private int posBufferUpto;
+
+    // docID of first doc in the block; only used/valid when blockFormat is dense
+    private int denseBlockBaseDoc;
+    private int bitIndex; // tracks nextDoc() iteration through dense bits
+    private final FixedBitSet denseDocs = new FixedBitSet(DENSE_BITSET_SIZE);
 
     private Lucene99SkipReader skipper;
     private boolean skipped;
@@ -741,6 +807,8 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
       }
       docBufferUpto = BLOCK_SIZE;
       skipped = false;
+      bitIndex = -1;
+      denseBlockBaseDoc = -1;
       return this;
     }
 
@@ -758,8 +826,13 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
       final int left = docFreq - blockUpto;
       assert left >= 0;
 
+      denseBlockBaseDoc = -1;
       if (left >= BLOCK_SIZE) {
-        forDeltaUtil.decodeAndPrefixSum(docIn, accum, docBuffer);
+        int headerByte = forDeltaUtil.decodeAndPrefixSum(docIn, accum, docBuffer, denseDocs);
+        if ((headerByte & 0x80) != 0) {
+          bitIndex = -1;
+          denseBlockBaseDoc = (int) accum;
+        }
         pforUtil.decode(docIn, freqBuffer);
         blockUpto += BLOCK_SIZE;
       } else if (docFreq == 1) {
@@ -773,9 +846,13 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         docBuffer[left] = NO_MORE_DOCS;
         blockUpto += left;
       }
-      accum = docBuffer[BLOCK_SIZE - 1];
-      docBufferUpto = 0;
+      if (denseBlockBaseDoc >= 0) {
+        accum += denseDocs.prevSetBit(denseDocs.length() - 1);
+      } else {
+        accum = docBuffer[BLOCK_SIZE - 1];
+      }
       assert docBuffer[BLOCK_SIZE] == NO_MORE_DOCS;
+      docBufferUpto = 0;
     }
 
     private void refillPositions() throws IOException {
@@ -851,17 +928,24 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
 
     @Override
     public int nextDoc() throws IOException {
+      // System.out.println("  enter nextDoc i=" + bitIndex + " [" + docBufferUpto + "]");
       if (docBufferUpto == BLOCK_SIZE) {
         refillDocs();
       }
 
-      doc = (int) docBuffer[docBufferUpto];
+      if (denseBlockBaseDoc >= 0) {
+        bitIndex = denseDocs.nextSetBit(bitIndex + 1);
+        doc = denseBlockBaseDoc + bitIndex;
+      } else {
+        doc = (int) docBuffer[docBufferUpto];
+      }
       freq = (int) freqBuffer[docBufferUpto];
       posPendingCount += freq;
       docBufferUpto++;
 
       position = 0;
       lastStartOffset = 0;
+      // System.out.println("  exit nextDoc " + doc + " [" + docBufferUpto + "] freq=" + freq);
       return doc;
     }
 
@@ -907,22 +991,44 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         refillDocs();
       }
 
-      // Now scan:
-      long doc;
-      while (true) {
-        doc = docBuffer[docBufferUpto];
-        freq = (int) freqBuffer[docBufferUpto];
-        posPendingCount += freq;
-        docBufferUpto++;
-
-        if (doc >= target) {
-          break;
+      if (denseBlockBaseDoc >= 0) {
+        int next = checkNextSetBit(denseDocs, target - denseBlockBaseDoc);
+        if (next == NO_MORE_DOCS) {
+          this.doc = NO_MORE_DOCS;
+        } else {
+          this.doc = denseBlockBaseDoc + next;
+          // count bits to know how many docs in this block we advanced
+          int advanceTo = docBufferUpto + denseDocs.count(bitIndex + 1, next);
+          while (docBufferUpto <= advanceTo) {
+            freq = (int) freqBuffer[docBufferUpto++];
+            posPendingCount += freq;
+          }
+          bitIndex = next;
         }
-      }
+        position = 0;
+        // System.out.println("  advance " + target + "->" + doc + " [" + docBufferUpto + "] freq="+
+        // freq);
+        return this.doc;
 
-      position = 0;
-      lastStartOffset = 0;
-      return this.doc = (int) doc;
+      } else {
+
+        // Now scan... this is an inlined/pared down version
+        // of nextDoc():
+        long doc;
+        while (true) {
+          doc = docBuffer[docBufferUpto];
+          freq = (int) freqBuffer[docBufferUpto];
+          posPendingCount += freq;
+          docBufferUpto++;
+
+          if (doc >= target) {
+            break;
+          }
+        }
+        position = 0;
+        lastStartOffset = 0;
+        return this.doc = (int) doc;
+      }
     }
 
     // TODO: in theory we could avoid loading frq block
@@ -1064,6 +1170,11 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
 
     private int docBufferUpto;
 
+    // docID of first doc in the block; only used/valid when blockFormat is dense
+    private int denseBlockBaseDoc;
+    private int bitIndex; // tracks nextDoc() iteration through dense bits
+    private final FixedBitSet denseDocs = new FixedBitSet(DENSE_BITSET_SIZE);
+
     private final Lucene99ScoreSkipReader skipper;
 
     final IndexInput docIn;
@@ -1148,8 +1259,16 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
       final int left = docFreq - blockUpto;
       assert left >= 0;
 
+      // System.out.println(getClass().getSimpleName() + " refillDocs");
+      denseBlockBaseDoc = -1;
       if (left >= BLOCK_SIZE) {
-        forDeltaUtil.decodeAndPrefixSum(docIn, accum, docBuffer);
+        int headerByte = forDeltaUtil.decodeAndPrefixSum(docIn, accum, docBuffer, denseDocs);
+        // System.out.println(getClass().getSimpleName() + " refillDocs " + ((headerByte & 0x80) !=
+        // 0 ? "dense " : "packed ") + (headerByte & 0x7f));
+        if ((headerByte & 0x80) != 0) {
+          bitIndex = -1;
+          denseBlockBaseDoc = (int) accum;
+        }
         if (indexHasFreqs) {
           isFreqsRead = false;
         }
@@ -1160,9 +1279,14 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         docBuffer[left] = NO_MORE_DOCS;
         blockUpto += left;
       }
-      accum = docBuffer[BLOCK_SIZE - 1];
-      docBufferUpto = 0;
+      if (denseBlockBaseDoc >= 0) {
+        // what docid range is encoded?
+        accum += denseDocs.prevSetBit(denseDocs.length() - 1);
+      } else {
+        accum = docBuffer[BLOCK_SIZE - 1];
+      }
       assert docBuffer[BLOCK_SIZE] == NO_MORE_DOCS;
+      docBufferUpto = 0;
     }
 
     @Override
@@ -1200,24 +1324,47 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
 
     @Override
     public int nextDoc() throws IOException {
+      // System.out.println("  enter nextDoc i=" + bitIndex + " [" + docBufferUpto + "]");
       if (docBufferUpto == BLOCK_SIZE) {
         refillDocs();
       }
-      return this.doc = (int) docBuffer[docBufferUpto++];
+      if (denseBlockBaseDoc >= 0) {
+        bitIndex = denseDocs.nextSetBit(bitIndex + 1);
+        doc = denseBlockBaseDoc + bitIndex;
+      } else {
+        doc = (int) docBuffer[docBufferUpto];
+      }
+      docBufferUpto++;
+      // System.out.println("  exit nextDoc " + doc + " [" + docBufferUpto + "]");
+      return doc;
     }
 
     @Override
     public int advance(int target) throws IOException {
+
+      // System.out.println("  enter advance " + target + " [" + docBufferUpto + "] nextSkipDoc=" +
+      // nextSkipDoc);
       if (target > nextSkipDoc) {
         advanceShallow(target);
       }
       if (docBufferUpto == BLOCK_SIZE) {
         refillDocs();
       }
-
-      int next = findFirstGreater(docBuffer, target, docBufferUpto);
-      this.doc = (int) docBuffer[next];
-      docBufferUpto = next + 1;
+      if (denseBlockBaseDoc >= 0) {
+        int next = checkNextSetBit(denseDocs, target - denseBlockBaseDoc);
+        if (next == NO_MORE_DOCS) {
+          doc = NO_MORE_DOCS;
+        } else {
+          doc = denseBlockBaseDoc + next;
+          docBufferUpto += denseDocs.count(bitIndex + 1, next) + 1;
+          bitIndex = next;
+        }
+      } else {
+        int next = findFirstGreater(docBuffer, target, docBufferUpto);
+        doc = (int) docBuffer[next];
+        docBufferUpto = next + 1;
+      }
+      // System.out.println("  exit advance " + target + "->" + doc + " [" + docBufferUpto + "]");
       return doc;
     }
 
@@ -1259,6 +1406,10 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
     private int docBufferUpto;
     private int posBufferUpto;
 
+    // docID of first doc in the block; only used/valid when blockFormat is dense
+    private int denseBlockBaseDoc;
+    private int bitIndex; // tracks nextDoc() iteration through dense bits
+    private final FixedBitSet denseDocs = new FixedBitSet(DENSE_BITSET_SIZE);
     private final Lucene99ScoreSkipReader skipper;
 
     final IndexInput docIn;
@@ -1359,15 +1510,25 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
       final int left = docFreq - docUpto;
       assert left >= 0;
 
+      denseBlockBaseDoc = -1;
       if (left >= BLOCK_SIZE) {
-        forDeltaUtil.decodeAndPrefixSum(docIn, accum, docBuffer);
+        int headerByte = forDeltaUtil.decodeAndPrefixSum(docIn, accum, docBuffer, denseDocs);
+        if ((headerByte & 0x80) != 0) {
+          bitIndex = -1;
+          denseBlockBaseDoc = (int) accum;
+        }
         pforUtil.decode(docIn, freqBuffer);
       } else {
         readVIntBlock(docIn, docBuffer, freqBuffer, left, true, true);
         prefixSum(docBuffer, left, accum);
         docBuffer[left] = NO_MORE_DOCS;
       }
-      accum = docBuffer[BLOCK_SIZE - 1];
+      if (denseBlockBaseDoc >= 0) {
+        // what docid range is encoded?
+        accum += denseDocs.prevSetBit(denseDocs.length() - 1);
+      } else {
+        accum = docBuffer[BLOCK_SIZE - 1];
+      }
       docBufferUpto = 0;
     }
 
@@ -1446,19 +1607,36 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         refillDocs();
       }
 
-      int next = findFirstGreater(docBuffer, target, docBufferUpto);
-      if (next == BLOCK_SIZE) {
-        return doc = NO_MORE_DOCS;
+      if (denseBlockBaseDoc >= 0) {
+        int next = checkNextSetBit(denseDocs, target - denseBlockBaseDoc);
+        if (next == NO_MORE_DOCS) {
+          this.doc = NO_MORE_DOCS;
+        } else {
+          this.doc = denseBlockBaseDoc + next;
+          int advanceTo = docBufferUpto + denseDocs.count(bitIndex + 1, next);
+          while (docBufferUpto <= advanceTo) {
+            freq = (int) freqBuffer[docBufferUpto++];
+            posPendingCount += freq;
+          }
+          position = 0;
+          bitIndex = next;
+        }
+        return this.doc;
+      } else {
+        int next = findFirstGreater(docBuffer, target, docBufferUpto);
+        if (next == BLOCK_SIZE) {
+          return doc = NO_MORE_DOCS;
+        }
+        this.doc = (int) docBuffer[next];
+        this.freq = (int) freqBuffer[next];
+        for (int i = docBufferUpto; i <= next; ++i) {
+          posPendingCount += freqBuffer[i];
+        }
+        docUpto += next - docBufferUpto + 1;
+        docBufferUpto = next + 1;
+        position = 0;
+        return doc;
       }
-      this.doc = (int) docBuffer[next];
-      this.freq = (int) freqBuffer[next];
-      for (int i = docBufferUpto; i <= next; ++i) {
-        posPendingCount += freqBuffer[i];
-      }
-      docUpto += next - docBufferUpto + 1;
-      docBufferUpto = next + 1;
-      position = 0;
-      return doc;
     }
 
     // TODO: in theory we could avoid loading frq block
@@ -1558,6 +1736,11 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
 
     private int docBufferUpto;
     private int posBufferUpto;
+
+    // docID of first doc in the block; only used/valid when blockFormat is dense
+    private int denseBlockBaseDoc;
+    private int bitIndex; // tracks nextDoc() iteration through dense bits
+    private final FixedBitSet denseDocs = new FixedBitSet(DENSE_BITSET_SIZE);
 
     private final Lucene99ScoreSkipReader skipper;
 
@@ -1746,8 +1929,13 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
       final int left = docFreq - docUpto;
       assert left >= 0;
 
+      denseBlockBaseDoc = -1;
       if (left >= BLOCK_SIZE) {
-        forDeltaUtil.decodeAndPrefixSum(docIn, accum, docBuffer);
+        int headerByte = forDeltaUtil.decodeAndPrefixSum(docIn, accum, docBuffer, denseDocs);
+        if ((headerByte & 0x80) != 0) {
+          bitIndex = -1;
+          denseBlockBaseDoc = (int) accum;
+        }
         if (indexHasFreq) {
           isFreqsRead =
               false; // freq block will be loaded lazily when necessary, we don't load it here
@@ -1757,7 +1945,11 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         prefixSum(docBuffer, left, accum);
         docBuffer[left] = NO_MORE_DOCS;
       }
-      accum = docBuffer[BLOCK_SIZE - 1];
+      if (denseBlockBaseDoc >= 0) {
+        accum += denseDocs.prevSetBit(denseDocs.length() - 1);
+      } else {
+        accum = docBuffer[BLOCK_SIZE - 1];
+      }
       docBufferUpto = 0;
     }
 
@@ -1887,25 +2079,36 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         refillDocs();
       }
 
-      // Now scan:
-      long doc;
-      while (true) {
-        doc = docBuffer[docBufferUpto];
-        docBufferUpto++;
-        docUpto++;
-
-        if (doc >= target) {
-          break;
+      if (denseBlockBaseDoc >= 0) {
+        int next = checkNextSetBit(denseDocs, target - denseBlockBaseDoc);
+        if (next == NO_MORE_DOCS) {
+          this.doc = NO_MORE_DOCS;
+        } else {
+          this.doc = denseBlockBaseDoc + next;
+          docBufferUpto += denseDocs.count(bitIndex + 1, next) + 1;
+          bitIndex = next;
         }
+        return this.doc;
+      } else {
+        // Now scan:
+        long doc;
+        while (true) {
+          doc = docBuffer[docBufferUpto];
+          docBufferUpto++;
+          docUpto++;
 
-        if (docBufferUpto == BLOCK_SIZE) {
-          return this.doc = NO_MORE_DOCS;
+          if (doc >= target) {
+            break;
+          }
+
+          if (docBufferUpto == BLOCK_SIZE) {
+            return this.doc = NO_MORE_DOCS;
+          }
         }
+        position = 0;
+        lastStartOffset = 0;
+        return this.doc = (int) doc;
       }
-      position = 0;
-      lastStartOffset = 0;
-
-      return this.doc = (int) doc;
     }
 
     // TODO: in theory we could avoid loading frq block
@@ -2046,6 +2249,14 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
     @Override
     public long cost() {
       return docFreq;
+    }
+  }
+
+  static int checkNextSetBit(FixedBitSet bitset, int index) {
+    if (index > bitset.length()) {
+      return NO_MORE_DOCS;
+    } else {
+      return bitset.nextSetBit(index);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/PostingBits.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/PostingBits.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene99;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+/**
+ * Specialized for Lucene99PostingsFormat. Cloned from FixedBitSet so it can be reused and resized.
+ * Also provides a count of bits traversed when advancing using nextSetBit.
+ */
+final class PostingBits {
+  private long[] bits; // Array of longs holding the bits
+  private int numBits; // The number of bits in use
+  private int numWords; // The exact number of longs needed to hold numBits (<= bits.length)
+
+  PostingBits(int numWords) {
+    this.numWords = numWords;
+    this.bits = new long[numWords];
+  }
+
+  /**
+   * Resizes the internal array if capacity needed to increase. This is a destructive operation; any
+   * existing bits may be lost. It is the caller's responsibility to fill the array with bits,
+   * properly zeroing out any trailing "ghost bits", and then call updateNumBits. It is only
+   * necessary to zero out the number of words that are actually in use. It is safe to leave garbage
+   * in bits[i] | i &gt; numWords.
+   */
+  void resize(int numBytes) {
+    numWords = (numBytes + 7) >> 3;
+    if (numWords > bits.length) {
+      bits = new long[numWords];
+    }
+  }
+
+  void updateNumBits() {
+    int maxBits = numWords << 6;
+    numBits = maxBits; // satisfy assertion in prevSetBit?
+    numBits = prevSetBit(maxBits - 1) + 1;
+  }
+
+  int length() {
+    return numBits;
+  }
+
+  long[] getBits() {
+    return bits;
+  }
+
+  int nextSetBit(int index) {
+    // Depends on the ghost bits being clear!
+    assert index >= 0 && index < numBits : "index=" + index + ", numBits=" + numBits;
+    int i = index >> 6;
+    long word = bits[i] >> index; // skip all the bits to the right of index
+
+    if (word != 0) {
+      return index + Long.numberOfTrailingZeros(word);
+    }
+
+    while (++i < numWords) {
+      word = bits[i];
+      if (word != 0) {
+        return (i << 6) + Long.numberOfTrailingZeros(word);
+      }
+    }
+
+    return NO_MORE_DOCS;
+  }
+
+  int prevSetBit(int index) {
+    assert index >= 0 && index < numBits : "index=" + index + " numBits=" + numBits;
+    int i = index >> 6;
+    final int subIndex = index & 0x3f; // index within the word
+    long word = (bits[i] << (63 - subIndex)); // skip all the bits to the left of index
+
+    if (word != 0) {
+      return (i << 6) + subIndex - Long.numberOfLeadingZeros(word); // See LUCENE-3197
+    }
+
+    while (--i >= 0) {
+      word = bits[i];
+      if (word != 0) {
+        return (i << 6) + 63 - Long.numberOfLeadingZeros(word);
+      }
+    }
+
+    return -1;
+  }
+
+  /** Like nextSetBit, but returns NO_MORE_DOCS if index > length(). */
+  int checkNextSetBit(int index) {
+    if (index > numBits) {
+      return NO_MORE_DOCS;
+    }
+    return nextSetBit(index);
+  }
+
+  /**
+   * @param startIndex low end of the range, inclusive
+   * @param endIndex high end of the range, exclusive
+   * @return the number of set (1) bits in the given range
+   */
+  public int count(int startIndex, int endIndex) {
+    assert startIndex >= 0 && startIndex < numBits
+        : "startIndex=" + startIndex + ", numBits=" + numBits;
+    assert endIndex >= 0 && endIndex <= numBits : "endIndex=" + endIndex + ", numBits=" + numBits;
+    if (endIndex <= startIndex) {
+      return 0;
+    }
+    int startWord = startIndex >> 6;
+    int endWord = (endIndex - 1) >> 6;
+
+    // maybe we can have fewer operations if we shift the word and get rid of these masks...
+    long startmask = -1L << startIndex;
+    long endmask = -1L >>> -endIndex;
+
+    if (startWord == endWord) {
+      return Long.bitCount(bits[startWord] & startmask & endmask);
+    }
+    int total = Long.bitCount(bits[startWord] & startmask) + Long.bitCount(bits[endWord] & endmask);
+    for (int word = startWord + 1; word < endWord; word++) {
+      total += Long.bitCount(bits[word]);
+    }
+    return total;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/PostingBits.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/PostingBits.java
@@ -27,8 +27,12 @@ final class PostingBits {
   private int numBits; // The number of bits in use
   private int numWords; // The exact number of longs needed to hold numBits (<= bits.length)
 
-  PostingBits(int numWords) {
-    this.numWords = numWords;
+  PostingBits() {
+    this(8);
+  }
+
+  PostingBits(int initialCapacity) {
+    this.numWords = initialCapacity;
     this.bits = new long[numWords];
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -533,6 +533,34 @@ public final class FixedBitSet extends BitSet {
     bits[endWord] |= endmask;
   }
 
+  /**
+   * @param startIndex low end of the range, inclusive
+   * @param endIndex high end of the range, exclusive
+   * @return the number of set (1) bits in the given range
+   */
+  public int count(int startIndex, int endIndex) {
+    assert startIndex >= 0 && startIndex < numBits
+        : "startIndex=" + startIndex + ", numBits=" + numBits;
+    assert endIndex >= 0 && endIndex <= numBits : "endIndex=" + endIndex + ", numBits=" + numBits;
+    if (endIndex <= startIndex) {
+      return 0;
+    }
+    int startWord = startIndex >> 6;
+    int endWord = (endIndex - 1) >> 6;
+
+    long startmask = -1L << startIndex;
+    long endmask = -1L >>> -endIndex;
+
+    if (startWord == endWord) {
+      return Long.bitCount(bits[startWord] & startmask & endmask);
+    }
+    int total = Long.bitCount(bits[startWord] & startmask) + Long.bitCount(bits[endWord] & endmask);
+    for (int word = startWord + 1; word < endWord; word++) {
+      total += Long.bitCount(bits[word]);
+    }
+    return total;
+  }
+
   @Override
   public void clear(int startIndex, int endIndex) {
     assert startIndex >= 0 && startIndex < numBits

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestDenseUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestDenseUtil.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene99;
+
+import org.apache.lucene.store.ByteArrayDataInput;
+import org.apache.lucene.store.ByteArrayDataOutput;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestDenseUtil extends LuceneTestCase {
+
+  private byte[] outBytes = new byte[128];
+  private ByteArrayDataOutput out = new ByteArrayDataOutput(outBytes);
+
+  public void testEncodeOne() throws Exception {
+    long[] longs = {0};
+    DenseUtil.encodeDeltas(longs, 1, out);
+    assertEquals(2, out.getPosition());
+    // length byte
+    assertEquals((byte) (0x80 | 1), outBytes[0]);
+    // first bit set
+    assertEquals(1, outBytes[1]);
+  }
+
+  public void testEncodeMoreThanOneLong() throws Exception {
+    // sum(longs) = 66
+    long[] longs = {0, 11, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1};
+    // start sum at 1 since even delta=0 requires 1 bit
+    long sum = 1;
+    for (long l : longs) {
+      sum += l;
+    }
+    assertEquals(67, sum);
+    DenseUtil.encodeDeltas(longs, 67, out);
+    assertEquals(10, out.getPosition());
+    // length byte
+    assertEquals((byte) (0x80 | 9), outBytes[0]);
+    // 0 (1) + (11 - 4)
+    assertEquals(1, outBytes[1]);
+    // (11 - 7) + 2 + (3 - 1)
+    assertEquals(0b00101000, outBytes[2]);
+    // (3 - 2) + 4 + (5 - 2)
+    assertEquals(0b00010001, outBytes[3]);
+    // (5 - 3) + 6
+    assertEquals((byte) 0b10000010, outBytes[4]);
+    // (7) + (8 - 7)
+    assertEquals(0b01000000, outBytes[5]);
+    // (8 - 1) + (9 - 8)
+    assertEquals(0b01000000, outBytes[6]);
+    // (9 - 1)
+    assertEquals((byte) 0b10000000, outBytes[7]);
+    // (10 - 2)
+    assertEquals(0, outBytes[8]);
+    // (10 - 8) + 1
+    assertEquals(0b00000110, outBytes[9]);
+  }
+
+  public void testDecodeRandom() throws Exception {
+    // max id we can encode is 8 * 128 = 1024
+    int numDocs = random().nextInt(64);
+    long[] deltas = new long[numDocs];
+    long[] docids = new long[numDocs];
+    long sum = 1;
+    deltas[0] = random().nextInt(16); // can be zero
+    sum += deltas[0];
+    docids[0] = deltas[0];
+    long lastDocId = docids[0];
+    for (int i = 1; i < numDocs; i++) {
+      deltas[i] = random().nextInt(1, 16);
+      sum += deltas[i];
+      docids[i] = lastDocId + deltas[i];
+      lastDocId = docids[i];
+    }
+    DenseUtil.encodeDeltas(deltas, (int) sum, out);
+    ByteArrayDataInput in = new ByteArrayDataInput(outBytes);
+    byte headerByte = in.readByte();
+    PostingBits bits = new PostingBits(1);
+    DenseUtil.readBlock(headerByte & 0x7f, in, bits);
+
+    int i = 0, nextBit = -1;
+    do {
+      nextBit = bits.nextSetBit(nextBit + 1);
+      assertEquals("wrong doc @" + i, docids[i++], nextBit);
+    } while (i < numDocs);
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentTermEnum.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentTermEnum.java
@@ -144,8 +144,7 @@ public class TestSegmentTermEnum extends LuceneTestCase {
       assertEquals(200, termEnum.docFreq());
       PostingsEnum postingsEnum = termEnum.postings(null);
       int count = 0;
-      int doc = -1;
-      while ((doc = postingsEnum.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+      while (postingsEnum.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
         count += 1;
       }
       assertEquals(200, count);

--- a/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
@@ -636,4 +636,34 @@ public class TestFixedBitSet extends BaseBitSetTestCase<FixedBitSet> {
     set.set(5);
     assertTrue(bits.get(5));
   }
+
+  public void testCount() {
+    int size = random().nextInt(1, 1000);
+    int numSet = random().nextInt(2000);
+    FixedBitSet bitset = new FixedBitSet(size);
+    int countSet = 0;
+    for (int i = 0; i < numSet; i++) {
+      int bitIndex = random().nextInt(size);
+      if (bitset.get(bitIndex) == false) {
+        countSet += 1;
+        bitset.set(bitIndex);
+      }
+    }
+    assertEquals(countSet, bitset.count(0, size));
+    assertEquals(0, bitset.count(0, 0));
+    if (size > 1) {
+      assertEquals(0, bitset.count(size - 1, size - 2));
+    }
+    for (int i = 0; i < 20; i++) {
+      int startIndex = random().nextInt(size);
+      int endIndex = random().nextInt(startIndex, size);
+      int count = 0;
+      for (int j = startIndex; j < endIndex; j++) {
+        if (bitset.get(j)) {
+          count += 1;
+        }
+      }
+      assertEquals(count, bitset.count(startIndex, endIndex));
+    }
+  }
 }


### PR DESCRIPTION
This is a proof-of-concept of encoding postings using dense bitmaps that encode both docs that have (with 1s) and don't have (with 0s) a term in them. It has various nocommits and it is still TBD whether this is worth pursuing. See #13147  