### PR TITLE
Replace (IO)Context#READ with (IO)Context.DEFAULT.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -92,6 +92,8 @@ API Changes
 * GITHUB#13219: The `readOnce`, `load` and `random` flags on `IOContext` have
   been replaced with a new `ReadAdvice` enum. (Adrien Grand)
 
+* GITHUB#13242: Replace `IOContext.READ` with `IOContext.DEFAULT`. (Adrien Grand)
+
 New Features
 ---------------------
 

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -185,10 +185,12 @@ access the members using method calls instead of field accesses. Affected classe
 The `readOnce`, `load` and `random` flags on `IOContext` have been replaced with a new `ReadAdvice`
 enum.
 
-### IOContext.LOAD removed
+### IOContext.LOAD and IOContext.READ removed
 
 `IOContext#LOAD` has been removed, it should be replaced with
-`ioContext.toReadAdvice(ReadAdvice.RANDOM_PRELOAD)`.
+`ioContext.withReadAdvice(ReadAdvice.RANDOM_PRELOAD)`.
+
+`IOContext.READ` has been removed, it should be replaced with `IOContext.DEFAULT`.
 
 ## Migration from Lucene 9.0 to Lucene 9.1
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/FieldsIndexReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/compressing/FieldsIndexReader.java
@@ -67,7 +67,7 @@ final class FieldsIndexReader extends FieldsIndex {
 
     indexInput =
         EndiannessReverserUtil.openInput(
-            dir, IndexFileNames.segmentFileName(name, suffix, extension), IOContext.READ);
+            dir, IndexFileNames.segmentFileName(name, suffix, extension), IOContext.DEFAULT);
     boolean success = false;
     try {
       CodecUtil.checkIndexHeader(

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/packed/TestLegacyDirectMonotonic.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/packed/TestLegacyDirectMonotonic.java
@@ -259,7 +259,7 @@ public class TestLegacyDirectMonotonic extends LuceneTestCase {
     }
 
     try (IndexInput metaIn = EndiannessReverserUtil.openInput(dir, "meta", IOContext.READONCE);
-        IndexInput dataIn = EndiannessReverserUtil.openInput(dir, "data", IOContext.READ)) {
+        IndexInput dataIn = EndiannessReverserUtil.openInput(dir, "data", IOContext.DEFAULT)) {
       LegacyDirectMonotonicReader.Meta meta =
           LegacyDirectMonotonicReader.loadMeta(metaIn, array.length, blockShift);
       LegacyDirectMonotonicReader reader =

--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdatesStream.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdatesStream.java
@@ -282,7 +282,7 @@ final class BufferedUpdatesStream implements Accountable {
         ReadersAndUpdates rld, IOConsumer<ReadersAndUpdates> onClose, SegmentCommitInfo info)
         throws IOException {
       this.rld = rld;
-      reader = rld.getReader(IOContext.READ);
+      reader = rld.getReader(IOContext.DEFAULT);
       startDelCount = rld.getDelCount();
       delGen = info.getBufferedDeletesGen();
       this.onClose = onClose;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -538,7 +538,7 @@ public class IndexWriter
           final ReadersAndUpdates rld = getPooledInstance(sci, true);
           try {
             assert Thread.holdsLock(IndexWriter.this);
-            SegmentReader segmentReader = rld.getReadOnlyClone(IOContext.READ);
+            SegmentReader segmentReader = rld.getReadOnlyClone(IOContext.DEFAULT);
             // only track this if we actually do fullFlush merges
             if (maxFullFlushMergeWaitMillis > 0) {
               openedReadOnlyClones.put(sci.info.name, segmentReader);
@@ -5427,7 +5427,7 @@ public class IndexWriter
       final IndexReaderWarmer mergedSegmentWarmer = config.getMergedSegmentWarmer();
       if (readerPool.isReaderPoolingEnabled() && mergedSegmentWarmer != null) {
         final ReadersAndUpdates rld = getPooledInstance(merge.info, true);
-        final SegmentReader sr = rld.getReader(IOContext.READ);
+        final SegmentReader sr = rld.getReader(IOContext.DEFAULT);
         try {
           mergedSegmentWarmer.warm(sr);
         } finally {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -284,7 +284,7 @@ final class IndexingChain implements Accountable {
             state.directory,
             state.segmentInfo,
             state.fieldInfos,
-            IOContext.READ,
+            IOContext.DEFAULT,
             state.segmentSuffix);
 
     t0 = System.nanoTime();

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -192,7 +192,7 @@ final class ReadersAndUpdates {
 
   public synchronized boolean delete(int docID) throws IOException {
     if (reader == null && pendingDeletes.mustInitOnDelete()) {
-      getReader(IOContext.READ).decRef(); // pass a reader to initialize the pending deletes
+      getReader(IOContext.DEFAULT).decRef(); // pass a reader to initialize the pending deletes
     }
     return pendingDeletes.delete(docID);
   }
@@ -241,7 +241,7 @@ final class ReadersAndUpdates {
   private synchronized CodecReader getLatestReader() throws IOException {
     if (this.reader == null) {
       // get a reader and dec the ref right away we just make sure we have a reader
-      getReader(IOContext.READ).decRef();
+      getReader(IOContext.DEFAULT).decRef();
     }
     if (pendingDeletes.needsRefresh(reader)) {
       // we have a reader but its live-docs are out of sync. let's create a temporary one that we

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
@@ -46,7 +46,7 @@ final class SegmentDocValues {
 
     // set SegmentReadState to list only the fields that are relevant to that gen
     SegmentReadState srs =
-        new SegmentReadState(dvDir, si.info, infos, IOContext.READ, segmentSuffix);
+        new SegmentReadState(dvDir, si.info, infos, IOContext.DEFAULT, segmentSuffix);
     DocValuesFormat dvFormat = si.info.getCodec().docValuesFormat();
     return new RefCount<DocValuesProducer>(dvFormat.fieldsProducer(srs)) {
       @SuppressWarnings("synthetic-access")

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -395,7 +395,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
       input.readBytes(segmentID, 0, segmentID.length);
       Codec codec = readCodec(input);
       SegmentInfo info =
-          codec.segmentInfoFormat().read(directory, segName, segmentID, IOContext.READ);
+          codec.segmentInfoFormat().read(directory, segName, segmentID, IOContext.DEFAULT);
       info.setCodec(codec);
       totalDocs += info.maxDoc();
       long delGen = CodecUtil.readBELong(input);

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentMerger.java
@@ -132,7 +132,7 @@ final class SegmentMerger {
             directory,
             mergeState.segmentInfo,
             mergeState.mergeFieldInfos,
-            IOContext.READ,
+            IOContext.DEFAULT,
             segmentWriteState.segmentSuffix);
 
     TaskExecutor taskExecutor = new TaskExecutor(mergeState.intraMergeTaskExecutor);

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -91,7 +91,8 @@ public final class StandardDirectoryReader extends DirectoryReader {
         try {
           for (int i = sis.size() - 1; i >= 0; i--) {
             readers[i] =
-                new SegmentReader(sis.info(i), sis.getIndexCreatedVersionMajor(), IOContext.READ);
+                new SegmentReader(
+                    sis.info(i), sis.getIndexCreatedVersionMajor(), IOContext.DEFAULT);
           }
           // This may throw CorruptIndexException if there are too many docs, so
           // it must be inside try clause so we close readers in that case:
@@ -229,7 +230,7 @@ public final class StandardDirectoryReader extends DirectoryReader {
                 != oldReader.getSegmentInfo().info.getUseCompoundFile()) {
           // this is a new reader; in case we hit an exception we can decRef it safely
           newReader =
-              new SegmentReader(commitInfo, infos.getIndexCreatedVersionMajor(), IOContext.READ);
+              new SegmentReader(commitInfo, infos.getIndexCreatedVersionMajor(), IOContext.DEFAULT);
           newReaders[i] = newReader;
         } else {
           if (oldReader.isNRT) {

--- a/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
@@ -374,7 +374,6 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
         return MERGE_BUFFER_SIZE;
       case DEFAULT:
       case FLUSH:
-      case READ:
       default:
         return BUFFER_SIZE;
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -3029,7 +3029,7 @@ public class TestIndexWriter extends LuceneTestCase {
         writer.commit();
         assertEquals(1, writer.getDocStats().maxDoc);
         // now check that we moved to 3
-        dir.openInput("segments_3", IOContext.READ).close();
+        dir.openInput("segments_3", IOContext.DEFAULT).close();
       }
       reader.close();
       in.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestReaderPool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestReaderPool.java
@@ -118,7 +118,7 @@ public class TestReaderPool extends LuceneTestCase {
     }
     for (SegmentCommitInfo commitInfo : segmentInfos) {
       ReadersAndUpdates readersAndUpdates = pool.get(commitInfo, true);
-      SegmentReader readOnlyClone = readersAndUpdates.getReadOnlyClone(IOContext.READ);
+      SegmentReader readOnlyClone = readersAndUpdates.getReadOnlyClone(IOContext.DEFAULT);
       PostingsEnum postings = readOnlyClone.postings(new Term("id", "" + id));
       boolean expectUpdate = false;
       int doc = -1;
@@ -162,7 +162,7 @@ public class TestReaderPool extends LuceneTestCase {
       assertEquals(expectUpdate, writtenToDisk);
       if (expectUpdate) {
         readersAndUpdates = pool.get(commitInfo, true);
-        SegmentReader updatedReader = readersAndUpdates.getReadOnlyClone(IOContext.READ);
+        SegmentReader updatedReader = readersAndUpdates.getReadOnlyClone(IOContext.DEFAULT);
         assertNotSame(-1, doc);
         NumericDocValues number = updatedReader.getNumericDocValues("number");
         assertEquals(doc, number.advance(doc));
@@ -195,7 +195,7 @@ public class TestReaderPool extends LuceneTestCase {
     }
     for (SegmentCommitInfo commitInfo : segmentInfos) {
       ReadersAndUpdates readersAndUpdates = pool.get(commitInfo, true);
-      SegmentReader readOnlyClone = readersAndUpdates.getReadOnlyClone(IOContext.READ);
+      SegmentReader readOnlyClone = readersAndUpdates.getReadOnlyClone(IOContext.DEFAULT);
       PostingsEnum postings = readOnlyClone.postings(new Term("id", "" + id));
       boolean expectUpdate = false;
       int doc = -1;
@@ -217,7 +217,7 @@ public class TestReaderPool extends LuceneTestCase {
       assertEquals(expectUpdate, writtenToDisk);
       if (expectUpdate) {
         readersAndUpdates = pool.get(commitInfo, true);
-        SegmentReader updatedReader = readersAndUpdates.getReadOnlyClone(IOContext.READ);
+        SegmentReader updatedReader = readersAndUpdates.getReadOnlyClone(IOContext.DEFAULT);
         assertNotSame(-1, doc);
         assertFalse(updatedReader.getLiveDocs().get(doc));
         readersAndUpdates.release(updatedReader);
@@ -255,7 +255,7 @@ public class TestReaderPool extends LuceneTestCase {
                 while (isDone.get() == false) {
                   for (SegmentCommitInfo commitInfo : segmentInfos) {
                     ReadersAndUpdates readersAndUpdates = pool.get(commitInfo, true);
-                    SegmentReader segmentReader = readersAndUpdates.getReader(IOContext.READ);
+                    SegmentReader segmentReader = readersAndUpdates.getReader(IOContext.DEFAULT);
                     readersAndUpdates.release(segmentReader);
                     pool.release(readersAndUpdates, random().nextBoolean());
                   }
@@ -279,7 +279,7 @@ public class TestReaderPool extends LuceneTestCase {
     for (int i = 0; i < reader.maxDoc(); i++) {
       for (SegmentCommitInfo commitInfo : segmentInfos) {
         ReadersAndUpdates readersAndUpdates = pool.get(commitInfo, true);
-        SegmentReader sr = readersAndUpdates.getReadOnlyClone(IOContext.READ);
+        SegmentReader sr = readersAndUpdates.getReadOnlyClone(IOContext.DEFAULT);
         PostingsEnum postings = sr.postings(new Term("id", "" + i));
         sr.decRef();
         if (postings != null) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentReader.java
@@ -42,7 +42,7 @@ public class TestSegmentReader extends LuceneTestCase {
     dir = newDirectory();
     DocHelper.setupDoc(testDoc);
     SegmentCommitInfo info = DocHelper.writeDoc(random(), dir, testDoc);
-    reader = new SegmentReader(info, Version.LATEST.major, IOContext.READ);
+    reader = new SegmentReader(info, Version.LATEST.major, IOContext.DEFAULT);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
@@ -110,7 +110,7 @@ public class TestMMapDirectory extends BaseDirectoryTestCase {
       }
 
       try (final IndexInput in =
-          dir.openInput("test", IOContext.READ.withReadAdvice(ReadAdvice.RANDOM))) {
+          dir.openInput("test", IOContext.DEFAULT.withReadAdvice(ReadAdvice.RANDOM))) {
         final byte[] readBytes = new byte[size];
         in.readBytes(readBytes, 0, readBytes.length);
         assertArrayEquals(bytes, readBytes);

--- a/lucene/core/src/test/org/apache/lucene/util/packed/TestDirectMonotonic.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/TestDirectMonotonic.java
@@ -296,7 +296,7 @@ public class TestDirectMonotonic extends LuceneTestCase {
     }
 
     try (IndexInput metaIn = dir.openInput("meta", IOContext.READONCE);
-        IndexInput dataIn = dir.openInput("data", IOContext.READ)) {
+        IndexInput dataIn = dir.openInput("data", IOContext.DEFAULT)) {
       DirectMonotonicReader.Meta meta =
           DirectMonotonicReader.loadMeta(metaIn, array.length, blockShift);
       DirectMonotonicReader reader =

--- a/lucene/demo/src/java/org/apache/lucene/demo/knn/KnnVectorDict.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/knn/KnnVectorDict.java
@@ -59,11 +59,11 @@ public class KnnVectorDict implements Closeable {
    *     '.bin' file.
    */
   public KnnVectorDict(Directory directory, String dictName) throws IOException {
-    try (IndexInput fstIn = directory.openInput(dictName + ".fst", IOContext.READ)) {
+    try (IndexInput fstIn = directory.openInput(dictName + ".fst", IOContext.DEFAULT)) {
       fst = new FST<>(readMetadata(fstIn, PositiveIntOutputs.getSingleton()), fstIn);
     }
 
-    vectors = directory.openInput(dictName + ".bin", IOContext.READ);
+    vectors = directory.openInput(dictName + ".bin", IOContext.DEFAULT);
     long size = vectors.length();
     vectors.seek(size - Integer.BYTES);
     dimension = vectors.readInt();

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestAlwaysRefreshDirectoryTaxonomyReader.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestAlwaysRefreshDirectoryTaxonomyReader.java
@@ -67,7 +67,7 @@ public class TestAlwaysRefreshDirectoryTaxonomyReader extends FacetTestCase {
     for (String file : dir1.listAll()) {
       if (isExtra(file) == false) {
         // the test framework creates these devious extra files just to chaos test the edge cases
-        commit1.copyFrom(dir1, file, file, IOContext.READ);
+        commit1.copyFrom(dir1, file, file, IOContext.DEFAULT);
       }
     }
 
@@ -103,7 +103,7 @@ public class TestAlwaysRefreshDirectoryTaxonomyReader extends FacetTestCase {
     // copy all index files from commit1
     for (String file : commit1.listAll()) {
       if (isExtra(file) == false) {
-        dir1.copyFrom(commit1, file, file, IOContext.READ);
+        dir1.copyFrom(commit1, file, file, IOContext.DEFAULT);
       }
     }
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/util/IndexUtils.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/util/IndexUtils.java
@@ -341,7 +341,7 @@ public final class IndexUtils {
       @Override
       protected String doBody(String segmentFileName) throws IOException {
         String format = "unknown";
-        try (IndexInput in = dir.openInput(segmentFileName, IOContext.READ)) {
+        try (IndexInput in = dir.openInput(segmentFileName, IOContext.DEFAULT)) {
           if (CodecUtil.CODEC_MAGIC == CodecUtil.readBEInt(in)) {
             int actualVersion =
                 CodecUtil.checkHeaderNoMagic(

--- a/lucene/misc/src/java/org/apache/lucene/misc/index/BPIndexReorderer.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/index/BPIndexReorderer.java
@@ -817,8 +817,8 @@ public final class BPIndexReorderer {
               });
     }
 
-    IndexInput termIDsInput = tempDir.openInput(termIDsFileName, IOContext.READ);
-    IndexInput startOffsets = tempDir.openInput(startOffsetsFileName, IOContext.READ);
+    IndexInput termIDsInput = tempDir.openInput(termIDsFileName, IOContext.DEFAULT);
+    IndexInput startOffsets = tempDir.openInput(startOffsetsFileName, IOContext.DEFAULT);
     return new ForwardIndex(startOffsets, termIDsInput, maxTerm);
   }
 

--- a/lucene/misc/src/java/org/apache/lucene/misc/store/ByteWritesTrackingDirectoryWrapper.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/ByteWritesTrackingDirectoryWrapper.java
@@ -65,7 +65,6 @@ public final class ByteWritesTrackingDirectoryWrapper extends FilterDirectory {
       case MERGE:
         return new ByteTrackingIndexOutput(output, mergedBytes);
       case DEFAULT:
-      case READ:
       default:
         return output;
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseCompoundFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseCompoundFormatTestCase.java
@@ -899,7 +899,7 @@ public abstract class BaseCompoundFormatTestCase extends BaseIndexFileFormatTest
 
     ReadBytesDirectoryWrapper readTrackingDir = new ReadBytesDirectoryWrapper(dir);
     CompoundDirectory compoundDir =
-        si.getCodec().compoundFormat().getCompoundReader(readTrackingDir, si, IOContext.READ);
+        si.getCodec().compoundFormat().getCompoundReader(readTrackingDir, si, IOContext.DEFAULT);
     compoundDir.checkIntegrity();
     Map<String, FixedBitSet> readBytes = readTrackingDir.getReadBytes();
     assertEquals(createdFiles, readBytes.keySet());

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
@@ -374,7 +374,8 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
         new SegmentWriteState(
             null, dir, segmentInfo, fieldInfos, null, new IOContext(new FlushInfo(1, 20)));
 
-    SegmentReadState readState = new SegmentReadState(dir, segmentInfo, fieldInfos, IOContext.READ);
+    SegmentReadState readState =
+        new SegmentReadState(dir, segmentInfo, fieldInfos, IOContext.DEFAULT);
 
     // PostingsFormat
     NormsProducer fakeNorms =

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
@@ -839,7 +839,7 @@ public class RandomPostingsTester {
     currentFieldInfos = newFieldInfos;
 
     SegmentReadState readState =
-        new SegmentReadState(dir, segmentInfo, newFieldInfos, IOContext.READ);
+        new SegmentReadState(dir, segmentInfo, newFieldInfos, IOContext.DEFAULT);
 
     return codec.postingsFormat().fieldsProducer(readState);
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1798,20 +1798,17 @@ public abstract class LuceneTestCase extends Assert {
     } else {
       // Make a totally random IOContext:
       final IOContext context;
-      switch (random.nextInt(5)) {
+      switch (random.nextInt(4)) {
         case 0:
           context = IOContext.DEFAULT;
           break;
         case 1:
-          context = IOContext.READ;
-          break;
-        case 2:
           context = IOContext.READONCE;
           break;
-        case 3:
+        case 2:
           context = new IOContext(new MergeInfo(randomNumDocs, size, true, -1));
           break;
-        case 4:
+        case 3:
           context = new IOContext(new FlushInfo(randomNumDocs, size));
           break;
         default:


### PR DESCRIPTION
`DEFAULT` doesn't mean much today and could be used whenever `READ` is used. So let's use `DEFAULT` all the time instead and remove `READ`.
