### PR TITLE
Avoid rare random test failures in TestLongValueFacetCounts

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -111,6 +111,8 @@ Bug Fixes
 
 * GITHUB#13627: Fix race condition on flush for DWPT seqNo generation. (Ben Trent, Ao Li)
 
+* GITHUB#13646: Fix rare test bug in TestLongValueFacetCounts that was introduced in 9.6. (Greg Miller)
+
 Other
 ---------------------
 (No changes)

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -385,7 +385,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (random().nextBoolean()) {
         topN = docCount;
       } else {
-        topN = RandomNumbers.randomIntBetween(random(), 1, docCount);
+        topN = RandomNumbers.randomIntBetween(random(), 1, docCount - 1);
       }
       if (VERBOSE) {
         System.out.println("  topN=" + topN);
@@ -477,7 +477,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (random().nextBoolean()) {
         topN = docCount;
       } else {
-        topN = RandomNumbers.randomIntBetween(random(), 1, docCount);
+        topN = RandomNumbers.randomIntBetween(random(), 1, docCount - 1);
       }
       actual = facetCounts.getTopChildren(topN, "field");
       assertSame(
@@ -647,7 +647,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (random().nextBoolean()) {
         topN = docCount;
       } else {
-        topN = RandomNumbers.randomIntBetween(random(), 1, docCount);
+        topN = RandomNumbers.randomIntBetween(random(), 1, docCount - 1);
       }
       if (VERBOSE) {
         System.out.println("  topN=" + topN);
@@ -717,7 +717,7 @@ public class TestLongValueFacetCounts extends FacetTestCase {
       if (random().nextBoolean()) {
         topN = docCount;
       } else {
-        topN = RandomNumbers.randomIntBetween(random(), 1, docCount);
+        topN = RandomNumbers.randomIntBetween(random(), 1, docCount - 1);
       }
       actual = facetCounts.getTopChildren(topN, "field");
       assertSame(


### PR DESCRIPTION
When backporting GH#13568 I realized we have some incorrect usages of RandomNumbers#randomIntBetween in TestLongValueFacetCounts. We use this in place of Random#nextInt for 9x code to work with jdk11, but #nextInt expects the upper bound to be exclusive while RandomNumbers is inclusive.
