### PR TITLE
Silence odd test runner warnings after gradle upgrade

### DIFF
--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -135,7 +135,9 @@ allprojects {
       
       jvmArgs '--enable-native-access=' + (project.path in [
               ':lucene:core',
-              ':lucene:codecs'
+              ':lucene:codecs',
+              ":lucene:distribution.tests",
+              ":lucene:test-framework"
       ] ? 'ALL-UNNAMED' : 'org.apache.lucene.core')
 
       def loggingConfigFile = layout.projectDirectory.file("${resources}/logging.properties")

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -133,7 +133,10 @@ allprojects {
         jvmArgs '--add-modules', 'jdk.incubator.vector'
       }
       
-      jvmArgs '--enable-native-access=' + (project.path == ':lucene:core' ? 'ALL-UNNAMED' : 'org.apache.lucene.core')
+      jvmArgs '--enable-native-access=' + (project.path in [
+              ':lucene:core',
+              ':lucene:codecs'
+      ] ? 'ALL-UNNAMED' : 'org.apache.lucene.core')
 
       def loggingConfigFile = layout.projectDirectory.file("${resources}/logging.properties")
       def tempDir = layout.projectDirectory.dir(testsTmpDir.toString())

--- a/lucene/core/src/test/org/apache/lucene/codecs/TestCodecLoadingDeadlock.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/TestCodecLoadingDeadlock.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.NamedThreadFactory;
+import org.apache.lucene.util.SuppressForbidden;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +51,7 @@ public class TestCodecLoadingDeadlock extends Assert {
   private static final int MAX_TIME_SECONDS = 30;
 
   @Test
+  @SuppressForbidden(reason = "Uses Path.toFile because ProcessBuilder requires it.")
   public void testDeadlock() throws Exception {
     // pick random codec names for stress test in separate process:
     final Random rnd = RandomizedContext.current().getRandom();


### PR DESCRIPTION
Gradle started to proxy syserr messages from test runner JVMs. We can see some odd messages like:
```
2024-06-07T21:46:31.293+0200 [ERROR] [system.err] WARNING: Java vector incubator module is not readable. For optimal vector performance, pass '--add-modules jdk.incubator.vector' to enable Vector API.
...
WARNING: Unknown module: org.apache.lucene.core specified to --enable-native-access
```

This PR tries to silence both. A proper fix would be to correct modularity for the codec subproject, but it's a different beast.