### PR TITLE
Minor cleanup in some Facet tests

### DIFF
--- a/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
@@ -85,7 +85,8 @@ public abstract class FacetTestCase extends LuceneTestCase {
    * @param docId docId for which facet labels are needed.
    * @param dimension Retain facet labels for supplied dimension only. A null value fetches all
    *     facet labels.
-   * @param facetLabelReader {@FacetLabelReader} instance use to get facet labels for input docId.
+   * @param facetLabelReader {@link FacetLabelReader} instance use to get facet labels for input
+   *     docId.
    * @return {@code List<FacetLabel>} containing matching facet labels.
    * @throws IOException when a low-level IO issue occurs while reading facet labels.
    */

--- a/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -179,12 +178,9 @@ public abstract class FacetTestCase extends LuceneTestCase {
               labelValues,
               i - numInRow,
               i,
-              new Comparator<LabelAndValue>() {
-                @Override
-                public int compare(LabelAndValue a, LabelAndValue b) {
-                  assert a.value.doubleValue() == b.value.doubleValue();
-                  return new BytesRef(a.label).compareTo(new BytesRef(b.label));
-                }
+              (a, b) -> {
+                assert a.value.doubleValue() == b.value.doubleValue();
+                return new BytesRef(a.label).compareTo(new BytesRef(b.label));
               });
         }
         numInRow = 1;
@@ -199,16 +195,13 @@ public abstract class FacetTestCase extends LuceneTestCase {
   protected void sortLabelValues(List<LabelAndValue> labelValues) {
     Collections.sort(
         labelValues,
-        new Comparator<LabelAndValue>() {
-          @Override
-          public int compare(LabelAndValue a, LabelAndValue b) {
-            if (a.value.doubleValue() > b.value.doubleValue()) {
-              return -1;
-            } else if (a.value.doubleValue() < b.value.doubleValue()) {
-              return 1;
-            } else {
-              return new BytesRef(a.label).compareTo(new BytesRef(b.label));
-            }
+        (a, b) -> {
+          if (a.value.doubleValue() > b.value.doubleValue()) {
+            return -1;
+          } else if (a.value.doubleValue() < b.value.doubleValue()) {
+            return 1;
+          } else {
+            return new BytesRef(a.label).compareTo(new BytesRef(b.label));
           }
         });
   }
@@ -216,16 +209,13 @@ public abstract class FacetTestCase extends LuceneTestCase {
   protected void sortFacetResults(List<FacetResult> results) {
     Collections.sort(
         results,
-        new Comparator<FacetResult>() {
-          @Override
-          public int compare(FacetResult a, FacetResult b) {
-            if (a.value.doubleValue() > b.value.doubleValue()) {
-              return -1;
-            } else if (b.value.doubleValue() > a.value.doubleValue()) {
-              return 1;
-            } else {
-              return a.dim.compareTo(b.dim);
-            }
+        (a, b) -> {
+          if (a.value.doubleValue() > b.value.doubleValue()) {
+            return -1;
+          } else if (b.value.doubleValue() > a.value.doubleValue()) {
+            return 1;
+          } else {
+            return a.dim.compareTo(b.dim);
           }
         });
   }

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -80,14 +80,12 @@ public class TestLongValueFacetCounts extends FacetTestCase {
         new String[0],
         6,
         101,
-        new LabelAndValue[] {
-          new LabelAndValue("0", 20),
-          new LabelAndValue("1", 20),
-          new LabelAndValue("2", 20),
-          new LabelAndValue("3", 20),
-          new LabelAndValue("4", 20),
-          new LabelAndValue("9223372036854775807", 1)
-        });
+        new LabelAndValue("0", 20),
+        new LabelAndValue("1", 20),
+        new LabelAndValue("2", 20),
+        new LabelAndValue("3", 20),
+        new LabelAndValue("4", 20),
+        new LabelAndValue("9223372036854775807", 1));
 
     r.close();
     d.close();
@@ -123,9 +121,8 @@ public class TestLongValueFacetCounts extends FacetTestCase {
         new String[0],
         2,
         9,
-        new LabelAndValue[] {
-          new LabelAndValue("0", 4), new LabelAndValue("1", 5),
-        });
+        new LabelAndValue("0", 4),
+        new LabelAndValue("1", 5));
 
     r.close();
     d.close();
@@ -156,11 +153,9 @@ public class TestLongValueFacetCounts extends FacetTestCase {
         new String[0],
         3,
         3,
-        new LabelAndValue[] {
-          new LabelAndValue("9223372036854775805", 1),
-          new LabelAndValue("9223372036854775806", 1),
-          new LabelAndValue("9223372036854775807", 1)
-        });
+        new LabelAndValue("9223372036854775805", 1),
+        new LabelAndValue("9223372036854775806", 1),
+        new LabelAndValue("9223372036854775807", 1));
 
     // since we have no insight into the value order in the hashMap, we sort labels by value and
     // count in
@@ -221,11 +216,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
     List<FacetResult> topDimsResults2 = facets.getTopDims(0, 1);
     assertEquals(0, topDimsResults2.size());
     // test getAllDims(0)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getAllDims(0);
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getAllDims(0));
 
     r.close();
     d.close();
@@ -364,8 +355,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
 
       // test getAllChildren
       expectedCounts.sort(
-          Comparator.comparing((Map.Entry<Long, Integer> a) -> a.getKey())
-              .thenComparingLong(Map.Entry::getValue));
+          Map.Entry.<Long, Integer>comparingByKey().thenComparingLong(Map.Entry::getValue));
       FacetResult allChildren = facetCounts.getAllChildren("field");
       // sort labels by value, count in ascending order
       Arrays.sort(
@@ -627,8 +617,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
 
       // test getAllChildren
       expectedCounts.sort(
-          Comparator.comparing((Map.Entry<Long, Integer> a) -> a.getKey())
-              .thenComparingLong(Map.Entry::getValue));
+          Map.Entry.<Long, Integer>comparingByKey().thenComparingLong(Map.Entry::getValue));
       FacetResult allChildren = facetCounts.getAllChildren("field");
       // sort labels by value, count in ascending order
       Arrays.sort(
@@ -833,9 +822,8 @@ public class TestLongValueFacetCounts extends FacetTestCase {
         new String[0],
         2,
         2,
-        new LabelAndValue[] {
-          new LabelAndValue("42", 1), new LabelAndValue("43", 1),
-        });
+        new LabelAndValue("42", 1),
+        new LabelAndValue("43", 1));
 
     r.close();
     dir.close();

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestMultipleIndexFields.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestMultipleIndexFields.java
@@ -86,7 +86,7 @@ public class TestMultipleIndexFields extends FacetTestCase {
     // prepare searcher to search against
     IndexSearcher searcher = newSearcher(ir);
 
-    FacetsCollector sfc = performSearch(tr, ir, searcher);
+    FacetsCollector sfc = performSearch(searcher);
 
     // Obtain facets results and hand-test them
     assertCorrectResults(getTaxonomyFacetCounts(tr, config, sfc));
@@ -124,7 +124,7 @@ public class TestMultipleIndexFields extends FacetTestCase {
     // prepare searcher to search against
     IndexSearcher searcher = newSearcher(ir);
 
-    FacetsCollector sfc = performSearch(tr, ir, searcher);
+    FacetsCollector sfc = performSearch(searcher);
 
     Map<String, Facets> facetsMap = new HashMap<>();
     facetsMap.put("Author", getTaxonomyFacetCounts(tr, config, sfc, "$author"));
@@ -168,7 +168,7 @@ public class TestMultipleIndexFields extends FacetTestCase {
     // prepare searcher to search against
     IndexSearcher searcher = newSearcher(ir);
 
-    FacetsCollector sfc = performSearch(tr, ir, searcher);
+    FacetsCollector sfc = performSearch(searcher);
 
     Map<String, Facets> facetsMap = new HashMap<>();
     Facets facets2 = getTaxonomyFacetCounts(tr, config, sfc, "$music");
@@ -225,7 +225,7 @@ public class TestMultipleIndexFields extends FacetTestCase {
     // prepare searcher to search against
     IndexSearcher searcher = newSearcher(ir);
 
-    FacetsCollector sfc = performSearch(tr, ir, searcher);
+    FacetsCollector sfc = performSearch(searcher);
 
     Map<String, Facets> facetsMap = new HashMap<>();
     facetsMap.put("Band", getTaxonomyFacetCounts(tr, config, sfc, "$bands"));
@@ -271,7 +271,7 @@ public class TestMultipleIndexFields extends FacetTestCase {
     // prepare searcher to search against
     IndexSearcher searcher = newSearcher(ir);
 
-    FacetsCollector sfc = performSearch(tr, ir, searcher);
+    FacetsCollector sfc = performSearch(searcher);
 
     Map<String, Facets> facetsMap = new HashMap<>();
     Facets facets2 = getTaxonomyFacetCounts(tr, config, sfc, "$music");
@@ -335,8 +335,7 @@ public class TestMultipleIndexFields extends FacetTestCase {
         });
   }
 
-  private FacetsCollector performSearch(TaxonomyReader tr, IndexReader ir, IndexSearcher searcher)
-      throws IOException {
+  private FacetsCollector performSearch(IndexSearcher searcher) throws IOException {
     FacetsCollector fc = new FacetsCollector();
     FacetsCollector.search(searcher, new MatchAllDocsQuery(), 10, fc);
     return fc;

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestMultipleIndexFields.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestMultipleIndexFields.java
@@ -300,9 +300,8 @@ public class TestMultipleIndexFields extends FacetTestCase {
         new String[0],
         2,
         5,
-        new LabelAndValue[] {
-          new LabelAndValue("Punk", 1), new LabelAndValue("Rock & Pop", 4),
-        });
+        new LabelAndValue("Punk", 1),
+        new LabelAndValue("Rock & Pop", 4));
     assertEquals(
         "dim=Band path=[Rock & Pop] value=4 childCount=4\n  The Beatles (1)\n  U2 (1)\n  REM (1)\n  Dave Matthews Band (1)\n",
         facets.getTopChildren(10, "Band", "Rock & Pop").toString());
@@ -312,12 +311,10 @@ public class TestMultipleIndexFields extends FacetTestCase {
         new String[] {"Rock & Pop"},
         4,
         4,
-        new LabelAndValue[] {
-          new LabelAndValue("Dave Matthews Band", 1),
-          new LabelAndValue("REM", 1),
-          new LabelAndValue("The Beatles", 1),
-          new LabelAndValue("U2", 1),
-        });
+        new LabelAndValue("Dave Matthews Band", 1),
+        new LabelAndValue("REM", 1),
+        new LabelAndValue("The Beatles", 1),
+        new LabelAndValue("U2", 1));
 
     assertEquals(
         "dim=Author path=[] value=3 childCount=3\n  Mark Twain (1)\n  Stephen King (1)\n  Kurt Vonnegut (1)\n",
@@ -328,11 +325,9 @@ public class TestMultipleIndexFields extends FacetTestCase {
         new String[0],
         3,
         3,
-        new LabelAndValue[] {
-          new LabelAndValue("Kurt Vonnegut", 1),
-          new LabelAndValue("Mark Twain", 1),
-          new LabelAndValue("Stephen King", 1),
-        });
+        new LabelAndValue("Kurt Vonnegut", 1),
+        new LabelAndValue("Mark Twain", 1),
+        new LabelAndValue("Stephen King", 1));
   }
 
   private FacetsCollector performSearch(IndexSearcher searcher) throws IOException {

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestRandomSamplingFacetsCollector.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestRandomSamplingFacetsCollector.java
@@ -119,7 +119,7 @@ public class TestRandomSamplingFacetsCollector extends FacetTestCase {
       float ei = (float) md.totalHits / totalHits;
       if (ei > 0.0f) {
         float oi = (float) numSampledDocs[i] / totalSampledDocs;
-        chi_square += (Math.pow(ei - oi, 2) / ei);
+        chi_square += (float) (Math.pow(ei - oi, 2) / ei);
       }
     }
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestStringValueFacetCounts.java
@@ -431,11 +431,7 @@ public class TestStringValueFacetCounts extends FacetTestCase {
       assertEquals(facetResult, topNDimsResult.get(0));
 
       // test getAllDims(0)
-      expectThrows(
-          IllegalArgumentException.class,
-          () -> {
-            facets.getAllDims(0);
-          });
+      expectThrows(IllegalArgumentException.class, () -> facets.getAllDims(0));
 
       // This is a little strange, but we request all labels at this point so that when we
       // secondarily sort by label value in order to compare to the expected results, we have
@@ -501,8 +497,7 @@ public class TestStringValueFacetCounts extends FacetTestCase {
 
     // sort expected counts by value, count
     expectedCountsSortedByValue.sort(
-        Comparator.comparing((Map.Entry<String, Integer> a) -> a.getKey())
-            .thenComparingInt(Map.Entry::getValue));
+        Map.Entry.<String, Integer>comparingByKey().thenComparingInt(Map.Entry::getValue));
 
     FacetResult facetResult = facets.getAllChildren("field");
     assertEquals(expectedTotalDocsWithValue, facetResult.value);

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestRangeFacetCounts.java
@@ -112,11 +112,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
         result.toString());
 
     // test getTopChildren(0, dim)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopChildren(0, "field");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getTopChildren(0, "field"));
 
     r.close();
     d.close();
@@ -169,11 +165,7 @@ public class TestRangeFacetCounts extends FacetTestCase {
         result.toString());
 
     // test getTopChildren(0, dim)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopChildren(0, "field");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getTopChildren(0, "field"));
 
     r.close();
     d.close();
@@ -287,37 +279,19 @@ public class TestRangeFacetCounts extends FacetTestCase {
     assertEquals(0, topNDimsResult.size());
 
     // test getAllDims(0)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getAllDims(0);
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getAllDims(0));
 
     r.close();
     d.close();
   }
 
   public void testUselessRange() {
+    expectThrows(IllegalArgumentException.class, () -> new LongRange("useless", 7, true, 6, true));
+    expectThrows(IllegalArgumentException.class, () -> new LongRange("useless", 7, true, 7, false));
     expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new LongRange("useless", 7, true, 6, true);
-        });
+        IllegalArgumentException.class, () -> new DoubleRange("useless", 7.0, true, 6.0, true));
     expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new LongRange("useless", 7, true, 7, false);
-        });
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new DoubleRange("useless", 7.0, true, 6.0, true);
-        });
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new DoubleRange("useless", 7.0, true, 7.0, false);
-        });
+        IllegalArgumentException.class, () -> new DoubleRange("useless", 7.0, true, 7.0, false));
   }
 
   public void testLongMinMax() throws Exception {

--- a/lucene/facet/src/test/org/apache/lucene/facet/rangeonrange/TestRangeOnRangeFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/rangeonrange/TestRangeOnRangeFacetCounts.java
@@ -100,11 +100,7 @@ public class TestRangeOnRangeFacetCounts extends FacetTestCase {
         result.toString());
 
     // test getTopChildren(0, dim)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopChildren(0, "field");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getTopChildren(0, "field"));
 
     r.close();
     d.close();
@@ -160,11 +156,7 @@ public class TestRangeOnRangeFacetCounts extends FacetTestCase {
         result.toString());
 
     // test getTopChildren(0, dim)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopChildren(0, "field");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getTopChildren(0, "field"));
 
     r.close();
     d.close();
@@ -224,11 +216,7 @@ public class TestRangeOnRangeFacetCounts extends FacetTestCase {
     assertEquals(0, topNDimsResult.size());
 
     // test getAllDims(0)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getAllDims(0);
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getAllDims(0));
 
     r.close();
     d.close();
@@ -289,60 +277,34 @@ public class TestRangeOnRangeFacetCounts extends FacetTestCase {
         result.get(0).toString());
 
     // test getTopChildren(0, dim)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopChildren(0, "field");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getTopChildren(0, "field"));
 
     r.close();
     d.close();
   }
 
   public void testUselessRangeSingleDim() {
+    expectThrows(IllegalArgumentException.class, () -> new LongRange("useless", 7, true, 6, true));
+    expectThrows(IllegalArgumentException.class, () -> new LongRange("useless", 7, true, 7, false));
     expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new LongRange("useless", 7, true, 6, true);
-        });
+        IllegalArgumentException.class, () -> new DoubleRange("useless", 7.0, true, 6.0, true));
     expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new LongRange("useless", 7, true, 7, false);
