### PR TITLE
Deduplicate bytes for `FieldReader#rootCode`

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/FieldReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/FieldReader.java
@@ -101,7 +101,7 @@ public final class FieldReader extends Terms {
     */
     BytesRef emptyOutput = metadata.getEmptyOutput();
     if (rootCode.equals(emptyOutput) == false) {
-      // TODO: this branch is never taken?
+      // TODO: this branch is never taken
       assert false;
       this.rootCode = rootCode;
     } else {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/FieldReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/FieldReader.java
@@ -78,7 +78,6 @@ public final class FieldReader extends Terms {
     this.sumTotalTermFreq = sumTotalTermFreq;
     this.sumDocFreq = sumDocFreq;
     this.docCount = docCount;
-    this.rootCode = rootCode;
     this.minTerm = minTerm;
     this.maxTerm = maxTerm;
     // if (DEBUG) {
@@ -100,6 +99,14 @@ public final class FieldReader extends Terms {
      w.close();
      }
     */
+    BytesRef emptyOutput = metadata.getEmptyOutput();
+    if (rootCode.equals(emptyOutput) == false) {
+      // TODO: this branch is never taken?
+      assert false;
+      this.rootCode = rootCode;
+    } else {
+      this.rootCode = emptyOutput;
+    }
   }
 
   long readVLongOutput(DataInput in) throws IOException {


### PR DESCRIPTION
Loooking at how these instances are serialized to disk it appears that the empty output in the FST metadata is always the same as the rootCode bytes and the assertion I put in here suggests as much as well? Maybe we can just do away with the `rootCode` field outright and simply refer to the FST here?
Without changing the serialization we could at least deduplicate here, saving hundreds of MB in some high-segment count use cases I observed in ES.

