### PR TITLE
Subtract deleted file size from the cache size of NRTCachingDirectory.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -144,6 +144,8 @@ Bug Fixes
 
 * GITHUB#12878: Fix the declared Exceptions of Expression#evaluate() to match those
   of DoubleValues#doubleValue(). (Uwe Schindler)
+  
+* GITHUB#13206: Subtract deleted file size from the cache size of NRTCachingDirectory. (Jean-François Boeuf)
 
 Changes in Backwards Compatibility Policy
 -----------------------------------------

--- a/lucene/core/src/test/org/apache/lucene/store/TestNRTCachingDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestNRTCachingDirectory.java
@@ -34,6 +34,7 @@ import org.apache.lucene.tests.store.BaseDirectoryTestCase;
 import org.apache.lucene.tests.util.LineFileDocs;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.junit.Assert;
 
 public class TestNRTCachingDirectory extends BaseDirectoryTestCase {
 
@@ -166,5 +167,28 @@ public class TestNRTCachingDirectory extends BaseDirectoryTestCase {
     nrtDir2.createTempOutput("bar", "baz", ioContext).close();
 
     dir.close();
+  }
+
+  public void testCacheSizeAfterDelete() throws IOException {
+    IOContext ioContext = new IOContext(new FlushInfo(3, 40));
+    String fn = "f1";
+    try (Directory dir = newDirectory();
+        NRTCachingDirectory nrt = new NRTCachingDirectory(dir, 1, 1); ) {
+      // deletes a closed file
+      try (IndexOutput out = nrt.createOutput(fn, ioContext)) {
+        for (int i = 0; i < 10; i++) out.writeInt(i);
+      }
+      Assert.assertEquals(40, nrt.ramBytesUsed());
+      nrt.deleteFile(fn);
+      Assert.assertEquals(0, nrt.ramBytesUsed());
+
+      // Deletes an unclosed file (write before and after deletion
+      try (IndexOutput out = nrt.createOutput(fn, ioContext)) {
+        for (int i = 0; i < 10; i++) out.writeInt(i);
+        nrt.deleteFile(fn);
+        for (int i = 0; i < 10; i++) out.writeInt(i);
+      }
+      Assert.assertEquals(0, nrt.ramBytesUsed());
+    }
   }
 }


### PR DESCRIPTION
The size of deleted files is not subtracted from the cache size of NRTCachingDirectory. As a consequence, the cache eventually appears to be full preventing new files from being cached despite there being available memory since files no longer consume memory once they are deleted.
There is a weakness in the fix if the file is concurrently deleted in another thread while being closed but I don't think this pathologic use case deserves the additional synchronization it would require.
