### PR TITLE
Optimize MaxScoreBulkScorer

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
@@ -332,12 +332,13 @@ final class MaxScoreBulkScorer extends BulkScorer {
     // make a difference when using custom scores (like FuzzyQuery), high query-time boosts, or
     // scoring based on wacky weights.
     System.arraycopy(allScorers, 0, scratch, 0, allScorers.length);
+    // Do not use Comparator#comparingDouble below, it might cause unnecessary allocations
     Arrays.sort(
         scratch,
-        (c1, c2) -> {
+        (scorer1, scorer2) -> {
           return Double.compare(
-              (double) c1.maxWindowScore / Math.max(1L, c1.cost),
-              (double) c2.maxWindowScore / Math.max(1L, c2.cost));
+              (double) scorer1.maxWindowScore / Math.max(1L, scorer1.cost),
+              (double) scorer2.maxWindowScore / Math.max(1L, scorer2.cost));
         });
     double maxScoreSum = 0;
     firstEssentialScorer = 0;

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
@@ -18,7 +18,6 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
@@ -43,7 +42,7 @@ final class MaxScoreBulkScorer extends BulkScorer {
   int firstRequiredScorer;
   private final long cost;
   float minCompetitiveScore;
-  private Score scorable = new Score();
+  private final Score scorable = new Score();
   final double[] maxScoreSums;
 
   private final long[] windowMatches = new long[FixedBitSet.bits2words(INNER_WINDOW_SIZE)];
@@ -335,8 +334,11 @@ final class MaxScoreBulkScorer extends BulkScorer {
     System.arraycopy(allScorers, 0, scratch, 0, allScorers.length);
     Arrays.sort(
         scratch,
-        Comparator.comparingDouble(
-            scorer -> (double) scorer.maxWindowScore / Math.max(1L, scorer.cost)));
+        (c1, c2) -> {
+          return Double.compare(
+              (double) c1.maxWindowScore / Math.max(1L, c1.cost),
+              (double) c2.maxWindowScore / Math.max(1L, c2.cost));
+        });
     double maxScoreSum = 0;
     firstEssentialScorer = 0;
     for (int i = 0; i < allScorers.length; ++i) {


### PR DESCRIPTION
Don't use Comparator.comparingDouble(...) in a hotish loop here, it causes allocations that escape analysis is not able to remove. => lets just manually inline this to get predictable behavior and save up to 0.5% of all allocations in some benchmark runs.
