### PR TITLE
Call HnswGraphBuilder.getCompletedGraph() in 94/95 back-compat writers

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
@@ -693,9 +693,9 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
       lastDocID = docID;
     }
 
-    OnHeapHnswGraph getGraph() {
+    OnHeapHnswGraph getGraph() throws IOException {
       if (vectors.size() > 0) {
-        return hnswGraphBuilder.getGraph();
+        return hnswGraphBuilder.getCompletedGraph();
       } else {
         return null;
       }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -732,9 +732,9 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
       lastDocID = docID;
     }
 
-    OnHeapHnswGraph getGraph() {
+    OnHeapHnswGraph getGraph() throws IOException {
       if (vectors.size() > 0) {
-        return hnswGraphBuilder.getGraph();
+        return hnswGraphBuilder.getCompletedGraph();
       } else {
         return null;
       }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -412,6 +412,7 @@ public class HnswGraphBuilder implements HnswBuilder {
   }
 
   void finish() throws IOException {
+    // System.out.println("finish " + frozen);
     connectComponents();
     frozen = true;
   }
@@ -438,7 +439,7 @@ public class HnswGraphBuilder implements HnswBuilder {
       maxConn *= 2;
     }
     List<Component> components = HnswUtil.components(hnsw, level, notFullyConnected, maxConn);
-    // System.out.println("HnswGraphBuilder.connectComponents " + components);
+    // System.out.println("HnswGraphBuilder.connectComponents level=" + level + ": " + components);
     boolean result = true;
     if (components.size() > 1) {
       // connect other components to the largest one


### PR DESCRIPTION
another in an ongoing series of patches to address merge stability test failures. Here we tweak the back-compat Lucene 94/95 writers so they will call the new connectComponents() method (via `getCompletedGraph()/finish()) when flushing. It's annoying we couldn't simply have changed HnswGraphBuilder.getGraph() since these already called that. However getGraph() is also called *while* building (to check RAM usage IIRC) so that wouldn't work.-  I checked previous versions and I think we should be good there as they would never call into this code path even when merging, but it's a little hard to trace by eye ... it's possible we could still see a test fail for some older version.   