### PR TITLE
Add new test case "testGetLines" for lucene/core/analysis/WordlistLoader

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/analysis/TestWordlistLoader.java
+++ b/lucene/core/src/test/org/apache/lucene/analysis/TestWordlistLoader.java
@@ -89,6 +89,7 @@ public class TestWordlistLoader extends LuceneTestCase {
     byte[] sByteArr = s.getBytes(charset);
     InputStream sInputStream = new ByteArrayInputStream(sByteArr);
     List<String> lines = WordlistLoader.getLines(sInputStream, charset);
+    assertEquals(3, lines.size());
     assertEquals("One", lines.get(0));
     assertEquals("Two", lines.get(1));
     assertEquals("Three", lines.get(2));

--- a/lucene/core/src/test/org/apache/lucene/analysis/TestWordlistLoader.java
+++ b/lucene/core/src/test/org/apache/lucene/analysis/TestWordlistLoader.java
@@ -89,8 +89,6 @@ public class TestWordlistLoader extends LuceneTestCase {
     byte[] sByteArr = s.getBytes(charset);
     InputStream sInputStream = new ByteArrayInputStream(sByteArr);
     List<String> lines = WordlistLoader.getLines(sInputStream, charset);
-    assertEquals(3, lines.size());
-    assertFalse(lines.contains("#Comment"));
     assertEquals("One", lines.get(0));
     assertEquals("Two", lines.get(1));
     assertEquals("Three", lines.get(2));

--- a/lucene/core/src/test/org/apache/lucene/analysis/TestWordlistLoader.java
+++ b/lucene/core/src/test/org/apache/lucene/analysis/TestWordlistLoader.java
@@ -17,8 +17,13 @@
 package org.apache.lucene.analysis;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestWordlistLoader extends LuceneTestCase {
@@ -76,5 +81,18 @@ public class TestWordlistLoader extends LuceneTestCase {
     assertTrue(wordset.contains("five"));
     assertTrue(wordset.contains("six"));
     assertTrue(wordset.contains("seven"));
+  }
+
+  public void testGetLines() throws IOException {
+    String s = "One \n#Comment \n \n Two \n  Three  \n";
+    Charset charset = StandardCharsets.UTF_8;
+    byte[] sByteArr = s.getBytes(charset);
+    InputStream sInputStream = new ByteArrayInputStream(sByteArr);
+    List<String> lines = WordlistLoader.getLines(sInputStream, charset);
+    assertEquals(3, lines.size());
+    assertFalse(lines.contains("#Comment"));
+    assertEquals("One", lines.get(0));
+    assertEquals("Two", lines.get(1));
+    assertEquals("Three", lines.get(2));
   }
 }


### PR DESCRIPTION
## Description
- Add new test case to test the ```getLines``` in ```WordlistLoader``` functions normally.
I create a string testcase that contains comment lines and blank lines to test ```getLines``` method. In order to pass a InputStream, I converted string into byteArray and then into byteArrayInputStream. This testcase proved that the function works well. By the definition of the function itself, the comment lines would have '#' at the start of the line, but I'm not sure if a line start with some spaces and then the '#' sign appears after the indentation count as a comment line as well. TBD  
