### PR TITLE
Mark TimeLimitingCollector as deprecated

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -31,8 +31,6 @@ import org.apache.lucene.util.automaton.CompiledAutomaton;
  * {@link QueryTimeout} implementation object to be checked periodically to see if the thread should
  * exit or not. If {@link QueryTimeout#shouldExit()} returns true, an {@link ExitingReaderException}
  * is thrown.
- *
- * @see org.apache.lucene.search.TimeLimitingCollector
  */
 public class ExitableDirectoryReader extends FilterDirectoryReader {
 

--- a/lucene/core/src/java/org/apache/lucene/search/Collector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Collector.java
@@ -37,8 +37,6 @@ import org.apache.lucene.index.LeafReaderContext;
  *   <li>{@link TopFieldCollector} subclasses {@link TopDocsCollector} and sorts according to a
  *       specified {@link Sort} object (sort by field). This is used internally by the {@link
  *       IndexSearcher} search methods that take an explicit {@link Sort}.
- *   <li>{@link TimeLimitingCollector}, which wraps any other Collector and aborts the search if
- *       it's taken too much time.
  *   <li>{@link PositiveScoresOnlyCollector} wraps any other Collector and prevents collection of
  *       hits whose score is &lt;= 0.0
  * </ul>

--- a/lucene/core/src/java/org/apache/lucene/search/TimeLimitingCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TimeLimitingCollector.java
@@ -18,6 +18,7 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.QueryTimeout;
 import org.apache.lucene.util.Counter;
 import org.apache.lucene.util.SuppressForbidden;
 import org.apache.lucene.util.ThreadInterruptedException;
@@ -27,8 +28,10 @@ import org.apache.lucene.util.ThreadInterruptedException;
  * maximum allowed search time limit. After this time is exceeded, the search thread is stopped by
  * throwing a {@link TimeExceededException}.
  *
+ * @deprecated Use {@link IndexSearcher#setTimeout(QueryTimeout)} to time out queries.
  * @see org.apache.lucene.index.ExitableDirectoryReader
  */
+@Deprecated
 public class TimeLimitingCollector implements Collector {
 
   /** Thrown when elapsed search time exceeds allowed search time. */


### PR DESCRIPTION
### Description

Follow-up to https://github.com/apache/lucene/pull/13202#issuecomment-2016947960

[`TimeLimitingCollector`](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/TimeLimitingCollector.java) only seems to be used from comments and tests. Can we mark it as `@Deprecated` and remove from `main` in another PR?