### PR TITLE
Fix failing unit test - TestTopDocsCollector#testResultsOrder

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -72,9 +72,6 @@ public class TestTopDocsCollector extends LuceneTestCase {
   }
 
   private static final class MyTopDocsCollector extends TopDocsCollector<ScoreDoc> {
-
-    private int idx = 0;
-
     public MyTopDocsCollector(int size) {
       super(new HitQueue(size, false));
     }
@@ -92,6 +89,7 @@ public class TestTopDocsCollector extends LuceneTestCase {
     public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
       final int base = context.docBase;
       return new LeafCollector() {
+        private int idx = 0;
 
         @Override
         public void collect(int doc) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -46,6 +46,7 @@ public class TestTopDocsCollector extends LuceneTestCase {
       implements CollectorManager<MyTopDocsCollector, MyTopDocsCollector> {
 
     private final int numHits;
+    private int idx = 0;
 
     MyTopDocsCollectorMananger(int numHits) {
       this.numHits = numHits;
@@ -53,7 +54,9 @@ public class TestTopDocsCollector extends LuceneTestCase {
 
     @Override
     public MyTopDocsCollector newCollector() {
-      return new MyTopDocsCollector(numHits);
+      MyTopDocsCollector myTopDocsCollector = new MyTopDocsCollector(numHits, idx);
+      idx += numHits;
+      return myTopDocsCollector;
     }
 
     @Override
@@ -73,10 +76,16 @@ public class TestTopDocsCollector extends LuceneTestCase {
 
   private static final class MyTopDocsCollector extends TopDocsCollector<ScoreDoc> {
 
-    private int idx = 0;
+    private int idx;
+
+    public MyTopDocsCollector(int size, int startIdx) {
+      super(new HitQueue(size, false));
+      this.idx = startIdx;
+    }
 
     public MyTopDocsCollector(int size) {
       super(new HitQueue(size, false));
+      this.idx = 0;
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -46,7 +46,6 @@ public class TestTopDocsCollector extends LuceneTestCase {
       implements CollectorManager<MyTopDocsCollector, MyTopDocsCollector> {
 
     private final int numHits;
-    private int idx = 0;
 
     MyTopDocsCollectorMananger(int numHits) {
       this.numHits = numHits;
@@ -54,9 +53,7 @@ public class TestTopDocsCollector extends LuceneTestCase {
 
     @Override
     public MyTopDocsCollector newCollector() {
-      MyTopDocsCollector myTopDocsCollector = new MyTopDocsCollector(numHits, idx);
-      idx += numHits;
-      return myTopDocsCollector;
+      return new MyTopDocsCollector(numHits);
     }
 
     @Override
@@ -76,16 +73,10 @@ public class TestTopDocsCollector extends LuceneTestCase {
 
   private static final class MyTopDocsCollector extends TopDocsCollector<ScoreDoc> {
 
-    private int idx;
-
-    public MyTopDocsCollector(int size, int startIdx) {
-      super(new HitQueue(size, false));
-      this.idx = startIdx;
-    }
+    private int idx = 0;
 
     public MyTopDocsCollector(int size) {
       super(new HitQueue(size, false));
-      this.idx = 0;
     }
 
     @Override
@@ -105,7 +96,7 @@ public class TestTopDocsCollector extends LuceneTestCase {
         @Override
         public void collect(int doc) {
           ++totalHits;
-          pq.insertWithOverflow(new ScoreDoc(doc + base, scores[idx++]));
+          pq.insertWithOverflow(new ScoreDoc(doc + base, scores[context.docBase + idx++]));
         }
 
         @Override


### PR DESCRIPTION
Closes #13620

I believe this bug happens due to having 2 collectors with the same indexes and the score of `9.17561f` is never inserted into the pq, failing the assertion.

Another potential solution is having a SingletonMyTopDocsCollectorMananger which always returns the same `MyTopDocsCollector`.

TEST: `./gradlew tidy && ./gradlew test` + `./gradlew test --tests TestTopDocsCollector.testResultsOrder -Dtests.seed=207A6071B3338CA6`