### PR TITLE
Adjust assertion check to not throw an NPE

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -736,10 +736,14 @@ public final class SortingCodecReader extends FilterCodecReader {
     if (timesCached > 1) {
       assert norms == false : "[" + field + "] norms must not be cached twice";
       boolean isSortField = false;
-      for (SortField sf : metaData.getSort().getSort()) {
-        if (field.equals(sf.getField())) {
-          isSortField = true;
-          break;
+      // For things that aren't sort fields, it's possible for sort to be null here
+      // In the event that we accidentally cache twice, its better not to throw an NPE
+      if (metaData.getSort() != null) {
+        for (SortField sf : metaData.getSort().getSort()) {
+          if (field.equals(sf.getField())) {
+            isSortField = true;
+            break;
+          }
         }
       }
       assert timesCached == 2


### PR DESCRIPTION
It is possible when checking this assertion, that we could throw an NPE as `metaData.getSort()` can be `null`.

Let's actually allow the assertions do their checks instead of throwing a scary NPE here.

related: https://github.com/apache/lucene/issues/13478