### PR TITLE
Remove useless todo in PerThreadPKLookup.

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/PerThreadPKLookup.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/PerThreadPKLookup.java
@@ -85,8 +85,6 @@ public class PerThreadPKLookup {
       if (termsEnums[seg].seekExact(id)) {
         postingsEnums[seg] = termsEnums[seg].postings(postingsEnums[seg], 0);
         int docID = -1;
-        // TODO: Can we get postings' last Doc directly? and return the last one we find.
-        // TODO: Maybe we should check liveDoc whether null out of the loop?
         while ((docID = postingsEnums[seg].nextDoc()) != PostingsEnum.NO_MORE_DOCS) {
           if (liveDocs[seg] == null || liveDocs[seg].get(docID)) {
             return docBases[seg] + docID;


### PR DESCRIPTION
### Description


No difference, see https://github.com/apache/lucene/pull/13557.