### PR TITLE
Reduce some unnecessary ArrayUtil#grow calls

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefBuilder.java
@@ -57,7 +57,9 @@ public class BytesRefBuilder {
 
   /** Ensure that this builder can hold at least <code>capacity</code> bytes without resizing. */
   public void grow(int capacity) {
-    ref.bytes = ArrayUtil.grow(ref.bytes, capacity);
+    if (ref.bytes.length < capacity) {
+      ref.bytes = ArrayUtil.grow(ref.bytes, capacity);
+    }
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/IntsRefBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntsRefBuilder.java
@@ -74,7 +74,9 @@ public class IntsRefBuilder {
    * @lucene.internal
    */
   public void grow(int newLength) {
-    ref.ints = ArrayUtil.grow(ref.ints, newLength);
+    if (ref.ints.length < newLength) {
+      ref.ints = ArrayUtil.grow(ref.ints, newLength);
+    }
   }
 
   /** Grow the reference array without copying the origin data to the new array. */


### PR DESCRIPTION
This change will slightly improve the performance of `DataOutput#writeGroupVInts` and some other methods related to `XXXRefBuilder#append`.

Here is a JMH benchmark for `Util.toIntsRef`, using java 21 on my MAC (intel chip).

```
Benchmark                    Mode  Cnt   Score   Error   Units
PR   ToIntsRefBenchMark.run  thrpt    5  38.208 ± 1.054  ops/us
main ToIntsRefBenchMark.run  thrpt    5   7.862 ± 0.832  ops/us
```


JMH benchmark code for `Util#toIntsRef`:

```java
public class ToIntsRefBenchMark {
  IntsRefBuilder intsRefBuilder = new IntsRefBuilder();
  BytesRef bytesRef = new BytesRef(new byte[32]);

  @Benchmark
  public void run() {
    Util.toIntsRef(bytesRef, intsRefBuilder);
  }
}
```
