### PR TITLE
hunspell: add Suggester#proceedPastRep to avoid losing relevant suggestions

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -253,6 +253,8 @@ API Changes
 
 * GITHUB#13469: Expose FlatVectorsFormat as a first-class format; can be configured using a custom Codec. (Michael Sokolov) 
 
+* GITHUB#13612: Hunspell: add Suggester#proceedPastRep to avoid losing relevant suggestions. (Peter Gromov)
+
 New Features
 ---------------------
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/ModifyingSuggester.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/ModifyingSuggester.java
@@ -31,6 +31,7 @@ class ModifyingSuggester {
   private final String misspelled;
   private final WordCase wordCase;
   private final FragmentChecker fragmentChecker;
+  private final boolean proceedPastRep;
   private final char[] tryChars;
   private final Hunspell speller;
 
@@ -39,13 +40,15 @@ class ModifyingSuggester {
       LinkedHashSet<Suggestion> result,
       String misspelled,
       WordCase wordCase,
-      FragmentChecker checker) {
+      FragmentChecker checker,
+      boolean proceedPastRep) {
     this.speller = speller;
     tryChars = speller.dictionary.tryChars.toCharArray();
     this.result = result;
     this.misspelled = misspelled;
     this.wordCase = wordCase;
     fragmentChecker = checker;
+    this.proceedPastRep = proceedPastRep;
   }
 
   /**
@@ -125,9 +128,9 @@ class ModifyingSuggester {
     boolean hasGoodSuggestions = trySuggestion(word.toUpperCase(Locale.ROOT));
 
     GradedSuggestions repResult = tryRep(word);
-    if (repResult == GradedSuggestions.Best) return true;
+    if (repResult == GradedSuggestions.Best && !proceedPastRep) return true;
 
-    hasGoodSuggestions |= repResult == GradedSuggestions.Normal;
+    hasGoodSuggestions |= repResult != GradedSuggestions.None;
 
     if (!speller.dictionary.mapTable.isEmpty()) {
       enumerateMapReplacements(word, "", 0);

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestSpellChecking.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestSpellChecking.java
@@ -59,6 +59,14 @@ public class TestSpellChecking extends LuceneTestCase {
 
   public void testRepSuggestions() throws Exception {
     doTest("rep");
+
+    //noinspection DataFlowIssue
+    Path aff = Path.of(getClass().getResource("rep.aff").toURI());
+    Dictionary dictionary = TestAllDictionaries.loadDictionary(aff);
+    Suggester suggester = new Suggester(dictionary);
+    assertEquals(List.of("auto's"), suggester.suggestNoTimeout("autos", () -> {}));
+    assertEquals(
+        List.of("auto's", "auto"), suggester.proceedPastRep().suggestNoTimeout("autos", () -> {}));
   }
 
   public void testPhSuggestions() throws Exception {


### PR DESCRIPTION
This PR introduces a way to get a copy of the suggester instance that doesn't stop after encountering acceptable words
(after applying REP rules). By default, Hunspell stops when it finds any, but this behavior may
not always be desirable, e.g., if we have "REP i ea", "tims" would be replaced only by "teams" and not "times", which 
could also be meant.