### PR TITLE
Hunspell: don't proceed with other suggestions if we found good REP ones

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -204,6 +204,8 @@ Improvements
 
 * GITHUB#13155: Hunspell: allow ignoring exceptions on duplicate ICONV/OCONV mappings (Peter Gromov)
 
+* GITHUB#13156: Hunspell: don't proceed with other suggestions if we found good REP ones (Peter Gromov)
+
 Optimizations
 ---------------------
 

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/ph.sug
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/ph.sug
@@ -1,11 +1,11 @@
 a lot
-in spite, inspire
+in spite
 what
 what
 Wednesday
 Wednesday
 Wednesday
 Wednesday
-which, witch, winch, wish
+which, witch
 Oh, my gosh!
 OH, MY GOSH!

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/rep.sug
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/rep.sug
@@ -5,6 +5,6 @@ a lot, lot
 un alunno
 bar
 vinte e un
-auto's, auto
+auto's
 art nouveau
 nouveau


### PR DESCRIPTION
This makes "rep" and "ph" from TestHunspellRepositoryTestCases pass on latest revisions of the original Hunspell (after https://github.com/hunspell/hunspell/commit/b88f9ea57bdb9b219f3c1d2c67f4f882f1f23194)
