### PR TITLE
Add sub query explanations in DisjunctionMaxQuery#explain on no-match

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -293,6 +293,8 @@ Improvements
 * GITHUB#12966: Move most of the responsibility from TaxonomyFacets implementations to TaxonomyFacets itself.
   This reduces code duplication and enables future development. (Stefan Vodita)
 
+* GITHUB#13362: Add sub query explanations to DisjuncationMaxQuery, if the overall query didn't match. (Tim Grein)
+
 Optimizations
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -293,7 +293,7 @@ Improvements
 * GITHUB#12966: Move most of the responsibility from TaxonomyFacets implementations to TaxonomyFacets itself.
   This reduces code duplication and enables future development. (Stefan Vodita)
 
-* GITHUB#13362: Add sub query explanations to DisjuncationMaxQuery, if the overall query didn't match. (Tim Grein)
+* GITHUB#13362: Add sub query explanations to DisjunctionMaxQuery, if the overall query didn't match. (Tim Grein)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
@@ -227,7 +227,7 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
           } else {
             otherSum += score;
           }
-        } else if(match == false){
+        } else if (match == false) {
           subsOnNoMatch.add(e);
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
@@ -216,9 +216,9 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
       List<Explanation> subs = new ArrayList<>();
       for (Weight wt : weights) {
         Explanation e = wt.explain(context, doc);
+        subs.add(e);
         if (e.isMatch()) {
           match = true;
-          subs.add(e);
           double score = e.getValue().doubleValue();
           if (score >= max) {
             otherSum += max;
@@ -236,7 +236,7 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
                 : "max plus " + tieBreakerMultiplier + " times others of:";
         return Explanation.match(score, desc, subs);
       } else {
-        return Explanation.noMatch("No matching clause");
+        return Explanation.noMatch("No matching clause", subs);
       }
     }
   } // end of DisjunctionMaxWeight inner class

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
@@ -213,12 +213,13 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
       boolean match = false;
       double max = 0;
       double otherSum = 0;
-      List<Explanation> subs = new ArrayList<>();
+      List<Explanation> subsOnMatch = new ArrayList<>();
+      List<Explanation> subsOnNoMatch = new ArrayList<>();
       for (Weight wt : weights) {
         Explanation e = wt.explain(context, doc);
-        subs.add(e);
         if (e.isMatch()) {
           match = true;
+          subsOnMatch.add(e);
           double score = e.getValue().doubleValue();
           if (score >= max) {
             otherSum += max;
@@ -226,6 +227,8 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
           } else {
             otherSum += score;
           }
+        } else if(match == false){
+          subsOnNoMatch.add(e);
         }
       }
       if (match) {
@@ -234,9 +237,9 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
             tieBreakerMultiplier == 0.0f
                 ? "max of:"
                 : "max plus " + tieBreakerMultiplier + " times others of:";
-        return Explanation.match(score, desc, subs);
+        return Explanation.match(score, desc, subsOnMatch);
       } else {
-        return Explanation.noMatch("No matching clause", subs);
+        return Explanation.noMatch("No matching clause", subsOnNoMatch);
       }
     }
   } // end of DisjunctionMaxWeight inner class

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -497,6 +497,36 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
     doTestRandomTopDocs(4, 1.0f, 0.5f, 0.05f, 0f);
   }
 
