### PR TITLE
Merge related HashMaps in FieldInfos#FieldNumbers into one map

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -263,7 +263,9 @@ Bug Fixes
 
 Other
 ---------------------
-(No changes)
+* GITHUB#13459: Merges all immutable attributes in FieldInfos.FieldNumbers into one Hashmap saving
+  memory when writing big indices. Fixes an exotic bug when calling clear where not all attributes
+  were cleared. (Ignacio Vera)
 
 ======================== Lucene 9.11.0 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -643,12 +643,10 @@ public class FieldInfos implements Iterable<FieldInfo> {
      *     {@code dvType} returns a new FieldInfo based based on the options in global field numbers
      */
     FieldInfo constructFieldInfo(String fieldName, DocValuesType dvType, int newFieldNumber) {
-      Integer fieldNumber;
+      FieldProperties fieldProperties;
       synchronized (this) {
-        fieldNumber = fieldProperties.get(fieldName).number;
+        fieldProperties = this.fieldProperties.get(fieldName);
       }
-      if (fieldNumber == null) return null;
-      FieldProperties fieldProperties = this.fieldProperties.get(fieldName);
       if (fieldProperties == null) return null;
       DocValuesType dvType0 = fieldProperties.docValuesType;
       if (dvType != dvType0) return null;

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -439,7 +439,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
                 fieldNumber,
                 fi.getIndexOptions(),
                 fi.getIndexOptions() != IndexOptions.NONE
-                    ? new IndexOptionsProperties(fi.hasVectors(), fi.hasNorms())
+                    ? new IndexOptionsProperties(fi.hasVectors(), fi.omitsNorms())
                     : null,
                 fi.getDocValuesType(),
                 new FieldDimensions(


### PR DESCRIPTION
This commit merges indexOptions, DocValuesType, FieldDimensions and FieldVectorProperties into one map by introducing the record FieldProperties.

In addition it moves to a record the internal classes FieldDimensions and FieldProperties.

fixes https://github.com/apache/lucene/issues/13459

