### PR TITLE
Fix ram estimate and its test for PackedInts.NullReader singleton

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
@@ -604,8 +604,10 @@ public class PackedInts {
 
     @Override
     public long ramBytesUsed() {
-      return RamUsageEstimator.alignObjectSize(
-          RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES);
+      return valueCount == PackedLongValues.DEFAULT_PAGE_SIZE
+          ? 0
+          : RamUsageEstimator.alignObjectSize(
+              RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES);
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
@@ -18,12 +18,15 @@ package org.apache.lucene.util.packed;
 
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Random;
 import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.store.DataInput;
@@ -966,6 +969,18 @@ public class TestPackedInts extends LuceneTestCase {
             .ramBytesUsed());
   }
 
+  private static final class IgnoreNullReaderSingletonAccumulator
+      extends RamUsageTester.Accumulator {
+    @Override
+    public long accumulateObject(
+        Object o, long shallowSize, Map<Field, Object> fieldValues, Collection<Object> queue) {
+      if (o == PackedInts.NullReader.forCount(PackedLongValues.DEFAULT_PAGE_SIZE)) {
+        return 0;
+      }
+      return super.accumulateObject(o, shallowSize, fieldValues, queue);
+    }
+  }
+
   public void testPackedLongValues() {
     final long[] arr =
         new long[RandomNumbers.randomIntBetween(random(), 1, TEST_NIGHTLY ? 1000000 : 10000)];
@@ -1017,7 +1032,8 @@ public class TestPackedInts extends LuceneTestCase {
         for (int i = 0; i < arr.length; ++i) {
           buf.add(arr[i]);
           if (rarely() && !TEST_NIGHTLY) {
-            final long expectedBytesUsed = RamUsageTester.ramUsed(buf);
+            final long expectedBytesUsed =
+                RamUsageTester.ramUsed(buf, new IgnoreNullReaderSingletonAccumulator());
             final long computedBytesUsed = buf.ramBytesUsed();
             assertEquals(expectedBytesUsed, computedBytesUsed);
           }
@@ -1044,7 +1060,8 @@ public class TestPackedInts extends LuceneTestCase {
         }
         assertFalse(it.hasNext());
 
-        final long expectedBytesUsed = RamUsageTester.ramUsed(values);
+        final long expectedBytesUsed =
+            RamUsageTester.ramUsed(values, new IgnoreNullReaderSingletonAccumulator());
         final long computedBytesUsed = values.ramBytesUsed();
         assertEquals(expectedBytesUsed, computedBytesUsed);
       }


### PR DESCRIPTION
Correct estimate for singleton to return `0` and use custom accumulator in tests to fix assertions. Tried not doing this in #13232 but turns out we need a little complexity here since the singleton is recognized by the `RamUsageTester` in so far that is only counted once if it shows up repeatedly in an array or so.

fixes #13249
