### PR TITLE
Fixes failing test case for TestOrdinalMap.testRamBytesUsed

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -391,6 +391,8 @@ Bug Fixes
 
 * GITHUB#13376: Fix integer overflow exception in postings encoding as group-varint. (Zhang Chao, Guo Feng)
 
+* GITHUB#13411: Fixes TestOrdinalMap.testRamBytesUsed for multiple default PackedInts.NullReader instances. (Amir Raza)
+
 Build
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -391,7 +391,7 @@ Bug Fixes
 
 * GITHUB#13376: Fix integer overflow exception in postings encoding as group-varint. (Zhang Chao, Guo Feng)
 
-* GITHUB#13411: Fixes TestOrdinalMap.testRamBytesUsed for multiple default PackedInts.NullReader instances. (Amir Raza)
+* GITHUB#13421: Fixes TestOrdinalMap.testRamBytesUsed for multiple default PackedInts.NullReader instances. (Amir Raza)
 
 Build
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
@@ -562,7 +562,7 @@ public class PackedInts {
   /** A {@link Reader} which has all its values equal to 0 (bitsPerValue = 0). */
   public static final class NullReader extends Reader {
 
-    private static final NullReader DEFAULT_PACKED_LONG_VALUES_PAGE_SIZE =
+    public static final NullReader DEFAULT_PACKED_LONG_VALUES_PAGE_SIZE =
         new NullReader(PackedLongValues.DEFAULT_PAGE_SIZE);
 
     private final int valueCount;

--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedInts.java
@@ -562,7 +562,7 @@ public class PackedInts {
   /** A {@link Reader} which has all its values equal to 0 (bitsPerValue = 0). */
   public static final class NullReader extends Reader {
 
-    public static final NullReader DEFAULT_PACKED_LONG_VALUES_PAGE_SIZE =
+    private static final NullReader DEFAULT_PACKED_LONG_VALUES_PAGE_SIZE =
         new NullReader(PackedLongValues.DEFAULT_PAGE_SIZE);
 
     private final int valueCount;

--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedLongValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedLongValues.java
@@ -29,7 +29,7 @@ public class PackedLongValues extends LongValues implements Accountable {
   private static final long BASE_RAM_BYTES_USED =
       RamUsageEstimator.shallowSizeOfInstance(PackedLongValues.class);
 
-  static final int DEFAULT_PAGE_SIZE = 256;
+  public static final int DEFAULT_PAGE_SIZE = 256;
   static final int MIN_PAGE_SIZE = 64;
   // More than 1M doesn't really makes sense with these appending buffers
   // since their goal is to try to have small numbers of bits per value

--- a/lucene/core/src/test/org/apache/lucene/index/TestOrdinalMap.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestOrdinalMap.java
@@ -31,6 +31,7 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.LongValues;
 import org.apache.lucene.util.packed.PackedInts;
+import org.apache.lucene.util.packed.PackedLongValues;
 
 public class TestOrdinalMap extends LuceneTestCase {
 
@@ -55,7 +56,7 @@ public class TestOrdinalMap extends LuceneTestCase {
             java.util.Collection<Object> queue) {
           if (o == LongValues.ZEROES
               || o == LongValues.IDENTITY
-              || o == PackedInts.NullReader.DEFAULT_PACKED_LONG_VALUES_PAGE_SIZE) {
+              || o == PackedInts.NullReader.forCount(PackedLongValues.DEFAULT_PAGE_SIZE)) {
             return 0L;
           }
           if (o instanceof OrdinalMap) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestOrdinalMap.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestOrdinalMap.java
@@ -30,6 +30,7 @@ import org.apache.lucene.tests.util.RamUsageTester;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.LongValues;
+import org.apache.lucene.util.packed.PackedInts;
 
 public class TestOrdinalMap extends LuceneTestCase {
 
@@ -52,7 +53,9 @@ public class TestOrdinalMap extends LuceneTestCase {
             long shallowSize,
             java.util.Map<Field, Object> fieldValues,
             java.util.Collection<Object> queue) {
-          if (o == LongValues.ZEROES || o == LongValues.IDENTITY) {
+          if (o == LongValues.ZEROES
+              || o == LongValues.IDENTITY
+              || o == PackedInts.NullReader.DEFAULT_PACKED_LONG_VALUES_PAGE_SIZE) {
             return 0L;
           }
           if (o instanceof OrdinalMap) {


### PR DESCRIPTION
### Description

closes #13372 

TestOrdinalMap#testRamBytesUsed was failing for the case when there are multiple Default instances for PackedInts.NullReader. Currently, we return 0 when the instance is built with default size i.e. 256. Ref: org.apache.lucene.util.packed.PackedInts.NullReader#ramBytesUsed

But this was not accounted for in the Accumulator being used. Made changes to skip the object if the reader is of default static instance.

Passes failing UT.

`./gradlew :lucene:core:test --tests "org.apache.lucene.index.TestOrdinalMap.testRamBytesUsed" -Ptests.seed=55680AD930225FC5 -Ptests.nightly=true`
