### PR TITLE
Remove intra-merge parallelism, relates to #13478

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -10,6 +10,8 @@ Bug Fixes
 
 * GITHUB#13498: Avoid performance regression by constructing lazily the PointTree in NumericComparator, (Ignacio Vera)
 
+* GITHUB#13501, GITHUB#13478: Remove intra-merge parallelism for everything except HNSW graph merges. (Ben Trent)
+
 ======================== Lucene 9.11.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentMerger.java
@@ -17,9 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import org.apache.lucene.codecs.Codec;
@@ -31,7 +29,6 @@ import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsWriter;
 import org.apache.lucene.codecs.StoredFieldsWriter;
 import org.apache.lucene.codecs.TermVectorsWriter;
-import org.apache.lucene.search.TaskExecutor;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.InfoStream;
@@ -135,36 +132,19 @@ final class SegmentMerger {
             IOContext.READ,
             segmentWriteState.segmentSuffix);
 
-    TaskExecutor taskExecutor = new TaskExecutor(mergeState.intraMergeTaskExecutor);
-    List<Callable<Void>> mergingTasks = new ArrayList<>();
-    mergingTasks.add(
-        () -> {
-          if (mergeState.mergeFieldInfos.hasNorms()) {
-            mergeWithLogging(
-                this::mergeNorms, segmentWriteState, segmentReadState, "norms", numMerged);
-          }
+    if (mergeState.mergeFieldInfos.hasNorms()) {
+      mergeWithLogging(this::mergeNorms, segmentWriteState, segmentReadState, "norms", numMerged);
+    }
 
-          mergeWithLogging(
-              this::mergeTerms, segmentWriteState, segmentReadState, "postings", numMerged);
-          return null;
-        });
+    mergeWithLogging(this::mergeTerms, segmentWriteState, segmentReadState, "postings", numMerged);
 
     if (mergeState.mergeFieldInfos.hasDocValues()) {
-      mergingTasks.add(
-          () -> {
-            mergeWithLogging(
-                this::mergeDocValues, segmentWriteState, segmentReadState, "doc values", numMerged);
-            return null;
-          });
+      mergeWithLogging(
+          this::mergeDocValues, segmentWriteState, segmentReadState, "doc values", numMerged);
     }
 
     if (mergeState.mergeFieldInfos.hasPointValues()) {
-      mergingTasks.add(
-          () -> {
-            mergeWithLogging(
-                this::mergePoints, segmentWriteState, segmentReadState, "points", numMerged);
-            return null;
-          });
+      mergeWithLogging(this::mergePoints, segmentWriteState, segmentReadState, "points", numMerged);
     }
 
     if (mergeState.mergeFieldInfos.hasVectorValues()) {
@@ -177,14 +157,9 @@ final class SegmentMerger {
     }
 
     if (mergeState.mergeFieldInfos.hasVectors()) {
-      mergingTasks.add(
-          () -> {
-            mergeWithLogging(this::mergeTermVectors, "term vectors");
-            return null;
-          });
+      mergeWithLogging(this::mergeTermVectors, "term vectors");
     }
 
-    taskExecutor.invokeAll(mergingTasks);
     // write the merged infos
     mergeWithLogging(
         this::mergeFieldInfos, segmentWriteState, segmentReadState, "field infos", numMerged);

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterForceMerge.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterForceMerge.java
@@ -18,26 +18,9 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Locale;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.DocValuesConsumer;
-import org.apache.lucene.codecs.DocValuesFormat;
-import org.apache.lucene.codecs.DocValuesProducer;
-import org.apache.lucene.codecs.FieldsConsumer;
-import org.apache.lucene.codecs.FieldsProducer;
-import org.apache.lucene.codecs.FilterCodec;
-import org.apache.lucene.codecs.NormsProducer;
-import org.apache.lucene.codecs.PostingsFormat;
-import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
-import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
-import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -46,7 +29,6 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.store.MockDirectoryWrapper;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.apache.lucene.util.BytesRef;
 
 public class TestIndexWriterForceMerge extends LuceneTestCase {
   public void testPartialMerge() throws IOException {
@@ -306,180 +288,5 @@ public class TestIndexWriterForceMerge extends LuceneTestCase {
     }
 
     dir.close();
-  }
-
-  public void testMergePerField() throws IOException {
-    IndexWriterConfig config = new IndexWriterConfig();
-    ConcurrentMergeScheduler mergeScheduler =
-        new ConcurrentMergeScheduler() {
-          @Override
-          public Executor getIntraMergeExecutor(MergePolicy.OneMerge merge) {
-            // always enable parallel merges
-            return intraMergeExecutor;
-          }
-        };
-    mergeScheduler.setMaxMergesAndThreads(4, 4);
-    config.setMergeScheduler(mergeScheduler);
-    Codec codec = TestUtil.getDefaultCodec();
-    CyclicBarrier barrier = new CyclicBarrier(2);
-    config.setCodec(
-        new FilterCodec(codec.getName(), codec) {
-          @Override
-          public PostingsFormat postingsFormat() {
-            return new PerFieldPostingsFormat() {
-              @Override
-              public PostingsFormat getPostingsFormatForField(String field) {
-                return new BlockingOnMergePostingsFormat(
-                    TestUtil.getDefaultPostingsFormat(), barrier);
-              }
-            };
-          }
-
-          @Override
-          public DocValuesFormat docValuesFormat() {
-            return new PerFieldDocValuesFormat() {
-              @Override
-              public DocValuesFormat getDocValuesFormatForField(String field) {
-                return new BlockingOnMergeDocValuesFormat(
-                    TestUtil.getDefaultDocValuesFormat(), barrier);
-              }
-            };
-          }
-        });
-    try (Directory directory = newDirectory();
-        IndexWriter writer = new IndexWriter(directory, config)) {
-      int numDocs = 50 + random().nextInt(100);
-      int numFields = 5 + random().nextInt(5);
-      for (int d = 0; d < numDocs; d++) {
-        Document doc = new Document();
-        for (int f = 0; f < numFields * 2; f++) {
-          String field = "f" + f;
-          String value = "v-" + random().nextInt(100);
-          if (f % 2 == 0) {
-            doc.add(new StringField(field, value, Field.Store.NO));
-          } else {
-            doc.add(new BinaryDocValuesField(field, new BytesRef(value)));
-          }
-          doc.add(new LongPoint("p" + f, random().nextInt(10000)));
-        }
-        writer.addDocument(doc);
-        if (random().nextInt(100) < 10) {
-          writer.flush();
-        }
-      }
-      writer.forceMerge(1);
-      try (DirectoryReader reader = DirectoryReader.open(writer)) {
-        assertEquals(numDocs, reader.numDocs());
-      }
-    }
-  }
-
-  static class BlockingOnMergePostingsFormat extends PostingsFormat {
-    private final PostingsFormat postingsFormat;
-    private final CyclicBarrier barrier;
-
-    BlockingOnMergePostingsFormat(PostingsFormat postingsFormat, CyclicBarrier barrier) {
-      super(postingsFormat.getName());
-      this.postingsFormat = postingsFormat;
-      this.barrier = barrier;
-    }
-
-    @Override
-    public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
-      var in = postingsFormat.fieldsConsumer(state);
-      return new FieldsConsumer() {
-        @Override
-        public void write(Fields fields, NormsProducer norms) throws IOException {
-          in.write(fields, norms);
-        }
-
-        @Override
-        public void merge(MergeState mergeState, NormsProducer norms) throws IOException {
-          try {
-            barrier.await(1, TimeUnit.SECONDS);
-          } catch (Exception e) {
-            throw new AssertionError("broken barrier", e);
-          }
-          in.merge(mergeState, norms);
-        }
-
-        @Override
-        public void close() throws IOException {
-          in.close();
-        }
-      };
-    }
-
-    @Override
-    public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
-      return postingsFormat.fieldsProducer(state);
-    }
-  }
-
-  static class BlockingOnMergeDocValuesFormat extends DocValuesFormat {
-    private final DocValuesFormat docValuesFormat;
-    private final CyclicBarrier barrier;
-
-    BlockingOnMergeDocValuesFormat(DocValuesFormat docValuesFormat, CyclicBarrier barrier) {
-      super(docValuesFormat.getName());
-      this.docValuesFormat = docValuesFormat;
-      this.barrier = barrier;
-    }
-
-    @Override
-    public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
-      DocValuesConsumer in = docValuesFormat.fieldsConsumer(state);
-      return new DocValuesConsumer() {
-        @Override
-        public void addNumericField(FieldInfo field, DocValuesProducer valuesProducer)
-            throws IOException {
-          in.addNumericField(field, valuesProducer);
-        }
-
-        @Override
-        public void addBinaryField(FieldInfo field, DocValuesProducer valuesProducer)
-            throws IOException {
-          in.addBinaryField(field, valuesProducer);
-        }
-
-        @Override
-        public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer)
-            throws IOException {
-          in.addSortedField(field, valuesProducer);
-        }
-
-        @Override
-        public void addSortedNumericField(FieldInfo field, DocValuesProducer valuesProducer)
-            throws IOException {
-          in.addSortedNumericField(field, valuesProducer);
-        }
-
-        @Override
-        public void addSortedSetField(FieldInfo field, DocValuesProducer valuesProducer)
-            throws IOException {
-          in.addSortedSetField(field, valuesProducer);
-        }
-
-        @Override
-        public void merge(MergeState mergeState) throws IOException {
-          try {
-            barrier.await(1, TimeUnit.SECONDS);
-          } catch (Exception e) {
-            throw new AssertionError("broken barrier", e);
-          }
-          in.merge(mergeState);
-        }
-
-        @Override
-        public void close() throws IOException {
-          in.close();
-        }
-      };
-    }
-
-    @Override
-    public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
-      return docValuesFormat.fieldsProducer(state);
-    }
   }
 }


### PR DESCRIPTION
Related to https://github.com/apache/lucene/issues/13478

We have seen numerous strange test failures due to intra-merge parallelism. Out of caution and ensuring we provide adequate testing, this commit removes it from 9.11.1. 

We will add intra-merge parallelism back with more testing in 9.12.