### PR TITLE
lucene-monitor: remove now-unused Scorable in QueryIndex.DataValues

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryIndex.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryIndex.java
@@ -34,7 +34,6 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.TermQuery;
@@ -123,7 +122,6 @@ abstract class QueryIndex implements Closeable {
     SortedDocValues cacheId;
     BinaryDocValues mq;
     Weight weight;
-    Scorable scorer;
     LeafReaderContext ctx;
     int docID;
 

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/ReadonlyQueryIndex.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/ReadonlyQueryIndex.java
@@ -161,11 +161,6 @@ class ReadonlyQueryIndex extends QueryIndex {
     }
 
     @Override
-    public void setScorer(Scorable scorer) {
-      this.dataValues.scorer = scorer;
-    }
-
-    @Override
     public void collect(int doc) throws IOException {
       dataValues.advanceTo(doc);
       BytesRef cache_id = dataValues.cacheId.lookupOrd(dataValues.cacheId.ordValue());

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/WritableQueryIndex.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/WritableQueryIndex.java
@@ -41,7 +41,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.SimpleCollector;
@@ -367,11 +366,6 @@ class WritableQueryIndex extends QueryIndex {
     @Override
     public void setWeight(Weight weight) {
       this.dataValues.weight = weight;
-    }
-
-    @Override
-    public void setScorer(Scorable scorer) {
-      this.dataValues.scorer = scorer;
     }
 
     @Override


### PR DESCRIPTION
Became unused via #13405 I think.