### PR TITLE
SimpleText[Float|Byte]VectorValues::scorer should return null when the vector values is empty

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -445,6 +445,9 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
 
     @Override
     public VectorScorer scorer(float[] target) {
+      if (size() == 0) {
+        return null;
+      }
       OffHeapFloatVectorValues values = this.copy();
       return new VectorScorer() {
         @Override

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
@@ -494,6 +494,9 @@ public final class Lucene91HnswVectorsReader extends KnnVectorsReader {
 
     @Override
     public VectorScorer scorer(float[] target) {
+      if (size == 0) {
+        return null;
+      }
       OffHeapFloatVectorValues values = this.copy();
       return new VectorScorer() {
         @Override

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/TestLucene90HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/TestLucene90HnswVectorsFormat.java
@@ -73,4 +73,9 @@ public class TestLucene90HnswVectorsFormat extends BaseKnnVectorsFormatTestCase 
   public void testByteVectorScorerIteration() {
     // unimplemented
   }
+
+  @Override
+  public void testEmptyByteVectorData() {
+    // unimplemented
+  }
 }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/TestLucene91HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/TestLucene91HnswVectorsFormat.java
@@ -72,4 +72,9 @@ public class TestLucene91HnswVectorsFormat extends BaseKnnVectorsFormatTestCase 
   public void testByteVectorScorerIteration() {
     // unimplemented
   }
+
+  @Override
+  public void testEmptyByteVectorData() {
+    // unimplemented
+  }
 }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/TestLucene92HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/TestLucene92HnswVectorsFormat.java
@@ -62,4 +62,9 @@ public class TestLucene92HnswVectorsFormat extends BaseKnnVectorsFormatTestCase 
   public void testByteVectorScorerIteration() {
     // unimplemented
   }
+
+  @Override
+  public void testEmptyByteVectorData() {
+    // unimplemented
+  }
 }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
@@ -360,6 +360,9 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
 
     @Override
     public VectorScorer scorer(float[] target) {
+      if (size() == 0) {
+        return null;
+      }
       SimpleTextFloatVectorValues simpleTextFloatVectorValues =
           new SimpleTextFloatVectorValues(this);
       return new VectorScorer() {
@@ -470,6 +473,9 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
 
     @Override
     public VectorScorer scorer(byte[] target) {
+      if (size() == 0) {
+        return null;
+      }
       SimpleTextByteVectorValues simpleTextByteVectorValues = new SimpleTextByteVectorValues(this);
       return new VectorScorer() {
         @Override


### PR DESCRIPTION
This commit ensures that `SimpleText[Float|Byte]VectorValues::scorer` returns null when the vector values is empty, as per the scorer javadoc.  Other KnnVectorsReader implementations have specialised empty implementations that do similar, e.g. `OffHeapFloatVectorValues.EmptyOffHeapVectorValues`. The `VectorScorer` interface in new in Lucene 9.11, see #13181 

An existing test randomly hits this, but a new test has been added that exercises this code path consistently. It's also useful to verify other KnnVectorsReader implementations.

closes #13443