### PR TITLE
Fix eclipse ide settings generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,9 @@ ext {
   // Minimum Java version required to compile and run Lucene.
   minJavaVersion = JavaVersion.toVersion(deps.versions.minJava.get())
 
+  // also change this in extractor tool: ExtractForeignAPI
+  vectorIncubatorJavaVersions = [ JavaVersion.VERSION_21, JavaVersion.VERSION_22 ] as Set
+
   // snapshot build marker used in scripts.
   snapshotBuild = version.contains("SNAPSHOT")
 
@@ -117,10 +120,6 @@ apply from: file('gradle/generation/local-settings.gradle')
 // Make sure the build environment is consistent.
 apply from: file('gradle/validation/check-environment.gradle')
 
-// IDE support, settings and specials.
-apply from: file('gradle/ide/intellij-idea.gradle')
-apply from: file('gradle/ide/eclipse.gradle')
-
 // Set up defaults and configure aspects for certain modules or functionality
 // (java, tests)
 apply from: file('gradle/java/folder-layout.gradle')
@@ -132,6 +131,10 @@ apply from: file('gradle/testing/fail-on-no-tests.gradle')
 apply from: file('gradle/testing/alternative-jdk-support.gradle')
 apply from: file('gradle/java/jar-manifest.gradle')
 apply from: file('gradle/java/modules.gradle')
+
+// IDE support, settings and specials.
+apply from: file('gradle/ide/intellij-idea.gradle')
+apply from: file('gradle/ide/eclipse.gradle')
 
 // Maven artifact publishing.
 apply from: file('gradle/maven/publications.gradle')

--- a/gradle/generation/extract-jdk-apis.gradle
+++ b/gradle/generation/extract-jdk-apis.gradle
@@ -17,13 +17,6 @@
 
 def resources = scriptResources(buildscript)
 
-configure(rootProject) {
-  ext {
-    // also change this in extractor tool: ExtractForeignAPI
-    vectorIncubatorJavaVersions = [ JavaVersion.VERSION_21, JavaVersion.VERSION_22 ] as Set
-  }
-}
-
 configure(project(":lucene:core")) {
   ext {
     apijars = layout.projectDirectory.dir("src/generated/jdk")

--- a/gradle/ide/eclipse.gradle
+++ b/gradle/ide/eclipse.gradle
@@ -108,7 +108,7 @@ configure(rootProject) {
 
     eclipseJdt {
         enabled = false
-        // dependsOn 'luceneEclipse'
+        dependsOn 'luceneEclipseJdt'
     }
 
     eclipseClasspath {

--- a/gradle/ide/eclipse.gradle
+++ b/gradle/ide/eclipse.gradle
@@ -23,7 +23,7 @@ def resources = scriptResources(buildscript)
 
 configure(rootProject) {
   if (gradle.startParameter.taskNames.contains("eclipse")) {
-    project.pluginManager.apply("java-library")
+    project.pluginManager.apply("java-base")
     project.pluginManager.apply("eclipse")
 
     def eclipseJavaVersion = propertyOrDefault("eclipse.javaVersion", deps.versions.minJava.get())

--- a/gradle/ide/eclipse.gradle
+++ b/gradle/ide/eclipse.gradle
@@ -22,10 +22,11 @@ import org.gradle.plugins.ide.eclipse.model.ClasspathEntry
 def resources = scriptResources(buildscript)
 
 configure(rootProject) {
-  plugins.withType(JavaPlugin) {
-    apply plugin: "eclipse"
+  if (gradle.startParameter.taskNames.contains("eclipse")) {
+    project.pluginManager.apply("java-library")
+    project.pluginManager.apply("eclipse")
 
-    def eclipseJavaVersion = propertyOrDefault("eclipse.javaVersion", rootProject.minJavaVersion)
+    def eclipseJavaVersion = propertyOrDefault("eclipse.javaVersion", deps.versions.minJava.get())
     def relativize = { other -> rootProject.rootDir.relativePath(other).toString() }
 
     eclipse {
@@ -105,9 +106,9 @@ configure(rootProject) {
         }
       }
 
-      eclipseJdt {
+    eclipseJdt {
         enabled = false
-        dependsOn 'luceneEclipse'
+        // dependsOn 'luceneEclipse'
     }
 
     eclipseClasspath {

--- a/gradle/validation/dependencies.gradle
+++ b/gradle/validation/dependencies.gradle
@@ -82,8 +82,8 @@ configure(rootProject) {
     ]
   }.configureEach {
     it.doLast {
-      File inFile = it.catalogFile.get().asFile
-      ant.fixcrlf(srcdir: inFile.getParent(), includes: inFile.getName(), eol: "lf", fixlast: "true", encoding: "UTF-8")
+      ant.fixcrlf(file: it.catalogFile.get().asFile,
+        eol: "lf", fixlast: "true", encoding: "UTF-8")
     }
   }
 

--- a/gradle/validation/dependencies.gradle
+++ b/gradle/validation/dependencies.gradle
@@ -83,11 +83,7 @@ configure(rootProject) {
   }.configureEach {
     it.doLast {
       File inFile = it.catalogFile.get().asFile
-      String text = inFile.getText()
-      String cleaned = text.replaceAll("\r\n", "\n")
-      if (!cleaned.equals(text)) {
-        inFile.setText(cleaned, "UTF-8")
-      }
+      ant.fixcrlf(srcdir: inFile.getParent(), includes: inFile.getName(), eol: "lf", fixlast: "true", encoding: "UTF-8")
     }
   }
 

--- a/gradle/validation/dependencies.gradle
+++ b/gradle/validation/dependencies.gradle
@@ -75,6 +75,22 @@ configure(rootProject) {
     it.dependsOn(":versionCatalogFormatDeps")
   }
 
+  // correct crlf/ default encoding after version catalog formatting finishes.
+  tasks.matching {
+    it.path in [
+      ":versionCatalogFormatDeps"
+    ]
+  }.configureEach {
+    it.doLast {
+      File inFile = it.catalogFile.get().asFile
+      String text = inFile.getText()
+      String cleaned = text.replaceAll("\r\n", "\n")
+      if (!cleaned.equals(text)) {
+        inFile.setText(cleaned, "UTF-8")
+      }
+    }
+  }
+
   tasks.matching {
     it.path in [
       ":versionCatalogUpdateDeps"

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -253,6 +253,11 @@ Other
 
 * GITHUB#13499: Remove usage of TopScoreDocCollector + TopFieldCollector deprecated methods (#create, #createSharedManager) (Jakub Slowinski)
 
+Build
+---------------------
+
+* GITHUB#13649: Fix eclipse ide settings generation #13649 (Uwe Schindler, Dawid Weiss)
+
 ======================== Lucene 9.12.0 =======================
 
 API Changes


### PR DESCRIPTION
A fix to https://github.com/apache/lucene/issues/13638.

I don't see how the refactoring in https://github.com/apache/lucene/pull/13484 had something to do with the ide setup breaking. There are some things we do in the build that make it run a bit unpredictably - accessing root project properties when they're not yet set, for example. 

I've tested this PR on a mac and the newest eclipse distribution and everything seems to work.