### PR TITLE
Fix failing BaseKnnVectorQueryTestCase#testTimeout

### DIFF
--- a/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
@@ -285,7 +285,6 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
   }
 
   /** Test that the query times out correctly. */
-  @AwaitsFix(bugUrl = "https://github.com/apache/lucene/issues/13272")
   public void testTimeout() throws IOException {
     try (Directory indexStore =
             getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
@@ -306,9 +305,9 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
       assertEquals(0, searcher.count(exactQuery)); // Same for exact search
 
       searcher.setTimeout(new CountingQueryTimeout(1)); // Only score 1 parent
-      // Note: This depends on the HNSW graph having just one layer,
-      // would be 0 in case of multiple layers
-      assertEquals(1, searcher.count(query)); // Expect only 1 result
+      // Note: We get partial results when the HNSW graph has 1 layer, but no results for > 1 layer
+      // because the timeout is exhausted while finding the best entry node for the last level
+      assertTrue(searcher.count(query) <= 1); // Expect at most 1 result
 
       searcher.setTimeout(new CountingQueryTimeout(1)); // Only score 1 parent
       assertEquals(1, searcher.count(exactQuery)); // Expect only 1 result


### PR DESCRIPTION
### Description

Fixes #13272 

The failure happens because of [this assumption](https://github.com/apache/lucene/blob/df0384c34fde8118513e7bc7b79dbde923070c8b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java#L788-L791) of the HNSW graph having just 1 level, but we get more than 1 for some seed values -- so the counting timeout of 1 node is exhausted while trying to find the best entry point for the last level, and we consequently get no results, failing [this assertion](https://github.com/apache/lucene/blob/df0384c34fde8118513e7bc7b79dbde923070c8b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java#L791)

The assertion wants to check that when an approximate search is performed (some docs are fed to the collector), we return partial results even after a timeout -- and we can check this explicitly in a separate test for `TimeLimitingKnnCollectorManager`

With that test in place, and since we cannot easily control the number of levels in the underlying graph, can we relax the test to check for "at most 1 result" instead of "exactly 1 result"?