### PR TITLE
lucene-monitor: make TermFilteredPresearcher.ANYTOKEN[_FIELD] public

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
@@ -70,8 +70,8 @@ public class TermFilteredPresearcher extends Presearcher {
   private final Set<String> filterFields;
   private final List<CustomQueryHandler> queryHandlers = new ArrayList<>();
 
-  static final String ANYTOKEN_FIELD = "__anytokenfield";
-  static final String ANYTOKEN = "__ANYTOKEN__";
+  public static final String ANYTOKEN_FIELD = "__anytokenfield";
+  public static final String ANYTOKEN = "__ANYTOKEN__";
 
   /** Creates a new TermFilteredPresearcher using the default term weighting */
   public TermFilteredPresearcher() {


### PR DESCRIPTION
This would allow applications -- e.g. @kotman12's https://github.com/apache/solr/pull/2382 -- to schematically validate the field w.r.t. existence and field type properties.

A more complex alternative solution would be to make things optionally configurable i.e. then applications 'know' what was configured and thus can validate it.