### PR TITLE
Support disabling IndexSearcher.maxClauseCount with a value of -1

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -733,7 +733,9 @@ public class IndexSearcher {
         rewrittenQuery = query.rewrite(this)) {
       query = rewrittenQuery;
     }
-    query.visit(getNumClausesCheckVisitor());
+    if (maxClauseCount > -1) {
+      query.visit(getNumClausesCheckVisitor());
+    }
     return query;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/QueryVisitor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/QueryVisitor.java
@@ -99,5 +99,11 @@ public abstract class QueryVisitor {
   }
 
   /** A QueryVisitor implementation that does nothing */
-  public static final QueryVisitor EMPTY_VISITOR = new QueryVisitor() {};
+  public static final QueryVisitor EMPTY_VISITOR =
+      new QueryVisitor() {
+        @Override
+        public boolean acceptField(String field) {
+          return false;
+        }
+      };
 }


### PR DESCRIPTION
This PR allows `IndexSearcher.maxClauseCount` to be -1 with the meaning of there being no limit.  This avoids pointless query tree visiting. 
Tangential:`TermInSetQuery.visit()` is disappointing.