### PR TITLE
Remove deprecated code

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -98,7 +98,7 @@ API Changes
 
 * GITHUB#13241: Remove Accountable interface on KnnVectorsReader. (Pulkit Gupta)
 
-* GITHUB#13262: Remove deprecated code IntField.IntField(name, value), VH_BE_DOUBLE (static memeber in BitUtil) and
+* GITHUB#13262: Remove deprecated code IntField.IntField(name, value), VH_BE_DOUBLE (static member in BitUtil) and
   BlockJoinSelector.wrap (Sanjay Dutt)
 
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -98,6 +98,9 @@ API Changes
 
 * GITHUB#13241: Remove Accountable interface on KnnVectorsReader. (Pulkit Gupta)
 
+* GITHUB#13262: Remove deprecated code IntField.IntField(name, value), VH_BE_DOUBLE (static memeber in BitUtil) and
+  BlockJoinSelector.wrap
+
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -98,9 +98,9 @@ API Changes
 
 * GITHUB#13241: Remove Accountable interface on KnnVectorsReader. (Pulkit Gupta)
 
-* GITHUB#13262: Remove deprecated code IntField.IntField(name, value), VH_BE_DOUBLE (static member in BitUtil) and
-  BlockJoinSelector.wrap (Sanjay Dutt)
-
+* GITHUB#13262: Removed deprecated constructors from DoubleField, FloatField, IntField, LongField, and LongPoint.
+  Additionally, deprecated methods have been removed from ByteBuffersIndexInput, BooleanQuery and others. Please refer
+  to MIGRATE.md for further details. (Sanjay Dutt)
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -99,7 +99,7 @@ API Changes
 * GITHUB#13241: Remove Accountable interface on KnnVectorsReader. (Pulkit Gupta)
 
 * GITHUB#13262: Remove deprecated code IntField.IntField(name, value), VH_BE_DOUBLE (static memeber in BitUtil) and
-  BlockJoinSelector.wrap
+  BlockJoinSelector.wrap (Sanjay Dutt)
 
 
 New Features

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -757,7 +757,7 @@ classes were `@Deprecated` starting with 9.0. Users are encouraged to rely on th
 taxonomy facet encodings where possible. If custom formats are needed, users will need
 to manage the indexed data on their own and create new `Facet` implementations to use it.
 
-### Deprecated code removal 
+### Deprecated code removal (GITHUB#13262)
 
 1. `IntField(String name, int value)`. Use `IntField(String, int, Field.Store)` with `Field.Store#NO` instead.
 2. `DoubleField(String name, double value)`. Use `DoubleField(String, double, Field.Store)` with `Field.Store#NO` instead.

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -756,3 +756,14 @@ Additionally, `OrdinalsReader` (and sub-classes) are fully removed starting with
 classes were `@Deprecated` starting with 9.0. Users are encouraged to rely on the default
 taxonomy facet encodings where possible. If custom formats are needed, users will need
 to manage the indexed data on their own and create new `Facet` implementations to use it.
+
+### Deprecated code removal 
+
+1. `IntField(String name, int value)`. Use `IntField(String, int, Field.Store)` with `Field.Store#NO` instead.
+2. `DoubleField(String name, double value)`. Use `DoubleField(String, double, Field.Store)` with `Field.Store#NO` instead.
+2. `FloatField(String name, float value)`. Use `FloatField(String, float, Field.Store)` with `Field.Store#NO` instead.
+3. `LongField(String name, long value)`. Use `LongField(String, long, Field.Store)` with `Field.Store#NO` instead.
+4. `LongPoint#newDistanceFeatureQuery(String field, float weight, long origin, long pivotDistance)`. Use `LongField#newDistanceFeatureQuery` instead
+5. `BooleanQuery#TooManyClauses`, `BooleanQuery#getMaxClauseCount()`, `BooleanQuery#setMaxClauseCount()`. Use `IndexSearcher#TooManyClauses`, `IndexSearcher#getMaxClauseCount()`, `IndexSearcher#setMaxClauseCount()` instead
+6. `ByteBuffersDataInput#size()`. Use `ByteBuffersDataInput#length()` instead
+7. `SortedSetDocValuesFacetField#label`. `FacetsConfig#pathToString(String[])` can be applied to path as a replacement if string path is desired.

