### PR TITLE
Add a double addressing vector scorer

### DIFF
--- a/lucene/codecs/src/java/org/apache/lucene/codecs/bitvectors/FlatBitVectorsScorer.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/bitvectors/FlatBitVectorsScorer.java
@@ -115,6 +115,11 @@ public class FlatBitVectorsScorer implements FlatVectorsScorer {
     }
 
     @Override
+    public float score(int firstOrd, int secondOrd) throws IOException {
+      return scorer(firstOrd).score(secondOrd);
+    }
+
+    @Override
     public RandomVectorScorerSupplier copy() throws IOException {
       return new BitRandomVectorScorerSupplier(vectorValues.copy());
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/DefaultFlatVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/DefaultFlatVectorScorer.java
@@ -110,6 +110,12 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
     }
 
     @Override
+    public float score(int firstOrd, int secondOrd) throws IOException {
+      return similarityFunction.compare(
+          vectors1.vectorValue(firstOrd), vectors2.vectorValue(secondOrd));
+    }
+
+    @Override
     public RandomVectorScorerSupplier copy() throws IOException {
       return new ByteScoringSupplier(vectors, similarityFunction);
     }
@@ -139,6 +145,12 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
           return similarityFunction.compare(vectors1.vectorValue(ord), vectors2.vectorValue(node));
         }
       };
+    }
+
+    @Override
+    public float score(int firstOrd, int secondOrd) throws IOException {
+      return similarityFunction.compare(
+          vectors1.vectorValue(firstOrd), vectors2.vectorValue(secondOrd));
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
@@ -125,28 +125,32 @@ public class ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       implements RandomVectorScorerSupplier {
 
     private final RandomAccessQuantizedByteVectorValues values;
+    private final RandomAccessQuantizedByteVectorValues values1;
     private final ScalarQuantizedVectorSimilarity similarity;
     private final VectorSimilarityFunction vectorSimilarityFunction;
 
     public ScalarQuantizedRandomVectorScorerSupplier(
         VectorSimilarityFunction similarityFunction,
         ScalarQuantizer scalarQuantizer,
-        RandomAccessQuantizedByteVectorValues values) {
-      this.similarity =
+        RandomAccessQuantizedByteVectorValues values)
+        throws IOException {
+      this(
           ScalarQuantizedVectorSimilarity.fromVectorSimilarity(
               similarityFunction,
               scalarQuantizer.getConstantMultiplier(),
-              scalarQuantizer.getBits());
-      this.values = values;
-      this.vectorSimilarityFunction = similarityFunction;
+              scalarQuantizer.getBits()),
+          similarityFunction,
+          values);
     }
 
     private ScalarQuantizedRandomVectorScorerSupplier(
         ScalarQuantizedVectorSimilarity similarity,
         VectorSimilarityFunction vectorSimilarityFunction,
-        RandomAccessQuantizedByteVectorValues values) {
+        RandomAccessQuantizedByteVectorValues values)
+        throws IOException {
       this.similarity = similarity;
       this.values = values;
+      this.values1 = values.copy();
       this.vectorSimilarityFunction = vectorSimilarityFunction;
     }
 
@@ -170,8 +174,8 @@ public class ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       return similarity.score(
           values.vectorValue(firstOrd),
           values.getScoreCorrectionConstant(firstOrd),
-          values.vectorValue(secondOrd),
-          values.getScoreCorrectionConstant(secondOrd));
+          values1.vectorValue(secondOrd),
+          values1.getScoreCorrectionConstant(secondOrd));
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
@@ -166,6 +166,15 @@ public class ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     }
 
     @Override
+    public float score(int firstOrd, int secondOrd) throws IOException {
+      return similarity.score(
+          values.vectorValue(firstOrd),
+          values.getScoreCorrectionConstant(firstOrd),
+          values.vectorValue(secondOrd),
+          values.getScoreCorrectionConstant(secondOrd));
+    }
+
+    @Override
     public RandomVectorScorerSupplier copy() throws IOException {
       return new ScalarQuantizedRandomVectorScorerSupplier(
           similarity, vectorSimilarityFunction, values.copy());

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
@@ -503,6 +503,11 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
     }
 
     @Override
+    public float score(int firstOrd, int secondOrd) throws IOException {
+      return supplier.score(firstOrd, secondOrd);
+    }
+
+    @Override
     public RandomVectorScorerSupplier copy() throws IOException {
       return supplier.copy();
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
@@ -292,6 +292,11 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     }
 
     @Override
