### PR TITLE
Fix global score update bug in MultiLeafKnnCollector

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -259,7 +259,9 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+
+* GITHUB#13463: Address bug in MultiLeafKnnCollector causing #minCompetitiveSimilarity to stay artificially low in
+  some corner cases. (Greg Miller)
 
 Other
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/knn/MultiLeafKnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/knn/MultiLeafKnnCollector.java
@@ -105,6 +105,9 @@ public final class MultiLeafKnnCollector implements KnnCollector {
     if (kResultsCollected) {
       // as we've collected k results, we can start do periodic updates with the global queue
       if (firstKResultsCollected || (subCollector.visitedCount() & interval) == 0) {
+        // BlockingFloatHeap#offer requires input to be sorted in ascending order, so we can't
+        // pass in the underlying updatesQueue array as-is since it is only partially ordered
+        // (see GH#13462):
         for (int i = 0; i < k(); i++) {
           updatesScratch[i] = updatesQueue.poll();
         }

--- a/lucene/core/src/java/org/apache/lucene/search/knn/MultiLeafKnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/knn/MultiLeafKnnCollector.java
@@ -110,7 +110,6 @@ public final class MultiLeafKnnCollector implements KnnCollector {
         }
         assert updatesQueue.size() == 0;
         cachedGlobalMinSim = globalSimilarityQueue.offer(updatesScratch);
-        updatesQueue.clear();
         globalSimUpdated = true;
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/search/knn/MultiLeafKnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/knn/MultiLeafKnnCollector.java
@@ -108,12 +108,15 @@ public final class MultiLeafKnnCollector implements KnnCollector {
         // BlockingFloatHeap#offer requires input to be sorted in ascending order, so we can't
         // pass in the underlying updatesQueue array as-is since it is only partially ordered
         // (see GH#13462):
-        for (int i = 0; i < k(); i++) {
-          updatesScratch[i] = updatesQueue.poll();
+        int len = updatesQueue.size();
+        if (len > 0) {
+          for (int i = 0; i < len; i++) {
+            updatesScratch[i] = updatesQueue.poll();
+          }
+          assert updatesQueue.size() == 0;
+          cachedGlobalMinSim = globalSimilarityQueue.offer(updatesScratch, len);
+          globalSimUpdated = true;
         }
-        assert updatesQueue.size() == 0;
-        cachedGlobalMinSim = globalSimilarityQueue.offer(updatesScratch);
-        globalSimUpdated = true;
       }
     }
     return localSimUpdated || globalSimUpdated;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/BlockingFloatHeap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/BlockingFloatHeap.java
@@ -72,12 +72,13 @@ public final class BlockingFloatHeap {
    * <p>Values must be sorted in ascending order.
    *
    * @param values a set of values to insert, must be sorted in ascending order
+   * @param len number of values from the {@code values} array to insert
    * @return the new 'top' element in the queue.
    */
-  public float offer(float[] values) {
+  public float offer(float[] values, int len) {
     lock.lock();
     try {
-      for (int i = values.length - 1; i >= 0; i--) {
+      for (int i = len - 1; i >= 0; i--) {
         if (size < maxSize) {
           push(values[i]);
         } else {

--- a/lucene/core/src/test/org/apache/lucene/search/knn/TestMultiLeafKnnCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/knn/TestMultiLeafKnnCollector.java
@@ -3,10 +3,10 @@ package org.apache.lucene.search.knn;
 import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.hnsw.BlockingFloatHeap;
-import org.junit.Ignore;
 
 public class TestMultiLeafKnnCollector extends LuceneTestCase {
-  @Ignore
+
+  /** Validates a fix for GH#13462 */
   public void testGlobalScoreCoordination() {
     int k = 7;
     BlockingFloatHeap globalHeap = new BlockingFloatHeap(k);
@@ -26,7 +26,9 @@ public class TestMultiLeafKnnCollector extends LuceneTestCase {
     assertEquals(100f, collector1.minCompetitiveSimilarity(), 0f);
 
     // Collect k (7) hits in collector2 with only two that are competitive (200 and 300),
-    // which also forces an update of the global heap with collector2's hits:
+    // which also forces an update of the global heap with collector2's hits. This is a tricky
+    // case where the heap will not be fully ordered, so it ensures global queue updates don't
+    // incorrectly short-circuit (see GH#13462):
     collector2.collect(0, 10f);
     collector2.collect(0, 11f);
     collector2.collect(0, 12f);
@@ -34,12 +36,6 @@ public class TestMultiLeafKnnCollector extends LuceneTestCase {
     collector2.collect(0, 200f);
     collector2.collect(0, 14f);
     collector2.collect(0, 300f);
-
-    // The value 200 is failing to get added to the global heap. collector2 keeps its local scores
-    // in a heap for the global update where the layout is [10, 11, 12, 13, 200, 14, 300]. This
-    // is a correct heap partial ordering but the logic for updating the global heap assumes the
-    // data is sorted and short-circuits the updates to the global heap after visiting the value
-    // 14 (it visits the values in descending order assuming they are fully sorted).
 
     // At this point, our global heap should contain [102, 103, 104, 105, 106, 200, 300] since
     // values 200 and 300 from collector2 should have pushed out 100 and 101 from collector1.

--- a/lucene/core/src/test/org/apache/lucene/search/knn/TestMultiLeafKnnCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/knn/TestMultiLeafKnnCollector.java
@@ -1,0 +1,44 @@
+package org.apache.lucene.search.knn;
+
+import org.apache.lucene.search.TopKnnCollector;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.hnsw.BlockingFloatHeap;
+import org.junit.Ignore;
+
+public class TestMultiLeafKnnCollector extends LuceneTestCase {
+  @Ignore
+  public void testGlobalScoreCoordination() {
+    int k = 7;
+    BlockingFloatHeap globalHeap = new BlockingFloatHeap(k);
+    MultiLeafKnnCollector collector1 =
+        new MultiLeafKnnCollector(k, globalHeap, new TopKnnCollector(k, Integer.MAX_VALUE));
+    MultiLeafKnnCollector collector2 =
+        new MultiLeafKnnCollector(k, globalHeap, new TopKnnCollector(k, Integer.MAX_VALUE));
+
+    // Collect k (7) hits in collector1 with scores [100, 106]:
+    for (int i = 0; i < k; i++) {
+      collector1.collect(0, 100f + i);
+    }
+
+    // The global heap should be updated since k hits were collected, and have a min score of
+    // 100:
+    assertEquals(100f, globalHeap.peek(), 0f);
+    assertEquals(100f, collector1.minCompetitiveSimilarity(), 0f);
+
+    // Collect k (7) hits in collector2 with only two that are competitive (200 and 300),
+    // which also forces an update of the global heap with collector2's hits:
+    collector2.collect(0, 10f);
+    collector2.collect(0, 11f);
+    collector2.collect(0, 12f);
+    collector2.collect(0, 13f);
+    collector2.collect(0, 200f);
+    collector2.collect(0, 14f);
+    collector2.collect(0, 300f);
+
+    // At this point, our global heap should contain [102, 103, 104, 105, 106, 200, 300] since
+    // values 200 and 300 from collector2 should have pushed out 100 and 101 from collector1.
+    // The min value on the global heap should be 102:
+    assertEquals(102f, globalHeap.peek(), 0f);
+    assertEquals(102f, collector2.minCompetitiveSimilarity(), 0f);
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/knn/TestMultiLeafKnnCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/knn/TestMultiLeafKnnCollector.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.search.knn;
 
 import org.apache.lucene.search.TopKnnCollector;

--- a/lucene/core/src/test/org/apache/lucene/search/knn/TestMultiLeafKnnCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/knn/TestMultiLeafKnnCollector.java
@@ -35,6 +35,12 @@ public class TestMultiLeafKnnCollector extends LuceneTestCase {
     collector2.collect(0, 14f);
     collector2.collect(0, 300f);
 
+    // The value 200 is failing to get added to the global heap. collector2 keeps its local scores
+    // in a heap for the global update where the layout is [10, 11, 12, 13, 200, 14, 300]. This
+    // is a correct heap partial ordering but the logic for updating the global heap assumes the
+    // data is sorted and short-circuits the updates to the global heap after visiting the value
+    // 14 (it visits the values in descending order assuming they are fully sorted).
+
     // At this point, our global heap should contain [102, 103, 104, 105, 106, 200, 300] since
     // values 200 and 300 from collector2 should have pushed out 100 and 101 from collector1.
     // The min value on the global heap should be 102:


### PR DESCRIPTION
Addresses the bug described in GH #13462

Relates to https://github.com/apache/lucene/pull/12962