### PR TITLE
Add support for reloading the SPI for KnnVectorsFormat class

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -392,6 +392,8 @@ Other
 
 * GITHUB#13385: Make NO_INTERVALS source as public to be used by Lucene clients instead of creating clones themselves (Aniketh Jain)
 
+* GITHUB#13393: Add support for reloading the SPI for KnnVectorsFormat class (Navneet Verma)
+
 ======================== Lucene 9.10.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -68,6 +68,19 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
     return name;
   }
 
+  /**
+   * Reloads the KnnVectorsFormat list from the given {@link ClassLoader}.
+   *
+   * <p><b>NOTE:</b> Only new KnnVectorsFormat are added, existing ones are never removed or
+   * replaced.
+   *
+   * <p><em>This method is expensive and should only be called for discovery of new KnnVectorsFormat
+   * on the given classpath/classloader!</em>
+   */
+  public static void reloadKnnVectorsFormat(ClassLoader classloader) {
+    Holder.getLoader().reload(classloader);
+  }
+
   /** looks up a format by name */
   public static KnnVectorsFormat forName(String name) {
     return Holder.getLoader().lookup(name);


### PR DESCRIPTION
### Description
Add support for reloading the SPI for KnnVectorsFormat class

Ref: https://github.com/apache/lucene/issues/13393

I would also like to backport it to 9.x branch of Lucene

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
