### PR TITLE
Add levels to DocValues skipper index

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -133,6 +133,8 @@ New Features
   DocValuesSkipper abstraction. A new flag is added to FieldType.java that configures whether
   to create a "skip index" for doc values. (Ignacio Vera)
 
+* GITHUB#13563: Add levels to doc values skip index. (Ignacio Vera)
+
 Improvements
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -320,12 +320,15 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
     return collector;
   }
 
-  private int getLevels(int index, int size) {
-    final int left = size - index;
-    for (int level = SKIP_INDEX_MAX_LEVEL - 1; level > 0; level--) {
-      final int numberIntervals = 1 << (SKIP_INDEX_LEVEL_SHIFT * level);
-      if (left >= numberIntervals && index % numberIntervals == 0) {
-        return level + 1;
+  private static int getLevels(int index, int size) {
+    if (Integer.numberOfTrailingZeros(index) >= SKIP_INDEX_LEVEL_SHIFT) {
+      // TODO: can we do it in constant time rather than linearly with SKIP_INDEX_MAX_LEVEL?
+      final int left = size - index;
+      for (int level = SKIP_INDEX_MAX_LEVEL - 1; level > 0; level--) {
+        final int numberIntervals = 1 << (SKIP_INDEX_LEVEL_SHIFT * level);
+        if (left >= numberIntervals && index % numberIntervals == 0) {
+          return level + 1;
+        }
       }
     }
     return 1;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -211,7 +211,8 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
     }
 
     void accumulate(SkipAccumulator other) {
-      maxDocID = other.maxDocID;
+      minDocID = Math.min(minDocID, other.minDocID);
+      maxDocID = Math.max(maxDocID, other.maxDocID);
       minValue = Math.min(minValue, other.minValue);
       maxValue = Math.max(maxValue, other.maxValue);
       docCount += other.docCount;
@@ -305,14 +306,10 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
       }
       // write the number of levels
       data.writeByte((byte) levels);
-      // write the maxDocIDs in reverse order. This is done so we don't
+      // write intervals in reverse order. This is done so we don't
       // need to read all of them in case of slipping
       for (int level = levels - 1; level >= 0; level--) {
         data.writeInt(accLevels[level].maxDocID);
-      }
-      // write the rest of the interval in natural order. This is only
-      // read if the interval is competitive.
-      for (int level = 0; level < levels; level++) {
         data.writeInt(accLevels[level].minDocID);
         data.writeLong(accLevels[level].maxValue);
         data.writeLong(accLevels[level].minValue);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -293,9 +293,10 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
     for (int i = 1; i < accumulators.size(); i++) {
       buildLevel(accumulators.get(i), accumulators.get(i - 1));
     }
-    for (int index = 0; index < accumulators.get(0).size(); index++) {
+    int totalAccumulators = accumulators.get(0).size();
+    for (int index = 0; index < totalAccumulators; index++) {
       // compute how many levels we need to write for the current accumulator
-      final int levels = getLevels(index, accumulators.size());
+      final int levels = getLevels(index, totalAccumulators);
       // build the levels
       final SkipAccumulator[] accLevels = new SkipAccumulator[levels];
       for (int level = 0; level < levels; level++) {
@@ -322,7 +323,7 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
 
   private static void buildLevel(
       List<SkipAccumulator> collector, List<SkipAccumulator> accumulators) {
-    int levelSize = 1 << SKIP_INDEX_MAX_LEVEL;
+    int levelSize = 1 << SKIP_INDEX_LEVEL_SHIFT;
     for (int i = 0; i < accumulators.size() - levelSize + 1; i += levelSize) {
       collector.add(SkipAccumulator.merge(accumulators, i, levelSize));
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
@@ -214,16 +214,16 @@ public final class Lucene90DocValuesFormat extends DocValuesFormat {
   static final long[] SKIP_INDEX_JUMP_LENGTH_PER_LEVEL = new long[SKIP_INDEX_MAX_LEVEL];
 
   static {
+    // Size of the interval minus read bytes (1 byte for level and 4 bytes for maxDocID)
+    SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[0] = SKIP_INDEX_INTERVAL_BYTES - 5L;
     for (int level = 1; level < SKIP_INDEX_MAX_LEVEL; level++) {
-      final int levelShift = level * SKIP_INDEX_LEVEL_SHIFT;
-      final int prevLevelShift = (level - 1) * SKIP_INDEX_LEVEL_SHIFT;
       // jump from previous level
       SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level] = SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level - 1];
-      // nodes added by new level minus first one
+      // nodes added by new level
       SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level] +=
-          ((1 << levelShift) - 1) * SKIP_INDEX_INTERVAL_BYTES;
-      // remove the byte levels added in the previous level except the first one
-      SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level] += 1 - (1 << prevLevelShift);
+          (1 << (level * SKIP_INDEX_LEVEL_SHIFT)) * SKIP_INDEX_INTERVAL_BYTES;
+      // remove the byte levels added in the previous level
+      SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level] -= (1 << ((level - 1) * SKIP_INDEX_LEVEL_SHIFT));
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
@@ -194,5 +194,34 @@ public final class Lucene90DocValuesFormat extends DocValuesFormat {
   static final int TERMS_DICT_REVERSE_INDEX_SIZE = 1 << TERMS_DICT_REVERSE_INDEX_SHIFT;
   static final int TERMS_DICT_REVERSE_INDEX_MASK = TERMS_DICT_REVERSE_INDEX_SIZE - 1;
 
+  // number of documents in an interval
   private static final int DEFAULT_SKIP_INDEX_INTERVAL_SIZE = 4096;
+  // number of intervals represented as a shift to create a new level, this is 1 << 3 == 8
+  // intervals.
+  static final int SKIP_INDEX_LEVEL_SHIFT = 3;
+  // max number of levels
+  // Increasing this number, it increases how much heap we need at index time.
+  // we currently need (1 * 8 * 8 * 8)  = 512 accumulators on heap
+  static final int SKIP_INDEX_MAX_LEVEL = 4;
+  // how many intervals at level 0 are in each level (1 << (SKIP_INDEX_LEVEL_SHIFT * level)).
+  static int[] SKIP_INDEX_NUMBER_INTERVALS_PER_LEVEL = new int[SKIP_INDEX_MAX_LEVEL];
+  // number of bytes to skip when skipping a level. It does not take into account the
+  // current interval that is being read.
+  static long[] SKIP_INDEX_JUMP_LENGTH_PER_LEVEL = new long[SKIP_INDEX_MAX_LEVEL];
+
+  static {
+    for (int level = 0; level < SKIP_INDEX_MAX_LEVEL; level++) {
+      SKIP_INDEX_NUMBER_INTERVALS_PER_LEVEL[level] = 1 << (SKIP_INDEX_LEVEL_SHIFT * level);
+      if (level > 0) {
+        SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level] =
+            // jump from previous level
+            SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level - 1]
+                // add nodes added by new level minus first one
+                + (SKIP_INDEX_NUMBER_INTERVALS_PER_LEVEL[level] - 1) * 29L
+                // remove the byte levels added in the previous level except the first one
+                - SKIP_INDEX_NUMBER_INTERVALS_PER_LEVEL[level - 1]
+                + 1;
+      }
+    }
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -1822,7 +1822,8 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
           assert target > maxDocID[0] : "target must be bigger that current interval";
           while (true) {
             levels = input.readByte();
-            assert levels <= SKIP_INDEX_MAX_LEVEL && levels > 0 : "level out of range";
+            assert levels <= SKIP_INDEX_MAX_LEVEL && levels > 0
+                : "level out of range [" + levels + "]";
             boolean competitive = true;
             // check if current interval is competitive or we can jump to the next position
             for (int level = levels - 1; level >= 0; level--) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -1840,7 +1840,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
             if (competitive) {
               // adjust levels
               while (levels < SKIP_INDEX_MAX_LEVEL) {
-                if (maxDocID[levels] == -1 || maxDocID[levels] < target) {
+                if (maxDocID[levels] < target) {
                   break;
                 }
                 levels++;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -1824,12 +1824,12 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
             levels = input.readByte();
             assert levels <= SKIP_INDEX_MAX_LEVEL && levels > 0
                 : "level out of range [" + levels + "]";
-            boolean competitive = true;
+            boolean valid = true;
             // check if current interval is competitive or we can jump to the next position
             for (int level = levels - 1; level >= 0; level--) {
               if ((maxDocID[level] = input.readInt()) < target) {
                 input.skipBytes(SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level]); // the jump for the level
-                competitive = false;
+                valid = false;
                 break;
               }
               minDocID[level] = input.readInt();
@@ -1837,12 +1837,9 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
               minValue[level] = input.readLong();
               docCount[level] = input.readInt();
             }
-            if (competitive) {
+            if (valid) {
               // adjust levels
-              while (levels < SKIP_INDEX_MAX_LEVEL) {
-                if (maxDocID[levels] < target) {
-                  break;
-                }
+              while (levels < SKIP_INDEX_MAX_LEVEL && maxDocID[levels] >= target) {
                 levels++;
               }
               break;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.codecs.lucene90;
 
+import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.SKIP_INDEX_JUMP_LENGTH_PER_LEVEL;
+import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.SKIP_INDEX_MAX_LEVEL;
 import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.TERMS_DICT_BLOCK_LZ4_SHIFT;
 
 import java.io.IOException;
@@ -1792,28 +1794,55 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     if (input.length() > 0) {
       input.prefetch(0, 1);
     }
+    // TODO: should we write to disk the actual max level for this segment?
     return new DocValuesSkipper() {
-      int minDocID = -1;
-      int maxDocID = -1;
-      long minValue, maxValue;
-      int docCount;
+      final int[] minDocID = new int[SKIP_INDEX_MAX_LEVEL];
+      final int[] maxDocID = new int[SKIP_INDEX_MAX_LEVEL];
+
+      {
+        for (int i = 0; i < SKIP_INDEX_MAX_LEVEL; i++) {
+          minDocID[i] = maxDocID[i] = -1;
+        }
+      }
+
+      final long[] minValue = new long[SKIP_INDEX_MAX_LEVEL];
+      final long[] maxValue = new long[SKIP_INDEX_MAX_LEVEL];
+      final int[] docCount = new int[SKIP_INDEX_MAX_LEVEL];
+      int levels;
 
       @Override
       public void advance(int target) throws IOException {
         if (target > entry.maxDocId) {
-          minDocID = DocIdSetIterator.NO_MORE_DOCS;
-          maxDocID = DocIdSetIterator.NO_MORE_DOCS;
+          // skipper is exhausted
+          for (int i = 0; i < SKIP_INDEX_MAX_LEVEL; i++) {
+            minDocID[i] = maxDocID[i] = DocIdSetIterator.NO_MORE_DOCS;
+          }
         } else {
+          // find next interval
+          assert target > maxDocID[0] : "target must be bigger that current interval";
           while (true) {
-            maxDocID = input.readInt();
-            if (maxDocID >= target) {
-              minDocID = input.readInt();
-              maxValue = input.readLong();
-              minValue = input.readLong();
-              docCount = input.readInt();
+            levels = input.readByte();
+            assert levels <= SKIP_INDEX_MAX_LEVEL && levels > 0 : "level out of range";
+            boolean competitive = true;
+            // check if current interval is competitive or we can jump to the next position
+            for (int level = levels - 1; level >= 0; level--) {
+              if ((maxDocID[level] = input.readInt()) < target) {
+                input.skipBytes(
+                    (level * 4L) // the number of maxDocID left
+                        + (levels * 24L) // the content of this interval
+                        + SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level]); // the jump for the level
+                competitive = false;
+                break;
+              }
+            }
+            if (competitive) {
+              for (int level = 0; level < levels; level++) {
+                minDocID[level] = input.readInt();
+                maxValue[level] = input.readLong();
+                minValue[level] = input.readLong();
+                docCount[level] = input.readInt();
+              }
               break;
-            } else {
-              input.skipBytes(24);
             }
           }
         }
@@ -1821,32 +1850,32 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
 
       @Override
       public int numLevels() {
-        return 1;
+        return levels;
       }
 
       @Override
       public int minDocID(int level) {
-        return minDocID;
+        return minDocID[level];
       }
 
       @Override
       public int maxDocID(int level) {
-        return maxDocID;
+        return maxDocID[level];
       }
 
       @Override
       public long minValue(int level) {
-        return minValue;
+        return minValue[level];
       }
 
       @Override
       public long maxValue(int level) {
-        return maxValue;
+        return maxValue[level];
       }
 
       @Override
       public int docCount(int level) {
-        return docCount;
+        return docCount[level];
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -1808,7 +1808,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
       final long[] minValue = new long[SKIP_INDEX_MAX_LEVEL];
       final long[] maxValue = new long[SKIP_INDEX_MAX_LEVEL];
       final int[] docCount = new int[SKIP_INDEX_MAX_LEVEL];
-      int levels;
+      int levels = 1;
 
       @Override
       public void advance(int target) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -3301,17 +3301,17 @@ public final class CheckIndex implements Closeable {
       if (skipper.maxDocID(0) == NO_MORE_DOCS) {
         break;
       }
+      if (skipper.minDocID(0) < doc) {
+        throw new CheckIndexException(
+            "skipper dv iterator for field: "
+                + fieldName
+                + " reports wrong minDocID, got "
+                + skipper.minDocID(0)
+                + " < "
+                + doc);
+      }
       int levels = skipper.numLevels();
       for (int level = 0; level < levels; level++) {
-        if (skipper.minDocID(level) < doc) {
-          throw new CheckIndexException(
-              "skipper dv iterator for field: "
-                  + fieldName
-                  + " reports wrong minDocID, got "
-                  + skipper.minDocID(level)
-                  + " < "
-                  + doc);
-        }
         if (skipper.minDocID(level) > skipper.maxDocID(level)) {
           throw new CheckIndexException(
               "skipper dv iterator for field: "

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormatVariableSkipInterval.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormatVariableSkipInterval.java
@@ -35,9 +35,4 @@ public class TestLucene90DocValuesFormatVariableSkipInterval extends BaseDocValu
             () -> new Lucene90DocValuesFormat(random().nextInt(Integer.MIN_VALUE, 2)));
     assertTrue(ex.getMessage().contains("skipIndexIntervalSize must be > 1"));
   }
-
-  @Override
-  public void testNumericDocValuesWithSkipperMedium() throws Exception {
-    super.testNumericDocValuesWithSkipperMedium();
-  }
 }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormatVariableSkipInterval.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormatVariableSkipInterval.java
@@ -35,4 +35,9 @@ public class TestLucene90DocValuesFormatVariableSkipInterval extends BaseDocValu
             () -> new Lucene90DocValuesFormat(random().nextInt(Integer.MIN_VALUE, 2)));
     assertTrue(ex.getMessage().contains("skipIndexIntervalSize must be > 1"));
   }
+
+  @Override
+  public void testNumericDocValuesWithSkipperMedium() throws Exception {
+    super.testNumericDocValuesWithSkipperMedium();
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormatVariableSkipInterval.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormatVariableSkipInterval.java
@@ -25,7 +25,8 @@ public class TestLucene90DocValuesFormatVariableSkipInterval extends BaseDocValu
 
   @Override
   protected Codec getCodec() {
-    return TestUtil.alwaysDocValuesFormat(new Lucene90DocValuesFormat(random().nextInt(2, 1024)));
+    // small interval size to test with many intervals
+    return TestUtil.alwaysDocValuesFormat(new Lucene90DocValuesFormat(random().nextInt(4, 16)));
   }
 
   public void testSkipIndexIntervalSize() {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -1194,11 +1194,13 @@ public class AssertingLeafReader extends FilterLeafReader {
     @Override
     public int minDocID(int level) {
       assertThread("Doc values skipper", creationThread);
-      Objects.checkIndex(level, numLevels());
       int minDocID = in.minDocID(level);
       assert minDocID <= in.maxDocID(level);
-      if (level > 0) {
-        assert minDocID <= in.minDocID(level - 1);
+      if (minDocID != -1 && minDocID != DocIdSetIterator.NO_MORE_DOCS) {
+        Objects.checkIndex(level, numLevels());
+      }
+      for (int i = 0; i < level; i++) {
+        assert minDocID >= in.minDocID(i);
       }
       return minDocID;
     }
@@ -1206,12 +1208,13 @@ public class AssertingLeafReader extends FilterLeafReader {
     @Override
     public int maxDocID(int level) {
       assertThread("Doc values skipper", creationThread);
-      Objects.checkIndex(level, numLevels());
       int maxDocID = in.maxDocID(level);
-
       assert maxDocID >= in.minDocID(level);
-      if (level > 0) {
-        assert maxDocID >= in.maxDocID(level - 1);
+      if (maxDocID != -1 && maxDocID != DocIdSetIterator.NO_MORE_DOCS) {
+        Objects.checkIndex(level, numLevels());
+      }
+      for (int i = 0; i < level; i++) {
+        assert maxDocID >= in.maxDocID(i);
       }
       return maxDocID;
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -1194,13 +1194,11 @@ public class AssertingLeafReader extends FilterLeafReader {
     @Override
     public int minDocID(int level) {
       assertThread("Doc values skipper", creationThread);
+      Objects.checkIndex(level, numLevels());
       int minDocID = in.minDocID(level);
       assert minDocID <= in.maxDocID(level);
-      if (minDocID != -1 && minDocID != DocIdSetIterator.NO_MORE_DOCS) {
-        Objects.checkIndex(level, numLevels());
-      }
-      for (int i = 0; i < level; i++) {
-        assert minDocID >= in.minDocID(i);
+      if (level > 0) {
+        assert minDocID <= in.minDocID(level - 1);
       }
       return minDocID;
     }
@@ -1208,13 +1206,12 @@ public class AssertingLeafReader extends FilterLeafReader {
     @Override
     public int maxDocID(int level) {
       assertThread("Doc values skipper", creationThread);
+      Objects.checkIndex(level, numLevels());
       int maxDocID = in.maxDocID(level);
+
       assert maxDocID >= in.minDocID(level);
-      if (maxDocID != -1 && maxDocID != DocIdSetIterator.NO_MORE_DOCS) {
-        Objects.checkIndex(level, numLevels());
-      }
-      for (int i = 0; i < level; i++) {
-        assert maxDocID >= in.maxDocID(i);
+      if (level > 0) {
+        assert maxDocID >= in.maxDocID(level - 1);
       }
       return maxDocID;
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
@@ -725,29 +725,30 @@ public abstract class BaseDocValuesFormatTestCase extends LegacyBaseDocValuesFor
     assertEquals(-1, skipper.maxDocID(0));
 
     iterator.advance(0);
+    int previousMaxDoc = -1;
     int docCount = 0;
     while (true) {
-      int previousMaxDoc = skipper.maxDocID(0);
       skipper.advance(previousMaxDoc + 1);
-      assertTrue(skipper.minDocID(0) > previousMaxDoc);
+      final int level = random().nextInt(skipper.numLevels());
+      assertTrue(skipper.minDocID(level) > previousMaxDoc);
       if (skipperHasAccurateDocBounds()) {
-        assertEquals(iterator.docID(), skipper.minDocID(0));
+        assertEquals(iterator.docID(), skipper.minDocID(level));
       } else {
         assertTrue(
-            "Expected: " + iterator.docID() + " but got " + skipper.minDocID(0),
-            skipper.minDocID(0) <= iterator.docID());
+            "Expected: " + iterator.docID() + " but got " + skipper.minDocID(level),
+            skipper.minDocID(level) <= iterator.docID());
       }
 
-      if (skipper.minDocID(0) == NO_MORE_DOCS) {
-        assertEquals(NO_MORE_DOCS, skipper.maxDocID(0));
+      if (skipper.minDocID(level) == NO_MORE_DOCS) {
+        assertEquals(NO_MORE_DOCS, skipper.maxDocID(level));
         break;
       }
-      assertTrue(skipper.docCount(0) > 0);
+      assertTrue(skipper.docCount(level) > 0);
 
       int maxDoc = -1;
       long minVal = Long.MAX_VALUE;
       long maxVal = Long.MIN_VALUE;
-      for (int i = 0; i < skipper.docCount(0); ++i) {
+      for (int i = 0; i < skipper.docCount(level); ++i) {
         assertNotEquals(NO_MORE_DOCS, iterator.docID());
         maxDoc = Math.max(maxDoc, iterator.docID());
         minVal = Math.min(minVal, iterator.minValue());
@@ -755,24 +756,25 @@ public abstract class BaseDocValuesFormatTestCase extends LegacyBaseDocValuesFor
         iterator.advance(iterator.docID() + 1);
       }
       if (skipperHasAccurateDocBounds()) {
-        assertEquals(maxDoc, skipper.maxDocID(0));
+        assertEquals(maxDoc, skipper.maxDocID(level));
       } else {
         assertTrue(
-            "Expected: " + maxDoc + " but got " + skipper.maxDocID(0),
-            skipper.maxDocID(0) >= maxDoc);
+            "Expected: " + maxDoc + " but got " + skipper.maxDocID(level),
+            skipper.maxDocID(level) >= maxDoc);
       }
       if (skipperHasAccurateValueBounds()) {
-        assertEquals(minVal, skipper.minValue(0));
-        assertEquals(maxVal, skipper.maxValue(0));
+        assertEquals(minVal, skipper.minValue(level));
+        assertEquals(maxVal, skipper.maxValue(level));
       } else {
         assertTrue(
-            "Expected: " + minVal + " but got " + skipper.minValue(0),
-            minVal >= skipper.minValue(0));
+            "Expected: " + minVal + " but got " + skipper.minValue(level),
+            minVal >= skipper.minValue(level));
         assertTrue(
-            "Expected: " + maxVal + " but got " + skipper.maxValue(0),
-            maxVal <= skipper.maxValue(0));
+            "Expected: " + maxVal + " but got " + skipper.maxValue(level),
+            maxVal <= skipper.maxValue(level));
       }
-      docCount += skipper.docCount(0);
+      docCount += skipper.docCount(level);
+      previousMaxDoc = skipper.maxDocID(level);
     }
 
     assertEquals(docCount, skipper.docCount());
@@ -784,18 +786,20 @@ public abstract class BaseDocValuesFormatTestCase extends LegacyBaseDocValuesFor
     if (skipper == null) {
       return;
     }
+    int level = 0;
     while (true) {
-      int doc = random().nextInt(skipper.maxDocID(0), maxDoc + 1) + 1;
+      int doc = random().nextInt(skipper.maxDocID(level), maxDoc + 1) + 1;
       skipper.advance(doc);
-      if (skipper.minDocID(0) == NO_MORE_DOCS) {
-        assertEquals(NO_MORE_DOCS, skipper.maxDocID(0));
+      if (skipper.minDocID(level) == NO_MORE_DOCS) {
+        assertEquals(NO_MORE_DOCS, skipper.maxDocID(level));
         return;
       }
+      level = random().nextInt(skipper.numLevels());
       if (iterator.advanceExact(doc)) {
-        assertTrue(iterator.docID() >= skipper.minDocID(0));
-        assertTrue(iterator.docID() <= skipper.maxDocID(0));
-        assertTrue(iterator.minValue() >= skipper.minValue(0));
-        assertTrue(iterator.maxValue() <= skipper.maxValue(0));
+        assertTrue(iterator.docID() >= skipper.minDocID(level));
+        assertTrue(iterator.docID() <= skipper.maxDocID(level));
+        assertTrue(iterator.minValue() >= skipper.minValue(level));
+        assertTrue(iterator.maxValue() <= skipper.maxValue(level));
       }
     }
   }


### PR DESCRIPTION
Currently the DocValues skipper index collects the stats every 4096 documents that allow implementors to used them to decide if they want to process those documents or they can be skipped. The idea of adding levels is to be able to skip several of those block (called intervals in the code) in one step by collecting the stats of the blocks and adding them to the index.

This implementation collects the stats of 8 of those intervals.  For the first level, the first interval gets a new level with the stats from the next 8 intervals, then the 9th interval gets another level with the stats from the following 8 intervals and so on. For the second level, the first interval gets a new level with the stats from the next 8 level1  intervals, which is the same as the stats from the first 64 level 0 intervals and so on. 

I run some  basic experiments and I must say I did not see much change on the performance, still it feels the right thing to do, therefore I opened this PR.

relates https://github.com/apache/lucene/issues/11432

