### PR TITLE
Fix points writing with no values

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -370,6 +370,8 @@ Bug Fixes
 * GITHUB#13369: Fix NRT opening failure when soft deletes are enabled and the document fails to index before a point
   field is written (Ben Trent)
 
+* GITHUB#13378: Fix points writing with no values (Chris Hegarty)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -513,6 +513,10 @@ public class BKDWriter implements Closeable {
 
     pointCount = values.size();
 
+    if (pointCount == 0) {
+      return null;
+    }
+
     final int numLeaves =
         Math.toIntExact((pointCount + config.maxPointsInLeafNode - 1) / config.maxPointsInLeafNode);
     final int numSplits = numLeaves - 1;

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
@@ -2338,6 +2338,8 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
     LeafReader onlyReader = getOnlyLeafReader(r);
     // we mark the failed doc as deleted
     assertEquals(onlyReader.numDeletedDocs(), 1);
+    // there are not points values (rather than an empty set of values)
+    assertNull(onlyReader.getPointValues("field"));
     onlyReader.close();
     w.close();
     dir.close();


### PR DESCRIPTION
This commit updates the writer to handle the case where there are no values.

Previously (before #13369), there was a check that there were some points values before trying to write, this is no longer the case. The code in `writeFieldNDims` has an assumption that the values is not empty - an empty values will result in calculating a negative number of splits, and a negate array size to hold the splits.

The fix is trivial, return null when values is empty - null is an allowable return value from this method. Note: `writeField1Dim` is able to handle an empty values.

After this change both the newly failing test, `TestIndexWriterExceptions2.testBasics`, and the test added for #13369, `testExceptionJustBeforeFlushWithPointValues`, pass successfully several thousands of times. No new test is added, as `testBasics` already covers this.

closes #13377