### PR TITLE
Use IOContext#RANDOM when appropriate.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -78,6 +78,12 @@ Optimizations
 * GITHUB#13149: Made PointRangeQuery faster, for some segment sizes, by reducing the amount of virtual calls to
   IntersectVisitor::visit(int). (Anton Hägerstrand)
 
+* GITHUB#13222: Vector data files - including quantized vectors, HNSW graphs,
+  stored fields data files and term vectors data files now advise the
+  underlying `Directory` to optimize for random-access. On recent Java versions
+  (>= 21) and POSIX systems, `MMapDirectory` would use MADV_RANDOM for these
+  files under the hood. (Adrien Grand)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -19,9 +19,12 @@ New Features
 * GITHUB#12915: Add new token filters for Japanese sutegana (捨て仮名). This introduces JapaneseHiraganaUppercaseFilter
   and JapaneseKatakanaUppercaseFilter. (Dai Sugimori)
 
-* GITHUB#13196: Add support for posix_madvise to MMapDirectory: If running on Linux/macOS and Java 21
-  or later, MMapDirectory uses IOContext to pass suitable MADV flags to kernel of operating system.
-  This may improve paging logic especially when large segments are merged under memory pressure.
+* GITHUB#13196, GITHUB#13222: Add support for posix_madvise to MMapDirectory: If running on
+  Linux/macOS and Java 21 or later, MMapDirectory uses IOContext to pass suitable MADV flags to
+  kernel of operating system. In particular, merging now passes POSIX_MADV_SEQUENTIAL to the readers
+  that are being merged, and searching passes POSIX_MADV_RANDOM to vector data files - including
+  quantized vector data files, HNSW graphs, stored fields data files and term vectors data files.
+  This may improve paging logic especially when working with large indexes under memory pressure.
   (Uwe Schindler, Chris Hegarty, Robert Muir, Adrien Grand)
 
 * GITHUB#13197: Expand support for new scalar bit levels for HNSW vectors. This includes 4-bit vectors and an option
@@ -77,12 +80,6 @@ Optimizations
 
 * GITHUB#13149: Made PointRangeQuery faster, for some segment sizes, by reducing the amount of virtual calls to
   IntersectVisitor::visit(int). (Anton Hägerstrand)
