### PR TITLE
CandidateMatcher public matching functions

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -110,6 +110,8 @@ API Changes
 
 * GITHUB#13499: Remove deprecated TopScoreDocCollector + TopFieldCollector methods (#create, #createSharedManager) (Jakub Slowinski)
 
+* GITHUB#13632: CandidateMatcher public matching functions (Bryan Jacobowitz)
+
 
 New Features
 ---------------------

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/CandidateMatcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/CandidateMatcher.java
@@ -64,7 +64,7 @@ public abstract class CandidateMatcher<T extends QueryMatch> {
    * @param metadata the query metadata
    * @throws IOException on IO errors
    */
-  protected abstract void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata)
+  public abstract void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata)
       throws IOException;
 
   /**
@@ -95,14 +95,14 @@ public abstract class CandidateMatcher<T extends QueryMatch> {
   public abstract T resolve(T match1, T match2);
 
   /** Called by the Monitor if running a query throws an Exception */
-  void reportError(String queryId, Exception e) {
+  public void reportError(String queryId, Exception e) {
     this.errors.put(queryId, e);
   }
 
   /**
    * @return the matches from this matcher
    */
-  final MultiMatchingQueries<T> finish(long buildTime, int queryCount) {
+  public final MultiMatchingQueries<T> finish(long buildTime, int queryCount) {
     doFinish();
     this.searchTime =
         TimeUnit.MILLISECONDS.convert(System.nanoTime() - searchTime, TimeUnit.NANOSECONDS);

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/CollectingMatcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/CollectingMatcher.java
@@ -35,7 +35,7 @@ abstract class CollectingMatcher<T extends QueryMatch> extends CandidateMatcher<
   }
 
   @Override
-  protected void matchQuery(final String queryId, Query matchQuery, Map<String, String> metadata)
+  public void matchQuery(final String queryId, Query matchQuery, Map<String, String> metadata)
       throws IOException {
     searcher.search(matchQuery, new MatchCollector(queryId, scoreMode));
   }

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/ExplainingMatch.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/ExplainingMatch.java
@@ -31,8 +31,8 @@ public class ExplainingMatch extends QueryMatch {
       searcher ->
           new CandidateMatcher<ExplainingMatch>(searcher) {
             @Override
-            protected void matchQuery(
-                String queryId, Query matchQuery, Map<String, String> metadata) throws IOException {
+            public void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata)
+                throws IOException {
               int maxDocs = searcher.getIndexReader().maxDoc();
               for (int i = 0; i < maxDocs; i++) {
                 Explanation explanation = searcher.explain(matchQuery, i);

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/HighlightsMatch.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/HighlightsMatch.java
@@ -46,8 +46,8 @@ public class HighlightsMatch extends QueryMatch {
           new CandidateMatcher<HighlightsMatch>(searcher) {
 
             @Override
-            protected void matchQuery(
-                String queryId, Query matchQuery, Map<String, String> metadata) throws IOException {
+            public void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata)
+                throws IOException {
               Weight w =
                   searcher.createWeight(
                       searcher.rewrite(matchQuery), ScoreMode.COMPLETE_NO_SCORES, 1);

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/ParallelMatcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/ParallelMatcher.java
@@ -74,7 +74,7 @@ public class ParallelMatcher<T extends QueryMatch> extends CandidateMatcher<T> {
   }
 
   @Override
-  protected void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata)
+  public void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata)
       throws IOException {
     try {
       queue.put(new MatcherTask(queryId, matchQuery, metadata));

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/PartitionMatcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/PartitionMatcher.java
@@ -79,7 +79,7 @@ public class PartitionMatcher<T extends QueryMatch> extends CandidateMatcher<T> 
   }
 
   @Override
-  protected void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata) {
+  public void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata) {
     tasks.add(new MatchTask(queryId, matchQuery, metadata));
   }
 

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryTimeListener.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryTimeListener.java
@@ -39,7 +39,7 @@ public interface QueryTimeListener {
       CandidateMatcher<T> matcher = factory.createMatcher(searcher);
       return new CandidateMatcher<T>(searcher) {
         @Override
-        protected void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata)
+        public void matchQuery(String queryId, Query matchQuery, Map<String, String> metadata)
             throws IOException {
           long t = System.nanoTime();
           matcher.matchQuery(queryId, matchQuery, metadata);

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestMonitor.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestMonitor.java
@@ -178,7 +178,7 @@ public class TestMonitor extends MonitorTestBase {
           docs ->
               new CandidateMatcher<QueryMatch>(docs) {
                 @Override
-                protected void matchQuery(
+                public void matchQuery(
                     String queryId, Query matchQuery, Map<String, String> metadata) {
                   assertEquals("value", metadata.get("key"));
                 }

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/outsidepackage/TestCandidateMatcherVisibility.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/outsidepackage/TestCandidateMatcherVisibility.java
@@ -19,160 +19,21 @@ package org.apache.lucene.monitor.outsidepackage;
 
 import java.io.IOException;
 import java.util.Collections;
-import org.apache.lucene.index.BinaryDocValues;
-import org.apache.lucene.index.ByteVectorValues;
-import org.apache.lucene.index.DocValuesSkipper;
-import org.apache.lucene.index.FieldInfos;
-import org.apache.lucene.index.FloatVectorValues;
-import org.apache.lucene.index.LeafMetaData;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.index.PointValues;
-import org.apache.lucene.index.SortedDocValues;
-import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.index.SortedSetDocValues;
-import org.apache.lucene.index.StoredFieldVisitor;
-import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.index.TermVectors;
-import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.memory.MemoryIndex;
 import org.apache.lucene.monitor.CandidateMatcher;
 import org.apache.lucene.monitor.QueryMatch;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.Version;
 import org.junit.Test;
 
 public class TestCandidateMatcherVisibility {
 
-  // Dummy empty IndexReader for use in creating a matcher
-  private LeafReader dummyIndexReader() {
-    return new LeafReader() {
-      @Override
-      public int maxDoc() {
-        return 0;
-      }
-
-      @Override
-      public int numDocs() {
-        return 0;
-      }
-
-      @Override
-      public FieldInfos getFieldInfos() {
-        return FieldInfos.EMPTY;
-      }
-
-      @Override
-      public Bits getLiveDocs() {
-        return null;
-      }
-
-      @Override
-      public Terms terms(String field) throws IOException {
-        return null;
-      }
-
-      @Override
-      public TermVectors termVectors() {
-        return TermVectors.EMPTY;
-      }
-
-      @Override
-      public NumericDocValues getNumericDocValues(String field) {
-        return null;
-      }
-
-      @Override
-      public BinaryDocValues getBinaryDocValues(String field) {
-        return null;
-      }
-
-      @Override
-      public SortedDocValues getSortedDocValues(String field) {
-        return null;
-      }
-
-      @Override
-      public SortedNumericDocValues getSortedNumericDocValues(String field) {
-        return null;
-      }
-
-      @Override
-      public SortedSetDocValues getSortedSetDocValues(String field) {
-        return null;
-      }
-
-      @Override
-      public NumericDocValues getNormValues(String field) {
-        return null;
-      }
-
-      @Override
-      public DocValuesSkipper getDocValuesSkipper(String field) {
-        return null;
-      }
-
-      @Override
-      public PointValues getPointValues(String field) {
-        return null;
-      }
-
-      @Override
-      public FloatVectorValues getFloatVectorValues(String field) {
-        return null;
-      }
-
-      @Override
-      public ByteVectorValues getByteVectorValues(String field) {
-        return null;
-      }
-
-      @Override
-      public void searchNearestVectors(
-          String field, float[] target, KnnCollector knnCollector, Bits acceptDocs) {}
-
-      @Override
-      public void searchNearestVectors(
-          String field, byte[] target, KnnCollector knnCollector, Bits acceptDocs) {}
-
-      @Override
-      protected void doClose() {}
-
-      @Override
-      public StoredFields storedFields() {
-        return new StoredFields() {
-          @Override
-          public void document(int doc, StoredFieldVisitor visitor) {}
-        };
-      }
-
-      @Override
-      public void checkIntegrity() throws IOException {}
-
-      @Override
-      public LeafMetaData getMetaData() {
-        return new LeafMetaData(Version.LATEST.major, Version.LATEST, null, false);
-      }
-
-      @Override
-      public CacheHelper getCoreCacheHelper() {
-        return null;
-      }
-
-      @Override
-      public CacheHelper getReaderCacheHelper() {
-        return null;
-      }
-    };
-  }
-
   private CandidateMatcher<QueryMatch> newCandidateMatcher() {
-    // Dummy searcher for use in creating a matcher
-    final IndexSearcher mockSearcher = new IndexSearcher(dummyIndexReader());
-    return QueryMatch.SIMPLE_MATCHER.createMatcher(mockSearcher);
+    // Index and searcher for use in creating a matcher
+    MemoryIndex index = new MemoryIndex();
+    final IndexSearcher searcher = index.createSearcher();
+    return QueryMatch.SIMPLE_MATCHER.createMatcher(searcher);
   }
 
   @Test

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/outsidepackage/TestCandidateMatcherVisibility.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/outsidepackage/TestCandidateMatcherVisibility.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.monitor.outsidepackage;
+
+import java.io.IOException;
+import java.util.Collections;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.LeafMetaData;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermVectors;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.monitor.CandidateMatcher;
+import org.apache.lucene.monitor.QueryMatch;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.Version;
+import org.junit.Test;
+
+public class TestCandidateMatcherVisibility {
+
+  // Dummy empty IndexReader for use in creating a matcher
+  private LeafReader dummyIndexReader() {
+    return new LeafReader() {
+      @Override
+      public int maxDoc() {
+        return 0;
+      }
+
+      @Override
+      public int numDocs() {
+        return 0;
+      }
+
+      @Override
+      public FieldInfos getFieldInfos() {
+        return FieldInfos.EMPTY;
+      }
+
+      @Override
+      public Bits getLiveDocs() {
+        return null;
+      }
+
+      @Override
+      public Terms terms(String field) throws IOException {
+        return null;
+      }
+
+      @Override
+      public TermVectors termVectors() {
+        return TermVectors.EMPTY;
+      }
+
+      @Override
+      public NumericDocValues getNumericDocValues(String field) {
+        return null;
+      }
+
+      @Override
+      public BinaryDocValues getBinaryDocValues(String field) {
+        return null;
+      }
+
+      @Override
+      public SortedDocValues getSortedDocValues(String field) {
+        return null;
+      }
+
+      @Override
+      public SortedNumericDocValues getSortedNumericDocValues(String field) {
+        return null;
+      }
+
+      @Override
+      public SortedSetDocValues getSortedSetDocValues(String field) {
+        return null;
+      }
+
+      @Override
+      public NumericDocValues getNormValues(String field) {
+        return null;
+      }
+
+      @Override
+      public DocValuesSkipper getDocValuesSkipper(String field) {
+        return null;
+      }
+
+      @Override
+      public PointValues getPointValues(String field) {
+        return null;
+      }
+
+      @Override
+      public FloatVectorValues getFloatVectorValues(String field) {
+        return null;
+      }
+
+      @Override
+      public ByteVectorValues getByteVectorValues(String field) {
+        return null;
+      }
+
+      @Override
+      public void searchNearestVectors(
+          String field, float[] target, KnnCollector knnCollector, Bits acceptDocs) {}
+
+      @Override
+      public void searchNearestVectors(
+          String field, byte[] target, KnnCollector knnCollector, Bits acceptDocs) {}
+
+      @Override
+      protected void doClose() {}
+
+      @Override
+      public StoredFields storedFields() {
+        return new StoredFields() {
+          @Override
+          public void document(int doc, StoredFieldVisitor visitor) {}
+        };
+      }
+
+      @Override
+      public void checkIntegrity() throws IOException {}
+
+      @Override
+      public LeafMetaData getMetaData() {
+        return new LeafMetaData(Version.LATEST.major, Version.LATEST, null, false);
+      }
+
+      @Override
+      public CacheHelper getCoreCacheHelper() {
+        return null;
+      }
+
+      @Override
+      public CacheHelper getReaderCacheHelper() {
+        return null;
+      }
+    };
+  }
+
+  private CandidateMatcher<QueryMatch> newCandidateMatcher() {
+    // Dummy searcher for use in creating a matcher
+    final IndexSearcher mockSearcher = new IndexSearcher(dummyIndexReader());
+    return QueryMatch.SIMPLE_MATCHER.createMatcher(mockSearcher);
+  }
+
+  @Test
+  public void testMatchQueryVisibleOutsidePackage() throws IOException {
+    CandidateMatcher<QueryMatch> matcher = newCandidateMatcher();
+    // This should compile from outside org.apache.lucene.monitor package
+    // (subpackage org.apache.lucene.monitor.outsidepackage cannot access package-private content
+    // from org.apache.lucene.monitor)
+    matcher.matchQuery("test", new TermQuery(new Term("test_field")), Collections.emptyMap());
+  }
+
+  @Test
+  public void testReportErrorVisibleOutsidePackage() {
+    CandidateMatcher<QueryMatch> matcher = newCandidateMatcher();
+    // This should compile from outside org.apache.lucene.monitor package
+    // (subpackage org.apache.lucene.monitor.outsidepackage cannot access package-private content
+    // from org.apache.lucene.monitor)
+    matcher.reportError("test", new RuntimeException("test exception"));
+  }
+
+  @Test
+  public void testFinishVisibleOutsidePackage() {
+    CandidateMatcher<QueryMatch> matcher = newCandidateMatcher();
+    // This should compile from outside org.apache.lucene.monitor package
+    // (subpackage org.apache.lucene.monitor.outsidepackage cannot access package-private content
+    // from org.apache.lucene.monitor)
+    matcher.finish(0, 0);
+  }
+}


### PR DESCRIPTION
### Description

In `CandidateMatcher`, increase visibility of `matchQuery()` (from protected), `finish()` and `reportError()` (from package-private) to public, so that a `CandidateMatcher` can be used effectively from outside the `org.apache.lucene.monitor` package.

### Problem

The current access protections on `CandidateMatcher` make it infeasible for a user of the Lucene Monitor library to use an existing `CandidateMatcher` if they are outside the `org.apache.lucene.monitor` package (e.g. as part of the implementation of their own `CandidateMatcher`).

For example, a user working outside of the `org.apache.lucene.monitor` package could not build their own version of `ParallelMatcher` by making use of the matcher from `QueryMatch.SIMPLE_MATCHER`, because they cannot access `matchQuery`, `reportError` or `finish` on it.

### Solution

This PR takes the simplest solution of increase the visibility of those functions in `CandidateMatcher` to `public`. This also requires modifying some existing `CandidateMatcher` implementations that override `protected matchQuery()` to instead override `public matchQuery()`. 

I've also added some just-compile tests in a subpackage `org.apache.lucene.monitor.otherpackage`, which call the newly-public functions to verify that they are accessible from outside the `org.apache.lucene.monitor` package.

See previous discussion of this approach and alternatives in #13109.

### Merge Request

If this PR gets merged, can you please use my `bjacobowitz1@bloomberg.net` email address for the squash+merge. Thank you.