### PR TITLE
Implement Weight#count for vector values in the FieldExistsQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -162,8 +162,6 @@ Optimizations
 
 * GITHUB#12552: Make FSTPostingsFormat load FSTs off-heap. (Tony X)
 
-* GITHUB#13322: Implement Weight#count for vector values in the FieldExistsQuery. (Pan Guixin)
-
 Bug Fixes
 ---------------------
 
@@ -404,6 +402,8 @@ Optimizations
 * GITHUB#13400: Replace Set<Integer> by IntHashSet and Set<Long> by LongHashSet. (Bruno Roustant)
 
 * GITHUB#13406: Replace List<Integer> by IntArrayList and List<Long> by LongArrayList. (Bruno Roustant)
+
+* GITHUB#13322: Implement Weight#count for vector values in the FieldExistsQuery. (Pan Guixin)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -162,6 +162,8 @@ Optimizations
 
 * GITHUB#12552: Make FSTPostingsFormat load FSTs off-heap. (Tony X)
 
+* GITHUB#13322: Implement Weight#count for vector values in the FieldExistsQuery. (Pan Guixin)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -255,6 +255,8 @@ Optimizations
 * GITHUB##13425: Rewrite SortedNumericDocValuesRangeQuery to MatchNoDocsQuery when the upper bound is smaller than the
   lower bound. (Ioana Tagirta)
 
+* GITHUB#13322: Implement Weight#count for vector values in the FieldExistsQuery. (Pan Guixin)
+
 Bug Fixes
 ---------------------
 (No changes)
@@ -402,8 +404,6 @@ Optimizations
 * GITHUB#13400: Replace Set<Integer> by IntHashSet and Set<Long> by LongHashSet. (Bruno Roustant)
 
 * GITHUB#13406: Replace List<Integer> by IntArrayList and List<Long> by LongArrayList. (Bruno Roustant)
-
-* GITHUB#13322: Implement Weight#count for vector values in the FieldExistsQuery. (Pan Guixin)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -240,10 +240,12 @@ public class FieldExistsQuery extends Query {
           return super.count(context);
         } else if (fieldInfo.hasVectorValues()) { // the field indexes vectors
           if (reader.hasDeletions() == false) {
-            return switch (fieldInfo.getVectorEncoding()) {
-              case FLOAT32 -> reader.getFloatVectorValues(field).size();
-              case BYTE -> reader.getByteVectorValues(field).size();
-            };
+            final DocIdSetIterator values =
+                switch (fieldInfo.getVectorEncoding()) {
+                  case FLOAT32 -> reader.getFloatVectorValues(field);
+                  case BYTE -> reader.getByteVectorValues(field);
+                };
+            return values == null ? 0 : Math.toIntExact(values.cost());
           }
           return super.count(context);
         } else if (fieldInfo.getDocValuesType()

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -283,12 +283,12 @@ public class FieldExistsQuery extends Query {
       case FLOAT32 -> {
         FloatVectorValues floatVectorValues = reader.getFloatVectorValues(field);
         assert floatVectorValues != null : "unexpected null float vector values";
-        yield floatVectorValues == null ? 0 : floatVectorValues.size();
+        yield floatVectorValues.size();
       }
       case BYTE -> {
         ByteVectorValues byteVectorValues = reader.getByteVectorValues(field);
         assert byteVectorValues != null : "unexpected null byte vector values";
-        yield byteVectorValues == null ? 0 : byteVectorValues.size();
+        yield byteVectorValues.size();
       }
     };
   }


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
Considering only one vector value can be indexed per doc, we can use the Float/ByteVectorValues#size method to implement Weight#count for vector values in the FieldExistsQuery