+    public float score(int firstOrd, int secondOrd) throws IOException {
+      return scorer(firstOrd).score(secondOrd);
+    }
+
+    @Override
     public ScalarQuantizedRandomVectorScorerSupplier copy() throws IOException {
       return new ScalarQuantizedRandomVectorScorerSupplier(values.copy(), vectorSimilarityFunction);
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
@@ -1133,6 +1133,11 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
     }
 
     @Override
+    public float score(int firstOrd, int secondOrd) throws IOException {
+      return supplier.score(firstOrd, secondOrd);
+    }
+
+    @Override
     public RandomVectorScorerSupplier copy() throws IOException {
       return supplier.copy();
     }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -365,9 +365,8 @@ public class HnswGraphBuilder implements HnswBuilder {
    */
   private boolean diversityCheck(int candidate, float score, NeighborArray neighbors)
       throws IOException {
-    RandomVectorScorer scorer = scorerSupplier.scorer(candidate);
     for (int i = 0; i < neighbors.size(); i++) {
-      float neighborSimilarity = scorer.score(neighbors.nodes()[i]);
+      float neighborSimilarity = scorerSupplier.score(candidate, neighbors.nodes()[i]);
       if (neighborSimilarity >= score) {
         return false;
       }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -265,12 +265,12 @@ public class NeighborArray {
       int uncheckedCursor,
       RandomVectorScorerSupplier scorerSupplier)
       throws IOException {
+    final int candidateNode = nodes[candidateIndex];
     float minAcceptedSimilarity = scores[candidateIndex];
-    RandomVectorScorer scorer = scorerSupplier.scorer(nodes[candidateIndex]);
     if (candidateIndex == uncheckedIndexes[uncheckedCursor]) {
       // the candidate itself is unchecked
       for (int i = candidateIndex - 1; i >= 0; i--) {
-        float neighborSimilarity = scorer.score(nodes[i]);
+        float neighborSimilarity = scorerSupplier.score(candidateNode, nodes[i]);
         // candidate node is too similar to node i given its score relative to the base node
         if (neighborSimilarity >= minAcceptedSimilarity) {
           return true;
@@ -281,7 +281,7 @@ public class NeighborArray {
       // inserted) unchecked nodes
       assert candidateIndex > uncheckedIndexes[uncheckedCursor];
       for (int i = uncheckedCursor; i >= 0; i--) {
-        float neighborSimilarity = scorer.score(nodes[uncheckedIndexes[i]]);
+        float neighborSimilarity = scorerSupplier.score(candidateNode, nodes[uncheckedIndexes[i]]);
         // candidate node is too similar to node i given its score relative to the base node
         if (neighborSimilarity >= minAcceptedSimilarity) {
           return true;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomAccessVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomAccessVectorValues.java
@@ -26,6 +26,9 @@ import org.apache.lucene.util.Bits;
  * Provides random access to vectors by dense ordinal. This interface is used by HNSW-based
  * implementations of KNN search.
  *
+ * <p>Not thread-safe, use {@link #copy()} to return an instance suitable for sharing with another
+ * thread. Each thread should have its own copy.
+ *
  * @lucene.experimental
  */
 public interface RandomAccessVectorValues {
@@ -39,6 +42,9 @@ public interface RandomAccessVectorValues {
   /**
    * Creates a new copy of this {@link RandomAccessVectorValues}. This is helpful when you need to
    * access different values at once, to avoid overwriting the underlying vector returned.
+   *
+   * <p>Additionally, users should always call copy before handing off a vector values to another
+   * thread.
    */
   RandomAccessVectorValues copy() throws IOException;
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
@@ -20,7 +20,11 @@ package org.apache.lucene.util.hnsw;
 import java.io.IOException;
 import org.apache.lucene.util.Bits;
 
-/** A {@link RandomVectorScorer} for scoring random nodes in batches against an abstract query. */
+/**
+ * A {@link RandomVectorScorer} for scoring random nodes in batches against an abstract query.
+ *
+ * @lucene.experimental
+ */
 public interface RandomVectorScorer {
   /**
    * Returns the score between the query and the provided node.
@@ -31,6 +35,9 @@ public interface RandomVectorScorer {
   float score(int node) throws IOException;
 
   /**
+   * Returns the maximum possible ordinal for this scorer. This scorer can score vectors with
+   * ordinals between 0 and maxOrd (exclusive).
+   *
    * @return the maximum possible ordinal for this scorer
    */
   int maxOrd();

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerSupplier.java
@@ -19,7 +19,14 @@ package org.apache.lucene.util.hnsw;
 
 import java.io.IOException;
 
-/** A supplier that creates {@link RandomVectorScorer} from an ordinal. */
+/**
+ * A supplier that creates {@link RandomVectorScorer} from an ordinal.
+ *
+ * <p>Not thread-safe, use {@link #copy()} to return an instance suitable for sharing with another
+ * thread. Each thread should have its own copy.
+ *
+ * @lucene.experimental
+ */
 public interface RandomVectorScorerSupplier {
   /**
    * This creates a {@link RandomVectorScorer} for scoring random nodes in batches against the given
@@ -32,7 +39,7 @@ public interface RandomVectorScorerSupplier {
 
   /**
    * Make a copy of the supplier, which will copy the underlying vectorValues so the copy is safe to
-   * be used in other threads.
+   * be used in another thread.
    */
   RandomVectorScorerSupplier copy() throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerSupplier.java
@@ -31,6 +31,15 @@ public interface RandomVectorScorerSupplier {
   RandomVectorScorer scorer(int ord) throws IOException;
 
   /**
+   * Returns the score between the given nodes.
+   *
+   * @param firstOrd the ordinal of the first node to compare
+   * @param secondOrd the ordinal of the second node to compare
+   * @return the score between the first second nodes.
+   */
+  float score(int firstOrd, int secondOrd) throws IOException;
+
+  /**
    * Make a copy of the supplier, which will copy the underlying vectorValues so the copy is safe to
    * be used in other threads.
    */

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorerSupplier.java
@@ -35,7 +35,7 @@ public interface RandomVectorScorerSupplier {
    *
    * @param firstOrd the ordinal of the first node to compare
    * @param secondOrd the ordinal of the second node to compare
-   * @return the score between the first second nodes.
+   * @return the score between the first and second nodes
    */
   float score(int firstOrd, int secondOrd) throws IOException;
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -118,7 +118,8 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
 
   protected RandomVectorScorerSupplier buildScorerSupplier(RandomAccessVectorValues vectors)
       throws IOException {
-    return flatVectorScorer.getRandomVectorScorerSupplier(similarityFunction, vectors);
+    return new DelegatingRandomVectorScorerSupplier(
+        flatVectorScorer.getRandomVectorScorerSupplier(similarityFunction, vectors));
   }
 
   protected RandomVectorScorer buildScorer(RandomAccessVectorValues vectors, T query)
@@ -1371,6 +1372,31 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     @Override
     public NodesIterator getNodesOnLevel(int level) throws IOException {
       return delegate.getNodesOnLevel(level);
+    }
+  }
+
+  static class DelegatingRandomVectorScorerSupplier implements RandomVectorScorerSupplier {
+    final RandomVectorScorerSupplier delegate;
+
+    DelegatingRandomVectorScorerSupplier(RandomVectorScorerSupplier delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public RandomVectorScorer scorer(int ord) throws IOException {
+      return delegate.scorer(ord);
+    }
+
+    @Override
+    public float score(int firstOrd, int secondOrd) throws IOException {
+      var res = delegate.score(firstOrd, secondOrd);
+      assertEquals(res, delegate.scorer(firstOrd).score(secondOrd), 0.0);
+      return res;
+    }
+
+    @Override
+    public RandomVectorScorerSupplier copy() throws IOException {
+      return new DelegatingRandomVectorScorerSupplier(delegate.copy());
     }
   }
 }


### PR DESCRIPTION
This commit adds a method to RandomVectorScorerSupplier that allows to score two vectors based their ordinals.

The existing model of this API first creates a scorer, that effectively binds the ordinal of the first vector, to then score the ordinal of a second vector agains the first. This results in a RandomVectorScorer instance being created each time we want to score against a different vector in the first position. Allowing to score against two given ordinals avoids the creation of a RandomVectorScorer instance, which is likely expensive during graph building.

The new API could seen as a convenience for `scorer(ord).score(node)`, or vice versa, but in fact there can be very different implementation characteristics of these - most notably the avoidance of the creation of a RandomVectorScorer instance.

This PR just updates a few places in the graph building to use the new API. Further analysis can determine where else this API would be beneficial.

