### PR TITLE
Compare to smallest and largest term before seeking target in SegmentTermsEnum.seekCeil.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnum.java
@@ -584,6 +584,22 @@ final class SegmentTermsEnum extends BaseTermsEnum {
       throw new IllegalStateException("terms index was not loaded");
     }
 
+    if (fr.size() > 0) {
+      if(target.compareTo(fr.getMin()) < 0){
+        // TODO: set current frame to min entry's block.
+        termExists = true;
+        term.copyBytes(fr.getMin());
+        System.out.println("target: " + target.utf8ToString() + ", term: " + term().utf8ToString() + ", frame: " + currentFrame);
+        return SeekStatus.NOT_FOUND;
+      }else if(target.compareTo(fr.getMax()) > 0){
+        // TODO: set current frame to max entry's block.
+        termExists = false;
+        term.clear();
+        System.out.println("target: " + target.utf8ToString() + ", term: " + term().utf8ToString() + ", frame: " + currentFrame);
+        return SeekStatus.END;
+      }
+    }
+
     term.grow(1 + target.length);
 
     assert clearEOF();
@@ -695,6 +711,8 @@ final class SegmentTermsEnum extends BaseTermsEnum {
           // if (DEBUG) {
           // System.out.println("  target is same as current; return FOUND");
           // }
+          System.out.println("target: " + target.utf8ToString() + ", term: " + term().utf8ToString() + ", frame: " + currentFrame);
+
           return SeekStatus.FOUND;
         } else {
           // if (DEBUG) {
@@ -768,11 +786,13 @@ final class SegmentTermsEnum extends BaseTermsEnum {
             // System.out.println("  return NOT_FOUND term=" +
             // ToStringUtils.bytesRefToString(term));
             // }
+            System.out.println("target: " + target.utf8ToString() + ", term: " + term().utf8ToString() + ", frame: " + currentFrame);
             return SeekStatus.NOT_FOUND;
           } else {
             // if (DEBUG) {
             // System.out.println("  return END");
             // }
+            System.out.println("target: " + target.utf8ToString() + ", term: " + term().utf8ToString() + ", frame: " + currentFrame);
             return SeekStatus.END;
           }
         } else {
@@ -780,6 +800,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
           // System.out.println("  return " + result + " term=" +
           // ToStringUtils.bytesRefToString(term));
           // }
+          System.out.println("target: " + target.utf8ToString() + ", term: " + term().utf8ToString() + ", frame: " + currentFrame);
           return result;
         }
       } else {
@@ -823,14 +844,20 @@ final class SegmentTermsEnum extends BaseTermsEnum {
         // if (DEBUG) {
         // System.out.println("  return NOT_FOUND term=" + term.get().utf8ToString() + " " + term);
         // }
+        System.out.println("target: " + target.utf8ToString() + ", term: " + term().utf8ToString() + ", frame: " + currentFrame);
+
         return SeekStatus.NOT_FOUND;
       } else {
         // if (DEBUG) {
         // System.out.println("  return END");
         // }
+        System.out.println("target: " + target.utf8ToString() + ", term: " + term().utf8ToString() + ", frame: " + currentFrame);
+
         return SeekStatus.END;
       }
     } else {
+      System.out.println("target: " + target.utf8ToString() + ", term: " + term().utf8ToString() + ", frame: " + currentFrame);
+
       return result;
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnumFrame.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnumFrame.java
@@ -854,4 +854,34 @@ final class SegmentTermsEnumFrame {
     ste.term.grow(termLength);
     System.arraycopy(suffixBytes, startBytePos, ste.term.bytes(), prefix, suffix);
   }
+
+  @Override
+  public String toString() {
+    return "fp: "
+        + fp
+        + ", fpOrig: "
+        + fpOrig
+        + ", fpEnd: "
+        + fpEnd
+        + ", lastSubFP: "
+        + lastSubFP
+        + ", entCount: "
+        + entCount
+        + ", nextEnt: "
+        + nextEnt
+        + ", isLeafBlock: "
+        + isLeafBlock
+        + ", isFloor: "
+        + isFloor
+        + ", isLastInFloor: "
+        + isLastInFloor
+        + ", nextFloorLabel: "
+        + nextFloorLabel
+        + ", suffixesPos: "
+        + suffixesReader.getPosition()
+        + ", suffixLengthsPos: "
+        + suffixLengthsReader.getPosition()
+        + ", floorDataPos: "
+        + floorDataReader.getPosition();
+  }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BasePostingsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BasePostingsFormatTestCase.java
@@ -455,6 +455,11 @@ public abstract class BasePostingsFormatTestCase extends BaseIndexFileFormatTest
       }
     }
     assertEquals(SeekStatus.END, termsEnum.seekCeil(new BytesRef(100400 + "")));
+
+    assertEquals(SeekStatus.NOT_FOUND, termsEnum.seekCeil(new BytesRef(100000 + "")));
+    assertEquals(new BytesRef(100001 + ""), termsEnum.term());
+    assertEquals(SeekStatus.END, termsEnum.seekCeil(new BytesRef(9 + "")));
+
     reader.close();
     iw.close();
     dir.close();


### PR DESCRIPTION
### Description

Similar to `SegmentTermsEnum.seekExact`, but we need to set `currentFrame` to `min/max` entry's block, otherwise we will fail when calling `SegmentTermsEnum.next`. 
