### PR TITLE
Fix container inefficiencies in FieldInfos.java

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
@@ -107,26 +107,30 @@ public final class CompetitiveImpactAccumulator {
 
   /** Get the set of competitive freq and norm pairs, ordered by increasing freq and norm. */
   public Collection<Impact> getCompetitiveFreqNormPairs() {
-    List<Impact> impacts = new ArrayList<>();
-    int maxFreqForLowerNorms = 0;
-    for (int i = 0; i < maxFreqs.length; ++i) {
-      int maxFreq = maxFreqs[i];
-      if (maxFreq > maxFreqForLowerNorms) {
-        impacts.add(new Impact(maxFreq, (byte) i));
-        maxFreqForLowerNorms = maxFreq;
-      }
-    }
-
     if (otherFreqNormPairs.isEmpty()) {
+      List<Impact> impacts = new ArrayList<>();
+      int maxFreqForLowerNorms = 0;
+      for (int i = 0; i < maxFreqs.length; ++i) {
+        int maxFreq = maxFreqs[i];
+        if (maxFreq > maxFreqForLowerNorms) {
+          impacts.add(new Impact(maxFreq, (byte) i));
+          maxFreqForLowerNorms = maxFreq;
+        }
+      }
       // Common case: all norms are bytes
       return impacts;
+    } else {
+      TreeSet<Impact> freqNormPairs = new TreeSet<>(this.otherFreqNormPairs);
+      int maxFreqForLowerNorms = 0;
+      for (int i = 0; i < maxFreqs.length; ++i) {
+        int maxFreq = maxFreqs[i];
+        if (maxFreq > maxFreqForLowerNorms) {
+          add(new Impact(maxFreq, (byte) i), freqNormPairs);
+          maxFreqForLowerNorms = maxFreq;
+        }
+      }
+      return Collections.unmodifiableSet(freqNormPairs);
     }
-
-    TreeSet<Impact> freqNormPairs = new TreeSet<>(this.otherFreqNormPairs);
-    for (Impact impact : impacts) {
-      add(impact, freqNormPairs);
-    }
-    return Collections.unmodifiableSet(freqNormPairs);
   }
 
   private void add(Impact newEntry, TreeSet<Impact> freqNormPairs) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/CompetitiveImpactAccumulator.java
@@ -107,30 +107,26 @@ public final class CompetitiveImpactAccumulator {
 
   /** Get the set of competitive freq and norm pairs, ordered by increasing freq and norm. */
   public Collection<Impact> getCompetitiveFreqNormPairs() {
-    if (otherFreqNormPairs.isEmpty()) {
-      List<Impact> impacts = new ArrayList<>();
-      int maxFreqForLowerNorms = 0;
-      for (int i = 0; i < maxFreqs.length; ++i) {
-        int maxFreq = maxFreqs[i];
-        if (maxFreq > maxFreqForLowerNorms) {
-          impacts.add(new Impact(maxFreq, (byte) i));
-          maxFreqForLowerNorms = maxFreq;
-        }
+    List<Impact> impacts = new ArrayList<>();
+    int maxFreqForLowerNorms = 0;
+    for (int i = 0; i < maxFreqs.length; ++i) {
+      int maxFreq = maxFreqs[i];
+      if (maxFreq > maxFreqForLowerNorms) {
+        impacts.add(new Impact(maxFreq, (byte) i));
+        maxFreqForLowerNorms = maxFreq;
       }
+    }
+
+    if (otherFreqNormPairs.isEmpty()) {
       // Common case: all norms are bytes
       return impacts;
-    } else {
-      TreeSet<Impact> freqNormPairs = new TreeSet<>(this.otherFreqNormPairs);
-      int maxFreqForLowerNorms = 0;
-      for (int i = 0; i < maxFreqs.length; ++i) {
-        int maxFreq = maxFreqs[i];
-        if (maxFreq > maxFreqForLowerNorms) {
-          add(new Impact(maxFreq, (byte) i), freqNormPairs);
-          maxFreqForLowerNorms = maxFreq;
-        }
-      }
-      return Collections.unmodifiableSet(freqNormPairs);
     }
+
+    TreeSet<Impact> freqNormPairs = new TreeSet<>(this.otherFreqNormPairs);
+    for (Impact impact : impacts) {
+      add(impact, freqNormPairs);
+    }
+    return Collections.unmodifiableSet(freqNormPairs);
   }
 
   private void add(Impact newEntry, TreeSet<Impact> freqNormPairs) {

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -156,7 +156,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
     this.softDeletesField = softDeletesField;
     this.parentField = parentField;
 
-    List<FieldInfo> valuesTemp = new ArrayList<>();
+    List<FieldInfo> valuesTemp = new ArrayList<>(infos.length);
     byNumber = new FieldInfo[size];
     for (int i = 0; i < size; i++) {
       byNumber[i] = byNumberTemp[i];

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -24,7 +24,6 @@ import static org.apache.lucene.index.FieldInfo.verifySameStoreTermVectors;
 import static org.apache.lucene.index.FieldInfo.verifySameVectorOptions;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -165,8 +164,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
         valuesTemp.add(byNumberTemp[i]);
       }
     }
-    values =
-        Collections.unmodifiableCollection(Arrays.asList(valuesTemp.toArray(new FieldInfo[0])));
+    values = Collections.unmodifiableCollection(valuesTemp);
   }
 
   /**


### PR DESCRIPTION
### Description
Hi,

We find that there exist container inefficiencies in FieldInfos.java. 

At line 169, there maybe a redundant operation that `Arrays.asList(valuesTemp.toArray(new FieldInfo[0]))` transform List object `valuesTemp` to array and then back to List.

We discovered the above containers inefficiencies by our tool cinst. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.
