### PR TITLE
Fix potential race condition in DocumentsWriter & DocumentsWriterDeleteQueue

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -230,6 +230,8 @@ Bug Fixes
 
 * GITHUB#13154: Hunspell GeneratingSuggester: ensure there are never more than 100 roots to process (Peter Gromov)
 
+* GITHUB#13169: Fix potential race condition in DocumentsWriter & DocumentsWriterDeleteQueue (Ben Trent)
+
 Other
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
@@ -540,13 +540,16 @@ final class DocumentsWriter implements Closeable, Accountable {
     return deleteQueue.getNextSequenceNumber();
   }
 
-  synchronized void resetDeleteQueue(DocumentsWriterDeleteQueue newQueue) {
+  synchronized long resetDeleteQueue(int maxNumPendingOps) {
+    final DocumentsWriterDeleteQueue newQueue = deleteQueue.advanceQueue(maxNumPendingOps);
     assert deleteQueue.isAdvanced();
     assert newQueue.isAdvanced() == false;
     assert deleteQueue.getLastSequenceNumber() <= newQueue.getLastSequenceNumber();
     assert deleteQueue.getMaxSeqNo() <= newQueue.getLastSequenceNumber()
         : "maxSeqNo: " + deleteQueue.getMaxSeqNo() + " vs. " + newQueue.getLastSequenceNumber();
+    long oldMaxSeqNo = deleteQueue.getMaxSeqNo();
     deleteQueue = newQueue;
+    return oldMaxSeqNo;
   }
 
   interface FlushNotifications { // TODO maybe we find a better name for this?

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -570,10 +570,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
         // Insert a gap in seqNo of current active thread count, in the worst case each of those
         // threads now have one operation in flight.  It's fine
         // if we have some sequence numbers that were never assigned:
-        DocumentsWriterDeleteQueue newQueue =
-            documentsWriter.deleteQueue.advanceQueue(perThreadPool.size());
-        seqNo = documentsWriter.deleteQueue.getMaxSeqNo();
-        documentsWriter.resetDeleteQueue(newQueue);
+        seqNo = documentsWriter.resetDeleteQueue(perThreadPool.size());
       } finally {
         perThreadPool.unlockNewWriters();
       }


### PR DESCRIPTION
13127 is failing due to seqNo being larger than `maxSeqNo` on `close()`. 

`maxSeqNo` is set during `DocumentsWriterDeleteQueue#advanceQueue`, synchronized on self. It utilizes `getLastSequenceNumber()`, which reads the `AtomicLong` for `seqNo`. 

However, `DocumentsWriterDeleteQueue#getNextSequenceNumber()` is not synchronized on self. Meaning after (or before) reading the `AtomicLong`, it could be incremented by this method. 

`DocumentsWriterDeleteQueue#getNextSequenceNumber()` is called in other synchronized methods, the one external one being `DocumentsWriter#getNextSequenceNumber`, which is synchronized on self (e.g. DocumentsWriter). 

When calling `DocumentsWriterFlushControl#markFullFlush`, neither the `DocumentsWriterDeleteQueue` nor `DocumentsWriterDeleteQueue` are locked, and it is possible for `documentsWriter.getNextSequenceNumber()` to be called after `documentsWriter.deleteQueue.advanceQueue` but before `documentsWriter.resetDeleteQueue`.

This commit moves the `documentsWriter.deleteQueue.advanceQueue` call into the already synchronized `documentsWriter.resetDeleteQueue` to ensure that `getNextSequenceNumber` cannot be called while the queue is being reset.

This is admittedly difficult to fully test. But I have seen many failures in continuous testing. So, if this commit does fix that test, I would expect those to disappear.

closes: https://github.com/apache/lucene/issues/13127