### PR TITLE
Don't assume non-zero aggregations in getTopDims or test checkResults

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -659,18 +659,16 @@ abstract class TaxonomyFacets extends Facets {
             intermediateResults.put(dim, topChildrenForPath);
             dimValue = topChildrenForPath.pathValue();
           }
-          if (valueComparator.compare(dimValue, 0) != 0) {
-            if (pq.size() < topNDims) {
-              pq.add(new DimValue(dim, dimOrd, dimValue));
-            } else {
-              if (valueComparator.compare(dimValue, pq.top().value) > 0
-                  || (valueComparator.compare(dimValue, pq.top().value) == 0
-                      && dim.compareTo(pq.top().dim) < 0)) {
-                DimValue bottomDim = pq.top();
-                bottomDim.dim = dim;
-                bottomDim.value = dimValue;
-                pq.updateTop();
-              }
+          if (pq.size() < topNDims) {
+            pq.add(new DimValue(dim, dimOrd, dimValue));
+          } else {
+            if (valueComparator.compare(dimValue, pq.top().value) > 0
+                || (valueComparator.compare(dimValue, pq.top().value) == 0
+                    && dim.compareTo(pq.top().dim) < 0)) {
+              DimValue bottomDim = pq.top();
+              bottomDim.dim = dim;
+              bottomDim.value = dimValue;
+              pq.updateTop();
             }
           }
         }

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
@@ -688,15 +688,13 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
         aggregatedValue = aggregationFunction.aggregate(aggregatedValue, ent.getValue());
       }
       sortLabelValues(labelValues);
-      if (aggregatedValue > 0) {
-        expected.add(
-            new FacetResult(
-                "dim" + i,
-                new String[0],
-                aggregatedValue,
-                labelValues.toArray(new LabelAndValue[labelValues.size()]),
-                labelValues.size()));
-      }
+      expected.add(
+          new FacetResult(
+              "dim" + i,
+              new String[0],
+              aggregatedValue,
+              labelValues.toArray(new LabelAndValue[labelValues.size()]),
+              labelValues.size()));
     }
 
     // Sort by highest value, tie break by value:


### PR DESCRIPTION
Partially fixes #13191 by removing implicit assumptions that aggregation values are not zero, which is no longer true after #12966.
