### PR TITLE
Speed up writeGroupVInts

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -228,7 +228,10 @@ Optimizations
 
 * GITHUB#13121: Speedup multi-segment HNSW graph search for diversifying child kNN queries. Builds on GITHUB#12962.
   (Ben Trent)
+
 * GITHUB#13184: Make the HitQueue size more appropriate for KNN exact search (Pan Guixin)
+
+* GITHUB#13203: Speed up writeGroupVInts (Zhang Chao)
 
 Bug Fixes
 ---------------------

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/GroupVIntBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/GroupVIntBenchmark.java
@@ -86,6 +86,7 @@ public class GroupVIntBenchmark {
       };
 
   final int maxSize = 256;
+  final long[] docs = new long[maxSize];
   final long[] values = new long[maxSize];
 
   IndexInput byteBufferGVIntIn;
@@ -95,6 +96,9 @@ public class GroupVIntBenchmark {
 
   ByteArrayDataInput byteArrayVIntIn;
   ByteArrayDataInput byteArrayGVIntIn;
+
+  // benchmark for write
+  ByteBuffersDataOutput byteBuffersGVIntOut = new ByteBuffersDataOutput();
 
   @Param({"64"})
   public int size;
@@ -153,7 +157,6 @@ public class GroupVIntBenchmark {
 
   @Setup(Level.Trial)
   public void init() throws Exception {
-    long[] docs = new long[maxSize];
     Random r = new Random(0);
     for (int i = 0; i < maxSize; ++i) {
       float randomFloat = r.nextFloat();
@@ -236,5 +239,11 @@ public class GroupVIntBenchmark {
     byteBuffersGVIntIn.seek(0);
     this.readGroupVIntsBaseline(byteBuffersGVIntIn, values, size);
     bh.consume(values);
+  }
+
+  @Benchmark
+  public void bench_writeGroupVInt(Blackhole bh) throws IOException {
+    byteBuffersGVIntOut.reset();
+    byteBuffersGVIntOut.writeGroupVInts(docs, size);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.GroupVIntUtil;
 
 /**
  * Abstract base class for performing write operations of Lucene's low-level data types.
@@ -30,7 +30,7 @@ import org.apache.lucene.util.BytesRefBuilder;
  * internal state like file position).
  */
 public abstract class DataOutput {
-  private final BytesRefBuilder groupVIntBytes = new BytesRefBuilder();
+  private byte[] groupVIntBytes;
 
   /**
    * Writes a single byte.
@@ -335,32 +335,9 @@ public abstract class DataOutput {
    * @lucene.experimental
    */
   public void writeGroupVInts(long[] values, int limit) throws IOException {
-    int off = 0;
-
-    // encode each group
-    while ((limit - off) >= 4) {
-      byte flag = 0;
-      groupVIntBytes.setLength(1);
-      flag |= (encodeGroupValue(Math.toIntExact(values[off++])) - 1) << 6;
-      flag |= (encodeGroupValue(Math.toIntExact(values[off++])) - 1) << 4;
-      flag |= (encodeGroupValue(Math.toIntExact(values[off++])) - 1) << 2;
-      flag |= (encodeGroupValue(Math.toIntExact(values[off++])) - 1);
-      groupVIntBytes.setByteAt(0, flag);
-      writeBytes(groupVIntBytes.bytes(), groupVIntBytes.length());
+    if (groupVIntBytes == null) {
+      groupVIntBytes = new byte[17];
     }
-
-    // tail vints
-    for (; off < limit; off++) {
-      writeVInt(Math.toIntExact(values[off]));
-    }
-  }
-
-  private int encodeGroupValue(int v) {
-    int lastOff = groupVIntBytes.length();
-    do {
-      groupVIntBytes.append((byte) (v & 0xFF));
-      v >>>= 8;
-    } while (v != 0);
-    return groupVIntBytes.length() - lastOff;
+    GroupVIntUtil.writeGroupVInts(this, groupVIntBytes, values, limit);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
@@ -336,7 +336,7 @@ public abstract class DataOutput {
    */
   public void writeGroupVInts(long[] values, int limit) throws IOException {
     if (groupVIntBytes == null) {
-      groupVIntBytes = new byte[17];
+      groupVIntBytes = new byte[GroupVIntUtil.MAX_LENGTH_PER_GROUP];
     }
     GroupVIntUtil.writeGroupVInts(this, groupVIntBytes, values, limit);
   }

--- a/lucene/core/src/java/org/apache/lucene/util/GroupVIntUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/GroupVIntUtil.java
@@ -18,6 +18,7 @@ package org.apache.lucene.util;
 
 import java.io.IOException;
 import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
 
 /**
  * This class contains utility methods and constants for group varint
@@ -110,5 +111,41 @@ public final class GroupVIntUtil {
     dst[offset + 3] = reader.read(pos) & MASKS[n4Minus1];
     pos += 1 + n4Minus1;
     return (int) (pos - posStart);
+  }
+
+  private static int numBytes(int v) {
+    // | 1 to return 1 when v = 0
+    return Integer.BYTES - (Integer.numberOfLeadingZeros(v | 1) >> 3);
+  }
+
+  public static void writeGroupVInts(DataOutput out, byte[] scratch, long[] values, int limit)
+      throws IOException {
+    int readPos = 0;
+
+    // encode each group
+    while ((limit - readPos) >= 4) {
+      int writePos = 0;
+      final int n1Minus1 = numBytes(Math.toIntExact(values[readPos])) - 1;
+      final int n2Minus1 = numBytes(Math.toIntExact(values[readPos + 1])) - 1;
+      final int n3Minus1 = numBytes(Math.toIntExact(values[readPos + 2])) - 1;
+      final int n4Minus1 = numBytes(Math.toIntExact(values[readPos + 3])) - 1;
+      int flag = (n1Minus1 << 6) | (n2Minus1 << 4) | (n3Minus1 << 2) | (n4Minus1);
+      scratch[writePos++] = (byte) flag;
+      BitUtil.VH_LE_INT.set(scratch, writePos, Math.toIntExact(values[readPos++]));
+      writePos += n1Minus1 + 1;
+      BitUtil.VH_LE_INT.set(scratch, writePos, Math.toIntExact(values[readPos++]));
+      writePos += n2Minus1 + 1;
+      BitUtil.VH_LE_INT.set(scratch, writePos, Math.toIntExact(values[readPos++]));
+      writePos += n3Minus1 + 1;
+      BitUtil.VH_LE_INT.set(scratch, writePos, Math.toIntExact(values[readPos++]));
+      writePos += n4Minus1 + 1;
+
+      out.writeBytes(scratch, writePos);
+    }
+
+    // tail vints
+    for (; readPos < limit; readPos++) {
+      out.writeVInt(Math.toIntExact(values[readPos]));
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/GroupVIntUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/GroupVIntUtil.java
@@ -118,6 +118,10 @@ public final class GroupVIntUtil {
     return Integer.BYTES - (Integer.numberOfLeadingZeros(v | 1) >> 3);
   }
 
+  /**
+   * The implementation for group-varint encoding, It uses a maximum of {@link
+   * #MAX_LENGTH_PER_GROUP} bytes scratch buffer.
+   */
   public static void writeGroupVInts(DataOutput out, byte[] scratch, long[] values, int limit)
       throws IOException {
     int readPos = 0;


### PR DESCRIPTION
This change uses `VarHandles` instead of `BytesRefBuilder#append` to speed up `writeGroupVInts`, which is more aligned with group-varint generally implementation.

Main:
```
Benchmark                                (size)   Mode  Cnt  Score   Error   Units
GroupVIntBenchmark.bench_writeGroupVInt      64  thrpt    5  1.050 ± 0.057  ops/us
```

PR:
```
Benchmark                                (size)   Mode  Cnt  Score   Error   Units
GroupVIntBenchmark.bench_writeGroupVInt      64  thrpt    5  2.924 ± 0.049  ops/us
```