### PR TITLE
Made the UnifiedHighlighter's hasUnrecognizedQuery function processes FunctionQuery the same way as MatchAllDocsQuery and MatchNoDocsQuery queries for performance reasons.

### DIFF
--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -100,11 +100,8 @@ public class UnifiedHighlighter {
 
   public static final int DEFAULT_CACHE_CHARS_THRESHOLD = 524288; // ~ 1 MB (2 byte chars)
 
-  public static final Set<Class<? extends Query>> QUERIES_WITH_NO_HL_EFFECT = Set.of(
-    MatchAllDocsQuery.class,
-    MatchNoDocsQuery.class,
-    FunctionQuery.class
-  );
+  public static final Set<Class<? extends Query>> QUERIES_WITH_NO_HL_EFFECT =
+      Set.of(MatchAllDocsQuery.class, MatchNoDocsQuery.class, FunctionQuery.class);
 
   protected static final LabelledCharArrayMatcher[] ZERO_LEN_AUTOMATA_ARRAY =
       new LabelledCharArrayMatcher[0];
@@ -1138,7 +1135,8 @@ public class UnifiedHighlighter {
           public void visitLeaf(Query query) {
             if (MultiTermHighlighting.canExtractAutomataFromLeafQuery(query) == false) {
               boolean no_effect_query = false;
-              for (Class<? extends Query> queryType: UnifiedHighlighter.QUERIES_WITH_NO_HL_EFFECT) {
+              for (Class<? extends Query> queryType :
+                  UnifiedHighlighter.QUERIES_WITH_NO_HL_EFFECT) {
                 if (queryType.isInstance(query)) {
                   no_effect_query = true;
                   break;

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -49,6 +49,7 @@ import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermVectors;
+import org.apache.lucene.queries.function.FunctionQuery;
 import org.apache.lucene.queries.spans.SpanQuery;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
@@ -1130,7 +1131,7 @@ public class UnifiedHighlighter {
           @Override
           public void visitLeaf(Query query) {
             if (MultiTermHighlighting.canExtractAutomataFromLeafQuery(query) == false) {
-              if (!(query instanceof MatchAllDocsQuery || query instanceof MatchNoDocsQuery)) {
+              if (!(query instanceof MatchAllDocsQuery || query instanceof MatchNoDocsQuery || query instanceof FunctionQuery)) {
                 hasUnknownLeaf[0] = true;
               }
             }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -100,6 +100,12 @@ public class UnifiedHighlighter {
 
   public static final int DEFAULT_CACHE_CHARS_THRESHOLD = 524288; // ~ 1 MB (2 byte chars)
 
+  public static final Set<Class<? extends Query>> QUERIES_WITH_NO_HL_EFFECT = Set.of(
+    MatchAllDocsQuery.class,
+    MatchNoDocsQuery.class,
+    FunctionQuery.class
+  );
+
   protected static final LabelledCharArrayMatcher[] ZERO_LEN_AUTOMATA_ARRAY =
       new LabelledCharArrayMatcher[0];
 
@@ -1131,9 +1137,15 @@ public class UnifiedHighlighter {
           @Override
           public void visitLeaf(Query query) {
             if (MultiTermHighlighting.canExtractAutomataFromLeafQuery(query) == false) {
-              if (!(query instanceof MatchAllDocsQuery
-                  || query instanceof MatchNoDocsQuery
-                  || query instanceof FunctionQuery)) {
+              boolean no_effect_query = false;
+              for (Class<? extends Query> queryType: UnifiedHighlighter.QUERIES_WITH_NO_HL_EFFECT) {
+                if (queryType.isInstance(query)) {
+                  no_effect_query = true;
+                  break;
+                }
+              }
+
+              if (!no_effect_query) {
                 hasUnknownLeaf[0] = true;
               }
             }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -1131,7 +1131,9 @@ public class UnifiedHighlighter {
           @Override
           public void visitLeaf(Query query) {
             if (MultiTermHighlighting.canExtractAutomataFromLeafQuery(query) == false) {
-              if (!(query instanceof MatchAllDocsQuery || query instanceof MatchNoDocsQuery || query instanceof FunctionQuery)) {
+              if (!(query instanceof MatchAllDocsQuery
+                  || query instanceof MatchNoDocsQuery
+                  || query instanceof FunctionQuery)) {
                 hasUnknownLeaf[0] = true;
               }
             }

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighter.java
@@ -38,11 +38,14 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.function.FunctionQuery;
+import org.apache.lucene.queries.function.valuesource.ConstValueSource;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
@@ -1659,6 +1662,54 @@ public class TestUnifiedHighlighter extends UnifiedHighlighterTestBase {
 
     String[] snippets = highlighter.highlight("title", query, topDocs);
     assertArrayEquals(new String[] {"This is the <b>title</b> field."}, snippets);
+
+    ir.close();
+  }
+
+  public void testPostingsOffsetStrategy() throws Exception {
+    if (this.fieldType.indexOptions() != IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS
+        || this.fieldType.storeTermVectors())
+      // ignore if fieldType is not POSTINGS only
+      return;
+
+    RandomIndexWriter iw = newIndexOrderPreservingWriter();
+
+    Field body = new Field("body", "", fieldType);
+    Document doc = new Document();
+    doc.add(body);
+
+    body.setStringValue(
+        "This is a test. Just a test highlighting from postings. Feel free to ignore.");
+    iw.addDocument(doc);
+    body.setStringValue("Highlighting the first term. Hope it works.");
+    iw.addDocument(doc);
+
+    IndexReader ir = iw.getReader();
+    iw.close();
+
+    IndexSearcher searcher = newSearcher(ir);
+    UnifiedHighlighter highlighter = randomUnifiedHighlighter(searcher, indexAnalyzer);
+    Query query = new TermQuery(new Term("body", "highlighting"));
+    TopDocs topDocs = searcher.search(query, 10, Sort.INDEXORDER);
+
+    Set<Term> queryTerms = UnifiedHighlighter.extractTerms(query);
+    FieldHighlighter fieldHighlighter = highlighter.getFieldHighlighter("body", query, queryTerms, 1);
+    assertEquals(UnifiedHighlighter.OffsetSource.POSTINGS, fieldHighlighter.getOffsetSource()); // TermQuery is compatible with POSTINGS offset strategy
+
+    String[] snippets = highlighter.highlight("body", query, topDocs);
+
+    for (Query noEffectQuery: new Query[] {new MatchAllDocsQuery(), new FunctionQuery(new ConstValueSource(5))}) {
+      final Query booleanQuery = new BooleanQuery.Builder()
+            .add(noEffectQuery, BooleanClause.Occur.MUST)
+            .add(query, BooleanClause.Occur.MUST)
+            .build();
+      queryTerms = UnifiedHighlighter.extractTerms(booleanQuery);
+      fieldHighlighter = highlighter.getFieldHighlighter("body", booleanQuery, queryTerms, 1);
+      assertEquals(noEffectQuery.getClass().toString(), UnifiedHighlighter.OffsetSource.POSTINGS, fieldHighlighter.getOffsetSource()); // combining to a query with no effet (on highlighting) should lead to the same highlighter behavior
+
+      String[] bqSnippets = highlighter.highlight("body", query, topDocs);
+      assertArrayEquals(bqSnippets.toString(), snippets, bqSnippets); // ensuring that the combined query does produce the same output
+    }
 
     ir.close();
   }

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighter.java
@@ -46,6 +46,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
@@ -1704,7 +1705,7 @@ public class TestUnifiedHighlighter extends UnifiedHighlighterTestBase {
 
     String[] snippets = highlighter.highlight("body", query, topDocs);
 
-    for (Query noEffectQuery: new Query[] {new MatchAllDocsQuery(), new FunctionQuery(new ConstValueSource(5))}) {
+    for (Query noEffectQuery: new Query[] {new MatchAllDocsQuery(), new MatchNoDocsQuery(), new FunctionQuery(new ConstValueSource(5))}) {
       final Query booleanQuery = new BooleanQuery.Builder()
             .add(noEffectQuery, BooleanClause.Occur.MUST)
             .add(query, BooleanClause.Occur.MUST)

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighter.java
@@ -1672,6 +1672,12 @@ public class TestUnifiedHighlighter extends UnifiedHighlighterTestBase {
       // ignore if fieldType is not POSTINGS only
       return;
 
+    final UnifiedHighlighter.OffsetSource expectedOffsetSource;
+    if (this.fieldType.storeTermVectors())
+      expectedOffsetSource = UnifiedHighlighter.OffsetSource.POSTINGS_WITH_TERM_VECTORS;
+    else
+      expectedOffsetSource = UnifiedHighlighter.OffsetSource.POSTINGS;
+
     RandomIndexWriter iw = newIndexOrderPreservingWriter();
 
     Field body = new Field("body", "", fieldType);
@@ -1694,7 +1700,7 @@ public class TestUnifiedHighlighter extends UnifiedHighlighterTestBase {
 
     Set<Term> queryTerms = UnifiedHighlighter.extractTerms(query);
     FieldHighlighter fieldHighlighter = highlighter.getFieldHighlighter("body", query, queryTerms, 1);
-    assertEquals(UnifiedHighlighter.OffsetSource.POSTINGS, fieldHighlighter.getOffsetSource()); // TermQuery is compatible with POSTINGS offset strategy
+    assertEquals(expectedOffsetSource, fieldHighlighter.getOffsetSource()); // TermQuery is compatible with POSTINGS offset strategy
 
     String[] snippets = highlighter.highlight("body", query, topDocs);
 
@@ -1705,7 +1711,7 @@ public class TestUnifiedHighlighter extends UnifiedHighlighterTestBase {
             .build();
       queryTerms = UnifiedHighlighter.extractTerms(booleanQuery);
       fieldHighlighter = highlighter.getFieldHighlighter("body", booleanQuery, queryTerms, 1);
-      assertEquals(noEffectQuery.getClass().toString(), UnifiedHighlighter.OffsetSource.POSTINGS, fieldHighlighter.getOffsetSource()); // combining to a query with no effet (on highlighting) should lead to the same highlighter behavior
+      assertEquals(noEffectQuery.getClass().toString(), expectedOffsetSource, fieldHighlighter.getOffsetSource()); // combining to a query with no effet (on highlighting) should lead to the same highlighter behavior
 
       String[] bqSnippets = highlighter.highlight("body", query, topDocs);
       assertArrayEquals(bqSnippets.toString(), snippets, bqSnippets); // ensuring that the combined query does produce the same output

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/visibility/TestUnifiedHighlighterExtensibility.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/visibility/TestUnifiedHighlighterExtensibility.java
@@ -27,11 +27,14 @@ import java.util.function.Predicate;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.function.FunctionQuery;
+import org.apache.lucene.queries.function.valuesource.ConstValueSource;
 import org.apache.lucene.queries.spans.SpanQuery;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.uhighlight.FieldHighlighter;
 import org.apache.lucene.search.uhighlight.FieldOffsetStrategy;
 import org.apache.lucene.search.uhighlight.LabelledCharArrayMatcher;
@@ -88,6 +91,33 @@ public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
           }
         };
     assertEquals(offsetSource, strategy.getOffsetSource());
+  }
+
+  static class TestExtendedUnifiedHighlighter extends UnifiedHighlighter {
+    boolean supportsNewQueryType = false;
+
+    public TestExtendedUnifiedHighlighter(Builder builder) {
+      super(builder);
+    }
+
+    @Override
+    protected boolean isIgnorableQuery(Query q) {
+      return super.isIgnorableQuery(q) || (this.supportsNewQueryType && q instanceof TermQuery);
+    }
+  }
+  ;
+
+  @Test
+  public void testUnifiedHighlighterIgnorableQueryExtensibility() {
+    final UnifiedHighlighter.Builder uhBuilder =
+        new UnifiedHighlighter.Builder(null, new MockAnalyzer(random()));
+    final TestExtendedUnifiedHighlighter uh = new TestExtendedUnifiedHighlighter(uhBuilder);
+
+    assertTrue(uh.isIgnorableQuery(new MatchAllDocsQuery()));
+    assertTrue(uh.isIgnorableQuery(new FunctionQuery(new ConstValueSource(46))));
+    assertFalse(uh.isIgnorableQuery(new TermQuery(new Term("term"))));
+    uh.supportsNewQueryType = true;
+    assertTrue(uh.isIgnorableQuery(new TermQuery(new Term("term"))));
   }
 
   /**


### PR DESCRIPTION
### Description

This pull request is a follow up to #12938. I took on the task of complying with @romseygeek's comment on behalf of [Lexum](https://lexum.com/en/).
I also rebased to the latest commit of `apache:main`.

Let me know if any other adjustment is needed.