-
-* GITHUB#13222: Vector data files - including quantized vectors, HNSW graphs,
-  stored fields data files and term vectors data files now advise the
-  underlying `Directory` to optimize for random-access. On recent Java versions
-  (>= 21) and POSIX systems, `MMapDirectory` would use MADV_RANDOM for these
-  files under the hood. (Adrien Grand)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
@@ -128,7 +128,7 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
     ChecksumIndexInput metaIn = null;
     try {
       // Open the data file
-      fieldsStream = d.openInput(fieldsStreamFN, context);
+      fieldsStream = d.openInput(fieldsStreamFN, context.withRandomAccess());
       version =
           CodecUtil.checkIndexHeader(
               fieldsStream, formatName, VERSION_START, VERSION_CURRENT, si.getId(), segmentSuffix);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -134,7 +134,7 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
       // Open the data file
       final String vectorsStreamFN =
           IndexFileNames.segmentFileName(segment, segmentSuffix, VECTORS_EXTENSION);
-      vectorsStream = d.openInput(vectorsStreamFN, context);
+      vectorsStream = d.openInput(vectorsStreamFN, context.withRandomAccess());
       version =
           CodecUtil.checkIndexHeader(
               vectorsStream, formatName, VERSION_START, VERSION_CURRENT, si.getId(), segmentSuffix);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
@@ -38,6 +38,7 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.IOUtils;
@@ -66,7 +67,10 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
               state,
               versionMeta,
               Lucene99FlatVectorsFormat.VECTOR_DATA_EXTENSION,
-              Lucene99FlatVectorsFormat.VECTOR_DATA_CODEC_NAME);
+              Lucene99FlatVectorsFormat.VECTOR_DATA_CODEC_NAME,
+              // Flat formats are used to randomly access vectors from their node ID that is stored
+              // in the HNSW graph.
+              state.context.withRandomAccess());
       success = true;
     } finally {
       if (success == false) {
@@ -102,11 +106,15 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
   }
 
   private static IndexInput openDataInput(
-      SegmentReadState state, int versionMeta, String fileExtension, String codecName)
+      SegmentReadState state,
+      int versionMeta,
+      String fileExtension,
+      String codecName,
+      IOContext context)
       throws IOException {
     String fileName =
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
-    IndexInput in = state.directory.openInput(fileName, state.context);
+    IndexInput in = state.directory.openInput(fileName, context);
     boolean success = false;
     try {
       int versionVectorData =

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
@@ -44,6 +44,7 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.ArrayUtil;
@@ -315,10 +316,13 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
       CodecUtil.writeFooter(tempVectorData);
       IOUtils.close(tempVectorData);
 
-      // copy the temporary file vectors to the actual data file
+      // This temp file will be accessed in a random-access fashion to construct the HNSW graph.
+      // Note: don't use the context from the state, which is a flush/merge context, not expecting
+      // to perform random reads.
       vectorDataInput =
           segmentWriteState.directory.openInput(
-              tempVectorData.getName(), segmentWriteState.context);
+              tempVectorData.getName(), IOContext.DEFAULT.withRandomAccess());
+      // copy the temporary file vectors to the actual data file
       vectorData.copyBytes(vectorDataInput, vectorDataInput.length() - CodecUtil.footerLength());
       CodecUtil.retrieveChecksum(vectorDataInput);
       long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
@@ -320,8 +320,7 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
       // Note: don't use the context from the state, which is a flush/merge context, not expecting
       // to perform random reads.
       vectorDataInput =
-          segmentWriteState.directory.openInput(
-              tempVectorData.getName(), IOContext.DEFAULT.withRandomAccess());
+          segmentWriteState.directory.openInput(tempVectorData.getName(), IOContext.RANDOM);
       // copy the temporary file vectors to the actual data file
       vectorData.copyBytes(vectorDataInput, vectorDataInput.length() - CodecUtil.footerLength());
       CodecUtil.retrieveChecksum(vectorDataInput);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -40,6 +40,7 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.Accountable;
@@ -102,7 +103,8 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
               state,
               versionMeta,
               Lucene99HnswVectorsFormat.VECTOR_INDEX_EXTENSION,
-              Lucene99HnswVectorsFormat.VECTOR_INDEX_CODEC_NAME);
+              Lucene99HnswVectorsFormat.VECTOR_INDEX_CODEC_NAME,
+              state.context.withRandomAccess());
       success = true;
     } finally {
       if (success == false) {
@@ -112,11 +114,15 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
   }
 
   private static IndexInput openDataInput(
-      SegmentReadState state, int versionMeta, String fileExtension, String codecName)
+      SegmentReadState state,
+      int versionMeta,
+      String fileExtension,
+      String codecName,
+      IOContext context)
       throws IOException {
     String fileName =
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
-    IndexInput in = state.directory.openInput(fileName, state.context);
+    IndexInput in = state.directory.openInput(fileName, context);
     boolean success = false;
     try {
       int versionVectorData =

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
@@ -36,6 +36,7 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.IOUtils;
@@ -93,7 +94,10 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
               state,
               versionMeta,
               Lucene99ScalarQuantizedVectorsFormat.VECTOR_DATA_EXTENSION,
-              Lucene99ScalarQuantizedVectorsFormat.VECTOR_DATA_CODEC_NAME);
+              Lucene99ScalarQuantizedVectorsFormat.VECTOR_DATA_CODEC_NAME,
+              // Quantized vectors are accessed randomly from their node ID stored in the HNSW
+              // graph.
+              state.context.withRandomAccess());
       success = true;
     } finally {
       if (success == false) {
@@ -166,11 +170,15 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
   }
 
   private static IndexInput openDataInput(
-      SegmentReadState state, int versionMeta, String fileExtension, String codecName)
+      SegmentReadState state,
+      int versionMeta,
+      String fileExtension,
+      String codecName,
+      IOContext context)
       throws IOException {
     String fileName =
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
-    IndexInput in = state.directory.openInput(fileName, state.context);
+    IndexInput in = state.directory.openInput(fileName, context);
     boolean success = false;
     try {
       int versionVectorData =

--- a/lucene/core/src/java/org/apache/lucene/store/IOContext.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IOContext.java
@@ -132,8 +132,22 @@ public class IOContext {
     this.mergeInfo = ctxt.mergeInfo;
     this.flushInfo = ctxt.flushInfo;
     this.readOnce = readOnce;
-    this.randomAccess = ctxt.randomAccess;
+    this.randomAccess = false;
     this.load = false;
+  }
+
+  /**
+   * Return an updated {@link IOContext} that has {@link IOContext#randomAccess} set to true if
+   * {@link IOContext#context} is {@link Context#READ} or {@link Context#DEFAULT}. Otherwise, this
+   * returns this instance. This helps preserve sequential access for merging, which is always the
+   * right choice, while allowing {@link IndexInput}s open for searching to use random access.
+   */
+  public IOContext withRandomAccess() {
+    if (context == Context.READ || context == Context.DEFAULT) {
+      return RANDOM;
+    } else {
+      return this;
+    }
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/store/IOContext.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IOContext.java
@@ -121,7 +121,8 @@ public class IOContext {
 
   /**
    * This constructor is used to initialize a {@link IOContext} instance with a new value for the
-   * readOnce variable.
+   * readOnce variable. This automatically sets {@link #randomAccess} and {@link #load} to {@code
+   * false}.
    *
    * @param ctxt {@link IOContext} object whose information is used to create the new instance
    *     except the readOnce variable.


### PR DESCRIPTION
This switches the following files to `IOContext#RANDOM`:
 - Stored fields data file.
 - Term vectors data file.
 - HNSW graph.
 - Temporary file storing vectors at merge time that we use to construct the merged HNSW graph.
 - Vector data files, including quantized data files.

I hesitated using `IOContext.RANDOM` on terms, since they have a random access pattern when running term queries, but a more sequential access pattern when running multi-term queries. I erred on the conservative side and did not switch them to `IOContext.RANDOM` for now.

For simplicity, I'm only touching the current codec, not previous codecs.