### PR TITLE
Reduce memory usage of SkipListWriter

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90SkipWriter.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90SkipWriter.java
@@ -46,8 +46,8 @@ import org.apache.lucene.store.IndexOutput;
  * uptos(position, payload). 4. start offset.
  */
 final class Lucene90SkipWriter extends MultiLevelSkipListWriter {
-  private int[] lastSkipDoc;
-  private long[] lastSkipDocPointer;
+  private final int[] lastSkipDoc;
+  private final long[] lastSkipDocPointer;
   private long[] lastSkipPosPointer;
   private long[] lastSkipPayPointer;
 
@@ -61,7 +61,7 @@ final class Lucene90SkipWriter extends MultiLevelSkipListWriter {
   private long curPayPointer;
   private int curPosBufferUpto;
   private int curPayloadByteUpto;
-  private CompetitiveImpactAccumulator[] curCompetitiveFreqNorms;
+  private final CompetitiveImpactAccumulator[] curCompetitiveFreqNorms;
   private boolean fieldHasPositions;
   private boolean fieldHasOffsets;
   private boolean fieldHasPayloads;
@@ -78,16 +78,16 @@ final class Lucene90SkipWriter extends MultiLevelSkipListWriter {
     this.posOut = posOut;
     this.payOut = payOut;
 
-    lastSkipDoc = new int[maxSkipLevels];
-    lastSkipDocPointer = new long[maxSkipLevels];
+    lastSkipDoc = new int[numberOfSkipLevels];
+    lastSkipDocPointer = new long[numberOfSkipLevels];
     if (posOut != null) {
-      lastSkipPosPointer = new long[maxSkipLevels];
+      lastSkipPosPointer = new long[numberOfSkipLevels];
       if (payOut != null) {
-        lastSkipPayPointer = new long[maxSkipLevels];
+        lastSkipPayPointer = new long[numberOfSkipLevels];
       }
     }
-    curCompetitiveFreqNorms = new CompetitiveImpactAccumulator[maxSkipLevels];
-    for (int i = 0; i < maxSkipLevels; ++i) {
+    curCompetitiveFreqNorms = new CompetitiveImpactAccumulator[numberOfSkipLevels];
+    for (int i = 0; i < numberOfSkipLevels; ++i) {
       curCompetitiveFreqNorms[i] = new CompetitiveImpactAccumulator();
     }
   }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/Lucene50SkipWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/Lucene50SkipWriter.java
@@ -46,8 +46,8 @@ import org.apache.lucene.store.IndexOutput;
  * uptos(position, payload). 4. start offset.
  */
 final class Lucene50SkipWriter extends MultiLevelSkipListWriter {
-  private int[] lastSkipDoc;
-  private long[] lastSkipDocPointer;
+  private final int[] lastSkipDoc;
+  private final long[] lastSkipDocPointer;
   private long[] lastSkipPosPointer;
   private long[] lastSkipPayPointer;
   private int[] lastPayloadByteUpto;
@@ -62,7 +62,7 @@ final class Lucene50SkipWriter extends MultiLevelSkipListWriter {
   private long curPayPointer;
   private int curPosBufferUpto;
   private int curPayloadByteUpto;
-  private CompetitiveImpactAccumulator[] curCompetitiveFreqNorms;
+  private final CompetitiveImpactAccumulator[] curCompetitiveFreqNorms;
   private boolean fieldHasPositions;
   private boolean fieldHasOffsets;
   private boolean fieldHasPayloads;
@@ -80,16 +80,16 @@ final class Lucene50SkipWriter extends MultiLevelSkipListWriter {
     this.payOut = payOut;
 
     lastSkipDoc = new int[maxSkipLevels];
-    lastSkipDocPointer = new long[maxSkipLevels];
+    lastSkipDocPointer = new long[numberOfSkipLevels];
     if (posOut != null) {
-      lastSkipPosPointer = new long[maxSkipLevels];
+      lastSkipPosPointer = new long[numberOfSkipLevels];
       if (payOut != null) {
-        lastSkipPayPointer = new long[maxSkipLevels];
+        lastSkipPayPointer = new long[numberOfSkipLevels];
       }
-      lastPayloadByteUpto = new int[maxSkipLevels];
+      lastPayloadByteUpto = new int[numberOfSkipLevels];
     }
-    curCompetitiveFreqNorms = new CompetitiveImpactAccumulator[maxSkipLevels];
-    for (int i = 0; i < maxSkipLevels; ++i) {
+    curCompetitiveFreqNorms = new CompetitiveImpactAccumulator[numberOfSkipLevels];
+    for (int i = 0; i < numberOfSkipLevels; ++i) {
       curCompetitiveFreqNorms[i] = new CompetitiveImpactAccumulator();
     }
   }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene84/Lucene84SkipWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene84/Lucene84SkipWriter.java
@@ -46,8 +46,8 @@ import org.apache.lucene.store.IndexOutput;
  * uptos(position, payload). 4. start offset.
  */
 final class Lucene84SkipWriter extends MultiLevelSkipListWriter {
-  private int[] lastSkipDoc;
-  private long[] lastSkipDocPointer;
+  private final int[] lastSkipDoc;
+  private final long[] lastSkipDocPointer;
   private long[] lastSkipPosPointer;
   private long[] lastSkipPayPointer;
   private int[] lastPayloadByteUpto;
@@ -62,7 +62,7 @@ final class Lucene84SkipWriter extends MultiLevelSkipListWriter {
   private long curPayPointer;
   private int curPosBufferUpto;
   private int curPayloadByteUpto;
-  private CompetitiveImpactAccumulator[] curCompetitiveFreqNorms;
+  private final CompetitiveImpactAccumulator[] curCompetitiveFreqNorms;
   private boolean fieldHasPositions;
   private boolean fieldHasOffsets;
   private boolean fieldHasPayloads;
@@ -79,17 +79,17 @@ final class Lucene84SkipWriter extends MultiLevelSkipListWriter {
     this.posOut = posOut;
     this.payOut = payOut;
 
-    lastSkipDoc = new int[maxSkipLevels];
-    lastSkipDocPointer = new long[maxSkipLevels];
+    lastSkipDoc = new int[numberOfSkipLevels];
+    lastSkipDocPointer = new long[numberOfSkipLevels];
     if (posOut != null) {
-      lastSkipPosPointer = new long[maxSkipLevels];
+      lastSkipPosPointer = new long[numberOfSkipLevels];
       if (payOut != null) {
-        lastSkipPayPointer = new long[maxSkipLevels];
+        lastSkipPayPointer = new long[numberOfSkipLevels];
       }
-      lastPayloadByteUpto = new int[maxSkipLevels];
+      lastPayloadByteUpto = new int[numberOfSkipLevels];
     }
-    curCompetitiveFreqNorms = new CompetitiveImpactAccumulator[maxSkipLevels];
-    for (int i = 0; i < maxSkipLevels; ++i) {
+    curCompetitiveFreqNorms = new CompetitiveImpactAccumulator[numberOfSkipLevels];
+    for (int i = 0; i < numberOfSkipLevels; ++i) {
       curCompetitiveFreqNorms[i] = new CompetitiveImpactAccumulator();
     }
   }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSkipWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSkipWriter.java
@@ -60,8 +60,8 @@ class SimpleTextSkipWriter extends MultiLevelSkipListWriter {
 
   SimpleTextSkipWriter(SegmentWriteState writeState) throws IOException {
     super(BLOCK_SIZE, skipMultiplier, maxSkipLevels, writeState.segmentInfo.maxDoc());
-    curCompetitiveFreqNorms = new CompetitiveImpactAccumulator[maxSkipLevels];
-    for (int i = 0; i < maxSkipLevels; ++i) {
+    curCompetitiveFreqNorms = new CompetitiveImpactAccumulator[numberOfSkipLevels];
+    for (int i = 0; i < numberOfSkipLevels; ++i) {
       curCompetitiveFreqNorms[i] = new CompetitiveImpactAccumulator();
     }
     resetSkip();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99SkipWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99SkipWriter.java
@@ -46,8 +46,8 @@ import org.apache.lucene.store.IndexOutput;
  * uptos(position, payload). 4. start offset.
  */
 public final class Lucene99SkipWriter extends MultiLevelSkipListWriter {
-  private int[] lastSkipDoc;
-  private long[] lastSkipDocPointer;
+  private final int[] lastSkipDoc;
+  private final long[] lastSkipDocPointer;
   private long[] lastSkipPosPointer;
   private long[] lastSkipPayPointer;
 
@@ -61,7 +61,7 @@ public final class Lucene99SkipWriter extends MultiLevelSkipListWriter {
   private long curPayPointer;
   private int curPosBufferUpto;
   private int curPayloadByteUpto;
-  private CompetitiveImpactAccumulator[] curCompetitiveFreqNorms;
+  private final CompetitiveImpactAccumulator[] curCompetitiveFreqNorms;
   private boolean fieldHasPositions;
   private boolean fieldHasOffsets;
   private boolean fieldHasPayloads;
@@ -78,16 +78,16 @@ public final class Lucene99SkipWriter extends MultiLevelSkipListWriter {
     this.posOut = posOut;
     this.payOut = payOut;
 
-    lastSkipDoc = new int[maxSkipLevels];
-    lastSkipDocPointer = new long[maxSkipLevels];
+    lastSkipDoc = new int[numberOfSkipLevels];
+    lastSkipDocPointer = new long[numberOfSkipLevels];
     if (posOut != null) {
-      lastSkipPosPointer = new long[maxSkipLevels];
+      lastSkipPosPointer = new long[numberOfSkipLevels];
       if (payOut != null) {
-        lastSkipPayPointer = new long[maxSkipLevels];
+        lastSkipPayPointer = new long[numberOfSkipLevels];
       }
     }
-    curCompetitiveFreqNorms = new CompetitiveImpactAccumulator[maxSkipLevels];
-    for (int i = 0; i < maxSkipLevels; ++i) {
+    curCompetitiveFreqNorms = new CompetitiveImpactAccumulator[numberOfSkipLevels];
+    for (int i = 0; i < numberOfSkipLevels; ++i) {
       curCompetitiveFreqNorms[i] = new CompetitiveImpactAccumulator();
     }
   }


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
Currently, we always use the size `Lucene99PostingsFormat.MAX_SKIP_LEVELS` to initialize the array fields of SkipListWriter. However, we have already calculated the maximum possible skip levels upfront in `MultiLevelSkipListWriter`.