### PR TITLE
Fix test failure TestDocumentsImpl.testGetDocumentFields

### DIFF
--- a/lucene/luke/src/test/org/apache/lucene/luke/models/documents/DocumentsTestBase.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/documents/DocumentsTestBase.java
@@ -19,6 +19,7 @@ package org.apache.lucene.luke.models.documents;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Random;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -53,7 +54,13 @@ public abstract class DocumentsTestBase extends LuceneTestCase {
     indexDir = createTempDir();
 
     Directory dir = newFSDirectory(indexDir);
-    RandomIndexWriter writer = new RandomIndexWriter(random(), dir, new StandardAnalyzer());
+    Random r = random();
+    RandomIndexWriter writer =
+        new RandomIndexWriter(
+            r,
+            dir,
+            newIndexWriterConfig(r, new StandardAnalyzer())
+                .setMergePolicy(newMergePolicy(r, false)));
 
     FieldType titleType = new FieldType();
     titleType.setIndexOptions(IndexOptions.DOCS_AND_FREQS);


### PR DESCRIPTION
This test relies on the order of reading the store fields being consistent with the writing order, This change disable the `MockRandomMergePolicy` for consistency.


```
./gradlew test --tests TestDocumentsImpl.testGetDocumentFields -Dtests.seed=6AC235CCDD415BC4 -Dtests.nightly=true -Dtests.locale=ceb-Latn-PH -Dtests.timezone=Africa/Djibouti -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```

```
   >     org.junit.ComparisonFailure: expected:<[Pride and Prejudice]> but was:<[The Adventures of Sherlock Holmes]>
   >         at __randomizedtesting.SeedInfo.seed([6AC235CCDD415BC4:F5CFD3BF14408724]:0)
   >         at junit@4.13.1/org.junit.Assert.assertEquals(Assert.java:117)
   >         at junit@4.13.1/org.junit.Assert.assertEquals(Assert.java:146)
   >         at org.apache.lucene.luke.models.documents.TestDocumentsImpl.testGetDocumentFields(TestDocumentsImpl.java:65)
```