### PR TITLE
Fix middle of sentence calculation in OpenNLPSentenceBreakIterator.preceding

### DIFF
--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPSentenceBreakIterator.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPSentenceBreakIterator.java
@@ -148,7 +148,7 @@ public final class OpenNLPSentenceBreakIterator extends BreakIterator {
       currentSentence = 0;
       return DONE;
     } else {
-      currentSentence = sentenceStarts.length / 2; // start search from the middle
+      currentSentence = (sentenceStarts.length - 1) / 2; // start search from the middle
       moveToSentenceAt(pos, 0, sentenceStarts.length - 1);
       if (0 == currentSentence) {
         text.setIndex(text.getBeginIndex());

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPSentenceBreakIterator.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPSentenceBreakIterator.java
@@ -203,6 +203,17 @@ public class TestOpenNLPSentenceBreakIterator extends LuceneTestCase {
     test0Sentences(bi);
   }
 
+  public void testPrecedingWithTwoSentences() throws IOException {
+    NLPSentenceDetectorOp sentenceDetectorOp =
+        OpenNLPOpsFactory.getSentenceDetector(sentenceModelFile);
+    BreakIterator bi = new OpenNLPSentenceBreakIterator(sentenceDetectorOp);
+    bi.setText("This is sentence one. This is sentence two.");
+
+    // set pos to somewhere in the second sentence
+    int precedingSentence = bi.preceding(25);
+    assertEquals(0, precedingSentence);
+  }
+
   private void test0Sentences(BreakIterator bi) {
     assertEquals(0, bi.current());
     assertEquals(0, bi.first());


### PR DESCRIPTION
The method [`preceding`](https://github.com/apache/lucene/blob/6445bc0a14ee22d107c072f4ef7b133faf780fe1/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPSentenceBreakIterator.java#L151) and [`following`](https://github.com/apache/lucene/blob/6445bc0a14ee22d107c072f4ef7b133faf780fe1/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPSentenceBreakIterator.java#L89) calculate the middle of a sentence differently. If the input text contains two sentences trying to get the preceding sentence to the second sentence will lead to an `ArrayIndexOutOfBoundsException` in this [line](https://github.com/apache/lucene/blob/6445bc0a14ee22d107c072f4ef7b133faf780fe1/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPSentenceBreakIterator.java#L103) as `currentSentence` will be `1` and `currentSentence + 1` will be `2`, which is out of bounds by `1`.

I've added a test case, which fails for the old logic and passes for the new logic.

Closes https://github.com/apache/lucene/issues/12210.