### PR TITLE
Fix comments containing 'the this'

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetField.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetField.java
@@ -42,7 +42,7 @@ public class FacetField extends Field {
   /** Path for this field. */
   public final String[] path;
 
-  /** Creates the this from {@code dim} and {@code path}. */
+  /** Creates this from {@code dim} and {@code path}. */
   public FacetField(String dim, String... path) {
     super("dummy", TYPE);
     verifyLabel(dim);

--- a/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
@@ -470,7 +470,7 @@ public final class JoinUtil {
    * <p>This join has certain restrictions and requirements: 1) A document can only refer to one
    * other document. (but can be referred by one or more documents) 2) Documents on each side of the
    * join must be distinguishable. Typically this can be done by adding an extra field that
-   * identifies the "from" and "to" side and then the fromQuery and toQuery must take the this into
+   * identifies the "from" and "to" side and then the fromQuery and toQuery must take this into
    * account. 3) There must be a single sorted doc values join field used by both the "from" and
    * "to" documents. This join field should store the join values as UTF-8 strings. 4) An ordinal
    * map must be provided that is created on top of the join field.

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -281,7 +281,7 @@ public class MemoryIndex {
       /**
        * Returns the offset of the currently written slice. The returned value should be used as the
        * end offset to initialize a {@link SliceReader} once this slice is fully written or to reset
-       * the this writer if another slice needs to be written.
+       * the writer if another slice needs to be written.
        */
       public int getCurrentOffset() {
         return offset;

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/SuggestField.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/SuggestField.java
@@ -42,7 +42,7 @@ import org.apache.lucene.util.BytesRef;
  * document.add(new SuggestField(name, "suggestion", 4));
  * </pre>
  *
- * To perform document suggestions based on the this field, use {@link
+ * To perform document suggestions based on the field, use {@link
  * SuggestIndexSearcher#suggest(CompletionQuery, int, boolean)}
  *
  * @lucene.experimental


### PR DESCRIPTION
I noticed a typo in a comment in the `FacetField` class, while fixing it I noticed that we have a few other occurrences in the code base, what are the odds :D


TEST: `./gradlew tidy`