### PR TITLE
Add int8_hnsw backcompat index creation to dev tools scripts

### DIFF
--- a/dev-tools/scripts/addBackcompatIndexes.py
+++ b/dev-tools/scripts/addBackcompatIndexes.py
@@ -40,6 +40,7 @@ def create_and_add_index(source, indextype, index_version, current_version, temp
       'cfs': 'index',
       'nocfs': 'index',
       'sorted': 'sorted',
+      'int8_hnsw': 'int8_hnsw',
       'moreterms': 'moreterms',
       'dvupdates': 'dvupdates',
       'emptyIndex': 'empty'
@@ -60,6 +61,7 @@ def create_and_add_index(source, indextype, index_version, current_version, temp
     'cfs': 'testCreateCFS',
     'nocfs': 'testCreateNoCFS',
     'sorted': 'testCreateSortedIndex',
+    'int8_hnsw': 'testCreateInt8HNSWIndices',
     'moreterms': 'testCreateMoreTermsIndex',
     'dvupdates': 'testCreateIndexWithDocValuesUpdates',
     'emptyIndex': 'testCreateEmptyIndex'
@@ -204,6 +206,7 @@ def main():
   current_version = scriptutil.Version.parse(scriptutil.find_current_version())
   create_and_add_index(source, 'cfs', c.version, current_version, c.temp_dir)
   create_and_add_index(source, 'nocfs', c.version, current_version, c.temp_dir)
+  create_and_add_index(source, 'int8_hnsw', c.version, current_version, c.temp_dir)
   should_make_sorted =     current_version.is_back_compat_with(c.version) \
                        and (c.version.major > 6 or (c.version.major == 6 and c.version.minor >= 2))
   if should_make_sorted:


### PR DESCRIPTION
I noticed during the 9.11 release, that I failed to update the `addBackcompatIndexes` script when I added new backcompat tests & indices. 


This commit remedies this. I will backport to 9x and 9.11 (for if there is ever a 9.11.1 release).