### PR TITLE
Override single byte writes to OutputStreamIndexOutput to remove locking

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/OutputStreamIndexOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/OutputStreamIndexOutput.java
@@ -135,5 +135,19 @@ public class OutputStreamIndexOutput extends IndexOutput {
       BitUtil.VH_LE_LONG.set(buf, count, i);
       count += Long.BYTES;
     }
+
+    @Override
+    public void write(int b) throws IOException {
+      // override single byte write to avoid synchronization overhead now that JEP374 removed biased
+      // locking
+      byte[] buffer = buf;
+      int count = this.count;
+      if (count >= buffer.length) {
+        super.write(b);
+      } else {
+        buffer[count] = (byte) b;
+        this.count = count + 1;
+      }
+    }
   }
 }


### PR DESCRIPTION
Single byte writes to BufferedOutputStream show up pretty hot in indexing benchmarks. We can save the locking overhead introduced by JEP374 by overriding and providing a no-lock fast path.

Didn't benchmark this with Lucene benchmarks but there's this https://gist.github.com/shipilev/71fd881f7cbf3f87028bf87385e84889 and the issue is somewhat obvious looking at the profiling for the nightlies I believe.
