### PR TITLE
Improve BaseRangeFieldQueryTestCase#verify failure output

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/BaseRangeFieldQueryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/BaseRangeFieldQueryTestCase.java
@@ -303,10 +303,12 @@ public abstract class BaseRangeFieldQueryTestCase extends LuceneTestCase {
         assertEquals(docID, docIDToID.nextDoc());
         int id = (int) docIDToID.longValue();
         boolean expected;
-        if (liveDocs != null && liveDocs.get(docID) == false) {
-          // document is deleted
+        boolean isDeleted = liveDocs != null && liveDocs.get(docID) == false;
+        boolean isMissing = ranges[id][0].isMissing;
+
+        if (isDeleted) {
           expected = false;
-        } else if (ranges[id][0].isMissing) {
+        } else if (isMissing) {
           expected = false;
         } else {
           expected = expectedResult(queryRange, ranges[id], queryType);
@@ -330,7 +332,8 @@ public abstract class BaseRangeFieldQueryTestCase extends LuceneTestCase {
             b.append(ranges[id][n]);
           }
           b.append("\n queryType=").append(queryType).append("\n");
-          b.append(" deleted?=").append(liveDocs != null && liveDocs.get(docID) == false);
+          b.append(" docDeleted?=").append(isDeleted).append("\n");
+          b.append(" rangeMissing?=").append(isMissing);
           fail("wrong hit (first of possibly more):\n\n" + b);
         }
       }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/BaseRangeFieldQueryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/BaseRangeFieldQueryTestCase.java
@@ -303,12 +303,12 @@ public abstract class BaseRangeFieldQueryTestCase extends LuceneTestCase {
         assertEquals(docID, docIDToID.nextDoc());
         int id = (int) docIDToID.longValue();
         boolean expected;
-        boolean isDeleted = liveDocs != null && liveDocs.get(docID) == false;
-        boolean isMissing = ranges[id][0].isMissing;
+        boolean docDeleted = liveDocs != null && liveDocs.get(docID) == false;
+        boolean rangeMissing = ranges[id][0].isMissing;
 
-        if (isDeleted) {
+        if (docDeleted) {
           expected = false;
-        } else if (isMissing) {
+        } else if (rangeMissing) {
           expected = false;
         } else {
           expected = expectedResult(queryRange, ranges[id], queryType);
@@ -332,8 +332,8 @@ public abstract class BaseRangeFieldQueryTestCase extends LuceneTestCase {
             b.append(ranges[id][n]);
           }
           b.append("\n queryType=").append(queryType).append("\n");
-          b.append(" docDeleted?=").append(isDeleted).append("\n");
-          b.append(" rangeMissing?=").append(isMissing);
+          b.append(" docDeleted?=").append(docDeleted).append("\n");
+          b.append(" rangeMissing?=").append(rangeMissing);
           fail("wrong hit (first of possibly more):\n\n" + b);
         }
       }


### PR DESCRIPTION
### Description

While debugging a test case I've noticed that the output on a test failure for `BaseRangeFieldQueryTestCase` can be slightly improved to understand better what's going on:

Before:
```
FAIL (iter 0): id=0 should not match but did
 queryRange=Box(...)
 box=Box(...)
 queryType=WITHIN
 deleted?=false
```

After:
```
FAIL (iter 0): id=0 should not match but did
 queryRange=Box(...)
 box=Box(...)
 queryType=INTERSECTS
 docDeleted?=false
 rangeMissing?=false
```

I've changed `deleted` to `docDeleted` so it's more explicit what's deleted and also added the info, if a range for a certain document is missing.