### PR TITLE
Make Gradle dashboard easy to find by adding a badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Apache Lucene is a high-performance, full-featured text search engine library
 written in Java.
 
 [![Build Status](https://ci-builds.apache.org/job/Lucene/job/Lucene-Artifacts-main/badge/icon?subject=Lucene)](https://ci-builds.apache.org/job/Lucene/job/Lucene-Artifacts-main/)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.apache.org/scans?search.buildToolType=gradle&search.rootProjectNames=lucene-root)
 
 ## Online Documentation
 


### PR DESCRIPTION
### Description

#12293 made it so we would publish builds which can be viewed at [ge.apache.org](https://ge.apache.org/scans?search.buildToolType=gradle&search.rootProjectNames=lucene-root), but I don't think we ever linked this dashboard anywhere so people could find it easily. This PR adds a badge to the README, which links to the builds dashboard, as seen in https://github.com/apache/creadur-rat/pull/266.
