### PR TITLE
Doc reordering avoid iterations: cooling using simulated annealing

### DIFF
--- a/lucene/misc/src/java/org/apache/lucene/misc/index/BPIndexReorderer.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/index/BPIndexReorderer.java
@@ -472,8 +472,12 @@ public final class BPIndexReorderer {
 
         @Override
         public int comparePivot(int j) {
-          int cmp = Float.compare(pivotBias, biases[j]);
-          if (cmp == 0) {
+          int cmp = Float.compare(pivotBias-iter, biases[j]);
+          if (cmp > 0) {
+            return cmp;
+          }
+          cmp = Float.compare(pivotBias, biases[j]);
+          if (cmp >= 0) {
             // Tie break on the doc ID to preserve doc ID ordering as much as possible
             cmp = pivotDoc - docIDs.ints[j];
           }


### PR DESCRIPTION
### Description
As described in the paper (Tradeoff Options for Bipartite Graph Partitioning), simulated annealing-type mechanism can be employed to reduce number of swaps with each iteration. If projected advantage swapping 2 docs across partitions isn't as appealing, in this case less than `iter` bits, then swap can be avoided. 
Swapping documents is a heavy operation as it requires recomputing biases for documents which are affected by the swap i.e. have common terms with other documents in the partition. 
Currently, its only employed once before starting the shuffle operation, where we check against the max gain possible for a given iteration and if its at least `iter` bits apart. This condition can be checked with each swap when performing quick select, if its worthy.  

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
