### PR TITLE
Fix TestFloatVectorSimilarityQuery.testBoostQuery

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
@@ -17,7 +17,14 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;


### PR DESCRIPTION
### Description

For the following seed `gradlew test --tests TestFloatVectorSimilarityQuery.testBoostQuery -Dtests.seed=3F71A3D0594CEBC0 -Dtests.nightly=true -Dtests.locale=de-Latn-DE -Dtests.timezone=Pacific/Wallis -Dtests.asserts=true -Dtests.file.encoding=UTF-8` `TestFloatVectorSimilarityQuery.testBoostQuery` produced the following two doc scores:

- `doc 29`: `0.4278701`
- `doc 8`: `0.42787006`

With a boost factor of `5.3713555` the boosted doc scores looked like this:

- `doc 29`: `2.2982423`
- `doc 8`: `2.2982423`

So the boosted doc scores were the same due to floating point precision limitations, when multiplying the original scores with tiny differences with a fairly large multiplier.

My change removes the assertion expecting the exact order to be the same (AFAIU this won't be possible for every scores/boost configurations due to precision limitations), but rather asserts that the `original doc score * boost factor` and the `boosted doc score` are equals within a certain delta.

Test passed with seed `3F71A3D0594CEBC0`.

Closes https://github.com/apache/lucene/issues/13173.