### PR TITLE
Fix demo application, if no knn dict was provided and over 100 docs are indexed

### DIFF
--- a/lucene/demo/src/java/org/apache/lucene/demo/IndexFiles.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/IndexFiles.java
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Date;
+import java.util.Objects;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.demo.knn.DemoEmbeddings;
@@ -175,7 +176,8 @@ public class IndexFiles implements AutoCloseable {
                 + " documents in "
                 + (end.getTime() - start.getTime())
                 + " ms");
-        if (reader.numDocs() > 100
+        if (Objects.isNull(vectorDictSource) == false
+            && reader.numDocs() > 100
             && vectorDictSize < 1_000_000
             && System.getProperty("smoketester") == null) {
           throw new RuntimeException(


### PR DESCRIPTION
### Description

If you index over 100 documents with the demo application without providing a KnnVector dictionary via the `-knn-dict` parameter you'll run always into this [code path](https://github.com/apache/lucene/blob/49db29e59f1d9c7de33bc09d42334a6afab943ac/lucene/demo/src/java/org/apache/lucene/demo/IndexFiles.java#L178-L183), which throws an exception. This PR extends the condition to only be executed, if an actual KnnVector dictionary was provided.

Note: As `test-files/docs` only contains 16 documents I hesitated to introduce additional 85 docs just for testing this specific functionality of the demo application. Happy to add it anyway, if needed. We could also parameterise the thresholds via an additional constructor, but again don't know, how extensively this should be tested.

Closes https://github.com/apache/lucene/issues/12330
