### PR TITLE
Fix vector scorer interface consistency

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
@@ -376,7 +376,7 @@ public abstract class OffHeapByteVectorValues extends ByteVectorValues
 
     @Override
     public VectorScorer scorer(byte[] query) {
-      throw new UnsupportedOperationException();
+      return null;
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
@@ -365,7 +365,7 @@ public abstract class OffHeapFloatVectorValues extends FloatVectorValues
 
     @Override
     public VectorScorer scorer(float[] query) {
-      throw new UnsupportedOperationException();
+      return null;
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
@@ -431,7 +431,7 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
 
     @Override
     public VectorScorer scorer(float[] query) throws IOException {
-      return quantizedVectorValues.vectorScorer(query);
+      return quantizedVectorValues.scorer(query);
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
@@ -1023,7 +1023,7 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
     }
 
     @Override
-    public VectorScorer vectorScorer(float[] target) throws IOException {
+    public VectorScorer scorer(float[] target) throws IOException {
       throw new UnsupportedOperationException();
     }
   }
@@ -1096,7 +1096,7 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
     }
 
     @Override
-    public VectorScorer vectorScorer(float[] target) throws IOException {
+    public VectorScorer scorer(float[] target) throws IOException {
       throw new UnsupportedOperationException();
     }
 
@@ -1202,7 +1202,7 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
     }
 
     @Override
-    public VectorScorer vectorScorer(float[] target) throws IOException {
+    public VectorScorer scorer(float[] target) throws IOException {
       throw new UnsupportedOperationException();
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/OffHeapQuantizedByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/OffHeapQuantizedByteVectorValues.java
@@ -268,7 +268,7 @@ public abstract class OffHeapQuantizedByteVectorValues extends QuantizedByteVect
     }
 
     @Override
-    public VectorScorer vectorScorer(float[] target) throws IOException {
+    public VectorScorer scorer(float[] target) throws IOException {
       DenseOffHeapVectorValues copy = copy();
       RandomVectorScorer vectorScorer =
           vectorsScorer.getRandomVectorScorer(similarityFunction, copy, target);
@@ -370,7 +370,7 @@ public abstract class OffHeapQuantizedByteVectorValues extends QuantizedByteVect
     }
 
     @Override
-    public VectorScorer vectorScorer(float[] target) throws IOException {
+    public VectorScorer scorer(float[] target) throws IOException {
       SparseOffHeapVectorValues copy = copy();
       RandomVectorScorer vectorScorer =
           vectorsScorer.getRandomVectorScorer(similarityFunction, copy, target);
@@ -457,8 +457,8 @@ public abstract class OffHeapQuantizedByteVectorValues extends QuantizedByteVect
     }
 
     @Override
-    public VectorScorer vectorScorer(float[] target) {
-      throw new UnsupportedOperationException();
+    public VectorScorer scorer(float[] target) {
+      return null;
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java
@@ -83,7 +83,7 @@ public abstract class ByteVectorValues extends DocIdSetIterator {
    * iteration over the scorer will not affect the iteration of this {@link ByteVectorValues}.
    *
    * @param query the query vector
-   * @return a {@link VectorScorer} instance
+   * @return a {@link VectorScorer} instance or null
    */
   public abstract VectorScorer scorer(byte[] query) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
@@ -84,7 +84,7 @@ public abstract class FloatVectorValues extends DocIdSetIterator {
    * iteration of this {@link FloatVectorValues}.
    *
    * @param query the query vector
-   * @return a {@link VectorScorer} instance
+   * @return a {@link VectorScorer} instance or null
    */
   public abstract VectorScorer scorer(float[] query) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java
@@ -259,6 +259,9 @@ abstract class AbstractVectorSimilarityQuery extends Query {
         VectorScorer scorer,
         DocIdSetIterator acceptDocs,
         float threshold) {
+      if (scorer == null) {
+        return null;
+      }
       float[] cachedScore = new float[1];
       DocIdSetIterator vectorIterator = scorer.iterator();
       DocIdSetIterator conjunction =

--- a/lucene/core/src/java/org/apache/lucene/search/FloatVectorSimilarityValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FloatVectorSimilarityValuesSource.java
@@ -37,29 +37,6 @@ class FloatVectorSimilarityValuesSource extends VectorSimilarityValuesSource {
   }
 
   @Override
-  public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
-    final FloatVectorValues vectorValues = ctx.reader().getFloatVectorValues(fieldName);
-    if (vectorValues == null) {
-      FloatVectorValues.checkField(ctx.reader(), fieldName);
-      return DoubleValues.EMPTY;
-    }
-    return new DoubleValues() {
-      private final VectorScorer scorer = vectorValues.scorer(queryVector);
-      private final DocIdSetIterator iterator = scorer.iterator();
-
-      @Override
-      public double doubleValue() throws IOException {
-        return scorer.score();
-      }
-
-      @Override
-      public boolean advanceExact(int doc) throws IOException {
-        return doc >= iterator.docID() && (iterator.docID() == doc || iterator.advance(doc) == doc);
-      }
-    };
-  }
-
-  @Override
   public VectorScorer getScorer(LeafReaderContext ctx) throws IOException {
     final FloatVectorValues vectorValues = ctx.reader().getFloatVectorValues(fieldName);
     if (vectorValues == null) {

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/QuantizedByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/QuantizedByteVectorValues.java
@@ -51,7 +51,7 @@ public abstract class QuantizedByteVectorValues extends DocIdSetIterator {
    * Return a {@link VectorScorer} for the given query vector.
    *
    * @param query the query vector
-   * @return a {@link VectorScorer} instance
+   * @return a {@link VectorScorer} instance or null
    */
   public abstract VectorScorer scorer(float[] query) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/QuantizedByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/QuantizedByteVectorValues.java
@@ -53,5 +53,5 @@ public abstract class QuantizedByteVectorValues extends DocIdSetIterator {
    * @param query the query vector
    * @return a {@link VectorScorer} instance
    */
-  public abstract VectorScorer vectorScorer(float[] query) throws IOException;
+  public abstract VectorScorer scorer(float[] query) throws IOException;
 }

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
@@ -92,6 +92,9 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
     }
 
     VectorScorer scorer = byteVectorValues.scorer(query);
+    if (scorer == null) {
+      return NO_RESULTS;
+    }
     DiversifyingChildrenFloatKnnVectorQuery.DiversifyingChildrenVectorScorer vectorScorer =
         new DiversifyingChildrenFloatKnnVectorQuery.DiversifyingChildrenVectorScorer(
             acceptIterator, parentBitSet, scorer);

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
@@ -90,10 +90,13 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
     if (parentBitSet == null) {
       return NO_RESULTS;
     }
+    VectorScorer floatVectorScorer = floatVectorValues.scorer(query);
+    if (floatVectorScorer == null) {
+      return NO_RESULTS;
+    }
 
     DiversifyingChildrenVectorScorer vectorScorer =
-        new DiversifyingChildrenVectorScorer(
-            acceptIterator, parentBitSet, floatVectorValues.scorer(query));
+        new DiversifyingChildrenVectorScorer(acceptIterator, parentBitSet, floatVectorScorer);
     final int queueSize = Math.min(k, Math.toIntExact(acceptIterator.cost()));
     HitQueue queue = new HitQueue(queueSize, true);
     TotalHits.Relation relation = TotalHits.Relation.EQUAL_TO;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -754,6 +754,10 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           if (vectorValues == null) {
             continue;
           }
+          if (vectorValues.size() == 0) {
+            assertNull(vectorValues.scorer(vectorToScore));
+            continue;
+          }
           VectorScorer scorer = vectorValues.scorer(vectorToScore);
           assertNotNull(scorer);
           DocIdSetIterator iterator = scorer.iterator();
@@ -807,6 +811,10 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         for (LeafReaderContext ctx : reader.leaves()) {
           ByteVectorValues vectorValues = ctx.reader().getByteVectorValues(fieldName);
           if (vectorValues == null) {
+            continue;
+          }
+          if (vectorValues.size() == 0) {
+            assertNull(vectorValues.scorer(vectorToScore));
             continue;
           }
           VectorScorer scorer = vectorValues.scorer(vectorToScore);


### PR DESCRIPTION
Follow up to: https://github.com/apache/lucene/pull/13181

I noticed the quantized interface had a slightly different name.

Additionally, testing showed we are inconsistent when there aren't any vectors to score. This makes the response consistent (e.g. `null` when there aren't any vectors).