### PR TITLE
Remove unchecked Scorable -> Scorer cast in lucene/monitor.

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/Monitor.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/Monitor.java
@@ -34,8 +34,6 @@ import org.apache.lucene.search.Matches;
 import org.apache.lucene.search.MatchesIterator;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.Weight;
 
 /**
  * A Monitor contains a set of {@link Query} objects with associated IDs, and efficiently matches
@@ -377,9 +375,7 @@ public class Monitor implements Closeable {
     @Override
     public void matchQuery(final String id, QueryCacheEntry query, QueryIndex.DataValues dataValues)
         throws IOException {
-      Scorer scorer = ((Scorer) dataValues.scorer);
-      Weight w = scorer.getWeight();
-      Matches matches = w.matches(dataValues.ctx, scorer.docID());
+      Matches matches = dataValues.weight.matches(dataValues.ctx, dataValues.docID);
       for (String field : matches) {
         MatchesIterator mi = matches.getMatches(field);
         while (mi.next()) {

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryIndex.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryIndex.java
@@ -38,6 +38,7 @@ import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefHash;
 
@@ -121,8 +122,10 @@ abstract class QueryIndex implements Closeable {
     SortedDocValues queryId;
     SortedDocValues cacheId;
     BinaryDocValues mq;
+    Weight weight;
     Scorable scorer;
     LeafReaderContext ctx;
+    int docID;
 
     void advanceTo(int doc) throws IOException {
       queryId.advanceExact(doc);
@@ -130,6 +133,7 @@ abstract class QueryIndex implements Closeable {
       if (mq != null) {
         mq.advanceExact(doc);
       }
+      this.docID = doc;
     }
   }
 

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/ReadonlyQueryIndex.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/ReadonlyQueryIndex.java
@@ -156,6 +156,11 @@ class ReadonlyQueryIndex extends QueryIndex {
     }
 
     @Override
+    public void setWeight(Weight weight) {
+      this.dataValues.weight = weight;
+    }
+
+    @Override
     public void setScorer(Scorable scorer) {
       this.dataValues.scorer = scorer;
     }

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/WritableQueryIndex.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/WritableQueryIndex.java
@@ -45,6 +45,7 @@ import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.SimpleCollector;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.NamedThreadFactory;
@@ -361,6 +362,11 @@ class WritableQueryIndex extends QueryIndex {
     MonitorQueryCollector(Map<String, QueryCacheEntry> queries, QueryCollector matcher) {
       this.queries = queries;
       this.matcher = matcher;
+    }
+
+    @Override
+    public void setWeight(Weight weight) {
+      this.dataValues.weight = weight;
     }
 
     @Override

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestPresearcherMatchCollector.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestPresearcherMatchCollector.java
@@ -42,7 +42,7 @@ public class TestPresearcherMatchCollector extends MonitorTestBase {
       PresearcherMatches<QueryMatch> matches = monitor.debug(doc, QueryMatch.SIMPLE_MATCHER);
 
       assertNotNull(matches.match("1", 0));
-      assertEquals(" field:test", matches.match("1", 0).presearcherMatches);
+      assertEquals(" field:(foo test)", matches.match("1", 0).presearcherMatches);
       assertNotNull(matches.match("1", 0).queryMatch);
 
       assertNotNull(matches.match("2", 0));
@@ -51,7 +51,7 @@ public class TestPresearcherMatchCollector extends MonitorTestBase {
       MatcherAssert.assertThat(pm, containsString("f2:(quuz)"));
 
       assertNotNull(matches.match("3", 0));
-      assertEquals(" field:foo", matches.match("3", 0).presearcherMatches);
+      assertEquals(" field:(foo test)", matches.match("3", 0).presearcherMatches);
       assertNull(matches.match("3", 0).queryMatch);
 
       assertNull(matches.match("4", 0));


### PR DESCRIPTION
While doing an unrelated refactoring, I got hit by this unchecked cast, which is incorrect when the presearcher query produces some specialized `BulkScorer`.