### PR TITLE
Rewrite LongRange.ValueSourceQuery/MultiValueSourceQuery to FieldExistsQuery on max range

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -341,6 +341,9 @@ Optimizations
 
 * GITHUB#13327: Reduce memory usage of field maps in FieldInfos and BlockTree TermsReader. (Bruno Roustant, David Smiley)
 
+* GITHUB#13383: Rewrite LongRange.ValueSourceQuery and LongRange.MultiValueSourceQuery
+  to FieldExistsQuery on a max range query. (Tim Grein)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -341,8 +341,8 @@ Optimizations
 
 * GITHUB#13327: Reduce memory usage of field maps in FieldInfos and BlockTree TermsReader. (Bruno Roustant, David Smiley)
 
-* GITHUB#13383: Rewrite LongRange.ValueSourceQuery and LongRange.MultiValueSourceQuery
-  to FieldExistsQuery on a max range query. (Tim Grein)
+* GITHUB#13383: Rewrite LongRange.ValueSourceQuery and LongRange.MultiValueSourceQuery to FieldExistsQuery on a
+  max range query. (Tim Grein)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
@@ -260,6 +260,7 @@ public abstract class LongValuesSource implements SegmentCacheable {
       return toLongValues(values);
     }
 
+    /** Get the field name. */
     public String getField() {
       return field;
     }

--- a/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
@@ -224,7 +224,7 @@ public abstract class LongValuesSource implements SegmentCacheable {
   }
 
   /**
-   * Class returning a single {@link LongValues} value from a specified field.
+   * Class returning {@link LongValues} value from a specified field.
    *
    * @lucene.internal
    */

--- a/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
@@ -223,7 +223,7 @@ public abstract class LongValuesSource implements SegmentCacheable {
     }
   }
 
-  private static class FieldValuesSource extends LongValuesSource {
+  public static class FieldValuesSource extends LongValuesSource {
 
     final String field;
 
@@ -253,6 +253,10 @@ public abstract class LongValuesSource implements SegmentCacheable {
     public LongValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
       final NumericDocValues values = DocValues.getNumeric(ctx.reader(), field);
       return toLongValues(values);
+    }
+
+    public String getField() {
+      return field;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
@@ -223,6 +223,11 @@ public abstract class LongValuesSource implements SegmentCacheable {
     }
   }
 
+  /**
+   * Class returning a single {@link LongValues} value from a specified field.
+   *
+   * @lucene.internal
+   */
   public static class FieldValuesSource extends LongValuesSource {
 
     final String field;

--- a/lucene/facet/src/java/org/apache/lucene/facet/MultiLongValuesSource.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/MultiLongValuesSource.java
@@ -102,7 +102,7 @@ public abstract class MultiLongValuesSource implements SegmentCacheable {
     return new DoubleLongValuesSources(this);
   }
 
-  private static class FieldMultiValueSource extends MultiLongValuesSource {
+  public static class FieldMultiValueSource extends MultiLongValuesSource {
     private final String field;
 
     FieldMultiValueSource(String field) {
@@ -128,6 +128,10 @@ public abstract class MultiLongValuesSource implements SegmentCacheable {
           return docValues.advanceExact(doc);
         }
       };
+    }
+
+    public String getField() {
+      return field;
     }
 
     @Override

--- a/lucene/facet/src/java/org/apache/lucene/facet/MultiLongValuesSource.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/MultiLongValuesSource.java
@@ -102,6 +102,11 @@ public abstract class MultiLongValuesSource implements SegmentCacheable {
     return new DoubleLongValuesSources(this);
   }
 
+  /**
+   * Class returning {@link MultiLongValues} from a specified field.
+   *
+   * @lucene.internal
+   */
   public static class FieldMultiValueSource extends MultiLongValuesSource {
     private final String field;
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/MultiLongValuesSource.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/MultiLongValuesSource.java
@@ -135,6 +135,7 @@ public abstract class MultiLongValuesSource implements SegmentCacheable {
       };
     }
 
+    /** Get the field name. */
     public String getField() {
       return field;
     }

--- a/lucene/facet/src/java/org/apache/lucene/facet/range/LongRange.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/LongRange.java
@@ -24,6 +24,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LongValues;
 import org.apache.lucene.search.LongValuesSource;
@@ -148,6 +149,13 @@ public final class LongRange extends Range {
           return new ValueSourceQuery(range, fastMatchRewritten, valueSource);
         }
       }
+
+      if (valueSource instanceof LongValuesSource.FieldValuesSource fieldSource
+          && range.min == Long.MIN_VALUE
+          && range.max == Long.MAX_VALUE) {
+        return new FieldExistsQuery(fieldSource.getField());
+      }
+
       return super.rewrite(indexSearcher);
     }
 
@@ -247,6 +255,13 @@ public final class LongRange extends Range {
           return new MultiValueSourceQuery(range, fastMatchRewritten, valuesSource);
         }
       }
+
+      if (valuesSource instanceof MultiLongValuesSource.FieldMultiValueSource fieldSource
+          && range.min == Long.MIN_VALUE
+          && range.max == Long.MAX_VALUE) {
+        return new FieldExistsQuery(fieldSource.getField());
+      }
+
       return super.rewrite(indexSearcher);
     }
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -122,6 +122,94 @@ public class TestRangeFacetCounts extends FacetTestCase {
     d.close();
   }
 
