### PR TITLE
Revert changes to IndexSearcher brought in by GH#13568

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -630,12 +630,45 @@ public class IndexSearcher {
    */
   public <C extends Collector, T> T search(Query query, CollectorManager<C, T> collectorManager)
       throws IOException {
-    CollectorOwner<C, T> collectorOwner = new CollectorOwner<>(collectorManager);
-    final C firstCollector = collectorOwner.newCollector();
+    final C firstCollector = collectorManager.newCollector();
     query = rewrite(query, firstCollector.scoreMode().needsScores());
     final Weight weight = createWeight(query, firstCollector.scoreMode(), 1);
-    search(weight, collectorOwner, firstCollector);
-    return collectorOwner.getResult();
+    return search(weight, collectorManager, firstCollector);
+  }
+
+  private <C extends Collector, T> T search(
+      Weight weight, CollectorManager<C, T> collectorManager, C firstCollector) throws IOException {
+    final LeafSlice[] leafSlices = getSlices();
+    if (leafSlices.length == 0) {
+      // there are no segments, nothing to offload to the executor, but we do need to call reduce to
+      // create some kind of empty result
+      assert leafContexts.isEmpty();
+      return collectorManager.reduce(Collections.singletonList(firstCollector));
+    } else {
+      final List<C> collectors = new ArrayList<>(leafSlices.length);
+      collectors.add(firstCollector);
+      final ScoreMode scoreMode = firstCollector.scoreMode();
+      for (int i = 1; i < leafSlices.length; ++i) {
+        final C collector = collectorManager.newCollector();
+        collectors.add(collector);
+        if (scoreMode != collector.scoreMode()) {
+          throw new IllegalStateException(
+              "CollectorManager does not always produce collectors with the same score mode");
+        }
+      }
+      final List<Callable<C>> listTasks = new ArrayList<>(leafSlices.length);
+      for (int i = 0; i < leafSlices.length; ++i) {
+        final LeafReaderContext[] leaves = leafSlices[i].leaves;
+        final C collector = collectors.get(i);
+        listTasks.add(
+            () -> {
+              search(Arrays.asList(leaves), weight, collector);
+              return collector;
+            });
+      }
+      List<C> results = taskExecutor.invokeAll(listTasks);
+      return collectorManager.reduce(results);
+    }
   }
 
   /**


### PR DESCRIPTION
Note that this results in some silly code duplication but it should fix the nightly benchmark regressions we're observing as a result of merging #13568. I think we should merge this, confirm the nightly benchmarks recover, and then work on reducing the code duplication by figuring out what the actual root cause of the regression is (since it's still not obvious to me).