### PR TITLE
Add prefetching for doc values and norms.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -359,6 +359,12 @@ public final class IndexedDISI extends DocIdSetIterator {
 
     this.slice = blockSlice;
     this.jumpTable = jumpTable;
+    // Prefetch the first pages of data. Following pages are expected to get prefetched through
+    // read-ahead.
+    if (slice.length() > 0) slice.prefetch(0, 1);
+    if (jumpTable != null && jumpTable.length() > 0) {
+      jumpTable.prefetch(0, 1);
+    }
     this.jumpTableEntryCount = jumpTableEntryCount;
     this.denseRankPower = denseRankPower;
     final int rankIndexShift = denseRankPower - 7;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -361,7 +361,9 @@ public final class IndexedDISI extends DocIdSetIterator {
     this.jumpTable = jumpTable;
     // Prefetch the first pages of data. Following pages are expected to get prefetched through
     // read-ahead.
-    if (slice.length() > 0) slice.prefetch(0, 1);
+    if (slice.length() > 0) {
+      slice.prefetch(0, 1);
+    }
     if (jumpTable != null && jumpTable.length() > 0) {
       jumpTable.prefetch(0, 1);
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -493,6 +493,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
       } else {
         final RandomAccessInput slice =
             data.randomAccessSlice(entry.valuesOffset, entry.valuesLength);
+        // Prefetch the first page of data. Following pages are expected to get prefetched through
+        // read-ahead.
+        if (slice.length() > 0) {
+          slice.prefetch(0, 1);
+        }
         if (entry.blockShift >= 0) {
           // dense but split into blocks of different bits per value
           return new DenseNumericDocValues(maxDoc) {
@@ -554,6 +559,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
       } else {
         final RandomAccessInput slice =
             data.randomAccessSlice(entry.valuesOffset, entry.valuesLength);
+        // Prefetch the first page of data. Following pages are expected to get prefetched through
+        // read-ahead.
+        if (slice.length() > 0) {
+          slice.prefetch(0, 1);
+        }
         if (entry.blockShift >= 0) {
           // sparse and split into blocks of different bits per value
           return new SparseNumericDocValues(disi) {
@@ -609,6 +619,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     } else {
       final RandomAccessInput slice =
           data.randomAccessSlice(entry.valuesOffset, entry.valuesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (slice.length() > 0) {
+        slice.prefetch(0, 1);
+      }
       if (entry.blockShift >= 0) {
         return new LongValues() {
           final VaryingBPVReader vBPVReader = new VaryingBPVReader(entry, slice);
@@ -739,6 +754,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     }
 
     final IndexInput bytesSlice = data.slice("fixed-binary", entry.dataOffset, entry.dataLength);
+    // Prefetch the first page of data. Following pages are expected to get prefetched through
+    // read-ahead.
+    if (bytesSlice.length() > 0) {
+      bytesSlice.prefetch(0, 1);
+    }
 
     if (entry.docsWithFieldOffset == -1) {
       // dense
@@ -759,6 +779,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
         // variable length
         final RandomAccessInput addressesData =
             this.data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
+        // Prefetch the first page of data. Following pages are expected to get prefetched through
+        // read-ahead.
+        if (addressesData.length() > 0) {
+          addressesData.prefetch(0, 1);
+        }
         final LongValues addresses =
             DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData, merging);
         return new DenseBinaryDocValues(maxDoc) {
@@ -801,6 +826,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
         // variable length
         final RandomAccessInput addressesData =
             this.data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
+        // Prefetch the first page of data. Following pages are expected to get prefetched through
+        // read-ahead.
+        if (addressesData.length() > 0) {
+          addressesData.prefetch(0, 1);
+        }
         final LongValues addresses =
             DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData);
         return new SparseBinaryDocValues(disi) {
@@ -838,6 +868,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
 
       final RandomAccessInput slice =
           data.randomAccessSlice(ordsEntry.valuesOffset, ordsEntry.valuesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (slice.length() > 0) {
+        slice.prefetch(0, 1);
+      }
       final LongValues values =
           getDirectReaderInstance(slice, ordsEntry.bitsPerValue, 0L, ordsEntry.numValues);
 
@@ -1305,6 +1340,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
 
     final RandomAccessInput addressesInput =
         data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
+    // Prefetch the first page of data. Following pages are expected to get prefetched through
+    // read-ahead.
+    if (addressesInput.length() > 0) {
+      addressesInput.prefetch(0, 1);
+    }
     final LongValues addresses =
         DirectMonotonicReader.getInstance(entry.addressesMeta, addressesInput, merging);
 
@@ -1448,11 +1488,21 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
 
       final RandomAccessInput addressesInput =
           data.randomAccessSlice(ordsEntry.addressesOffset, ordsEntry.addressesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (addressesInput.length() > 0) {
+        addressesInput.prefetch(0, 1);
+      }
       final LongValues addresses =
           DirectMonotonicReader.getInstance(ordsEntry.addressesMeta, addressesInput);
 
       final RandomAccessInput slice =
           data.randomAccessSlice(ordsEntry.valuesOffset, ordsEntry.valuesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (slice.length() > 0) {
+        slice.prefetch(0, 1);
+      }
       final LongValues values = DirectReader.getInstance(slice, ordsEntry.bitsPerValue);
 
       if (ordsEntry.docsWithFieldOffset == -1) { // dense
@@ -1651,6 +1701,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
               ? null
               : data.randomAccessSlice(
                   entry.valueJumpTableOffset, data.length() - entry.valueJumpTableOffset);
+      if (rankSlice != null && rankSlice.length() > 0) {
+        // Prefetch the first page of data. Following pages are expected to get prefetched through
+        // read-ahead.
+        rankSlice.prefetch(0, 1);
+      }
       shift = entry.blockShift;
       mul = entry.gcd;
       mask = (1 << shift) - 1;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
@@ -255,7 +255,9 @@ final class Lucene90NormsProducer extends NormsProducer implements Cloneable {
       }
       // Prefetch the first page of data. Following pages are expected to get prefetched through
       // read-ahead.
-      slice.prefetch(0, 1);
+      if (slice.length() > 0) {
+        slice.prefetch(0, 1);
+      }
     }
     return slice;
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
@@ -253,6 +253,9 @@ final class Lucene90NormsProducer extends NormsProducer implements Cloneable {
       if (merging) {
         dataInputs.put(field.number, slice);
       }
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      slice.prefetch(0, 1);
     }
     return slice;
   }
@@ -328,7 +331,7 @@ final class Lucene90NormsProducer extends NormsProducer implements Cloneable {
 
       @Override
       public long length() {
-        throw new UnsupportedOperationException("Unused by IndexedDISI");
+        return inF.length();
       }
 
       @Override
@@ -339,6 +342,11 @@ final class Lucene90NormsProducer extends NormsProducer implements Cloneable {
       @Override
       public void close() throws IOException {
         throw new UnsupportedOperationException("Unused by IndexedDISI");
+      }
+
+      @Override
+      public void prefetch(long offset, long length) throws IOException {
+        // Not delegating to the wrapped instance on purpose. This is only used for merging.
       }
     };
   }

--- a/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
@@ -185,6 +185,11 @@ public abstract class IndexInput extends DataInput implements Closeable {
         }
 
         @Override
+        public void prefetch(long offset, long length) throws IOException {
+          slice.prefetch(offset, length);
+        }
+
+        @Override
         public String toString() {
           return "RandomAccessInput(" + IndexInput.this.toString() + ")";
         }

--- a/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
@@ -70,4 +70,11 @@ public interface RandomAccessInput {
    * @see BitUtil#VH_LE_LONG
    */
   long readLong(long pos) throws IOException;
+
+  /**
+   * Prefetch data in the background.
+   *
+   * @see IndexInput#prefetch
+   */
+  default void prefetch(long offset, long length) throws IOException {}
 }


### PR DESCRIPTION
This follows a similar approach as postings and only prefetches the first page of data.

I verified that it works well for collectors such as `TopFieldCollector`, as `IndexSearcher` first pulls a `LeafCollector`, then a `BulkScorer` and only then starts feeding the `BulkScorer` into the `LeafCollector`. So the background I/O for the `LeafCollector` which will prefetch the first page of doc values and the background I/O for the `BulkScorer` will run in parallel.