+  public void testLongMaxRange_SingleValued_MinAndMaxInclusive() throws IOException {
+    Directory d = newDirectory();
+    RandomIndexWriter w = new RandomIndexWriter(random(), d);
+
+    Document doc = new Document();
+    String fieldName = "field";
+    NumericDocValuesField field = new NumericDocValuesField(fieldName, 0L);
+    doc.add(field);
+    for (long value = 0; value < 100; value++) {
+      field.setLongValue(value);
+      w.addDocument(doc);
+    }
+
+    // Also add Long.MAX_VALUE
+    field.setLongValue(Long.MAX_VALUE);
+    w.addDocument(doc);
+
+    // Also add Long.MIN_VALUE
+    field.setLongValue(Long.MIN_VALUE);
+    w.addDocument(doc);
+
+    // Add doc without the field
+    Document docWithoutField = new Document();
+    docWithoutField.add(new NumericDocValuesField("otherField", 0L));
+    w.addDocument(docWithoutField);
+
+    IndexReader r = w.getReader();
+    w.close();
+
+    IndexSearcher s = newSearcher(r);
+
+    Query matchAllByMaxRange =
+        new LongRange("all", Long.MIN_VALUE, true, Long.MAX_VALUE, true)
+            .getQuery(null, LongValuesSource.fromLongField(fieldName));
+
+    FacetsCollector result = s.search(matchAllByMaxRange, new FacetsCollectorManager());
+
+    assertEquals(102, numHitsOverAllFacets(result));
+
+    r.close();
+    d.close();
+  }
+
+  public void testLongMaxRange_SingleValued_MinAndMaxExclusive() throws IOException {
+    Directory d = newDirectory();
+    RandomIndexWriter w = new RandomIndexWriter(random(), d);
+
+    Document doc = new Document();
+    String fieldName = "field";
+    NumericDocValuesField field = new NumericDocValuesField(fieldName, 0L);
+    doc.add(field);
+    for (long value = 0; value < 100; value++) {
+      field.setLongValue(value);
+      w.addDocument(doc);
+    }
+
+    // Also add Long.MAX_VALUE
+    field.setLongValue(Long.MAX_VALUE);
+    w.addDocument(doc);
+
+    // Also add Long.MIN_VALUE
+    field.setLongValue(Long.MIN_VALUE);
+    w.addDocument(doc);
+
+    // Add doc without the field
+    Document docWithoutField = new Document();
+    docWithoutField.add(new NumericDocValuesField("otherField", 0L));
+    w.addDocument(docWithoutField);
+
+    IndexReader r = w.getReader();
+    w.close();
+
+    IndexSearcher s = newSearcher(r);
+
+    Query matchAllByMaxRange =
+        new LongRange("all", Long.MIN_VALUE, false, Long.MAX_VALUE, false)
+            .getQuery(null, LongValuesSource.fromLongField(fieldName));
+
+    FacetsCollector result = s.search(matchAllByMaxRange, new FacetsCollectorManager());
+
+    // As min and max are exclusive the two docs having
+    // Long.MAX_VALUE and Long.MIN_VALUE as values shouldn't match
+    assertEquals(100, numHitsOverAllFacets(result));
+
+    r.close();
+    d.close();
+  }
+
   public void testBasicLongMultiValued() throws Exception {
     Directory d = newDirectory();
     RandomIndexWriter w = new RandomIndexWriter(random(), d);
@@ -174,6 +262,104 @@ public class TestRangeFacetCounts extends FacetTestCase {
         () -> {
           facets.getTopChildren(0, "field");
         });
+
+    r.close();
+    d.close();
+  }
+
+  public void testLongMaxRange_MultiValued_MinAndMaxInclusive() throws IOException {
+    Directory d = newDirectory();
+    RandomIndexWriter w = new RandomIndexWriter(random(), d);
+
+    Document doc = new Document();
+    String fieldName = "field";
+    SortedNumericDocValuesField field1 = new SortedNumericDocValuesField(fieldName, 0L);
+    SortedNumericDocValuesField field2 = new SortedNumericDocValuesField(fieldName, 0L);
+    doc.add(field1);
+    doc.add(field2);
+    for (long value = 0; value < 100; value++) {
+      field1.setLongValue(value);
+      field2.setLongValue(value);
+      w.addDocument(doc);
+    }
+
+    // Also add Long.MAX_VALUE
+    field1.setLongValue(Long.MAX_VALUE);
+    field2.setLongValue(Long.MAX_VALUE);
+    w.addDocument(doc);
+
+    // Also add Long.MIN_VALUE
+    field1.setLongValue(Long.MIN_VALUE);
+    field2.setLongValue(Long.MIN_VALUE);
+    w.addDocument(doc);
+
+    // Add doc without the field
+    Document docWithoutField = new Document();
+    docWithoutField.add(new NumericDocValuesField("otherField", 0L));
+    w.addDocument(docWithoutField);
+
+    IndexReader r = w.getReader();
+    w.close();
+
+    IndexSearcher s = newSearcher(r);
+
+    Query matchAllByMaxRange =
+        new LongRange("all", Long.MIN_VALUE, true, Long.MAX_VALUE, true)
+            .getQuery(null, MultiLongValuesSource.fromLongField(fieldName));
+
+    FacetsCollector result = s.search(matchAllByMaxRange, new FacetsCollectorManager());
+
+    assertEquals(102, numHitsOverAllFacets(result));
+
+    r.close();
+    d.close();
+  }
+
+  public void testLongMaxRange_MultiValued_MinAndMaxExclusive() throws IOException {
+    Directory d = newDirectory();
+    RandomIndexWriter w = new RandomIndexWriter(random(), d);
+
+    Document doc = new Document();
+    String fieldName = "field";
+    SortedNumericDocValuesField field1 = new SortedNumericDocValuesField(fieldName, 0L);
+    SortedNumericDocValuesField field2 = new SortedNumericDocValuesField(fieldName, 0L);
+    doc.add(field1);
+    doc.add(field2);
+    for (long value = 0; value < 100; value++) {
+      field1.setLongValue(value);
+      field2.setLongValue(value);
+      w.addDocument(doc);
+    }
+
+    // Also add Long.MAX_VALUE
+    field1.setLongValue(Long.MAX_VALUE);
+    field2.setLongValue(Long.MAX_VALUE);
+    w.addDocument(doc);
+
+    // Also add Long.MIN_VALUE
+    field1.setLongValue(Long.MIN_VALUE);
+    field2.setLongValue(Long.MIN_VALUE);
+    w.addDocument(doc);
+
+    // Add doc without the field
+    Document docWithoutField = new Document();
+    docWithoutField.add(new NumericDocValuesField("otherField", 0L));
+    w.addDocument(docWithoutField);
+
+    IndexReader r = w.getReader();
+    w.close();
+
+    IndexSearcher s = newSearcher(r);
+
+    Query matchAllByMaxRange =
+        new LongRange("all", Long.MIN_VALUE, false, Long.MAX_VALUE, false)
+            .getQuery(null, MultiLongValuesSource.fromLongField(fieldName));
+
+    FacetsCollector result = s.search(matchAllByMaxRange, new FacetsCollectorManager());
+
+    // As min and max are exclusive the two docs
+    // having Long.MAX_VALUE and Long.MIN_VALUE as values shouldn't match
+    assertEquals(100, numHitsOverAllFacets(result));
 
     r.close();
     d.close();
@@ -1814,5 +2000,12 @@ public class TestRangeFacetCounts extends FacetTestCase {
     assertFalse(
         new DoubleRange("field", -7d, true, 17d, false).hashCode()
             == new DoubleRange("field", -7d, true, 18, false).hashCode());
+  }
+
+  private int numHitsOverAllFacets(FacetsCollector facetsCollector) {
+    return facetsCollector.getMatchingDocs().stream()
+        .map(matchingDocs -> matchingDocs.totalHits)
+        .reduce(Integer::sum)
+        .orElse(0);
   }
 }


### PR DESCRIPTION
Related to https://github.com/apache/lucene/issues/13375

### Description

With this change `ValueSourceQuery` and `MultiValueSourceQuery` will be rewritten to a `FieldExistsQuery`, if the query range uses the maximum range possible (`[Long.MIN_VALUE, Long.MAX_VALUE]`) as the exact values of the queried field won't matter anymore as every value lies within the maximum possible range. If the query range uses exclusive boundaries the query won't be rewritten as a field could contain a value being `Long.MIN_VALUE` or `Long.MAX_VALUE` which wouldn't match anymore.

I've made `LongValuesSource.FieldValuesSource` and `MultiLongValuesSource.FieldMultiValueSource` public and added a corresponding `getField` accessor which will be needed to check, whether the value source is actually relying on the specific field.

I'll plan to open a separate PR for `DoubleRange` performing a similar optimization.