--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
@@ -157,7 +157,7 @@ public abstract class CompressionMode {
 
     @Override
     public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-      final int len = (int) buffersInput.size();
+      final int len = (int) buffersInput.length();
       byte[] bytes = new byte[len];
       buffersInput.readBytes(bytes, 0, len);
       LZ4.compress(bytes, 0, len, out, ht);
@@ -179,7 +179,7 @@ public abstract class CompressionMode {
 
     @Override
     public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-      final int len = (int) buffersInput.size();
+      final int len = (int) buffersInput.length();
       byte[] bytes = new byte[len];
       buffersInput.readBytes(bytes, 0, len);
       LZ4.compress(bytes, 0, len, out, ht);
@@ -265,7 +265,7 @@ public abstract class CompressionMode {
 
     @Override
     public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-      final int len = (int) buffersInput.size();
+      final int len = (int) buffersInput.length();
 
       byte[] bytes = new byte[len];
       buffersInput.readBytes(bytes, 0, len);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
@@ -202,7 +202,7 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
 
     @Override
     public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-      final int len = (int) (buffersInput.size() - buffersInput.position());
+      final int len = (int) (buffersInput.length() - buffersInput.position());
       final int dictLength = len / (NUM_SUB_BLOCKS * DICT_SIZE_FACTOR);
       final int blockLength = (len - dictLength + NUM_SUB_BLOCKS - 1) / NUM_SUB_BLOCKS;
       out.writeVInt(dictLength);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -171,7 +171,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
 
     @Override
     public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
-      final int len = (int) (buffersInput.size() - buffersInput.position());
+      final int len = (int) (buffersInput.length() - buffersInput.position());
       final int dictLength = Math.min(LZ4.MAX_DISTANCE, len / (NUM_SUB_BLOCKS * DICT_SIZE_FACTOR));
       final int blockLength = (len - dictLength + NUM_SUB_BLOCKS - 1) / NUM_SUB_BLOCKS;
       buffer = ArrayUtil.growNoCopy(buffer, dictLength + blockLength);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
@@ -253,7 +253,7 @@ public final class Lucene90CompressingStoredFieldsWriter extends StoredFieldsWri
     // compress stored fields to fieldsStream.
     if (sliced) {
       // big chunk, slice it, using ByteBuffersDataInput ignore memory copy
-      final int capacity = (int) bytebuffers.size();
+      final int capacity = (int) bytebuffers.length();
       for (int compressed = 0; compressed < capacity; compressed += chunkSize) {
         int l = Math.min(chunkSize, capacity - compressed);
         ByteBuffersDataInput bbdi = bytebuffers.slice(compressed, l);

--- a/lucene/core/src/java/org/apache/lucene/document/DoubleField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/DoubleField.java
@@ -60,20 +60,6 @@ public final class DoubleField extends Field {
   private final StoredValue storedValue;
 
   /**
-   * Creates a new DoubleField, indexing the provided point and storing it as a DocValue
-   *
-   * @param name field name
-   * @param value the double value
-   * @throws IllegalArgumentException if the field name or value is null.
-   * @deprecated Use {@link #DoubleField(String, double, Field.Store)} with {@link Field.Store#NO}
-   *     instead.
-   */
-  @Deprecated
-  public DoubleField(String name, double value) {
-    this(name, value, Field.Store.NO);
-  }
-
-  /**
    * Creates a new DoubleField, indexing the provided point, storing it as a DocValue, and
    * optionally storing it as a stored field.
    *

--- a/lucene/core/src/java/org/apache/lucene/document/FloatField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FloatField.java
@@ -60,20 +60,6 @@ public final class FloatField extends Field {
   private final StoredValue storedValue;
 
   /**
-   * Creates a new FloatField, indexing the provided point and storing it as a DocValue
-   *
-   * @param name field name
-   * @param value the float value
-   * @throws IllegalArgumentException if the field name or value is null.
-   * @deprecated Use {@link #FloatField(String, float, Field.Store)} with {@link Field.Store#NO}
-   *     instead.
-   */
-  @Deprecated
-  public FloatField(String name, float value) {
-    this(name, value, Field.Store.NO);
-  }
-
-  /**
    * Creates a new FloatField, indexing the provided point, storing it as a DocValue, and optionally
    * storing it as a stored field.
    *

--- a/lucene/core/src/java/org/apache/lucene/document/IntField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/IntField.java
@@ -62,20 +62,6 @@ public final class IntField extends Field {
   private final StoredValue storedValue;
 
   /**
-   * Creates a new IntField, indexing the provided point and storing it as a DocValue.
-   *
-   * @param name field name
-   * @param value the int value
-   * @throws IllegalArgumentException if the field name or value is null.
-   * @deprecated Use {@link #IntField(String, int, Field.Store)} with {@link Field.Store#NO}
-   *     instead.
-   */
-  @Deprecated
-  public IntField(String name, int value) {
-    this(name, value, Field.Store.NO);
-  }
-
-  /**
    * Creates a new IntField, indexing the provided point, storing it as a DocValue, and optionally
    * storing it as a stored field.
    *

--- a/lucene/core/src/java/org/apache/lucene/document/LongField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LongField.java
@@ -65,20 +65,6 @@ public final class LongField extends Field {
   private final StoredValue storedValue;
 
   /**
-   * Creates a new LongField, indexing the provided point and storing it as a DocValue
-   *
-   * @param name field name
-   * @param value the long value
-   * @throws IllegalArgumentException if the field name or value is null.
-   * @deprecated Use {@link #LongField(String, long, Field.Store)} with {@link Field.Store#NO}
-   *     instead.
-   */
-  @Deprecated
-  public LongField(String name, long value) {
-    this(name, value, Field.Store.NO);
-  }
-
-  /**
    * Creates a new LongField, indexing the provided point, storing it as a DocValue, and optionally
    * storing it as a stored field.
    *

--- a/lucene/core/src/java/org/apache/lucene/document/LongPoint.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LongPoint.java
@@ -19,8 +19,6 @@ package org.apache.lucene.document;
 import java.util.Arrays;
 import java.util.Collection;
 import org.apache.lucene.index.PointValues;
-import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.PointInSetQuery;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
@@ -300,23 +298,5 @@ public final class LongPoint extends Field {
       unboxed[i] = boxed[i];
     }
     return newSetQuery(field, unboxed);
-  }
-
-  /**
-   * Given a field that indexes the same long values into a {@link LongPoint} and doc values (either
-   * {@link NumericDocValuesField} or {@link SortedNumericDocValuesField}), this returns a query
-   * that scores documents based on their distance to {@code origin}: {@code score = weight *
-   * pivotDistance / (pivotDistance + distance)}, ie. score is in the {@code [0, weight]} range, is
-   * equal to {@code weight} when the document's value is equal to {@code origin} and is equal to
-   * {@code weight/2} when the document's value is distant of {@code pivotDistance} from {@code
-   * origin}. In case of multi-valued fields, only the closest point to {@code origin} will be
-   * considered. This query is typically useful to boost results based on recency by adding this
-   * query to a {@link Occur#SHOULD} clause of a {@link BooleanQuery}. @Deprecated Use {@link
-   * LongField#newDistanceFeatureQuery}
-   */
-  @Deprecated
-  public static Query newDistanceFeatureQuery(
-      String field, float weight, long origin, long pivotDistance) {
-    return LongField.newDistanceFeatureQuery(field, weight, origin, pivotDistance);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/PrefixCodedTerms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PrefixCodedTerms.java
@@ -115,7 +115,7 @@ public class PrefixCodedTerms implements Accountable {
 
     private TermIterator(long delGen, ByteBuffersDataInput input) {
       this.input = input;
-      end = input.size();
+      end = input.length();
       this.delGen = delGen;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
@@ -49,7 +49,7 @@ final class SortingStoredFieldsConsumer extends StoredFieldsConsumer {
             @Override
             public void compress(ByteBuffersDataInput buffersInput, DataOutput out)
                 throws IOException {
-              out.copyBytes(buffersInput, buffersInput.size());
+              out.copyBytes(buffersInput, buffersInput.length());
             }
           };
         }

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -39,38 +39,6 @@ import org.apache.lucene.search.BooleanClause.Occur;
  */
 public class BooleanQuery extends Query implements Iterable<BooleanClause> {
 
-  /**
-   * Thrown when an attempt is made to add more than {@link #getMaxClauseCount()} clauses. This
-   * typically happens if a PrefixQuery, FuzzyQuery, WildcardQuery, or TermRangeQuery is expanded to
-   * many terms during search.
-   *
-   * @deprecated use {@link IndexSearcher.TooManyClauses}
-   */
-  @Deprecated // Remove in Lucene 10
-  public static class TooManyClauses extends IndexSearcher.TooManyClauses {}
-
-  /**
-   * Return the maximum number of clauses permitted, 1024 by default. Attempts to add more than the
-   * permitted number of clauses cause {@link TooManyClauses} to be thrown.
-   *
-   * @see IndexSearcher#setMaxClauseCount(int)
-   * @deprecated use {@link IndexSearcher#getMaxClauseCount()}
-   */
-  @Deprecated // Remove in Lucene 10
-  public static int getMaxClauseCount() {
-    return IndexSearcher.getMaxClauseCount();
-  }
-
-  /**
-   * Set the maximum number of clauses permitted per BooleanQuery. Default value is 1024.
-   *
-   * @deprecated use {@link IndexSearcher#setMaxClauseCount(int)}
-   */
-  @Deprecated // Remove in Lucene 10
-  public static void setMaxClauseCount(int maxClauseCount) {
-    IndexSearcher.setMaxClauseCount(maxClauseCount);
-  }
-
   /** A builder for boolean queries. */
   public static class Builder {
 

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
@@ -83,16 +83,6 @@ public final class ByteBuffersDataInput extends DataInput
     this.pos = offset;
   }
 
-  /**
-   * Returns the total number of bytes in this stream.
-   *
-   * @deprecated Use {@link #length()} instead.
-   */
-  @Deprecated
-  public long size() {
-    return length();
-  }
-
   @Override
   public long ramBytesUsed() {
     // Return a rough estimation for allocated blocks. Note that we do not make

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersIndexInput.java
@@ -53,7 +53,7 @@ public final class ByteBuffersIndexInput extends IndexInput implements RandomAcc
   @Override
   public long length() {
     ensureOpen();
-    return in.size();
+    return in.length();
   }
 
   @Override
@@ -215,7 +215,7 @@ public final class ByteBuffersIndexInput extends IndexInput implements RandomAcc
   public IndexInput clone() {
     ensureOpen();
     ByteBuffersIndexInput cloned =
-        new ByteBuffersIndexInput(in.slice(0, in.size()), "(clone of) " + toString());
+        new ByteBuffersIndexInput(in.slice(0, in.length()), "(clone of) " + toString());
     try {
       cloned.seek(getFilePointer());
     } catch (IOException e) {

--- a/lucene/core/src/java/org/apache/lucene/util/BitUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitUtil.java
@@ -185,16 +185,6 @@ public final class BitUtil {
       MethodHandles.byteArrayViewVarHandle(float[].class, ByteOrder.BIG_ENDIAN);
 
   /**
-   * A {@link VarHandle} to read/write big endian {@code double} from a byte array. Shape: {@code
-   * double vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, double val)}
-   *
-   * @deprecated Better use little endian unless it is needed for backwards compatibility.
-   */
-  @Deprecated
-  public static final VarHandle VH_BE_DOUBLE =
-      MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.BIG_ENDIAN);
-
-  /**
    * returns the next highest power of two, or the current value if it's already a power of two or
    * zero
    */

--- a/lucene/core/src/java/org/apache/lucene/util/BitUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitUtil.java
@@ -185,6 +185,16 @@ public final class BitUtil {
       MethodHandles.byteArrayViewVarHandle(float[].class, ByteOrder.BIG_ENDIAN);
 
   /**
+   * A {@link VarHandle} to read/write big endian {@code double} from a byte array. Shape: {@code
+   * double vh.get(byte[] arr, int ofs)} and {@code void vh.set(byte[] arr, int ofs, double val)}
+   *
+   * @deprecated Better use little endian unless it is needed for backwards compatibility.
+   */
+  @Deprecated
+  public static final VarHandle VH_BE_DOUBLE =
+      MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.BIG_ENDIAN);
+
+  /**
    * returns the next highest power of two, or the current value if it's already a power of two or
    * zero
    */

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataInput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataInput.java
@@ -37,7 +37,7 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
   public void testSanity() throws IOException {
     ByteBuffersDataOutput out = new ByteBuffersDataOutput();
     ByteBuffersDataInput o1 = out.toDataInput();
-    assertEquals(0, o1.size());
+    assertEquals(0, o1.length());
     LuceneTestCase.expectThrows(
         EOFException.class,
         () -> {
@@ -47,9 +47,9 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
     out.writeByte((byte) 1);
 
     ByteBuffersDataInput o2 = out.toDataInput();
-    assertEquals(1, o2.size());
+    assertEquals(1, o2.length());
     assertEquals(0, o2.position());
-    assertEquals(0, o1.size());
+    assertEquals(0, o1.length());
 
     assertTrue(o2.ramBytesUsed() > 0);
     assertEquals(1, o2.readByte());
@@ -106,7 +106,7 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
           dst.toDataInput().slice(prefix.length, dst.size() - prefix.length - suffix.length);
 
       assertEquals(0, src.position());
-      assertEquals(dst.size() - prefix.length - suffix.length, src.size());
+      assertEquals(dst.size() - prefix.length - suffix.length, src.length());
       for (IOConsumer<DataInput> c : reply) {
         c.accept(src);
       }
@@ -190,8 +190,8 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
         curr = skipTo + 1; // +1 for read byte
       }
 
-      in.seek(in.size());
-      assertEquals(in.size(), in.position());
+      in.seek(in.length());
+      assertEquals(in.length(), in.position());
       LuceneTestCase.expectThrows(
           EOFException.class,
           () -> {
@@ -203,18 +203,18 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
   @Test
   public void testSlicingWindow() throws Exception {
     ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
-    assertEquals(0, dst.toDataInput().slice(0, 0).size());
+    assertEquals(0, dst.toDataInput().slice(0, 0).length());
 
     dst.writeBytes(randomBytesOfLength(1024 * 8));
     ByteBuffersDataInput in = dst.toDataInput();
     for (int offset = 0, max = (int) dst.size(); offset < max; offset++) {
-      assertEquals(0, in.slice(offset, 0).size());
-      assertEquals(1, in.slice(offset, 1).size());
+      assertEquals(0, in.slice(offset, 0).length());
+      assertEquals(1, in.slice(offset, 1).length());
 
       int window = Math.min(max - offset, 1024);
-      assertEquals(window, in.slice(offset, window).size());
+      assertEquals(window, in.slice(offset, window).length());
     }
-    assertEquals(0, in.slice((int) dst.size(), 0).size());
+    assertEquals(0, in.slice((int) dst.size(), 0).length());
   }
 
   @Test
@@ -265,17 +265,17 @@ public final class TestByteBuffersDataInput extends RandomizedTest {
     buffers.get(0).position(shift);
 
     ByteBuffersDataInput dst = new ByteBuffersDataInput(buffers);
-    assertEquals(simulatedLength, dst.size());
+    assertEquals(simulatedLength, dst.length());
 
-    final long max = dst.size();
+    final long max = dst.length();
     long offset = 0;
     for (; offset < max; offset += randomIntBetween(MB, 4 * MB)) {
-      assertEquals(0, dst.slice(offset, 0).size());
-      assertEquals(1, dst.slice(offset, 1).size());
+      assertEquals(0, dst.slice(offset, 0).length());
+      assertEquals(1, dst.slice(offset, 1).length());
 
       long window = Math.min(max - offset, 1024);
       ByteBuffersDataInput slice = dst.slice(offset, window);
-      assertEquals(window, slice.size());
+      assertEquals(window, slice.length());
 
       // Sanity check of the content against original pages.
       for (int i = 0; i < window; i++) {

--- a/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetField.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/sortedset/SortedSetDocValuesFacetField.java
@@ -44,15 +44,6 @@ public class SortedSetDocValuesFacetField extends Field {
   /** Path. */
   public final String[] path;
 
-  /**
-   * String form of path.
-   *
-   * @deprecated This field will be removed in a future version. {@link
-   *     FacetsConfig#pathToString(String[])} can be applied to {@code path} as a replacement if
-   *     string path is desired.
-   */
-  @Deprecated public final String label;
-
   /** Sole constructor. */
   public SortedSetDocValuesFacetField(String dim, String... path) {
     super("dummy", TYPE);
@@ -65,7 +56,6 @@ public class SortedSetDocValuesFacetField extends Field {
     }
     this.dim = dim;
     this.path = path;
-    this.label = FacetsConfig.pathToString(path);
   }
 
   @Override

--- a/lucene/join/src/java/org/apache/lucene/search/join/BlockJoinSelector.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/BlockJoinSelector.java
@@ -106,16 +106,6 @@ public class BlockJoinSelector {
    * Wraps the provided {@link SortedDocValues} in order to only select one value per parent among
    * its {@code children} using the configured {@code selection} type.
    */
-  @Deprecated
-  public static SortedDocValues wrap(
-      final SortedDocValues values, Type selection, BitSet parents, BitSet children) {
-    return wrap(values, selection, parents, toIter(children));
-  }
-
-  /**
-   * Wraps the provided {@link SortedDocValues} in order to only select one value per parent among
-   * its {@code children} using the configured {@code selection} type.
-   */
   public static SortedDocValues wrap(
       final SortedDocValues values, Type selection, BitSet parents, DocIdSetIterator children) {
     if (values.docID() != -1) {
@@ -123,16 +113,6 @@ public class BlockJoinSelector {
           "values iterator was already consumed: values.docID=" + values.docID());
     }
     return ToParentDocValues.wrap(values, selection, parents, children);
-  }
-
-  /**
-   * Wraps the provided {@link SortedNumericDocValues} in order to only select one value per parent
-   * among its {@code children} using the configured {@code selection} type.
-   */
-  @Deprecated
-  public static NumericDocValues wrap(
-      SortedNumericDocValues sortedNumerics, Type selection, BitSet parents, BitSet children) {
-    return wrap(sortedNumerics, selection, parents, toIter(children));
   }
 
   /** creates an iterator for the given bitset */
@@ -165,17 +145,6 @@ public class BlockJoinSelector {
         throw new AssertionError();
     }
     return wrap(values, selection, parents, children);
-  }
-
-  /**
-   * Wraps the provided {@link NumericDocValues}, iterating over only child documents, in order to
-   * only select one value per parent among its {@code children} using the configured {@code
-   * selection} type.
-   */
-  @Deprecated
-  public static NumericDocValues wrap(
-      final NumericDocValues values, Type selection, BitSet parents, BitSet children) {
-    return wrap(values, selection, parents, toIter(children));
   }
 
   /**

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/IntervalBuilder.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/IntervalBuilder.java
@@ -51,7 +51,7 @@ import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionLengthAttribute;
 import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.graph.GraphTokenStreamFiniteStrings;
@@ -201,11 +201,10 @@ final class IntervalBuilder {
   private static List<IntervalsSource> analyzeGraph(TokenStream source) throws IOException {
     source.reset();
     GraphTokenStreamFiniteStrings graph = new GraphTokenStreamFiniteStrings(source);
-
     List<IntervalsSource> clauses = new ArrayList<>();
     int[] articulationPoints = graph.articulationPoints();
     int lastState = 0;
-    int maxClauseCount = BooleanQuery.getMaxClauseCount();
+    int maxClauseCount = IndexSearcher.getMaxClauseCount();
     for (int i = 0; i <= articulationPoints.length; i++) {
       int start = lastState;
       int end = -1;
@@ -220,7 +219,7 @@ final class IntervalBuilder {
           TokenStream ts = it.next();
           IntervalsSource phrase = combineSources(analyzeTerms(ts), 0, true);
           if (paths.size() >= maxClauseCount) {
-            throw new BooleanQuery.TooManyClauses();
+            throw new IndexSearcher.TooManyClauses();
           }
           paths.add(phrase);
         }


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

closes #13262 

Additionally I removed deprecated code from two more classes: VH_BE_DOUBLE (static member in BitUtil) and variant of BlockJoinSelector.wrap method. Both classes are tagged with @lucene.internal and I searched in Solr and elasticSearch. Let me know If any potential issues arise from its removal, I'll reinstate it.