### PR TITLE
Fix more vector similarity query tests

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
@@ -131,6 +131,7 @@ abstract class BaseVectorSimilarityQueryTestCase<
     try (Directory indexStore = getIndexStore(getRandomVectors(numDocs, dim));
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
+      assumeTrue("graph is disconnected", HnswTestUtil.graphIsConnected(reader, vectorField));
 
       // All vectors are above -Infinity
       Query query1 =


### PR DESCRIPTION
Related to https://github.com/apache/lucene/pull/13260

The test failure is in 9x, but we need to add the fix here.

@msokolov I am planning to backport your code & then add this test fix. Do you agree?