### PR TITLE
Ensure negative scores aren not returned from scalar quantization scorer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -359,7 +359,7 @@ Bug Fixes
 
 * GITHUB#12966: Aggregation facets no longer assume that aggregation values are positive. (Stefan Vodita)
 
-* GITHUB#13356: Ensure negative scores aren not returned from scalar quantization scorer. (Ben Trent)
+* GITHUB#13356: Ensure negative scores are not returned from scalar quantization scorer. (Ben Trent)
 
 Build
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -359,6 +359,8 @@ Bug Fixes
 
 * GITHUB#12966: Aggregation facets no longer assume that aggregation values are positive. (Stefan Vodita)
 
+* GITHUB#13356: Ensure negative scores aren not returned from scalar quantization scorer. (Ben Trent)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
@@ -100,11 +100,10 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     return switch (sim) {
       case EUCLIDEAN -> new Euclidean(values, constMultiplier, targetBytes);
       case COSINE, DOT_PRODUCT -> dotProductFactory(
-          targetBytes, offsetCorrection, sim, constMultiplier, values, f -> (1 + f) / 2);
+          targetBytes, offsetCorrection, constMultiplier, values, f -> Math.max((1 + f) / 2, 0));
       case MAXIMUM_INNER_PRODUCT -> dotProductFactory(
           targetBytes,
           offsetCorrection,
-          sim,
           constMultiplier,
           values,
           VectorUtil::scaleMaxInnerProductScore);
@@ -114,7 +113,6 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
   private static RandomVectorScorer.AbstractRandomVectorScorer dotProductFactory(
       byte[] targetBytes,
       float offsetCorrection,
-      VectorSimilarityFunction sim,
       float constMultiplier,
       RandomAccessQuantizedByteVectorValues values,
       FloatToFloatFunction scoreAdjustmentFunction) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
@@ -177,6 +177,8 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       byte[] storedVector = values.vectorValue(vectorOrdinal);
       float vectorOffset = values.getScoreCorrectionConstant(vectorOrdinal);
       int dotProduct = VectorUtil.dotProduct(storedVector, targetBytes);
+      // For the current implementation of scalar quantization, all dotproducts should be >= 0;
+      assert dotProduct >= 0;
       float adjustedDistance = dotProduct * constMultiplier + offsetCorrection + vectorOffset;
       return scoreAdjustmentFunction.apply(adjustedDistance);
     }
@@ -214,6 +216,8 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       values.getSlice().readBytes(compressedVector, 0, compressedVector.length);
       float vectorOffset = values.getScoreCorrectionConstant(vectorOrdinal);
       int dotProduct = VectorUtil.int4DotProductPacked(targetBytes, compressedVector);
+      // For the current implementation of scalar quantization, all dotproducts should be >= 0;
+      assert dotProduct >= 0;
       float adjustedDistance = dotProduct * constMultiplier + offsetCorrection + vectorOffset;
       return scoreAdjustmentFunction.apply(adjustedDistance);
     }
@@ -245,6 +249,8 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       byte[] storedVector = values.vectorValue(vectorOrdinal);
       float vectorOffset = values.getScoreCorrectionConstant(vectorOrdinal);
       int dotProduct = VectorUtil.int4DotProduct(storedVector, targetBytes);
+      // For the current implementation of scalar quantization, all dotproducts should be >= 0;
+      assert dotProduct >= 0;
       float adjustedDistance = dotProduct * constMultiplier + offsetCorrection + vectorOffset;
       return scoreAdjustmentFunction.apply(adjustedDistance);
     }

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizedVectorSimilarity.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizedVectorSimilarity.java
@@ -80,6 +80,8 @@ public interface ScalarQuantizedVectorSimilarity {
     public float score(
         byte[] queryVector, float queryOffset, byte[] storedVector, float vectorOffset) {
       int dotProduct = comparator.compare(storedVector, queryVector);
+      // For the current implementation of scalar quantization, all dotproducts should be >= 0;
+      assert dotProduct >= 0;
       float adjustedDistance = dotProduct * constMultiplier + queryOffset + vectorOffset;
       return Math.max((1 + adjustedDistance) / 2, 0);
     }
@@ -99,6 +101,8 @@ public interface ScalarQuantizedVectorSimilarity {
     public float score(
         byte[] queryVector, float queryOffset, byte[] storedVector, float vectorOffset) {
       int dotProduct = comparator.compare(storedVector, queryVector);
+      // For the current implementation of scalar quantization, all dotproducts should be >= 0;
+      assert dotProduct >= 0;
       float adjustedDistance = dotProduct * constMultiplier + queryOffset + vectorOffset;
       return scaleMaxInnerProductScore(adjustedDistance);
     }

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizedVectorSimilarity.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizedVectorSimilarity.java
@@ -81,7 +81,7 @@ public interface ScalarQuantizedVectorSimilarity {
         byte[] queryVector, float queryOffset, byte[] storedVector, float vectorOffset) {
       int dotProduct = comparator.compare(storedVector, queryVector);
       float adjustedDistance = dotProduct * constMultiplier + queryOffset + vectorOffset;
-      return (1 + adjustedDistance) / 2;
+      return Math.max((1 + adjustedDistance) / 2, 0);
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizedVectorSimilarity.java
+++ b/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizedVectorSimilarity.java
@@ -30,6 +30,26 @@ import org.apache.lucene.util.VectorUtil;
 
 public class TestScalarQuantizedVectorSimilarity extends LuceneTestCase {
 
+  public void testNonZeroScores() {
+    byte[][] quantized = new byte[2][32];
+    for (VectorSimilarityFunction similarityFunction : VectorSimilarityFunction.values()) {
+      float multiplier = random().nextFloat();
+      if (random().nextBoolean()) {
+        multiplier = -multiplier;
+      }
+      for (byte bits : new byte[] {4, 7}) {
+        ScalarQuantizedVectorSimilarity quantizedSimilarity =
+            ScalarQuantizedVectorSimilarity.fromVectorSimilarity(
+                similarityFunction, multiplier, bits);
+        float negativeOffsetA = -(random().nextFloat() * (random().nextInt(10) + 1));
+        float negativeOffsetB = -(random().nextFloat() * (random().nextInt(10) + 1));
+        float score =
+            quantizedSimilarity.score(quantized[0], negativeOffsetA, quantized[1], negativeOffsetB);
+        assertTrue(score >= 0);
+      }
+    }
+  }
+
   public void testToEuclidean() throws IOException {
     int dims = 128;
     int numVecs = 100;


### PR DESCRIPTION
Depending on how we quantize and then scale, we can edge down below `0` for dotproduct scores. 

This is exceptionally rare, I have only seen it in extreme circumstances in tests (with random data and low dimensionality).