### PR TITLE
Inter-segment I/O concurrency.

### DIFF
--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerTimingType.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerTimingType.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 public enum QueryProfilerTimingType {
   CREATE_WEIGHT,
   COUNT,
+  BUILD_SCORER_SUPPLIER,
   BUILD_SCORER,
   NEXT_DOC,
   ADVANCE,

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerWeight.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerWeight.java
@@ -51,7 +51,7 @@ class QueryProfilerWeight extends FilterWeight {
 
   @Override
   public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
-    QueryProfilerTimer timer = profile.getTimer(QueryProfilerTimingType.BUILD_SCORER);
+    QueryProfilerTimer timer = profile.getTimer(QueryProfilerTimingType.BUILD_SCORER_SUPPLIER);
     timer.start();
     final ScorerSupplier subQueryScorerSupplier;
     try {
@@ -66,6 +66,7 @@ class QueryProfilerWeight extends FilterWeight {
 
       @Override
       public Scorer get(long loadCost) throws IOException {
+        QueryProfilerTimer timer = profile.getTimer(QueryProfilerTimingType.BUILD_SCORER);
         timer.start();
         try {
           return new QueryProfilerScorer(subQueryScorerSupplier.get(loadCost), profile);

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestQueryProfilerIndexSearcher.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestQueryProfilerIndexSearcher.java
@@ -85,6 +85,8 @@ public class TestQueryProfilerIndexSearcher extends LuceneTestCase {
         breakdown.get(QueryProfilerTimingType.CREATE_WEIGHT.toString()), greaterThan(0L));
     MatcherAssert.assertThat(breakdown.get(QueryProfilerTimingType.COUNT.toString()), equalTo(0L));
     MatcherAssert.assertThat(
+        breakdown.get(QueryProfilerTimingType.BUILD_SCORER_SUPPLIER.toString()), greaterThan(0L));
+    MatcherAssert.assertThat(
         breakdown.get(QueryProfilerTimingType.BUILD_SCORER.toString()), greaterThan(0L));
     MatcherAssert.assertThat(
         breakdown.get(QueryProfilerTimingType.NEXT_DOC.toString()), greaterThan(0L));
@@ -99,6 +101,9 @@ public class TestQueryProfilerIndexSearcher extends LuceneTestCase {
         greaterThan(0L));
     MatcherAssert.assertThat(
         breakdown.get(QueryProfilerTimingType.COUNT.toString() + "_count"), equalTo(0L));
+    MatcherAssert.assertThat(
+        breakdown.get(QueryProfilerTimingType.BUILD_SCORER_SUPPLIER.toString() + "_count"),
+        greaterThan(0L));
     MatcherAssert.assertThat(
         breakdown.get(QueryProfilerTimingType.BUILD_SCORER.toString() + "_count"), greaterThan(0L));
     MatcherAssert.assertThat(
@@ -161,6 +166,8 @@ public class TestQueryProfilerIndexSearcher extends LuceneTestCase {
         breakdown.get(QueryProfilerTimingType.CREATE_WEIGHT.toString()), greaterThan(0L));
     MatcherAssert.assertThat(breakdown.get(QueryProfilerTimingType.COUNT.toString()), equalTo(0L));
     MatcherAssert.assertThat(
+        breakdown.get(QueryProfilerTimingType.BUILD_SCORER_SUPPLIER.toString()), greaterThan(0L));
+    MatcherAssert.assertThat(
         breakdown.get(QueryProfilerTimingType.BUILD_SCORER.toString()), greaterThan(0L));
     MatcherAssert.assertThat(
         breakdown.get(QueryProfilerTimingType.NEXT_DOC.toString()), greaterThan(0L));
@@ -174,6 +181,8 @@ public class TestQueryProfilerIndexSearcher extends LuceneTestCase {
         greaterThan(0L));
     MatcherAssert.assertThat(
         breakdown.get(QueryProfilerTimingType.COUNT.toString() + "_count"), equalTo(0L));
+    MatcherAssert.assertThat(
+        breakdown.get(QueryProfilerTimingType.BUILD_SCORER_SUPPLIER.toString()), greaterThan(0L));
     MatcherAssert.assertThat(
         breakdown.get(QueryProfilerTimingType.BUILD_SCORER.toString() + "_count"), greaterThan(0L));
     MatcherAssert.assertThat(

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1946,6 +1946,7 @@ public abstract class LuceneTestCase extends Assert {
         ret = random.nextBoolean() ? new IndexSearcher(r) : new IndexSearcher(r.getContext());
       }
       ret.setSimilarity(classEnvRule.similarity);
+      ret.setIOConcurrencySumMaxDocThreshold(TestUtil.nextInt(random(), 0, r.maxDoc()));
       return ret;
     } else {
       final ExecutorService ex;
@@ -1992,6 +1993,7 @@ public abstract class LuceneTestCase extends Assert {
       if (random().nextBoolean()) {
         ret.setTimeout(() -> false);
       }
+      ret.setIOConcurrencySumMaxDocThreshold(TestUtil.nextInt(random(), 0, r.maxDoc()));
       return ret;
     }
   }


### PR DESCRIPTION
When searching across multiple segments, one doesn't need to wait until the first segment is done collecting to start doing the I/O for terms dictionary lookups in the next segment. However, doing so introduces a risk that the search on the first segment needs to visit so much data that it in-turn evicts data that we had prefetched for the second segment before we start searching this second segment. So we need some way to control the amount of inter-segment I/O concurrency that we allow. I went for a threshold on the sum of the max doc of the segments for which we do I/O concurrently, the reasoning being that you can search many small segments concurrently since they won't load much into the page cache anyway, but you need to be more careful with larger segments. This heuristic is not perfect as it only looks at what happens in a single thread and only looks at `maxDoc` rather than e.g. the on-disk size of data, but I would still expect it to work well enough in practice. I opted for a conservative default value of 1,000,000. Said otherwise, Lucene will do (part of the) I/O concurrently for as many segments as possible whose sum of `maxDoc` doesn't exceed 1,000,000.

We should do the same for collectors, but we cannot do it at the moment because we have a number of implementations that expect a segment to be fully collected before `Collector#getLeafCollector` is called on the next segment. So I am leaving it for a follow-up change.