### PR TITLE
Do not use mock merge policy for TestSimilarity

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestSimilarity.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSimilarity.java
@@ -60,7 +60,9 @@ public class TestSimilarity extends LuceneTestCase {
         new RandomIndexWriter(
             random(),
             store,
-            newIndexWriterConfig(new MockAnalyzer(random())).setSimilarity(new SimpleSimilarity()));
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setSimilarity(new SimpleSimilarity())
+                .setMergePolicy(newMergePolicy(random(), false)));
 
     Document d1 = new Document();
     d1.add(newTextField("field", "a c", Field.Store.YES));


### PR DESCRIPTION
The test relies on the writing order which may be reorder by `MockRandomMergePolicy`

```
./gradlew :lucene:core:test --tests "org.apache.lucene.search.TestSimilarity.testSimilarity" -Ptests.seed=120D66F049F980C1 -Ptests.nightly=true
```


```
org.apache.lucene.search.TestSimilarity > testSimilarity FAILED
    java.lang.AssertionError: expected:<1.0> but was:<2.0>
        at __randomizedtesting.SeedInfo.seed([120D66F049F980C1:E3A226C8491915DA]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:577)
        at org.junit.Assert.assertEquals(Assert.java:701)
        at org.apache.lucene.search.TestSimilarity$1$1.collect(TestSimilarity.java:100)
        at org.apache.lucene.tests.search.AssertingLeafCollector$AssertingDocIdStream.lambda$forEach$0(AssertingLeafCollector.java:119)
        at org.apache.lucene.tests.search.AssertingLeafCollector$AssertingDocIdStream.lambda$forEach$0(AssertingLeafCollector.java:119)
        at org.apache.lucene.search.BooleanScorer$DocIdStreamView.forEach(BooleanScorer.java:169)
        at org.apache.lucene.tests.search.AssertingLeafCollector$AssertingDocIdStream.forEach(AssertingLeafCollector.java:114)
        at org.apache.lucene.tests.search.AssertingLeafCollector$AssertingDocIdStream.forEach(AssertingLeafCollector.java:114)
        at org.apache.lucene.search.LeafCollector.collect(LeafCollector.java:106)
```