### PR TITLE
Fix test failure TestKnnByteVectorQuery#testTimeLimitingKnnCollectorManager

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/TimeLimitingKnnCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TimeLimitingKnnCollectorManager.java
@@ -42,13 +42,13 @@ public class TimeLimitingKnnCollectorManager implements KnnCollectorManager {
     if (queryTimeout == null) {
       return collector;
     }
-    return new TimeoutingKnnCollector(collector);
+    return new TimeLimitingKnnCollector(collector);
   }
 
-  class TimeoutingKnnCollector implements KnnCollector {
+  class TimeLimitingKnnCollector implements KnnCollector {
     private final KnnCollector collector;
 
-    TimeoutingKnnCollector(KnnCollector collector) {
+    TimeLimitingKnnCollector(KnnCollector collector) {
       this.collector = collector;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/search/TimeLimitingKnnCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TimeLimitingKnnCollectorManager.java
@@ -42,54 +42,62 @@ public class TimeLimitingKnnCollectorManager implements KnnCollectorManager {
     if (queryTimeout == null) {
       return collector;
     }
-    return new KnnCollector() {
-      @Override
-      public boolean earlyTerminated() {
-        return queryTimeout.shouldExit() || collector.earlyTerminated();
-      }
+    return new TimeoutingKnnCollector(collector);
+  }
 
-      @Override
-      public void incVisitedCount(int count) {
-        collector.incVisitedCount(count);
-      }
+  class TimeoutingKnnCollector implements KnnCollector {
+    final KnnCollector collector;
 
-      @Override
-      public long visitedCount() {
-        return collector.visitedCount();
-      }
+    TimeoutingKnnCollector(KnnCollector collector) {
+      this.collector = collector;
+    }
 
-      @Override
-      public long visitLimit() {
-        return collector.visitLimit();
-      }
+    @Override
+    public boolean earlyTerminated() {
+      return queryTimeout.shouldExit() || collector.earlyTerminated();
+    }
 
-      @Override
-      public int k() {
-        return collector.k();
-      }
+    @Override
+    public void incVisitedCount(int count) {
+      collector.incVisitedCount(count);
+    }
 
-      @Override
-      public boolean collect(int docId, float similarity) {
-        return collector.collect(docId, similarity);
-      }
+    @Override
+    public long visitedCount() {
+      return collector.visitedCount();
+    }
 
-      @Override
-      public float minCompetitiveSimilarity() {
-        return collector.minCompetitiveSimilarity();
-      }
+    @Override
+    public long visitLimit() {
+      return collector.visitLimit();
+    }
 
-      @Override
-      public TopDocs topDocs() {
-        TopDocs docs = collector.topDocs();
+    @Override
+    public int k() {
+      return collector.k();
+    }
 
-        // Mark results as partial if timeout is met
-        TotalHits.Relation relation =
-            queryTimeout.shouldExit()
-                ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
-                : docs.totalHits.relation;
+    @Override
+    public boolean collect(int docId, float similarity) {
+      return collector.collect(docId, similarity);
+    }
 
-        return new TopDocs(new TotalHits(docs.totalHits.value, relation), docs.scoreDocs);
-      }
-    };
+    @Override
+    public float minCompetitiveSimilarity() {
+      return collector.minCompetitiveSimilarity();
+    }
+
+    @Override
+    public TopDocs topDocs() {
+      TopDocs docs = collector.topDocs();
+
+      // Mark results as partial if timeout is met
+      TotalHits.Relation relation =
+          queryTimeout.shouldExit()
+              ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
+              : docs.totalHits.relation;
+
+      return new TopDocs(new TotalHits(docs.totalHits.value, relation), docs.scoreDocs);
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/TimeLimitingKnnCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TimeLimitingKnnCollectorManager.java
@@ -46,7 +46,7 @@ public class TimeLimitingKnnCollectorManager implements KnnCollectorManager {
   }
 
   class TimeoutingKnnCollector implements KnnCollector {
-    final KnnCollector collector;
+    private final KnnCollector collector;
 
     TimeoutingKnnCollector(KnnCollector collector) {
       this.collector = collector;

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -44,7 +44,6 @@ import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.knn.KnnCollectorManager;
-import org.apache.lucene.search.knn.MultiLeafKnnCollector;
 import org.apache.lucene.search.knn.TopKnnCollectorManager;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
@@ -785,9 +784,8 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
           noTimeoutManager.newCollector(Integer.MAX_VALUE, searcher.leafContexts.getFirst());
 
       // Check that a normal collector is created without timeout
-      assertTrue(
-          noTimeoutCollector instanceof TopKnnCollector
-              || noTimeoutCollector instanceof MultiLeafKnnCollector);
+      assertFalse(
+          noTimeoutCollector instanceof TimeLimitingKnnCollectorManager.TimeoutingKnnCollector);
       noTimeoutCollector.collect(0, 0);
       assertFalse(noTimeoutCollector.earlyTerminated());
 

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -785,7 +785,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
 
       // Check that a normal collector is created without timeout
       assertFalse(
-          noTimeoutCollector instanceof TimeLimitingKnnCollectorManager.TimeoutingKnnCollector);
+          noTimeoutCollector instanceof TimeLimitingKnnCollectorManager.TimeLimitingKnnCollector);
       noTimeoutCollector.collect(0, 0);
       assertFalse(noTimeoutCollector.earlyTerminated());
 

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -44,6 +44,7 @@ import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.search.knn.MultiLeafKnnCollector;
 import org.apache.lucene.search.knn.TopKnnCollectorManager;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
@@ -784,7 +785,9 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
           noTimeoutManager.newCollector(Integer.MAX_VALUE, searcher.leafContexts.getFirst());
 
       // Check that a normal collector is created without timeout
-      assertTrue(noTimeoutCollector instanceof TopKnnCollector);
+      assertTrue(
+          noTimeoutCollector instanceof TopKnnCollector
+              || noTimeoutCollector instanceof MultiLeafKnnCollector);
       noTimeoutCollector.collect(0, 0);
       assertFalse(noTimeoutCollector.earlyTerminated());
 


### PR DESCRIPTION
`TopKnnCollectorManager#newCollector` will return `MultiLeafKnnCollector` instance if the index has multiple segments

```
org.apache.lucene.search.TestKnnByteVectorQuery > testTimeLimitingKnnCollectorManager FAILED
    java.lang.AssertionError
        at __randomizedtesting.SeedInfo.seed([A0DCCB76BFBF940C:8E1E7418F5C62B46]:0)
        at org.junit.Assert.fail(Assert.java:87)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at org.junit.Assert.assertTrue(Assert.java:53)
        at org.apache.lucene.search.BaseKnnVectorQueryTestCase.testTimeLimitingKnnCollectorManager(BaseKnnVectorQueryTestCase.java:787)
        at org.apache.lucene.search.TestKnnByteVectorQuery.testTimeLimitingKnnCollectorManager(TestKnnByteVectorQuery.java:30)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```

```
gradlew test --tests TestKnnByteVectorQuery.testTimeLimitingKnnCollectorManager -Dtests.seed=A0DCCB76BFBF940C -Dtests.nightly=true
```