### PR TITLE
gh-13340: Allow adding a parent field to an index with no fields

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1122,6 +1122,7 @@ public class IndexWriter
       globalFieldNumberMap = getFieldNumberMap();
       if (create == false
           && conf.getParentField() != null
+          && globalFieldNumberMap.getFieldNames().isEmpty() == false
           && globalFieldNumberMap.getFieldNames().contains(conf.getParentField()) == false) {
         throw new IllegalArgumentException(
             "can't add a parent field to an already existing index without a parent field");

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -4851,7 +4851,9 @@ public class TestIndexWriter extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
       try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-        writer.addDocument(new Document());
+        Document d = new Document();
+        d.add(new TextField("f", "a", Field.Store.NO));
+        writer.addDocument(d);
       }
       IllegalArgumentException iae =
           expectThrows(
@@ -4957,6 +4959,21 @@ public class TestIndexWriter extends LuceneTestCase {
       assertEquals(
           "can't add [parent] as non parent document field; this IndexWriter is configured with [parent] as parent document field",
           iae.getMessage());
+    }
+  }
+
+  public void testParentFieldEmptyIndex() throws IOException {
+    try (Directory dir = newMockDirectory()) {
+      IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
+      iwc.setParentField("parent");
+      try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+        writer.commit();
+      }
+      IndexWriterConfig iwc2 = new IndexWriterConfig(new MockAnalyzer(random()));
+      iwc2.setParentField("parent");
+      try (IndexWriter writer = new IndexWriter(dir, iwc2)) {
+        writer.commit();
+      }
     }
   }
 }


### PR DESCRIPTION
Addresses #13340 . It relaxes the previous rule that adding a parent field to an existing index is *always* forbidden, allowing it in the case where no fields have been created. In such a case it will be safe, and this enables the trivial case of opening and closing a new empty index twice to work in a sensible way.