-        });
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new DoubleRange("useless", 7.0, true, 6.0, true);
-        });
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new DoubleRange("useless", 7.0, true, 7.0, false);
-        });
+        IllegalArgumentException.class, () -> new DoubleRange("useless", 7.0, true, 7.0, false));
   }
 
   public void testUselessMultiDimRange() {
     expectThrows(
         IllegalArgumentException.class,
-        () -> {
-          new LongRange("useless", longArray(7L, 7L), longArray(6L, 6L));
-        });
+        () -> new LongRange("useless", longArray(7L, 7L), longArray(6L, 6L)));
     expectThrows(
         IllegalArgumentException.class,
-        () -> {
-          new LongRange("useless", longArray(7L, 7L), longArray(7L, 6L));
-        });
+        () -> new LongRange("useless", longArray(7L, 7L), longArray(7L, 6L)));
     expectThrows(
         IllegalArgumentException.class,
-        () -> {
-          new DoubleRange("useless", doubleArray(7.0, 7.0), doubleArray(6.0, 6.0));
-        });
+        () -> new DoubleRange("useless", doubleArray(7.0, 7.0), doubleArray(6.0, 6.0)));
     expectThrows(
         IllegalArgumentException.class,
-        () -> {
-          new DoubleRange("useless", doubleArray(7.0, 7.0), doubleArray(7.0, 6.0));
-        });
+        () -> new DoubleRange("useless", doubleArray(7.0, 7.0), doubleArray(7.0, 6.0)));
   }
 
   public void testSingleDimLongMinMax() throws Exception {
@@ -769,11 +731,7 @@ public class TestRangeOnRangeFacetCounts extends FacetTestCase {
         result.toString());
 
     // test getTopChildren(0, dim)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopChildren(0, "field");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getTopChildren(0, "field"));
 
     IOUtils.close(r, d);
   }
