### PR TITLE
Making NO_INTERVALS to be used by clients of Lucene

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -362,6 +362,8 @@ Other
 
 * GITHUB#13077: Add public getter for SynonymQuery#field (Andrey Bozhko)
 
+* GITHUB#13385: Make NO_INTERVALS source as public to be used by Lucene clients instead of creating clones themselves.
+
 ======================== Lucene 9.10.0 =======================
 
 API Changes

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -362,7 +362,7 @@ Other
 
 * GITHUB#13077: Add public getter for SynonymQuery#field (Andrey Bozhko)
 
-* GITHUB#13385: Make NO_INTERVALS source as public to be used by Lucene clients instead of creating clones themselves.
+* GITHUB#13385: Make NO_INTERVALS source as public to be used by Lucene clients instead of creating clones themselves (Aniketh Jain)
 
 ======================== Lucene 9.10.0 =======================
 

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/IntervalBuilder.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/IntervalBuilder.java
@@ -236,7 +236,7 @@ final class IntervalBuilder {
     return clauses;
   }
 
-  static final IntervalsSource NO_INTERVALS =
+  public static final IntervalsSource NO_INTERVALS =
       new IntervalsSource() {
         @Override
         public IntervalIterator intervals(String field, LeafReaderContext ctx) {


### PR DESCRIPTION
### Description
A [bug](https://github.com/opensearch-project/OpenSearch/issues/13616) was reported in OpenSearch which caused Interval Queries containing sub-query in rules to fail with `Sub-iterators of ConjunctionDISI are not on the same document ` if an no_match query was generated after going through the search analyser. 

A similar issue was found in Lucene a few years back and was fixed by [this PR](https://github.com/apache/lucene/pull/11760) 

I am proposing to make `NO_INTERVALS` present in Lucene as `public` so it can be used by it's clients like OpenSearch rather than creating a clone of the same. 