### PR TITLE
Replace AtomicLong with LongAdder in HitsThresholdChecker

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/HitsThresholdChecker.java
+++ b/lucene/core/src/java/org/apache/lucene/search/HitsThresholdChecker.java
@@ -17,13 +17,13 @@
 
 package org.apache.lucene.search;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 
 /** Used for defining custom algorithms to allow searches to early terminate */
 abstract class HitsThresholdChecker {
   /** Implementation of HitsThresholdChecker which allows global hit counting */
   private static class GlobalHitsThresholdChecker extends HitsThresholdChecker {
-    private final AtomicLong globalHitCount = new AtomicLong();
+    private final LongAdder globalHitCount = new LongAdder();
 
     GlobalHitsThresholdChecker(int totalHitsThreshold) {
       super(totalHitsThreshold);
@@ -32,12 +32,12 @@ abstract class HitsThresholdChecker {
 
     @Override
     void incrementHitCount() {
-      globalHitCount.incrementAndGet();
+      globalHitCount.increment();
     }
 
     @Override
     boolean isThresholdReached() {
-      return globalHitCount.getAcquire() > getHitsThreshold();
+      return globalHitCount.longValue() > getHitsThreshold();
     }
 
     @Override


### PR DESCRIPTION
The value for the global count is incremented a lot more than it is read, the space overhead of LongAdder seems irrelevant => lets use LongAdder. The performance gain from using it is the higher the more threads you use, but at 4 threads already very visible in benchmarks.

For wikimediumall I see:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
           BrowseMonthSSDVFacets        4.75      (6.3%)        4.65      (8.2%)   -2.2% ( -15% -   13%) 0.348
                       LowPhrase       40.41      (9.1%)       39.59      (7.0%)   -2.0% ( -16% -   15%) 0.427
          OrHighMedDayTaxoFacets        2.49      (7.0%)        2.48      (4.6%)   -0.1% ( -10% -   12%) 0.957
     BrowseRandomLabelSSDVFacets        3.53      (6.2%)        3.53      (6.4%)   -0.0% ( -11% -   13%) 0.989
                       MedPhrase      586.66      (4.8%)      588.40      (5.0%)    0.3% (  -9% -   10%) 0.849
                      AndHighMed      251.69      (9.1%)      253.84      (3.6%)    0.9% ( -10% -   15%) 0.698
                      AndHighLow     1321.95     (10.0%)     1335.73      (5.9%)    1.0% ( -13% -   18%) 0.688
        AndHighHighDayTaxoFacets        4.15      (3.8%)        4.20      (2.9%)    1.0% (  -5% -    7%) 0.323
            MedTermDayTaxoFacets       20.33      (4.5%)       20.58      (4.1%)    1.2% (  -7% -   10%) 0.367
                        PKLookup      245.17      (3.6%)      248.31      (3.6%)    1.3% (  -5% -    8%) 0.266
           BrowseMonthTaxoFacets        8.21     (55.1%)        8.32     (55.6%)    1.3% ( -70% -  249%) 0.940
             LowIntervalsOrdered       50.77      (9.8%)       51.48     (10.5%)    1.4% ( -17% -   24%) 0.662
         AndHighMedDayTaxoFacets       24.18      (1.5%)       24.56      (1.8%)    1.6% (  -1% -    4%) 0.003
     BrowseRandomLabelTaxoFacets        4.21      (5.9%)        4.28      (5.9%)    1.8% (  -9% -   14%) 0.341
       BrowseDayOfYearSSDVFacets        4.56      (5.9%)        4.64     (10.7%)    1.8% ( -13% -   19%) 0.512
                      HighPhrase       51.95      (6.3%)       52.90      (6.8%)    1.8% ( -10% -   15%) 0.381
                          Fuzzy2       77.27      (3.6%)       79.02      (5.7%)    2.3% (  -6% -   11%) 0.130
                         Respell       45.66      (1.8%)       46.73      (1.7%)    2.3% (  -1% -    5%) 0.000
                          Fuzzy1      103.35      (4.0%)      106.17      (3.6%)    2.7% (  -4% -   10%) 0.022
                          IntNRQ       27.92      (8.6%)       28.70      (6.7%)    2.8% ( -11% -   19%) 0.254
            BrowseDateSSDVFacets        1.24     (13.2%)        1.28     (11.8%)    3.7% ( -18% -   33%) 0.351
                      OrHighHigh       61.55     (12.0%)       64.18     (12.0%)    4.3% ( -17% -   32%) 0.260
            BrowseDateTaxoFacets        4.92      (5.8%)        5.14     (12.5%)    4.6% ( -12% -   24%) 0.139
                    OrNotHighLow      985.77      (6.9%)     1031.87      (3.7%)    4.7% (  -5% -   16%) 0.008
                 MedSloppyPhrase       98.83      (8.9%)      104.44      (9.1%)    5.7% ( -11% -   26%) 0.046
               HighTermMonthSort     1340.66     (10.5%)     1419.43      (7.1%)    5.9% ( -10% -   26%) 0.038
       BrowseDayOfYearTaxoFacets        4.93      (5.7%)        5.23     (12.4%)    6.0% ( -11% -   25%) 0.049
                        Wildcard       51.85      (6.9%)       55.03      (5.4%)    6.1% (  -5% -   19%) 0.002
                     AndHighHigh      145.76      (6.2%)      155.93     (10.0%)    7.0% (  -8% -   24%) 0.008
                     MedSpanNear       27.61      (8.1%)       29.85      (7.1%)    8.1% (  -6% -   25%) 0.001
                 LowSloppyPhrase      125.48     (12.5%)      135.78     (11.1%)    8.2% ( -13% -   36%) 0.028
                       OrHighMed      146.22      (8.3%)      159.53      (9.3%)    9.1% (  -7% -   29%) 0.001
                         Prefix3      923.91     (15.1%)     1013.30      (6.7%)    9.7% ( -10% -   37%) 0.009
                       OrHighLow      747.82      (4.7%)      820.26      (4.7%)    9.7% (   0% -   19%) 0.000
                HighSloppyPhrase       24.47      (4.6%)       26.93      (4.1%)   10.0% (   1% -   19%) 0.000
             MedIntervalsOrdered       68.46     (11.9%)       75.68     (12.4%)   10.5% ( -12% -   39%) 0.006
                    HighSpanNear       13.57      (3.2%)       15.32      (5.0%)   12.9% (   4% -   21%) 0.000
                     LowSpanNear       84.84      (6.0%)       95.80      (4.7%)   12.9% (   2% -   25%) 0.000
            HighIntervalsOrdered       19.93      (8.4%)       23.28     (11.2%)   16.8% (  -2% -   39%) 0.000
                         MedTerm      670.60      (4.6%)      897.88      (9.5%)   33.9% (  18% -   50%) 0.000
                    OrNotHighMed      201.35      (4.0%)      271.43      (6.6%)   34.8% (  23% -   47%) 0.000
                         LowTerm      583.19      (3.6%)      872.31      (5.1%)   49.6% (  39% -   60%) 0.000
                   OrNotHighHigh      227.42      (4.3%)      353.58      (8.3%)   55.5% (  41% -   71%) 0.000
            HighTermTitleBDVSort       22.16      (4.1%)       35.54     (12.1%)   60.4% (  42% -   79%) 0.000
                      TermDTSort       79.33      (3.7%)      140.30     (17.6%)   76.9% (  53% -  101%) 0.000
                   OrHighNotHigh      184.76      (3.6%)      339.75     (12.3%)   83.9% (  65% -  103%) 0.000
               HighTermTitleSort       33.86      (3.2%)       64.43     (14.3%)   90.3% (  70% -  111%) 0.000
                    OrHighNotMed      187.30      (4.1%)      357.81     (14.8%)   91.0% (  69% -  114%) 0.000
                    OrHighNotLow      245.45      (6.5%)      492.07     (11.3%)  100.5% (  77% -  126%) 0.000
                        HighTerm      152.40      (4.3%)      313.65     (17.1%)  105.8% (  80% -  132%) 0.000
           HighTermDayOfYearSort      135.35      (2.3%)      311.95     (25.0%)  130.5% ( 100% -  161%) 0.000
```