### PR TITLE
Test KNN query works seamlessly regardless of underlying format

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -956,8 +956,8 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
     try (Directory directory = newDirectory()) {
       MockAnalyzer mockAnalyzer = new MockAnalyzer(random());
       IndexWriterConfig iwc = newIndexWriterConfig(mockAnalyzer);
-      KnnVectorsFormat format1 = new Lucene99HnswVectorsFormat();
-      KnnVectorsFormat format2 = new Lucene99HnswScalarQuantizedVectorsFormat();
+      KnnVectorsFormat format1 = randomVectorFormat();
+      KnnVectorsFormat format2 = randomVectorFormat();
       iwc.setCodec(
           new AssertingCodec() {
             @Override

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -25,7 +25,6 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
@@ -960,32 +959,32 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
       KnnVectorsFormat format1 = new Lucene99HnswVectorsFormat();
       KnnVectorsFormat format2 = new Lucene99HnswScalarQuantizedVectorsFormat();
       iwc.setCodec(
-              new AssertingCodec() {
-                @Override
-                public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-                  return format1;
-                }
-              });
+          new AssertingCodec() {
+            @Override
+            public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+              return format1;
+            }
+          });
 
       try (IndexWriter iwriter = new IndexWriter(directory, iwc)) {
         Document doc = new Document();
-        doc.add(getKnnVectorField("field1", new float[]{1, 1, 1}));
+        doc.add(getKnnVectorField("field1", new float[] {1, 1, 1}));
         iwriter.addDocument(doc);
 
         doc.clear();
-        doc.add(getKnnVectorField("field1", new float[]{1, 2, 3}));
+        doc.add(getKnnVectorField("field1", new float[] {1, 2, 3}));
         iwriter.addDocument(doc);
         iwriter.commit();
       }
 
       iwc = newIndexWriterConfig(mockAnalyzer);
       iwc.setCodec(
-              new AssertingCodec() {
-                @Override
-                public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-                  return format2;
-                }
-              });
+          new AssertingCodec() {
+            @Override
+            public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+              return format2;
+            }
+          });
 
       try (IndexWriter iwriter = new IndexWriter(directory, iwc)) {
         Document doc = new Document();
@@ -1000,11 +999,10 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
       }
 
       try (IndexReader ireader = DirectoryReader.open(directory)) {
-        AbstractKnnVectorQuery vectorQuery = getKnnVectorQuery("field1", new float[]{1, 2, 3}, 10);
+        AbstractKnnVectorQuery vectorQuery = getKnnVectorQuery("field1", new float[] {1, 2, 3}, 10);
         TopDocs hits1 = new IndexSearcher(ireader).search(vectorQuery, 4);
         assertEquals(4, hits1.scoreDocs.length);
       }
     }
   }
-
 }

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -48,7 +48,10 @@ import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.apache.lucene.util.*;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
 
 /** Test cases for AbstractKnnVectorQuery objects. */
 abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -26,8 +26,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.lucene.codecs.KnnVectorsFormat;
-import org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat;
-import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.IntPoint;

--- a/lucene/test-framework/src/java/module-info.java
+++ b/lucene/test-framework/src/java/module-info.java
@@ -18,7 +18,8 @@
 /** Lucene test framework. */
 @SuppressWarnings({"module", "requires-automatic", "requires-transitive-automatic"})
 module org.apache.lucene.test_framework {
-  requires org.apache.lucene.core;
+    uses org.apache.lucene.codecs.KnnVectorsFormat;
+    requires org.apache.lucene.core;
   requires org.apache.lucene.codecs;
   requires transitive junit;
   requires transitive randomizedtesting.runner;

--- a/lucene/test-framework/src/java/module-info.java
+++ b/lucene/test-framework/src/java/module-info.java
@@ -18,8 +18,9 @@
 /** Lucene test framework. */
 @SuppressWarnings({"module", "requires-automatic", "requires-transitive-automatic"})
 module org.apache.lucene.test_framework {
-    uses org.apache.lucene.codecs.KnnVectorsFormat;
-    requires org.apache.lucene.core;
+  uses org.apache.lucene.codecs.KnnVectorsFormat;
+
+  requires org.apache.lucene.core;
   requires org.apache.lucene.codecs;
   requires transitive junit;
   requires transitive randomizedtesting.runner;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -89,6 +89,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeSet;
@@ -100,6 +101,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import junit.framework.AssertionFailedError;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
@@ -3212,5 +3214,14 @@ public abstract class LuceneTestCase extends Assert {
     }
 
     return it;
+  }
+
+  protected KnnVectorsFormat randomVectorFormat() {
+    ServiceLoader<KnnVectorsFormat> formats = java.util.ServiceLoader.load(KnnVectorsFormat.class);
+    List<KnnVectorsFormat> availableFormats = new ArrayList<>();
+    for (KnnVectorsFormat f : formats) {
+      availableFormats.add(f);
+    }
+    return RandomPicks.randomFrom(random(), availableFormats);
   }
 }


### PR DESCRIPTION
### Description

This introduces just a test to check that a `KnnVectorQuery` runs the same when a same field is indexed with different `KnnVectorFormats` (e.g. `Lucene99HnswVectorsFormat` and `Lucene99HnswScalarQuantizedVectorsFormat`).