### PR TITLE
Fix TestDocumentsImpl.testFirstTermDoc

### DIFF
--- a/lucene/luke/src/test/org/apache/lucene/luke/models/documents/TestDocumentsImpl.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/documents/TestDocumentsImpl.java
@@ -186,8 +186,7 @@ public class TestDocumentsImpl extends DocumentsTestBase {
     documents.firstTerm("title").orElseThrow(IllegalStateException::new);
     Term term = documents.seekTerm("adv").orElseThrow(IllegalStateException::new);
     assertEquals("adventures", term.text());
-    int docid = documents.firstTermDoc().orElseThrow(IllegalStateException::new);
-    assertEquals(1, docid);
+    assertTrue(documents.firstTermDoc().isPresent());
   }
 
   @Test


### PR DESCRIPTION
### Description

`TestDocumentsImpl` uses the `DocumentsTestBase`, which uses the `RandomIndexWriter` internally for setting up documents to test on. `addDocument` inside `RandomIndexWriter` can lead to a different sequence of doc id assignments. Therefore it probably makes sense to simply check for the existence of a document with the specified term (it's the only containing `adv` in `DocumentsTestBase`) instead of asserting on the id, which is influenced by the writing order. 

Test passes with failing seed `2BA7909ED992C491`.

Closes https://github.com/apache/lucene/issues/13130.
