### PR TITLE
[9.x] Do not randomize readOnce contexts in tests

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1838,8 +1838,8 @@ public abstract class LuceneTestCase extends Assert {
 
   /** TODO: javadoc */
   public static IOContext newIOContext(Random random, IOContext oldContext) {
-    if (oldContext == IOContext.READONCE) {
-      return oldContext; // don't mess with the READONCE singleton
+    if (oldContext.readOnce) {
+      return oldContext; // don't mess with readOnce contexts
     }
     final int randomNumDocs = random.nextInt(4192);
     final int size = random.nextInt(512) * randomNumDocs;


### PR DESCRIPTION
This is a follow on to #13578, where the backport generalised the test check to the `readOnce` value of the context, rather than the `READONCE` singleton. The randomisation should be updated too reflect this too, was just missed at the time.

relates: #13578