@@ -830,11 +788,7 @@ public class TestRangeOnRangeFacetCounts extends FacetTestCase {
         result.toString());
 
     // test getTopChildren(0, dim)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopChildren(0, "field");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getTopChildren(0, "field"));
 
     IOUtils.close(r, d);
   }

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestFacetLabel.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestFacetLabel.java
@@ -160,88 +160,43 @@ public class TestFacetLabel extends FacetTestCase {
 
     // empty or null components should not be allowed.
     for (String[] components : components_tests) {
+      expectThrows(IllegalArgumentException.class, () -> new FacetLabel(components));
+      expectThrows(IllegalArgumentException.class, () -> new FacetField("dim", components));
       expectThrows(
           IllegalArgumentException.class,
-          () -> {
-            new FacetLabel(components);
-          });
+          () -> new AssociationFacetField(new BytesRef(), "dim", components));
       expectThrows(
           IllegalArgumentException.class,
-          () -> {
-            new FacetField("dim", components);
-          });
+          () -> new IntAssociationFacetField(17, "dim", components));
       expectThrows(
           IllegalArgumentException.class,
-          () -> {
-            new AssociationFacetField(new BytesRef(), "dim", components);
-          });
-      expectThrows(
-          IllegalArgumentException.class,
-          () -> {
-            new IntAssociationFacetField(17, "dim", components);
-          });
-      expectThrows(
-          IllegalArgumentException.class,
-          () -> {
-            new FloatAssociationFacetField(17.0f, "dim", components);
-          });
+          () -> new FloatAssociationFacetField(17.0f, "dim", components));
     }
 
