### PR TITLE
Fix duplicate values in org.apache.lucene.analysis.ko.dict.UserDictionary

### DIFF
--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UserDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UserDictionary.java
@@ -135,7 +135,7 @@ public final class UserDictionary implements Dictionary<UserMorphData> {
     this.fst =
         new TokenInfoFST(FST.fromFSTReader(fstCompiler.compile(), fstCompiler.getFSTReader()));
     int[][] segmentations = _segmentations.toArray(new int[_segmentations.size()][]);
-    if (entryIndex != rightIds.length) {
+    if (entryIndex < rightIds.length) {
       rightIds = ArrayUtil.copyOfSubArray(rightIds, 0, entryIndex);
     }
     this.morphAtts = new UserMorphData(segmentations, rightIds);

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UserDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UserDictionary.java
@@ -132,12 +132,12 @@ public final class UserDictionary implements Dictionary<UserMorphData> {
       lastToken = token;
       ord++;
     }
-    this.fst =
-        new TokenInfoFST(FST.fromFSTReader(fstCompiler.compile(), fstCompiler.getFSTReader()));
-    int[][] segmentations = _segmentations.toArray(new int[_segmentations.size()][]);
     if (entryIndex < rightIds.length) {
       rightIds = ArrayUtil.copyOfSubArray(rightIds, 0, entryIndex);
     }
+    this.fst =
+        new TokenInfoFST(FST.fromFSTReader(fstCompiler.compile(), fstCompiler.getFSTReader()));
+    int[][] segmentations = _segmentations.toArray(new int[_segmentations.size()][]);
     this.morphAtts = new UserMorphData(segmentations, rightIds);
   }
 

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UserDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UserDictionary.java
@@ -134,7 +134,6 @@ public final class UserDictionary implements Dictionary<UserMorphData> {
     this.fst =
         new TokenInfoFST(FST.fromFSTReader(fstCompiler.compile(), fstCompiler.getFSTReader()));
     int[][] segmentations = _segmentations.toArray(new int[_segmentations.size()][]);
-    assert entryIndex == rightIds.length;
     this.morphAtts = new UserMorphData(segmentations, rightIds);
   }
 

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UserDictionary.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/dict/UserDictionary.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.lucene.analysis.morph.Dictionary;
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.IntsRefBuilder;
 import org.apache.lucene.util.fst.FST;
 import org.apache.lucene.util.fst.FSTCompiler;
@@ -134,6 +135,9 @@ public final class UserDictionary implements Dictionary<UserMorphData> {
     this.fst =
         new TokenInfoFST(FST.fromFSTReader(fstCompiler.compile(), fstCompiler.getFSTReader()));
     int[][] segmentations = _segmentations.toArray(new int[_segmentations.size()][]);
+    if (entryIndex != rightIds.length) {
+      rightIds = ArrayUtil.copyOfSubArray(rightIds, 0, entryIndex);
+    }
     this.morphAtts = new UserMorphData(segmentations, rightIds);
   }
 

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
@@ -567,6 +567,13 @@ public class TestKoreanTokenizer extends BaseTokenStreamTestCase {
       assertTrue(dict.getRightId(3) != 0);
       assertThrows(ArrayIndexOutOfBoundsException.class, () -> dict.getRightId(4));
     }
+
+    String dupdup = "c++\nC쁠쁠\n세종\n세종\n세종시 세종 시\n세종시 세종 시";
+    try (Reader rulesReader = new StringReader(dupdup)) {
+      var dict = UserDictionary.open(rulesReader);
+      assertTrue(dict.getRightId(3) != 0);
+      assertThrows(ArrayIndexOutOfBoundsException.class, () -> dict.getRightId(4));
+    }
   }
 
   private void assertReadings(Analyzer analyzer, String input, String... readings)

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
@@ -563,8 +563,8 @@ public class TestKoreanTokenizer extends BaseTokenStreamTestCase {
   public void testDuplicate() throws IOException {
     String s = "c++\nC쁠쁠\n세종\n세종\n세종시 세종 시";
     try (Reader rulesReader = new StringReader(s)) {
-      var dict = UserDictionary.open(rulesReader); // throws assertion if the bug exists
-      var four = dict.getRightId(3);
+      var dict = UserDictionary.open(rulesReader);
+      assertTrue(dict.getRightId(3) != 0);
       assertThrows(ArrayIndexOutOfBoundsException.class, () -> dict.getRightId(4));
     }
   }

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.apache.lucene.analysis.Analyzer;
@@ -557,6 +558,13 @@ public class TestKoreanTokenizer extends BaseTokenStreamTestCase {
         new POS.Type[] {POS.Type.MORPHEME},
         new POS.Tag[] {POS.Tag.SL},
         new POS.Tag[] {POS.Tag.SL});
+  }
+
+  public void testDuplicate() throws IOException {
+      String s = "c++\nC쁠쁠\n세종\n세종\n세종시 세종 시";
+      try (Reader rulesReader = new StringReader(s)) {
+          UserDictionary.open(rulesReader); // throws assertion if the bug exists
+      }
   }
 
   private void assertReadings(Analyzer analyzer, String input, String... readings)

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
@@ -561,10 +561,12 @@ public class TestKoreanTokenizer extends BaseTokenStreamTestCase {
   }
 
   public void testDuplicate() throws IOException {
-      String s = "c++\nC쁠쁠\n세종\n세종\n세종시 세종 시";
-      try (Reader rulesReader = new StringReader(s)) {
-          UserDictionary.open(rulesReader); // throws assertion if the bug exists
-      }
+    String s = "c++\nC쁠쁠\n세종\n세종\n세종시 세종 시";
+    try (Reader rulesReader = new StringReader(s)) {
+      var dict = UserDictionary.open(rulesReader); // throws assertion if the bug exists
+      var four = dict.getRightId(3);
+      assertThrows(ArrayIndexOutOfBoundsException.class, () -> dict.getRightId(4));
+    }
   }
 
   private void assertReadings(Analyzer analyzer, String input, String... readings)


### PR DESCRIPTION
Remove incorrect assertion in org.apache.lucene.analysis.ko.dict.UserDictionary, and replace with array copy if duplicate values are passed.

closes #13426