### PR TITLE
Revert cosine deprecation

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -249,9 +249,7 @@ Other
 API Changes
 ---------------------
 
-* GITHUB#13281: Mark COSINE VectorSimilarityFunction as deprecated. (Pulkit Gupta)
-
-* GITHUB#13469: Expose FlatVectorsFormat as a first-class format; can be configured using a custom Codec. (Michael Sokolov) 
+* GITHUB#13469: Expose FlatVectorsFormat as a first-class format; can be configured using a custom Codec. (Michael Sokolov)
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
@@ -66,10 +66,7 @@ public enum VectorSimilarityFunction {
    * vectors to unit length, and instead use {@link VectorSimilarityFunction#DOT_PRODUCT}. You
    * should only use this function if you need to preserve the original vectors and cannot normalize
    * them in advance. The similarity score is normalised to assure it is positive.
-   *
-   * @deprecated Use MAXIMUM_INNER_PRODUCT or DOT_PRODUCT instead
    */
-  @Deprecated
   COSINE {
     @Override
     public float compare(float[] v1, float[] v2) {

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -70,9 +70,7 @@ public final class VectorUtil {
    * Returns the cosine similarity between the two vectors.
    *
    * @throws IllegalArgumentException if the vectors' dimensions differ.
-   * @deprecated use dot-product instead using normalized vectors
    */
-  @Deprecated
   public static float cosine(float[] a, float[] b) {
     if (a.length != b.length) {
       throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
@@ -82,12 +80,7 @@ public final class VectorUtil {
     return r;
   }
 
-  /**
-   * Returns the cosine similarity between the two vectors.
-   *
-   * @deprecated use dot-product instead using normalized vectors
-   */
-  @Deprecated
+  /** Returns the cosine similarity between the two vectors. */
   public static float cosine(byte[] a, byte[] b) {
     if (a.length != b.length) {
       throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);


### PR DESCRIPTION
Opening for more pointed discussion. See latest discussion here: https://github.com/apache/lucene/issues/13281


I was hoping to have a full answer for folks who use `byte` models by Lucene 10, but I just don't have that. 

I still want to remove the internal cosine optimized methods. We can do this if we store magnitudes along side the raw vectors. This way we can remove all the internal optimized cosine code as its complicated.