+    expectThrows(IllegalArgumentException.class, () -> new FacetField(null, new String[] {"abc"}));
+    expectThrows(IllegalArgumentException.class, () -> new FacetField("", "abc"));
     expectThrows(
         IllegalArgumentException.class,
-        () -> {
-          new FacetField(null, new String[] {"abc"});
-        });
+        () -> new IntAssociationFacetField(17, null, new String[] {"abc"}));
     expectThrows(
         IllegalArgumentException.class,
-        () -> {
-          new FacetField("", new String[] {"abc"});
-        });
+        () -> new IntAssociationFacetField(17, "", new String[] {"abc"}));
     expectThrows(
         IllegalArgumentException.class,
-        () -> {
-          new IntAssociationFacetField(17, null, new String[] {"abc"});
-        });
+        () -> new FloatAssociationFacetField(17.0f, null, new String[] {"abc"}));
     expectThrows(
         IllegalArgumentException.class,
-        () -> {
-          new IntAssociationFacetField(17, "", new String[] {"abc"});
-        });
+        () -> new FloatAssociationFacetField(17.0f, "", new String[] {"abc"}));
     expectThrows(
         IllegalArgumentException.class,
-        () -> {
-          new FloatAssociationFacetField(17.0f, null, new String[] {"abc"});
-        });
+        () -> new AssociationFacetField(new BytesRef(), null, "abc"));
     expectThrows(
         IllegalArgumentException.class,
-        () -> {
-          new FloatAssociationFacetField(17.0f, "", new String[] {"abc"});
-        });
+        () -> new AssociationFacetField(new BytesRef(), "", new String[] {"abc"}));
     expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new AssociationFacetField(new BytesRef(), null, new String[] {"abc"});
