### PR TITLE
fixing a wrong check of RollingCharBuffer

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/RollingCharBuffer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/RollingCharBuffer.java
@@ -79,7 +79,7 @@ public final class RollingCharBuffer {
 
       final int toRead = buffer.length - Math.max(count, nextWrite);
       final int readCount = reader.read(buffer, nextWrite, toRead);
-      if (readCount == -1) {
+      if (readCount <= 0) {
         end = true;
         return -1;
       }


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
The method code is as follows:

'  public int get(int pos) throws IOException {
...
      final int readCount = reader.read(buffer, nextWrite, toRead);
      if (readCount == -1) {
        end = true;
        return -1;
      }
'
When readCount fails, it can return 0. This value should aslo be checked. 