### PR TITLE
Udpate ReadTask to not rely on search(Query, Collector)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -206,6 +206,9 @@ Changes in Backwards Compatibility Policy
 * GITHUB#13230: Remove the Kp and Lovins snowball algorithms which are not supported
   or intended for general use. (Robert Muir)
 
+* GITHUB#13602: SearchWithCollectorTask no longer supports the `collector.class` config parameter to load a custom
+  collector implementation. `collector.manager.class` allows users to load a collector manager instead. (Luca Cavanna)
+
 Other
 ---------------------
 

--- a/lucene/benchmark/conf/collector-small.alg
+++ b/lucene/benchmark/conf/collector-small.alg
@@ -17,11 +17,10 @@
 # -------------------------------------------------------------------------------------
 # multi val params are iterated by NewRound's, added to reports, start with column name.
 
-# collector.class can be:
-#    Fully Qualified Class Name of a Collector with a empty constructor
-#    topScoreDocOrdered - Creates a TopScoreDocCollector that requires in order docs
-#    topScoreDocUnordered - Like above, but allows out of order
-collector.class=coll:topScoreDoc
+# collector.manager.class can be:
+#    Fully Qualified Class Name of a CollectorManager with a empty constructor
+#    topScoreDoc - Creates a TopScoreDocCollectorManager
+collector.manager.class=coll:topScoreDoc
 
 analyzer=org.apache.lucene.analysis.core.WhitespaceAnalyzer
 directory=FSDirectory

--- a/lucene/benchmark/conf/collector.alg
+++ b/lucene/benchmark/conf/collector.alg
@@ -17,11 +17,10 @@
 # -------------------------------------------------------------------------------------
 # multi val params are iterated by NewRound's, added to reports, start with column name.
 
-# collector.class can be:
-#    Fully Qualified Class Name of a Collector with a empty constructor
-#    topScoreDocOrdered - Creates a TopScoreDocCollector that requires in order docs
-#    topScoreDocUnordered - Like above, but allows out of order
-collector.class=coll:topScoreDoc
+# collector.manager.class can be:
+#    Fully Qualified Class Name of a CollectorManager with a empty constructor
+#    topScoreDoc - Creates a TopScoreDocCollectorManager
+collector.manager.class=coll:topScoreDoc
 
 analyzer=org.apache.lucene.analysis.core.WhitespaceAnalyzer
 directory=FSDirectory

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/ReadTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/ReadTask.java
@@ -24,7 +24,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.StoredFields;
-import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
@@ -119,9 +119,7 @@ public abstract class ReadTask extends PerfTask {
             hits = searcher.search(q, numHits);
           }
         } else {
-          Collector collector = createCollector();
-
-          searcher.search(q, collector);
+          searcher.search(q, createCollectorManager());
           // hits = collector.topDocs();
         }
 
@@ -184,9 +182,8 @@ public abstract class ReadTask extends PerfTask {
     return res;
   }
 
-  protected Collector createCollector() throws Exception {
-    return new TopScoreDocCollectorManager(numHits(), withTotalHits() ? Integer.MAX_VALUE : 1)
-        .newCollector();
+  protected CollectorManager<?, ?> createCollectorManager() throws Exception {
+    return new TopScoreDocCollectorManager(numHits(), withTotalHits() ? Integer.MAX_VALUE : 1);
   }
 
   protected Document retrieveDoc(StoredFields storedFields, int id) throws IOException {

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchWithCollectorTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchWithCollectorTask.java
@@ -19,8 +19,8 @@ package org.apache.lucene.benchmark.byTask.tasks;
 import org.apache.lucene.benchmark.byTask.PerfRunData;
 import org.apache.lucene.benchmark.byTask.feeds.QueryMaker;
 import org.apache.lucene.benchmark.byTask.utils.Config;
-import org.apache.lucene.search.Collector;
-import org.apache.lucene.search.TopScoreDocCollector;
+import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.search.TopScoreDocCollectorManager;
 
 /** Does search w/ a custom collector */
 public class SearchWithCollectorTask extends SearchTask {
@@ -46,17 +46,17 @@ public class SearchWithCollectorTask extends SearchTask {
   }
 
   @Override
-  protected Collector createCollector() throws Exception {
-    Collector collector = null;
+  protected CollectorManager<?, ?> createCollectorManager() throws Exception {
+    CollectorManager<?, ?> collectorManager;
     if (clnName.equalsIgnoreCase("topScoreDoc") == true) {
-      collector = TopScoreDocCollector.create(numHits(), Integer.MAX_VALUE);
+      collectorManager = new TopScoreDocCollectorManager(numHits(), Integer.MAX_VALUE);
     } else if (clnName.length() > 0) {
-      collector = Class.forName(clnName).asSubclass(Collector.class).getConstructor().newInstance();
-
+      collectorManager =
+          Class.forName(clnName).asSubclass(CollectorManager.class).getConstructor().newInstance();
     } else {
-      collector = super.createCollector();
+      collectorManager = super.createCollectorManager();
     }
-    return collector;
+    return collectorManager;
   }
 
   @Override

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchWithCollectorTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchWithCollectorTask.java
@@ -37,7 +37,11 @@ public class SearchWithCollectorTask extends SearchTask {
     // check to make sure either the doc is being stored
     PerfRunData runData = getRunData();
     Config config = runData.getConfig();
-    clnName = config.get("collector.class", "");
+    if (config.get("collector.class", null) != null) {
+      throw new IllegalArgumentException(
+          "collector.class is no longer supported as a config parameter, use collector.manager.class instead to provide a CollectorManager class name");
+    }
+    clnName = config.get("collector.manager.class", "");
   }
 
   @Override


### PR DESCRIPTION
This commit modifies ReadTask to no longer call the deprecated search(Query, Collector). Instead, it creates a collector manager and calls search(Query, CollectorManager).

The existing protected createCollector method is removed in favour of createCollectorManager that returns now a CollectorManager in place of a Collector.

SearchWithCollectorTask works the same way if "topScoreDoc" is provided as config. Loading of a custom collector will no longer work, and needs to be replaced with loading a collector manager by class name instead.