### PR TITLE
Fix TestIndexWriterOnError.testIOError failure.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
@@ -77,7 +77,7 @@ final class SegmentDocValues {
   /** Decrement the reference count of the given {@link DocValuesProducer} generations. */
   synchronized void decRef(LongArrayList dvProducersGens) throws IOException {
     IOUtils.applyToAll(
-        dvProducersGens.stream().mapToObj(Long::valueOf),
+        dvProducersGens.stream().<Long>mapToObj(Long::valueOf).toList(),
         gen -> {
           RefCount<DocValuesProducer> dvp = genDVProducers.get(gen);
           assert dvp != null : "gen=" + gen;

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
@@ -77,7 +77,7 @@ final class SegmentDocValues {
   /** Decrement the reference count of the given {@link DocValuesProducer} generations. */
   synchronized void decRef(LongArrayList dvProducersGens) throws IOException {
     IOUtils.applyToAll(
-        dvProducersGens.stream().<Long>mapToObj(Long::valueOf).toList(),
+        dvProducersGens.stream().mapToObj(Long::valueOf).toList(),
         gen -> {
           RefCount<DocValuesProducer> dvp = genDVProducers.get(gen);
           assert dvp != null : "gen=" + gen;

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
@@ -20,10 +20,10 @@ import java.io.IOException;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.internal.hppc.LongArrayList;
-import org.apache.lucene.internal.hppc.LongCursor;
 import org.apache.lucene.internal.hppc.LongObjectHashMap;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
+import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RefCount;
 
 /**
@@ -76,10 +76,12 @@ final class SegmentDocValues {
 
   /** Decrement the reference count of the given {@link DocValuesProducer} generations. */
   synchronized void decRef(LongArrayList dvProducersGens) throws IOException {
-    for (LongCursor gen : dvProducersGens) {
-      RefCount<DocValuesProducer> dvp = genDVProducers.get(gen.value);
-      assert dvp != null : "gen=" + gen;
-      dvp.decRef();
-    }
+    IOUtils.applyToAll(
+        dvProducersGens.stream().mapToObj(Long::valueOf),
+        gen -> {
+          RefCount<DocValuesProducer> dvp = genDVProducers.get(gen);
+          assert dvp != null : "gen=" + gen;
+          dvp.decRef();
+        });
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 import org.apache.lucene.store.Directory;
 
 /**
@@ -460,11 +461,18 @@ public final class IOUtils {
    * The first exception thrown by the consumer is re-thrown and subsequent exceptions are
    * suppressed.
    */
-  @SuppressWarnings("StreamToIterable")
   public static <T> void applyToAll(Collection<T> collection, IOConsumer<T> consumer)
       throws IOException {
+    applyToAll(collection.stream(), consumer);
+  }
+
+  /**
+   * Applies the consumer to all non-null elements in the stream even if an exception is thrown. The
+   * first exception thrown by the consumer is re-thrown and subsequent exceptions are suppressed.
+   */
+  @SuppressWarnings("StreamToIterable")
+  public static <T> void applyToAll(Stream<T> stream, IOConsumer<T> consumer) throws IOException {
     IOUtils.close(
-        collection.stream().filter(Objects::nonNull).map(t -> (Closeable) () -> consumer.accept(t))
-            ::iterator);
+        stream.filter(Objects::nonNull).map(t -> (Closeable) () -> consumer.accept(t))::iterator);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
@@ -40,7 +40,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Stream;
 import org.apache.lucene.store.Directory;
 
 /**
@@ -461,18 +460,11 @@ public final class IOUtils {
    * The first exception thrown by the consumer is re-thrown and subsequent exceptions are
    * suppressed.
    */
+  @SuppressWarnings("StreamToIterable")
   public static <T> void applyToAll(Collection<T> collection, IOConsumer<T> consumer)
       throws IOException {
-    applyToAll(collection.stream(), consumer);
-  }
-
-  /**
-   * Applies the consumer to all non-null elements in the stream even if an exception is thrown. The
-   * first exception thrown by the consumer is re-thrown and subsequent exceptions are suppressed.
-   */
-  @SuppressWarnings("StreamToIterable")
-  public static <T> void applyToAll(Stream<T> stream, IOConsumer<T> consumer) throws IOException {
     IOUtils.close(
-        stream.filter(Objects::nonNull).map(t -> (Closeable) () -> consumer.accept(t))::iterator);
+        collection.stream().filter(Objects::nonNull).map(t -> (Closeable) () -> consumer.accept(t))
+            ::iterator);
   }
 }


### PR DESCRIPTION
Pull request #13406 inadvertly broke Lucene's handling of tragic exceptions by stopping after the first `DocValuesProducer` whose `close()` calls throws an exception, instead of keeping calling `close()` on further producers in the list.

This moves back to the previous behavior.

Closes #13434