### PR TITLE
Add a separate option to allow running Panama Vectorization for all tests with suitable C2 defaults

### DIFF
--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -51,7 +51,7 @@ allprojects {
            includeInReproLine: false
           ],
           [propName: 'tests.jvmargs',
-           value: { -> propertyOrEnvOrDefault("tests.jvmargs", "TEST_JVM_ARGS", isCIBuild ? "" : "-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1") },
+           value: { -> envOrDefault("TEST_JVM_ARGS", (isCIBuild || testsDefaultVectorizationRequested()) ? "" : "-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1") },
            description: "Arguments passed to each forked JVM."],
           // Other settings.
           [propName: 'tests.neverUpToDate', value: true,
@@ -66,6 +66,8 @@ allprojects {
         }
         return propertyOrDefault(option.propName, option.value)
       }
+      
+      testsDefaultVectorizationRequested = { -> Boolean.parseBoolean(resolvedTestOption('tests.defaultvectorization')) }
 
       testsCwd = file("${buildDir}/tmp/tests-cwd")
       testsTmpDir = file(resolvedTestOption("tests.workDir"))
@@ -116,8 +118,6 @@ allprojects {
 
       ignoreFailures = resolvedTestOption("tests.haltonfailure").toBoolean() == false
 
-      jvmArgs Commandline.translateCommandline(resolvedTestOption("tests.jvmargs"))
-      
       // Up to JDK-15 we have to enforce --illegal-access=deny, because we want no code to access
       // JDK internals; JDK-16 and later will default to deny, see https://openjdk.java.net/jeps/396:
       if (rootProject.runtimeJavaVersion < JavaVersion.VERSION_16) {

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -67,7 +67,7 @@ allprojects {
         return propertyOrDefault(option.propName, option.value)
       }
       
-      testsDefaultVectorizationRequested = { -> Boolean.parseBoolean(resolvedTestOption('tests.defaultvectorization')) }
+      testsDefaultVectorizationRequested = { -> Boolean.parseBoolean(resolvedTestOption('tests.defaultvectorization') as String) }
 
       testsCwd = file("${buildDir}/tmp/tests-cwd")
       testsTmpDir = file(resolvedTestOption("tests.workDir"))

--- a/gradle/testing/randomization.gradle
+++ b/gradle/testing/randomization.gradle
@@ -112,8 +112,7 @@ allprojects {
           [propName: 'tests.forceintegervectors',
             value: { -> testsDefaultVectorizationRequested() ? false : (randomVectorSize != 'default') },
             description: "Forces use of integer vectors even when slow."],
-          [propName: 'tests.defaultvectorization',
-            value: { -> (randomVectorSize == 'default') },
+          [propName: 'tests.defaultvectorization', value: false,
             description: "Uses defaults for running tests with correct JVM settings to test Panama vectorization (tests.jvmargs, tests.vectorsize, tests.forceintegervectors)."],
       ]
     }

--- a/gradle/testing/randomization.gradle
+++ b/gradle/testing/randomization.gradle
@@ -106,15 +106,14 @@ allprojects {
           [propName: 'tests.bwcdir', value: null, description: "Data for backward-compatibility indexes."],
           // vectorization related
           [propName: 'tests.vectorsize',
-             value: { ->
-               isCIBuild ? "" : RandomPicks.randomFrom(new Random(projectSeedLong), ["", "128", "256", "512"])
-             },
-             description: "Sets preferred vector size in bits."],
+           value: { -> testsDefaultVectorizationRequested() ? 'default' :
+            RandomPicks.randomFrom(new Random(projectSeedLong), ["default", "128", "256", "512"]) },
+           description: "Sets preferred vector size in bits."],
           [propName: 'tests.forceintegervectors',
-             value: { ->
-                 isCIBuild ? false : true
-             },
-             description: "Forces use of integer vectors even when slow."],
+            value: { -> !testsDefaultVectorizationRequested() },
+            description: "Forces use of integer vectors even when slow."],
+          [propName: 'tests.defaultvectorization', value: false,
+            description: "Uses defaults for running tests with correct JVM settings to test Panama vectorization (tests.jvmargs, tests.vectorsize, tests.forceintegervectors)."],
       ]
     }
   }
