### PR TITLE
Protect against nan & inf values in quantizer and test with tiny vectors

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -363,6 +363,8 @@ Bug Fixes
 
 * GITHUB#13356: Ensure negative scores are not returned from scalar quantization scorer. (Ben Trent)
 
+* GITHUB#13366: Disallow NaN and Inf values in scalar quantization and better handle extreme cases. (Ben Trent)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizer.java
@@ -87,6 +87,12 @@ public class ScalarQuantizer {
    * @param bits the number of bits to use for quantization
    */
   public ScalarQuantizer(float minQuantile, float maxQuantile, byte bits) {
+    if (Float.isNaN(minQuantile)
+        || Float.isInfinite(minQuantile)
+        || Float.isNaN(maxQuantile)
+        || Float.isInfinite(maxQuantile)) {
+      throw new IllegalStateException("Scalar quantizer does not support infinite or NaN values");
+    }
     assert maxQuantile >= minQuantile;
     assert bits > 0 && bits <= 8;
     this.minQuantile = minQuantile;
@@ -380,10 +386,20 @@ public class ScalarQuantizer {
     }
 
     // Here we gather the upper and lower bounds for the quantile grid search
-    float al = (float) lowerSum[1] / count;
-    float bu = (float) upperSum[1] / count;
+    final float al = (float) lowerSum[1] / count;
+    final float bu = (float) upperSum[1] / count;
     final float au = (float) lowerSum[0] / count;
     final float bl = (float) upperSum[0] / count;
+    if (Float.isNaN(al)
+        || Float.isInfinite(al)
+        || Float.isNaN(au)
+        || Float.isInfinite(au)
+        || Float.isNaN(bl)
+        || Float.isInfinite(bl)
+        || Float.isNaN(bu)
+        || Float.isInfinite(bu)) {
+      throw new IllegalStateException("Quantile calculation resulted in NaN or infinite values");
+    }
     final float[] lowerCandidates = new float[16];
     final float[] upperCandidates = new float[16];
     int idx = 0;
@@ -448,8 +464,16 @@ public class ScalarQuantizer {
     int bestQuandrantUpper = 0;
     for (int i = 0; i < lowerCandidates.length; i += 4) {
       float lower = lowerCandidates[i];
+      if (Float.isNaN(lower) || Float.isInfinite(lower)) {
+        assert false : "Lower candidate is NaN or infinite";
+        continue;
+      }
       for (int j = 0; j < upperCandidates.length; j += 4) {
         float upper = upperCandidates[j];
+        if (Float.isNaN(upper) || Float.isInfinite(upper)) {
+          assert false : "Upper candidate is NaN or infinite";
+          continue;
+        }
         if (upper <= lower) {
           continue;
         }
@@ -468,6 +492,13 @@ public class ScalarQuantizer {
       for (int j = bestQuandrantUpper + 1; j < bestQuandrantUpper + 4; j++) {
         float lower = lowerCandidates[i];
         float upper = upperCandidates[j];
+        if (Float.isNaN(lower)
+            || Float.isInfinite(lower)
+            || Float.isNaN(upper)
+            || Float.isInfinite(upper)) {
+          assert false : "Lower or upper candidate is NaN or infinite";
+          continue;
+        }
         if (upper <= lower) {
           continue;
         }
@@ -532,8 +563,14 @@ public class ScalarQuantizer {
    * @return lower and upper quantile values
    */
   static float[] getUpperAndLowerQuantile(float[] arr, float confidenceInterval) {
+    assert arr.length > 0;
+    // If we have 1 or 2 values, we can't calculate the quantiles, simply return the min and max
+    if (arr.length <= 2) {
+      Arrays.sort(arr);
+      return new float[] {arr[0], arr[arr.length - 1]};
+    }
     int selectorIndex = (int) (arr.length * (1f - confidenceInterval) / 2f + 0.5f);
-    if (selectorIndex > 0 && arr.length > 2) {
+    if (selectorIndex > 0) {
       Selector selector = new FloatSelector(arr);
       selector.select(0, arr.length, arr.length - selectorIndex);
       selector.select(0, arr.length - selectorIndex, selectorIndex);

--- a/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizer.java
+++ b/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizer.java
@@ -28,6 +28,50 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestScalarQuantizer extends LuceneTestCase {
 
+  public void testTinyVectors() throws IOException {
+    for (VectorSimilarityFunction function : VectorSimilarityFunction.values()) {
+      int dims = random().nextInt(9) + 1;
+      int numVecs = random().nextInt(9) + 10;
+      float[][] floats = randomFloats(numVecs, dims);
+      for (byte bits : new byte[] {4, 7}) {
+        FloatVectorValues floatVectorValues = fromFloats(floats);
+        ScalarQuantizer scalarQuantizer =
+            random().nextBoolean()
+                ? ScalarQuantizer.fromVectors(floatVectorValues, 0.9f, numVecs, bits)
+                : ScalarQuantizer.fromVectorsAutoInterval(
+                    floatVectorValues, function, numVecs, bits);
+        // We simply assert that we created a scalar quantizer and didn't trip any assertions
+        // the quality of the quantization might be poor, but this is expected as sampling size is
+        // tiny
+        assertNotNull(scalarQuantizer);
+      }
+    }
+  }
+
+  public void testNanAndInfValueFailure() {
+    for (VectorSimilarityFunction function : VectorSimilarityFunction.values()) {
+      int dims = random().nextInt(9) + 1;
+      int numVecs = random().nextInt(9) + 10;
+      float[][] floats = new float[numVecs][dims];
+      for (int i = 0; i < numVecs; i++) {
+        for (int j = 0; j < dims; j++) {
+          floats[i][j] = random().nextBoolean() ? Float.NaN : Float.POSITIVE_INFINITY;
+        }
+      }
+      for (byte bits : new byte[] {4, 7}) {
+        FloatVectorValues floatVectorValues = fromFloats(floats);
+        expectThrows(
+            IllegalStateException.class,
+            () -> ScalarQuantizer.fromVectors(floatVectorValues, 0.9f, numVecs, bits));
+        expectThrows(
+            IllegalStateException.class,
+            () ->
+                ScalarQuantizer.fromVectorsAutoInterval(
+                    floatVectorValues, function, numVecs, bits));
+      }
+    }
+  }
+
   public void testQuantizeAndDeQuantize7Bit() throws IOException {
     int dims = 128;
     int numVecs = 100;


### PR DESCRIPTION
In testing, it was noticed that tiny vectors (<= 2 dims) could cause weird behavior in the quantizer.

Additionally, we should fail any quantization that ends up with NaN or Inf values.