### PR TITLE
mention KnnVectorsFormat in o.a.l.codecs package javadocs

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/package-info.java
@@ -31,6 +31,7 @@
  *   <li>SegmentInfo - see {@link org.apache.lucene.codecs.SegmentInfoFormat}
  *   <li>Norms - see {@link org.apache.lucene.codecs.NormsFormat}
  *   <li>Live documents - see {@link org.apache.lucene.codecs.LiveDocsFormat}
+ *   <li>Numeric vectors - see {@link org.apache.lucene.codecs.KnnVectorsFormat}
  * </ul>
  *
  * For some concrete implementations beyond Lucene's official index format, see the <a


### PR DESCRIPTION
I found a dusty corner we seem to have missed