### PR TITLE
Call ArrayUtil.copyArray instead of ArrayUtil.copySubArray for full array copy.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
@@ -44,7 +44,7 @@ public class ScalarQuantizedVectorScorer implements FlatVectorsScorer {
         switch (similarityFunction) {
           case EUCLIDEAN, DOT_PRODUCT, MAXIMUM_INNER_PRODUCT -> query;
           case COSINE -> {
-            float[] queryCopy = ArrayUtil.copyOfSubArray(query, 0, query.length);
+            float[] queryCopy = ArrayUtil.copyOf(query);
             VectorUtil.l2normalize(queryCopy);
             yield queryCopy;
           }

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
@@ -44,7 +44,7 @@ public class ScalarQuantizedVectorScorer implements FlatVectorsScorer {
         switch (similarityFunction) {
           case EUCLIDEAN, DOT_PRODUCT, MAXIMUM_INNER_PRODUCT -> query;
           case COSINE -> {
-            float[] queryCopy = ArrayUtil.copyOf(query);
+            float[] queryCopy = ArrayUtil.copyArray(query);
             VectorUtil.l2normalize(queryCopy);
             yield queryCopy;
           }

--- a/lucene/core/src/java/org/apache/lucene/search/BlendedTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BlendedTermQuery.java
@@ -268,7 +268,7 @@ public final class BlendedTermQuery extends Query {
 
   @Override
   public final Query rewrite(IndexSearcher indexSearcher) throws IOException {
-    final TermStates[] contexts = ArrayUtil.copyOfSubArray(this.contexts, 0, this.contexts.length);
+    final TermStates[] contexts = ArrayUtil.copyOf(this.contexts);
     for (int i = 0; i < contexts.length; ++i) {
       if (contexts[i] == null
           || contexts[i].wasBuiltFor(indexSearcher.getTopReaderContext()) == false) {

--- a/lucene/core/src/java/org/apache/lucene/search/BlendedTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BlendedTermQuery.java
@@ -268,7 +268,7 @@ public final class BlendedTermQuery extends Query {
 
   @Override
   public final Query rewrite(IndexSearcher indexSearcher) throws IOException {
-    final TermStates[] contexts = ArrayUtil.copyOf(this.contexts);
+    final TermStates[] contexts = ArrayUtil.copyArray(this.contexts);
     for (int i = 0; i < contexts.length; ++i) {
       if (contexts[i] == null
           || contexts[i].wasBuiltFor(indexSearcher.getTopReaderContext()) == false) {

--- a/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
@@ -128,6 +128,6 @@ public class KnnByteVectorQuery extends AbstractKnnVectorQuery {
    * @return the target query vector of the search. Each vector element is a byte.
    */
   public byte[] getTargetCopy() {
-    return ArrayUtil.copyOf(target);
+    return ArrayUtil.copyArray(target);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
@@ -128,6 +128,6 @@ public class KnnByteVectorQuery extends AbstractKnnVectorQuery {
    * @return the target query vector of the search. Each vector element is a byte.
    */
   public byte[] getTargetCopy() {
-    return ArrayUtil.copyOfSubArray(target, 0, target.length);
+    return ArrayUtil.copyOf(target);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
@@ -131,6 +131,6 @@ public class KnnFloatVectorQuery extends AbstractKnnVectorQuery {
    * @return the target query vector of the search. Each vector element is a float.
    */
   public float[] getTargetCopy() {
-    return ArrayUtil.copyOfSubArray(target, 0, target.length);
+    return ArrayUtil.copyOf(target);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
@@ -131,6 +131,6 @@ public class KnnFloatVectorQuery extends AbstractKnnVectorQuery {
    * @return the target query vector of the search. Each vector element is a float.
    */
   public float[] getTargetCopy() {
-    return ArrayUtil.copyOf(target);
+    return ArrayUtil.copyArray(target);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
@@ -624,6 +624,13 @@ public final class ArrayUtil {
   }
 
   /**
+   * Copies an array into a new array.
+   */
+  public static byte[] copyOf(byte[] array) {
+    return copyOfSubArray(array, 0, array.length);
+  }
+
+  /**
    * Copies the specified range of the given array into a new sub array.
    *
    * @param array the input array
@@ -634,6 +641,13 @@ public final class ArrayUtil {
     final byte[] copy = new byte[to - from];
     System.arraycopy(array, from, copy, 0, to - from);
     return copy;
+  }
+
+  /**
+   * Copies an array into a new array.
+   */
+  public static char[] copyOf(char[] array) {
+    return copyOfSubArray(array, 0, array.length);
   }
 
   /**
@@ -650,6 +664,13 @@ public final class ArrayUtil {
   }
 
   /**
+   * Copies an array into a new array.
+   */
+  public static short[] copyOf(short[] array) {
+    return copyOfSubArray(array, 0, array.length);
+  }
+
+  /**
    * Copies the specified range of the given array into a new sub array.
    *
    * @param array the input array
@@ -660,6 +681,13 @@ public final class ArrayUtil {
     final short[] copy = new short[to - from];
     System.arraycopy(array, from, copy, 0, to - from);
     return copy;
+  }
+
+  /**
+   * Copies an array into a new array.
+   */
+  public static int[] copyOf(int[] array) {
+    return copyOfSubArray(array, 0, array.length);
   }
 
   /**
@@ -676,6 +704,13 @@ public final class ArrayUtil {
   }
 
   /**
+   * Copies an array into a new array.
+   */
+  public static long[] copyOf(long[] array) {
+    return copyOfSubArray(array, 0, array.length);
+  }
+
+  /**
    * Copies the specified range of the given array into a new sub array.
    *
    * @param array the input array
@@ -686,6 +721,13 @@ public final class ArrayUtil {
     final long[] copy = new long[to - from];
     System.arraycopy(array, from, copy, 0, to - from);
     return copy;
+  }
+
+  /**
+   * Copies an array into a new array.
+   */
+  public static float[] copyOf(float[] array) {
+    return copyOfSubArray(array, 0, array.length);
   }
 
   /**
@@ -702,6 +744,13 @@ public final class ArrayUtil {
   }
 
   /**
+   * Copies an array into a new array.
+   */
+  public static double[] copyOf(double[] array) {
+    return copyOfSubArray(array, 0, array.length);
+  }
+
+  /**
    * Copies the specified range of the given array into a new sub array.
    *
    * @param array the input array
@@ -712,6 +761,13 @@ public final class ArrayUtil {
     final double[] copy = new double[to - from];
     System.arraycopy(array, from, copy, 0, to - from);
     return copy;
+  }
+
+  /**
+   * Copies an array into a new array.
+   */
+  public static <T> T[] copyOf(T[] array) {
+    return copyOfSubArray(array, 0, array.length);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
@@ -623,9 +623,7 @@ public final class ArrayUtil {
     }.select(from, to, k);
   }
 
-  /**
-   * Copies an array into a new array.
-   */
+  /** Copies an array into a new array. */
   public static byte[] copyArray(byte[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
@@ -643,9 +641,7 @@ public final class ArrayUtil {
     return copy;
   }
 
-  /**
-   * Copies an array into a new array.
-   */
+  /** Copies an array into a new array. */
   public static char[] copyArray(char[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
@@ -663,9 +659,7 @@ public final class ArrayUtil {
     return copy;
   }
 
-  /**
-   * Copies an array into a new array.
-   */
+  /** Copies an array into a new array. */
   public static short[] copyArray(short[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
@@ -683,9 +677,7 @@ public final class ArrayUtil {
     return copy;
   }
 
-  /**
-   * Copies an array into a new array.
-   */
+  /** Copies an array into a new array. */
   public static int[] copyArray(int[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
@@ -703,9 +695,7 @@ public final class ArrayUtil {
     return copy;
   }
 
-  /**
-   * Copies an array into a new array.
-   */
+  /** Copies an array into a new array. */
   public static long[] copyArray(long[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
@@ -723,9 +713,7 @@ public final class ArrayUtil {
     return copy;
   }
 
-  /**
-   * Copies an array into a new array.
-   */
+  /** Copies an array into a new array. */
   public static float[] copyArray(float[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
@@ -743,9 +731,7 @@ public final class ArrayUtil {
     return copy;
   }
 
-  /**
-   * Copies an array into a new array.
-   */
+  /** Copies an array into a new array. */
   public static double[] copyArray(double[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
@@ -763,9 +749,7 @@ public final class ArrayUtil {
     return copy;
   }
 
-  /**
-   * Copies an array into a new array.
-   */
+  /** Copies an array into a new array. */
   public static <T> T[] copyArray(T[] array) {
     return copyOfSubArray(array, 0, array.length);
   }

--- a/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
@@ -626,7 +626,7 @@ public final class ArrayUtil {
   /**
    * Copies an array into a new array.
    */
-  public static byte[] copyOf(byte[] array) {
+  public static byte[] copyArray(byte[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
 
@@ -646,7 +646,7 @@ public final class ArrayUtil {
   /**
    * Copies an array into a new array.
    */
-  public static char[] copyOf(char[] array) {
+  public static char[] copyArray(char[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
 
@@ -666,7 +666,7 @@ public final class ArrayUtil {
   /**
    * Copies an array into a new array.
    */
-  public static short[] copyOf(short[] array) {
+  public static short[] copyArray(short[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
 
@@ -686,7 +686,7 @@ public final class ArrayUtil {
   /**
    * Copies an array into a new array.
    */
-  public static int[] copyOf(int[] array) {
+  public static int[] copyArray(int[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
 
@@ -706,7 +706,7 @@ public final class ArrayUtil {
   /**
    * Copies an array into a new array.
    */
-  public static long[] copyOf(long[] array) {
+  public static long[] copyArray(long[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
 
@@ -726,7 +726,7 @@ public final class ArrayUtil {
   /**
    * Copies an array into a new array.
    */
-  public static float[] copyOf(float[] array) {
+  public static float[] copyArray(float[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
 
@@ -746,7 +746,7 @@ public final class ArrayUtil {
   /**
    * Copies an array into a new array.
    */
-  public static double[] copyOf(double[] array) {
+  public static double[] copyArray(double[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
 
@@ -766,7 +766,7 @@ public final class ArrayUtil {
   /**
    * Copies an array into a new array.
    */
-  public static <T> T[] copyOf(T[] array) {
+  public static <T> T[] copyArray(T[] array) {
     return copyOfSubArray(array, 0, array.length);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
@@ -229,7 +229,7 @@ public class TestBoolean2 extends LuceneTestCase {
 
     // adjust the expected doc numbers according to our filler docs
     if (0 < NUM_FILLER_DOCS) {
-      expDocNrs = ArrayUtil.copyOfSubArray(expDocNrs, 0, expDocNrs.length);
+      expDocNrs = ArrayUtil.copyOf(expDocNrs);
       for (int i = 0; i < expDocNrs.length; i++) {
         expDocNrs[i] = PRE_FILLER_DOCS + ((NUM_FILLER_DOCS + 1) * expDocNrs[i]);
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
@@ -229,7 +229,7 @@ public class TestBoolean2 extends LuceneTestCase {
 
     // adjust the expected doc numbers according to our filler docs
     if (0 < NUM_FILLER_DOCS) {
-      expDocNrs = ArrayUtil.copyOf(expDocNrs);
+      expDocNrs = ArrayUtil.copyArray(expDocNrs);
       for (int i = 0; i < expDocNrs.length; i++) {
         expDocNrs[i] = PRE_FILLER_DOCS + ((NUM_FILLER_DOCS + 1) * expDocNrs[i]);
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -755,7 +755,7 @@ public class TestPhraseQuery extends LuceneTestCase {
   public void testTopPhrases() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
-    String[] docs = ArrayUtil.copyOf(DOCS);
+    String[] docs = ArrayUtil.copyArray(DOCS);
     Collections.shuffle(Arrays.asList(docs), random());
     for (String value : DOCS) {
       Document doc = new Document();

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -755,7 +755,7 @@ public class TestPhraseQuery extends LuceneTestCase {
   public void testTopPhrases() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
-    String[] docs = ArrayUtil.copyOfSubArray(DOCS, 0, DOCS.length);
+    String[] docs = ArrayUtil.copyOf(DOCS);
     Collections.shuffle(Arrays.asList(docs), random());
     for (String value : DOCS) {
       Document doc = new Document();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanationsWithFillerDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanationsWithFillerDocs.java
@@ -103,7 +103,7 @@ public class TestSimpleExplanationsWithFillerDocs extends TestSimpleExplanations
   @Override
   public void qtest(Query q, int[] expDocNrs) throws Exception {
 
-    expDocNrs = ArrayUtil.copyOfSubArray(expDocNrs, 0, expDocNrs.length);
+    expDocNrs = ArrayUtil.copyOf(expDocNrs);
     for (int i = 0; i < expDocNrs.length; i++) {
       expDocNrs[i] = PRE_FILLER_DOCS + ((NUM_FILLER_DOCS + 1) * expDocNrs[i]);
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanationsWithFillerDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanationsWithFillerDocs.java
@@ -103,7 +103,7 @@ public class TestSimpleExplanationsWithFillerDocs extends TestSimpleExplanations
   @Override
   public void qtest(Query q, int[] expDocNrs) throws Exception {
 
-    expDocNrs = ArrayUtil.copyOf(expDocNrs);
+    expDocNrs = ArrayUtil.copyArray(expDocNrs);
     for (int i = 0; i < expDocNrs.length; i++) {
       expDocNrs[i] = PRE_FILLER_DOCS + ((NUM_FILLER_DOCS + 1) * expDocNrs[i]);
     }

--- a/lucene/core/src/test/org/apache/lucene/util/BaseSortTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/BaseSortTestCase.java
@@ -49,7 +49,7 @@ public abstract class BaseSortTestCase extends LuceneTestCase {
 
   public void assertSorted(Entry[] original, Entry[] sorted) {
     assertEquals(original.length, sorted.length);
-    Entry[] actuallySorted = ArrayUtil.copyOfSubArray(original, 0, original.length);
+    Entry[] actuallySorted = ArrayUtil.copyOf(original);
     Arrays.sort(actuallySorted);
     for (int i = 0; i < original.length; ++i) {
       assertEquals(actuallySorted[i].value, sorted[i].value);

--- a/lucene/core/src/test/org/apache/lucene/util/BaseSortTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/BaseSortTestCase.java
@@ -49,7 +49,7 @@ public abstract class BaseSortTestCase extends LuceneTestCase {
 
   public void assertSorted(Entry[] original, Entry[] sorted) {
     assertEquals(original.length, sorted.length);
-    Entry[] actuallySorted = ArrayUtil.copyOf(original);
+    Entry[] actuallySorted = ArrayUtil.copyArray(original);
     Arrays.sort(actuallySorted);
     for (int i = 0; i < original.length; ++i) {
       assertEquals(actuallySorted[i].value, sorted[i].value);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockByteVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockByteVectorValues.java
@@ -50,10 +50,7 @@ class MockByteVectorValues extends AbstractMockVectorValues<byte[]>
   @Override
   public MockByteVectorValues copy() {
     return new MockByteVectorValues(
-        ArrayUtil.copyArray(values),
-        dimension,
-        ArrayUtil.copyArray(denseValues),
-        numVectors);
+        ArrayUtil.copyArray(values), dimension, ArrayUtil.copyArray(denseValues), numVectors);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockByteVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockByteVectorValues.java
@@ -50,9 +50,9 @@ class MockByteVectorValues extends AbstractMockVectorValues<byte[]>
   @Override
   public MockByteVectorValues copy() {
     return new MockByteVectorValues(
-        ArrayUtil.copyOf(values),
+        ArrayUtil.copyArray(values),
         dimension,
-        ArrayUtil.copyOf(denseValues),
+        ArrayUtil.copyArray(denseValues),
         numVectors);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockByteVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockByteVectorValues.java
@@ -50,9 +50,9 @@ class MockByteVectorValues extends AbstractMockVectorValues<byte[]>
   @Override
   public MockByteVectorValues copy() {
     return new MockByteVectorValues(
-        ArrayUtil.copyOfSubArray(values, 0, values.length),
+        ArrayUtil.copyOf(values),
         dimension,
-        ArrayUtil.copyOfSubArray(denseValues, 0, denseValues.length),
+        ArrayUtil.copyOf(denseValues),
         numVectors);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
@@ -50,10 +50,7 @@ class MockVectorValues extends AbstractMockVectorValues<float[]>
   @Override
   public MockVectorValues copy() {
     return new MockVectorValues(
-        ArrayUtil.copyArray(values),
-        dimension,
-        ArrayUtil.copyArray(denseValues),
-        numVectors);
+        ArrayUtil.copyArray(values), dimension, ArrayUtil.copyArray(denseValues), numVectors);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
@@ -50,9 +50,9 @@ class MockVectorValues extends AbstractMockVectorValues<float[]>
   @Override
   public MockVectorValues copy() {
     return new MockVectorValues(
-        ArrayUtil.copyOf(values),
+        ArrayUtil.copyArray(values),
         dimension,
-        ArrayUtil.copyOf(denseValues),
+        ArrayUtil.copyArray(denseValues),
         numVectors);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockVectorValues.java
@@ -50,9 +50,9 @@ class MockVectorValues extends AbstractMockVectorValues<float[]>
   @Override
   public MockVectorValues copy() {
     return new MockVectorValues(
-        ArrayUtil.copyOfSubArray(values, 0, values.length),
+        ArrayUtil.copyOf(values),
         dimension,
-        ArrayUtil.copyOfSubArray(denseValues, 0, denseValues.length),
+        ArrayUtil.copyOf(denseValues),
         numVectors);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizedVectorSimilarity.java
+++ b/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizedVectorSimilarity.java
@@ -209,7 +209,7 @@ public class TestScalarQuantizedVectorSimilarity extends LuceneTestCase {
     int i = 0;
     float[] offsets = new float[floats.length];
     for (float[] f : floats) {
-      float[] v = ArrayUtil.copyOf(f);
+      float[] v = ArrayUtil.copyArray(f);
       VectorUtil.l2normalize(v);
       quantized[i] = new byte[v.length];
       offsets[i] = scalarQuantizer.quantize(v, quantized[i], similarityFunction);
@@ -226,7 +226,7 @@ public class TestScalarQuantizedVectorSimilarity extends LuceneTestCase {
         if (curDoc == -1 || curDoc >= floats.length) {
           throw new IOException("Current doc not set or too many iterations");
         }
-        float[] v = ArrayUtil.copyOf(floats[curDoc]);
+        float[] v = ArrayUtil.copyArray(floats[curDoc]);
         VectorUtil.l2normalize(v);
         return v;
       }

--- a/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizedVectorSimilarity.java
+++ b/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizedVectorSimilarity.java
@@ -209,7 +209,7 @@ public class TestScalarQuantizedVectorSimilarity extends LuceneTestCase {
     int i = 0;
     float[] offsets = new float[floats.length];
     for (float[] f : floats) {
-      float[] v = ArrayUtil.copyOfSubArray(f, 0, f.length);
+      float[] v = ArrayUtil.copyOf(f);
       VectorUtil.l2normalize(v);
       quantized[i] = new byte[v.length];
       offsets[i] = scalarQuantizer.quantize(v, quantized[i], similarityFunction);
@@ -226,7 +226,7 @@ public class TestScalarQuantizedVectorSimilarity extends LuceneTestCase {
         if (curDoc == -1 || curDoc >= floats.length) {
           throw new IOException("Current doc not set or too many iterations");
         }
-        float[] v = ArrayUtil.copyOfSubArray(floats[curDoc], 0, floats[curDoc].length);
+        float[] v = ArrayUtil.copyOf(floats[curDoc]);
         VectorUtil.l2normalize(v);
         return v;
       }

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestDistanceStrategy.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestDistanceStrategy.java
@@ -108,7 +108,7 @@ public class TestDistanceStrategy extends StrategyTestCase {
 
   void checkDistValueSource(Point pt, float... distances) throws IOException {
     float multiplier = random().nextFloat() * 100f;
-    float[] dists2 = ArrayUtil.copyOf(distances);
+    float[] dists2 = ArrayUtil.copyArray(distances);
     for (int i = 0; i < dists2.length; i++) {
       dists2[i] *= multiplier;
     }

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestDistanceStrategy.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestDistanceStrategy.java
@@ -108,7 +108,7 @@ public class TestDistanceStrategy extends StrategyTestCase {
 
   void checkDistValueSource(Point pt, float... distances) throws IOException {
     float multiplier = random().nextFloat() * 100f;
-    float[] dists2 = ArrayUtil.copyOfSubArray(distances, 0, distances.length);
+    float[] dists2 = ArrayUtil.copyOf(distances);
     for (int i = 0; i < dists2.length; i++) {
       dists2[i] *= multiplier;
     }


### PR DESCRIPTION
ArrayUtil provides copySubArray() as replacement of Array.copyOf and Array.copyOfRange (with better bounds check). Unfortunately ArrayUtil does not provide copyArray(), so it is weird for callers to have to call a method named copySubArray() when we want to copy the full array.

This PR adds ArrayUtil.copyArray(), and replaces the calls to ArrayUtil.copySubArray(array, 0, array.length) with calls to ArrayUtil.copyArray(array).
I used the following regex to match all calls:
`copyOfSubArray\(([^,]+), 0, \1\.length\)`
and this one to replace
`copyArray($1)`