-        });
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new AssociationFacetField(new BytesRef(), "", new String[] {"abc"});
-        });
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new SortedSetDocValuesFacetField(null, "abc");
-        });
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new SortedSetDocValuesFacetField("", "abc");
-        });
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new SortedSetDocValuesFacetField("dim", "");
-        });
+        IllegalArgumentException.class, () -> new SortedSetDocValuesFacetField(null, "abc"));
+    expectThrows(IllegalArgumentException.class, () -> new SortedSetDocValuesFacetField("", "abc"));
+    expectThrows(IllegalArgumentException.class, () -> new SortedSetDocValuesFacetField("dim", ""));
   }
 
   @Test
@@ -258,10 +213,6 @@ public class TestFacetLabel extends FacetTestCase {
 
     // long paths should not be allowed
     final String longPath = bigComp;
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          new FacetLabel("dim", longPath);
-        });
+    expectThrows(IllegalArgumentException.class, () -> new FacetLabel("dim", longPath));
   }
 }

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
@@ -287,11 +287,7 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
     tw.replaceTaxonomy(taxoDir2);
     taxoDir2.close();
 
-    expectThrows(
-        IllegalStateException.class,
-        () -> {
-          mgr.maybeRefresh();
-        });
+    expectThrows(IllegalStateException.class, mgr::maybeRefresh);
 
     w.close();
     IOUtils.close(mgr, tw, taxoDir, dir);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyCombined.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyCombined.java
@@ -525,21 +525,10 @@ public class TestTaxonomyCombined extends FacetTestCase {
     }
 
     // check parent of of invalid ordinals:
