### PR TITLE
Make the default ReadAdvice configurable by sysprop

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -163,9 +163,11 @@ Bug Fixes
 Changes in Runtime Behavior
 ---------------------
 
-* GITHUB#13244: IOContext now uses ReadAdvice#RANDOM by default for read
+* GITHUB#13244, GITHUB#13264: IOContext now uses ReadAdvice#RANDOM by default for read
   operations. An implication is that `MMapDirectory` will use POSIX_MADV_RANDOM
-  on POSIX systems. (Adrien Grand)
+  on POSIX systems. To fallback to OS default behaviour, pass system property via
+  `-Dorg.apache.lucene.store.defaultReadAdvice=normal`. This may be useful on systems
+  with lots of RAM as this increases read-ahead. (Adrien Grand, Uwe Schindler)
 
 Changes in Backwards Compatibility Policy
 -----------------------------------------

--- a/lucene/core/src/java/org/apache/lucene/store/IOContext.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IOContext.java
@@ -18,6 +18,7 @@ package org.apache.lucene.store;
 
 import java.util.Arrays;
 import java.util.Objects;
+import org.apache.lucene.util.Constants;
 
 /**
  * IOContext holds additional details on the merge/search context. An IOContext object can never be
@@ -48,14 +49,14 @@ public record IOContext(
   /**
    * A default context for normal reads/writes. Use {@link #withReadAdvice(ReadAdvice)} to specify
    * another {@link ReadAdvice}.
+   *
+   * <p>It will use {@link ReadAdvice#RANDOM} by default, unless set by system property {@code
+   * org.apache.lucene.store.defaultReadAdvice}.
    */
-  public static final IOContext DEFAULT = new IOContext(ReadAdvice.RANDOM);
+  public static final IOContext DEFAULT = new IOContext(Constants.DEFAULT_READADVICE);
 
   /** A default context for reads with {@link ReadAdvice#SEQUENTIAL}. */
   public static final IOContext READONCE = new IOContext(ReadAdvice.SEQUENTIAL);
-
-  private static final IOContext[] DEFAULT_READADVICE_CACHE =
-      Arrays.stream(ReadAdvice.values()).map(IOContext::new).toArray(IOContext[]::new);
 
   @SuppressWarnings("incomplete-switch")
   public IOContext {
@@ -90,6 +91,9 @@ public record IOContext(
     this(Context.MERGE, mergeInfo, null, ReadAdvice.SEQUENTIAL);
   }
 
+  private static final IOContext[] READADVICE_TO_IOCONTEXT =
+      Arrays.stream(ReadAdvice.values()).map(IOContext::new).toArray(IOContext[]::new);
+
   /**
    * Return an updated {@link IOContext} that has the provided {@link ReadAdvice} if the {@link
    * Context} is a {@link Context#DEFAULT} context, otherwise return this existing instance. This
@@ -99,7 +103,7 @@ public record IOContext(
    */
   public IOContext withReadAdvice(ReadAdvice advice) {
     if (context == Context.DEFAULT) {
-      return DEFAULT_READADVICE_CACHE[advice.ordinal()];
+      return READADVICE_TO_IOCONTEXT[advice.ordinal()];
     } else {
       return this;
     }

--- a/lucene/core/src/java/org/apache/lucene/util/Constants.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Constants.java
@@ -18,7 +18,10 @@ package org.apache.lucene.util;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.logging.Logger;
+import org.apache.lucene.store.ReadAdvice;
 
 /** Some useful constants. */
 public final class Constants {
@@ -151,6 +154,16 @@ public final class Constants {
     // everyone else is slow, until proven otherwise by benchmarks
     return false;
   }
+
+  /**
+   * The default {@link ReadAdvice} used for opening index files. It will be {@link
+   * ReadAdvice#RANDOM} by default, unless set by system property {@code
+   * org.apache.lucene.store.defaultReadAdvice}.
+   */
+  public static final ReadAdvice DEFAULT_READADVICE =
+      Optional.ofNullable(getSysProp("org.apache.lucene.store.defaultReadAdvice"))
+          .map(a -> ReadAdvice.valueOf(a.toUpperCase(Locale.ROOT)))
+          .orElse(ReadAdvice.RANDOM);
 
   private static String getSysProp(String property) {
     try {


### PR DESCRIPTION
Followup after #13244: This makes the default `ReadAdvice` for index files configurable via system property `org.apache.lucene.store.defaultReadAdvice`.

I moved the corresponding constant to the `oal.util.Constants` class because this makes reading and error reporting easier as @rmuir and I added some framework to safely support security manager and map those variables (we used this for vectorization).

It would be good to move all reading of system properties to that class so we do not have the splattered AccessControllers everywhere.