### PR TITLE
Add 'passageSortComparator' option in FieldHighlighter

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -298,6 +298,8 @@ Improvements
 * GITHUB#13385: Add Intervals.noIntervals() method to produce an empty IntervalsSource.
   (Aniketh Jain, Uwe Schindler, Alan Woodward))
 
+* GITHUB#13276: UnifiedHighlighter: new 'passageSortComparator' option to allow sorting other than offset order. (Seunghan Jung)
+
 Optimizations
 ---------------------
 

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/FieldHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/FieldHighlighter.java
@@ -40,6 +40,7 @@ public class FieldHighlighter {
   protected final int maxPassages;
   protected final int maxNoHighlightPassages;
   protected final PassageFormatter passageFormatter;
+  protected final Comparator<Passage> passageSortComparator;
 
   public FieldHighlighter(
       String field,
@@ -48,7 +49,8 @@ public class FieldHighlighter {
       PassageScorer passageScorer,
       int maxPassages,
       int maxNoHighlightPassages,
-      PassageFormatter passageFormatter) {
+      PassageFormatter passageFormatter,
+      Comparator<Passage> passageSortComparator) {
     this.field = field;
     this.fieldOffsetStrategy = fieldOffsetStrategy;
     this.breakIterator = breakIterator;
@@ -56,6 +58,7 @@ public class FieldHighlighter {
     this.maxPassages = maxPassages;
     this.maxNoHighlightPassages = maxNoHighlightPassages;
     this.passageFormatter = passageFormatter;
+    this.passageSortComparator = passageSortComparator;
   }
 
   public String getField() {
@@ -191,8 +194,7 @@ public class FieldHighlighter {
     maybeAddPassage(passageQueue, passageScorer, passage, contentLength);
 
     Passage[] passages = passageQueue.toArray(new Passage[passageQueue.size()]);
-    // sort in ascending order
-    Arrays.sort(passages, Comparator.comparingInt(Passage::getStartOffset));
+    Arrays.sort(passages, passageSortComparator);
     return passages;
   }
 

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/visibility/TestUnifiedHighlighterExtensibility.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/visibility/TestUnifiedHighlighterExtensibility.java
@@ -20,6 +20,7 @@ package org.apache.lucene.search.uhighlight.visibility;
 import java.io.IOException;
 import java.text.BreakIterator;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -130,6 +131,11 @@ public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
           }
 
           @Override
+          protected Comparator<Passage> getPassageSortComparator(String field) {
+            return super.getPassageSortComparator(field);
+          }
+
+          @Override
           public Analyzer getIndexAnalyzer() {
             return super.getIndexAnalyzer();
           }
@@ -186,7 +192,8 @@ public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
                 getScorer(field),
                 maxPassages,
                 getMaxNoHighlightPassages(field),
-                getFormatter(field));
+                getFormatter(field),
+                getPassageSortComparator(field));
           }
 
           @Override
@@ -240,7 +247,7 @@ public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
   public void testFieldHiglighterExtensibility() {
     final String fieldName = "fieldName";
     FieldHighlighter fieldHighlighter =
-        new FieldHighlighter(fieldName, null, null, null, 1, 1, null) {
+        new FieldHighlighter(fieldName, null, null, null, 1, 1, null, null) {
           @Override
           protected Passage[] highlightOffsetsEnums(OffsetsEnum offsetsEnums) throws IOException {
             return super.highlightOffsetsEnums(offsetsEnums);
@@ -262,7 +269,8 @@ public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
         PassageScorer passageScorer,
         int maxPassages,
         int maxNoHighlightPassages,
-        PassageFormatter passageFormatter) {
+        PassageFormatter passageFormatter,
+        Comparator<Passage> passageSortComparator) {
       super(
           field,
           fieldOffsetStrategy,
@@ -270,7 +278,8 @@ public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
           passageScorer,
           maxPassages,
           maxNoHighlightPassages,
-          passageFormatter);
+          passageFormatter,
+          passageSortComparator);
     }
 
     @Override


### PR DESCRIPTION
### Description

`FieldHighlighter` always sorts the final selected passages based on startOffset, but this may not align with the user's intentions.

For example, in the case of Solr's multiValue fields, the order might just be a simple listing of items without any significance. In such cases, the order in which passages appear is not important. It might be more effective to maintain sorting by score in these situations.

Therefore, it seems necessary to allow for the final sorting criteria to be determined in accordance with the user's intentions.
