### PR TITLE
Remove incorrect/expensive use of ServiceLoader for choosing random format

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -18,6 +18,7 @@
 package org.apache.lucene.codecs;
 
 import java.io.IOException;
+import java.util.Set;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.SegmentReadState;
@@ -84,6 +85,11 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
   /** looks up a format by name */
   public static KnnVectorsFormat forName(String name) {
     return Holder.getLoader().lookup(name);
+  }
+
+  /** returns a list of all available format names */
+  public static Set<String> availableKnnVectorsFormats() {
+    return Holder.getLoader().availableServices();
   }
 
   /** Returns a {@link KnnVectorsWriter} to write the vectors to the index. */


### PR DESCRIPTION
This cleans up the code:
- Remove expensive usage of ServiceLoader which might be inconsistent with the NamedSPI code
- Add a better readable version with comment about the special case regarding bit vectors