### PR TITLE
Avoid modify merge state in per field mergers

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
@@ -148,9 +148,8 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
       }
 
       // Delegate the merge to the appropriate consumer
-      PerFieldMergeState pfMergeState = new PerFieldMergeState(mergeState);
       for (Map.Entry<DocValuesConsumer, Collection<String>> e : consumersToField.entrySet()) {
-        e.getKey().merge(pfMergeState.apply(e.getValue()));
+        e.getKey().merge(PerFieldMergeState.restrictFields(mergeState, e.getValue()));
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
@@ -149,12 +149,8 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
 
       // Delegate the merge to the appropriate consumer
       PerFieldMergeState pfMergeState = new PerFieldMergeState(mergeState);
-      try {
-        for (Map.Entry<DocValuesConsumer, Collection<String>> e : consumersToField.entrySet()) {
-          e.getKey().merge(pfMergeState.apply(e.getValue()));
-        }
-      } finally {
-        pfMergeState.reset();
+      for (Map.Entry<DocValuesConsumer, Collection<String>> e : consumersToField.entrySet()) {
+        e.getKey().merge(pfMergeState.apply(e.getValue()));
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldMergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldMergeState.java
@@ -33,36 +33,27 @@ import org.apache.lucene.index.Terms;
 
 /** Utility class to update the {@link MergeState} instance to be restricted to a set of fields. */
 final class PerFieldMergeState {
-  private final MergeState in;
-  private final MergeState copy;
-
-  PerFieldMergeState(MergeState in) {
-    this.in = in;
-    this.copy =
-        new MergeState(
-            in,
-            new FieldInfos[in.fieldInfos.length],
-            new FieldsProducer[in.fieldsProducers.length]);
-  }
 
   /**
-   * Update the input {@link MergeState} instance to restrict the fields to the given ones.
+   * Create a new MergeState from the given {@link MergeState} instance with restricted fields.
    *
-   * @param fields The fields to keep in the updated instance.
-   * @return The updated instance.
+   * @param fields The fields to keep in the new instance.
+   * @return The new MergeState with restricted fields
    */
-  MergeState apply(Collection<String> fields) {
-    copy.mergeFieldInfos = new FilterFieldInfos(in.mergeFieldInfos, fields);
+  static MergeState restrictFields(MergeState in, Collection<String> fields) {
+    var fieldInfos = new FieldInfos[in.fieldInfos.length];
     for (int i = 0; i < in.fieldInfos.length; i++) {
-      copy.fieldInfos[i] = new FilterFieldInfos(in.fieldInfos[i], fields);
+      fieldInfos[i] = new FilterFieldInfos(in.fieldInfos[i], fields);
     }
+    var fieldsProducers = new FieldsProducer[in.fieldsProducers.length];
     for (int i = 0; i < in.fieldsProducers.length; i++) {
-      copy.fieldsProducers[i] =
+      fieldsProducers[i] =
           in.fieldsProducers[i] == null
               ? null
               : new FilterFieldsProducer(in.fieldsProducers[i], fields);
     }
-    return copy;
+    var mergeFieldInfos = new FilterFieldInfos(in.mergeFieldInfos, fields);
+    return new MergeState(in, mergeFieldInfos, fieldInfos, fieldsProducers);
   }
 
   private static class FilterFieldInfos extends FieldInfos {

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldMergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldMergeState.java
@@ -31,7 +31,7 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.Terms;
 
-/** Utility class to update the {@link MergeState} instance to be restricted to a set of fields. */
+/** Utility class creating a new {@link MergeState} to be restricted to a set of fields. */
 final class PerFieldMergeState {
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldMergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldMergeState.java
@@ -53,7 +53,23 @@ final class PerFieldMergeState {
               : new FilterFieldsProducer(in.fieldsProducers[i], fields);
     }
     var mergeFieldInfos = new FilterFieldInfos(in.mergeFieldInfos, fields);
-    return new MergeState(in, mergeFieldInfos, fieldInfos, fieldsProducers);
+    return new MergeState(
+        in.docMaps,
+        in.segmentInfo,
+        mergeFieldInfos,
+        in.storedFieldsReaders,
+        in.termVectorsReaders,
+        in.normsProducers,
+        in.docValuesProducers,
+        fieldInfos,
+        in.liveDocs,
+        fieldsProducers,
+        in.pointsReaders,
+        in.knnVectorsReaders,
+        in.maxDocs,
+        in.infoStream,
+        in.intraMergeTaskExecutor,
+        in.needsIndexSort);
   }
 
   private static class FilterFieldInfos extends FieldInfos {

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
@@ -195,14 +195,13 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
       // Merge postings
       boolean success = false;
       try {
-        PerFieldMergeState pfMergeState = new PerFieldMergeState(mergeState);
         for (Map.Entry<PostingsFormat, FieldsGroup> ent : formatToGroups.entrySet()) {
           PostingsFormat format = ent.getKey();
           final FieldsGroup group = ent.getValue();
 
           FieldsConsumer consumer = format.fieldsConsumer(group.state);
           toClose.add(consumer);
-          consumer.merge(pfMergeState.apply(group.fields), norms);
+          consumer.merge(PerFieldMergeState.restrictFields(mergeState, group.fields), norms);
         }
         success = true;
       } finally {

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
@@ -193,9 +193,9 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
       Map<PostingsFormat, FieldsGroup> formatToGroups = buildFieldsGroupMapping(indexedFieldNames);
 
       // Merge postings
-      PerFieldMergeState pfMergeState = new PerFieldMergeState(mergeState);
       boolean success = false;
       try {
+        PerFieldMergeState pfMergeState = new PerFieldMergeState(mergeState);
         for (Map.Entry<PostingsFormat, FieldsGroup> ent : formatToGroups.entrySet()) {
           PostingsFormat format = ent.getKey();
           final FieldsGroup group = ent.getValue();
@@ -206,7 +206,6 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
         }
         success = true;
       } finally {
-        pfMergeState.reset();
         if (!success) {
           IOUtils.closeWhileHandlingException(toClose);
         }

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -23,7 +23,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import org.apache.lucene.codecs.*;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.codecs.PointsReader;
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.codecs.TermVectorsReader;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.InfoStream;
@@ -265,13 +271,18 @@ public class MergeState {
    * Creates a new state from an existing state with new fieldInfos and FieldsProducer.
    *
    * @param state the state to be copied
+   * @param mergeFieldInfos the new field infos of the merged segment
    * @param fieldInfos the new field infos
    * @param fieldsProducers the new field producers
    */
-  public MergeState(MergeState state, FieldInfos[] fieldInfos, FieldsProducer[] fieldsProducers) {
+  public MergeState(
+      MergeState state,
+      FieldInfos mergeFieldInfos,
+      FieldInfos[] fieldInfos,
+      FieldsProducer[] fieldsProducers) {
     this.docMaps = state.docMaps;
     this.segmentInfo = state.segmentInfo;
-    this.mergeFieldInfos = state.mergeFieldInfos;
+    this.mergeFieldInfos = mergeFieldInfos;
     this.storedFieldsReaders = state.storedFieldsReaders;
     this.termVectorsReaders = state.termVectorsReaders;
     this.normsProducers = state.normsProducers;

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -23,13 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import org.apache.lucene.codecs.DocValuesProducer;
-import org.apache.lucene.codecs.FieldsProducer;
-import org.apache.lucene.codecs.KnnVectorsReader;
-import org.apache.lucene.codecs.NormsProducer;
-import org.apache.lucene.codecs.PointsReader;
-import org.apache.lucene.codecs.StoredFieldsReader;
-import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.*;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.InfoStream;
@@ -265,5 +259,31 @@ public class MergeState {
       }
     }
     return docMapBuilder.build();
+  }
+
+  /**
+   * Creates a new state from an existing state with new fieldInfos and FieldsProducer.
+   *
+   * @param state the state to be copied
+   * @param fieldInfos the new field infos
+   * @param fieldsProducers the new field producers
+   */
+  public MergeState(MergeState state, FieldInfos[] fieldInfos, FieldsProducer[] fieldsProducers) {
+    this.docMaps = state.docMaps;
+    this.segmentInfo = state.segmentInfo;
+    this.mergeFieldInfos = state.mergeFieldInfos;
+    this.storedFieldsReaders = state.storedFieldsReaders;
+    this.termVectorsReaders = state.termVectorsReaders;
+    this.normsProducers = state.normsProducers;
+    this.docValuesProducers = state.docValuesProducers;
+    this.fieldInfos = fieldInfos;
+    this.liveDocs = state.liveDocs;
+    this.fieldsProducers = fieldsProducers;
+    this.pointsReaders = state.pointsReaders;
+    this.knnVectorsReaders = state.knnVectorsReaders;
+    this.maxDocs = state.maxDocs;
+    this.infoStream = state.infoStream;
+    this.intraMergeTaskExecutor = state.intraMergeTaskExecutor;
+    this.needsIndexSort = state.needsIndexSort;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -267,34 +267,39 @@ public class MergeState {
     return docMapBuilder.build();
   }
 
-  /**
-   * Creates a new state from an existing state with new fieldInfos and FieldsProducer.
-   *
-   * @param state the state to be copied
-   * @param mergeFieldInfos the new field infos of the merged segment
-   * @param fieldInfos the new field infos
-   * @param fieldsProducers the new field producers
-   */
+  /** Create a new merge instance. */
   public MergeState(
-      MergeState state,
+      DocMap[] docMaps,
+      SegmentInfo segmentInfo,
       FieldInfos mergeFieldInfos,
+      StoredFieldsReader[] storedFieldsReaders,
+      TermVectorsReader[] termVectorsReaders,
+      NormsProducer[] normsProducers,
+      DocValuesProducer[] docValuesProducers,
       FieldInfos[] fieldInfos,
-      FieldsProducer[] fieldsProducers) {
-    this.docMaps = state.docMaps;
-    this.segmentInfo = state.segmentInfo;
+      Bits[] liveDocs,
+      FieldsProducer[] fieldsProducers,
+      PointsReader[] pointsReaders,
+      KnnVectorsReader[] knnVectorsReaders,
+      int[] maxDocs,
+      InfoStream infoStream,
+      Executor intraMergeTaskExecutor,
+      boolean needsIndexSort) {
+    this.docMaps = docMaps;
+    this.segmentInfo = segmentInfo;
     this.mergeFieldInfos = mergeFieldInfos;
-    this.storedFieldsReaders = state.storedFieldsReaders;
-    this.termVectorsReaders = state.termVectorsReaders;
-    this.normsProducers = state.normsProducers;
-    this.docValuesProducers = state.docValuesProducers;
+    this.storedFieldsReaders = storedFieldsReaders;
+    this.termVectorsReaders = termVectorsReaders;
+    this.normsProducers = normsProducers;
+    this.docValuesProducers = docValuesProducers;
     this.fieldInfos = fieldInfos;
-    this.liveDocs = state.liveDocs;
+    this.liveDocs = liveDocs;
     this.fieldsProducers = fieldsProducers;
-    this.pointsReaders = state.pointsReaders;
-    this.knnVectorsReaders = state.knnVectorsReaders;
-    this.maxDocs = state.maxDocs;
-    this.infoStream = state.infoStream;
-    this.intraMergeTaskExecutor = state.intraMergeTaskExecutor;
-    this.needsIndexSort = state.needsIndexSort;
+    this.pointsReaders = pointsReaders;
+    this.knnVectorsReaders = knnVectorsReaders;
+    this.maxDocs = maxDocs;
+    this.infoStream = infoStream;
+    this.intraMergeTaskExecutor = intraMergeTaskExecutor;
+    this.needsIndexSort = needsIndexSort;
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterForceMerge.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterForceMerge.java
@@ -18,14 +18,25 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Locale;
-import java.util.concurrent.*;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.codecs.*;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
 import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.store.Directory;
@@ -342,13 +353,14 @@ public class TestIndexWriterForceMerge extends LuceneTestCase {
       for (int d = 0; d < numDocs; d++) {
         Document doc = new Document();
         for (int f = 0; f < numFields * 2; f++) {
-          String field = "f-" + f;
+          String field = "f" + f;
           String value = "v-" + random().nextInt(100);
           if (f % 2 == 0) {
             doc.add(new StringField(field, value, Field.Store.NO));
           } else {
             doc.add(new BinaryDocValuesField(field, new BytesRef(value)));
           }
+          doc.add(new LongPoint("p" + f, random().nextInt(10000)));
         }
         writer.addDocument(doc);
         if (random().nextInt(100) < 10) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterForceMerge.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterForceMerge.java
@@ -320,7 +320,7 @@ public class TestIndexWriterForceMerge extends LuceneTestCase {
         };
     mergeScheduler.setMaxMergesAndThreads(4, 4);
     config.setMergeScheduler(mergeScheduler);
-    Codec codec = config.getCodec();
+    Codec codec = TestUtil.getDefaultCodec();
     CyclicBarrier barrier = new CyclicBarrier(2);
     config.setCodec(
         new FilterCodec(codec.getName(), codec) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterForceMerge.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterForceMerge.java
@@ -18,9 +18,15 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.concurrent.*;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.codecs.*;
+import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
+import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -29,6 +35,7 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.store.MockDirectoryWrapper;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
 
 public class TestIndexWriterForceMerge extends LuceneTestCase {
   public void testPartialMerge() throws IOException {
@@ -288,5 +295,173 @@ public class TestIndexWriterForceMerge extends LuceneTestCase {
     }
 
     dir.close();
+  }
+
+  public void testMergePerField() throws IOException {
+    IndexWriterConfig config = new IndexWriterConfig();
+    ConcurrentMergeScheduler mergeScheduler =
+        new ConcurrentMergeScheduler() {
+          @Override
+          public Executor getIntraMergeExecutor(MergePolicy.OneMerge merge) {
+            // always enable parallel merges
+            return intraMergeExecutor;
+          }
+        };
+    mergeScheduler.setMaxMergesAndThreads(4, 4);
+    config.setMergeScheduler(mergeScheduler);
+    Codec codec = config.getCodec();
+    CyclicBarrier barrier = new CyclicBarrier(2);
+    config.setCodec(
+        new FilterCodec(codec.getName(), codec) {
+          @Override
+          public PostingsFormat postingsFormat() {
+            return new PerFieldPostingsFormat() {
+              @Override
+              public PostingsFormat getPostingsFormatForField(String field) {
+                return new BlockingOnMergePostingsFormat(
+                    TestUtil.getDefaultPostingsFormat(), barrier);
+              }
+            };
+          }
+
+          @Override
+          public DocValuesFormat docValuesFormat() {
+            return new PerFieldDocValuesFormat() {
+              @Override
+              public DocValuesFormat getDocValuesFormatForField(String field) {
+                return new BlockingOnMergeDocValuesFormat(
+                    TestUtil.getDefaultDocValuesFormat(), barrier);
+              }
+            };
+          }
+        });
+    try (Directory directory = newDirectory();
+        IndexWriter writer = new IndexWriter(directory, config)) {
+      int numDocs = 50 + random().nextInt(500);
+      int numFields = 10 + random().nextInt(20);
+      for (int d = 0; d < numDocs; d++) {
+        Document doc = new Document();
+        for (int f = 0; f < numFields; f++) {
+          String field = "f-" + f;
+          String value = "v-" + random().nextInt(100);
+          doc.add(new StringField(field, value, Field.Store.NO));
+          doc.add(new BinaryDocValuesField(field, new BytesRef(value)));
+          writer.addDocument(doc);
+        }
+        if (random().nextInt(100) < 10) {
+          writer.flush();
+        }
+      }
+      writer.forceMerge(1);
+    }
+  }
+
+  static class BlockingOnMergePostingsFormat extends PostingsFormat {
+    private final PostingsFormat postingsFormat;
+    private final CyclicBarrier barrier;
+
+    BlockingOnMergePostingsFormat(PostingsFormat postingsFormat, CyclicBarrier barrier) {
+      super(postingsFormat.getName());
+      this.postingsFormat = postingsFormat;
+      this.barrier = barrier;
+    }
+
+    @Override
+    public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+      var in = postingsFormat.fieldsConsumer(state);
+      return new FieldsConsumer() {
+        @Override
+        public void write(Fields fields, NormsProducer norms) throws IOException {
+          in.write(fields, norms);
+        }
+
+        @Override
+        public void merge(MergeState mergeState, NormsProducer norms) throws IOException {
+          try {
+            barrier.await(1, TimeUnit.SECONDS);
+          } catch (Exception e) {
+            throw new AssertionError("broken barrier", e);
+          }
+          in.merge(mergeState, norms);
+        }
+
+        @Override
+        public void close() throws IOException {
+          in.close();
+        }
+      };
+    }
+
+    @Override
+    public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
+      return postingsFormat.fieldsProducer(state);
+    }
+  }
+
+  static class BlockingOnMergeDocValuesFormat extends DocValuesFormat {
+    private final DocValuesFormat docValuesFormat;
+    private final CyclicBarrier barrier;
+
+    BlockingOnMergeDocValuesFormat(DocValuesFormat docValuesFormat, CyclicBarrier barrier) {
+      super(docValuesFormat.getName());
+      this.docValuesFormat = docValuesFormat;
+      this.barrier = barrier;
+    }
+
+    @Override
+    public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+      DocValuesConsumer in = docValuesFormat.fieldsConsumer(state);
+      return new DocValuesConsumer() {
+        @Override
+        public void addNumericField(FieldInfo field, DocValuesProducer valuesProducer)
+            throws IOException {
+          in.addNumericField(field, valuesProducer);
+        }
+
+        @Override
+        public void addBinaryField(FieldInfo field, DocValuesProducer valuesProducer)
+            throws IOException {
+          in.addBinaryField(field, valuesProducer);
+        }
+
+        @Override
+        public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer)
+            throws IOException {
+          in.addSortedField(field, valuesProducer);
+        }
+
+        @Override
+        public void addSortedNumericField(FieldInfo field, DocValuesProducer valuesProducer)
+            throws IOException {
+          in.addSortedNumericField(field, valuesProducer);
+        }
+
+        @Override
+        public void addSortedSetField(FieldInfo field, DocValuesProducer valuesProducer)
+            throws IOException {
+          in.addSortedSetField(field, valuesProducer);
+        }
+
+        @Override
+        public void merge(MergeState mergeState) throws IOException {
+          try {
+            barrier.await(1, TimeUnit.SECONDS);
+          } catch (Exception e) {
+            throw new AssertionError("broken barrier", e);
+          }
+          in.merge(mergeState);
+        }
+
+        @Override
+        public void close() throws IOException {
+          in.close();
+        }
+      };
+    }
+
+    @Override
+    public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
+      return docValuesFormat.fieldsProducer(state);
+    }
   }
 }


### PR DESCRIPTION
The PerFieldDocValuesFormat and PerFieldPostingsFormat mutate and reset the fieldInfos of the mergeState during merges. Consequently, other running merge sub-tasks may fail to see some fieldInfos. This was problematic since we introduced concurrency for merge sub-tasks.

Relates #13190
