### PR TITLE
Align toString methods in geo module

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/geo/Circle.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Circle.java
@@ -91,7 +91,7 @@ public final class Circle extends LatLonGeometry {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("CIRCLE(");
+    sb.append("Circle(");
     sb.append("[" + lat + "," + lon + "]");
     sb.append(" radius = " + radiusMeters + " meters");
     sb.append(')');

--- a/lucene/core/src/java/org/apache/lucene/geo/Line.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Line.java
@@ -134,7 +134,7 @@ public class Line extends LatLonGeometry {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("LINE(");
+    sb.append("Line(");
     for (int i = 0; i < lats.length; i++) {
       sb.append("[").append(lons[i]).append(", ").append(lats[i]).append("]");
     }

--- a/lucene/core/src/java/org/apache/lucene/geo/Polygon.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Polygon.java
@@ -208,6 +208,7 @@ public final class Polygon extends LatLonGeometry {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
+    sb.append("Polygon");
     for (int i = 0; i < polyLats.length; i++) {
       sb.append("[").append(polyLats[i]).append(", ").append(polyLons[i]).append("] ");
     }

--- a/lucene/core/src/java/org/apache/lucene/geo/Rectangle2D.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Rectangle2D.java
@@ -271,7 +271,7 @@ final class Rectangle2D implements Component2D {
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder();
-    sb.append("XYRectangle(x=");
+    sb.append("Rectangle2D(x=");
     sb.append(minX);
     sb.append(" TO ");
     sb.append(maxX);

--- a/lucene/core/src/java/org/apache/lucene/geo/XYCircle.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/XYCircle.java
@@ -92,7 +92,7 @@ public final class XYCircle extends XYGeometry {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("CIRCLE(");
+    sb.append("XYCircle(");
     sb.append("[" + x + "," + y + "]");
     sb.append(" radius = " + radius);
     sb.append(')');

--- a/lucene/core/src/java/org/apache/lucene/geo/XYLine.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/XYLine.java
@@ -126,7 +126,7 @@ public class XYLine extends XYGeometry {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("XYLINE(");
+    sb.append("XYLine(");
     for (int i = 0; i < x.length; i++) {
       sb.append("[").append(x[i]).append(", ").append(y[i]).append("]");
     }

--- a/lucene/core/src/java/org/apache/lucene/geo/XYPoint.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/XYPoint.java
@@ -78,7 +78,7 @@ public final class XYPoint extends XYGeometry {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("Point(");
+    sb.append("XYPoint(");
     sb.append(x);
     sb.append(",");
     sb.append(y);

--- a/lucene/core/src/java/org/apache/lucene/geo/XYPolygon.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/XYPolygon.java
@@ -187,6 +187,7 @@ public final class XYPolygon extends XYGeometry {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
+    sb.append("XYPolygon");
     for (int i = 0; i < x.length; i++) {
       sb.append("[").append(x[i]).append(", ").append(y[i]).append("] ");
     }


### PR DESCRIPTION
### Description

Some `toString` methods in the `geo` module sometimes use uppercase or the class name. I've aligned them to use always the class name.