### PR TITLE
Replace Map<Long, Object> by primitive LongObjectHashMap.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -343,6 +343,8 @@ Optimizations
 
 * GITHUB#13368: Replace Map<Integer, Object> by primitive IntObjectHashMap. (Bruno Roustant)
 
+* GITHUB#13392: Replace Map<Long, Object> by primitive LongObjectHashMap. (Bruno Roustant)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BiSegGraph.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BiSegGraph.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.analysis.cn.smart.Utility;
 import org.apache.lucene.util.hppc.IntObjectHashMap;
+import org.apache.lucene.util.hppc.ObjectCursor;
 
 /**
  * Graph representing possible token pairs (bigrams) at each start offset in the sentence.
@@ -218,7 +219,7 @@ class BiSegGraph {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    for (IntObjectHashMap.ObjectCursor<ArrayList<SegTokenPair>> segList :
+    for (ObjectCursor<ArrayList<SegTokenPair>> segList :
         tokenPairListTable.values()) {
       for (SegTokenPair pair : segList.value) {
         sb.append(pair).append("\n");

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BiSegGraph.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BiSegGraph.java
@@ -219,8 +219,7 @@ class BiSegGraph {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    for (ObjectCursor<ArrayList<SegTokenPair>> segList :
-        tokenPairListTable.values()) {
+    for (ObjectCursor<ArrayList<SegTokenPair>> segList : tokenPairListTable.values()) {
       for (SegTokenPair pair : segList.value) {
         sb.append(pair).append("\n");
       }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -22,9 +22,7 @@ import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.NUMERIC_
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.DocValuesConsumer;
@@ -54,6 +52,7 @@ import org.apache.lucene.util.LongsRef;
 import org.apache.lucene.util.MathUtil;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.compress.LZ4;
+import org.apache.lucene.util.hppc.LongObjectHashMap;
 import org.apache.lucene.util.packed.DirectMonotonicWriter;
 import org.apache.lucene.util.packed.DirectWriter;
 
@@ -273,7 +272,7 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
     meta.writeLong(numValues);
     final int numBitsPerValue;
     boolean doBlocks = false;
-    Map<Long, Integer> encode = null;
+    LongObjectHashMap<Integer> encode = null;
     if (min >= max) { // meta[-1]: All values are 0
       numBitsPerValue = 0;
       meta.writeInt(-1); // tablesize
@@ -289,7 +288,7 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
         for (Long v : sortedUniqueValues) {
           meta.writeLong(v); // table[] entry
         }
-        encode = new HashMap<>();
+        encode = new LongObjectHashMap<>();
         for (int i = 0; i < sortedUniqueValues.length; ++i) {
           encode.put(sortedUniqueValues[i], i);
         }
@@ -339,7 +338,7 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
       int numBitsPerValue,
       long min,
       long gcd,
-      Map<Long, Integer> encode)
+      LongObjectHashMap<Integer> encode)
       throws IOException {
     DirectWriter writer = DirectWriter.getInstance(data, numValues, numBitsPerValue);
     for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -52,7 +52,7 @@ import org.apache.lucene.util.LongsRef;
 import org.apache.lucene.util.MathUtil;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.compress.LZ4;
-import org.apache.lucene.util.hppc.LongObjectHashMap;
+import org.apache.lucene.util.hppc.LongIntHashMap;
 import org.apache.lucene.util.packed.DirectMonotonicWriter;
 import org.apache.lucene.util.packed.DirectWriter;
 
@@ -272,7 +272,7 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
     meta.writeLong(numValues);
     final int numBitsPerValue;
     boolean doBlocks = false;
-    LongObjectHashMap<Integer> encode = null;
+    LongIntHashMap encode = null;
     if (min >= max) { // meta[-1]: All values are 0
       numBitsPerValue = 0;
       meta.writeInt(-1); // tablesize
@@ -288,7 +288,7 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
         for (Long v : sortedUniqueValues) {
           meta.writeLong(v); // table[] entry
         }
-        encode = new LongObjectHashMap<>();
+        encode = new LongIntHashMap();
         for (int i = 0; i < sortedUniqueValues.length; ++i) {
           encode.put(sortedUniqueValues[i], i);
         }
@@ -338,7 +338,7 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
       int numBitsPerValue,
       long min,
       long gcd,
-      LongObjectHashMap<Integer> encode)
+      LongIntHashMap encode)
       throws IOException {
     DirectWriter writer = DirectWriter.getInstance(data, numValues, numBitsPerValue);
     for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
@@ -32,7 +32,8 @@ import org.apache.lucene.util.hppc.LongObjectHashMap;
  */
 final class SegmentDocValues {
 
-  private final LongObjectHashMap<RefCount<DocValuesProducer>> genDVProducers = new LongObjectHashMap<>();
+  private final LongObjectHashMap<RefCount<DocValuesProducer>> genDVProducers =
+      new LongObjectHashMap<>();
 
   private RefCount<DocValuesProducer> newDocValuesProducer(
       SegmentCommitInfo si, Directory dir, final Long gen, FieldInfos infos) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
@@ -17,15 +17,14 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RefCount;
+import org.apache.lucene.util.hppc.LongObjectHashMap;
 
 /**
  * Manages the {@link DocValuesProducer} held by {@link SegmentReader} and keeps track of their
@@ -33,7 +32,7 @@ import org.apache.lucene.util.RefCount;
  */
 final class SegmentDocValues {
 
-  private final Map<Long, RefCount<DocValuesProducer>> genDVProducers = new HashMap<>();
+  private final LongObjectHashMap<RefCount<DocValuesProducer>> genDVProducers = new LongObjectHashMap<>();
 
   private RefCount<DocValuesProducer> newDocValuesProducer(
       SegmentCommitInfo si, Directory dir, final Long gen, FieldInfos infos) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/HashContainers.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/HashContainers.java
@@ -1,0 +1,30 @@
+package org.apache.lucene.util.hppc;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Constants for primitive maps.
+ */
+public class HashContainers {
+
+    public static final int DEFAULT_EXPECTED_ELEMENTS = 4;
+
+    public static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
+    /** Minimal sane load factor (99 empty slots per 100). */
+    public static final float MIN_LOAD_FACTOR = 1 / 100.0f;
+
+    /** Maximum sane load factor (1 empty slot per 100). */
+    public static final float MAX_LOAD_FACTOR = 99 / 100.0f;
+
+    /** Minimum hash buffer size. */
+    public static final int MIN_HASH_ARRAY_LENGTH = 4;
+
+    /**
+     * Maximum array size for hash containers (power-of-two and still allocable in Java, not a
+     * negative int).
+     */
+    public static final int MAX_HASH_ARRAY_LENGTH = 0x80000000 >>> 1;
+
+    static final AtomicInteger ITERATION_SEED = new AtomicInteger();
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/HashContainers.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/HashContainers.java
@@ -1,30 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.lucene.util.hppc;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-/**
- * Constants for primitive maps.
- */
+/** Constants for primitive maps. */
 public class HashContainers {
 
-    public static final int DEFAULT_EXPECTED_ELEMENTS = 4;
+  public static final int DEFAULT_EXPECTED_ELEMENTS = 4;
 
-    public static final float DEFAULT_LOAD_FACTOR = 0.75f;
+  public static final float DEFAULT_LOAD_FACTOR = 0.75f;
 
-    /** Minimal sane load factor (99 empty slots per 100). */
-    public static final float MIN_LOAD_FACTOR = 1 / 100.0f;
+  /** Minimal sane load factor (99 empty slots per 100). */
+  public static final float MIN_LOAD_FACTOR = 1 / 100.0f;
 
-    /** Maximum sane load factor (1 empty slot per 100). */
-    public static final float MAX_LOAD_FACTOR = 99 / 100.0f;
+  /** Maximum sane load factor (1 empty slot per 100). */
+  public static final float MAX_LOAD_FACTOR = 99 / 100.0f;
 
-    /** Minimum hash buffer size. */
-    public static final int MIN_HASH_ARRAY_LENGTH = 4;
+  /** Minimum hash buffer size. */
+  public static final int MIN_HASH_ARRAY_LENGTH = 4;
 
-    /**
-     * Maximum array size for hash containers (power-of-two and still allocable in Java, not a
-     * negative int).
-     */
-    public static final int MAX_HASH_ARRAY_LENGTH = 0x80000000 >>> 1;
+  /**
+   * Maximum array size for hash containers (power-of-two and still allocable in Java, not a
+   * negative int).
+   */
+  public static final int MAX_HASH_ARRAY_LENGTH = 0x80000000 >>> 1;
 
-    static final AtomicInteger ITERATION_SEED = new AtomicInteger();
+  static final AtomicInteger ITERATION_SEED = new AtomicInteger();
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/IntIntHashMap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/IntIntHashMap.java
@@ -17,11 +17,15 @@
 
 package org.apache.lucene.util.hppc;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+
 import static org.apache.lucene.util.BitUtil.nextHighestPowerOfTwo;
 
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.lucene.util.hppc.HashContainers.*;
 
 /**
  * A hash map of <code>int</code> to <code>int</code>, implemented using open addressing with linear
@@ -31,28 +35,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * <p>github: https://github.com/carrotsearch/hppc release 0.9.0
  */
-public class IntIntHashMap implements Iterable<IntIntHashMap.IntIntCursor>, Cloneable {
+public class IntIntHashMap implements Iterable<IntIntHashMap.IntIntCursor>, Accountable, Cloneable {
 
-  public static final int DEFAULT_EXPECTED_ELEMENTS = 4;
-
-  public static final float DEFAULT_LOAD_FACTOR = 0.75f;
-
-  private static final AtomicInteger ITERATION_SEED = new AtomicInteger();
-
-  /** Minimal sane load factor (99 empty slots per 100). */
-  public static final float MIN_LOAD_FACTOR = 1 / 100.0f;
-
-  /** Maximum sane load factor (1 empty slot per 100). */
-  public static final float MAX_LOAD_FACTOR = 99 / 100.0f;
-
-  /** Minimum hash buffer size. */
-  public static final int MIN_HASH_ARRAY_LENGTH = 4;
-
-  /**
-   * Maximum array size for hash containers (power-of-two and still allocable in Java, not a
-   * negative int).
-   */
-  public static final int MAX_HASH_ARRAY_LENGTH = 0x80000000 >>> 1;
+  private static final long BASE_RAM_BYTES_USED =
+          RamUsageEstimator.shallowSizeOfInstance(IntIntHashMap.class);
 
   /** The array holding keys. */
   public int[] keys;
@@ -461,6 +447,11 @@ public class IntIntHashMap implements Iterable<IntIntHashMap.IntIntCursor>, Clon
    */
   protected int nextIterationSeed() {
     return iterationSeed = BitMixer.mixPhi(iterationSeed);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(keys) + RamUsageEstimator.sizeOf(values);
   }
 
   /** An iterator implementation for {@link #iterator}. */

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/IntIntHashMap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/IntIntHashMap.java
@@ -17,15 +17,13 @@
 
 package org.apache.lucene.util.hppc;
 
-import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.RamUsageEstimator;
-
 import static org.apache.lucene.util.BitUtil.nextHighestPowerOfTwo;
+import static org.apache.lucene.util.hppc.HashContainers.*;
 
 import java.util.Arrays;
 import java.util.Iterator;
-
-import static org.apache.lucene.util.hppc.HashContainers.*;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 
 /**
  * A hash map of <code>int</code> to <code>int</code>, implemented using open addressing with linear
@@ -38,7 +36,7 @@ import static org.apache.lucene.util.hppc.HashContainers.*;
 public class IntIntHashMap implements Iterable<IntIntHashMap.IntIntCursor>, Accountable, Cloneable {
 
   private static final long BASE_RAM_BYTES_USED =
-          RamUsageEstimator.shallowSizeOfInstance(IntIntHashMap.class);
+      RamUsageEstimator.shallowSizeOfInstance(IntIntHashMap.class);
 
   /** The array holding keys. */
   public int[] keys;

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/IntObjectHashMap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/IntObjectHashMap.java
@@ -17,14 +17,13 @@
 
 package org.apache.lucene.util.hppc;
 
-import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.RamUsageEstimator;
-
 import static org.apache.lucene.util.BitUtil.nextHighestPowerOfTwo;
+import static org.apache.lucene.util.hppc.HashContainers.*;
 
 import java.util.Arrays;
 import java.util.Iterator;
-import static org.apache.lucene.util.hppc.HashContainers.*;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 
 /**
  * A hash map of <code>int</code> to <code>Object</code>, implemented using open addressing with
@@ -39,7 +38,7 @@ public class IntObjectHashMap<VType>
     implements Iterable<IntObjectHashMap.IntObjectCursor<VType>>, Accountable, Cloneable {
 
   private static final long BASE_RAM_BYTES_USED =
-          RamUsageEstimator.shallowSizeOfInstance(IntObjectHashMap.class);
+      RamUsageEstimator.shallowSizeOfInstance(IntObjectHashMap.class);
 
   /** The array holding keys. */
   public int[] keys;

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/LongCursor.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/LongCursor.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hppc;
+
+/** Forked from HPPC, holding int index and long value */
+public final class LongCursor {
+  /**
+   * The current value's index in the container this cursor belongs to. The meaning of this index is
+   * defined by the container (usually it will be an index in the underlying storage buffer).
+   */
+  public int index;
+
+  /** The current value. */
+  public long value;
+
+  @Override
+  public String toString() {
+    return "[cursor, index: " + index + ", value: " + value + "]";
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/LongObjectHashMap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/LongObjectHashMap.java
@@ -17,14 +17,13 @@
 
 package org.apache.lucene.util.hppc;
 
-import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.RamUsageEstimator;
+import static org.apache.lucene.util.BitUtil.nextHighestPowerOfTwo;
+import static org.apache.lucene.util.hppc.HashContainers.*;
 
 import java.util.Arrays;
 import java.util.Iterator;
-
-import static org.apache.lucene.util.BitUtil.nextHighestPowerOfTwo;
-import static org.apache.lucene.util.hppc.HashContainers.*;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 
 /**
  * A hash map of <code>long</code> to <code>Object</code>, implemented using open addressing with
@@ -39,7 +38,7 @@ public class LongObjectHashMap<VType>
     implements Iterable<LongObjectHashMap.LongObjectCursor<VType>>, Accountable, Cloneable {
 
   private static final long BASE_RAM_BYTES_USED =
-          RamUsageEstimator.shallowSizeOfInstance(LongObjectHashMap.class);
+      RamUsageEstimator.shallowSizeOfInstance(LongObjectHashMap.class);
 
   /** The array holding keys. */
   public long[] keys;

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/LongObjectHashMap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/LongObjectHashMap.java
@@ -27,7 +27,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 
 /**
  * A hash map of <code>long</code> to <code>Object</code>, implemented using open addressing with
- * linear probing for collision resolution.
+ * linear probing for collision resolution. Supports null values.
  *
  * <p>Mostly forked and trimmed from com.carrotsearch.hppc.LongObjectHashMap
  *

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/LongObjectHashMap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/LongObjectHashMap.java
@@ -20,29 +20,29 @@ package org.apache.lucene.util.hppc;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 
-import static org.apache.lucene.util.BitUtil.nextHighestPowerOfTwo;
-
 import java.util.Arrays;
 import java.util.Iterator;
+
+import static org.apache.lucene.util.BitUtil.nextHighestPowerOfTwo;
 import static org.apache.lucene.util.hppc.HashContainers.*;
 
 /**
- * A hash map of <code>int</code> to <code>Object</code>, implemented using open addressing with
+ * A hash map of <code>long</code> to <code>Object</code>, implemented using open addressing with
  * linear probing for collision resolution.
  *
- * <p>Mostly forked and trimmed from com.carrotsearch.hppc.IntObjectHashMap
+ * <p>Mostly forked and trimmed from com.carrotsearch.hppc.LongObjectHashMap
  *
  * <p>github: https://github.com/carrotsearch/hppc release 0.9.0
  */
 @SuppressWarnings("unchecked")
-public class IntObjectHashMap<VType>
-    implements Iterable<IntObjectHashMap.IntObjectCursor<VType>>, Accountable, Cloneable {
+public class LongObjectHashMap<VType>
+    implements Iterable<LongObjectHashMap.LongObjectCursor<VType>>, Accountable, Cloneable {
 
   private static final long BASE_RAM_BYTES_USED =
-          RamUsageEstimator.shallowSizeOfInstance(IntObjectHashMap.class);
+          RamUsageEstimator.shallowSizeOfInstance(LongObjectHashMap.class);
 
   /** The array holding keys. */
-  public int[] keys;
+  public long[] keys;
 
   /** The array holding values. */
   public Object[] values;
@@ -71,7 +71,7 @@ public class IntObjectHashMap<VType>
   protected int iterationSeed;
 
   /** New instance with sane defaults. */
-  public IntObjectHashMap() {
+  public LongObjectHashMap() {
     this(DEFAULT_EXPECTED_ELEMENTS);
   }
 
@@ -81,7 +81,7 @@ public class IntObjectHashMap<VType>
    * @param expectedElements The expected number of elements guaranteed not to cause buffer
    *     expansion (inclusive).
    */
-  public IntObjectHashMap(int expectedElements) {
+  public LongObjectHashMap(int expectedElements) {
     this(expectedElements, DEFAULT_LOAD_FACTOR);
   }
 
@@ -93,19 +93,19 @@ public class IntObjectHashMap<VType>
    * @param loadFactor The load factor for internal buffers. Insane load factors (zero, full
    *     capacity) are rejected by {@link #verifyLoadFactor(double)}.
    */
-  public IntObjectHashMap(int expectedElements, double loadFactor) {
+  public LongObjectHashMap(int expectedElements, double loadFactor) {
     this.loadFactor = verifyLoadFactor(loadFactor);
     iterationSeed = ITERATION_SEED.incrementAndGet();
     ensureCapacity(expectedElements);
   }
 
   /** Create a hash map from all key-value pairs of another container. */
-  public IntObjectHashMap(Iterable<? extends IntObjectCursor<? extends VType>> container) {
+  public LongObjectHashMap(Iterable<? extends LongObjectCursor<? extends VType>> container) {
     this();
     putAll(container);
   }
 
-  public VType put(int key, VType value) {
+  public VType put(long key, VType value) {
     assert assigned < mask + 1;
 
     final int mask = this.mask;
@@ -115,10 +115,10 @@ public class IntObjectHashMap<VType>
       values[mask + 1] = value;
       return previousValue;
     } else {
-      final int[] keys = this.keys;
+      final long[] keys = this.keys;
       int slot = hashKey(key) & mask;
 
-      int existing;
+      long existing;
       while (!((existing = keys[slot]) == 0)) {
         if (((existing) == (key))) {
           final VType previousValue = (VType) values[slot];
@@ -140,9 +140,9 @@ public class IntObjectHashMap<VType>
     }
   }
 
-  public int putAll(Iterable<? extends IntObjectCursor<? extends VType>> iterable) {
+  public int putAll(Iterable<? extends LongObjectCursor<? extends VType>> iterable) {
     final int count = size();
-    for (IntObjectCursor<? extends VType> c : iterable) {
+    for (LongObjectCursor<? extends VType> c : iterable) {
       put(c.key, c.value);
     }
     return size() - count;
@@ -161,7 +161,7 @@ public class IntObjectHashMap<VType>
    * @return <code>true</code> if <code>key</code> did not exist and <code>value</code> was placed
    *     in the map.
    */
-  public boolean putIfAbsent(int key, VType value) {
+  public boolean putIfAbsent(long key, VType value) {
     int keyIndex = indexOf(key);
     if (!indexExists(keyIndex)) {
       indexInsert(keyIndex, key, value);
@@ -171,7 +171,7 @@ public class IntObjectHashMap<VType>
     }
   }
 
-  public VType remove(int key) {
+  public VType remove(long key) {
     final int mask = this.mask;
     if (((key) == 0)) {
       hasEmptyKey = false;
@@ -179,10 +179,10 @@ public class IntObjectHashMap<VType>
       values[mask + 1] = 0;
       return previousValue;
     } else {
-      final int[] keys = this.keys;
+      final long[] keys = this.keys;
       int slot = hashKey(key) & mask;
 
-      int existing;
+      long existing;
       while (!((existing = keys[slot]) == 0)) {
         if (((existing) == (key))) {
           final VType previousValue = (VType) values[slot];
@@ -196,15 +196,15 @@ public class IntObjectHashMap<VType>
     }
   }
 
-  public VType get(int key) {
+  public VType get(long key) {
     if (((key) == 0)) {
       return hasEmptyKey ? (VType) values[mask + 1] : null;
     } else {
-      final int[] keys = this.keys;
+      final long[] keys = this.keys;
       final int mask = this.mask;
       int slot = hashKey(key) & mask;
 
-      int existing;
+      long existing;
       while (!((existing = keys[slot]) == 0)) {
         if (((existing) == (key))) {
           return (VType) values[slot];
@@ -216,15 +216,15 @@ public class IntObjectHashMap<VType>
     }
   }
 
-  public VType getOrDefault(int key, VType defaultValue) {
+  public VType getOrDefault(long key, VType defaultValue) {
     if (((key) == 0)) {
       return hasEmptyKey ? (VType) values[mask + 1] : defaultValue;
     } else {
-      final int[] keys = this.keys;
+      final long[] keys = this.keys;
       final int mask = this.mask;
       int slot = hashKey(key) & mask;
 
-      int existing;
+      long existing;
       while (!((existing = keys[slot]) == 0)) {
         if (((existing) == (key))) {
           return (VType) values[slot];
@@ -236,15 +236,15 @@ public class IntObjectHashMap<VType>
     }
   }
 
-  public boolean containsKey(int key) {
+  public boolean containsKey(long key) {
     if (((key) == 0)) {
       return hasEmptyKey;
     } else {
-      final int[] keys = this.keys;
+      final long[] keys = this.keys;
       final int mask = this.mask;
       int slot = hashKey(key) & mask;
 
-      int existing;
+      long existing;
       while (!((existing = keys[slot]) == 0)) {
         if (((existing) == (key))) {
           return true;
@@ -256,15 +256,15 @@ public class IntObjectHashMap<VType>
     }
   }
 
-  public int indexOf(int key) {
+  public int indexOf(long key) {
     final int mask = this.mask;
     if (((key) == 0)) {
       return hasEmptyKey ? mask + 1 : ~(mask + 1);
     } else {
-      final int[] keys = this.keys;
+      final long[] keys = this.keys;
       int slot = hashKey(key) & mask;
 
-      int existing;
+      long existing;
       while (!((existing = keys[slot]) == 0)) {
         if (((existing) == (key))) {
           return slot;
@@ -298,7 +298,7 @@ public class IntObjectHashMap<VType>
     return previousValue;
   }
 
-  public void indexInsert(int index, int key, VType value) {
+  public void indexInsert(int index, long key, VType value) {
     assert index < 0 : "The index must not point at an existing key.";
 
     index = ~index;
@@ -363,7 +363,7 @@ public class IntObjectHashMap<VType>
   @Override
   public int hashCode() {
     int h = hasEmptyKey ? 0xDEADBEEF : 0;
-    for (IntObjectCursor<VType> c : this) {
+    for (LongObjectCursor<VType> c : this) {
       h += BitMixer.mix(c.key) + BitMixer.mix(c.value);
     }
     return h;
@@ -375,13 +375,13 @@ public class IntObjectHashMap<VType>
   }
 
   /** Return true if all keys of some other container exist in this container. */
-  protected boolean equalElements(IntObjectHashMap<?> other) {
+  protected boolean equalElements(LongObjectHashMap<?> other) {
     if (other.size() != size()) {
       return false;
     }
 
-    for (IntObjectCursor<?> c : other) {
-      int key = c.key;
+    for (LongObjectCursor<?> c : other) {
+      long key = c.key;
       if (!containsKey(key) || !java.util.Objects.equals(c.value, get(key))) {
         return false;
       }
@@ -398,7 +398,7 @@ public class IntObjectHashMap<VType>
    */
   public void ensureCapacity(int expectedElements) {
     if (expectedElements > resizeAt || keys == null) {
-      final int[] prevKeys = this.keys;
+      final long[] prevKeys = this.keys;
       final VType[] prevValues = (VType[]) this.values;
       allocateBuffers(minBufferSize(expectedElements, loadFactor));
       if (prevKeys != null && !isEmpty()) {
@@ -417,7 +417,7 @@ public class IntObjectHashMap<VType>
   }
 
   @Override
-  public Iterator<IntObjectCursor<VType>> iterator() {
+  public Iterator<LongObjectCursor<VType>> iterator() {
     return new EntryIterator();
   }
 
@@ -435,24 +435,24 @@ public class IntObjectHashMap<VType>
   }
 
   /** An iterator implementation for {@link #iterator}. */
-  private final class EntryIterator extends AbstractIterator<IntObjectCursor<VType>> {
-    private final IntObjectCursor<VType> cursor;
+  private final class EntryIterator extends AbstractIterator<LongObjectCursor<VType>> {
+    private final LongObjectCursor<VType> cursor;
     private final int increment;
     private int index;
     private int slot;
 
     public EntryIterator() {
-      cursor = new IntObjectCursor<VType>();
+      cursor = new LongObjectCursor<VType>();
       int seed = nextIterationSeed();
       increment = iterationIncrement(seed);
       slot = seed & mask;
     }
 
     @Override
-    protected IntObjectCursor<VType> fetch() {
-      final int mask = IntObjectHashMap.this.mask;
+    protected LongObjectCursor<VType> fetch() {
+      final int mask = LongObjectHashMap.this.mask;
       while (index <= mask) {
-        int existing;
+        long existing;
         index++;
         slot = (slot + increment) & mask;
         if (!((existing = keys[slot]) == 0)) {
@@ -480,21 +480,21 @@ public class IntObjectHashMap<VType>
   }
 
   /** A view of the keys inside this hash map. */
-  public final class KeysContainer implements Iterable<IntCursor> {
+  public final class KeysContainer implements Iterable<LongCursor> {
 
     @Override
-    public Iterator<IntCursor> iterator() {
+    public Iterator<LongCursor> iterator() {
       return new KeysIterator();
     }
 
     public int size() {
-      return IntObjectHashMap.this.size();
+      return LongObjectHashMap.this.size();
     }
 
-    public int[] toArray() {
-      int[] array = new int[size()];
+    public long[] toArray() {
+      long[] array = new long[size()];
       int i = 0;
-      for (IntCursor cursor : this) {
+      for (LongCursor cursor : this) {
         array[i++] = cursor.value;
       }
       return array;
@@ -502,24 +502,24 @@ public class IntObjectHashMap<VType>
   }
 
   /** An iterator over the set of assigned keys. */
-  private final class KeysIterator extends AbstractIterator<IntCursor> {
-    private final IntCursor cursor;
+  private final class KeysIterator extends AbstractIterator<LongCursor> {
+    private final LongCursor cursor;
     private final int increment;
     private int index;
     private int slot;
 
     public KeysIterator() {
-      cursor = new IntCursor();
+      cursor = new LongCursor();
       int seed = nextIterationSeed();
       increment = iterationIncrement(seed);
       slot = seed & mask;
     }
 
     @Override
-    protected IntCursor fetch() {
-      final int mask = IntObjectHashMap.this.mask;
+    protected LongCursor fetch() {
+      final int mask = LongObjectHashMap.this.mask;
       while (index <= mask) {
-        int existing;
+        long existing;
         index++;
         slot = (slot + increment) & mask;
         if (!((existing = keys[slot]) == 0)) {
@@ -555,7 +555,7 @@ public class IntObjectHashMap<VType>
     }
 
     public int size() {
-      return IntObjectHashMap.this.size();
+      return LongObjectHashMap.this.size();
     }
 
     public VType[] toArray() {
@@ -584,7 +584,7 @@ public class IntObjectHashMap<VType>
 
     @Override
     protected ObjectCursor<VType> fetch() {
-      final int mask = IntObjectHashMap.this.mask;
+      final int mask = LongObjectHashMap.this.mask;
       while (index <= mask) {
         index++;
         slot = (slot + increment) & mask;
@@ -606,10 +606,10 @@ public class IntObjectHashMap<VType>
   }
 
   @Override
-  public IntObjectHashMap<VType> clone() {
+  public LongObjectHashMap<VType> clone() {
     try {
       /*  */
-      IntObjectHashMap<VType> cloned = (IntObjectHashMap<VType>) super.clone();
+      LongObjectHashMap<VType> cloned = (LongObjectHashMap<VType>) super.clone();
       cloned.keys = keys.clone();
       cloned.values = values.clone();
       cloned.hasEmptyKey = hasEmptyKey;
@@ -627,7 +627,7 @@ public class IntObjectHashMap<VType>
     buffer.append("[");
 
     boolean first = true;
-    for (IntObjectCursor<VType> cursor : this) {
+    for (LongObjectCursor<VType> cursor : this) {
       if (!first) {
         buffer.append(", ");
       }
@@ -641,13 +641,13 @@ public class IntObjectHashMap<VType>
   }
 
   /** Creates a hash map from two index-aligned arrays of key-value pairs. */
-  public static <VType> IntObjectHashMap<VType> from(int[] keys, VType[] values) {
+  public static <VType> LongObjectHashMap<VType> from(long[] keys, VType[] values) {
     if (keys.length != values.length) {
       throw new IllegalArgumentException(
           "Arrays of keys and values must have an identical length.");
     }
 
-    IntObjectHashMap<VType> map = new IntObjectHashMap<>(keys.length);
+    LongObjectHashMap<VType> map = new LongObjectHashMap<>(keys.length);
     for (int i = 0; i < keys.length; i++) {
       map.put(keys[i], values[i]);
     }
@@ -660,7 +660,7 @@ public class IntObjectHashMap<VType>
    *
    * <p>The output from this function should evenly distribute keys across the entire integer range.
    */
-  protected int hashKey(int key) {
+  protected int hashKey(long key) {
     assert !((key) == 0); // Handled as a special case (empty slot marker).
     return BitMixer.mixPhi(key);
   }
@@ -675,14 +675,14 @@ public class IntObjectHashMap<VType>
   }
 
   /** Rehash from old buffers to new buffers. */
-  protected void rehash(int[] fromKeys, VType[] fromValues) {
+  protected void rehash(long[] fromKeys, VType[] fromValues) {
     assert fromKeys.length == fromValues.length && checkPowerOfTwo(fromKeys.length - 1);
 
     // Rehash all stored key/value pairs into the new buffers.
-    final int[] keys = this.keys;
+    final long[] keys = this.keys;
     final VType[] values = (VType[]) this.values;
     final int mask = this.mask;
-    int existing;
+    long existing;
 
     // Copy the zero element's slot, then rehash everything else.
     int from = fromKeys.length - 1;
@@ -708,11 +708,11 @@ public class IntObjectHashMap<VType>
     assert Integer.bitCount(arraySize) == 1;
 
     // Ensure no change is done if we hit an OOM.
-    int[] prevKeys = this.keys;
+    long[] prevKeys = this.keys;
     VType[] prevValues = (VType[]) this.values;
     try {
       int emptyElementSlot = 1;
-      this.keys = (new int[arraySize + emptyElementSlot]);
+      this.keys = (new long[arraySize + emptyElementSlot]);
       this.values = new Object[arraySize + emptyElementSlot];
     } catch (OutOfMemoryError e) {
       this.keys = prevKeys;
@@ -734,11 +734,11 @@ public class IntObjectHashMap<VType>
    * assign the pending element to the previous buffer (possibly violating the invariant of having
    * at least one empty slot) and rehash all keys, substituting new buffers at the end.
    */
-  protected void allocateThenInsertThenRehash(int slot, int pendingKey, VType pendingValue) {
+  protected void allocateThenInsertThenRehash(int slot, long pendingKey, VType pendingValue) {
     assert assigned == resizeAt && ((keys[slot]) == 0) && !((pendingKey) == 0);
 
     // Try to allocate new buffers first. If we OOM, we leave in a consistent state.
-    final int[] prevKeys = this.keys;
+    final long[] prevKeys = this.keys;
     final VType[] prevValues = (VType[]) this.values;
     allocateBuffers(nextBufferSize(mask + 1, size(), loadFactor));
     assert this.keys.length > prevKeys.length;
@@ -814,7 +814,7 @@ public class IntObjectHashMap<VType>
    * Shift all the slot-conflicting keys and values allocated to (and including) <code>slot</code>.
    */
   protected void shiftConflictingKeys(int gapSlot) {
-    final int[] keys = this.keys;
+    final long[] keys = this.keys;
     final VType[] values = (VType[]) this.values;
     final int mask = this.mask;
 
@@ -822,7 +822,7 @@ public class IntObjectHashMap<VType>
     int distance = 0;
     while (true) {
       final int slot = (gapSlot + (++distance)) & mask;
-      final int existing = keys[slot];
+      final long existing = keys[slot];
       if (((existing) == 0)) {
         break;
       }
@@ -848,7 +848,7 @@ public class IntObjectHashMap<VType>
   }
 
   /** Forked from HPPC, holding int index,key and value */
-  public static final class IntObjectCursor<VType> {
+  public static final class LongObjectCursor<VType> {
     /**
      * The current key and value's index in the container this cursor belongs to. The meaning of
      * this index is defined by the container (usually it will be an index in the underlying storage
@@ -857,7 +857,7 @@ public class IntObjectHashMap<VType>
     public int index;
 
     /** The current key. */
-    public int key;
+    public long key;
 
     /** The current value. */
     public VType value;

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/ObjectCursor.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/ObjectCursor.java
@@ -1,22 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.lucene.util.hppc;
 
-/**
- * Forked from HPPC, holding int index and Object value
- */
+/** Forked from HPPC, holding int index and Object value */
 public final class ObjectCursor<VType> {
-    /**
-     * The current value's index in the container this cursor belongs to. The meaning of this index
-     * is defined by the container (usually it will be an index in the underlying storage buffer).
-     */
-    public int index;
+  /**
+   * The current value's index in the container this cursor belongs to. The meaning of this index is
+   * defined by the container (usually it will be an index in the underlying storage buffer).
+   */
+  public int index;
 
-    /**
-     * The current value.
-     */
-    public VType value;
+  /** The current value. */
+  public VType value;
 
-    @Override
-    public String toString() {
-        return "[cursor, index: " + index + ", value: " + value + "]";
-    }
+  @Override
+  public String toString() {
+    return "[cursor, index: " + index + ", value: " + value + "]";
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hppc/ObjectCursor.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hppc/ObjectCursor.java
@@ -1,0 +1,22 @@
+package org.apache.lucene.util.hppc;
+
+/**
+ * Forked from HPPC, holding int index and Object value
+ */
+public final class ObjectCursor<VType> {
+    /**
+     * The current value's index in the container this cursor belongs to. The meaning of this index
+     * is defined by the container (usually it will be an index in the underlying storage buffer).
+     */
+    public int index;
+
+    /**
+     * The current value.
+     */
+    public VType value;
+
+    @Override
+    public String toString() {
+        return "[cursor, index: " + index + ", value: " + value + "]";
+    }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/hppc/TestIntIntHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hppc/TestIntIntHashMap.java
@@ -52,12 +52,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
     return v;
   }
 
-  public int[] asArray(int... elements) {
-    int[] values = (new int[elements.length]);
-    for (int i = 0; i < elements.length; i++) values[i] = elements[i];
-    return values;
-  }
-
   /** Create a new array of a given type and copy the arguments to this array. */
   /*  */
   public final int[] newArray(int... elements) {

--- a/lucene/core/src/test/org/apache/lucene/util/hppc/TestIntObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hppc/TestIntObjectHashMap.java
@@ -49,57 +49,20 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   protected int key9 = cast(9), k9 = key9;
 
   /** Convert to target type from an integer used to test stuff. */
-  public int cast(Integer v) {
-    return v.intValue();
+  public int cast(int v) {
+    return v;
   }
 
-  public int[] asArray(int... ints) {
-    int[] values = (new int[ints.length]);
-    for (int i = 0; i < ints.length; i++) values[i] = ints[i];
+  public int[] asArray(int... elements) {
+    int[] values = (new int[elements.length]);
+    for (int i = 0; i < elements.length; i++) values[i] = elements[i];
     return values;
   }
 
   /** Create a new array of a given type and copy the arguments to this array. */
   /*  */
   public final int[] newArray(int... elements) {
-    return newArray0(elements);
-  }
-
-  /*  */
-  private final int[] newArray0(int... elements) {
     return elements;
-  }
-
-  public int[] newArray(int v0) {
-    return this.newArray0(v0);
-  }
-
-  public int[] newArray(int v0, int v1) {
-    return this.newArray0(v0, v1);
-  }
-
-  public int[] newArray(int v0, int v1, int v2) {
-    return this.newArray0(v0, v1, v2);
-  }
-
-  public int[] newArray(int v0, int v1, int v2, int v3) {
-    return this.newArray0(v0, v1, v2, v3);
-  }
-
-  public int[] newArray(int v0, int v1, int v2, int v3, int v4, int v5, int v6) {
-    return this.newArray0(v0, v1, v2, v3, v4, v5, v6);
-  }
-
-  public int[] newArray(int v0, int v1, int v2, int v3, int v4, int v5) {
-    return this.newArray0(v0, v1, v2, v3, v4, v5);
-  }
-
-  public int[] newArray(int v0, int v1, int v2, int v3, int v4) {
-    return this.newArray0(v0, v1, v2, v3, v4);
-  }
-
-  public int[] newArray(int v0, int v1, int v2, int v3, int v4, int v5, int v6, int v7) {
-    return this.newArray0(v0, v1, v2, v3, v4, v5, v6, v7);
   }
 
   public static int randomIntBetween(int min, int max) {
@@ -298,10 +261,25 @@ public class TestIntObjectHashMap extends LuceneTestCase {
 
   /* */
   @Test
+  public void testNullValue() {
+    map.put(key1, null);
+
+    assertTrue(map.containsKey(key1));
+    assertNull(map.get(key1));
+  }
+
+  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals(value1, map.put(key1, value3));
     assertEquals(value3, map.get(key1));
+
+    assertEquals(value3, map.put(key1, null));
+    assertTrue(map.containsKey(key1));
+    assertNull(map.get(key1));
+
+    assertNull(map.put(key1, value1));
+    assertEquals(value1, map.get(key1));
   }
 
   /* */
@@ -381,6 +359,16 @@ public class TestIntObjectHashMap extends LuceneTestCase {
 
     map.remove(empty);
     assertEquals(null, map.get(empty));
+
+    map.put(empty, null);
+    assertEquals(1, map.size());
+    assertTrue(map.containsKey(empty));
+    assertNull(map.get(empty));
+
+    map.remove(empty);
+    assertEquals(0, map.size());
+    assertFalse(map.containsKey(empty));
+    assertNull(map.get(empty));
   }
 
   /* */
@@ -577,7 +565,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     map.put(key3, value1);
 
     int counted = 0;
-    for (IntObjectHashMap.ObjectCursor c : map.values()) {
+    for (ObjectCursor c : map.values()) {
       assertEquals(map.values[c.index], c.value);
       counted++;
     }
@@ -608,7 +596,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   @Test
   public void testEqualsSubClass() {
     class Sub extends IntObjectHashMap {}
-    ;
 
     IntObjectHashMap l1 = newInstance();
     l1.put(k1, value0);

--- a/lucene/core/src/test/org/apache/lucene/util/hppc/TestLongIntHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hppc/TestLongIntHashMap.java
@@ -26,41 +26,48 @@ import org.junit.After;
 import org.junit.Test;
 
 /**
- * Tests for {@link IntObjectHashMap}.
+ * Tests for {@link LongIntHashMap}.
  *
- * <p>Mostly forked and trimmed from com.carrotsearch.hppc.IntObjectHashMapTest
+ * <p>Mostly forked and trimmed from com.carrotsearch.hppc.LongIntHashMapTest
  *
  * <p>github: https://github.com/carrotsearch/hppc release: 0.9.0
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
-public class TestIntObjectHashMap extends LuceneTestCase {
+public class TestLongIntHashMap extends LuceneTestCase {
   /* Ready to use key values. */
 
-  protected int keyE = 0;
-  protected int key0 = cast(0), k0 = key0;
-  protected int key1 = cast(1), k1 = key1;
-  protected int key2 = cast(2), k2 = key2;
-  protected int key3 = cast(3), k3 = key3;
-  protected int key4 = cast(4), k4 = key4;
-  protected int key5 = cast(5), k5 = key5;
-  protected int key6 = cast(6), k6 = key6;
-  protected int key7 = cast(7), k7 = key7;
-  protected int key8 = cast(8), k8 = key8;
-  protected int key9 = cast(9), k9 = key9;
+  protected long keyE = 0;
+  protected long key0 = cast(0), k0 = key0;
+  protected long key1 = cast(1), k1 = key1;
+  protected long key2 = cast(2), k2 = key2;
+  protected long key3 = cast(3), k3 = key3;
+  protected long key4 = cast(4), k4 = key4;
+  protected long key5 = cast(5), k5 = key5;
+  protected long key6 = cast(6), k6 = key6;
+  protected long key7 = cast(7), k7 = key7;
+  protected long key8 = cast(8), k8 = key8;
+  protected long key9 = cast(9), k9 = key9;
 
   /** Convert to target type from an integer used to test stuff. */
-  public int cast(int v) {
+  public long cast(int v) {
     return v;
   }
 
   /** Create a new array of a given type and copy the arguments to this array. */
   /*  */
-  public final int[] newArray(int... elements) {
+  public final long[] newArray(long... elements) {
     return elements;
   }
 
   public static int randomIntBetween(int min, int max) {
     return min + random().nextInt(max + 1 - min);
+  }
+
+  /** Check if the array's content is identical to a given sequence of elements. */
+  public static void assertSortedListEquals(long[] array, long... elements) {
+    assertEquals(elements.length, array.length);
+    Arrays.sort(array);
+    Arrays.sort(elements);
+    assertArrayEquals(elements, array);
   }
 
   /** Check if the array's content is identical to a given sequence of elements. */
@@ -71,13 +78,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     assertArrayEquals(elements, array);
   }
 
-  /** Check if the array's content is identical to a given sequence of elements. */
-  public static void assertSortedListEquals(Object[] array, Object... elements) {
-    assertEquals(elements.length, array.length);
-    Arrays.sort(array);
-    assertArrayEquals(elements, array);
-  }
-
   protected int value0 = vcast(0);
   protected int value1 = vcast(1);
   protected int value2 = vcast(2);
@@ -85,10 +85,10 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   protected int value4 = vcast(4);
 
   /** Per-test fresh initialized instance. */
-  public IntObjectHashMap<Object> map = newInstance();
+  public LongIntHashMap map = newInstance();
 
-  protected IntObjectHashMap newInstance() {
-    return new IntObjectHashMap();
+  protected LongIntHashMap newInstance() {
+    return new LongIntHashMap();
   }
 
   @After
@@ -115,14 +115,14 @@ public class TestIntObjectHashMap extends LuceneTestCase {
 
   /** Create a new array of a given type and copy the arguments to this array. */
   /*  */
-  protected final Object[] newvArray(Object... elements) {
+  protected final int[] newvArray(int... elements) {
     return elements;
   }
 
-  private void assertSameMap(final IntObjectHashMap<Object> c1, final IntObjectHashMap<Object> c2) {
+  private void assertSameMap(final LongIntHashMap c1, final LongIntHashMap c2) {
     assertEquals(c1.size(), c2.size());
 
-    for (IntObjectHashMap.IntObjectCursor entry : c1) {
+    for (LongIntHashMap.LongIntCursor entry : c1) {
       assertTrue(c2.containsKey(entry.key));
       assertEquals(entry.value, c2.get(entry.key));
     }
@@ -132,8 +132,8 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
-    IntObjectHashMap map =
-        new IntObjectHashMap(0) {
+    LongIntHashMap map =
+        new LongIntHashMap(0) {
           @Override
           protected void allocateBuffers(int arraySize) {
             super.allocateBuffers(arraySize);
@@ -162,7 +162,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     map.put(key1, value2);
     map.put(key2, value3);
 
-    for (IntObjectHashMap.IntObjectCursor c : map) {
+    for (LongIntHashMap.LongIntCursor c : map) {
       assertTrue(map.indexExists(c.index));
       assertEquals(c.value, map.indexGet(c.index));
     }
@@ -216,7 +216,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     map.put(key2, value2);
     map.put(key3, value3);
 
-    assertSameMap(map, new IntObjectHashMap(map));
+    assertSameMap(map, new LongIntHashMap(map));
   }
 
   /* */
@@ -226,8 +226,8 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     map.put(key2, value2);
     map.put(key3, value3);
 
-    IntObjectHashMap map2 =
-        IntObjectHashMap.from(newArray(key1, key2, key3), newvArray(value1, value2, value3));
+    LongIntHashMap map2 =
+        LongIntHashMap.from(newArray(key1, key2, key3), newvArray(value1, value2, value3));
 
     assertSameMap(map, map2);
   }
@@ -255,25 +255,10 @@ public class TestIntObjectHashMap extends LuceneTestCase {
 
   /* */
   @Test
-  public void testNullValue() {
-    map.put(key1, null);
-
-    assertTrue(map.containsKey(key1));
-    assertNull(map.get(key1));
-  }
-
-  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals(value1, map.put(key1, value3));
     assertEquals(value3, map.get(key1));
-
-    assertEquals(value3, map.put(key1, null));
-    assertTrue(map.containsKey(key1));
-    assertNull(map.get(key1));
-
-    assertNull(map.put(key1, value1));
-    assertEquals(value1, map.get(key1));
   }
 
   /* */
@@ -301,7 +286,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     map.put(key1, value1);
     map.put(key2, value1);
 
-    IntObjectHashMap map2 = newInstance();
+    LongIntHashMap map2 = newInstance();
 
     map2.put(key2, value2);
     map2.put(keyE, value1);
@@ -325,12 +310,24 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     assertEquals(value1, map.get(key1));
   }
 
+  @Test
+  public void testPutOrAdd() {
+    assertEquals(value1, map.putOrAdd(key1, value1, value2));
+    assertEquals(value3, map.putOrAdd(key1, value1, value2));
+  }
+
+  @Test
+  public void testAddTo() {
+    assertEquals(value1, map.addTo(key1, value1));
+    assertEquals(value3, map.addTo(key1, value2));
+  }
+
   /* */
   @Test
   public void testRemove() {
     map.put(key1, value1);
     assertEquals(value1, map.remove(key1));
-    assertEquals(null, map.remove(key1));
+    assertEquals(0, map.remove(key1));
     assertEquals(0, map.size());
 
     // These are internals, but perhaps worth asserting too.
@@ -352,17 +349,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     assertEquals(value1, map.iterator().next().value);
 
     map.remove(empty);
-    assertEquals(null, map.get(empty));
-
-    map.put(empty, null);
-    assertEquals(1, map.size());
-    assertTrue(map.containsKey(empty));
-    assertNull(map.get(empty));
-
-    map.remove(empty);
-    assertEquals(0, map.size());
-    assertFalse(map.containsKey(empty));
-    assertNull(map.get(empty));
+    assertEquals(0, map.get(empty));
   }
 
   /* */
@@ -383,7 +370,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     map.put(key3, value1);
 
     int counted = 0;
-    for (IntCursor c : map.keys()) {
+    for (LongCursor c : map.keys()) {
       assertEquals(map.keys[c.index], c.value);
       counted++;
     }
@@ -429,7 +416,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     map.remove(key2);
 
     int count = 0;
-    for (IntObjectHashMap.IntObjectCursor cursor : map) {
+    for (LongIntHashMap.LongIntCursor cursor : map) {
       count++;
       assertTrue(map.containsKey(cursor.key));
       assertEquals(cursor.value, map.get(cursor.key));
@@ -449,7 +436,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
     map =
-        new IntObjectHashMap(elements, 1f) {
+        new LongIntHashMap(elements, 1f) {
           @Override
           protected double verifyLoadFactor(double loadFactor) {
             // Skip load factor sanity range checking.
@@ -470,7 +457,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     }
 
     // Non-existent key.
-    int outOfSet = cast(elements + 1);
+    long outOfSet = cast(elements + 1);
     map.remove(outOfSet);
     assertFalse(map.containsKey(outOfSet));
     assertEquals(reallocationsBefore, reallocations.get());
@@ -491,17 +478,17 @@ public class TestIntObjectHashMap extends LuceneTestCase {
 
   @Test
   public void testHashCodeEquals() {
-    IntObjectHashMap l0 = newInstance();
+    LongIntHashMap l0 = newInstance();
     assertEquals(0, l0.hashCode());
     assertEquals(l0, newInstance());
 
-    IntObjectHashMap l1 =
-        IntObjectHashMap.from(newArray(key1, key2, key3), newvArray(value1, value2, value3));
+    LongIntHashMap l1 =
+        LongIntHashMap.from(newArray(key1, key2, key3), newvArray(value1, value2, value3));
 
-    IntObjectHashMap l2 =
-        IntObjectHashMap.from(newArray(key2, key1, key3), newvArray(value2, value1, value3));
+    LongIntHashMap l2 =
+        LongIntHashMap.from(newArray(key2, key1, key3), newvArray(value2, value1, value3));
 
-    IntObjectHashMap l3 = IntObjectHashMap.from(newArray(key1, key2), newvArray(value2, value1));
+    LongIntHashMap l3 = LongIntHashMap.from(newArray(key1, key2), newvArray(value2, value1));
 
     assertEquals(l1.hashCode(), l2.hashCode());
     assertEquals(l1, l2);
@@ -512,9 +499,9 @@ public class TestIntObjectHashMap extends LuceneTestCase {
 
   @Test
   public void testBug_HPPC37() {
-    IntObjectHashMap l1 = IntObjectHashMap.from(newArray(key1), newvArray(value1));
+    LongIntHashMap l1 = LongIntHashMap.from(newArray(key1), newvArray(value1));
 
-    IntObjectHashMap l2 = IntObjectHashMap.from(newArray(key2), newvArray(value1));
+    LongIntHashMap l2 = LongIntHashMap.from(newArray(key2), newvArray(value1));
 
     assertFalse(l1.equals(l2));
     assertFalse(l2.equals(l1));
@@ -529,7 +516,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     this.map.put(key2, value2);
     this.map.put(key3, value3);
 
-    IntObjectHashMap cloned = map.clone();
+    LongIntHashMap cloned = map.clone();
     cloned.remove(key1);
 
     assertSortedListEquals(map.keys().toArray(), key1, key2, key3);
@@ -559,7 +546,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     map.put(key3, value1);
 
     int counted = 0;
-    for (ObjectCursor c : map.values()) {
+    for (IntCursor c : map.values()) {
       assertEquals(map.values[c.index], c.value);
       counted++;
     }
@@ -569,15 +556,15 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   /* */
   @Test
   public void testEqualsSameClass() {
-    IntObjectHashMap l1 = newInstance();
+    LongIntHashMap l1 = newInstance();
     l1.put(k1, value0);
     l1.put(k2, value1);
     l1.put(k3, value2);
 
-    IntObjectHashMap l2 = new IntObjectHashMap(l1);
+    LongIntHashMap l2 = new LongIntHashMap(l1);
     l2.putAll(l1);
 
-    IntObjectHashMap l3 = new IntObjectHashMap(l2);
+    LongIntHashMap l3 = new LongIntHashMap(l2);
     l3.putAll(l2);
     l3.put(k4, value0);
 
@@ -589,18 +576,18 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   /* */
   @Test
   public void testEqualsSubClass() {
-    class Sub extends IntObjectHashMap {}
+    class Sub extends LongIntHashMap {}
 
-    IntObjectHashMap l1 = newInstance();
+    LongIntHashMap l1 = newInstance();
     l1.put(k1, value0);
     l1.put(k2, value1);
     l1.put(k3, value2);
 
-    IntObjectHashMap l2 = new Sub();
+    LongIntHashMap l2 = new Sub();
     l2.putAll(l1);
     l2.put(k4, value3);
 
-    IntObjectHashMap l3 = new Sub();
+    LongIntHashMap l3 = new Sub();
     l3.putAll(l2);
 
     assertNotEquals(l1, l2);

--- a/lucene/core/src/test/org/apache/lucene/util/hppc/TestLongObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hppc/TestLongObjectHashMap.java
@@ -17,50 +17,52 @@
 
 package org.apache.lucene.util.hppc;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.After;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
- * Tests for {@link IntIntHashMap}.
+ * Tests for {@link LongObjectHashMap}.
  *
- * <p>Mostly forked and trimmed from com.carrotsearch.hppc.IntIntHashMapTest
+ * <p>Mostly forked and trimmed from com.carrotsearch.hppc.LongObjectHashMapTest
  *
  * <p>github: https://github.com/carrotsearch/hppc release: 0.9.0
  */
-public class TestIntIntHashMap extends LuceneTestCase {
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class TestLongObjectHashMap extends LuceneTestCase {
   /* Ready to use key values. */
 
-  protected int keyE = 0;
-  protected int key0 = cast(0), k0 = key0;
-  protected int key1 = cast(1), k1 = key1;
-  protected int key2 = cast(2), k2 = key2;
-  protected int key3 = cast(3), k3 = key3;
-  protected int key4 = cast(4), k4 = key4;
-  protected int key5 = cast(5), k5 = key5;
-  protected int key6 = cast(6), k6 = key6;
-  protected int key7 = cast(7), k7 = key7;
-  protected int key8 = cast(8), k8 = key8;
-  protected int key9 = cast(9), k9 = key9;
+  protected long keyE = 0;
+  protected long key0 = cast(0), k0 = key0;
+  protected long key1 = cast(1), k1 = key1;
+  protected long key2 = cast(2), k2 = key2;
+  protected long key3 = cast(3), k3 = key3;
+  protected long key4 = cast(4), k4 = key4;
+  protected long key5 = cast(5), k5 = key5;
+  protected long key6 = cast(6), k6 = key6;
+  protected long key7 = cast(7), k7 = key7;
+  protected long key8 = cast(8), k8 = key8;
+  protected long key9 = cast(9), k9 = key9;
 
   /** Convert to target type from an integer used to test stuff. */
-  public int cast(int v) {
+  public long cast(int v) {
     return v;
   }
 
-  public int[] asArray(int... elements) {
-    int[] values = (new int[elements.length]);
+  public long[] asArray(long... elements) {
+    long[] values = (new long[elements.length]);
     for (int i = 0; i < elements.length; i++) values[i] = elements[i];
     return values;
   }
 
   /** Create a new array of a given type and copy the arguments to this array. */
   /*  */
-  public final int[] newArray(int... elements) {
+  public final long[] newArray(long... elements) {
     return elements;
   }
 
@@ -69,10 +71,17 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /** Check if the array's content is identical to a given sequence of elements. */
-  public static void assertSortedListEquals(int[] array, int... elements) {
+  public static void assertSortedListEquals(long[] array, long... elements) {
     assertEquals(elements.length, array.length);
     Arrays.sort(array);
     Arrays.sort(elements);
+    assertArrayEquals(elements, array);
+  }
+
+  /** Check if the array's content is identical to a given sequence of elements. */
+  public static void assertSortedListEquals(Object[] array, Object... elements) {
+    assertEquals(elements.length, array.length);
+    Arrays.sort(array);
     assertArrayEquals(elements, array);
   }
 
@@ -83,10 +92,10 @@ public class TestIntIntHashMap extends LuceneTestCase {
   protected int value4 = vcast(4);
 
   /** Per-test fresh initialized instance. */
-  public IntIntHashMap map = newInstance();
+  public LongObjectHashMap<Object> map = newInstance();
 
-  protected IntIntHashMap newInstance() {
-    return new IntIntHashMap();
+  protected LongObjectHashMap newInstance() {
+    return new LongObjectHashMap();
   }
 
   @After
@@ -113,14 +122,14 @@ public class TestIntIntHashMap extends LuceneTestCase {
 
   /** Create a new array of a given type and copy the arguments to this array. */
   /*  */
-  protected final int[] newvArray(int... elements) {
+  protected final Object[] newvArray(Object... elements) {
     return elements;
   }
 
-  private void assertSameMap(final IntIntHashMap c1, final IntIntHashMap c2) {
+  private void assertSameMap(final LongObjectHashMap<Object> c1, final LongObjectHashMap<Object> c2) {
     assertEquals(c1.size(), c2.size());
 
-    for (IntIntHashMap.IntIntCursor entry : c1) {
+    for (LongObjectHashMap.LongObjectCursor entry : c1) {
       assertTrue(c2.containsKey(entry.key));
       assertEquals(entry.value, c2.get(entry.key));
     }
@@ -130,8 +139,8 @@ public class TestIntIntHashMap extends LuceneTestCase {
   @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
-    IntIntHashMap map =
-        new IntIntHashMap(0) {
+    LongObjectHashMap map =
+        new LongObjectHashMap(0) {
           @Override
           protected void allocateBuffers(int arraySize) {
             super.allocateBuffers(arraySize);
@@ -160,7 +169,7 @@ public class TestIntIntHashMap extends LuceneTestCase {
     map.put(key1, value2);
     map.put(key2, value3);
 
-    for (IntIntHashMap.IntIntCursor c : map) {
+    for (LongObjectHashMap.LongObjectCursor c : map) {
       assertTrue(map.indexExists(c.index));
       assertEquals(c.value, map.indexGet(c.index));
     }
@@ -214,7 +223,7 @@ public class TestIntIntHashMap extends LuceneTestCase {
     map.put(key2, value2);
     map.put(key3, value3);
 
-    assertSameMap(map, new IntIntHashMap(map));
+    assertSameMap(map, new LongObjectHashMap(map));
   }
 
   /* */
@@ -224,8 +233,8 @@ public class TestIntIntHashMap extends LuceneTestCase {
     map.put(key2, value2);
     map.put(key3, value3);
 
-    IntIntHashMap map2 =
-        IntIntHashMap.from(newArray(key1, key2, key3), newvArray(value1, value2, value3));
+    LongObjectHashMap map2 =
+        LongObjectHashMap.from(newArray(key1, key2, key3), newvArray(value1, value2, value3));
 
     assertSameMap(map, map2);
   }
@@ -253,10 +262,25 @@ public class TestIntIntHashMap extends LuceneTestCase {
 
   /* */
   @Test
+  public void testNullValue() {
+    map.put(key1, null);
+
+    assertTrue(map.containsKey(key1));
+    assertNull(map.get(key1));
+  }
+
+  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals(value1, map.put(key1, value3));
     assertEquals(value3, map.get(key1));
+
+    assertEquals(value3, map.put(key1, null));
+    assertTrue(map.containsKey(key1));
+    assertNull(map.get(key1));
+
+    assertNull(map.put(key1, value1));
+    assertEquals(value1, map.get(key1));
   }
 
   /* */
@@ -284,7 +308,7 @@ public class TestIntIntHashMap extends LuceneTestCase {
     map.put(key1, value1);
     map.put(key2, value1);
 
-    IntIntHashMap map2 = newInstance();
+    LongObjectHashMap map2 = newInstance();
 
     map2.put(key2, value2);
     map2.put(keyE, value1);
@@ -308,24 +332,12 @@ public class TestIntIntHashMap extends LuceneTestCase {
     assertEquals(value1, map.get(key1));
   }
 
-  @Test
-  public void testPutOrAdd() {
-    assertEquals(value1, map.putOrAdd(key1, value1, value2));
-    assertEquals(value3, map.putOrAdd(key1, value1, value2));
-  }
-
-  @Test
-  public void testAddTo() {
-    assertEquals(value1, map.addTo(key1, value1));
-    assertEquals(value3, map.addTo(key1, value2));
-  }
-
   /* */
   @Test
   public void testRemove() {
     map.put(key1, value1);
     assertEquals(value1, map.remove(key1));
-    assertEquals(0, map.remove(key1));
+    assertEquals(null, map.remove(key1));
     assertEquals(0, map.size());
 
     // These are internals, but perhaps worth asserting too.
@@ -347,7 +359,17 @@ public class TestIntIntHashMap extends LuceneTestCase {
     assertEquals(value1, map.iterator().next().value);
 
     map.remove(empty);
-    assertEquals(0, map.get(empty));
+    assertEquals(null, map.get(empty));
+
+    map.put(empty, null);
+    assertEquals(1, map.size());
+    assertTrue(map.containsKey(empty));
+    assertNull(map.get(empty));
+
+    map.remove(empty);
+    assertEquals(0, map.size());
+    assertFalse(map.containsKey(empty));
+    assertNull(map.get(empty));
   }
 
   /* */
@@ -368,7 +390,7 @@ public class TestIntIntHashMap extends LuceneTestCase {
     map.put(key3, value1);
 
     int counted = 0;
-    for (IntCursor c : map.keys()) {
+    for (LongCursor c : map.keys()) {
       assertEquals(map.keys[c.index], c.value);
       counted++;
     }
@@ -414,7 +436,7 @@ public class TestIntIntHashMap extends LuceneTestCase {
     map.remove(key2);
 
     int count = 0;
-    for (IntIntHashMap.IntIntCursor cursor : map) {
+    for (LongObjectHashMap.LongObjectCursor cursor : map) {
       count++;
       assertTrue(map.containsKey(cursor.key));
       assertEquals(cursor.value, map.get(cursor.key));
@@ -434,7 +456,7 @@ public class TestIntIntHashMap extends LuceneTestCase {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
     map =
-        new IntIntHashMap(elements, 1f) {
+        new LongObjectHashMap(elements, 1f) {
           @Override
           protected double verifyLoadFactor(double loadFactor) {
             // Skip load factor sanity range checking.
@@ -455,7 +477,7 @@ public class TestIntIntHashMap extends LuceneTestCase {
     }
 
     // Non-existent key.
-    int outOfSet = cast(elements + 1);
+    long outOfSet = cast(elements + 1);
     map.remove(outOfSet);
     assertFalse(map.containsKey(outOfSet));
     assertEquals(reallocationsBefore, reallocations.get());
@@ -476,17 +498,17 @@ public class TestIntIntHashMap extends LuceneTestCase {
 
   @Test
   public void testHashCodeEquals() {
-    IntIntHashMap l0 = newInstance();
+    LongObjectHashMap l0 = newInstance();
     assertEquals(0, l0.hashCode());
     assertEquals(l0, newInstance());
 
-    IntIntHashMap l1 =
-        IntIntHashMap.from(newArray(key1, key2, key3), newvArray(value1, value2, value3));
+    LongObjectHashMap l1 =
+        LongObjectHashMap.from(newArray(key1, key2, key3), newvArray(value1, value2, value3));
 
-    IntIntHashMap l2 =
-        IntIntHashMap.from(newArray(key2, key1, key3), newvArray(value2, value1, value3));
+    LongObjectHashMap l2 =
+        LongObjectHashMap.from(newArray(key2, key1, key3), newvArray(value2, value1, value3));
 
-    IntIntHashMap l3 = IntIntHashMap.from(newArray(key1, key2), newvArray(value2, value1));
+    LongObjectHashMap l3 = LongObjectHashMap.from(newArray(key1, key2), newvArray(value2, value1));
 
     assertEquals(l1.hashCode(), l2.hashCode());
     assertEquals(l1, l2);
@@ -497,9 +519,9 @@ public class TestIntIntHashMap extends LuceneTestCase {
 
   @Test
   public void testBug_HPPC37() {
-    IntIntHashMap l1 = IntIntHashMap.from(newArray(key1), newvArray(value1));
+    LongObjectHashMap l1 = LongObjectHashMap.from(newArray(key1), newvArray(value1));
 
-    IntIntHashMap l2 = IntIntHashMap.from(newArray(key2), newvArray(value1));
+    LongObjectHashMap l2 = LongObjectHashMap.from(newArray(key2), newvArray(value1));
 
     assertFalse(l1.equals(l2));
     assertFalse(l2.equals(l1));
@@ -514,7 +536,7 @@ public class TestIntIntHashMap extends LuceneTestCase {
     this.map.put(key2, value2);
     this.map.put(key3, value3);
 
-    IntIntHashMap cloned = map.clone();
+    LongObjectHashMap cloned = map.clone();
     cloned.remove(key1);
 
     assertSortedListEquals(map.keys().toArray(), key1, key2, key3);
@@ -544,7 +566,7 @@ public class TestIntIntHashMap extends LuceneTestCase {
     map.put(key3, value1);
 
     int counted = 0;
-    for (IntCursor c : map.values()) {
+    for (ObjectCursor c : map.values()) {
       assertEquals(map.values[c.index], c.value);
       counted++;
     }
@@ -554,15 +576,15 @@ public class TestIntIntHashMap extends LuceneTestCase {
   /* */
   @Test
   public void testEqualsSameClass() {
-    IntIntHashMap l1 = newInstance();
+    LongObjectHashMap l1 = newInstance();
     l1.put(k1, value0);
     l1.put(k2, value1);
     l1.put(k3, value2);
 
-    IntIntHashMap l2 = new IntIntHashMap(l1);
+    LongObjectHashMap l2 = new LongObjectHashMap(l1);
     l2.putAll(l1);
 
-    IntIntHashMap l3 = new IntIntHashMap(l2);
+    LongObjectHashMap l3 = new LongObjectHashMap(l2);
     l3.putAll(l2);
     l3.put(k4, value0);
 
@@ -574,18 +596,18 @@ public class TestIntIntHashMap extends LuceneTestCase {
   /* */
   @Test
   public void testEqualsSubClass() {
-    class Sub extends IntIntHashMap {}
+    class Sub extends LongObjectHashMap {}
 
-    IntIntHashMap l1 = newInstance();
+    LongObjectHashMap l1 = newInstance();
     l1.put(k1, value0);
     l1.put(k2, value1);
     l1.put(k3, value2);
 
-    IntIntHashMap l2 = new Sub();
+    LongObjectHashMap l2 = new Sub();
     l2.putAll(l1);
     l2.put(k4, value3);
 
-    IntIntHashMap l3 = new Sub();
+    LongObjectHashMap l3 = new Sub();
     l3.putAll(l2);
 
     assertNotEquals(l1, l2);

--- a/lucene/core/src/test/org/apache/lucene/util/hppc/TestLongObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hppc/TestLongObjectHashMap.java
@@ -17,14 +17,13 @@
 
 package org.apache.lucene.util.hppc;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.After;
-import org.junit.Test;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.After;
+import org.junit.Test;
 
 /**
  * Tests for {@link LongObjectHashMap}.
@@ -126,7 +125,8 @@ public class TestLongObjectHashMap extends LuceneTestCase {
     return elements;
   }
 
-  private void assertSameMap(final LongObjectHashMap<Object> c1, final LongObjectHashMap<Object> c2) {
+  private void assertSameMap(
+      final LongObjectHashMap<Object> c1, final LongObjectHashMap<Object> c2) {
     assertEquals(c1.size(), c2.size());
 
     for (LongObjectHashMap.LongObjectCursor entry : c1) {

--- a/lucene/core/src/test/org/apache/lucene/util/hppc/TestLongObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hppc/TestLongObjectHashMap.java
@@ -53,12 +53,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
     return v;
   }
 
-  public long[] asArray(long... elements) {
-    long[] values = (new long[elements.length]);
-    for (int i = 0; i < elements.length; i++) values[i] = elements[i];
-    return values;
-  }
-
   /** Create a new array of a given type and copy the arguments to this array. */
   /*  */
   public final long[] newArray(long... elements) {

--- a/lucene/facet/src/java/org/apache/lucene/facet/range/OverlappingLongRangeCounter.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/OverlappingLongRangeCounter.java
@@ -16,12 +16,11 @@
  */
 package org.apache.lucene.facet.range;
 
+import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.LongIntHashMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import com.carrotsearch.hppc.LongArrayList;
-import com.carrotsearch.hppc.LongIntHashMap;
 import org.apache.lucene.util.FixedBitSet;
 
 /**

--- a/lucene/facet/src/java/org/apache/lucene/facet/range/OverlappingLongRangeCounter.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/OverlappingLongRangeCounter.java
@@ -244,17 +244,17 @@ class OverlappingLongRangeCounter extends LongRangeCounter {
     endsMap.put(Long.MAX_VALUE, 2);
 
     for (LongRange range : ranges) {
-      int cur = endsMap.get(range.min);
-      if (cur == 0) {
-        endsMap.put(range.min, 1);
+      int index = endsMap.indexOf(range.min);
+      if (index < 0) {
+        endsMap.indexInsert(index, range.min, 1);
       } else {
-        endsMap.put(range.min, cur | 1);
+        endsMap.indexReplace(index, endsMap.indexGet(index) | 1);
       }
-      cur = endsMap.get(range.max);
-      if (cur == 0) {
-        endsMap.put(range.max, 2);
+      index = endsMap.indexOf(range.max);
+      if (index < 0) {
+        endsMap.indexInsert(index, range.max, 2);
       } else {
-        endsMap.put(range.max, cur | 2);
+        endsMap.indexReplace(index, endsMap.indexGet(index) | 2);
       }
     }
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/range/OverlappingLongRangeCounter.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/OverlappingLongRangeCounter.java
@@ -17,10 +17,11 @@
 package org.apache.lucene.facet.range;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+
+import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.LongIntHashMap;
 import org.apache.lucene.util.FixedBitSet;
 
 /**
@@ -238,28 +239,28 @@ class OverlappingLongRangeCounter extends LongRangeCounter {
     // track the start vs end case separately because if a
     // given point is both, then it must be its own
     // elementary interval:
-    Map<Long, Integer> endsMap = new HashMap<>();
+    LongIntHashMap endsMap = new LongIntHashMap();
 
     endsMap.put(Long.MIN_VALUE, 1);
     endsMap.put(Long.MAX_VALUE, 2);
 
     for (LongRange range : ranges) {
-      Integer cur = endsMap.get(range.min);
-      if (cur == null) {
+      int cur = endsMap.get(range.min);
+      if (cur == 0) {
         endsMap.put(range.min, 1);
       } else {
         endsMap.put(range.min, cur | 1);
       }
       cur = endsMap.get(range.max);
-      if (cur == null) {
+      if (cur == 0) {
         endsMap.put(range.max, 2);
       } else {
         endsMap.put(range.max, cur | 2);
       }
     }
 
-    List<Long> endsList = new ArrayList<>(endsMap.keySet());
-    Collections.sort(endsList);
+    LongArrayList endsList = new LongArrayList(endsMap.keys());
+    Arrays.sort(endsList.buffer, 0, endsList.size());
 
     // Build elementaryIntervals (a 1D Venn diagram):
     List<InclusiveRange> elementaryIntervals = new ArrayList<>();

--- a/lucene/join/build.gradle
+++ b/lucene/join/build.gradle
@@ -21,5 +21,7 @@ description = 'Index-time and Query-time joins for normalized content'
 
 dependencies {
   moduleApi project(':lucene:core')
+  moduleImplementation 'com.carrotsearch:hppc'
+
   moduleTestImplementation project(':lucene:test-framework')
 }

--- a/lucene/join/src/java/module-info.java
+++ b/lucene/join/src/java/module-info.java
@@ -16,8 +16,10 @@
  */
 
 /** Index-time and Query-time joins for normalized content */
+@SuppressWarnings({"requires-automatic"})
 module org.apache.lucene.join {
   requires org.apache.lucene.core;
+  requires com.carrotsearch.hppc;
 
   exports org.apache.lucene.search.join;
 }

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingNearestChildrenKnnCollector.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingNearestChildrenKnnCollector.java
@@ -17,14 +17,13 @@
 
 package org.apache.lucene.search.join;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.lucene.search.AbstractKnnCollector;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.hppc.IntIntHashMap;
 
 /**
  * This collects the nearest children vectors. Diversifying the results over the provided parent
@@ -117,7 +116,7 @@ class DiversifyingNearestChildrenKnnCollector extends AbstractKnnCollector {
     // Used to keep track of nodeId -> positionInHeap. This way when new scores are added for a
     // node, the heap can be
     // updated efficiently.
-    private final Map<Integer, Integer> nodeIdHeapIndex;
+    private final IntIntHashMap nodeIdHeapIndex;
     private boolean closed = false;
 
     public NodeIdCachingHeap(int maxSize) {
@@ -130,8 +129,7 @@ class DiversifyingNearestChildrenKnnCollector extends AbstractKnnCollector {
       // NOTE: we add +1 because all access to heap is 1-based not 0-based.  heap[0] is unused.
       heapSize = maxSize + 1;
       this.maxSize = maxSize;
-      this.nodeIdHeapIndex =
-          new HashMap<>(maxSize < 2 ? maxSize + 1 : (int) (maxSize / 0.75 + 1.0));
+      this.nodeIdHeapIndex = new IntIntHashMap(maxSize);
       this.heapNodes = new ParentChildScore[heapSize];
     }
 
@@ -179,8 +177,9 @@ class DiversifyingNearestChildrenKnnCollector extends AbstractKnnCollector {
       if (closed) {
         throw new IllegalStateException();
       }
-      Integer previousNodeIndex = nodeIdHeapIndex.get(parentNode);
-      if (previousNodeIndex != null) {
+      int index = nodeIdHeapIndex.indexOf(parentNode);
+      if (index >= 0) {
+        int previousNodeIndex = nodeIdHeapIndex.indexGet(index);
         if (heapNodes[previousNodeIndex].score < score) {
           updateElement(previousNodeIndex, node, parentNode, score);
           return true;

--- a/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
@@ -17,13 +17,15 @@
 package org.apache.lucene.search.join;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Locale;
-import java.util.Map;
-import java.util.TreeSet;
-import java.util.function.BiConsumer;
-import java.util.function.LongFunction;
+import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.LongFloatHashMap;
+import com.carrotsearch.hppc.LongHashSet;
+import com.carrotsearch.hppc.LongIntHashMap;
+import com.carrotsearch.hppc.cursors.LongCursor;
+import com.carrotsearch.hppc.procedures.LongFloatProcedure;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.IntPoint;
@@ -147,46 +149,55 @@ public final class JoinUtil {
       IndexSearcher fromSearcher,
       ScoreMode scoreMode)
       throws IOException {
-    TreeSet<Long> joinValues = new TreeSet<>();
-    Map<Long, Float> aggregatedScores = new HashMap<>();
-    Map<Long, Integer> occurrences = new HashMap<>();
+    LongHashSet joinValues = new LongHashSet();
+    LongFloatHashMap aggregatedScores = new LongFloatHashMap();
+    LongIntHashMap occurrences = new LongIntHashMap();
     boolean needsScore = scoreMode != ScoreMode.None;
-    BiConsumer<Long, Float> scoreAggregator;
+    LongFloatProcedure scoreAggregator;
     if (scoreMode == ScoreMode.Max) {
       scoreAggregator =
           (key, score) -> {
-            Float currentValue = aggregatedScores.putIfAbsent(key, score);
-            if (currentValue != null) {
-              aggregatedScores.put(key, Math.max(currentValue, score));
-            }
-          };
+          int index = aggregatedScores.indexOf(key);
+          if (index < 0) {
+              aggregatedScores.indexInsert(index, key, score);
+          } else {
+              float currentScore = aggregatedScores.indexGet(index);
+              aggregatedScores.indexReplace(index, Math.max(currentScore, score));
+          }
+      };
     } else if (scoreMode == ScoreMode.Min) {
       scoreAggregator =
           (key, score) -> {
-            Float currentValue = aggregatedScores.putIfAbsent(key, score);
-            if (currentValue != null) {
-              aggregatedScores.put(key, Math.min(currentValue, score));
-            }
+              int index = aggregatedScores.indexOf(key);
+              if (index < 0) {
+                  aggregatedScores.indexInsert(index, key, score);
+              } else {
+                  float currentScore = aggregatedScores.indexGet(index);
+                  aggregatedScores.indexReplace(index, Math.min(currentScore, score));
+              }
           };
     } else if (scoreMode == ScoreMode.Total) {
       scoreAggregator =
           (key, score) -> {
-            Float currentValue = aggregatedScores.putIfAbsent(key, score);
-            if (currentValue != null) {
-              aggregatedScores.put(key, currentValue + score);
-            }
+              int index = aggregatedScores.indexOf(key);
+              if (index < 0) {
+                  aggregatedScores.indexInsert(index, key, score);
+              } else {
+                  float currentScore = aggregatedScores.indexGet(index);
+                  aggregatedScores.indexReplace(index, currentScore + score);
+              }
           };
     } else if (scoreMode == ScoreMode.Avg) {
       scoreAggregator =
           (key, score) -> {
-            Float currentSore = aggregatedScores.putIfAbsent(key, score);
-            if (currentSore != null) {
-              aggregatedScores.put(key, currentSore + score);
-            }
-            Integer currentOccurrence = occurrences.putIfAbsent(key, 1);
-            if (currentOccurrence != null) {
-              occurrences.put(key, ++currentOccurrence);
-            }
+              int index = aggregatedScores.indexOf(key);
+              if (index < 0) {
+                  aggregatedScores.indexInsert(index, key, score);
+              } else {
+                  float currentScore = aggregatedScores.indexGet(index);
+                  aggregatedScores.indexReplace(index, currentScore + score);
+              }
+              occurrences.addTo(key, 1);
           };
     } else {
       scoreAggregator =
@@ -195,12 +206,12 @@ public final class JoinUtil {
           };
     }
 
-    LongFunction<Float> joinScorer;
+    LongFloatFunction joinScorer;
     if (scoreMode == ScoreMode.Avg) {
       joinScorer =
           (joinValue) -> {
-            Float aggregatedScore = aggregatedScores.get(joinValue);
-            Integer occurrence = occurrences.get(joinValue);
+            float aggregatedScore = aggregatedScores.get(joinValue);
+            int occurrence = occurrences.get(joinValue);
             return aggregatedScore / occurrence;
           };
     } else {
@@ -222,7 +233,7 @@ public final class JoinUtil {
                   long value = sortedNumericDocValues.nextValue();
                   joinValues.add(value);
                   if (needsScore) {
-                    scoreAggregator.accept(value, scorer.score());
+                    scoreAggregator.apply(value, scorer.score());
                   }
                 }
               }
@@ -271,7 +282,7 @@ public final class JoinUtil {
               }
               joinValues.add(value);
               if (needsScore) {
-                scoreAggregator.accept(value, scorer.score());
+                scoreAggregator.apply(value, scorer.score());
               }
             }
 
@@ -296,7 +307,9 @@ public final class JoinUtil {
     }
     fromSearcher.search(fromQuery, collector);
 
-    Iterator<Long> iterator = joinValues.iterator();
+    LongArrayList joinValuesList = new LongArrayList(joinValues);
+    Arrays.sort(joinValuesList.buffer, 0, joinValuesList.size());
+    Iterator<LongCursor> iterator = joinValuesList.iterator();
 
     final int bytesPerDim;
     final BytesRef encoded = new BytesRef();
@@ -308,10 +321,10 @@ public final class JoinUtil {
             @Override
             public BytesRef next() {
               if (iterator.hasNext()) {
-                long value = iterator.next();
-                IntPoint.encodeDimension((int) value, encoded.bytes, 0);
+                LongCursor value = iterator.next();
+                IntPoint.encodeDimension((int) value.value, encoded.bytes, 0);
                 if (needsScore) {
-                  score = joinScorer.apply(value);
+                  score = joinScorer.apply(value.value);
                 }
                 return encoded;
               } else {
@@ -326,10 +339,10 @@ public final class JoinUtil {
             @Override
             public BytesRef next() {
               if (iterator.hasNext()) {
-                long value = iterator.next();
-                LongPoint.encodeDimension(value, encoded.bytes, 0);
+                LongCursor value = iterator.next();
+                LongPoint.encodeDimension(value.value, encoded.bytes, 0);
                 if (needsScore) {
-                  score = joinScorer.apply(value);
+                  score = joinScorer.apply(value.value);
                 }
                 return encoded;
               } else {
@@ -344,10 +357,10 @@ public final class JoinUtil {
             @Override
             public BytesRef next() {
               if (iterator.hasNext()) {
-                long value = iterator.next();
-                FloatPoint.encodeDimension(Float.intBitsToFloat((int) value), encoded.bytes, 0);
+                LongCursor value = iterator.next();
+                FloatPoint.encodeDimension(Float.intBitsToFloat((int) value.value), encoded.bytes, 0);
                 if (needsScore) {
-                  score = joinScorer.apply(value);
+                  score = joinScorer.apply(value.value);
                 }
                 return encoded;
               } else {
@@ -362,10 +375,10 @@ public final class JoinUtil {
             @Override
             public BytesRef next() {
               if (iterator.hasNext()) {
-                long value = iterator.next();
-                DoublePoint.encodeDimension(Double.longBitsToDouble(value), encoded.bytes, 0);
+                LongCursor value = iterator.next();
+                DoublePoint.encodeDimension(Double.longBitsToDouble(value.value), encoded.bytes, 0);
                 if (needsScore) {
-                  score = joinScorer.apply(value);
+                  score = joinScorer.apply(value.value);
                 }
                 return encoded;
               } else {
@@ -582,5 +595,11 @@ public final class JoinUtil {
         min,
         max,
         searcher.getTopReaderContext().id());
+  }
+
+  /** Similar to {@link java.util.function.LongFunction} for primitive argument and result. */
+  private interface LongFloatFunction {
+
+    float apply(long value);
   }
 }

--- a/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
@@ -177,26 +177,11 @@ public final class JoinUtil {
             }
           };
     } else if (scoreMode == ScoreMode.Total) {
-      scoreAggregator =
-          (key, score) -> {
-            int index = aggregatedScores.indexOf(key);
-            if (index < 0) {
-              aggregatedScores.indexInsert(index, key, score);
-            } else {
-              float currentScore = aggregatedScores.indexGet(index);
-              aggregatedScores.indexReplace(index, currentScore + score);
-            }
-          };
+      scoreAggregator = aggregatedScores::addTo;
     } else if (scoreMode == ScoreMode.Avg) {
       scoreAggregator =
           (key, score) -> {
-            int index = aggregatedScores.indexOf(key);
-            if (index < 0) {
-              aggregatedScores.indexInsert(index, key, score);
-            } else {
-              float currentScore = aggregatedScores.indexGet(index);
-              aggregatedScores.indexReplace(index, currentScore + score);
-            }
+            aggregatedScores.addTo(key, score);
             occurrences.addTo(key, 1);
           };
     } else {

--- a/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
@@ -16,16 +16,16 @@
  */
 package org.apache.lucene.search.join;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.Locale;
 import com.carrotsearch.hppc.LongArrayList;
 import com.carrotsearch.hppc.LongFloatHashMap;
 import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongIntHashMap;
 import com.carrotsearch.hppc.cursors.LongCursor;
 import com.carrotsearch.hppc.procedures.LongFloatProcedure;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Locale;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.IntPoint;
@@ -157,47 +157,47 @@ public final class JoinUtil {
     if (scoreMode == ScoreMode.Max) {
       scoreAggregator =
           (key, score) -> {
-          int index = aggregatedScores.indexOf(key);
-          if (index < 0) {
+            int index = aggregatedScores.indexOf(key);
+            if (index < 0) {
               aggregatedScores.indexInsert(index, key, score);
-          } else {
+            } else {
               float currentScore = aggregatedScores.indexGet(index);
               aggregatedScores.indexReplace(index, Math.max(currentScore, score));
-          }
-      };
+            }
+          };
     } else if (scoreMode == ScoreMode.Min) {
       scoreAggregator =
           (key, score) -> {
-              int index = aggregatedScores.indexOf(key);
-              if (index < 0) {
-                  aggregatedScores.indexInsert(index, key, score);
-              } else {
-                  float currentScore = aggregatedScores.indexGet(index);
-                  aggregatedScores.indexReplace(index, Math.min(currentScore, score));
-              }
+            int index = aggregatedScores.indexOf(key);
+            if (index < 0) {
+              aggregatedScores.indexInsert(index, key, score);
+            } else {
+              float currentScore = aggregatedScores.indexGet(index);
+              aggregatedScores.indexReplace(index, Math.min(currentScore, score));
+            }
           };
     } else if (scoreMode == ScoreMode.Total) {
       scoreAggregator =
           (key, score) -> {
-              int index = aggregatedScores.indexOf(key);
-              if (index < 0) {
-                  aggregatedScores.indexInsert(index, key, score);
-              } else {
-                  float currentScore = aggregatedScores.indexGet(index);
-                  aggregatedScores.indexReplace(index, currentScore + score);
-              }
+            int index = aggregatedScores.indexOf(key);
+            if (index < 0) {
+              aggregatedScores.indexInsert(index, key, score);
+            } else {
+              float currentScore = aggregatedScores.indexGet(index);
+              aggregatedScores.indexReplace(index, currentScore + score);
+            }
           };
     } else if (scoreMode == ScoreMode.Avg) {
       scoreAggregator =
           (key, score) -> {
-              int index = aggregatedScores.indexOf(key);
-              if (index < 0) {
-                  aggregatedScores.indexInsert(index, key, score);
-              } else {
-                  float currentScore = aggregatedScores.indexGet(index);
-                  aggregatedScores.indexReplace(index, currentScore + score);
-              }
-              occurrences.addTo(key, 1);
+            int index = aggregatedScores.indexOf(key);
+            if (index < 0) {
+              aggregatedScores.indexInsert(index, key, score);
+            } else {
+              float currentScore = aggregatedScores.indexGet(index);
+              aggregatedScores.indexReplace(index, currentScore + score);
+            }
+            occurrences.addTo(key, 1);
           };
     } else {
       scoreAggregator =
@@ -358,7 +358,8 @@ public final class JoinUtil {
             public BytesRef next() {
               if (iterator.hasNext()) {
                 LongCursor value = iterator.next();
-                FloatPoint.encodeDimension(Float.intBitsToFloat((int) value.value), encoded.bytes, 0);
+                FloatPoint.encodeDimension(
+                    Float.intBitsToFloat((int) value.value), encoded.bytes, 0);
                 if (needsScore) {
                   score = joinScorer.apply(value.value);
                 }

--- a/lucene/misc/src/java/org/apache/lucene/misc/search/DiversifiedTopDocsCollector.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/search/DiversifiedTopDocsCollector.java
@@ -19,8 +19,6 @@ package org.apache.lucene.misc.search;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.misc.search.DiversifiedTopDocsCollector.ScoreDocKey;
@@ -32,6 +30,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.PriorityQueue;
+import org.apache.lucene.util.hppc.LongObjectHashMap;
 
 /**
  * A {@link TopDocsCollector} that controls diversity in results by ensuring no more than
@@ -69,7 +68,7 @@ public abstract class DiversifiedTopDocsCollector extends TopDocsCollector<Score
   ScoreDocKey spare;
   private ScoreDocKeyQueue globalQueue;
   private int numHits;
-  private Map<Long, ScoreDocKeyQueue> perKeyQueues;
+  private LongObjectHashMap<ScoreDocKeyQueue> perKeyQueues;
   protected int maxNumPerKey;
   private Deque<ScoreDocKeyQueue> sparePerKeyQueues = new ArrayDeque<>();
 
@@ -77,7 +76,7 @@ public abstract class DiversifiedTopDocsCollector extends TopDocsCollector<Score
     super(new ScoreDocKeyQueue(numHits));
     // Need to access pq.lessThan() which is protected so have to cast here...
     this.globalQueue = (ScoreDocKeyQueue) pq;
-    perKeyQueues = new HashMap<Long, ScoreDocKeyQueue>();
+    perKeyQueues = new LongObjectHashMap<>();
     this.numHits = numHits;
     this.maxNumPerKey = maxHitsPerKey;
   }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/TermAutomatonQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/TermAutomatonQuery.java
@@ -54,6 +54,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.Transition;
+import org.apache.lucene.util.hppc.IntObjectHashMap;
 
 // TODO
 //    - compare perf to PhraseQuery exact and sloppy
@@ -86,7 +87,7 @@ public class TermAutomatonQuery extends Query implements Accountable {
   private final Automaton.Builder builder;
   Automaton det;
   private final Map<BytesRef, Integer> termToID = new HashMap<>();
-  private final Map<Integer, BytesRef> idToTerm = new HashMap<>();
+  private final IntObjectHashMap<BytesRef> idToTerm = new IntObjectHashMap<>();
   private int anyTermID = -1;
 
   public TermAutomatonQuery(String field) {
@@ -209,7 +210,7 @@ public class TermAutomatonQuery extends Query implements Accountable {
   @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
       throws IOException {
-    Map<Integer, TermStates> termStates = new HashMap<>();
+    IntObjectHashMap<TermStates> termStates = new IntObjectHashMap<>();
 
     for (Map.Entry<BytesRef, Integer> ent : termToID.entrySet()) {
       if (ent.getKey() != null) {
@@ -360,14 +361,14 @@ public class TermAutomatonQuery extends Query implements Accountable {
 
   final class TermAutomatonWeight extends Weight {
     final Automaton automaton;
-    private final Map<Integer, TermStates> termStates;
+    private final IntObjectHashMap<TermStates> termStates;
     private final Similarity.SimScorer stats;
     private final Similarity similarity;
 
     public TermAutomatonWeight(
         Automaton automaton,
         IndexSearcher searcher,
-        Map<Integer, TermStates> termStates,
+        IntObjectHashMap<TermStates> termStates,
         float boost)
         throws IOException {
       super(TermAutomatonQuery.this);
@@ -375,14 +376,13 @@ public class TermAutomatonQuery extends Query implements Accountable {
       this.termStates = termStates;
       this.similarity = searcher.getSimilarity();
       List<TermStatistics> allTermStats = new ArrayList<>();
-      for (Map.Entry<Integer, BytesRef> ent : idToTerm.entrySet()) {
-        Integer termID = ent.getKey();
-        if (ent.getValue() != null) {
-          TermStates ts = termStates.get(termID);
+      for (IntObjectHashMap.IntObjectCursor<BytesRef> ent : idToTerm) {
+        if (ent.value != null) {
+          TermStates ts = termStates.get(ent.key);
           if (ts.docFreq() > 0) {
             allTermStats.add(
                 searcher.termStatistics(
-                    new Term(field, ent.getValue()), ts.docFreq(), ts.totalTermFreq()));
+                    new Term(field, ent.value), ts.docFreq(), ts.totalTermFreq()));
           }
         }
       }
@@ -410,18 +410,18 @@ public class TermAutomatonQuery extends Query implements Accountable {
       EnumAndScorer[] enums = new EnumAndScorer[idToTerm.size()];
 
       boolean any = false;
-      for (Map.Entry<Integer, TermStates> ent : termStates.entrySet()) {
-        TermStates termStates = ent.getValue();
+      for (IntObjectHashMap.IntObjectCursor<TermStates> ent : termStates) {
+        TermStates termStates = ent.value;
         assert termStates.wasBuiltFor(ReaderUtil.getTopLevelContext(context))
             : "The top-reader used to create Weight is not the same as the current reader's top-reader ("
                 + ReaderUtil.getTopLevelContext(context);
-        BytesRef term = idToTerm.get(ent.getKey());
+        BytesRef term = idToTerm.get(ent.key);
         TermState state = termStates.get(context);
         if (state != null) {
           TermsEnum termsEnum = context.reader().terms(field).iterator();
           termsEnum.seekExact(term, state);
-          enums[ent.getKey()] =
-              new EnumAndScorer(ent.getKey(), termsEnum.postings(null, PostingsEnum.POSITIONS));
+          enums[ent.key] =
+              new EnumAndScorer(ent.key, termsEnum.postings(null, PostingsEnum.POSITIONS));
           any = true;
         }
       }

--- a/lucene/spatial-extras/build.gradle
+++ b/lucene/spatial-extras/build.gradle
@@ -30,6 +30,8 @@ dependencies {
   moduleApi 'org.locationtech.spatial4j:spatial4j'
   moduleApi 'io.sgr:s2-geometry-library-java'
 
+  moduleImplementation 'com.carrotsearch:hppc'
+
   moduleTestImplementation project(':lucene:test-framework')
   moduleTestImplementation project(':lucene:spatial-test-fixtures')
   moduleTestImplementation 'org.locationtech.jts:jts-core'

--- a/lucene/spatial-extras/src/java/module-info.java
+++ b/lucene/spatial-extras/src/java/module-info.java
@@ -20,6 +20,7 @@
 module org.apache.lucene.spatial_extras {
   requires spatial4j;
   requires s2.geometry.library.java;
+  requires com.carrotsearch.hppc;
   requires org.apache.lucene.core;
   requires org.apache.lucene.spatial3d;
 

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/util/CachingDoubleValueSource.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/util/CachingDoubleValueSource.java
@@ -16,13 +16,13 @@
  */
 package org.apache.lucene.spatial.util;
 
+import com.carrotsearch.hppc.IntDoubleHashMap;
 import java.io.IOException;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DoubleValues;
 import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
-import com.carrotsearch.hppc.IntDoubleHashMap;
 
 /**
  * Caches the doubleVal of another value source in a HashMap so that it is computed only once.

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/util/CachingDoubleValueSource.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/util/CachingDoubleValueSource.java
@@ -22,7 +22,7 @@ import org.apache.lucene.search.DoubleValues;
 import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.util.hppc.IntObjectHashMap;
+import com.carrotsearch.hppc.IntDoubleHashMap;
 
 /**
  * Caches the doubleVal of another value source in a HashMap so that it is computed only once.
@@ -32,11 +32,11 @@ import org.apache.lucene.util.hppc.IntObjectHashMap;
 public class CachingDoubleValueSource extends DoubleValuesSource {
 
   final DoubleValuesSource source;
-  final IntObjectHashMap<Double> cache;
+  final IntDoubleHashMap cache;
 
   public CachingDoubleValueSource(DoubleValuesSource source) {
     this.source = source;
-    cache = new IntObjectHashMap<>();
+    cache = new IntDoubleHashMap();
   }
 
   @Override
@@ -53,11 +53,14 @@ public class CachingDoubleValueSource extends DoubleValuesSource {
 
       @Override
       public double doubleValue() throws IOException {
+        double v;
         int key = base + doc;
-        Double v = cache.get(key);
-        if (v == null) {
+        int index = cache.indexOf(key);
+        if (index < 0) {
           v = vals.doubleValue();
-          cache.put(key, v);
+          cache.indexInsert(index, key, v);
+        } else {
+          v = cache.indexGet(index);
         }
         return v;
       }


### PR DESCRIPTION
No functional changes, only replacements by primitve maps.

Adds LongObjectHashMap and LongIntHashMap to the org.apache.lucene.util.hppc package, with some refactoring.

Adds a dependency to com.carrotsearch.hppc to the join and spatial modules. This dependency is already present in the facet module. This way these packages can use primitive hash map with float or double values.

The changes in the JoinUtil class are a good example of usage of primitive structures. This highly reduces the auto-boxing around primitives.