### PR TITLE
Fix test failure on TestPoint#testEqualsAndHashCode

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/geo/TestPoint.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestPoint.java
@@ -56,7 +56,7 @@ public class TestPoint extends LuceneTestCase {
     if (Double.compare(point.getLat(), otherPoint.getLat()) != 0
         || Double.compare(point.getLon(), otherPoint.getLon()) != 0) {
       assertNotEquals(point, otherPoint);
-      assertNotEquals(point.hashCode(), otherPoint.hashCode());
+      // it is possible to have hashcode collisions
     } else {
       assertEquals(point, otherPoint);
       assertEquals(point.hashCode(), otherPoint.hashCode());


### PR DESCRIPTION
If two objects are different, it might have the same hashcode. in this case, `Point(-180.0,90.0)` and  `Point(180.0,-90.0)` will have the same hashcode value.

```
org.apache.lucene.geo.TestPoint > testEqualsAndHashCode FAILED
    java.lang.AssertionError: Values should be different. Actual: -1965031424
        at __randomizedtesting.SeedInfo.seed([ADA73B977A63C061:DE69C35A79C6BF50]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failEquals(Assert.java:187)
        at org.junit.Assert.assertNotEquals(Assert.java:201)
        at org.junit.Assert.assertNotEquals(Assert.java:213)
        at org.apache.lucene.geo.TestPoint.testEqualsAndHashCode(TestPoint.java:59)
```

```
./gradlew :lucene:core:test --tests "org.apache.lucene.geo.TestPoint.testEqualsAndHashCode"  -Ptests.seed=ADA73B977A63C061
```

We had similar issues in the other tests like `TestCircle#testEqualsAndHashCode`,  `TestXYPolygon#testEqualsAndHashCode`. it seems it also needs to be removed. for random values, the hash code must be different is a wrong assumption. 