### PR TITLE
Avoid performance regression by constructing lazily the PointTree in NumericComparator

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -39,7 +39,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+
+* GITHUB#13498: Avoid performance regression by constructing lazily the PointTree in NumericComparator, (Ignacio Vera)
 
 Other
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -90,7 +90,8 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     private final LeafReaderContext context;
     protected final NumericDocValues docValues;
     private final PointValues pointValues;
-    private final PointValues.PointTree pointTree;
+    // lazily constructed
+    private PointValues.PointTree pointTree;
     // if skipping functionality should be enabled on this segment
     private final boolean enableSkipping;
     private final int maxDoc;
@@ -130,12 +131,10 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
                   + " expected "
                   + bytesCount);
         }
-        this.pointTree = pointValues.getPointTree();
         this.enableSkipping = true; // skipping is enabled when points are available
         this.maxDoc = context.reader().maxDoc();
         this.competitiveIterator = DocIdSetIterator.all(maxDoc);
       } else {
-        this.pointTree = null;
         this.enableSkipping = false;
         this.maxDoc = 0;
       }
@@ -286,7 +285,8 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
           };
       final long threshold = iteratorCost >>> 3;
 
-      if (PointValues.isEstimatedPointCountGreaterThanOrEqualTo(visitor, pointTree, threshold)) {
+      if (PointValues.isEstimatedPointCountGreaterThanOrEqualTo(
+          visitor, getPointTree(), threshold)) {
         // the new range is not selective enough to be worth materializing, it doesn't reduce number
         // of docs at least 8x
         updateSkipInterval(false);
@@ -301,6 +301,13 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
       competitiveIterator = result.build().iterator();
       iteratorCost = competitiveIterator.cost();
       updateSkipInterval(true);
+    }
+
+    private PointValues.PointTree getPointTree() throws IOException {
+      if (pointTree == null) {
+        pointTree = pointValues.getPointTree();
+      }
+      return pointTree;
     }
 
     private void updateSkipInterval(boolean success) {

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -90,7 +90,7 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     private final LeafReaderContext context;
     protected final NumericDocValues docValues;
     private final PointValues pointValues;
-    // lazily constructed
+    // lazily constructed to avoid performance overhead when this is not used
     private PointValues.PointTree pointTree;
     // if skipping functionality should be enabled on this segment
     private final boolean enableSkipping;


### PR DESCRIPTION
We notice a performance regression in Elasticsearch which we could trace back to the changes in https://github.com/apache/lucene/pull/13199. This change makes constructing NumericComparators more expensive die to the construction of a PointTree eagerly in the constructor. This is particular noticeable when the PointTree is not used later and  your constructing several of them.

This. commit proposes to build the PointTree lazily. The original PR proposed it but it was changed due to simplicity.

We are only targeting the 9.x line as main has already diverged and doing it in a different way.