### PR TITLE
Fix race condition on flush for DWPT seqNo generation

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -346,6 +346,8 @@ Bug Fixes
 * GITHUB#13553: Correct RamUsageEstimate for scalar quantized knn vector formats so that raw vectors are correctly
   accounted for. (Ben Trent)
 
+* GITHUB#13627: Fix race condition on flush for DWPT seqNo generation. (Ben Trent, Ao Li)
+
 Other
 --------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
@@ -430,10 +430,16 @@ final class DocumentsWriter implements Closeable, Accountable {
       }
       flushingDWPT = flushControl.doAfterDocument(dwpt);
     } finally {
-      if (dwpt.isFlushPending() || dwpt.isAborted()) {
-        dwpt.unlock();
-      } else {
-        perThreadPool.marksAsFreeAndUnlock(dwpt);
+      // If a flush is occurring, we don't want to allow this dwpt to be reused
+      // If it is aborted, we shouldn't allow it to be reused
+      // If the deleteQueue is advanced, this means the maximum seqNo has been set and it cannot be
+      // reused
+      synchronized (flushControl) {
+        if (dwpt.isFlushPending() || dwpt.isAborted() || dwpt.isQueueAdvanced()) {
+          dwpt.unlock();
+        } else {
+          perThreadPool.marksAsFreeAndUnlock(dwpt);
+        }
       }
       assert dwpt.isHeldByCurrentThread() == false : "we didn't release the dwpt even on abort";
     }

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterDeleteQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterDeleteQueue.java
@@ -636,7 +636,7 @@ final class DocumentsWriterDeleteQueue implements Accountable, Closeable {
   }
 
   /** Returns <code>true</code> if it was advanced. */
-  boolean isAdvanced() {
+  synchronized boolean isAdvanced() {
     return advanced;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThread.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThread.java
@@ -718,6 +718,10 @@ final class DocumentsWriterPerThread implements Accountable, Lock {
     return flushPending.get() == Boolean.TRUE;
   }
 
+  boolean isQueueAdvanced() {
+    return deleteQueue.isAdvanced();
+  }
+
   /** Sets this DWPT as flush pending. This can only be set once. */
   void setFlushPending() {
     flushPending.set(Boolean.TRUE);

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThreadPool.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThreadPool.java
@@ -138,13 +138,17 @@ final class DocumentsWriterPerThreadPool implements Iterable<DocumentsWriterPerT
 
   void marksAsFreeAndUnlock(DocumentsWriterPerThread state) {
     final long ramBytesUsed = state.ramBytesUsed();
+    assert state.isFlushPending() == false
+            && state.isAborted() == false
+            && state.isQueueAdvanced() == false
+        : "DWPT has pending flush: "
+            + state.isFlushPending()
+            + " aborted="
+            + state.isAborted()
+            + " queueAdvanced="
+            + state.isQueueAdvanced();
     assert contains(state)
         : "we tried to add a DWPT back to the pool but the pool doesn't know about this DWPT";
-    // If we are closed we don't add the DWPT back to the free list. It has to be a "new" DWPT
-    if (state.deleteQueue.isAdvanced()) {
-      state.unlock();
-      return;
-    }
     freeList.addAndUnlock(state, ramBytesUsed);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThreadPool.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThreadPool.java
@@ -140,6 +140,11 @@ final class DocumentsWriterPerThreadPool implements Iterable<DocumentsWriterPerT
     final long ramBytesUsed = state.ramBytesUsed();
     assert contains(state)
         : "we tried to add a DWPT back to the pool but the pool doesn't know about this DWPT";
+    // If we are closed we don't add the DWPT back to the free list. It has to be a "new" DWPT
+    if (state.deleteQueue.isAdvanced()) {
+      state.unlock();
+      return;
+    }
     freeList.addAndUnlock(state, ramBytesUsed);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterPerThreadPool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterPerThreadPool.java
@@ -67,45 +67,6 @@ public class TestDocumentsWriterPerThreadPool extends LuceneTestCase {
     }
   }
 
-  public void testLockReleaseWithAdvancedDeleteQueue() throws IOException {
-    try (Directory directory = newDirectory()) {
-      DocumentsWriterDeleteQueue deleteQueue = new DocumentsWriterDeleteQueue(null);
-      DocumentsWriterPerThreadPool pool =
-          new DocumentsWriterPerThreadPool(
-              () ->
-                  new DocumentsWriterPerThread(
-                      Version.LATEST.major,
-                      "",
-                      directory,
-                      directory,
-                      newIndexWriterConfig(),
-                      deleteQueue,
-                      null,
-                      new AtomicLong(),
-                      false));
-
-      DocumentsWriterPerThread first = pool.getAndLock();
-      assertEquals(1, pool.size());
-      DocumentsWriterPerThread second = pool.getAndLock();
-      assertEquals(2, pool.size());
-      assertNotSame(first, second);
-      deleteQueue.advanceQueue(pool.size());
-      // first should not be placed back into the free list
-      pool.marksAsFreeAndUnlock(first);
-      DocumentsWriterPerThread third = pool.getAndLock();
-      assertNotSame(first, third);
-      assertEquals(3, pool.size());
-      pool.checkout(third);
-      assertEquals(2, pool.size());
-      pool.marksAsFreeAndUnlock(second);
-      for (DocumentsWriterPerThread lastPerThead : pool.filterAndLock(x -> true)) {
-        pool.checkout(lastPerThead);
-        lastPerThead.unlock();
-      }
-      assertEquals(0, pool.size());
-    }
-  }
-
   public void testCloseWhileNewWritersLocked() throws IOException, InterruptedException {
     try (Directory directory = newDirectory()) {
       DocumentsWriterPerThreadPool pool =


### PR DESCRIPTION
There is a tricky race condition with DWPT threads. It is possible that a flush starts by advancing the deleteQueue (in charge of creating seqNo). Thus, the referenced deleteQueue, there should be a cap on the number of actions left. 

However, it is possible after the advance, but before the DWPT are actually marked for flush, the DWPT gets freed and taken again to be used.

To replicate this extreme behavior, see: https://github.com/apache/lucene/compare/main...benwtrent:lucene:test-replicate-and-debug-13127?expand=1

This commit will prevent DWPT from being added back to the free list if their queue has been advanced. This is because the `maxSeqNo` for that queue was created accounting only for the current number of active threads. If the thread gets passed out again and still references the already advanced queue, it is possible that seqNo actually advances past the set `maxSeqNo`. 


closes: https://github.com/apache/lucene/issues/13127
closes: https://github.com/apache/lucene/issues/13571