+    expectThrows(IndexOutOfBoundsException.class, () -> tw.getParent(-1));
     expectThrows(
-        IndexOutOfBoundsException.class,
-        () -> {
-          tw.getParent(-1);
-        });
-    expectThrows(
-        IndexOutOfBoundsException.class,
-        () -> {
-          tw.getParent(TaxonomyReader.INVALID_ORDINAL);
-        });
-    expectThrows(
-        IndexOutOfBoundsException.class,
-        () -> {
-          tw.getParent(tr.getSize());
-        });
+        IndexOutOfBoundsException.class, () -> tw.getParent(TaxonomyReader.INVALID_ORDINAL));
+    expectThrows(IndexOutOfBoundsException.class, () -> tw.getParent(tr.getSize()));
   }
 
   /**

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyCombined.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyCombined.java
@@ -150,7 +150,7 @@ public class TestTaxonomyCombined extends FacetTestCase {
     if (path.length == 0) {
       return "<empty>";
     }
-    return "<" + path.toString() + ">";
+    return "<" + path + ">";
   }
 
   /**

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
@@ -227,9 +227,8 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
         2,
         -1,
         Map.of("a", 100, "b", 50),
-        new LabelAndValue[] {
-          new LabelAndValue("a", 200), new LabelAndValue("b", 150),
-        });
+        new LabelAndValue("a", 200),
+        new LabelAndValue("b", 150));
     assertEquals(
         "Wrong count for category 'a'!", 200, facets.getSpecificValue("int", "a").intValue());
     assertEquals(
@@ -311,9 +310,8 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
         2,
         -1f,
         Map.of("a", 100, "b", 50),
-        new LabelAndValue[] {
-          new LabelAndValue("a", 50.0f), new LabelAndValue("b", 9.999995f),
-        });
+        new LabelAndValue("a", 50.0f),
+        new LabelAndValue("b", 9.999995f));
 
     assertEquals(
         "Wrong count for category 'a'!",
@@ -424,23 +422,11 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
     Facets facets =
         new TaxonomyFacetFloatAssociations(
             "wrong_field", taxoReader, config, fc, AssociationAggregationFunction.SUM);
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getSpecificValue("float");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getSpecificValue("float"));
 
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopChildren(10, "float");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getTopChildren(10, "float"));
 
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getAllChildren("float");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getAllChildren("float"));
   }
 
   public void testMixedTypesInSameIndexField() throws Exception {
@@ -455,10 +441,7 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
     doc.add(new IntAssociationFacetField(14, "a", "x"));
     doc.add(new FloatAssociationFacetField(55.0f, "b", "y"));
     expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          writer.addDocument(config.build(taxoWriter, doc));
-        });
+        IllegalArgumentException.class, () -> writer.addDocument(config.build(taxoWriter, doc)));
     writer.close();
     IOUtils.close(taxoWriter, dir, taxoDir);
   }
@@ -475,10 +458,7 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
     Document doc = new Document();
     doc.add(new IntAssociationFacetField(14, "a", "x"));
     expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          writer.addDocument(config.build(taxoWriter, doc));
-        });
+        IllegalArgumentException.class, () -> writer.addDocument(config.build(taxoWriter, doc)));
 
     writer.close();
     IOUtils.close(taxoWriter, dir, taxoDir);
@@ -496,10 +476,7 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
     Document doc = new Document();
     doc.add(new IntAssociationFacetField(14, "a", "x"));
     expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          writer.addDocument(config.build(taxoWriter, doc));
-        });
+        IllegalArgumentException.class, () -> writer.addDocument(config.build(taxoWriter, doc)));
 
     writer.close();
     IOUtils.close(taxoWriter, dir, taxoDir);
@@ -528,9 +505,8 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
         new String[0],
         2,
         -1,
-        new LabelAndValue[] {
-          new LabelAndValue("a", 100), new LabelAndValue("b", 150),
-        });
+        new LabelAndValue("a", 100),
+        new LabelAndValue("b", 150));
 
     assertEquals(
         "Wrong count for category 'a'!", 100, facets.getSpecificValue("int", "a").intValue());

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts2.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts2.java
@@ -122,8 +122,7 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     doc.add(new StringField(A.field(), A.text(), Store.NO));
   }
 
-  private static void addFacets(Document doc, FacetsConfig config, boolean updateTermExpectedCounts)
-      throws IOException {
+  private static void addFacets(Document doc, boolean updateTermExpectedCounts) throws IOException {
     List<FacetField> docCategories = randomCategories(random());
     for (FacetField ff : docCategories) {
       doc.add(ff);
@@ -163,29 +162,27 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     indexWriter.commit(); // flush a segment
   }
 
-  private static void indexDocsWithFacetsNoTerms(
-      IndexWriter indexWriter, TaxonomyWriter taxoWriter, Map<String, Integer> expectedCounts)
+  private static void indexDocsWithFacetsNoTerms(IndexWriter indexWriter, TaxonomyWriter taxoWriter)
       throws IOException {
     Random random = random();
     int numDocs = atLeast(random, 2);
     FacetsConfig config = getConfig();
     for (int i = 0; i < numDocs; i++) {
       Document doc = new Document();
-      addFacets(doc, config, false);
+      addFacets(doc, false);
       indexWriter.addDocument(config.build(taxoWriter, doc));
     }
     indexWriter.commit(); // flush a segment
   }
 
   private static void indexDocsWithFacetsAndTerms(
-      IndexWriter indexWriter, TaxonomyWriter taxoWriter, Map<String, Integer> expectedCounts)
-      throws IOException {
+      IndexWriter indexWriter, TaxonomyWriter taxoWriter) throws IOException {
     Random random = random();
     int numDocs = atLeast(random, 2);
     FacetsConfig config = getConfig();
     for (int i = 0; i < numDocs; i++) {
       Document doc = new Document();
-      addFacets(doc, config, true);
+      addFacets(doc, true);
       addField(doc);
       indexWriter.addDocument(config.build(taxoWriter, doc));
     }
@@ -193,8 +190,7 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
   }
 
   private static void indexDocsWithFacetsAndSomeTerms(
-      IndexWriter indexWriter, TaxonomyWriter taxoWriter, Map<String, Integer> expectedCounts)
-      throws IOException {
+      IndexWriter indexWriter, TaxonomyWriter taxoWriter) throws IOException {
     Random random = random();
     int numDocs = atLeast(random, 2);
     FacetsConfig config = getConfig();
@@ -204,7 +200,7 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
       if (hasContent) {
         addField(doc);
       }
-      addFacets(doc, config, hasContent);
+      addFacets(doc, hasContent);
       indexWriter.addDocument(config.build(taxoWriter, doc));
     }
     indexWriter.commit(); // flush a segment
@@ -256,13 +252,13 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     indexDocsNoFacets(indexWriter);
 
     // segment w/ categories, no content
-    indexDocsWithFacetsNoTerms(indexWriter, taxoWriter, allExpectedCounts);
+    indexDocsWithFacetsNoTerms(indexWriter, taxoWriter);
 
     // segment w/ categories and content
-    indexDocsWithFacetsAndTerms(indexWriter, taxoWriter, allExpectedCounts);
+    indexDocsWithFacetsAndTerms(indexWriter, taxoWriter);
 
     // segment w/ categories and some content
-    indexDocsWithFacetsAndSomeTerms(indexWriter, taxoWriter, allExpectedCounts);
+    indexDocsWithFacetsAndSomeTerms(indexWriter, taxoWriter);
 
     indexWriter.close();
     IOUtils.close(taxoWriter);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
@@ -694,7 +694,7 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
                 "dim" + i,
                 new String[0],
                 aggregatedValue,
-                labelValues.toArray(new LabelAndValue[labelValues.size()]),
+                labelValues.toArray(new LabelAndValue[0]),
                 labelValues.size()));
       }
     }
@@ -718,8 +718,8 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
     sortTies(actual);
 
     if (VERBOSE) {
-      System.out.println("expected=\n" + expected.toString());
-      System.out.println("actual=\n" + actual.toString());
+      System.out.println("expected=\n" + expected);
+      System.out.println("actual=\n" + actual);
     }
 
     assertFloatValuesEquals(expected, actual);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
@@ -134,11 +134,7 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
 
     // test getTopChildren(0, dim)
     final Facets f = facets;
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          f.getTopChildren(0, "Author");
-        });
+    expectThrows(IllegalArgumentException.class, () -> f.getTopChildren(0, "Author"));
 
     taxoReader.close();
     searcher.getIndexReader().close();
@@ -207,11 +203,7 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
     List<FacetResult> results = facets.getAllDims(10);
 
     // test getAllDims(0)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getAllDims(0);
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getAllDims(0));
 
     assertEquals(3, results.size());
     assertEquals(
@@ -236,18 +228,10 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
     assertEquals(results, allDimsResults);
 
     // test getTopDims(0, 1)
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopDims(0, 1);
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getTopDims(0, 1));
 
     // test getTopDims(1, 0) with topNChildren = 0
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopDims(1, 0);
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getTopDims(1, 0));
 
     IOUtils.close(searcher.getIndexReader(), taxoReader, dir, taxoDir);
   }
@@ -297,17 +281,9 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
     // test default implementation of getTopDims
     List<FacetResult> topDimsResults = facets.getTopDims(10, 10);
     assertTrue(topDimsResults.isEmpty());
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getSpecificValue("a");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getSpecificValue("a"));
 
-    expectThrows(
-        IllegalArgumentException.class,
-        () -> {
-          facets.getTopChildren(10, "a");
-        });
+    expectThrows(IllegalArgumentException.class, () -> facets.getTopChildren(10, "a"));
 
     IOUtils.close(searcher.getIndexReader(), taxoReader, dir, taxoDir);
   }

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestAddTaxonomy.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestAddTaxonomy.java
@@ -43,20 +43,18 @@ public class TestAddTaxonomy extends FacetTestCase {
       Thread[] addThreads = new Thread[4];
       for (int j = 0; j < addThreads.length; j++) {
         addThreads[j] =
-            new Thread() {
-              @Override
-              public void run() {
-                Random random = random();
-                while (numCats.decrementAndGet() > 0) {
-                  String cat = Integer.toString(random.nextInt(range));
-                  try {
-                    tw.addCategory(new FacetLabel("a", cat));
-                  } catch (IOException e) {
-                    throw new RuntimeException(e);
+            new Thread(
+                () -> {
+                  Random random = random();
+                  while (numCats.decrementAndGet() > 0) {
+                    String cat = Integer.toString(random.nextInt(range));
+                    try {
+                      tw.addCategory(new FacetLabel("a", cat));
+                    } catch (IOException e) {
+                      throw new RuntimeException(e);
+                    }
                   }
-                }
-              }
-            };
+                });
       }
 
       for (Thread t : addThreads) t.start();
@@ -203,19 +201,17 @@ public class TestAddTaxonomy extends FacetTestCase {
     Directory dest = newDirectory();
     final DirectoryTaxonomyWriter destTW = new DirectoryTaxonomyWriter(dest);
     Thread t =
-        new Thread() {
-          @Override
-          public void run() {
-            for (int i = 0; i < numCategories; i++) {
-              try {
-                destTW.addCategory(new FacetLabel("a", Integer.toString(i)));
-              } catch (IOException e) {
-                // shouldn't happen - if it does, let the test fail on uncaught exception.
-                throw new RuntimeException(e);
+        new Thread(
+            () -> {
+              for (int i = 0; i < numCategories; i++) {
+                try {
+                  destTW.addCategory(new FacetLabel("a", Integer.toString(i)));
+                } catch (IOException e) {
+                  // shouldn't happen - if it does, let the test fail on uncaught exception.
+                  throw new RuntimeException(e);
+                }
               }
-            }
-          }
-        };
+            });
     t.start();
 
     OrdinalMap map = new MemoryOrdinalMap();

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestAddTaxonomy.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestAddTaxonomy.java
@@ -83,11 +83,9 @@ public class TestAddTaxonomy extends FacetTestCase {
   }
 
   private void validate(Directory dest, Directory src, OrdinalMap ordMap) throws Exception {
-    DirectoryTaxonomyReader destTR = new DirectoryTaxonomyReader(dest);
-    try {
+    try (DirectoryTaxonomyReader destTR = new DirectoryTaxonomyReader(dest)) {
       final int destSize = destTR.getSize();
-      DirectoryTaxonomyReader srcTR = new DirectoryTaxonomyReader(src);
-      try {
+      try (DirectoryTaxonomyReader srcTR = new DirectoryTaxonomyReader(src)) {
         int[] map = ordMap.getMap();
 
         // validate taxo sizes
@@ -107,11 +105,7 @@ public class TestAddTaxonomy extends FacetTestCase {
           assertTrue(cp + " not found in destination", destOrdinal > 0);
           assertEquals(destOrdinal, map[j]);
         }
-      } finally {
-        srcTR.close();
       }
-    } finally {
-      destTR.close();
     }
   }
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestConcurrentFacetedIndexing.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestConcurrentFacetedIndexing.java
@@ -109,35 +109,32 @@ public class TestConcurrentFacetedIndexing extends FacetTestCase {
 
     for (int i = 0; i < indexThreads.length; i++) {
       indexThreads[i] =
-          new Thread() {
+          new Thread(
+              () -> {
+                Random random = random();
+                while (numDocs.decrementAndGet() > 0) {
+                  try {
+                    Document doc = new Document();
+                    int numCats = random.nextInt(3) + 1; // 1-3
+                    while (numCats-- > 0) {
+                      FacetField ff = newCategory();
+                      doc.add(ff);
 
-            @Override
-            public void run() {
-              Random random = random();
-              while (numDocs.decrementAndGet() > 0) {
-                try {
-                  Document doc = new Document();
-                  int numCats = random.nextInt(3) + 1; // 1-3
-                  while (numCats-- > 0) {
-                    FacetField ff = newCategory();
-                    doc.add(ff);
-
-                    FacetLabel label = new FacetLabel(ff.dim, ff.path);
-                    // add all prefixes to values
-                    int level = label.length;
-                    while (level > 0) {
-                      String s = FacetsConfig.pathToString(label.components, level);
-                      values.put(s, s);
-                      --level;
+                      FacetLabel label = new FacetLabel(ff.dim, ff.path);
+                      // add all prefixes to values
+                      int level = label.length;
+                      while (level > 0) {
+                        String s = FacetsConfig.pathToString(label.components, level);
+                        values.put(s, s);
+                        --level;
+                      }
                     }
+                    iw.addDocument(config.build(tw, doc));
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
                   }
-                  iw.addDocument(config.build(tw, doc));
-                } catch (IOException e) {
-                  throw new RuntimeException(e);
                 }
-              }
-            }
-          };
+              });
     }
 
     for (Thread t : indexThreads) t.start();

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyWriter.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyWriter.java
@@ -318,37 +318,35 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     Thread[] addThreads = new Thread[RandomNumbers.randomIntBetween(random(), 1, 12)];
     for (int z = 0; z < addThreads.length; z++) {
       addThreads[z] =
-          new Thread() {
-            @Override
-            public void run() {
-              Random random = random();
-              while (numCats.decrementAndGet() > 0) {
-                try {
-                  int value = random.nextInt(range);
-                  FacetLabel cp =
-                      new FacetLabel(
-                          Integer.toString(value / 1000),
-                          Integer.toString(value / 10000),
-                          Integer.toString(value / 100000),
-                          Integer.toString(value));
-                  int ord = tw.addCategory(cp);
-                  assertTrue(
-                      "invalid parent for ordinal " + ord + ", category " + cp,
-                      tw.getParent(ord) != -1);
-                  String l1 = FacetsConfig.pathToString(cp.components, 1);
-                  String l2 = FacetsConfig.pathToString(cp.components, 2);
-                  String l3 = FacetsConfig.pathToString(cp.components, 3);
-                  String l4 = FacetsConfig.pathToString(cp.components, 4);
-                  values.put(l1, l1);
-                  values.put(l2, l2);
-                  values.put(l3, l3);
-                  values.put(l4, l4);
-                } catch (IOException e) {
-                  throw new RuntimeException(e);
+          new Thread(
+              () -> {
+                Random random = random();
+                while (numCats.decrementAndGet() > 0) {
+                  try {
+                    int value = random.nextInt(range);
+                    FacetLabel cp =
+                        new FacetLabel(
+                            Integer.toString(value / 1000),
+                            Integer.toString(value / 10000),
+                            Integer.toString(value / 100000),
+                            Integer.toString(value));
+                    int ord = tw.addCategory(cp);
+                    assertTrue(
+                        "invalid parent for ordinal " + ord + ", category " + cp,
+                        tw.getParent(ord) != -1);
+                    String l1 = FacetsConfig.pathToString(cp.components, 1);
+                    String l2 = FacetsConfig.pathToString(cp.components, 2);
+                    String l3 = FacetsConfig.pathToString(cp.components, 3);
+                    String l4 = FacetsConfig.pathToString(cp.components, 4);
+                    values.put(l1, l1);
+                    values.put(l2, l2);
+                    values.put(l3, l3);
+                    values.put(l4, l4);
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
                 }
-              }
-            }
-          };
+              });
     }
 
     for (Thread t : addThreads) t.start();


### PR DESCRIPTION
Fixing some IDE "warnings", such as removing some dead code + fixing a link + adding use of try-with-resources.

Did not fix `'search(org.apache.lucene.search.Query, org.apache.lucene.search.Collector)' is deprecated`, since it will be fixed as part of Issue: 12892.

While I am already touching these, let me know if anyone has strong opinions and I can also fix the `Statement lambda can be replaced with expression lambda` or `Redundant array creation for calling varargs method` "warnings".
