### PR TITLE
Avoid creating large buffer in TestMMapDirectory.testWithRandom

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
@@ -100,7 +100,7 @@ public class TestMMapDirectory extends BaseDirectoryTestCase {
 
   // Opens the input with IOContext.RANDOM to ensure basic code path coverage for POSIX_MADV_RANDOM.
   public void testWithRandom() throws Exception {
-    final int size = 8 * 1024 * 1024; // large enough to trigger madvise
+    final int size = 8 * 1024;
     byte[] bytes = new byte[size];
     random().nextBytes(bytes);
 


### PR DESCRIPTION
This commit avoids creating an unnecessary large buffer in TestMMapDirectory.testWithRandom.


relates #13196