### PR TITLE
Propagate the flush IOContext to stored fields / term vectors writers when index sorting is enabled.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
@@ -101,9 +101,7 @@ final class SortingStoredFieldsConsumer extends StoredFieldsConsumer {
     // Don't pull a merge instance, since merge instances optimize for
     // sequential access while we consume stored fields in random order here.
     StoredFieldsWriter sortWriter =
-        codec
-            .storedFieldsFormat()
-            .fieldsWriter(state.directory, state.segmentInfo, state.context);
+        codec.storedFieldsFormat().fieldsWriter(state.directory, state.segmentInfo, state.context);
     try {
       reader.checkIntegrity();
       CopyVisitor visitor = new CopyVisitor(sortWriter);

--- a/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
@@ -103,7 +103,7 @@ final class SortingStoredFieldsConsumer extends StoredFieldsConsumer {
     StoredFieldsWriter sortWriter =
         codec
             .storedFieldsFormat()
-            .fieldsWriter(state.directory, state.segmentInfo, IOContext.DEFAULT);
+            .fieldsWriter(state.directory, state.segmentInfo, state.context);
     try {
       reader.checkIntegrity();
       CopyVisitor visitor = new CopyVisitor(sortWriter);

--- a/lucene/core/src/java/org/apache/lucene/index/SortingTermVectorsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingTermVectorsConsumer.java
@@ -68,7 +68,7 @@ final class SortingTermVectorsConsumer extends TermVectorsConsumer {
       TermVectorsWriter writer =
           codec
               .termVectorsFormat()
-              .vectorsWriter(state.directory, state.segmentInfo, IOContext.DEFAULT);
+              .vectorsWriter(state.directory, state.segmentInfo, state.context);
       try {
         reader.checkIntegrity();
         for (int docID = 0; docID < state.segmentInfo.maxDoc(); docID++) {


### PR DESCRIPTION
This fixes index sorting to pass the correct `IOContext` to stored fields and term vectors writers when index sorting is enabled. This is important for things like `NRTCachingDirectory`.
