### PR TITLE
Fix bug in SQ when just a single vector present in a segment

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -370,6 +370,8 @@ Bug Fixes
 * GITHUB#13369: Fix NRT opening failure when soft deletes are enabled and the document fails to index before a point
   field is written (Ben Trent)
 
+* GITHUB#13374: Fix bug in SQ when just a single vector present (Chris Hegarty)
+
 Build
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -372,7 +372,7 @@ Bug Fixes
 
 * GITHUB#13378: Fix points writing with no values (Chris Hegarty)
 
-* GITHUB#13374: Fix bug in SQ when just a single vector present (Chris Hegarty)
+* GITHUB#13374: Fix bug in SQ when just a single vector present in a segment (Chris Hegarty)
 
 Build
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizer.java
@@ -698,7 +698,7 @@ public class ScalarQuantizer {
         }
         corr.add(1 - errors.var() / scoreVariance);
       }
-      return corr.mean;
+      return Double.isNaN(corr.mean) ? 0.0 : corr.mean;
     }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestLucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestLucene99ScalarQuantizedVectorScorer.java
@@ -18,6 +18,7 @@
 package org.apache.lucene.codecs.lucene99;
 
 import static org.apache.lucene.codecs.lucene99.OffHeapQuantizedByteVectorValues.compressBytes;
+import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,12 +30,14 @@ import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.hnsw.DefaultFlatVectorScorer;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -262,6 +265,45 @@ public class TestLucene99ScalarQuantizedVectorScorer extends LuceneTestCase {
         baos.write(ba);
       }
       return baos.toByteArray();
+    }
+  }
+
+  @com.carrotsearch.randomizedtesting.annotations.Repeat(iterations = 1000)
+  public void testSingleVectorPerSegment() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter writer =
+          new IndexWriter(dir, new IndexWriterConfig().setCodec(getCodec(7, false)))) {
+        Document doc2 = new Document();
+        doc2.add(new KnnFloatVectorField("field", new float[] {0.8f, 0.6f}, DOT_PRODUCT));
+        doc2.add(newTextField("id", "A", Field.Store.YES));
+        writer.addDocument(doc2);
+        writer.commit();
+
+        Document doc1 = new Document();
+        doc1.add(new KnnFloatVectorField("field", new float[] {0.6f, 0.8f}, DOT_PRODUCT));
+        doc1.add(newTextField("id", "B", Field.Store.YES));
+        writer.addDocument(doc1);
+        writer.commit();
+
+        Document doc3 = new Document();
+        doc3.add(new KnnFloatVectorField("field", new float[] {-0.6f, -0.8f}, DOT_PRODUCT));
+        doc3.add(newTextField("id", "C", Field.Store.YES));
+
+        writer.addDocument(doc3);
+        writer.commit();
+
+        writer.forceMerge(1);
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        LeafReader leafReader = getOnlyLeafReader(reader);
+        StoredFields storedFields = reader.storedFields();
+        float[] queryVector = new float[] {0.6f, 0.8f};
+        var hits = leafReader.searchNearestVectors("field", queryVector, 3, null, 100);
+        assertEquals(hits.scoreDocs.length, 3);
+        assertEquals("B", storedFields.document(hits.scoreDocs[0].doc).get("id"));
+        assertEquals("A", storedFields.document(hits.scoreDocs[1].doc).get("id"));
+        assertEquals("C", storedFields.document(hits.scoreDocs[2].doc).get("id"));
+      }
     }
   }
 }


### PR DESCRIPTION
This commit fixes a corner case in the ScalarQuantizer when just a single vector is present. I ran into this when updating a test that previously passed successfully with Lucene 9.10 but fails in 9.x.

The score error correction is calculated to be NaN, as there are no score docs or variance.