### PR TITLE
Fix testAddDocumentOnDiskFull to handle IllegalStateException from IndexWriter#close

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
@@ -111,7 +111,7 @@ public class TestIndexWriterOnDiskFull extends LuceneTestCase {
                 System.out.println("TEST: now close");
               }
               writer.close();
-            } catch (IOException e) {
+            } catch (IOException | IllegalStateException e) {
               if (VERBOSE) {
                 System.out.println("TEST: exception on close; retry w/ no disk space limit");
                 e.printStackTrace(System.out);


### PR DESCRIPTION
This issue is similar to https://github.com/apache/lucene/issues/11755, but it occurs in `IndexWriter#close` and also has about half of the time of reproduction.



```
    java.lang.IllegalStateException: this writer hit an unrecoverable error; cannot commit
        at __randomizedtesting.SeedInfo.seed([EAA58E75C71B5109:66BDB60A3A8E87CD]:0)
        at org.apache.lucene.index.IndexWriter.startCommit(IndexWriter.java:5577)
        at org.apache.lucene.index.IndexWriter.prepareCommitInternal(IndexWriter.java:3781)
        at org.apache.lucene.index.IndexWriter.commitInternal(IndexWriter.java:4122)
        at org.apache.lucene.index.IndexWriter.shutdown(IndexWriter.java:1331)
        at org.apache.lucene.index.IndexWriter.close(IndexWriter.java:1369)
        at org.apache.lucene.index.TestIndexWriterOnDiskFull.testAddDocumentOnDiskFull(TestIndexWriterOnDiskFull.java:113)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1758)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:982)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
        at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48)
        at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
        at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
        at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
        at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
        at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
        at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
        at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:843)
        at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:490)
        at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:955)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:840)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:891)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:902)
        at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
        at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
        at org.apache.lucene.tests.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:38)
        at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
        at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
        at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
        at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
        at org.apache.lucene.tests.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
        at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
        at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
        at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
        at org.apache.lucene.tests.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:47)
        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
        at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
        at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
        at com.carrotsearch.randomizedtesting.ThreadLeakControl.lambda$forkTimeoutingTask$0(ThreadLeakControl.java:850)
        at java.base/java.lang.Thread.run(Thread.java:1583)

        Caused by:
        java.io.IOException: fake disk full at 5792 bytes when writing _2.fdm (file length=0)
            at org.apache.lucene.tests.store.MockIndexOutputWrapper.checkDiskFull(MockIndexOutputWrapper.java:92)
            at org.apache.lucene.tests.store.MockIndexOutputWrapper.writeBytes(MockIndexOutputWrapper.java:138)
            at org.apache.lucene.tests.store.MockIndexOutputWrapper.writeByte(MockIndexOutputWrapper.java:131)
            at org.apache.lucene.store.RateLimitedIndexOutput.writeByte(RateLimitedIndexOutput.java:49)
            at org.apache.lucene.codecs.CodecUtil.writeBEInt(CodecUtil.java:654)
            at org.apache.lucene.codecs.CodecUtil.writeHeader(CodecUtil.java:83)
            at org.apache.lucene.codecs.CodecUtil.writeIndexHeader(CodecUtil.java:126)
            at org.apache.lucene.codecs.lucene90.compressing.Lucene90CompressingStoredFieldsWriter.<init>(Lucene90CompressingStoredFieldsWriter.java:132)
            at org.apache.lucene.codecs.lucene90.compressing.Lucene90CompressingStoredFieldsFormat.fieldsWriter(Lucene90CompressingStoredFieldsFormat.java:140)
            at org.apache.lucene.codecs.lucene90.Lucene90StoredFieldsFormat.fieldsWriter(Lucene90StoredFieldsFormat.java:154)
            at org.apache.lucene.tests.codecs.asserting.AssertingStoredFieldsFormat.fieldsWriter(AssertingStoredFieldsFormat.java:49)
            at org.apache.lucene.index.SegmentMerger.mergeFields(SegmentMerger.java:260)
            at org.apache.lucene.index.SegmentMerger.mergeWithLogging(SegmentMerger.java:300)
            at org.apache.lucene.index.SegmentMerger.merge(SegmentMerger.java:115)
            at org.apache.lucene.index.IndexWriter.mergeMiddle(IndexWriter.java:5278)
            at org.apache.lucene.index.IndexWriter.merge(IndexWriter.java:4746)
            at org.apache.lucene.index.IndexWriter$IndexWriterMergeSource.merge(IndexWriter.java:6567)
            at org.apache.lucene.index.ConcurrentMergeScheduler.doMerge(ConcurrentMergeScheduler.java:668)
            at org.apache.lucene.index.ConcurrentMergeScheduler$MergeThread.run(ConcurrentMergeScheduler.java:729)
```



```
./gradlew test --tests TestIndexWriterOnDiskFull.testAddDocumentOnDiskFull -Dtests.seed=EAA58E75C71B5109 -Dtests.nightly=true
```


