### PR TITLE
Introduce IORunnable to fix failure in TestIndexWriterOnDiskFull.testAddIndexOnDiskFull

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene86/Lucene86PointsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene86/Lucene86PointsWriter.java
@@ -33,6 +33,7 @@ import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.IORunnable;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.bkd.BKDConfig;
 import org.apache.lucene.util.bkd.BKDWriter;
@@ -143,7 +144,7 @@ public class Lucene86PointsWriter extends PointsWriter {
             values.size())) {
 
       if (values instanceof MutablePointTree) {
-        Runnable finalizer =
+        IORunnable finalizer =
             writer.writeField(
                 metaOut, indexOut, dataOut, fieldInfo.name, (MutablePointTree) values);
         if (finalizer != null) {
@@ -172,7 +173,7 @@ public class Lucene86PointsWriter extends PointsWriter {
           });
 
       // We could have 0 points on merge since all docs with dimensional fields may be deleted:
-      Runnable finalizer = writer.finish(metaOut, indexOut, dataOut);
+      IORunnable finalizer = writer.finish(metaOut, indexOut, dataOut);
       if (finalizer != null) {
         metaOut.writeInt(fieldInfo.number);
         finalizer.run();
@@ -267,7 +268,7 @@ public class Lucene86PointsWriter extends PointsWriter {
               }
             }
 
-            Runnable finalizer = writer.merge(metaOut, indexOut, dataOut, docMaps, pointValues);
+            IORunnable finalizer = writer.merge(metaOut, indexOut, dataOut, docMaps, pointValues);
             if (finalizer != null) {
               metaOut.writeInt(fieldInfo.number);
               finalizer.run();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsWriter.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.IORunnable;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.bkd.BKDConfig;
 import org.apache.lucene.util.bkd.BKDWriter;
@@ -137,7 +138,7 @@ public class Lucene90PointsWriter extends PointsWriter {
             values.size())) {
 
       if (values instanceof MutablePointTree) {
-        Runnable finalizer =
+        IORunnable finalizer =
             writer.writeField(
                 metaOut, indexOut, dataOut, fieldInfo.name, (MutablePointTree) values);
         if (finalizer != null) {
@@ -166,7 +167,7 @@ public class Lucene90PointsWriter extends PointsWriter {
           });
 
       // We could have 0 points on merge since all docs with dimensional fields may be deleted:
-      Runnable finalizer = writer.finish(metaOut, indexOut, dataOut);
+      IORunnable finalizer = writer.finish(metaOut, indexOut, dataOut);
       if (finalizer != null) {
         metaOut.writeInt(fieldInfo.number);
         finalizer.run();
@@ -261,7 +262,7 @@ public class Lucene90PointsWriter extends PointsWriter {
               }
             }
 
-            Runnable finalizer = writer.merge(metaOut, indexOut, dataOut, docMaps, pointValues);
+            IORunnable finalizer = writer.merge(metaOut, indexOut, dataOut, docMaps, pointValues);
             if (finalizer != null) {
               metaOut.writeInt(fieldInfo.number);
               finalizer.run();

--- a/lucene/core/src/java/org/apache/lucene/util/IORunnable.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IORunnable.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util;
+
+import java.io.IOException;
+
+/**
+ * A Runnable that may throw an IOException
+ *
+ * @see java.lang.Runnable
+ */
+@FunctionalInterface
+public interface IORunnable {
+  public abstract void run() throws IOException;
+}

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/Test4BBKDPoints.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/Test4BBKDPoints.java
@@ -26,6 +26,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.Monster;
+import org.apache.lucene.util.IORunnable;
 import org.apache.lucene.util.NumericUtils;
 
 // e.g. run like this: ant test -Dtestcase=Test4BBKDPoints -Dtests.nightly=true -Dtests.verbose=true
@@ -66,7 +67,7 @@ public class Test4BBKDPoints extends LuceneTestCase {
       }
     }
     IndexOutput out = dir.createOutput("1d.bkd", IOContext.DEFAULT);
-    Runnable finalizer = w.finish(out, out, out);
+    IORunnable finalizer = w.finish(out, out, out);
     long indexFP = out.getFilePointer();
     finalizer.run();
     out.close();
@@ -115,7 +116,7 @@ public class Test4BBKDPoints extends LuceneTestCase {
       }
     }
     IndexOutput out = dir.createOutput("2d.bkd", IOContext.DEFAULT);
-    Runnable finalizer = w.finish(out, out, out);
+    IORunnable finalizer = w.finish(out, out, out);
     long indexFP = out.getFilePointer();
     finalizer.run();
     out.close();

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
@@ -41,6 +41,7 @@ import org.apache.lucene.tests.store.MockDirectoryWrapper;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IORunnable;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.NumericUtils;
 
@@ -62,7 +63,7 @@ public class TestBKD extends LuceneTestCase {
 
       long indexFP;
       try (IndexOutput out = dir.createOutput("bkd", IOContext.DEFAULT)) {
-        Runnable finalizer = w.finish(out, out, out);
+        IORunnable finalizer = w.finish(out, out, out);
         indexFP = out.getFilePointer();
         finalizer.run();
       }
@@ -133,7 +134,7 @@ public class TestBKD extends LuceneTestCase {
 
       long indexFP;
       try (IndexOutput out = dir.createOutput("bkd", IOContext.DEFAULT)) {
-        Runnable finalizer = w.finish(out, out, out);
+        IORunnable finalizer = w.finish(out, out, out);
         indexFP = out.getFilePointer();
         finalizer.run();
       }
@@ -228,7 +229,7 @@ public class TestBKD extends LuceneTestCase {
 
       long indexFP;
       try (IndexOutput out = dir.createOutput("bkd", IOContext.DEFAULT)) {
-        Runnable finalizer = w.finish(out, out, out);
+        IORunnable finalizer = w.finish(out, out, out);
         indexFP = out.getFilePointer();
         finalizer.run();
       }
@@ -735,7 +736,7 @@ public class TestBKD extends LuceneTestCase {
           }
           final int curDocIDBase = lastDocIDBase;
           docMaps.add(docID1 -> curDocIDBase + docID1);
-          Runnable finalizer = w.finish(out, out, out);
+          IORunnable finalizer = w.finish(out, out, out);
           toMerge.add(out.getFilePointer());
           finalizer.run();
           valuesInThisSeg = TestUtil.nextInt(random(), numValues / 10, numValues / 2);
@@ -760,7 +761,7 @@ public class TestBKD extends LuceneTestCase {
 
       if (toMerge != null) {
         if (segCount > 0) {
-          Runnable finalizer = w.finish(out, out, out);
+          IORunnable finalizer = w.finish(out, out, out);
           toMerge.add(out.getFilePointer());
           finalizer.run();
           final int curDocIDBase = lastDocIDBase;
@@ -783,14 +784,14 @@ public class TestBKD extends LuceneTestCase {
           readers.add(getPointValues(in));
         }
         out = dir.createOutput("bkd2", IOContext.DEFAULT);
-        Runnable finalizer = w.merge(out, out, out, docMaps, readers);
+        IORunnable finalizer = w.merge(out, out, out, docMaps, readers);
         indexFP = out.getFilePointer();
         finalizer.run();
         out.close();
         in.close();
         in = dir.openInput("bkd2", IOContext.DEFAULT);
       } else {
-        Runnable finalizer = w.finish(out, out, out);
+        IORunnable finalizer = w.finish(out, out, out);
         indexFP = out.getFilePointer();
         finalizer.run();
         out.close();
@@ -1204,7 +1205,7 @@ public class TestBKD extends LuceneTestCase {
       }
 
       IndexOutput out = dir.createOutput("bkd", IOContext.DEFAULT);
-      Runnable finalizer = w.finish(out, out, out);
+      IORunnable finalizer = w.finish(out, out, out);
       long fp = out.getFilePointer();
       finalizer.run();
       out.close();
@@ -1270,7 +1271,7 @@ public class TestBKD extends LuceneTestCase {
     }
     final long indexFP;
     try (IndexOutput out = dir.createOutput("bkd", IOContext.DEFAULT)) {
-      Runnable finalizer = w.finish(out, out, out);
+      IORunnable finalizer = w.finish(out, out, out);
       indexFP = out.getFilePointer();
       finalizer.run();
       w.close();
@@ -1332,7 +1333,7 @@ public class TestBKD extends LuceneTestCase {
       }
 
       IndexOutput out = dir.createOutput("bkd", IOContext.DEFAULT);
-      Runnable finalizer = w.finish(out, out, out);
+      IORunnable finalizer = w.finish(out, out, out);
       long fp = out.getFilePointer();
       finalizer.run();
       out.close();
@@ -1399,7 +1400,7 @@ public class TestBKD extends LuceneTestCase {
     }
 
     IndexOutput out = dir.createOutput("bkd", IOContext.DEFAULT);
-    Runnable finalizer = w.finish(out, out, out);
+    IORunnable finalizer = w.finish(out, out, out);
     long fp = out.getFilePointer();
     finalizer.run();
     out.close();
@@ -1467,7 +1468,7 @@ public class TestBKD extends LuceneTestCase {
     }
     final long indexFP;
     try (IndexOutput out = dir.createOutput("bkd", IOContext.DEFAULT)) {
-      Runnable finalizer = w.finish(out, out, out);
+      IORunnable finalizer = w.finish(out, out, out);
       indexFP = out.getFilePointer();
       finalizer.run();
       w.close();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
@@ -53,6 +53,7 @@ import org.apache.lucene.tests.codecs.bloom.TestBloomFilteredLucenePostings;
 import org.apache.lucene.tests.codecs.mockrandom.MockRandomPostingsFormat;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.IORunnable;
 import org.apache.lucene.util.bkd.BKDConfig;
 import org.apache.lucene.util.bkd.BKDWriter;
 
@@ -149,7 +150,7 @@ public class RandomCodec extends AssertingCodec {
 
                   // We could have 0 points on merge since all docs with dimensional fields may be
                   // deleted:
-                  Runnable finalizer = writer.finish(metaOut, indexOut, dataOut);
+                  IORunnable finalizer = writer.finish(metaOut, indexOut, dataOut);
                   if (finalizer != null) {
                     metaOut.writeInt(fieldInfo.number);
                     finalizer.run();


### PR DESCRIPTION
As discussed in  #13116, The `Runnable` in `BKDWriter` won't be used in the `Thread` framework, it just call `run` method directly, this change introduce `IORunnable` to prevent throwing `UncheckedIOException`. 

Note: this failure reproducible on branch_9x and branch_9_10, but not reproducible on main branch for the same seed. Any suggestions is welcomed!

Closes #13116.
