### PR TITLE
Disable ConcurrentMergeScheduler's auto I/O throttling by default.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -177,6 +177,9 @@ Changes in Runtime Behavior
   `-Dorg.apache.lucene.store.defaultReadAdvice=normal`. This may be useful on systems
   with lots of RAM as this increases read-ahead. (Adrien Grand, Uwe Schindler)
 
+* GITHUB13293: Auto I/O throttling is now disabled by default on ConcurrentMergeScheduler.
+  (Adrien Grand)
+
 Changes in Backwards Compatibility Policy
 -----------------------------------------
 

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -231,6 +231,12 @@ List<Object> results = searcher.search(query, new CustomCollectorManager());
 `KnnVectorsReader` objects use small heap memory, so it's not worth maintaining heap usage for them hence removed
 `Accountable` interface from `KnnVectorsReader`.
 
+### Auto I/O throttling disabled by default in ConcurrentMergeScheduler
+
+ConcurrentMergeScheduler now disables auto I/O throttling by default. There is still some throttling
+happening at the CPU level, since ConcurrentMergeScheduler has a maximum number of threads it can
+use, which is only a fraction of the total number of threads of the host by default.
+
 ## Migration from Lucene 9.0 to Lucene 9.1
 
 ### Test framework package migration and module (LUCENE-10301)

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -773,17 +773,3 @@ Additionally, `OrdinalsReader` (and sub-classes) are fully removed starting with
 classes were `@Deprecated` starting with 9.0. Users are encouraged to rely on the default
 taxonomy facet encodings where possible. If custom formats are needed, users will need
 to manage the indexed data on their own and create new `Facet` implementations to use it.
-<<<<<<< HEAD
-
-### Deprecated code removal (GITHUB#13262)
-
-1. `IntField(String name, int value)`. Use `IntField(String, int, Field.Store)` with `Field.Store#NO` instead.
-2. `DoubleField(String name, double value)`. Use `DoubleField(String, double, Field.Store)` with `Field.Store#NO` instead.
-2. `FloatField(String name, float value)`. Use `FloatField(String, float, Field.Store)` with `Field.Store#NO` instead.
-3. `LongField(String name, long value)`. Use `LongField(String, long, Field.Store)` with `Field.Store#NO` instead.
-4. `LongPoint#newDistanceFeatureQuery(String field, float weight, long origin, long pivotDistance)`. Use `LongField#newDistanceFeatureQuery` instead
-5. `BooleanQuery#TooManyClauses`, `BooleanQuery#getMaxClauseCount()`, `BooleanQuery#setMaxClauseCount()`. Use `IndexSearcher#TooManyClauses`, `IndexSearcher#getMaxClauseCount()`, `IndexSearcher#setMaxClauseCount()` instead
-6. `ByteBuffersDataInput#size()`. Use `ByteBuffersDataInput#length()` instead
-7. `SortedSetDocValuesFacetField#label`. `FacetsConfig#pathToString(String[])` can be applied to path as a replacement if string path is desired.
-=======
->>>>>>> main

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -242,7 +242,7 @@ List<Object> results = searcher.search(query, new CustomCollectorManager());
 6. `ByteBuffersDataInput#size()`. Use `ByteBuffersDataInput#length()` instead
 7. `SortedSetDocValuesFacetField#label`. `FacetsConfig#pathToString(String[])` can be applied to path as a replacement if string path is desired.
 
-### Auto I/O throttling disabled by default in ConcurrentMergeScheduler
+### Auto I/O throttling disabled by default in ConcurrentMergeScheduler (GITHUB#13293)
 
 ConcurrentMergeScheduler now disables auto I/O throttling by default. There is still some throttling
 happening at the CPU level, since ConcurrentMergeScheduler has a maximum number of threads it can

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -108,7 +108,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
   protected double targetMBPerSec = START_MB_PER_SEC;
 
   /** true if we should rate-limit writes for each merge */
-  private boolean doAutoIOThrottle = true;
+  private boolean doAutoIOThrottle = false;
 
   private double forceMergeMBPerSec = Double.POSITIVE_INFINITY;
 
@@ -202,7 +202,11 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
 
   /**
    * Turn on dynamic IO throttling, to adaptively rate limit writes bytes/sec to the minimal rate
-   * necessary so merges do not fall behind. By default this is enabled.
+   * necessary so merges do not fall behind. By default this is disabled and writes are not
+   * rate-limited.
+   *
+   * <p><b>NOTE</b>: I/O throttling may not apply to ongoing merges, but it would apply to new
+   * merges.
    */
   public synchronized void enableAutoIOThrottle() {
     doAutoIOThrottle = true;
@@ -281,6 +285,13 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     if (!MergeThread.class.isInstance(mergeThread)) {
       throw new AssertionError(
           "wrapForMerge should be called from MergeThread. Current thread: " + mergeThread);
+    }
+
+    if (getAutoIOThrottle() == false) {
+      // Don't pay the overhead of additional wrapping if auto I/O throttling is disabled. This
+      // means that if I/O throttle suddenly gets enabled, it will not apply to merges that are
+      // already going, only to new merges. This is fine.
+      return in;
     }
 
     // Return a wrapped Directory which has rate-limited output.

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -204,9 +204,6 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
    * Turn on dynamic IO throttling, to adaptively rate limit writes bytes/sec to the minimal rate
    * necessary so merges do not fall behind. By default this is disabled and writes are not
    * rate-limited.
-   *
-   * <p><b>NOTE</b>: I/O throttling may not apply to ongoing merges, but it would apply to new
-   * merges.
    */
   public synchronized void enableAutoIOThrottle() {
     doAutoIOThrottle = true;
@@ -285,13 +282,6 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     if (!MergeThread.class.isInstance(mergeThread)) {
       throw new AssertionError(
           "wrapForMerge should be called from MergeThread. Current thread: " + mergeThread);
-    }
-
-    if (getAutoIOThrottle() == false) {
-      // Don't pay the overhead of additional wrapping if auto I/O throttling is disabled. This
-      // means that if I/O throttle suddenly gets enabled, it will not apply to merges that are
-      // already going, only to new merges. This is fine.
-      return in;
     }
 
     // Return a wrapped Directory which has rate-limited output.

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
@@ -900,10 +900,11 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
 
   public void testAutoIOThrottleGetter() throws Exception {
     ConcurrentMergeScheduler cms = new ConcurrentMergeScheduler();
-    cms.disableAutoIOThrottle();
     assertFalse(cms.getAutoIOThrottle());
     cms.enableAutoIOThrottle();
     assertTrue(cms.getAutoIOThrottle());
+    cms.disableAutoIOThrottle();
+    assertFalse(cms.getAutoIOThrottle());
   }
 
   public void testNonSpinningDefaults() throws Exception {
@@ -944,6 +945,7 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
             super.doStall();
           }
         };
+    cms.enableAutoIOThrottle();
     cms.setMaxMergesAndThreads(2, 1);
     iwc.setMergeScheduler(cms);
     iwc.setMaxBufferedDocs(2);


### PR DESCRIPTION
Disable ConcurrentMergeScheduler's auto I/O throttling by default.
    
This is motivated by the fact that merges can hardly steal all I/O resources
from searches on modern NVMe drives. Merges are still not allowed to use all
CPU since they have a budget for the number of threads which is a fraction of
the number of threads that the host can run.

Closes #13193