### PR TITLE
expand TestSegmentToThreadMapping coverage w.r.t. (excess) documents per slice

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -102,9 +102,9 @@ public class IndexSearcher {
    * Thresholds for index slice allocation logic. To change the default, extend <code> IndexSearcher
    * </code> and use custom values
    */
-  private static final int MAX_DOCS_PER_SLICE = 250_000;
+  public static final int MAX_DOCS_PER_SLICE = 250_000;
 
-  private static final int MAX_SEGMENTS_PER_SLICE = 5;
+  public static final int MAX_SEGMENTS_PER_SLICE = 5;
 
   final IndexReader reader; // package private for testing!
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
@@ -163,7 +163,7 @@ public class TestSegmentToThreadMapping extends LuceneTestCase {
   public void testSingleSlice() {
     LeafReader largeSegmentReader = dummyIndexReader(50_000);
     LeafReader firstMediumSegmentReader = dummyIndexReader(30_000);
-    LeafReader secondMediumSegmentReader = dummyIndexReader(30__000);
+    LeafReader secondMediumSegmentReader = dummyIndexReader(30_000);
     LeafReader thirdMediumSegmentReader = dummyIndexReader(30_000);
     List<LeafReaderContext> leafReaderContexts = new ArrayList<>();
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
@@ -297,6 +297,11 @@ public class TestSegmentToThreadMapping extends LuceneTestCase {
     assertTrue(resultSlices.length > 0);
   }
 
+  public void testConstantsUnchanged() {
+    assertEquals(250_000, IndexSearcher.MAX_DOCS_PER_SLICE);
+    assertEquals(5, IndexSearcher.MAX_SEGMENTS_PER_SLICE);
+  }
+
   public void testTwoPreciseSlices() {
     LeafReader firstSegmentReader = dummyIndexReader(250_000);
     LeafReader secondSegmentReader = dummyIndexReader(250_000);


### PR DESCRIPTION
https://github.com/apache/lucene/blob/releases/lucene/9.11.0/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java#L333-L376