+  public void testExplainMatch() throws IOException {
+    Query sub1 = tq("hed", "elephant");
+    Query sub2 = tq("dek", "elephant");
+
+    final DisjunctionMaxQuery dq = new DisjunctionMaxQuery(Arrays.asList(sub1, sub2), 0.0f);
+
+    final Weight dw = s.createWeight(s.rewrite(dq), ScoreMode.COMPLETE, 1);
+    LeafReaderContext context = (LeafReaderContext) s.getTopReaderContext();
+    Explanation explanation = dw.explain(context, 1);
+
+    assertEquals("max of:", explanation.getDescription());
+    // Two matching sub queries should be included in the explanation details
+    assertEquals(2, explanation.getDetails().length);
+  }
+
+  public void testExplainNoMatch() throws IOException {
+    Query sub1 = tq("abc", "elephant");
+    Query sub2 = tq("def", "elephant");
+
+    final DisjunctionMaxQuery dq = new DisjunctionMaxQuery(Arrays.asList(sub1, sub2), 0.0f);
+
+    final Weight dw = s.createWeight(s.rewrite(dq), ScoreMode.COMPLETE, 1);
+    LeafReaderContext context = (LeafReaderContext) s.getTopReaderContext();
+    Explanation explanation = dw.explain(context, 1);
+
+    assertEquals("No matching clause", explanation.getDescription());
+    // Two non-matching sub queries should be included in the explanation details
+    assertEquals(2, explanation.getDetails().length);
+  }
+
   private void doTestRandomTopDocs(int numFields, double... freqs) throws IOException {
     assert numFields == freqs.length;
     Directory dir = newDirectory();

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -498,6 +498,7 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
   }
 
   public void testExplainMatch() throws IOException {
+    // Both match
     Query sub1 = tq("hed", "elephant");
     Query sub2 = tq("dek", "elephant");
 
@@ -513,6 +514,7 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
   }
 
   public void testExplainNoMatch() throws IOException {
+    // No match
     Query sub1 = tq("abc", "elephant");
     Query sub2 = tq("def", "elephant");
 
@@ -525,6 +527,24 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
     assertEquals("No matching clause", explanation.getDescription());
     // Two non-matching sub queries should be included in the explanation details
     assertEquals(2, explanation.getDetails().length);
+  }
+
+  public void testExplainMatch_OneNonMatchingSubQuery_NotIncludedInExplanation() throws IOException {
+    // Matches
+    Query sub1 = tq("hed", "elephant");
+
+    // Doesn't match
+    Query sub2 = tq("def", "elephant");
+
+    final DisjunctionMaxQuery dq = new DisjunctionMaxQuery(Arrays.asList(sub1, sub2), 0.0f);
+
+    final Weight dw = s.createWeight(s.rewrite(dq), ScoreMode.COMPLETE, 1);
+    LeafReaderContext context = (LeafReaderContext) s.getTopReaderContext();
+    Explanation explanation = dw.explain(context, 1);
+
+    assertEquals("max of:", explanation.getDescription());
+    // Only the matching sub query (sub1) should be included in the explanation details
+    assertEquals(1, explanation.getDetails().length);
   }
 
   private void doTestRandomTopDocs(int numFields, double... freqs) throws IOException {

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -529,7 +529,8 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
     assertEquals(2, explanation.getDetails().length);
   }
 
-  public void testExplainMatch_OneNonMatchingSubQuery_NotIncludedInExplanation() throws IOException {
+  public void testExplainMatch_OneNonMatchingSubQuery_NotIncludedInExplanation()
+      throws IOException {
     // Matches
     Query sub1 = tq("hed", "elephant");
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
@@ -417,7 +417,7 @@ public class CheckHits {
     if (descr.startsWith("score based on ") && descr.contains("child docs in range")) {
       assertTrue("Child doc explanations are missing", detail.length > 0);
     }
-    if (detail.length > 0) {
+    if (detail.length > 0 && expl.isMatch()) {
       if (detail.length == 1 && COMPUTED_FROM_PATTERN.matcher(descr).matches() == false) {
         // simple containment, unless it's a freq of: (which lets a query explain how the freq is
         // calculated),


### PR DESCRIPTION
## Closes https://github.com/apache/lucene/issues/13357

### Description

https://github.com/apache/lucene/issues/13357 states that it's useful to have the explanations of the sub queries of `DisjuncationMaxQuery` present, even if the document didn't match. Considering that other queries like `CoveringQuery` also include [explanations, if the document didn't match](https://github.com/apache/lucene/blob/25f1efd8eb34c2eb135a3c0850723ca5b03deec7/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CoveringQuery.java#L218-L223) I've adjusted the logic according to the issue's proposal.

Also added tests for `explain` (match and no match case). I've also adjusted `CheckHits#verifyExplanation` to only check sub explanations, if the overall explanation returned a hit and scores need to be checked.