### PR TITLE
Delete all live docs when query matched a whole segment.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -412,7 +412,6 @@ final class FrozenBufferedUpdates {
             // deleted count?
             // TODO: We just Implemented isMatchAll for PointRangeQuery, Does TermRangeQuery needs
             // this?
-            // TODO: Check whether applyTermDeletes needs this.
             if (scorer.isMatchAll()) {
               delCount += segState.rld.deleteAll();
               assert segState.rld.isFullyDeleted();
@@ -475,10 +474,10 @@ final class FrozenBufferedUpdates {
       BytesRef delTerm;
       TermDocsIterator termDocsIterator = new TermDocsIterator(segState.reader, true);
       while ((delTerm = iter.next()) != null) {
-        // TODO: Maybe we need postings' docCount to judge whether match all.
         final DocIdSetIterator iterator = termDocsIterator.nextTerm(iter.field(), delTerm);
         if (iterator != null) {
           int docID;
+          // One term matches all docs is unusual.
           while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
             // NOTE: there is no limit check on the docID
             // when deleting by Term (unlike by Query)

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -475,6 +475,8 @@ final class FrozenBufferedUpdates {
       BytesRef delTerm;
       TermDocsIterator termDocsIterator = new TermDocsIterator(segState.reader, true);
       while ((delTerm = iter.next()) != null) {
+        // TODO: We need docCount to judge whether match all.
+        // TODO: We can break loop, when already fully deleted. (same to delete by query)
         final DocIdSetIterator iterator = termDocsIterator.nextTerm(iter.field(), delTerm);
         if (iterator != null) {
           int docID;

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -475,8 +475,7 @@ final class FrozenBufferedUpdates {
       BytesRef delTerm;
       TermDocsIterator termDocsIterator = new TermDocsIterator(segState.reader, true);
       while ((delTerm = iter.next()) != null) {
-        // TODO: We need docCount to judge whether match all.
-        // TODO: We can break loop, when already fully deleted. (same to delete by query)
+        // TODO: Maybe we need postings' docCount to judge whether match all.
         final DocIdSetIterator iterator = termDocsIterator.nextTerm(iter.field(), delTerm);
         if (iterator != null) {
           int docID;

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -477,7 +477,8 @@ final class FrozenBufferedUpdates {
         final DocIdSetIterator iterator = termDocsIterator.nextTerm(iter.field(), delTerm);
         if (iterator != null) {
           int docID;
-          // One term matches all docs is unusual.
+          // It is unusual that one term matches all docs, so it is worthless to implement delete
+          // all.
           while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
             // NOTE: there is no limit check on the docID
             // when deleting by Term (unlike by Query)

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -410,7 +410,8 @@ final class FrozenBufferedUpdates {
           } else {
             // TODO: Cant we just set this segment fully deleted, without keeping the correct
             // deleted count?
-            // TODO: We just Implemented isMatchAll for PointRangeQuery, Does TermRangeQuery needs this?
+            // TODO: We just Implemented isMatchAll for PointRangeQuery, Does TermRangeQuery needs
+            // this?
             // TODO: Check whether applyTermDeletes needs this.
             if (scorer.isMatchAll()) {
               delCount += segState.rld.deleteAll();

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -408,10 +408,19 @@ final class FrozenBufferedUpdates {
               }
             }
           } else {
-            int docID;
-            while ((docID = it.nextDoc()) < limit) {
-              if (segState.rld.delete(docID)) {
-                delCount++;
+            // TODO: Cant we just set this segment fully deleted, without keeping the correct
+            // deleted count?
+            // TODO: We just Implemented isMatchAll for PointRangeQuery, Does TermRangeQuery needs this?
+            // TODO: Check whether applyTermDeletes needs this.
+            if (scorer.isMatchAll()) {
+              delCount += segState.rld.deleteAll();
+              assert segState.rld.isFullyDeleted();
+            } else {
+              int docID;
+              while ((docID = it.nextDoc()) < limit) {
+                if (segState.rld.delete(docID)) {
+                  delCount++;
+                }
               }
             }
           }

--- a/lucene/core/src/java/org/apache/lucene/index/PendingDeletes.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PendingDeletes.java
@@ -105,6 +105,19 @@ class PendingDeletes {
     return didDelete;
   }
 
+  /** Delete all live documents in this segment and return deleted count. */
+  // TODO: Cant we just set this segment fully deleted, without keep the correct deleted count?
+  long deleteAll() throws IOException {
+    assert info.info.maxDoc() > 0;
+    FixedBitSet mutableBits = getMutableBits();
+    assert mutableBits != null;
+
+    int liveCount = mutableBits.cardinality();
+    mutableBits.clear();
+    pendingDeleteCount += liveCount;
+    return liveCount;
+  }
+
   /** Returns a snapshot of the current live docs. */
   Bits getLiveDocs() {
     // Prevent modifications to the returned live docs

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -197,6 +197,13 @@ final class ReadersAndUpdates {
     return pendingDeletes.delete(docID);
   }
 
+  public synchronized long deleteAll() throws IOException {
+    if (reader == null && pendingDeletes.mustInitOnDelete()) {
+      getReader(IOContext.DEFAULT).decRef(); // pass a reader to initialize the pending deletes
+    }
+    return pendingDeletes.deleteAll();
+  }
+
   // NOTE: removes callers ref
   public synchronized void dropReaders() throws IOException {
     // TODO: can we somehow use IOUtils here...?  problem is

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -347,8 +347,11 @@ public abstract class PointRangeQuery extends Query {
           return new ScorerSupplier() {
             @Override
             public Scorer get(long leadCost) {
-              return new ConstantScoreScorer(
-                  weight, score(), scoreMode, DocIdSetIterator.all(reader.maxDoc()));
+              ConstantScoreScorer constantScoreScorer =
+                  new ConstantScoreScorer(
+                      weight, score(), scoreMode, DocIdSetIterator.all(reader.maxDoc()));
+              constantScoreScorer.setMatchAll(true);
+              return constantScoreScorer;
             }
 
             @Override

--- a/lucene/core/src/java/org/apache/lucene/search/Scorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Scorer.java
@@ -30,6 +30,8 @@ public abstract class Scorer extends Scorable {
   /** the Scorer's parent Weight */
   protected final Weight weight;
 
+  private boolean isMatchAll;
+
   /**
    * Constructs a Scorer
    *
@@ -98,4 +100,14 @@ public abstract class Scorer extends Scorable {
    * {@link #advanceShallow(int) shallow-advanced} to included and {@code upTo} included.
    */
   public abstract float getMaxScore(int upTo) throws IOException;
+
+  /** Set whether we can match all docs in this scored segment. */
+  public void setMatchAll(boolean isMatchAll) {
+    this.isMatchAll = isMatchAll;
+  }
+
+  /** Return true if we matched all docs in this scored segment. */
+  public boolean isMatchAll() {
+    return isMatchAll;
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -226,49 +226,6 @@ public class TestIndexWriter extends LuceneTestCase {
     dir.close();
   }
 
-  public void testDeleteByTerms() throws IOException {
-    Directory dir = newDirectory();
-    IndexWriter writer =
-        new IndexWriter(
-            dir,
-            new IndexWriterConfig(new MockAnalyzer(random()))
-                .setMergePolicy(NoMergePolicy.INSTANCE));
-
-    Document doc;
-    for (int i = 0; i < 10; i++) {
-      doc = new Document();
-      doc.add(new KeywordField("content", i + "", Field.Store.NO));
-      writer.addDocument(doc);
-    }
-    writer.flush();
-
-    for (int i = 10; i < 20; i++) {
-      doc = new Document();
-      doc.add(new KeywordField("content", i + "", Field.Store.NO));
-      writer.addDocument(doc);
-    }
-    writer.flush();
-
-    for (int i = 20; i < 30; i++) {
-      doc = new Document();
-      doc.add(new KeywordField("content", i + "", Field.Store.NO));
-      writer.addDocument(doc);
-    }
-    writer.flush();
-    writer.deleteDocuments(new Term("content", "10"));
-
-    DirectoryReader reader = DirectoryReader.open(writer);
-    IndexSearcher searcher = newSearcher(reader);
-    assertEquals(
-        0, searcher.search(LongPoint.newRangeQuery("content", 10, 19), 100).totalHits.value);
-    assertEquals(
-        20, searcher.search(LongPoint.newRangeQuery("content", 0, 30), 100).totalHits.value);
-
-    reader.close();
-    writer.close();
-    dir.close();
-  }
-
   static void addDoc(IndexWriter writer) throws IOException {
     Document doc = new Document();
     doc.add(newTextField("content", "aaa", Field.Store.NO));

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -226,6 +226,49 @@ public class TestIndexWriter extends LuceneTestCase {
     dir.close();
   }
 
+  public void testDeleteByTerms() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter writer =
+        new IndexWriter(
+            dir,
+            new IndexWriterConfig(new MockAnalyzer(random()))
+                .setMergePolicy(NoMergePolicy.INSTANCE));
+
+    Document doc;
+    for (int i = 0; i < 10; i++) {
+      doc = new Document();
+      doc.add(new KeywordField("content", i + "", Field.Store.NO));
+      writer.addDocument(doc);
+    }
+    writer.flush();
+
+    for (int i = 10; i < 20; i++) {
+      doc = new Document();
+      doc.add(new KeywordField("content", i + "", Field.Store.NO));
+      writer.addDocument(doc);
+    }
+    writer.flush();
+
+    for (int i = 20; i < 30; i++) {
+      doc = new Document();
+      doc.add(new KeywordField("content", i + "", Field.Store.NO));
+      writer.addDocument(doc);
+    }
+    writer.flush();
+    writer.deleteDocuments(new Term("content", "10"));
+
+    DirectoryReader reader = DirectoryReader.open(writer);
+    IndexSearcher searcher = newSearcher(reader);
+    assertEquals(
+        0, searcher.search(LongPoint.newRangeQuery("content", 10, 19), 100).totalHits.value);
+    assertEquals(
+        20, searcher.search(LongPoint.newRangeQuery("content", 0, 30), 100).totalHits.value);
+
+    reader.close();
+    writer.close();
+    dir.close();
+  }
+
   static void addDoc(IndexWriter writer) throws IOException {
     Document doc = new Document();
     doc.add(newTextField("content", "aaa", Field.Store.NO));


### PR DESCRIPTION
### Description

We can delete all live docs when a query matched a whole segment, in `FrozenBufferedUpdates.applyQueryDeletes`.

I have implemented it for `PointRangeQuery`, and also trying to implement it for other queries.