### PR TITLE
Slightly speed up decoding blocks of postings/freqs/positions.

### DIFF
--- a/gradle/generation/forUtil.gradle
+++ b/gradle/generation/forUtil.gradle
@@ -43,6 +43,32 @@ configure(project(":lucene:core")) {
           andThenTasks: ["spotlessJava", "spotlessJavaApply"],
           mustRunBefore: [ "compileJava" ]
   ])
+
+  task generateForDeltaUtilInternal() {
+    description "Regenerate gen_ForDeltaUtil.py"
+    group "generation"
+
+    def genDir = file("src/java/org/apache/lucene/codecs/lucene912")
+    def genScript = file("${genDir}/gen_ForDeltaUtil.py")
+    def genOutput = file("${genDir}/ForDeltaUtil.java")
+
+    inputs.file genScript
+    outputs.file genOutput
+
+    doLast {
+      quietExec {
+        workingDir genDir
+        executable project.externalTool("python3")
+        args = [ '-B', genScript ]
+      }
+    }
+  }
+
+  regenerate.dependsOn wrapWithPersistentChecksums(generateForDeltaUtilInternal, [
+          andThenTasks: ["spotlessJava", "spotlessJavaApply"],
+          mustRunBefore: [ "compileJava" ]
+  ])
+
 }
 
 configure(project(":lucene:backward-codecs")) {

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ForUtilBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ForUtilBenchmark.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.codecs.lucene912.ForDeltaUtil;
+import org.apache.lucene.codecs.lucene912.ForUtil;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.IOUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(
+    value = 5,
+    jvmArgsAppend = {"-Xmx1g", "-Xms1g", "-XX:+AlwaysPreTouch"})
+public class ForUtilBenchmark {
+
+  private Path path;
+  private Directory dir;
+  private IndexInput in;
+  private final ForUtil forUtil = new ForUtil();
+  private final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
+  private final long[] values = new long[128];
+
+  @Param({"6", "8", "10"})
+  public int bpv;
+
+  @Setup(Level.Trial)
+  public void setup() throws Exception {
+    path = Files.createTempDirectory("forUtil");
+    dir = MMapDirectory.open(path);
+    try (IndexOutput out = dir.createOutput("docs", IOContext.DEFAULT)) {
+      Random r = new Random(0);
+      // Write enough random data to not reach EOF while decoding
+      for (int i = 0; i < 100; ++i) {
+        out.writeLong(r.nextLong());
+      }
+    }
+    in = dir.openInput("docs", IOContext.DEFAULT);
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws Exception {
+    if (dir != null) {
+      dir.deleteFile("docs");
+    }
+    IOUtils.close(in, dir);
+    in = null;
+    dir = null;
+    Files.deleteIfExists(path);
+  }
+
+  @Benchmark
+  public void decode(Blackhole bh) throws IOException {
+    in.seek(3); // random unaligned offset
+    forUtil.decode(bpv, in, values);
+    bh.consume(values);
+  }
+
+  @Benchmark
+  public void decodeAndPrefixSum(Blackhole bh) throws IOException {
+    in.seek(3); // random unaligned offset
+    forDeltaUtil.decodeAndPrefixSum(bpv, in, 100, values);
+    bh.consume(values);
+  }
+}

--- a/lucene/core/src/generated/checksums/generateForDeltaUtil.json
+++ b/lucene/core/src/generated/checksums/generateForDeltaUtil.json
@@ -1,0 +1,4 @@
+{
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForDeltaUtil.java": "46b57c764f070280ed88c5f068faf80b4a8baf2d",
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForDeltaUtil.py": "a1525793a4eaba4acb9c51541b9a52a3b9774a96"
+}

--- a/lucene/core/src/generated/checksums/generateForUtil.json
+++ b/lucene/core/src/generated/checksums/generateForUtil.json
@@ -1,4 +1,4 @@
 {
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForUtil.java": "5ff856e80cab30f9e5704aa89f3197f017d07624",
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForUtil.py": "3ccf92b3ddbff6340a13e8a55090bfb900dc7be2"
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForUtil.java": "3964898a56c1bb01b3ae6e78cd15cf1aa2f65f9f",
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForUtil.py": "139a1e47c4e1d7955bb5e58bef0de4eca138a37b"
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForDeltaUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForDeltaUtil.java
@@ -1,3 +1,5 @@
+// This file has been automatically generated, DO NOT EDIT
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,12 +19,23 @@
 package org.apache.lucene.codecs.lucene912;
 
 import java.io.IOException;
+import java.util.Arrays;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.packed.PackedInts;
 
-/** Utility class to encode/decode increasing sequences of 128 integers. */
-public class ForDeltaUtil {
+// Inspired from https://fulmicoton.com/posts/bitpacking/
+// Encodes multiple integers in a long to get SIMD-like speedups.
+// If bitsPerValue <= 9 then we pack 4 ints per long
+// else we pack 2 ints per long
+// This allows computing a prefix sum without overflowing.
+public final class ForDeltaUtil {
+
+  static final int BLOCK_SIZE = 128;
+  private static final int BLOCK_SIZE_LOG2 = 7;
+  private static final int ONE_BLOCK_SIZE_FOURTH = BLOCK_SIZE / 4;
+  private static final int TWO_BLOCK_SIZE_FOURTHS = BLOCK_SIZE / 2;
+  private static final int THREE_BLOCK_SIZE_FOURTHS = 3 * BLOCK_SIZE / 4;
 
   // IDENTITY_PLUS_ONE[i] == i+1
   private static final long[] IDENTITY_PLUS_ONE = new long[ForUtil.BLOCK_SIZE];
@@ -41,10 +54,275 @@ public class ForDeltaUtil {
     }
   }
 
-  private final ForUtil forUtil;
+  private static long expandMask32(long mask32) {
+    return mask32 | (mask32 << 32);
+  }
 
-  ForDeltaUtil(ForUtil forUtil) {
-    this.forUtil = forUtil;
+  private static long expandMask16(long mask16) {
+    return expandMask32(mask16 | (mask16 << 16));
+  }
+
+  private static long mask32(int bitsPerValue) {
+    return expandMask32((1L << bitsPerValue) - 1);
+  }
+
+  private static long mask16(int bitsPerValue) {
+    return expandMask16((1L << bitsPerValue) - 1);
+  }
+
+  private static void expand16(long[] arr) {
+    for (int i = 0; i < 32; ++i) {
+      long l = arr[i];
+      arr[i] = (l >>> 48) & 0xFFFFL;
+      arr[32 + i] = (l >>> 32) & 0xFFFFL;
+      arr[64 + i] = (l >>> 16) & 0xFFFFL;
+      arr[96 + i] = l & 0xFFFFL;
+    }
+  }
+
+  private static void collapse16(long[] arr) {
+    for (int i = 0; i < 32; ++i) {
+      arr[i] = (arr[i] << 48) | (arr[32 + i] << 32) | (arr[64 + i] << 16) | arr[96 + i];
+    }
+  }
+
+  private static void expand32(long[] arr) {
+    for (int i = 0; i < 64; ++i) {
+      long l = arr[i];
+      arr[i] = l >>> 32;
+      arr[64 + i] = l & 0xFFFFFFFFL;
+    }
+  }
+
+  private static void collapse32(long[] arr) {
+    for (int i = 0; i < 64; ++i) {
+      arr[i] = (arr[i] << 32) | arr[64 + i];
+    }
+  }
+
+  private static void prefixSum16(long[] arr, long base) {
+    // When the number of bits per value is 9 or less, we can sum up all values in a block without
+    // risking overflowing a 16-bits integer. This allows computing the prefix sum by summing up 4
+    // values at once.
+    innerPrefixSum16(arr);
+    expand16(arr);
+    final long l0 = base;
+    final long l1 = l0 + arr[ONE_BLOCK_SIZE_FOURTH - 1];
+    final long l2 = l1 + arr[TWO_BLOCK_SIZE_FOURTHS - 1];
+    final long l3 = l2 + arr[THREE_BLOCK_SIZE_FOURTHS - 1];
+
+    for (int i = 0; i < ONE_BLOCK_SIZE_FOURTH; ++i) {
+      arr[i] += l0;
+      arr[ONE_BLOCK_SIZE_FOURTH + i] += l1;
+      arr[TWO_BLOCK_SIZE_FOURTHS + i] += l2;
+      arr[THREE_BLOCK_SIZE_FOURTHS + i] += l3;
+    }
+  }
+
+  private static void prefixSum32(long[] arr, long base) {
+    arr[0] += base << 32;
+    innerPrefixSum32(arr);
+    expand32(arr);
+    final long l = arr[BLOCK_SIZE / 2 - 1];
+    for (int i = BLOCK_SIZE / 2; i < BLOCK_SIZE; ++i) {
+      arr[i] += l;
+    }
+  }
+
+  // For some reason, unrolling seems to help
+  private static void innerPrefixSum16(long[] arr) {
+    arr[1] += arr[0];
+    arr[2] += arr[1];
+    arr[3] += arr[2];
+    arr[4] += arr[3];
+    arr[5] += arr[4];
+    arr[6] += arr[5];
+    arr[7] += arr[6];
+    arr[8] += arr[7];
+    arr[9] += arr[8];
+    arr[10] += arr[9];
+    arr[11] += arr[10];
+    arr[12] += arr[11];
+    arr[13] += arr[12];
+    arr[14] += arr[13];
+    arr[15] += arr[14];
+    arr[16] += arr[15];
+    arr[17] += arr[16];
+    arr[18] += arr[17];
+    arr[19] += arr[18];
+    arr[20] += arr[19];
+    arr[21] += arr[20];
+    arr[22] += arr[21];
+    arr[23] += arr[22];
+    arr[24] += arr[23];
+    arr[25] += arr[24];
+    arr[26] += arr[25];
+    arr[27] += arr[26];
+    arr[28] += arr[27];
+    arr[29] += arr[28];
+    arr[30] += arr[29];
+    arr[31] += arr[30];
+  }
+
+  // For some reason unrolling seems to help
+  private static void innerPrefixSum32(long[] arr) {
+    arr[1] += arr[0];
+    arr[2] += arr[1];
+    arr[3] += arr[2];
+    arr[4] += arr[3];
+    arr[5] += arr[4];
+    arr[6] += arr[5];
+    arr[7] += arr[6];
+    arr[8] += arr[7];
+    arr[9] += arr[8];
+    arr[10] += arr[9];
+    arr[11] += arr[10];
+    arr[12] += arr[11];
+    arr[13] += arr[12];
+    arr[14] += arr[13];
+    arr[15] += arr[14];
+    arr[16] += arr[15];
+    arr[17] += arr[16];
+    arr[18] += arr[17];
+    arr[19] += arr[18];
+    arr[20] += arr[19];
+    arr[21] += arr[20];
+    arr[22] += arr[21];
+    arr[23] += arr[22];
+    arr[24] += arr[23];
+    arr[25] += arr[24];
+    arr[26] += arr[25];
+    arr[27] += arr[26];
+    arr[28] += arr[27];
+    arr[29] += arr[28];
+    arr[30] += arr[29];
+    arr[31] += arr[30];
+    arr[32] += arr[31];
+    arr[33] += arr[32];
+    arr[34] += arr[33];
+    arr[35] += arr[34];
+    arr[36] += arr[35];
+    arr[37] += arr[36];
+    arr[38] += arr[37];
+    arr[39] += arr[38];
+    arr[40] += arr[39];
+    arr[41] += arr[40];
+    arr[42] += arr[41];
+    arr[43] += arr[42];
+    arr[44] += arr[43];
+    arr[45] += arr[44];
+    arr[46] += arr[45];
+    arr[47] += arr[46];
+    arr[48] += arr[47];
+    arr[49] += arr[48];
+    arr[50] += arr[49];
+    arr[51] += arr[50];
+    arr[52] += arr[51];
+    arr[53] += arr[52];
+    arr[54] += arr[53];
+    arr[55] += arr[54];
+    arr[56] += arr[55];
+    arr[57] += arr[56];
+    arr[58] += arr[57];
+    arr[59] += arr[58];
+    arr[60] += arr[59];
+    arr[61] += arr[60];
+    arr[62] += arr[61];
+    arr[63] += arr[62];
+  }
+
+  /**
+   * Compute the number of bits per value that should be used when {@code bitsPerValue} bits are
+   * required.
+   */
+  static int computeActualBitsPerValue(int bitsPerValue) {
+    int i = Arrays.binarySearch(FAST_BITS_PER_VALUE, bitsPerValue);
+    if (i < 0) {
+      i = -1 - i;
+    }
+    return FAST_BITS_PER_VALUE[i];
+  }
+
+  private final long[] tmp = new long[BLOCK_SIZE / 2];
+
+  /** Encode 128 integers from {@code longs} into {@code out}. */
+  void encode(long[] longs, int bitsPerValue, DataOutput out) throws IOException {
+    assert Arrays.binarySearch(FAST_BITS_PER_VALUE, bitsPerValue) >= 0 : bitsPerValue;
+    final int nextPrimitive;
+    final int numLongs;
+    if (bitsPerValue <= 9) {
+      nextPrimitive = 16;
+      numLongs = BLOCK_SIZE / 4;
+      collapse16(longs);
+    } else {
+      nextPrimitive = 32;
+      numLongs = BLOCK_SIZE / 2;
+      collapse32(longs);
+    }
+
+    final int numLongsPerShift = bitsPerValue * 2;
+    int idx = 0;
+    int shift = nextPrimitive - bitsPerValue;
+    for (int i = 0; i < numLongsPerShift; ++i) {
+      tmp[i] = longs[idx++] << shift;
+    }
+    for (shift = shift - bitsPerValue; shift >= 0; shift -= bitsPerValue) {
+      for (int i = 0; i < numLongsPerShift; ++i) {
+        tmp[i] |= longs[idx++] << shift;
+      }
+    }
+
+    final int remainingBitsPerLong = shift + bitsPerValue;
+    final long maskRemainingBitsPerLong;
+    if (nextPrimitive == 16) {
+      maskRemainingBitsPerLong = MASKS16[remainingBitsPerLong];
+    } else {
+      maskRemainingBitsPerLong = MASKS32[remainingBitsPerLong];
+    }
+
+    int tmpIdx = 0;
+    int remainingBitsPerValue = bitsPerValue;
+    while (idx < numLongs) {
+      if (remainingBitsPerValue >= remainingBitsPerLong) {
+        remainingBitsPerValue -= remainingBitsPerLong;
+        tmp[tmpIdx++] |= (longs[idx] >>> remainingBitsPerValue) & maskRemainingBitsPerLong;
+        if (remainingBitsPerValue == 0) {
+          idx++;
+          remainingBitsPerValue = bitsPerValue;
+        }
+      } else {
+        final long mask1, mask2;
+        if (nextPrimitive == 16) {
+          mask1 = MASKS16[remainingBitsPerValue];
+          mask2 = MASKS16[remainingBitsPerLong - remainingBitsPerValue];
+        } else {
+          mask1 = MASKS32[remainingBitsPerValue];
+          mask2 = MASKS32[remainingBitsPerLong - remainingBitsPerValue];
+        }
+        tmp[tmpIdx] |= (longs[idx++] & mask1) << (remainingBitsPerLong - remainingBitsPerValue);
+        remainingBitsPerValue = bitsPerValue - remainingBitsPerLong + remainingBitsPerValue;
+        tmp[tmpIdx++] |= (longs[idx] >>> remainingBitsPerValue) & mask2;
+      }
+    }
+
+    for (int i = 0; i < numLongsPerShift; ++i) {
+      out.writeLong(tmp[i]);
+    }
+  }
+
+  /** Number of bytes required to encode 128 integers of {@code bitsPerValue} bits per value. */
+  int numBytes(int bitsPerValue) {
+    return bitsPerValue << (BLOCK_SIZE_LOG2 - 3);
+  }
+
+  /**
+   * The pattern that this shiftLongs method applies is recognized by the C2 compiler, which
+   * generates SIMD instructions for it in order to shift multiple longs at once.
+   */
+  private static void shiftLongs(long[] a, int count, long[] b, int bi, int shift, long mask) {
+    for (int i = 0; i < count; ++i) {
+      b[bi + i] = (a[i] >>> shift) & mask;
+    }
   }
 
   /**
@@ -60,9 +338,10 @@ public class ForDeltaUtil {
         or |= l;
       }
       assert or != 0;
-      final int bitsPerValue = PackedInts.bitsRequired(or);
+      int bitsPerValue = PackedInts.bitsRequired(or);
+      bitsPerValue = computeActualBitsPerValue(bitsPerValue);
       out.writeByte((byte) bitsPerValue);
-      forUtil.encode(longs, bitsPerValue, out);
+      encode(longs, bitsPerValue, out);
     }
   }
 
@@ -72,12 +351,355 @@ public class ForDeltaUtil {
     if (bitsPerValue == 0) {
       prefixSumOfOnes(longs, base);
     } else {
-      forUtil.decodeAndPrefixSum(bitsPerValue, in, base, longs);
+      decodeAndPrefixSum(bitsPerValue, in, base, longs);
     }
   }
 
   void skip(DataInput in) throws IOException {
     final int bitsPerValue = Byte.toUnsignedInt(in.readByte());
-    in.skipBytes(forUtil.numBytes(bitsPerValue));
+    in.skipBytes(numBytes(bitsPerValue));
+  }
+
+  private static final int[] FAST_BITS_PER_VALUE =
+      new int[] {1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 14, 16, 20, 24, 32};
+  private static final long[] MASKS16 = new long[16];
+  private static final long[] MASKS32 = new long[32];
+
+  static {
+    for (int i = 0; i < 16; ++i) {
+      MASKS16[i] = mask16(i);
+    }
+    for (int i = 0; i < 32; ++i) {
+      MASKS32[i] = mask32(i);
+    }
+  }
+
+  // mark values in array as final longs to avoid the cost of reading array, arrays should only be
+  // used when the idx is a variable
+  private static final long MASK16_0 = MASKS16[0];
+  private static final long MASK16_1 = MASKS16[1];
+  private static final long MASK16_2 = MASKS16[2];
+  private static final long MASK16_3 = MASKS16[3];
+  private static final long MASK16_4 = MASKS16[4];
+  private static final long MASK16_5 = MASKS16[5];
+  private static final long MASK16_6 = MASKS16[6];
+  private static final long MASK16_7 = MASKS16[7];
+  private static final long MASK16_8 = MASKS16[8];
+  private static final long MASK16_9 = MASKS16[9];
+  private static final long MASK16_10 = MASKS16[10];
+  private static final long MASK16_11 = MASKS16[11];
+  private static final long MASK16_12 = MASKS16[12];
+  private static final long MASK16_13 = MASKS16[13];
+  private static final long MASK16_14 = MASKS16[14];
+  private static final long MASK16_15 = MASKS16[15];
+  private static final long MASK32_0 = MASKS32[0];
+  private static final long MASK32_1 = MASKS32[1];
+  private static final long MASK32_2 = MASKS32[2];
+  private static final long MASK32_3 = MASKS32[3];
+  private static final long MASK32_4 = MASKS32[4];
+  private static final long MASK32_5 = MASKS32[5];
+  private static final long MASK32_6 = MASKS32[6];
+  private static final long MASK32_7 = MASKS32[7];
+  private static final long MASK32_8 = MASKS32[8];
+  private static final long MASK32_9 = MASKS32[9];
+  private static final long MASK32_10 = MASKS32[10];
+  private static final long MASK32_11 = MASKS32[11];
+  private static final long MASK32_12 = MASKS32[12];
+  private static final long MASK32_13 = MASKS32[13];
+  private static final long MASK32_14 = MASKS32[14];
+  private static final long MASK32_15 = MASKS32[15];
+  private static final long MASK32_16 = MASKS32[16];
+  private static final long MASK32_17 = MASKS32[17];
+  private static final long MASK32_18 = MASKS32[18];
+  private static final long MASK32_19 = MASKS32[19];
+  private static final long MASK32_20 = MASKS32[20];
+  private static final long MASK32_21 = MASKS32[21];
+  private static final long MASK32_22 = MASKS32[22];
+  private static final long MASK32_23 = MASKS32[23];
+  private static final long MASK32_24 = MASKS32[24];
+  private static final long MASK32_25 = MASKS32[25];
+  private static final long MASK32_26 = MASKS32[26];
+  private static final long MASK32_27 = MASKS32[27];
+  private static final long MASK32_28 = MASKS32[28];
+  private static final long MASK32_29 = MASKS32[29];
+  private static final long MASK32_30 = MASKS32[30];
+  private static final long MASK32_31 = MASKS32[31];
+
+  // public for benchmarking
+  /** Delta-decode 128 integers into {@code longs}. */
+  public void decodeAndPrefixSum(int bitsPerValue, DataInput in, long base, long[] longs)
+      throws IOException {
+    switch (bitsPerValue) {
+      case 1:
+        decode1(in, tmp, longs);
+        prefixSum16(longs, base);
+        break;
+      case 2:
+        decode2(in, tmp, longs);
+        prefixSum16(longs, base);
+        break;
+      case 3:
+        decode3(in, tmp, longs);
+        prefixSum16(longs, base);
+        break;
+      case 4:
+        decode4(in, tmp, longs);
+        prefixSum16(longs, base);
+        break;
+      case 5:
+        decode5(in, tmp, longs);
+        prefixSum16(longs, base);
+        break;
+      case 6:
+        decode6(in, tmp, longs);
+        prefixSum16(longs, base);
+        break;
+      case 8:
+        decode8(in, tmp, longs);
+        prefixSum16(longs, base);
+        break;
+      case 9:
+        decode9(in, tmp, longs);
+        prefixSum16(longs, base);
+        break;
+      case 10:
+        decode10(in, tmp, longs);
+        prefixSum32(longs, base);
+        break;
+      case 12:
+        decode12(in, tmp, longs);
+        prefixSum32(longs, base);
+        break;
+      case 14:
+        decode14(in, tmp, longs);
+        prefixSum32(longs, base);
+        break;
+      case 16:
+        decode16(in, tmp, longs);
+        prefixSum32(longs, base);
+        break;
+      case 20:
+        decode20(in, tmp, longs);
+        prefixSum32(longs, base);
+        break;
+      case 24:
+        decode24(in, tmp, longs);
+        prefixSum32(longs, base);
+        break;
+      case 32:
+        decode32(in, tmp, longs);
+        prefixSum32(longs, base);
+        break;
+      default:
+        throw new UnsupportedOperationException("bpv=" + bitsPerValue);
+    }
+  }
+
+  private static void decode1(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 2);
+    shiftLongs(tmp, 2, longs, 0, 15, MASK16_1);
+    shiftLongs(tmp, 2, longs, 2, 14, MASK16_1);
+    shiftLongs(tmp, 2, longs, 4, 13, MASK16_1);
+    shiftLongs(tmp, 2, longs, 6, 12, MASK16_1);
+    shiftLongs(tmp, 2, longs, 8, 11, MASK16_1);
+    shiftLongs(tmp, 2, longs, 10, 10, MASK16_1);
+    shiftLongs(tmp, 2, longs, 12, 9, MASK16_1);
+    shiftLongs(tmp, 2, longs, 14, 8, MASK16_1);
+    shiftLongs(tmp, 2, longs, 16, 7, MASK16_1);
+    shiftLongs(tmp, 2, longs, 18, 6, MASK16_1);
+    shiftLongs(tmp, 2, longs, 20, 5, MASK16_1);
+    shiftLongs(tmp, 2, longs, 22, 4, MASK16_1);
+    shiftLongs(tmp, 2, longs, 24, 3, MASK16_1);
+    shiftLongs(tmp, 2, longs, 26, 2, MASK16_1);
+    shiftLongs(tmp, 2, longs, 28, 1, MASK16_1);
+    shiftLongs(tmp, 2, longs, 30, 0, MASK16_1);
+  }
+
+  private static void decode2(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 4);
+    shiftLongs(tmp, 4, longs, 0, 14, MASK16_2);
+    shiftLongs(tmp, 4, longs, 4, 12, MASK16_2);
+    shiftLongs(tmp, 4, longs, 8, 10, MASK16_2);
+    shiftLongs(tmp, 4, longs, 12, 8, MASK16_2);
+    shiftLongs(tmp, 4, longs, 16, 6, MASK16_2);
+    shiftLongs(tmp, 4, longs, 20, 4, MASK16_2);
+    shiftLongs(tmp, 4, longs, 24, 2, MASK16_2);
+    shiftLongs(tmp, 4, longs, 28, 0, MASK16_2);
+  }
+
+  private static void decode3(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 6);
+    shiftLongs(tmp, 6, longs, 0, 13, MASK16_3);
+    shiftLongs(tmp, 6, longs, 6, 10, MASK16_3);
+    shiftLongs(tmp, 6, longs, 12, 7, MASK16_3);
+    shiftLongs(tmp, 6, longs, 18, 4, MASK16_3);
+    shiftLongs(tmp, 6, longs, 24, 1, MASK16_3);
+    shiftLongs(tmp, 6, tmp, 0, 0, MASK16_1);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 30; iter < 2; ++iter, tmpIdx += 3, longsIdx += 1) {
+      long l0 = tmp[tmpIdx + 0] << 2;
+      l0 |= tmp[tmpIdx + 1] << 1;
+      l0 |= tmp[tmpIdx + 2] << 0;
+      longs[longsIdx + 0] = l0;
+    }
+  }
+
+  private static void decode4(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 8);
+    shiftLongs(tmp, 8, longs, 0, 12, MASK16_4);
+    shiftLongs(tmp, 8, longs, 8, 8, MASK16_4);
+    shiftLongs(tmp, 8, longs, 16, 4, MASK16_4);
+    shiftLongs(tmp, 8, longs, 24, 0, MASK16_4);
+  }
+
+  private static void decode5(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 10);
+    shiftLongs(tmp, 10, longs, 0, 11, MASK16_5);
+    shiftLongs(tmp, 10, longs, 10, 6, MASK16_5);
+    shiftLongs(tmp, 10, longs, 20, 1, MASK16_5);
+    shiftLongs(tmp, 10, tmp, 0, 0, MASK16_1);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 30; iter < 2; ++iter, tmpIdx += 5, longsIdx += 1) {
+      long l0 = tmp[tmpIdx + 0] << 4;
+      l0 |= tmp[tmpIdx + 1] << 3;
+      l0 |= tmp[tmpIdx + 2] << 2;
+      l0 |= tmp[tmpIdx + 3] << 1;
+      l0 |= tmp[tmpIdx + 4] << 0;
+      longs[longsIdx + 0] = l0;
+    }
+  }
+
+  private static void decode6(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 12);
+    shiftLongs(tmp, 12, longs, 0, 10, MASK16_6);
+    shiftLongs(tmp, 12, longs, 12, 4, MASK16_6);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 24; iter < 4; ++iter, tmpIdx += 3, longsIdx += 2) {
+      long l0 = (tmp[tmpIdx + 0] & MASK16_4) << 2;
+      l0 |= (tmp[tmpIdx + 1] >>> 2) & MASK16_2;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK16_2) << 4;
+      l1 |= (tmp[tmpIdx + 2] & MASK16_4) << 0;
+      longs[longsIdx + 1] = l1;
+    }
+  }
+
+  private static void decode8(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 16);
+    shiftLongs(tmp, 16, longs, 0, 8, MASK16_8);
+    shiftLongs(tmp, 16, longs, 16, 0, MASK16_8);
+  }
+
+  private static void decode9(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 18);
+    shiftLongs(tmp, 18, longs, 0, 7, MASK16_9);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 18; iter < 2; ++iter, tmpIdx += 9, longsIdx += 7) {
+      long l0 = (tmp[tmpIdx + 0] & MASK16_7) << 2;
+      l0 |= (tmp[tmpIdx + 1] >>> 5) & MASK16_2;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK16_5) << 4;
+      l1 |= (tmp[tmpIdx + 2] >>> 3) & MASK16_4;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 2] & MASK16_3) << 6;
+      l2 |= (tmp[tmpIdx + 3] >>> 1) & MASK16_6;
+      longs[longsIdx + 2] = l2;
+      long l3 = (tmp[tmpIdx + 3] & MASK16_1) << 8;
+      l3 |= (tmp[tmpIdx + 4] & MASK16_7) << 1;
+      l3 |= (tmp[tmpIdx + 5] >>> 6) & MASK16_1;
+      longs[longsIdx + 3] = l3;
+      long l4 = (tmp[tmpIdx + 5] & MASK16_6) << 3;
+      l4 |= (tmp[tmpIdx + 6] >>> 4) & MASK16_3;
+      longs[longsIdx + 4] = l4;
+      long l5 = (tmp[tmpIdx + 6] & MASK16_4) << 5;
+      l5 |= (tmp[tmpIdx + 7] >>> 2) & MASK16_5;
+      longs[longsIdx + 5] = l5;
+      long l6 = (tmp[tmpIdx + 7] & MASK16_2) << 7;
+      l6 |= (tmp[tmpIdx + 8] & MASK16_7) << 0;
+      longs[longsIdx + 6] = l6;
+    }
+  }
+
+  private static void decode10(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 20);
+    shiftLongs(tmp, 20, longs, 0, 22, MASK32_10);
+    shiftLongs(tmp, 20, longs, 20, 12, MASK32_10);
+    shiftLongs(tmp, 20, longs, 40, 2, MASK32_10);
+    shiftLongs(tmp, 20, tmp, 0, 0, MASK32_2);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 60; iter < 4; ++iter, tmpIdx += 5, longsIdx += 1) {
+      long l0 = tmp[tmpIdx + 0] << 8;
+      l0 |= tmp[tmpIdx + 1] << 6;
+      l0 |= tmp[tmpIdx + 2] << 4;
+      l0 |= tmp[tmpIdx + 3] << 2;
+      l0 |= tmp[tmpIdx + 4] << 0;
+      longs[longsIdx + 0] = l0;
+    }
+  }
+
+  private static void decode12(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 24);
+    shiftLongs(tmp, 24, longs, 0, 20, MASK32_12);
+    shiftLongs(tmp, 24, longs, 24, 8, MASK32_12);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 48; iter < 8; ++iter, tmpIdx += 3, longsIdx += 2) {
+      long l0 = (tmp[tmpIdx + 0] & MASK32_8) << 4;
+      l0 |= (tmp[tmpIdx + 1] >>> 4) & MASK32_4;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK32_4) << 8;
+      l1 |= (tmp[tmpIdx + 2] & MASK32_8) << 0;
+      longs[longsIdx + 1] = l1;
+    }
+  }
+
+  private static void decode14(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 28);
+    shiftLongs(tmp, 28, longs, 0, 18, MASK32_14);
+    shiftLongs(tmp, 28, longs, 28, 4, MASK32_14);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 56; iter < 4; ++iter, tmpIdx += 7, longsIdx += 2) {
+      long l0 = (tmp[tmpIdx + 0] & MASK32_4) << 10;
+      l0 |= (tmp[tmpIdx + 1] & MASK32_4) << 6;
+      l0 |= (tmp[tmpIdx + 2] & MASK32_4) << 2;
+      l0 |= (tmp[tmpIdx + 3] >>> 2) & MASK32_2;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 3] & MASK32_2) << 12;
+      l1 |= (tmp[tmpIdx + 4] & MASK32_4) << 8;
+      l1 |= (tmp[tmpIdx + 5] & MASK32_4) << 4;
+      l1 |= (tmp[tmpIdx + 6] & MASK32_4) << 0;
+      longs[longsIdx + 1] = l1;
+    }
+  }
+
+  private static void decode16(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 32);
+    shiftLongs(tmp, 32, longs, 0, 16, MASK32_16);
+    shiftLongs(tmp, 32, longs, 32, 0, MASK32_16);
+  }
+
+  private static void decode20(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 40);
+    shiftLongs(tmp, 40, longs, 0, 12, MASK32_20);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 40; iter < 8; ++iter, tmpIdx += 5, longsIdx += 3) {
+      long l0 = (tmp[tmpIdx + 0] & MASK32_12) << 8;
+      l0 |= (tmp[tmpIdx + 1] >>> 4) & MASK32_8;
+      longs[longsIdx + 0] = l0;
+      long l1 = (tmp[tmpIdx + 1] & MASK32_4) << 16;
+      l1 |= (tmp[tmpIdx + 2] & MASK32_12) << 4;
+      l1 |= (tmp[tmpIdx + 3] >>> 8) & MASK32_4;
+      longs[longsIdx + 1] = l1;
+      long l2 = (tmp[tmpIdx + 3] & MASK32_8) << 12;
+      l2 |= (tmp[tmpIdx + 4] & MASK32_12) << 0;
+      longs[longsIdx + 2] = l2;
+    }
+  }
+
+  private static void decode24(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 48);
+    shiftLongs(tmp, 48, longs, 0, 8, MASK32_24);
+    shiftLongs(tmp, 48, tmp, 0, 0, MASK32_8);
+    for (int iter = 0, tmpIdx = 0, longsIdx = 48; iter < 16; ++iter, tmpIdx += 3, longsIdx += 1) {
+      long l0 = tmp[tmpIdx + 0] << 16;
+      l0 |= tmp[tmpIdx + 1] << 8;
+      l0 |= tmp[tmpIdx + 2] << 0;
+      longs[longsIdx + 0] = l0;
+    }
+  }
+
+  private static void decode32(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(tmp, 0, 64);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForUtil.java
@@ -19,6 +19,7 @@
 package org.apache.lucene.codecs.lucene912;
 
 import java.io.IOException;
+import java.util.Arrays;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 
@@ -27,7 +28,7 @@ import org.apache.lucene.store.DataOutput;
 // If bitsPerValue <= 8 then we pack 8 ints per long
 // else if bitsPerValue <= 16 we pack 4 ints per long
 // else we pack 2 ints per long
-final class ForUtil {
+public final class ForUtil {
 
   static final int BLOCK_SIZE = 128;
   private static final int BLOCK_SIZE_LOG2 = 7;
@@ -70,16 +71,6 @@ final class ForUtil {
     }
   }
 
-  private static void expand8To32(long[] arr) {
-    for (int i = 0; i < 16; ++i) {
-      long l = arr[i];
-      arr[i] = (l >>> 24) & 0x000000FF000000FFL;
-      arr[16 + i] = (l >>> 16) & 0x000000FF000000FFL;
-      arr[32 + i] = (l >>> 8) & 0x000000FF000000FFL;
-      arr[48 + i] = l & 0x000000FF000000FFL;
-    }
-  }
-
   private static void collapse8(long[] arr) {
     for (int i = 0; i < 16; ++i) {
       arr[i] =
@@ -104,14 +95,6 @@ final class ForUtil {
     }
   }
 
-  private static void expand16To32(long[] arr) {
-    for (int i = 0; i < 32; ++i) {
-      long l = arr[i];
-      arr[i] = (l >>> 16) & 0x0000FFFF0000FFFFL;
-      arr[32 + i] = l & 0x0000FFFF0000FFFFL;
-    }
-  }
-
   private static void collapse16(long[] arr) {
     for (int i = 0; i < 32; ++i) {
       arr[i] = (arr[i] << 48) | (arr[32 + i] << 32) | (arr[64 + i] << 16) | arr[96 + i];
@@ -132,98 +115,23 @@ final class ForUtil {
     }
   }
 
-  private static void prefixSum8(long[] arr, long base) {
-    expand8To32(arr);
-    prefixSum32(arr, base);
-  }
-
-  private static void prefixSum16(long[] arr, long base) {
-    // We need to move to the next primitive size to avoid overflows
-    expand16To32(arr);
-    prefixSum32(arr, base);
-  }
-
-  private static void prefixSum32(long[] arr, long base) {
-    arr[0] += base << 32;
-    innerPrefixSum32(arr);
-    expand32(arr);
-    final long l = arr[BLOCK_SIZE / 2 - 1];
-    for (int i = BLOCK_SIZE / 2; i < BLOCK_SIZE; ++i) {
-      arr[i] += l;
+  /**
+   * Compute the number of bits per value that should be used when {@code bitsPerValue} bits are
+   * required.
+   */
+  static int computeActualBitsPerValue(int bitsPerValue) {
+    int i = Arrays.binarySearch(FAST_BITS_PER_VALUE, bitsPerValue);
+    if (i < 0) {
+      i = -1 - i;
     }
-  }
-
-  // For some reason unrolling seems to help
-  private static void innerPrefixSum32(long[] arr) {
-    arr[1] += arr[0];
-    arr[2] += arr[1];
-    arr[3] += arr[2];
-    arr[4] += arr[3];
-    arr[5] += arr[4];
-    arr[6] += arr[5];
-    arr[7] += arr[6];
-    arr[8] += arr[7];
-    arr[9] += arr[8];
-    arr[10] += arr[9];
-    arr[11] += arr[10];
-    arr[12] += arr[11];
-    arr[13] += arr[12];
-    arr[14] += arr[13];
-    arr[15] += arr[14];
-    arr[16] += arr[15];
-    arr[17] += arr[16];
-    arr[18] += arr[17];
-    arr[19] += arr[18];
-    arr[20] += arr[19];
-    arr[21] += arr[20];
-    arr[22] += arr[21];
-    arr[23] += arr[22];
-    arr[24] += arr[23];
-    arr[25] += arr[24];
-    arr[26] += arr[25];
-    arr[27] += arr[26];
-    arr[28] += arr[27];
-    arr[29] += arr[28];
-    arr[30] += arr[29];
-    arr[31] += arr[30];
-    arr[32] += arr[31];
-    arr[33] += arr[32];
-    arr[34] += arr[33];
-    arr[35] += arr[34];
-    arr[36] += arr[35];
-    arr[37] += arr[36];
-    arr[38] += arr[37];
-    arr[39] += arr[38];
-    arr[40] += arr[39];
-    arr[41] += arr[40];
-    arr[42] += arr[41];
-    arr[43] += arr[42];
-    arr[44] += arr[43];
-    arr[45] += arr[44];
-    arr[46] += arr[45];
-    arr[47] += arr[46];
-    arr[48] += arr[47];
-    arr[49] += arr[48];
-    arr[50] += arr[49];
-    arr[51] += arr[50];
-    arr[52] += arr[51];
-    arr[53] += arr[52];
-    arr[54] += arr[53];
-    arr[55] += arr[54];
-    arr[56] += arr[55];
-    arr[57] += arr[56];
-    arr[58] += arr[57];
-    arr[59] += arr[58];
-    arr[60] += arr[59];
-    arr[61] += arr[60];
-    arr[62] += arr[61];
-    arr[63] += arr[62];
+    return FAST_BITS_PER_VALUE[i];
   }
 
   private final long[] tmp = new long[BLOCK_SIZE / 2];
 
   /** Encode 128 integers from {@code longs} into {@code out}. */
   void encode(long[] longs, int bitsPerValue, DataOutput out) throws IOException {
+    assert Arrays.binarySearch(FAST_BITS_PER_VALUE, bitsPerValue) >= 0 : bitsPerValue;
     final int nextPrimitive;
     final int numLongs;
     if (bitsPerValue <= 8) {
@@ -300,38 +208,6 @@ final class ForUtil {
     return bitsPerValue << (BLOCK_SIZE_LOG2 - 3);
   }
 
-  private static void decodeSlow(int bitsPerValue, DataInput in, long[] tmp, long[] longs)
-      throws IOException {
-    final int numLongs = bitsPerValue << 1;
-    in.readLongs(tmp, 0, numLongs);
-    final long mask = MASKS32[bitsPerValue];
-    int longsIdx = 0;
-    int shift = 32 - bitsPerValue;
-    for (; shift >= 0; shift -= bitsPerValue) {
-      shiftLongs(tmp, numLongs, longs, longsIdx, shift, mask);
-      longsIdx += numLongs;
-    }
-    final int remainingBitsPerLong = shift + bitsPerValue;
-    final long mask32RemainingBitsPerLong = MASKS32[remainingBitsPerLong];
-    int tmpIdx = 0;
-    int remainingBits = remainingBitsPerLong;
-    for (; longsIdx < BLOCK_SIZE / 2; ++longsIdx) {
-      int b = bitsPerValue - remainingBits;
-      long l = (tmp[tmpIdx++] & MASKS32[remainingBits]) << b;
-      while (b >= remainingBitsPerLong) {
-        b -= remainingBitsPerLong;
-        l |= (tmp[tmpIdx++] & mask32RemainingBitsPerLong) << b;
-      }
-      if (b > 0) {
-        l |= (tmp[tmpIdx] >>> (remainingBitsPerLong - b)) & MASKS32[b];
-        remainingBits = remainingBitsPerLong - b;
-      } else {
-        remainingBits = remainingBitsPerLong;
-      }
-      longs[longsIdx] = l;
-    }
-  }
-
   /**
    * The pattern that this shiftLongs method applies is recognized by the C2 compiler, which
    * generates SIMD instructions for it in order to shift multiple longs at once.
@@ -342,6 +218,8 @@ final class ForUtil {
     }
   }
 
+  private static final int[] FAST_BITS_PER_VALUE =
+      new int[] {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16, 20, 24, 32};
   private static final long[] MASKS8 = new long[8];
   private static final long[] MASKS16 = new long[16];
   private static final long[] MASKS32 = new long[32];
@@ -366,47 +244,33 @@ final class ForUtil {
   private static final long MASK8_4 = MASKS8[4];
   private static final long MASK8_5 = MASKS8[5];
   private static final long MASK8_6 = MASKS8[6];
-  private static final long MASK8_7 = MASKS8[7];
   private static final long MASK16_1 = MASKS16[1];
   private static final long MASK16_2 = MASKS16[2];
   private static final long MASK16_3 = MASKS16[3];
   private static final long MASK16_4 = MASKS16[4];
   private static final long MASK16_5 = MASKS16[5];
   private static final long MASK16_6 = MASKS16[6];
-  private static final long MASK16_7 = MASKS16[7];
-  private static final long MASK16_9 = MASKS16[9];
+  private static final long MASK16_8 = MASKS16[8];
   private static final long MASK16_10 = MASKS16[10];
-  private static final long MASK16_11 = MASKS16[11];
   private static final long MASK16_12 = MASKS16[12];
-  private static final long MASK16_13 = MASKS16[13];
   private static final long MASK16_14 = MASKS16[14];
-  private static final long MASK16_15 = MASKS16[15];
   private static final long MASK32_1 = MASKS32[1];
   private static final long MASK32_2 = MASKS32[2];
   private static final long MASK32_3 = MASKS32[3];
   private static final long MASK32_4 = MASKS32[4];
   private static final long MASK32_5 = MASKS32[5];
   private static final long MASK32_6 = MASKS32[6];
-  private static final long MASK32_7 = MASKS32[7];
   private static final long MASK32_8 = MASKS32[8];
-  private static final long MASK32_9 = MASKS32[9];
   private static final long MASK32_10 = MASKS32[10];
-  private static final long MASK32_11 = MASKS32[11];
   private static final long MASK32_12 = MASKS32[12];
-  private static final long MASK32_13 = MASKS32[13];
   private static final long MASK32_14 = MASKS32[14];
-  private static final long MASK32_15 = MASKS32[15];
-  private static final long MASK32_17 = MASKS32[17];
-  private static final long MASK32_18 = MASKS32[18];
-  private static final long MASK32_19 = MASKS32[19];
+  private static final long MASK32_16 = MASKS32[16];
   private static final long MASK32_20 = MASKS32[20];
-  private static final long MASK32_21 = MASKS32[21];
-  private static final long MASK32_22 = MASKS32[22];
-  private static final long MASK32_23 = MASKS32[23];
   private static final long MASK32_24 = MASKS32[24];
 
+  // public for benchmarking
   /** Decode 128 integers into {@code longs}. */
-  void decode(int bitsPerValue, DataInput in, long[] longs) throws IOException {
+  public void decode(int bitsPerValue, DataInput in, long[] longs) throws IOException {
     switch (bitsPerValue) {
       case 1:
         decode1(in, tmp, longs);
@@ -432,189 +296,40 @@ final class ForUtil {
         decode6(in, tmp, longs);
         expand8(longs);
         break;
-      case 7:
-        decode7(in, tmp, longs);
-        expand8(longs);
-        break;
       case 8:
         decode8(in, tmp, longs);
         expand8(longs);
         break;
-      case 9:
-        decode9(in, tmp, longs);
-        expand16(longs);
-        break;
       case 10:
         decode10(in, tmp, longs);
-        expand16(longs);
-        break;
-      case 11:
-        decode11(in, tmp, longs);
         expand16(longs);
         break;
       case 12:
         decode12(in, tmp, longs);
         expand16(longs);
         break;
-      case 13:
-        decode13(in, tmp, longs);
-        expand16(longs);
-        break;
       case 14:
         decode14(in, tmp, longs);
-        expand16(longs);
-        break;
-      case 15:
-        decode15(in, tmp, longs);
         expand16(longs);
         break;
       case 16:
         decode16(in, tmp, longs);
         expand16(longs);
         break;
-      case 17:
-        decode17(in, tmp, longs);
-        expand32(longs);
-        break;
-      case 18:
-        decode18(in, tmp, longs);
-        expand32(longs);
-        break;
-      case 19:
-        decode19(in, tmp, longs);
-        expand32(longs);
-        break;
       case 20:
         decode20(in, tmp, longs);
-        expand32(longs);
-        break;
-      case 21:
-        decode21(in, tmp, longs);
-        expand32(longs);
-        break;
-      case 22:
-        decode22(in, tmp, longs);
-        expand32(longs);
-        break;
-      case 23:
-        decode23(in, tmp, longs);
         expand32(longs);
         break;
       case 24:
         decode24(in, tmp, longs);
         expand32(longs);
         break;
-      default:
-        decodeSlow(bitsPerValue, in, tmp, longs);
+      case 32:
+        decode32(in, tmp, longs);
         expand32(longs);
         break;
-    }
-  }
-
-  /** Delta-decode 128 integers into {@code longs}. */
-  void decodeAndPrefixSum(int bitsPerValue, DataInput in, long base, long[] longs)
-      throws IOException {
-    switch (bitsPerValue) {
-      case 1:
-        decode1(in, tmp, longs);
-        prefixSum8(longs, base);
-        break;
-      case 2:
-        decode2(in, tmp, longs);
-        prefixSum8(longs, base);
-        break;
-      case 3:
-        decode3(in, tmp, longs);
-        prefixSum8(longs, base);
-        break;
-      case 4:
-        decode4(in, tmp, longs);
-        prefixSum8(longs, base);
-        break;
-      case 5:
-        decode5(in, tmp, longs);
-        prefixSum8(longs, base);
-        break;
-      case 6:
-        decode6(in, tmp, longs);
-        prefixSum8(longs, base);
-        break;
-      case 7:
-        decode7(in, tmp, longs);
-        prefixSum8(longs, base);
-        break;
-      case 8:
-        decode8(in, tmp, longs);
-        prefixSum8(longs, base);
-        break;
-      case 9:
-        decode9(in, tmp, longs);
-        prefixSum16(longs, base);
-        break;
-      case 10:
-        decode10(in, tmp, longs);
-        prefixSum16(longs, base);
-        break;
-      case 11:
-        decode11(in, tmp, longs);
-        prefixSum16(longs, base);
-        break;
-      case 12:
-        decode12(in, tmp, longs);
-        prefixSum16(longs, base);
-        break;
-      case 13:
-        decode13(in, tmp, longs);
-        prefixSum16(longs, base);
-        break;
-      case 14:
-        decode14(in, tmp, longs);
-        prefixSum16(longs, base);
-        break;
-      case 15:
-        decode15(in, tmp, longs);
-        prefixSum16(longs, base);
-        break;
-      case 16:
-        decode16(in, tmp, longs);
-        prefixSum16(longs, base);
-        break;
-      case 17:
-        decode17(in, tmp, longs);
-        prefixSum32(longs, base);
-        break;
-      case 18:
-        decode18(in, tmp, longs);
-        prefixSum32(longs, base);
-        break;
-      case 19:
-        decode19(in, tmp, longs);
-        prefixSum32(longs, base);
-        break;
-      case 20:
-        decode20(in, tmp, longs);
-        prefixSum32(longs, base);
-        break;
-      case 21:
-        decode21(in, tmp, longs);
-        prefixSum32(longs, base);
-        break;
-      case 22:
-        decode22(in, tmp, longs);
-        prefixSum32(longs, base);
-        break;
-      case 23:
-        decode23(in, tmp, longs);
-        prefixSum32(longs, base);
-        break;
-      case 24:
-        decode24(in, tmp, longs);
-        prefixSum32(longs, base);
-        break;
       default:
-        decodeSlow(bitsPerValue, in, tmp, longs);
-        prefixSum32(longs, base);
-        break;
+        throw new UnsupportedOperationException("bpv=" + bitsPerValue);
     }
   }
 
@@ -687,53 +402,8 @@ final class ForUtil {
     }
   }
 
-  private static void decode7(DataInput in, long[] tmp, long[] longs) throws IOException {
-    in.readLongs(tmp, 0, 14);
-    shiftLongs(tmp, 14, longs, 0, 1, MASK8_7);
-    shiftLongs(tmp, 14, tmp, 0, 0, MASK8_1);
-    for (int iter = 0, tmpIdx = 0, longsIdx = 14; iter < 2; ++iter, tmpIdx += 7, longsIdx += 1) {
-      long l0 = tmp[tmpIdx + 0] << 6;
-      l0 |= tmp[tmpIdx + 1] << 5;
-      l0 |= tmp[tmpIdx + 2] << 4;
-      l0 |= tmp[tmpIdx + 3] << 3;
-      l0 |= tmp[tmpIdx + 4] << 2;
-      l0 |= tmp[tmpIdx + 5] << 1;
-      l0 |= tmp[tmpIdx + 6] << 0;
-      longs[longsIdx + 0] = l0;
-    }
-  }
-
   private static void decode8(DataInput in, long[] tmp, long[] longs) throws IOException {
     in.readLongs(longs, 0, 16);
-  }
-
-  private static void decode9(DataInput in, long[] tmp, long[] longs) throws IOException {
-    in.readLongs(tmp, 0, 18);
-    shiftLongs(tmp, 18, longs, 0, 7, MASK16_9);
-    for (int iter = 0, tmpIdx = 0, longsIdx = 18; iter < 2; ++iter, tmpIdx += 9, longsIdx += 7) {
-      long l0 = (tmp[tmpIdx + 0] & MASK16_7) << 2;
-      l0 |= (tmp[tmpIdx + 1] >>> 5) & MASK16_2;
-      longs[longsIdx + 0] = l0;
-      long l1 = (tmp[tmpIdx + 1] & MASK16_5) << 4;
-      l1 |= (tmp[tmpIdx + 2] >>> 3) & MASK16_4;
-      longs[longsIdx + 1] = l1;
-      long l2 = (tmp[tmpIdx + 2] & MASK16_3) << 6;
-      l2 |= (tmp[tmpIdx + 3] >>> 1) & MASK16_6;
-      longs[longsIdx + 2] = l2;
-      long l3 = (tmp[tmpIdx + 3] & MASK16_1) << 8;
-      l3 |= (tmp[tmpIdx + 4] & MASK16_7) << 1;
-      l3 |= (tmp[tmpIdx + 5] >>> 6) & MASK16_1;
-      longs[longsIdx + 3] = l3;
-      long l4 = (tmp[tmpIdx + 5] & MASK16_6) << 3;
-      l4 |= (tmp[tmpIdx + 6] >>> 4) & MASK16_3;
-      longs[longsIdx + 4] = l4;
-      long l5 = (tmp[tmpIdx + 6] & MASK16_4) << 5;
-      l5 |= (tmp[tmpIdx + 7] >>> 2) & MASK16_5;
-      longs[longsIdx + 5] = l5;
-      long l6 = (tmp[tmpIdx + 7] & MASK16_2) << 7;
-      l6 |= (tmp[tmpIdx + 8] & MASK16_7) << 0;
-      longs[longsIdx + 6] = l6;
-    }
   }
 
   private static void decode10(DataInput in, long[] tmp, long[] longs) throws IOException {
@@ -753,33 +423,6 @@ final class ForUtil {
     }
   }
 
-  private static void decode11(DataInput in, long[] tmp, long[] longs) throws IOException {
-    in.readLongs(tmp, 0, 22);
-    shiftLongs(tmp, 22, longs, 0, 5, MASK16_11);
-    for (int iter = 0, tmpIdx = 0, longsIdx = 22; iter < 2; ++iter, tmpIdx += 11, longsIdx += 5) {
-      long l0 = (tmp[tmpIdx + 0] & MASK16_5) << 6;
-      l0 |= (tmp[tmpIdx + 1] & MASK16_5) << 1;
-      l0 |= (tmp[tmpIdx + 2] >>> 4) & MASK16_1;
-      longs[longsIdx + 0] = l0;
-      long l1 = (tmp[tmpIdx + 2] & MASK16_4) << 7;
-      l1 |= (tmp[tmpIdx + 3] & MASK16_5) << 2;
-      l1 |= (tmp[tmpIdx + 4] >>> 3) & MASK16_2;
-      longs[longsIdx + 1] = l1;
-      long l2 = (tmp[tmpIdx + 4] & MASK16_3) << 8;
-      l2 |= (tmp[tmpIdx + 5] & MASK16_5) << 3;
-      l2 |= (tmp[tmpIdx + 6] >>> 2) & MASK16_3;
-      longs[longsIdx + 2] = l2;
-      long l3 = (tmp[tmpIdx + 6] & MASK16_2) << 9;
-      l3 |= (tmp[tmpIdx + 7] & MASK16_5) << 4;
-      l3 |= (tmp[tmpIdx + 8] >>> 1) & MASK16_4;
-      longs[longsIdx + 3] = l3;
-      long l4 = (tmp[tmpIdx + 8] & MASK16_1) << 10;
-      l4 |= (tmp[tmpIdx + 9] & MASK16_5) << 5;
-      l4 |= (tmp[tmpIdx + 10] & MASK16_5) << 0;
-      longs[longsIdx + 4] = l4;
-    }
-  }
-
   private static void decode12(DataInput in, long[] tmp, long[] longs) throws IOException {
     in.readLongs(tmp, 0, 24);
     shiftLongs(tmp, 24, longs, 0, 4, MASK16_12);
@@ -789,31 +432,6 @@ final class ForUtil {
       l0 |= tmp[tmpIdx + 1] << 4;
       l0 |= tmp[tmpIdx + 2] << 0;
       longs[longsIdx + 0] = l0;
-    }
-  }
-
-  private static void decode13(DataInput in, long[] tmp, long[] longs) throws IOException {
-    in.readLongs(tmp, 0, 26);
-    shiftLongs(tmp, 26, longs, 0, 3, MASK16_13);
-    for (int iter = 0, tmpIdx = 0, longsIdx = 26; iter < 2; ++iter, tmpIdx += 13, longsIdx += 3) {
-      long l0 = (tmp[tmpIdx + 0] & MASK16_3) << 10;
-      l0 |= (tmp[tmpIdx + 1] & MASK16_3) << 7;
-      l0 |= (tmp[tmpIdx + 2] & MASK16_3) << 4;
-      l0 |= (tmp[tmpIdx + 3] & MASK16_3) << 1;
-      l0 |= (tmp[tmpIdx + 4] >>> 2) & MASK16_1;
-      longs[longsIdx + 0] = l0;
-      long l1 = (tmp[tmpIdx + 4] & MASK16_2) << 11;
-      l1 |= (tmp[tmpIdx + 5] & MASK16_3) << 8;
-      l1 |= (tmp[tmpIdx + 6] & MASK16_3) << 5;
-      l1 |= (tmp[tmpIdx + 7] & MASK16_3) << 2;
-      l1 |= (tmp[tmpIdx + 8] >>> 1) & MASK16_2;
-      longs[longsIdx + 1] = l1;
-      long l2 = (tmp[tmpIdx + 8] & MASK16_1) << 12;
-      l2 |= (tmp[tmpIdx + 9] & MASK16_3) << 9;
-      l2 |= (tmp[tmpIdx + 10] & MASK16_3) << 6;
-      l2 |= (tmp[tmpIdx + 11] & MASK16_3) << 3;
-      l2 |= (tmp[tmpIdx + 12] & MASK16_3) << 0;
-      longs[longsIdx + 2] = l2;
     }
   }
 
@@ -833,165 +451,8 @@ final class ForUtil {
     }
   }
 
-  private static void decode15(DataInput in, long[] tmp, long[] longs) throws IOException {
-    in.readLongs(tmp, 0, 30);
-    shiftLongs(tmp, 30, longs, 0, 1, MASK16_15);
-    shiftLongs(tmp, 30, tmp, 0, 0, MASK16_1);
-    for (int iter = 0, tmpIdx = 0, longsIdx = 30; iter < 2; ++iter, tmpIdx += 15, longsIdx += 1) {
-      long l0 = tmp[tmpIdx + 0] << 14;
-      l0 |= tmp[tmpIdx + 1] << 13;
-      l0 |= tmp[tmpIdx + 2] << 12;
-      l0 |= tmp[tmpIdx + 3] << 11;
-      l0 |= tmp[tmpIdx + 4] << 10;
-      l0 |= tmp[tmpIdx + 5] << 9;
-      l0 |= tmp[tmpIdx + 6] << 8;
-      l0 |= tmp[tmpIdx + 7] << 7;
-      l0 |= tmp[tmpIdx + 8] << 6;
-      l0 |= tmp[tmpIdx + 9] << 5;
-      l0 |= tmp[tmpIdx + 10] << 4;
-      l0 |= tmp[tmpIdx + 11] << 3;
-      l0 |= tmp[tmpIdx + 12] << 2;
-      l0 |= tmp[tmpIdx + 13] << 1;
-      l0 |= tmp[tmpIdx + 14] << 0;
-      longs[longsIdx + 0] = l0;
-    }
-  }
-
   private static void decode16(DataInput in, long[] tmp, long[] longs) throws IOException {
     in.readLongs(longs, 0, 32);
-  }
-
-  private static void decode17(DataInput in, long[] tmp, long[] longs) throws IOException {
-    in.readLongs(tmp, 0, 34);
-    shiftLongs(tmp, 34, longs, 0, 15, MASK32_17);
-    for (int iter = 0, tmpIdx = 0, longsIdx = 34; iter < 2; ++iter, tmpIdx += 17, longsIdx += 15) {
-      long l0 = (tmp[tmpIdx + 0] & MASK32_15) << 2;
-      l0 |= (tmp[tmpIdx + 1] >>> 13) & MASK32_2;
-      longs[longsIdx + 0] = l0;
-      long l1 = (tmp[tmpIdx + 1] & MASK32_13) << 4;
-      l1 |= (tmp[tmpIdx + 2] >>> 11) & MASK32_4;
-      longs[longsIdx + 1] = l1;
-      long l2 = (tmp[tmpIdx + 2] & MASK32_11) << 6;
-      l2 |= (tmp[tmpIdx + 3] >>> 9) & MASK32_6;
-      longs[longsIdx + 2] = l2;
-      long l3 = (tmp[tmpIdx + 3] & MASK32_9) << 8;
-      l3 |= (tmp[tmpIdx + 4] >>> 7) & MASK32_8;
-      longs[longsIdx + 3] = l3;
-      long l4 = (tmp[tmpIdx + 4] & MASK32_7) << 10;
-      l4 |= (tmp[tmpIdx + 5] >>> 5) & MASK32_10;
-      longs[longsIdx + 4] = l4;
-      long l5 = (tmp[tmpIdx + 5] & MASK32_5) << 12;
-      l5 |= (tmp[tmpIdx + 6] >>> 3) & MASK32_12;
-      longs[longsIdx + 5] = l5;
-      long l6 = (tmp[tmpIdx + 6] & MASK32_3) << 14;
-      l6 |= (tmp[tmpIdx + 7] >>> 1) & MASK32_14;
-      longs[longsIdx + 6] = l6;
-      long l7 = (tmp[tmpIdx + 7] & MASK32_1) << 16;
-      l7 |= (tmp[tmpIdx + 8] & MASK32_15) << 1;
-      l7 |= (tmp[tmpIdx + 9] >>> 14) & MASK32_1;
-      longs[longsIdx + 7] = l7;
-      long l8 = (tmp[tmpIdx + 9] & MASK32_14) << 3;
-      l8 |= (tmp[tmpIdx + 10] >>> 12) & MASK32_3;
-      longs[longsIdx + 8] = l8;
-      long l9 = (tmp[tmpIdx + 10] & MASK32_12) << 5;
-      l9 |= (tmp[tmpIdx + 11] >>> 10) & MASK32_5;
-      longs[longsIdx + 9] = l9;
-      long l10 = (tmp[tmpIdx + 11] & MASK32_10) << 7;
-      l10 |= (tmp[tmpIdx + 12] >>> 8) & MASK32_7;
-      longs[longsIdx + 10] = l10;
-      long l11 = (tmp[tmpIdx + 12] & MASK32_8) << 9;
-      l11 |= (tmp[tmpIdx + 13] >>> 6) & MASK32_9;
-      longs[longsIdx + 11] = l11;
-      long l12 = (tmp[tmpIdx + 13] & MASK32_6) << 11;
-      l12 |= (tmp[tmpIdx + 14] >>> 4) & MASK32_11;
-      longs[longsIdx + 12] = l12;
-      long l13 = (tmp[tmpIdx + 14] & MASK32_4) << 13;
-      l13 |= (tmp[tmpIdx + 15] >>> 2) & MASK32_13;
-      longs[longsIdx + 13] = l13;
-      long l14 = (tmp[tmpIdx + 15] & MASK32_2) << 15;
-      l14 |= (tmp[tmpIdx + 16] & MASK32_15) << 0;
-      longs[longsIdx + 14] = l14;
-    }
-  }
-
-  private static void decode18(DataInput in, long[] tmp, long[] longs) throws IOException {
-    in.readLongs(tmp, 0, 36);
-    shiftLongs(tmp, 36, longs, 0, 14, MASK32_18);
-    for (int iter = 0, tmpIdx = 0, longsIdx = 36; iter < 4; ++iter, tmpIdx += 9, longsIdx += 7) {
-      long l0 = (tmp[tmpIdx + 0] & MASK32_14) << 4;
-      l0 |= (tmp[tmpIdx + 1] >>> 10) & MASK32_4;
-      longs[longsIdx + 0] = l0;
-      long l1 = (tmp[tmpIdx + 1] & MASK32_10) << 8;
-      l1 |= (tmp[tmpIdx + 2] >>> 6) & MASK32_8;
-      longs[longsIdx + 1] = l1;
-      long l2 = (tmp[tmpIdx + 2] & MASK32_6) << 12;
-      l2 |= (tmp[tmpIdx + 3] >>> 2) & MASK32_12;
-      longs[longsIdx + 2] = l2;
-      long l3 = (tmp[tmpIdx + 3] & MASK32_2) << 16;
-      l3 |= (tmp[tmpIdx + 4] & MASK32_14) << 2;
-      l3 |= (tmp[tmpIdx + 5] >>> 12) & MASK32_2;
-      longs[longsIdx + 3] = l3;
-      long l4 = (tmp[tmpIdx + 5] & MASK32_12) << 6;
-      l4 |= (tmp[tmpIdx + 6] >>> 8) & MASK32_6;
-      longs[longsIdx + 4] = l4;
-      long l5 = (tmp[tmpIdx + 6] & MASK32_8) << 10;
-      l5 |= (tmp[tmpIdx + 7] >>> 4) & MASK32_10;
-      longs[longsIdx + 5] = l5;
-      long l6 = (tmp[tmpIdx + 7] & MASK32_4) << 14;
-      l6 |= (tmp[tmpIdx + 8] & MASK32_14) << 0;
-      longs[longsIdx + 6] = l6;
-    }
-  }
-
-  private static void decode19(DataInput in, long[] tmp, long[] longs) throws IOException {
-    in.readLongs(tmp, 0, 38);
-    shiftLongs(tmp, 38, longs, 0, 13, MASK32_19);
-    for (int iter = 0, tmpIdx = 0, longsIdx = 38; iter < 2; ++iter, tmpIdx += 19, longsIdx += 13) {
-      long l0 = (tmp[tmpIdx + 0] & MASK32_13) << 6;
-      l0 |= (tmp[tmpIdx + 1] >>> 7) & MASK32_6;
-      longs[longsIdx + 0] = l0;
-      long l1 = (tmp[tmpIdx + 1] & MASK32_7) << 12;
-      l1 |= (tmp[tmpIdx + 2] >>> 1) & MASK32_12;
-      longs[longsIdx + 1] = l1;
-      long l2 = (tmp[tmpIdx + 2] & MASK32_1) << 18;
-      l2 |= (tmp[tmpIdx + 3] & MASK32_13) << 5;
-      l2 |= (tmp[tmpIdx + 4] >>> 8) & MASK32_5;
-      longs[longsIdx + 2] = l2;
-      long l3 = (tmp[tmpIdx + 4] & MASK32_8) << 11;
-      l3 |= (tmp[tmpIdx + 5] >>> 2) & MASK32_11;
-      longs[longsIdx + 3] = l3;
-      long l4 = (tmp[tmpIdx + 5] & MASK32_2) << 17;
-      l4 |= (tmp[tmpIdx + 6] & MASK32_13) << 4;
-      l4 |= (tmp[tmpIdx + 7] >>> 9) & MASK32_4;
-      longs[longsIdx + 4] = l4;
-      long l5 = (tmp[tmpIdx + 7] & MASK32_9) << 10;
-      l5 |= (tmp[tmpIdx + 8] >>> 3) & MASK32_10;
-      longs[longsIdx + 5] = l5;
-      long l6 = (tmp[tmpIdx + 8] & MASK32_3) << 16;
-      l6 |= (tmp[tmpIdx + 9] & MASK32_13) << 3;
-      l6 |= (tmp[tmpIdx + 10] >>> 10) & MASK32_3;
-      longs[longsIdx + 6] = l6;
-      long l7 = (tmp[tmpIdx + 10] & MASK32_10) << 9;
-      l7 |= (tmp[tmpIdx + 11] >>> 4) & MASK32_9;
-      longs[longsIdx + 7] = l7;
-      long l8 = (tmp[tmpIdx + 11] & MASK32_4) << 15;
-      l8 |= (tmp[tmpIdx + 12] & MASK32_13) << 2;
-      l8 |= (tmp[tmpIdx + 13] >>> 11) & MASK32_2;
-      longs[longsIdx + 8] = l8;
-      long l9 = (tmp[tmpIdx + 13] & MASK32_11) << 8;
-      l9 |= (tmp[tmpIdx + 14] >>> 5) & MASK32_8;
-      longs[longsIdx + 9] = l9;
-      long l10 = (tmp[tmpIdx + 14] & MASK32_5) << 14;
-      l10 |= (tmp[tmpIdx + 15] & MASK32_13) << 1;
-      l10 |= (tmp[tmpIdx + 16] >>> 12) & MASK32_1;
-      longs[longsIdx + 10] = l10;
-      long l11 = (tmp[tmpIdx + 16] & MASK32_12) << 7;
-      l11 |= (tmp[tmpIdx + 17] >>> 6) & MASK32_7;
-      longs[longsIdx + 11] = l11;
-      long l12 = (tmp[tmpIdx + 17] & MASK32_6) << 13;
-      l12 |= (tmp[tmpIdx + 18] & MASK32_13) << 0;
-      longs[longsIdx + 12] = l12;
-    }
   }
 
   private static void decode20(DataInput in, long[] tmp, long[] longs) throws IOException {
@@ -1011,129 +472,6 @@ final class ForUtil {
     }
   }
 
-  private static void decode21(DataInput in, long[] tmp, long[] longs) throws IOException {
-    in.readLongs(tmp, 0, 42);
-    shiftLongs(tmp, 42, longs, 0, 11, MASK32_21);
-    for (int iter = 0, tmpIdx = 0, longsIdx = 42; iter < 2; ++iter, tmpIdx += 21, longsIdx += 11) {
-      long l0 = (tmp[tmpIdx + 0] & MASK32_11) << 10;
-      l0 |= (tmp[tmpIdx + 1] >>> 1) & MASK32_10;
-      longs[longsIdx + 0] = l0;
-      long l1 = (tmp[tmpIdx + 1] & MASK32_1) << 20;
-      l1 |= (tmp[tmpIdx + 2] & MASK32_11) << 9;
-      l1 |= (tmp[tmpIdx + 3] >>> 2) & MASK32_9;
-      longs[longsIdx + 1] = l1;
-      long l2 = (tmp[tmpIdx + 3] & MASK32_2) << 19;
-      l2 |= (tmp[tmpIdx + 4] & MASK32_11) << 8;
-      l2 |= (tmp[tmpIdx + 5] >>> 3) & MASK32_8;
-      longs[longsIdx + 2] = l2;
-      long l3 = (tmp[tmpIdx + 5] & MASK32_3) << 18;
-      l3 |= (tmp[tmpIdx + 6] & MASK32_11) << 7;
-      l3 |= (tmp[tmpIdx + 7] >>> 4) & MASK32_7;
-      longs[longsIdx + 3] = l3;
-      long l4 = (tmp[tmpIdx + 7] & MASK32_4) << 17;
-      l4 |= (tmp[tmpIdx + 8] & MASK32_11) << 6;
-      l4 |= (tmp[tmpIdx + 9] >>> 5) & MASK32_6;
-      longs[longsIdx + 4] = l4;
-      long l5 = (tmp[tmpIdx + 9] & MASK32_5) << 16;
-      l5 |= (tmp[tmpIdx + 10] & MASK32_11) << 5;
-      l5 |= (tmp[tmpIdx + 11] >>> 6) & MASK32_5;
-      longs[longsIdx + 5] = l5;
-      long l6 = (tmp[tmpIdx + 11] & MASK32_6) << 15;
-      l6 |= (tmp[tmpIdx + 12] & MASK32_11) << 4;
-      l6 |= (tmp[tmpIdx + 13] >>> 7) & MASK32_4;
-      longs[longsIdx + 6] = l6;
-      long l7 = (tmp[tmpIdx + 13] & MASK32_7) << 14;
-      l7 |= (tmp[tmpIdx + 14] & MASK32_11) << 3;
-      l7 |= (tmp[tmpIdx + 15] >>> 8) & MASK32_3;
-      longs[longsIdx + 7] = l7;
-      long l8 = (tmp[tmpIdx + 15] & MASK32_8) << 13;
-      l8 |= (tmp[tmpIdx + 16] & MASK32_11) << 2;
-      l8 |= (tmp[tmpIdx + 17] >>> 9) & MASK32_2;
-      longs[longsIdx + 8] = l8;
-      long l9 = (tmp[tmpIdx + 17] & MASK32_9) << 12;
-      l9 |= (tmp[tmpIdx + 18] & MASK32_11) << 1;
-      l9 |= (tmp[tmpIdx + 19] >>> 10) & MASK32_1;
-      longs[longsIdx + 9] = l9;
-      long l10 = (tmp[tmpIdx + 19] & MASK32_10) << 11;
-      l10 |= (tmp[tmpIdx + 20] & MASK32_11) << 0;
-      longs[longsIdx + 10] = l10;
-    }
-  }
-
-  private static void decode22(DataInput in, long[] tmp, long[] longs) throws IOException {
-    in.readLongs(tmp, 0, 44);
-    shiftLongs(tmp, 44, longs, 0, 10, MASK32_22);
-    for (int iter = 0, tmpIdx = 0, longsIdx = 44; iter < 4; ++iter, tmpIdx += 11, longsIdx += 5) {
-      long l0 = (tmp[tmpIdx + 0] & MASK32_10) << 12;
-      l0 |= (tmp[tmpIdx + 1] & MASK32_10) << 2;
-      l0 |= (tmp[tmpIdx + 2] >>> 8) & MASK32_2;
-      longs[longsIdx + 0] = l0;
-      long l1 = (tmp[tmpIdx + 2] & MASK32_8) << 14;
-      l1 |= (tmp[tmpIdx + 3] & MASK32_10) << 4;
-      l1 |= (tmp[tmpIdx + 4] >>> 6) & MASK32_4;
-      longs[longsIdx + 1] = l1;
-      long l2 = (tmp[tmpIdx + 4] & MASK32_6) << 16;
-      l2 |= (tmp[tmpIdx + 5] & MASK32_10) << 6;
-      l2 |= (tmp[tmpIdx + 6] >>> 4) & MASK32_6;
-      longs[longsIdx + 2] = l2;
-      long l3 = (tmp[tmpIdx + 6] & MASK32_4) << 18;
-      l3 |= (tmp[tmpIdx + 7] & MASK32_10) << 8;
-      l3 |= (tmp[tmpIdx + 8] >>> 2) & MASK32_8;
-      longs[longsIdx + 3] = l3;
-      long l4 = (tmp[tmpIdx + 8] & MASK32_2) << 20;
-      l4 |= (tmp[tmpIdx + 9] & MASK32_10) << 10;
-      l4 |= (tmp[tmpIdx + 10] & MASK32_10) << 0;
-      longs[longsIdx + 4] = l4;
-    }
-  }
-
-  private static void decode23(DataInput in, long[] tmp, long[] longs) throws IOException {
-    in.readLongs(tmp, 0, 46);
-    shiftLongs(tmp, 46, longs, 0, 9, MASK32_23);
-    for (int iter = 0, tmpIdx = 0, longsIdx = 46; iter < 2; ++iter, tmpIdx += 23, longsIdx += 9) {
-      long l0 = (tmp[tmpIdx + 0] & MASK32_9) << 14;
-      l0 |= (tmp[tmpIdx + 1] & MASK32_9) << 5;
-      l0 |= (tmp[tmpIdx + 2] >>> 4) & MASK32_5;
-      longs[longsIdx + 0] = l0;
-      long l1 = (tmp[tmpIdx + 2] & MASK32_4) << 19;
-      l1 |= (tmp[tmpIdx + 3] & MASK32_9) << 10;
-      l1 |= (tmp[tmpIdx + 4] & MASK32_9) << 1;
-      l1 |= (tmp[tmpIdx + 5] >>> 8) & MASK32_1;
-      longs[longsIdx + 1] = l1;
-      long l2 = (tmp[tmpIdx + 5] & MASK32_8) << 15;
-      l2 |= (tmp[tmpIdx + 6] & MASK32_9) << 6;
-      l2 |= (tmp[tmpIdx + 7] >>> 3) & MASK32_6;
-      longs[longsIdx + 2] = l2;
-      long l3 = (tmp[tmpIdx + 7] & MASK32_3) << 20;
-      l3 |= (tmp[tmpIdx + 8] & MASK32_9) << 11;
-      l3 |= (tmp[tmpIdx + 9] & MASK32_9) << 2;
-      l3 |= (tmp[tmpIdx + 10] >>> 7) & MASK32_2;
-      longs[longsIdx + 3] = l3;
-      long l4 = (tmp[tmpIdx + 10] & MASK32_7) << 16;
-      l4 |= (tmp[tmpIdx + 11] & MASK32_9) << 7;
-      l4 |= (tmp[tmpIdx + 12] >>> 2) & MASK32_7;
-      longs[longsIdx + 4] = l4;
-      long l5 = (tmp[tmpIdx + 12] & MASK32_2) << 21;
-      l5 |= (tmp[tmpIdx + 13] & MASK32_9) << 12;
-      l5 |= (tmp[tmpIdx + 14] & MASK32_9) << 3;
-      l5 |= (tmp[tmpIdx + 15] >>> 6) & MASK32_3;
-      longs[longsIdx + 5] = l5;
-      long l6 = (tmp[tmpIdx + 15] & MASK32_6) << 17;
-      l6 |= (tmp[tmpIdx + 16] & MASK32_9) << 8;
-      l6 |= (tmp[tmpIdx + 17] >>> 1) & MASK32_8;
-      longs[longsIdx + 6] = l6;
-      long l7 = (tmp[tmpIdx + 17] & MASK32_1) << 22;
-      l7 |= (tmp[tmpIdx + 18] & MASK32_9) << 13;
-      l7 |= (tmp[tmpIdx + 19] & MASK32_9) << 4;
-      l7 |= (tmp[tmpIdx + 20] >>> 5) & MASK32_4;
-      longs[longsIdx + 7] = l7;
-      long l8 = (tmp[tmpIdx + 20] & MASK32_5) << 18;
-      l8 |= (tmp[tmpIdx + 21] & MASK32_9) << 9;
-      l8 |= (tmp[tmpIdx + 22] & MASK32_9) << 0;
-      longs[longsIdx + 8] = l8;
-    }
-  }
-
   private static void decode24(DataInput in, long[] tmp, long[] longs) throws IOException {
     in.readLongs(tmp, 0, 48);
     shiftLongs(tmp, 48, longs, 0, 8, MASK32_24);
@@ -1144,5 +482,9 @@ final class ForUtil {
       l0 |= tmp[tmpIdx + 2] << 0;
       longs[longsIdx + 0] = l0;
     }
+  }
+
+  private static void decode32(DataInput in, long[] tmp, long[] longs) throws IOException {
+    in.readLongs(longs, 0, 64);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -341,7 +341,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
   final class BlockDocsEnum extends PostingsEnum {
 
     final ForUtil forUtil = new ForUtil();
-    final ForDeltaUtil forDeltaUtil = new ForDeltaUtil(forUtil);
+    final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
     final PForUtil pforUtil = new PForUtil(forUtil);
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];
@@ -624,7 +624,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
   final class EverythingEnum extends PostingsEnum {
 
     final ForUtil forUtil = new ForUtil();
-    final ForDeltaUtil forDeltaUtil = new ForDeltaUtil(forUtil);
+    final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
     final PForUtil pforUtil = new PForUtil(forUtil);
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];
@@ -1207,7 +1207,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
   final class BlockImpactsDocsEnum extends ImpactsEnum {
 
     final ForUtil forUtil = new ForUtil();
-    final ForDeltaUtil forDeltaUtil = new ForDeltaUtil(forUtil);
+    final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
     final PForUtil pforUtil = new PForUtil(forUtil);
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];
@@ -1561,7 +1561,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
   final class BlockImpactsPostingsEnum extends ImpactsEnum {
 
     final ForUtil forUtil = new ForUtil();
-    final ForDeltaUtil forDeltaUtil = new ForDeltaUtil(forUtil);
+    final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
     final PForUtil pforUtil = new PForUtil(forUtil);
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsWriter.java
@@ -141,7 +141,7 @@ public class Lucene912PostingsWriter extends PushPostingsWriterBase {
       CodecUtil.writeIndexHeader(
           docOut, DOC_CODEC, VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
       final ForUtil forUtil = new ForUtil();
-      forDeltaUtil = new ForDeltaUtil(forUtil);
+      forDeltaUtil = new ForDeltaUtil();
       pforUtil = new PForUtil(forUtil);
       if (state.fieldInfos.hasProx()) {
         posDeltaBuffer = new long[BLOCK_SIZE];

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/PanamaPostingUtil.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/PanamaPostingUtil.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.internal.vectorization;
+
+public class PanamaPostingUtil {}

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestForDeltaUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestForDeltaUtil.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene912;
+
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.packed.PackedInts;
+
+public class TestForDeltaUtil extends LuceneTestCase {
+
+  public void testEncodeDecode() throws IOException {
+    final int iterations = RandomNumbers.randomIntBetween(random(), 50, 1000);
+    final int[] values = new int[iterations * ForUtil.BLOCK_SIZE];
+
+    for (int i = 0; i < iterations; ++i) {
+      final int bpv = TestUtil.nextInt(random(), 1, 31 - 7);
+      for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
+        values[i * ForUtil.BLOCK_SIZE + j] =
+            RandomNumbers.randomIntBetween(random(), 1, (int) PackedInts.maxValue(bpv));
+      }
+    }
+
+    final Directory d = new ByteBuffersDirectory();
+    final long endPointer;
+
+    {
+      // encode
+      IndexOutput out = d.createOutput("test.bin", IOContext.DEFAULT);
+      final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
+
+      for (int i = 0; i < iterations; ++i) {
+        long[] source = new long[ForUtil.BLOCK_SIZE];
+        for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
+          source[j] = values[i * ForUtil.BLOCK_SIZE + j];
+        }
+        forDeltaUtil.encodeDeltas(source, out);
+      }
+      endPointer = out.getFilePointer();
+      out.close();
+    }
+
+    {
+      // decode
+      IndexInput in = d.openInput("test.bin", IOContext.READONCE);
+      final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
+      for (int i = 0; i < iterations; ++i) {
+        long base = 0;
+        final long[] restored = new long[ForUtil.BLOCK_SIZE];
+        forDeltaUtil.decodeAndPrefixSum(in, base, restored);
+        final long[] expected = new long[ForUtil.BLOCK_SIZE];
+        for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
+          expected[j] = values[i * ForUtil.BLOCK_SIZE + j];
+          if (j > 0) {
+            expected[j] += expected[j - 1];
+          } else {
+            expected[j] += base;
+          }
+        }
+        assertArrayEquals(Arrays.toString(restored), expected, restored);
+      }
+      assertEquals(endPointer, in.getFilePointer());
+      in.close();
+    }
+
+    d.close();
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestForUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestForUtil.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene912;
+
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.packed.PackedInts;
+
+public class TestForUtil extends LuceneTestCase {
+
+  public void testEncodeDecode() throws IOException {
+    final int iterations = RandomNumbers.randomIntBetween(random(), 50, 1000);
+    final int[] values = new int[iterations * ForUtil.BLOCK_SIZE];
+
+    for (int i = 0; i < iterations; ++i) {
+      final int bpv = TestUtil.nextInt(random(), 1, 31);
+      for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
+        values[i * ForUtil.BLOCK_SIZE + j] =
+            RandomNumbers.randomIntBetween(random(), 0, (int) PackedInts.maxValue(bpv));
+      }
+    }
+
+    final Directory d = new ByteBuffersDirectory();
+    final long endPointer;
+
+    {
+      // encode
+      IndexOutput out = d.createOutput("test.bin", IOContext.DEFAULT);
+      final ForUtil forUtil = new ForUtil();
+
+      for (int i = 0; i < iterations; ++i) {
+        long[] source = new long[ForUtil.BLOCK_SIZE];
+        long or = 0;
+        for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
+          source[j] = values[i * ForUtil.BLOCK_SIZE + j];
+          or |= source[j];
+        }
+        int bpv = PackedInts.bitsRequired(or);
+        bpv = ForUtil.computeActualBitsPerValue(bpv);
+        out.writeByte((byte) bpv);
+        forUtil.encode(source, bpv, out);
+      }
+      endPointer = out.getFilePointer();
+      out.close();
+    }
+
+    {
+      // decode
+      IndexInput in = d.openInput("test.bin", IOContext.READONCE);
+      final ForUtil forUtil = new ForUtil();
+      for (int i = 0; i < iterations; ++i) {
+        final int bitsPerValue = in.readByte();
+        final long currentFilePointer = in.getFilePointer();
+        final long[] restored = new long[ForUtil.BLOCK_SIZE];
+        forUtil.decode(bitsPerValue, in, restored);
+        int[] ints = new int[ForUtil.BLOCK_SIZE];
+        for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
+          ints[j] = Math.toIntExact(restored[j]);
+        }
+        assertArrayEquals(
+            Arrays.toString(ints),
+            ArrayUtil.copyOfSubArray(values, i * ForUtil.BLOCK_SIZE, (i + 1) * ForUtil.BLOCK_SIZE),
+            ints);
+        assertEquals(forUtil.numBytes(bitsPerValue), in.getFilePointer() - currentFilePointer);
+      }
+      assertEquals(endPointer, in.getFilePointer());
+      in.close();
+    }
+
+    d.close();
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestPForUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestPForUtil.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene912;
+
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.packed.PackedInts;
+
+public class TestPForUtil extends LuceneTestCase {
+
+  public void testEncodeDecode() throws IOException {
+    final int iterations = RandomNumbers.randomIntBetween(random(), 50, 1000);
+    final int[] values = createTestData(iterations, 31);
+
+    final Directory d = new ByteBuffersDirectory();
+    final long endPointer = encodeTestData(iterations, values, d);
+
+    IndexInput in = d.openInput("test.bin", IOContext.READONCE);
+    final PForUtil pforUtil = new PForUtil(new ForUtil());
+    for (int i = 0; i < iterations; ++i) {
+      if (random().nextInt(5) == 0) {
+        pforUtil.skip(in);
+        continue;
+      }
+      final long[] restored = new long[ForUtil.BLOCK_SIZE];
+      pforUtil.decode(in, restored);
+      int[] ints = new int[ForUtil.BLOCK_SIZE];
+      for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
+        ints[j] = Math.toIntExact(restored[j]);
+      }
+      assertArrayEquals(
+          Arrays.toString(ints),
+          ArrayUtil.copyOfSubArray(values, i * ForUtil.BLOCK_SIZE, (i + 1) * ForUtil.BLOCK_SIZE),
+          ints);
+    }
+    assertEquals(endPointer, in.getFilePointer());
+    in.close();
+
+    d.close();
+  }
+
+  private int[] createTestData(int iterations, int maxBpv) {
+    final int[] values = new int[iterations * ForUtil.BLOCK_SIZE];
+
+    for (int i = 0; i < iterations; ++i) {
+      final int bpv = TestUtil.nextInt(random(), 0, maxBpv);
+      for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
+        values[i * ForUtil.BLOCK_SIZE + j] =
+            RandomNumbers.randomIntBetween(random(), 0, (int) PackedInts.maxValue(bpv));
+        if (random().nextInt(100) == 0) {
+          final int exceptionBpv;
+          if (random().nextInt(10) == 0) {
+            exceptionBpv = Math.min(bpv + TestUtil.nextInt(random(), 9, 16), maxBpv);
+          } else {
+            exceptionBpv = Math.min(bpv + TestUtil.nextInt(random(), 1, 8), maxBpv);
+          }
+          values[i * ForUtil.BLOCK_SIZE + j] |= random().nextInt(1 << (exceptionBpv - bpv)) << bpv;
+        }
+      }
+    }
+
+    return values;
+  }
+
+  private long encodeTestData(int iterations, int[] values, Directory d) throws IOException {
+    IndexOutput out = d.createOutput("test.bin", IOContext.DEFAULT);
+    final PForUtil pforUtil = new PForUtil(new ForUtil());
+
+    for (int i = 0; i < iterations; ++i) {
+      long[] source = new long[ForUtil.BLOCK_SIZE];
+      for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
+        source[j] = values[i * ForUtil.BLOCK_SIZE + j];
+      }
+      pforUtil.encode(source, out);
+    }
+    final long endPointer = out.getFilePointer();
+    out.close();
+
+    return endPointer;
+  }
+}


### PR DESCRIPTION
This does two things:
 - Switch to a different layout for bits per value less than or equal to 9 that allows computing the prefix sum by summing up 4 ints as once, by treating them as 16-bit integers. It only works if bpv <= 9 because 128 * 2^9 = 2^16. JMH benchmarks suggest that computing a prefix sum from deltas stored in a `MemorySegmentIndexInput` is about 5% faster.
 - Avoid the slower numbers of bits per value. E.g. if you need 15 bits per value, encoding on 16 bits per value requires little additional space but makes decoding faster. This is similar to what `DirectReader` is doing. This also helps reduce the amount of generated code.
