### PR TITLE
Optimization: Use precalculated IOContexts for withReadAdvice() to not create new instances all the time

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/IOContext.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IOContext.java
@@ -16,7 +16,11 @@
  */
 package org.apache.lucene.store;
 
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * IOContext holds additional details on the merge/search context. A IOContext object can never be
@@ -48,6 +52,10 @@ public record IOContext(
       new IOContext(Context.DEFAULT, null, null, ReadAdvice.NORMAL);
 
   public static final IOContext READONCE = new IOContext(ReadAdvice.SEQUENTIAL);
+
+  private static final Map<ReadAdvice, IOContext> DEFAULT_READADVICE_CACHE =
+      Arrays.stream(ReadAdvice.values())
+          .collect(Collectors.toUnmodifiableMap(Function.identity(), IOContext::new));
 
   @SuppressWarnings("incomplete-switch")
   public IOContext {
@@ -93,7 +101,7 @@ public record IOContext(
    */
   public IOContext withReadAdvice(ReadAdvice advice) {
     if (context == Context.DEFAULT) {
-      return new IOContext(advice);
+      return DEFAULT_READADVICE_CACHE.get(advice);
     } else {
       return this;
     }

--- a/lucene/core/src/java/org/apache/lucene/store/IOContext.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IOContext.java
@@ -17,11 +17,7 @@
 package org.apache.lucene.store;
 
 import java.util.Arrays;
-import java.util.EnumMap;
-import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * IOContext holds additional details on the merge/search context. A IOContext object can never be
@@ -54,11 +50,8 @@ public record IOContext(
 
   public static final IOContext READONCE = new IOContext(ReadAdvice.SEQUENTIAL);
 
-  private static final Map<ReadAdvice, IOContext> DEFAULT_READADVICE_CACHE =
-      Arrays.stream(ReadAdvice.values())
-          .collect(
-              Collectors.collectingAndThen(
-                  Collectors.toMap(Function.identity(), IOContext::new), EnumMap::new));
+  private static final IOContext[] DEFAULT_READADVICE_CACHE =
+      Arrays.stream(ReadAdvice.values()).map(IOContext::new).toArray(IOContext[]::new);
 
   @SuppressWarnings("incomplete-switch")
   public IOContext {
@@ -104,7 +97,7 @@ public record IOContext(
    */
   public IOContext withReadAdvice(ReadAdvice advice) {
     if (context == Context.DEFAULT) {
-      return DEFAULT_READADVICE_CACHE.get(advice);
+      return DEFAULT_READADVICE_CACHE[advice.ordinal()];
     } else {
       return this;
     }

--- a/lucene/core/src/java/org/apache/lucene/store/IOContext.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IOContext.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.store;
 
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -55,7 +56,9 @@ public record IOContext(
 
   private static final Map<ReadAdvice, IOContext> DEFAULT_READADVICE_CACHE =
       Arrays.stream(ReadAdvice.values())
-          .collect(Collectors.toUnmodifiableMap(Function.identity(), IOContext::new));
+          .collect(
+              Collectors.collectingAndThen(
+                  Collectors.toMap(Function.identity(), IOContext::new), EnumMap::new));
 
   @SuppressWarnings("incomplete-switch")
   public IOContext {


### PR DESCRIPTION
Followup of #13242: This optimizes the `IOContext#withReadAdvice()` method to use precalculated instances of `IOContext` to not create new instances all the time.