### PR TITLE
Use IndexInput#prefetch for postings, skip data and impacts

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
@@ -917,7 +917,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
           payloadByteUpto = skipper.getPayloadByteUpto();
         }
         nextSkipDoc = skipper.getNextSkipDoc();
-      } else if (skipOffset >= 0) {
+      } else {
         // We don't need skip data yet, but we have evidence that advance() is used, so prefetch it
         // in the background.
         if (prefetchedSkipData == false) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
@@ -2087,15 +2087,15 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
       if (state.skipOffset < 0) {
         // This postings list is very short as it doesn't have skip data, prefetch the page that
         // holds the first byte of the postings list.
-        docIn.prefetch(1);
+        docIn.prefetch(state.docStartFP, 1);
       } else if (state.skipOffset <= MAX_POSTINGS_SIZE_FOR_FULL_PREFETCH) {
         // This postings list is short as it fits on a few pages, prefetch it all, plus one byte to
         // make sure to include some skip data.
-        docIn.prefetch(state.skipOffset + 1);
+        docIn.prefetch(state.docStartFP, state.skipOffset + 1);
       } else {
         // Default case: prefetch the page that holds the first byte of postings. We'll prefetch
         // skip data when we have evidence that it is used.
-        docIn.prefetch(1);
+        docIn.prefetch(state.docStartFP, 1);
       }
     }
     // Note: we don't prefetch positions or offsets, which are less likely to be needed.
@@ -2106,10 +2106,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
     if (skipOffset > MAX_POSTINGS_SIZE_FOR_FULL_PREFETCH) {
       // If skipOffset is less than this value, skip data was already prefetched when doing
       // #seekAndPrefetchPostings
-      long fp = docIn.getFilePointer();
-      docIn.seek(docStartFP + skipOffset);
-      docIn.prefetch(1);
-      docIn.seek(fp);
+      docIn.prefetch(docStartFP + skipOffset, 1);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99PostingsReader.java
@@ -922,6 +922,7 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
         // in the background.
         if (prefetchedSkipData == false) {
           prefetchSkipData(docIn, docTermStartFP, skipOffset);
+          prefetchedSkipData = true;
         }
       }
       if (docBufferUpto == BLOCK_SIZE) {


### PR DESCRIPTION
This uses the `IndexInput#prefetch` API for postings. This relies on heuristics, as we don't know ahead of time what data we will need from a postings list:
 - Postings lists are prefetched entirely when they are short (< 16kB).
 - Impacts enums also prefetch the first page of skip data.
 - Postings enums prefetc skip data on the first call to advance().

Positions, offsets and payloads are never prefetched.

Putting the `IndexInput#prefetch` call in `TermsEnum#postings` and `TermsEnum#impacts` works well because `BooleanQuery` will first create postings/impacts enums for all clauses before it starts unioning/intersecting them. This allows the prefetching logic to run in parallel across all clauses of the same query on the same segment.