### PR TITLE
gh-13640: Connect hnsw graph components when flushing

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
@@ -636,7 +636,7 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
     OnHeapHnswGraph getGraph() throws IOException {
       assert flatFieldVectorsWriter.isFinished();
       if (node > 0) {
-        return hnswGraphBuilder.getGraph();
+        return hnswGraphBuilder.getCompletedGraph();
       } else {
         return null;
       }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -429,7 +429,7 @@ public class HnswGraphBuilder implements HnswBuilder {
       maxConn *= 2;
     }
     List<Component> components = HnswUtil.components(hnsw, level, notFullyConnected, maxConn);
-    // System.out.println("HnswGraphBuilder.connectComponents " + components);
+    // System.out.println("HnswGraphBuilder.connectComponents(level=" + level + "): " + components);
     boolean result = true;
     if (components.size() > 1) {
       // connect other components to the largest one

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
@@ -264,5 +264,10 @@ public class HnswUtil {
     int size() {
       return size;
     }
+
+    @Override
+    public String toString() {
+      return "HnswUtil.Component<" + start + "," + size + ">";
+    }
   }
 }


### PR DESCRIPTION
It turns out that on branch9x we were not calling connectComponents on flush, only on merge, so the graph would grow when merging violating the stability test  