### PR TITLE
Fix NPE for when fields are missing in `searchNearestVectors`

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -246,6 +246,9 @@ public abstract non-sealed class LeafReader extends IndexReader {
   public final TopDocs searchNearestVectors(
       String field, float[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException {
     FieldInfo fi = getFieldInfos().fieldInfo(field);
+    if (fi == null) {
+      return TopDocsCollector.EMPTY_TOPDOCS;
+    }
     FloatVectorValues floatVectorValues = getFloatVectorValues(fi.name);
     if (floatVectorValues == null) {
       return TopDocsCollector.EMPTY_TOPDOCS;
@@ -287,6 +290,9 @@ public abstract non-sealed class LeafReader extends IndexReader {
   public final TopDocs searchNearestVectors(
       String field, byte[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException {
     FieldInfo fi = getFieldInfos().fieldInfo(field);
+    if (fi == null) {
+      return TopDocsCollector.EMPTY_TOPDOCS;
+    }
     ByteVectorValues byteVectorValues = getByteVectorValues(fi.name);
     if (byteVectorValues == null) {
       return TopDocsCollector.EMPTY_TOPDOCS;

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -246,7 +246,7 @@ public abstract non-sealed class LeafReader extends IndexReader {
   public final TopDocs searchNearestVectors(
       String field, float[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException {
     FieldInfo fi = getFieldInfos().fieldInfo(field);
-    if (fi == null) {
+    if (fi == null || fi.getVectorDimension() == 0) {
       return TopDocsCollector.EMPTY_TOPDOCS;
     }
     FloatVectorValues floatVectorValues = getFloatVectorValues(fi.name);
@@ -290,7 +290,7 @@ public abstract non-sealed class LeafReader extends IndexReader {
   public final TopDocs searchNearestVectors(
       String field, byte[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException {
     FieldInfo fi = getFieldInfos().fieldInfo(field);
-    if (fi == null) {
+    if (fi == null || fi.getVectorDimension() == 0) {
       return TopDocsCollector.EMPTY_TOPDOCS;
     }
     ByteVectorValues byteVectorValues = getByteVectorValues(fi.name);

--- a/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
@@ -71,6 +71,36 @@ public class TestPerFieldKnnVectorsFormat extends BaseKnnVectorsFormatTestCase {
     return codec;
   }
 
+  public void testMissingFieldReturnsNoResults() throws IOException {
+    try (Directory directory = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig(new MockAnalyzer(random()));
+      iwc.setCodec(
+          new AssertingCodec() {
+            @Override
+            public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+              return TestUtil.getDefaultKnnVectorsFormat();
+            }
+          });
+      try (IndexWriter iwriter = new IndexWriter(directory, iwc)) {
+        Document doc = new Document();
+        doc.add(newTextField("id", "1", Field.Store.YES));
+        iwriter.addDocument(doc);
+      }
+
+      try (IndexReader ireader = DirectoryReader.open(directory)) {
+        LeafReader reader = ireader.leaves().get(0).reader();
+        TopDocs hits1 =
+            reader.searchNearestVectors(
+                "missing_field",
+                new float[] {1, 2, 3},
+                10,
+                reader.getLiveDocs(),
+                Integer.MAX_VALUE);
+        assertEquals(0, hits1.scoreDocs.length);
+      }
+    }
+  }
+
   public void testTwoFieldsTwoFormats() throws IOException {
     try (Directory directory = newDirectory()) {
       // we don't use RandomIndexWriter because it might add more values than we expect !!!!1

--- a/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
@@ -89,14 +89,18 @@ public class TestPerFieldKnnVectorsFormat extends BaseKnnVectorsFormatTestCase {
 
       try (IndexReader ireader = DirectoryReader.open(directory)) {
         LeafReader reader = ireader.leaves().get(0).reader();
-        TopDocs hits1 =
+        TopDocs hits =
             reader.searchNearestVectors(
                 "missing_field",
                 new float[] {1, 2, 3},
                 10,
                 reader.getLiveDocs(),
                 Integer.MAX_VALUE);
-        assertEquals(0, hits1.scoreDocs.length);
+        assertEquals(0, hits.scoreDocs.length);
+        hits =
+            reader.searchNearestVectors(
+                "id", new float[] {1, 2, 3}, 10, reader.getLiveDocs(), Integer.MAX_VALUE);
+        assertEquals(0, hits.scoreDocs.length);
       }
     }
   }


### PR DESCRIPTION
Related to: https://github.com/apache/lucene/pull/13162

Since this is unreleased, no changelog entry is necessary.