### PR TITLE
Fix TestHnswByteVectorGraph.testSortedAndUnsortedIndicesReturnSameResults

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -345,7 +345,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
         for (int i = 0; i < 10; i++) {
           // ask to explore a lot of candidates to ensure the same returned hits,
           // as graphs of 2 indices are organized differently
-          Query query = knnQuery("vector", randomVector(dim), 60);
+          Query query = knnQuery("vector", randomVector(dim), 80);
           int searchSize = 5;
           List<String> ids1 = new ArrayList<>(searchSize);
           List<Integer> docs1 = new ArrayList<>(searchSize);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -345,7 +345,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
         for (int i = 0; i < 10; i++) {
           // ask to explore a lot of candidates to ensure the same returned hits,
           // as graphs of 2 indices are organized differently
-          Query query = knnQuery("vector", randomVector(dim), 80);
+          Query query = knnQuery("vector", randomVector(dim), 60);
           int searchSize = 5;
           List<String> ids1 = new ArrayList<>(searchSize);
           List<Integer> docs1 = new ArrayList<>(searchSize);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -282,7 +282,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     AbstractMockVectorValues<T> vectors = vectorValues(nDoc, dim);
 
     int M = random().nextInt(10) + 5;
-    int beamWidth = random().nextInt(10) + 5;
+    int beamWidth = random().nextInt(10) + 10;
     VectorSimilarityFunction similarityFunction =
         RandomizedTest.randomFrom(VectorSimilarityFunction.values());
     long seed = random().nextLong();


### PR DESCRIPTION
## Closes https://github.com/apache/lucene/issues/13210

#### Description

The following test failed as it produced two different lists of ids for a sorted and unsorted HNSW byte vector graph as one graph didn't find a higher scoring doc the other one found:
`gradlew test --tests TestHnswByteVectorGraph.testSortedAndUnsortedIndicesReturnSameResults -Dtests.seed=B41BEC5619361A16 -Dtests.locale=hi-IN -Dtests.timezone=Atlantic/Stanley -Dtests.asserts=true -Dtests.file.encoding=UTF-8`

Considering that the graphs of 2 indices are organized differently we need to explore a lot of candidates to ensure that both searchers find the same docs. Increasing `beamWidth` (number of nearest neighbor candidates to track while searching the graph for each newly inserted node) from `5` to `10` fixes the test.