@@ -176,6 +175,8 @@ allprojects {
         // and not the test JVM itself.
         systemProperties testOptionsResolved
 
+        jvmArgs Commandline.translateCommandline(testOptionsResolved['tests.jvmargs'])
+      
         if (Boolean.parseBoolean(testOptionsResolved['tests.asserts'])) {
           jvmArgs("-ea", "-esa")
         } else {

--- a/gradle/testing/randomization.gradle
+++ b/gradle/testing/randomization.gradle
@@ -63,6 +63,7 @@ allprojects {
 allprojects {
   plugins.withType(JavaPlugin) {
     ext {
+      String randomVectorSize = RandomPicks.randomFrom(new Random(projectSeedLong), ["default", "128", "256", "512"])
       testOptions += [
           // seed, repetition and amplification.
           [propName: 'tests.seed', value: { -> rootSeed }, description: "Sets the master randomization seed."],
@@ -106,11 +107,10 @@ allprojects {
           [propName: 'tests.bwcdir', value: null, description: "Data for backward-compatibility indexes."],
           // vectorization related
           [propName: 'tests.vectorsize',
-           value: { -> testsDefaultVectorizationRequested() ? 'default' :
-            RandomPicks.randomFrom(new Random(projectSeedLong), ["default", "128", "256", "512"]) },
+           value: { -> testsDefaultVectorizationRequested() ? 'default' : randomVectorSize },
            description: "Sets preferred vector size in bits."],
           [propName: 'tests.forceintegervectors',
-            value: { -> !testsDefaultVectorizationRequested() },
+            value: { -> testsDefaultVectorizationRequested() ? false : (randomVectorSize != 'default') },
             description: "Forces use of integer vectors even when slow."],
           [propName: 'tests.defaultvectorization', value: false,
             description: "Uses defaults for running tests with correct JVM settings to test Panama vectorization (tests.jvmargs, tests.vectorsize, tests.forceintegervectors)."],

--- a/gradle/testing/randomization.gradle
+++ b/gradle/testing/randomization.gradle
@@ -112,7 +112,8 @@ allprojects {
           [propName: 'tests.forceintegervectors',
             value: { -> testsDefaultVectorizationRequested() ? false : (randomVectorSize != 'default') },
             description: "Forces use of integer vectors even when slow."],
-          [propName: 'tests.defaultvectorization', value: false,
+          [propName: 'tests.defaultvectorization',
+            value: { -> (randomVectorSize == 'default') },
             description: "Uses defaults for running tests with correct JVM settings to test Panama vectorization (tests.jvmargs, tests.vectorsize, tests.forceintegervectors)."],
       ]
     }

--- a/gradle/testing/randomization.gradle
+++ b/gradle/testing/randomization.gradle
@@ -107,10 +107,14 @@ allprojects {
           // vectorization related
           [propName: 'tests.vectorsize',
              value: { ->
-               RandomPicks.randomFrom(new Random(projectSeedLong), ["128", "256", "512"])
+               isCIBuild ? "" : RandomPicks.randomFrom(new Random(projectSeedLong), ["", "128", "256", "512"])
              },
              description: "Sets preferred vector size in bits."],
-          [propName: 'tests.forceintegervectors', value: "true", description: "Forces use of integer vectors even when slow."],
+          [propName: 'tests.forceintegervectors',
+             value: { ->
+                 isCIBuild ? false : true
+             },
+             description: "Forces use of integer vectors even when slow."],
       ]
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -47,7 +47,7 @@ public abstract class VectorizationProvider {
     try {
       vs =
           Stream.ofNullable(System.getProperty("tests.vectorsize"))
-              .filter(Predicate.not(String::isEmpty))
+              .filter(Predicate.not(Set.of("", "default")::contains))
               .mapToInt(Integer::parseInt)
               .findAny();
     } catch (


### PR DESCRIPTION
This commit adds a separate option, tests.defaultvectorization, to allow running Panama Vectorization for all tests with suitable C2 defaults.

For example:
```
./gradlew :lucene:core:test -Ptests.defaultvectorization=true
```

A `default` value has also been added to the value in the random picks of vector bit size, which effectively enables the Panama Vector similarities implementation for all tests except TestVectorUtilSupport. This will cover more cases in the general workflow.

When modify or testing the Panama Vector similarities implementation directly, namely TestVectorUtilSupport, the following pattern continues to work:
```
for bits in default 128 256 512; do ./gradlew -p lucene/core test --tests TestVectorUtilSupport -Dtests.vectorsize=$bits; done
```

relates #13344