### PR TITLE
gh-13340: Allow adding a parent field to an index with no fields (#13341) (#13483)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -10,6 +10,8 @@ Bug Fixes
 
 * GITHUB#13498: Avoid performance regression by constructing lazily the PointTree in NumericComparator, (Ignacio Vera)
 
+* GITHUB#13498, GITHUB#13340: Allow adding a parent field to an index with no fields (Michael Sokolov)
+
 ======================== Lucene 9.11.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1125,6 +1125,7 @@ public class IndexWriter
       globalFieldNumberMap = getFieldNumberMap();
       if (create == false
           && conf.getParentField() != null
+          && globalFieldNumberMap.getFieldNames().isEmpty() == false
           && globalFieldNumberMap.getFieldNames().contains(conf.getParentField()) == false) {
         throw new IllegalArgumentException(
             "can't add a parent field to an already existing index without a parent field");

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -4949,7 +4949,9 @@ public class TestIndexWriter extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
       try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-        writer.addDocument(new Document());
+        Document d = new Document();
+        d.add(new TextField("f", "a", Field.Store.NO));
+        writer.addDocument(d);
       }
       IllegalArgumentException iae =
           expectThrows(
@@ -5055,6 +5057,21 @@ public class TestIndexWriter extends LuceneTestCase {
       assertEquals(
           "can't add [parent] as non parent document field; this IndexWriter is configured with [parent] as parent document field",
           iae.getMessage());
+    }
+  }
+
+  public void testParentFieldEmptyIndex() throws IOException {
+    try (Directory dir = newMockDirectory()) {
+      IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
+      iwc.setParentField("parent");
+      try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+        writer.commit();
+      }
+      IndexWriterConfig iwc2 = new IndexWriterConfig(new MockAnalyzer(random()));
+      iwc2.setParentField("parent");
+      try (IndexWriter writer = new IndexWriter(dir, iwc2)) {
+        writer.commit();
+      }
     }
   }
 }


### PR DESCRIPTION
This backports @msokolov 's change to 9.11.1 and adds a CHANGES entry for the bugfix.