### PR TITLE
Fix quantized vector writer ram estimates

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -295,6 +295,9 @@ Bug Fixes
 * GITHUB#13463: Address bug in MultiLeafKnnCollector causing #minCompetitiveSimilarity to stay artificially low in
   some corner cases. (Greg Miller)
 
+* GITHUB#13553: Correct RamUsageEstimate for scalar quantized knn vector formats so that raw vectors are correctly
+  accounted for. (Ben Trent)
+
 Other
 --------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
@@ -171,6 +171,7 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
   @Override
   public long ramBytesUsed() {
     long total = SHALLOW_RAM_BYTES_USED;
+    // The vector delegate will also account for this writer's KnnFieldVectorsWriter objects
     total += flatVectorWriter.ramBytesUsed();
     return total;
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
@@ -172,9 +172,6 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
   public long ramBytesUsed() {
     long total = SHALLOW_RAM_BYTES_USED;
     total += flatVectorWriter.ramBytesUsed();
-    for (FieldWriter<?> field : fields) {
-      total += field.ramBytesUsed();
-    }
     return total;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
@@ -299,6 +299,7 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
   @Override
   public long ramBytesUsed() {
     long total = SHALLOW_RAM_BYTES_USED;
+    // The vector delegate will also account for this writer's KnnFieldVectorsWriter objects
     total += rawVectorDelegate.ramBytesUsed();
     return total;
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
@@ -299,9 +299,7 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
   @Override
   public long ramBytesUsed() {
     long total = SHALLOW_RAM_BYTES_USED;
-    for (FieldWriter field : fields) {
-      total += field.ramBytesUsed();
-    }
+    total += rawVectorDelegate.ramBytesUsed();
     return total;
   }
 


### PR DESCRIPTION
I still need to write a test, but wanted to open this PR early.

Scalar Quantized vector writer ram usage estimates completely ignores the raw float vectors. Meaning, if you have flush based on ram usage configured, you can easily overshoot that estimate and cause an OOM.