### PR TITLE
Correct quantized HNSW validation to be in-line with HNSW

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswScalarQuantizedVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswScalarQuantizedVectorsFormat.java
@@ -120,10 +120,6 @@ public final class Lucene99HnswScalarQuantizedVectorsFormat extends KnnVectorsFo
     }
     this.maxConn = maxConn;
     this.beamWidth = beamWidth;
-    if (numMergeWorkers > 1 && mergeExec == null) {
-      throw new IllegalArgumentException(
-          "No executor service passed in when " + numMergeWorkers + " merge workers are requested");
-    }
     if (numMergeWorkers == 1 && mergeExec != null) {
       throw new IllegalArgumentException(
           "No executor service is needed as we'll use single thread to merge");

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestLucene99HnswQuantizedVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestLucene99HnswQuantizedVectorsFormat.java
@@ -219,9 +219,6 @@ public class TestLucene99HnswQuantizedVectorsFormat extends BaseKnnVectorsFormat
         () -> new Lucene99HnswScalarQuantizedVectorsFormat(20, 100, 0, 7, false, 0.8f, null));
     expectThrows(
         IllegalArgumentException.class,
-        () -> new Lucene99HnswScalarQuantizedVectorsFormat(20, 100, 100, 7, false, null, null));
-    expectThrows(
-        IllegalArgumentException.class,
         () ->
             new Lucene99HnswScalarQuantizedVectorsFormat(
                 20, 100, 1, 7, false, null, new SameThreadExecutorService()));


### PR DESCRIPTION
When intra-merge parallelism was introduced, the validation that `numWorkers` must `==1` with a `null` executor service was removed from `Lucene99HnswVectorsFormat`. However, I forgot to remove that validation from `Lucene99HnswScalarQuantizedVectorsFormat`. 

This corrects that mistake, allowing `Lucene99HnswScalarQuantizedVectorsFormat` and `Lucene99HnswVectorsFormat` to take advantage of the merge-schedulers intra-merge threading.