### PR TITLE
Narrow MASKS and UTF8Byte.value's type, assign MASKS by left shift in UTF32ToUTF8

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
@@ -202,8 +202,6 @@ public final class UTF32ToUTF8 {
       int byteCount = 1 + startUTF8.len - upto;
       final int limit = endUTF8.len - upto;
       while (byteCount < limit) {
-        // wasteful: we only need first byte, and, we should
-        // statically encode this first byte:
         tmpUTF8a.setFirstByte(startCodes[byteCount - 1]);
         tmpUTF8b.setFirstByte(endCodes[byteCount - 1]);
         all(start, end, tmpUTF8a.byteAt(0), tmpUTF8b.byteAt(0), tmpUTF8a.len - 1);

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
@@ -35,13 +35,11 @@ public final class UTF32ToUTF8 {
   private static final int[] startCodes = new int[] {0, 128, 2048, 65536};
   private static final int[] endCodes = new int[] {127, 2047, 65535, 1114111};
 
-  static int[] MASKS = new int[8];
+  static byte[] MASKS = new byte[8];
 
   static {
-    int v = 2;
     for (int i = 0; i < 7; i++) {
-      MASKS[i + 1] = v - 1;
-      v *= 2;
+      MASKS[i + 1] = (byte) ((2 << i) - 1);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
@@ -72,7 +72,7 @@ public final class UTF32ToUTF8 {
       return bytes[idx].bits;
     }
 
-    private void set(int code, boolean setRest) {
+    private void set(int code) {
       if (code < 128) {
         // 0xxxxxxx
         bytes[0].value = code;
@@ -82,25 +82,40 @@ public final class UTF32ToUTF8 {
         // 110yyyxx 10xxxxxx
         bytes[0].value = (6 << 5) | (code >> 6);
         bytes[0].bits = 5;
-        if (setRest) {
-          setRest(code, 1);
-        }
+        setRest(code, 1);
         len = 2;
       } else if (code < 65536) {
         // 1110yyyy 10yyyyxx 10xxxxxx
         bytes[0].value = (14 << 4) | (code >> 12);
         bytes[0].bits = 4;
-        if (setRest) {
-          setRest(code, 2);
-        }
+        setRest(code, 2);
         len = 3;
       } else {
         // 11110zzz 10zzyyyy 10yyyyxx 10xxxxxx
         bytes[0].value = (30 << 3) | (code >> 18);
         bytes[0].bits = 3;
-        if (setRest) {
-          setRest(code, 3);
-        }
+        setRest(code, 3);
+        len = 4;
+      }
+    }
+
+    // Only set first byte value for tmp utf8.
+    private void setFirstByte(int code) {
+      if (code < 128) {
+        // 0xxxxxxx
+        bytes[0].value = code;
+        len = 1;
+      } else if (code < 2048) {
+        // 110yyyxx 10xxxxxx
+        bytes[0].value = (6 << 5) | (code >> 6);
+        len = 2;
+      } else if (code < 65536) {
+        // 1110yyyy 10yyyyxx 10xxxxxx
+        bytes[0].value = (14 << 4) | (code >> 12);
+        len = 3;
+      } else {
+        // 11110zzz 10zzyyyy 10yyyyxx 10xxxxxx
+        bytes[0].value = (30 << 3) | (code >> 18);
         len = 4;
       }
     }
@@ -137,8 +152,8 @@ public final class UTF32ToUTF8 {
 
   // Builds necessary utf8 edges between start & end
   void convertOneEdge(int start, int end, int startCodePoint, int endCodePoint) {
-    startUTF8.set(startCodePoint, true);
-    endUTF8.set(endCodePoint, true);
+    startUTF8.set(startCodePoint);
+    endUTF8.set(endCodePoint);
     build(start, end, startUTF8, endUTF8, 0);
   }
 
@@ -189,8 +204,8 @@ public final class UTF32ToUTF8 {
       while (byteCount < limit) {
         // wasteful: we only need first byte, and, we should
         // statically encode this first byte:
-        tmpUTF8a.set(startCodes[byteCount - 1], false);
-        tmpUTF8b.set(endCodes[byteCount - 1], false);
+        tmpUTF8a.setFirstByte(startCodes[byteCount - 1]);
+        tmpUTF8b.setFirstByte(endCodes[byteCount - 1]);
         all(start, end, tmpUTF8a.byteAt(0), tmpUTF8b.byteAt(0), tmpUTF8a.len - 1);
         byteCount++;
       }

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
@@ -72,7 +72,7 @@ public final class UTF32ToUTF8 {
       return bytes[idx].bits;
     }
 
-    private void set(int code) {
+    private void set(int code, boolean setRest) {
       if (code < 128) {
         // 0xxxxxxx
         bytes[0].value = code;
@@ -82,19 +82,25 @@ public final class UTF32ToUTF8 {
         // 110yyyxx 10xxxxxx
         bytes[0].value = (6 << 5) | (code >> 6);
         bytes[0].bits = 5;
-        setRest(code, 1);
+        if (setRest) {
+          setRest(code, 1);
+        }
         len = 2;
       } else if (code < 65536) {
         // 1110yyyy 10yyyyxx 10xxxxxx
         bytes[0].value = (14 << 4) | (code >> 12);
         bytes[0].bits = 4;
-        setRest(code, 2);
+        if (setRest) {
+          setRest(code, 2);
+        }
         len = 3;
       } else {
         // 11110zzz 10zzyyyy 10yyyyxx 10xxxxxx
         bytes[0].value = (30 << 3) | (code >> 18);
         bytes[0].bits = 3;
-        setRest(code, 3);
+        if (setRest) {
+          setRest(code, 3);
+        }
         len = 4;
       }
     }
@@ -131,8 +137,8 @@ public final class UTF32ToUTF8 {
 
   // Builds necessary utf8 edges between start & end
   void convertOneEdge(int start, int end, int startCodePoint, int endCodePoint) {
-    startUTF8.set(startCodePoint);
-    endUTF8.set(endCodePoint);
+    startUTF8.set(startCodePoint, true);
+    endUTF8.set(endCodePoint, true);
     build(start, end, startUTF8, endUTF8, 0);
   }
 
@@ -183,8 +189,8 @@ public final class UTF32ToUTF8 {
       while (byteCount < limit) {
         // wasteful: we only need first byte, and, we should
         // statically encode this first byte:
-        tmpUTF8a.set(startCodes[byteCount - 1]);
-        tmpUTF8b.set(endCodes[byteCount - 1]);
+        tmpUTF8a.set(startCodes[byteCount - 1], false);
+        tmpUTF8b.set(endCodes[byteCount - 1], false);
         all(start, end, tmpUTF8a.byteAt(0), tmpUTF8b.byteAt(0), tmpUTF8a.len - 1);
         byteCount++;
       }

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
@@ -47,7 +47,7 @@ public final class UTF32ToUTF8 {
   // define a code point.  value is the byte value; bits is
   // how many bits are "used" by utf8 at that byte
   private static class UTF8Byte {
-    int value; // TODO: change to byte
+    byte value;
     byte bits;
   }
 
@@ -65,7 +65,7 @@ public final class UTF32ToUTF8 {
     }
 
     public int byteAt(int idx) {
-      return bytes[idx].value;
+      return bytes[idx].value & 0xFF;
     }
 
     public int numBits(int idx) {
@@ -75,24 +75,24 @@ public final class UTF32ToUTF8 {
     private void set(int code) {
       if (code < 128) {
         // 0xxxxxxx
-        bytes[0].value = code;
+        bytes[0].value = (byte) code;
         bytes[0].bits = 7;
         len = 1;
       } else if (code < 2048) {
         // 110yyyxx 10xxxxxx
-        bytes[0].value = (6 << 5) | (code >> 6);
+        bytes[0].value = (byte) ((6 << 5) | (code >> 6));
         bytes[0].bits = 5;
         setRest(code, 1);
         len = 2;
       } else if (code < 65536) {
         // 1110yyyy 10yyyyxx 10xxxxxx
-        bytes[0].value = (14 << 4) | (code >> 12);
+        bytes[0].value = (byte) ((14 << 4) | (code >> 12));
         bytes[0].bits = 4;
         setRest(code, 2);
         len = 3;
       } else {
         // 11110zzz 10zzyyyy 10yyyyxx 10xxxxxx
-        bytes[0].value = (30 << 3) | (code >> 18);
+        bytes[0].value = (byte) ((30 << 3) | (code >> 18));
         bytes[0].bits = 3;
         setRest(code, 3);
         len = 4;
@@ -103,26 +103,26 @@ public final class UTF32ToUTF8 {
     private void setFirstByte(int code) {
       if (code < 128) {
         // 0xxxxxxx
-        bytes[0].value = code;
+        bytes[0].value = (byte) code;
         len = 1;
       } else if (code < 2048) {
         // 110yyyxx 10xxxxxx
-        bytes[0].value = (6 << 5) | (code >> 6);
+        bytes[0].value = (byte) ((6 << 5) | (code >> 6));
         len = 2;
       } else if (code < 65536) {
         // 1110yyyy 10yyyyxx 10xxxxxx
-        bytes[0].value = (14 << 4) | (code >> 12);
+        bytes[0].value = (byte) ((14 << 4) | (code >> 12));
         len = 3;
       } else {
         // 11110zzz 10zzyyyy 10yyyyxx 10xxxxxx
-        bytes[0].value = (30 << 3) | (code >> 18);
+        bytes[0].value = (byte) ((30 << 3) | (code >> 18));
         len = 4;
       }
     }
 
     private void setRest(int code, int numBytes) {
       for (int i = 0; i < numBytes; i++) {
-        bytes[numBytes - i].value = 128 | (code & MASKS[6]);
+        bytes[numBytes - i].value = (byte) (128 | (code & MASKS[6]));
         bytes[numBytes - i].bits = 6;
         code = code >> 6;
       }
@@ -135,7 +135,7 @@ public final class UTF32ToUTF8 {
         if (i > 0) {
           b.append(' ');
         }
-        b.append(Integer.toBinaryString(bytes[i].value));
+        b.append(Integer.toBinaryString(byteAt(i)));
       }
       return b.toString();
     }


### PR DESCRIPTION
### Description

Change `MASKS` from `int[]` to `byte[]`, and assign it with left shift in `UTF32ToUTF8`.

Edit: 
This change also implemented: 
Only set first byte value for tmp UTF8.
Change `UTF8Byte.value` type from `int` to `byte`.