### PR TITLE
Fix max score computation in BlockMaxConjunctionBulkScorer.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionBulkScorer.java
@@ -67,7 +67,7 @@ final class BlockMaxConjunctionBulkScorer extends BulkScorer {
       scorers[i].advanceShallow(windowMin);
     }
 
-    float maxWindowScore = 0;
+    double maxWindowScore = 0;
     for (int i = 0; i < scorers.length; ++i) {
       float maxClauseScore = scorers[i].getMaxScore(windowMax);
       sumOfOtherClauses[i] = maxClauseScore;
@@ -76,7 +76,7 @@ final class BlockMaxConjunctionBulkScorer extends BulkScorer {
     for (int i = sumOfOtherClauses.length - 2; i >= 0; --i) {
       sumOfOtherClauses[i] += sumOfOtherClauses[i + 1];
     }
-    return maxWindowScore;
+    return (float) maxWindowScore;
   }
 
   @Override


### PR DESCRIPTION
It sums up max scores in a float when it should sum them up in a double like we do for `Scorer#score()`. Otherwise, max scores may be returned that are less than actual scores.

This bug was introduced in #13343, so it is not released yet.

Closes #13371
Closes #13396