### PR TITLE
Fix numDeletesToMerge for unchanged segments

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -6129,16 +6129,14 @@ public class IndexWriter
     validate(info);
     MergePolicy mergePolicy = config.getMergePolicy();
     final ReadersAndUpdates rld = getPooledInstance(info, true);
-    int numDeletesToMerge;
-    if (rld != null) {
-      numDeletesToMerge = rld.numDeletesToMerge(mergePolicy);
-    } else {
-      // if we don't have a  pooled instance lets just return the hard deletes, this is safe!
-      numDeletesToMerge = info.getDelCount();
+    try {
+      final int numDeletesToMerge = rld.numDeletesToMerge(mergePolicy);
+      assert numDeletesToMerge <= info.info.maxDoc()
+          : "numDeletesToMerge: " + numDeletesToMerge + " > maxDoc: " + info.info.maxDoc();
+      return numDeletesToMerge;
+    } finally {
+      release(rld);
     }
-    assert numDeletesToMerge <= info.info.maxDoc()
-        : "numDeletesToMerge: " + numDeletesToMerge + " > maxDoc: " + info.info.maxDoc();
-    return numDeletesToMerge;
   }
 
   void release(ReadersAndUpdates readersAndUpdates) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -6128,7 +6128,7 @@ public class IndexWriter
     ensureOpen(false);
     validate(info);
     MergePolicy mergePolicy = config.getMergePolicy();
-    final ReadersAndUpdates rld = getPooledInstance(info, false);
+    final ReadersAndUpdates rld = getPooledInstance(info, true);
     int numDeletesToMerge;
     if (rld != null) {
       numDeletesToMerge = rld.numDeletesToMerge(mergePolicy);


### PR DESCRIPTION
Currently, we do not trigger numDeletesToMerge for unchanged segments that have not yet entered the reader pool. Consequently, there are cases where force merges overlook segments with soft-deletes, as the merge policy only takes into account hard deletes when determining merge specifications.