### PR TITLE
Convert BKDConfig to a record

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene60/bkd/BKDWriter60.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene60/bkd/BKDWriter60.java
@@ -642,13 +642,13 @@ public class BKDWriter60 implements Closeable {
       throws IOException {
     assert docMaps == null || readers.size() == docMaps.size();
 
-    BKDMergeQueue queue = new BKDMergeQueue(config.bytesPerDim, readers.size());
+    BKDMergeQueue queue = new BKDMergeQueue(config.bytesPerDim(), readers.size());
 
     for (int i = 0; i < readers.size(); i++) {
       PointValues pointValues = readers.get(i);
-      assert pointValues.getNumDimensions() == config.numDims
-          && pointValues.getBytesPerDimension() == config.bytesPerDim
-          && pointValues.getNumIndexDimensions() == config.numIndexDims;
+      assert pointValues.getNumDimensions() == config.numDims()
+          && pointValues.getBytesPerDimension() == config.bytesPerDim()
+          && pointValues.getNumIndexDimensions() == config.numIndexDims();
       MergeState.DocMap docMap;
       if (docMaps == null) {
         docMap = null;

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextBKDWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextBKDWriter.java
@@ -144,28 +144,28 @@ final class SimpleTextBKDWriter implements Closeable {
     this.maxDoc = maxDoc;
     docsSeen = new FixedBitSet(maxDoc);
 
-    scratchDiff = new byte[config.bytesPerDim];
-    scratch1 = new byte[config.packedBytesLength];
-    scratch2 = new byte[config.packedBytesLength];
-    commonPrefixLengths = new int[config.numDims];
+    scratchDiff = new byte[config.bytesPerDim()];
+    scratch1 = new byte[config.packedBytesLength()];
+    scratch2 = new byte[config.packedBytesLength()];
+    commonPrefixLengths = new int[config.numDims()];
 
-    minPackedValue = new byte[config.packedIndexBytesLength];
-    maxPackedValue = new byte[config.packedIndexBytesLength];
+    minPackedValue = new byte[config.packedIndexBytesLength()];
+    maxPackedValue = new byte[config.packedIndexBytesLength()];
 
     // Maximum number of points we hold in memory at any time
     maxPointsSortInHeap =
-        (int) ((maxMBSortInHeap * 1024 * 1024) / (config.bytesPerDoc * config.numDims));
+        (int) ((maxMBSortInHeap * 1024 * 1024) / (config.bytesPerDoc() * config.numDims()));
 
     // Finally, we must be able to hold at least the leaf node in heap during build:
-    if (maxPointsSortInHeap < config.maxPointsInLeafNode) {
+    if (maxPointsSortInHeap < config.maxPointsInLeafNode()) {
       throw new IllegalArgumentException(
           "maxMBSortInHeap="
               + maxMBSortInHeap
               + " only allows for maxPointsSortInHeap="
               + maxPointsSortInHeap
-              + ", but this is less than config.maxPointsInLeafNode="
-              + config.maxPointsInLeafNode
-              + "; either increase maxMBSortInHeap or decrease config.maxPointsInLeafNode");
+              + ", but this is less than config.maxPointsInLeafNode()="
+              + config.maxPointsInLeafNode()
+              + "; either increase maxMBSortInHeap or decrease config.maxPointsInLeafNode()");
     }
 
     this.maxMBSortInHeap = maxMBSortInHeap;
@@ -183,10 +183,10 @@ final class SimpleTextBKDWriter implements Closeable {
   }
 
   public void add(byte[] packedValue, int docID) throws IOException {
-    if (packedValue.length != config.packedBytesLength) {
+    if (packedValue.length != config.packedBytesLength()) {
       throw new IllegalArgumentException(
           "packedValue should be length="
-              + config.packedBytesLength
+              + config.packedBytesLength()
               + " (got: "
               + packedValue.length
               + ")");
@@ -209,30 +209,30 @@ final class SimpleTextBKDWriter implements Closeable {
       } else {
         pointWriter = new HeapPointWriter(config, Math.toIntExact(totalPointCount));
       }
-      System.arraycopy(packedValue, 0, minPackedValue, 0, config.packedIndexBytesLength);
-      System.arraycopy(packedValue, 0, maxPackedValue, 0, config.packedIndexBytesLength);
+      System.arraycopy(packedValue, 0, minPackedValue, 0, config.packedIndexBytesLength());
+      System.arraycopy(packedValue, 0, maxPackedValue, 0, config.packedIndexBytesLength());
     } else {
-      for (int dim = 0; dim < config.numIndexDims; dim++) {
-        int offset = dim * config.bytesPerDim;
+      for (int dim = 0; dim < config.numIndexDims(); dim++) {
+        int offset = dim * config.bytesPerDim();
         if (Arrays.compareUnsigned(
                 packedValue,
                 offset,
-                offset + config.bytesPerDim,
+                offset + config.bytesPerDim(),
                 minPackedValue,
                 offset,
-                offset + config.bytesPerDim)
+                offset + config.bytesPerDim())
             < 0) {
-          System.arraycopy(packedValue, offset, minPackedValue, offset, config.bytesPerDim);
+          System.arraycopy(packedValue, offset, minPackedValue, offset, config.bytesPerDim());
         }
         if (Arrays.compareUnsigned(
                 packedValue,
                 offset,
-                offset + config.bytesPerDim,
+                offset + config.bytesPerDim(),
                 maxPackedValue,
                 offset,
-                offset + config.bytesPerDim)
+                offset + config.bytesPerDim())
             > 0) {
-          System.arraycopy(packedValue, offset, maxPackedValue, offset, config.bytesPerDim);
+          System.arraycopy(packedValue, offset, maxPackedValue, offset, config.bytesPerDim());
         }
       }
     }
@@ -254,7 +254,7 @@ final class SimpleTextBKDWriter implements Closeable {
    */
   public long writeField(IndexOutput out, String fieldName, MutablePointTree reader)
       throws IOException {
-    if (config.numIndexDims == 1) {
+    if (config.numIndexDims() == 1) {
       return writeField1Dim(out, fieldName, reader);
     } else {
       return writeFieldNDims(out, fieldName, reader);
@@ -280,7 +280,7 @@ final class SimpleTextBKDWriter implements Closeable {
     long countPerLeaf = pointCount = values.size();
     long innerNodeCount = 1;
 
-    while (countPerLeaf > config.maxPointsInLeafNode) {
+    while (countPerLeaf > config.maxPointsInLeafNode()) {
       countPerLeaf = (countPerLeaf + 1) / 2;
       innerNodeCount *= 2;
     }
@@ -289,7 +289,7 @@ final class SimpleTextBKDWriter implements Closeable {
 
     checkMaxLeafNodeCount(numLeaves);
 
-    final byte[] splitPackedValues = new byte[numLeaves * (config.bytesPerDim + 1)];
+    final byte[] splitPackedValues = new byte[numLeaves * (config.bytesPerDim() + 1)];
     final long[] leafBlockFPs = new long[numLeaves];
 
     // compute the min/max for this slice
@@ -297,37 +297,37 @@ final class SimpleTextBKDWriter implements Closeable {
     Arrays.fill(maxPackedValue, (byte) 0);
     for (int i = 0; i < Math.toIntExact(pointCount); ++i) {
       values.getValue(i, scratchBytesRef1);
-      for (int dim = 0; dim < config.numIndexDims; dim++) {
-        int offset = dim * config.bytesPerDim;
+      for (int dim = 0; dim < config.numIndexDims(); dim++) {
+        int offset = dim * config.bytesPerDim();
         if (Arrays.compareUnsigned(
                 scratchBytesRef1.bytes,
                 scratchBytesRef1.offset + offset,
-                scratchBytesRef1.offset + offset + config.bytesPerDim,
+                scratchBytesRef1.offset + offset + config.bytesPerDim(),
                 minPackedValue,
                 offset,
-                offset + config.bytesPerDim)
+                offset + config.bytesPerDim())
             < 0) {
           System.arraycopy(
               scratchBytesRef1.bytes,
               scratchBytesRef1.offset + offset,
               minPackedValue,
               offset,
-              config.bytesPerDim);
+              config.bytesPerDim());
         }
         if (Arrays.compareUnsigned(
                 scratchBytesRef1.bytes,
                 scratchBytesRef1.offset + offset,
-                scratchBytesRef1.offset + offset + config.bytesPerDim,
+                scratchBytesRef1.offset + offset + config.bytesPerDim(),
                 maxPackedValue,
                 offset,
-                offset + config.bytesPerDim)
+                offset + config.bytesPerDim())
             > 0) {
           System.arraycopy(
               scratchBytesRef1.bytes,
               scratchBytesRef1.offset + offset,
               maxPackedValue,
               offset,
-              config.bytesPerDim);
+              config.bytesPerDim());
         }
       }
 
@@ -345,7 +345,7 @@ final class SimpleTextBKDWriter implements Closeable {
         maxPackedValue,
         splitPackedValues,
         leafBlockFPs,
-        new int[config.maxPointsInLeafNode]);
+        new int[config.maxPointsInLeafNode()]);
 
     long indexFP = out.getFilePointer();
     writeIndex(out, leafBlockFPs, splitPackedValues, Math.toIntExact(countPerLeaf));
@@ -387,15 +387,15 @@ final class SimpleTextBKDWriter implements Closeable {
     final IndexOutput out;
     final List<Long> leafBlockFPs = new ArrayList<>();
     final List<byte[]> leafBlockStartValues = new ArrayList<>();
-    final byte[] leafValues = new byte[config.maxPointsInLeafNode * config.packedBytesLength];
-    final int[] leafDocs = new int[config.maxPointsInLeafNode];
+    final byte[] leafValues = new byte[config.maxPointsInLeafNode() * config.packedBytesLength()];
+    final int[] leafDocs = new int[config.maxPointsInLeafNode()];
     long valueCount;
     int leafCount;
 
     OneDimensionBKDWriter(IndexOutput out) {
-      if (config.numIndexDims != 1) {
+      if (config.numIndexDims() != 1) {
         throw new UnsupportedOperationException(
-            "config.numIndexDims must be 1 but got " + config.numIndexDims);
+            "config.numIndexDims() must be 1 but got " + config.numIndexDims());
       }
       if (pointCount != 0) {
         throw new IllegalStateException("cannot mix add and merge");
@@ -411,7 +411,7 @@ final class SimpleTextBKDWriter implements Closeable {
 
       this.out = out;
 
-      lastPackedValue = new byte[config.packedBytesLength];
+      lastPackedValue = new byte[config.packedBytesLength()];
     }
 
     // for asserts
@@ -426,8 +426,8 @@ final class SimpleTextBKDWriter implements Closeable {
           packedValue,
           0,
           leafValues,
-          leafCount * config.packedBytesLength,
-          config.packedBytesLength);
+          leafCount * config.packedBytesLength(),
+          config.packedBytesLength());
       leafDocs[leafCount] = docID;
       docsSeen.set(docID);
       leafCount++;
@@ -441,7 +441,7 @@ final class SimpleTextBKDWriter implements Closeable {
                 + " values");
       }
 
-      if (leafCount == config.maxPointsInLeafNode) {
+      if (leafCount == config.maxPointsInLeafNode()) {
         // We write a block once we hit exactly the max count ... this is different from
         // when we flush a new segment, where we write between max/2 and max per leaf block,
         // so merged segments will behave differently from newly flushed segments:
@@ -471,43 +471,44 @@ final class SimpleTextBKDWriter implements Closeable {
       // System.out.println("BKDW: now rotate numInnerNodes=" + numInnerNodes + " leafBlockStarts="
       // + leafBlockStartValues.size());
 
-      byte[] index = new byte[(1 + numInnerNodes) * (1 + config.bytesPerDim)];
+      byte[] index = new byte[(1 + numInnerNodes) * (1 + config.bytesPerDim())];
       rotateToTree(1, 0, numInnerNodes, index, leafBlockStartValues);
       long[] arr = new long[leafBlockFPs.size()];
       for (int i = 0; i < leafBlockFPs.size(); i++) {
         arr[i] = leafBlockFPs.get(i);
       }
-      writeIndex(out, arr, index, config.maxPointsInLeafNode);
+      writeIndex(out, arr, index, config.maxPointsInLeafNode());
       return indexFP;
     }
 
     private void writeLeafBlock() throws IOException {
       assert leafCount != 0;
       if (valueCount == 0) {
-        System.arraycopy(leafValues, 0, minPackedValue, 0, config.packedIndexBytesLength);
+        System.arraycopy(leafValues, 0, minPackedValue, 0, config.packedIndexBytesLength());
       }
       System.arraycopy(
           leafValues,
-          (leafCount - 1) * config.packedBytesLength,
+          (leafCount - 1) * config.packedBytesLength(),
           maxPackedValue,
           0,
-          config.packedIndexBytesLength);
+          config.packedIndexBytesLength());
 
       valueCount += leafCount;
 
       if (leafBlockFPs.size() > 0) {
         // Save the first (minimum) value in each leaf block except the first, to build the split
         // value index in the end:
-        leafBlockStartValues.add(ArrayUtil.copyOfSubArray(leafValues, 0, config.packedBytesLength));
+        leafBlockStartValues.add(
+            ArrayUtil.copyOfSubArray(leafValues, 0, config.packedBytesLength()));
       }
       leafBlockFPs.add(out.getFilePointer());
       checkMaxLeafNodeCount(leafBlockFPs.size());
 
-      Arrays.fill(commonPrefixLengths, config.bytesPerDim);
+      Arrays.fill(commonPrefixLengths, config.bytesPerDim());
       // Find per-dim common prefix:
-      for (int dim = 0; dim < config.numDims; dim++) {
-        int offset1 = dim * config.bytesPerDim;
-        int offset2 = (leafCount - 1) * config.packedBytesLength + offset1;
+      for (int dim = 0; dim < config.numDims(); dim++) {
+        int offset1 = dim * config.bytesPerDim();
+        int offset2 = (leafCount - 1) * config.packedBytesLength() + offset1;
         for (int j = 0; j < commonPrefixLengths[dim]; j++) {
           if (leafValues[offset1 + j] != leafValues[offset2 + j]) {
             commonPrefixLengths[dim] = j;
@@ -523,24 +524,24 @@ final class SimpleTextBKDWriter implements Closeable {
             final BytesRef scratch = new BytesRef();
 
             {
-              scratch.length = config.packedBytesLength;
+              scratch.length = config.packedBytesLength();
               scratch.bytes = leafValues;
             }
 
             @Override
             public BytesRef apply(int i) {
-              scratch.offset = config.packedBytesLength * i;
+              scratch.offset = config.packedBytesLength() * i;
               return scratch;
             }
           };
       assert valuesInOrderAndBounds(
           leafCount,
           0,
-          ArrayUtil.copyOfSubArray(leafValues, 0, config.packedBytesLength),
+          ArrayUtil.copyOfSubArray(leafValues, 0, config.packedBytesLength()),
           ArrayUtil.copyOfSubArray(
               leafValues,
-              (leafCount - 1) * config.packedBytesLength,
-              leafCount * config.packedBytesLength),
+              (leafCount - 1) * config.packedBytesLength(),
+              leafCount * config.packedBytesLength()),
           packedValues,
           leafDocs,
           0);
@@ -552,7 +553,7 @@ final class SimpleTextBKDWriter implements Closeable {
   private void rotateToTree(
       int nodeID, int offset, int count, byte[] index, List<byte[]> leafBlockStartValues) {
     // System.out.println("ROTATE: nodeID=" + nodeID + " offset=" + offset + " count=" + count + "
-    // bpd=" + config.bytesPerDim + " index.length=" + index.length);
+    // bpd=" + config.bytesPerDim() + " index.length=" + index.length);
     if (count == 1) {
       // Leaf index node
       // System.out.println("  leaf index node");
@@ -561,8 +562,8 @@ final class SimpleTextBKDWriter implements Closeable {
           leafBlockStartValues.get(offset),
           0,
           index,
-          nodeID * (1 + config.bytesPerDim) + 1,
-          config.bytesPerDim);
+          nodeID * (1 + config.bytesPerDim()) + 1,
+          config.bytesPerDim());
     } else if (count > 1) {
       // Internal index node: binary partition of count
       int countAtLevel = 1;
@@ -587,8 +588,8 @@ final class SimpleTextBKDWriter implements Closeable {
               leafBlockStartValues.get(rootOffset),
               0,
               index,
-              nodeID * (1 + config.bytesPerDim) + 1,
-              config.bytesPerDim);
+              nodeID * (1 + config.bytesPerDim()) + 1,
+              config.bytesPerDim());
           // System.out.println("  index[" + nodeID + "] = blockStartValues[" + rootOffset + "]");
 
           // TODO: we could optimize/specialize, when we know it's simply fully balanced binary tree
@@ -611,10 +612,10 @@ final class SimpleTextBKDWriter implements Closeable {
   }
 
   private void checkMaxLeafNodeCount(int numLeaves) {
-    if ((1 + config.bytesPerDim) * (long) numLeaves > ArrayUtil.MAX_ARRAY_LENGTH) {
+    if ((1 + config.bytesPerDim()) * (long) numLeaves > ArrayUtil.MAX_ARRAY_LENGTH) {
       throw new IllegalStateException(
-          "too many nodes; increase config.maxPointsInLeafNode (currently "
-              + config.maxPointsInLeafNode
+          "too many nodes; increase config.maxPointsInLeafNode() (currently "
+              + config.maxPointsInLeafNode()
               + ") and reindex");
     }
   }
@@ -652,7 +653,7 @@ final class SimpleTextBKDWriter implements Closeable {
     long countPerLeaf = pointCount;
     long innerNodeCount = 1;
 
-    while (countPerLeaf > config.maxPointsInLeafNode) {
+    while (countPerLeaf > config.maxPointsInLeafNode()) {
       countPerLeaf = (countPerLeaf + 1) / 2;
       innerNodeCount *= 2;
     }
@@ -667,20 +668,20 @@ final class SimpleTextBKDWriter implements Closeable {
 
     // Indexed by nodeID, but first (root) nodeID is 1.  We do 1+ because the lead byte at each
     // recursion says which dim we split on.
-    byte[] splitPackedValues = new byte[Math.multiplyExact(numLeaves, 1 + config.bytesPerDim)];
+    byte[] splitPackedValues = new byte[Math.multiplyExact(numLeaves, 1 + config.bytesPerDim())];
 
     // +1 because leaf count is power of 2 (e.g. 8), and innerNodeCount is power of 2 minus 1 (e.g.
     // 7)
     long[] leafBlockFPs = new long[numLeaves];
 
     // Make sure the math above "worked":
-    assert pointCount / numLeaves <= config.maxPointsInLeafNode
+    assert pointCount / numLeaves <= config.maxPointsInLeafNode()
         : "pointCount="
             + pointCount
             + " numLeaves="
             + numLeaves
-            + " config.maxPointsInLeafNode="
-            + config.maxPointsInLeafNode;
+            + " config.maxPointsInLeafNode()="
+            + config.maxPointsInLeafNode();
 
     // We re-use the selector so we do not need to create an object every time.
     BKDRadixSelector radixSelector =
@@ -699,7 +700,7 @@ final class SimpleTextBKDWriter implements Closeable {
           maxPackedValue,
           splitPackedValues,
           leafBlockFPs,
-          new int[config.maxPointsInLeafNode]);
+          new int[config.maxPointsInLeafNode()]);
 
       // If no exception, we should have cleaned everything up:
       assert tempDir.getCreatedFiles().isEmpty();
@@ -724,15 +725,15 @@ final class SimpleTextBKDWriter implements Closeable {
       IndexOutput out, long[] leafBlockFPs, byte[] splitPackedValues, int maxPointsInLeafNode)
       throws IOException {
     write(out, NUM_DATA_DIMS);
-    writeInt(out, config.numDims);
+    writeInt(out, config.numDims());
     newline(out);
 
     write(out, NUM_INDEX_DIMS);
-    writeInt(out, config.numIndexDims);
+    writeInt(out, config.numIndexDims());
     newline(out);
 
     write(out, BYTES_PER_DIM);
-    writeInt(out, config.bytesPerDim);
+    writeInt(out, config.bytesPerDim());
     newline(out);
 
     write(out, MAX_LEAF_POINTS);
@@ -767,8 +768,8 @@ final class SimpleTextBKDWriter implements Closeable {
       newline(out);
     }
 
-    assert (splitPackedValues.length % (1 + config.bytesPerDim)) == 0;
-    int count = splitPackedValues.length / (1 + config.bytesPerDim);
+    assert (splitPackedValues.length % (1 + config.bytesPerDim())) == 0;
+    int count = splitPackedValues.length / (1 + config.bytesPerDim());
     assert count == leafBlockFPs.length;
 
     write(out, SPLIT_COUNT);
@@ -777,10 +778,12 @@ final class SimpleTextBKDWriter implements Closeable {
 
     for (int i = 0; i < count; i++) {
       write(out, SPLIT_DIM);
-      writeInt(out, splitPackedValues[i * (1 + config.bytesPerDim)] & 0xff);
+      writeInt(out, splitPackedValues[i * (1 + config.bytesPerDim())] & 0xff);
       newline(out);
       write(out, SPLIT_VALUE);
-      br = new BytesRef(splitPackedValues, 1 + (i * (1 + config.bytesPerDim)), config.bytesPerDim);
+      br =
+          new BytesRef(
+              splitPackedValues, 1 + (i * (1 + config.bytesPerDim())), config.bytesPerDim());
       write(out, br.toString());
       newline(out);
     }
@@ -852,25 +855,25 @@ final class SimpleTextBKDWriter implements Closeable {
   /** Called only in assert */
   private boolean valueInBounds(
       BytesRef packedValue, byte[] minPackedValue, byte[] maxPackedValue) {
-    for (int dim = 0; dim < config.numIndexDims; dim++) {
-      int offset = config.bytesPerDim * dim;
+    for (int dim = 0; dim < config.numIndexDims(); dim++) {
+      int offset = config.bytesPerDim() * dim;
       if (Arrays.compareUnsigned(
               packedValue.bytes,
               packedValue.offset + offset,
-              packedValue.offset + offset + config.bytesPerDim,
+              packedValue.offset + offset + config.bytesPerDim(),
               minPackedValue,
               offset,
-              offset + config.bytesPerDim)
+              offset + config.bytesPerDim())
           < 0) {
         return false;
       }
       if (Arrays.compareUnsigned(
               packedValue.bytes,
               packedValue.offset + offset,
-              packedValue.offset + offset + config.bytesPerDim,
+              packedValue.offset + offset + config.bytesPerDim(),
               maxPackedValue,
               offset,
-              offset + config.bytesPerDim)
+              offset + config.bytesPerDim())
           > 0) {
         return false;
       }
@@ -882,13 +885,13 @@ final class SimpleTextBKDWriter implements Closeable {
   protected int split(byte[] minPackedValue, byte[] maxPackedValue) {
     // Find which dim has the largest span so we can split on it:
     int splitDim = -1;
-    for (int dim = 0; dim < config.numIndexDims; dim++) {
-      NumericUtils.subtract(config.bytesPerDim, dim, maxPackedValue, minPackedValue, scratchDiff);
+    for (int dim = 0; dim < config.numIndexDims(); dim++) {
+      NumericUtils.subtract(config.bytesPerDim(), dim, maxPackedValue, minPackedValue, scratchDiff);
       if (splitDim == -1
           || Arrays.compareUnsigned(
-                  scratchDiff, 0, config.bytesPerDim, scratch1, 0, config.bytesPerDim)
+                  scratchDiff, 0, config.bytesPerDim(), scratch1, 0, config.bytesPerDim())
               > 0) {
-        System.arraycopy(scratchDiff, 0, scratch1, 0, config.bytesPerDim);
+        System.arraycopy(scratchDiff, 0, scratch1, 0, config.bytesPerDim());
         splitDim = dim;
       }
     }
@@ -931,15 +934,15 @@ final class SimpleTextBKDWriter implements Closeable {
     if (nodeID >= leafNodeOffset) {
       // leaf node
       final int count = to - from;
-      assert count <= config.maxPointsInLeafNode;
+      assert count <= config.maxPointsInLeafNode();
 
       // Compute common prefixes
-      Arrays.fill(commonPrefixLengths, config.bytesPerDim);
+      Arrays.fill(commonPrefixLengths, config.bytesPerDim());
       reader.getValue(from, scratchBytesRef1);
       for (int i = from + 1; i < to; ++i) {
         reader.getValue(i, scratchBytesRef2);
-        for (int dim = 0; dim < config.numDims; dim++) {
-          final int offset = dim * config.bytesPerDim;
+        for (int dim = 0; dim < config.numDims(); dim++) {
+          final int offset = dim * config.bytesPerDim();
           for (int j = 0; j < commonPrefixLengths[dim]; j++) {
             if (scratchBytesRef1.bytes[scratchBytesRef1.offset + offset + j]
                 != scratchBytesRef2.bytes[scratchBytesRef2.offset + offset + j]) {
@@ -951,23 +954,23 @@ final class SimpleTextBKDWriter implements Closeable {
       }
 
       // Find the dimension that has the least number of unique bytes at commonPrefixLengths[dim]
-      FixedBitSet[] usedBytes = new FixedBitSet[config.numDims];
-      for (int dim = 0; dim < config.numDims; ++dim) {
-        if (commonPrefixLengths[dim] < config.bytesPerDim) {
+      FixedBitSet[] usedBytes = new FixedBitSet[config.numDims()];
+      for (int dim = 0; dim < config.numDims(); ++dim) {
+        if (commonPrefixLengths[dim] < config.bytesPerDim()) {
           usedBytes[dim] = new FixedBitSet(256);
         }
       }
       for (int i = from + 1; i < to; ++i) {
-        for (int dim = 0; dim < config.numDims; dim++) {
+        for (int dim = 0; dim < config.numDims(); dim++) {
           if (usedBytes[dim] != null) {
-            byte b = reader.getByteAt(i, dim * config.bytesPerDim + commonPrefixLengths[dim]);
+            byte b = reader.getByteAt(i, dim * config.bytesPerDim() + commonPrefixLengths[dim]);
             usedBytes[dim].set(Byte.toUnsignedInt(b));
           }
         }
       }
       int sortedDim = 0;
       int sortedDimCardinality = Integer.MAX_VALUE;
-      for (int dim = 0; dim < config.numDims; ++dim) {
+      for (int dim = 0; dim < config.numDims(); ++dim) {
         if (usedBytes[dim] != null) {
           final int cardinality = usedBytes[dim].cardinality();
           if (cardinality < sortedDimCardinality) {
@@ -1001,7 +1004,7 @@ final class SimpleTextBKDWriter implements Closeable {
       // Write the common prefixes:
       reader.getValue(from, scratchBytesRef1);
       System.arraycopy(
-          scratchBytesRef1.bytes, scratchBytesRef1.offset, scratch1, 0, config.packedBytesLength);
+          scratchBytesRef1.bytes, scratchBytesRef1.offset, scratch1, 0, config.packedBytesLength());
 
       // Write the full values:
       IntFunction<BytesRef> packedValues =
@@ -1023,10 +1026,10 @@ final class SimpleTextBKDWriter implements Closeable {
       final int splitDim = split(minPackedValue, maxPackedValue);
       final int mid = (from + to + 1) >>> 1;
 
-      int commonPrefixLen = config.bytesPerDim;
-      for (int i = 0; i < config.bytesPerDim; ++i) {
-        if (minPackedValue[splitDim * config.bytesPerDim + i]
-            != maxPackedValue[splitDim * config.bytesPerDim + i]) {
+      int commonPrefixLen = config.bytesPerDim();
+      for (int i = 0; i < config.bytesPerDim(); ++i) {
+        if (minPackedValue[splitDim * config.bytesPerDim() + i]
+            != maxPackedValue[splitDim * config.bytesPerDim() + i]) {
           commonPrefixLen = i;
           break;
         }
@@ -1044,32 +1047,32 @@ final class SimpleTextBKDWriter implements Closeable {
           scratchBytesRef2);
 
       // set the split value
-      final int address = nodeID * (1 + config.bytesPerDim);
+      final int address = nodeID * (1 + config.bytesPerDim());
       splitPackedValues[address] = (byte) splitDim;
       reader.getValue(mid, scratchBytesRef1);
       System.arraycopy(
           scratchBytesRef1.bytes,
-          scratchBytesRef1.offset + splitDim * config.bytesPerDim,
+          scratchBytesRef1.offset + splitDim * config.bytesPerDim(),
           splitPackedValues,
           address + 1,
-          config.bytesPerDim);
+          config.bytesPerDim());
 
       byte[] minSplitPackedValue =
-          ArrayUtil.copyOfSubArray(minPackedValue, 0, config.packedIndexBytesLength);
+          ArrayUtil.copyOfSubArray(minPackedValue, 0, config.packedIndexBytesLength());
       byte[] maxSplitPackedValue =
-          ArrayUtil.copyOfSubArray(maxPackedValue, 0, config.packedIndexBytesLength);
+          ArrayUtil.copyOfSubArray(maxPackedValue, 0, config.packedIndexBytesLength());
       System.arraycopy(
           scratchBytesRef1.bytes,
-          scratchBytesRef1.offset + splitDim * config.bytesPerDim,
+          scratchBytesRef1.offset + splitDim * config.bytesPerDim(),
           minSplitPackedValue,
-          splitDim * config.bytesPerDim,
-          config.bytesPerDim);
+          splitDim * config.bytesPerDim(),
+          config.bytesPerDim());
       System.arraycopy(
           scratchBytesRef1.bytes,
-          scratchBytesRef1.offset + splitDim * config.bytesPerDim,
+          scratchBytesRef1.offset + splitDim * config.bytesPerDim(),
           maxSplitPackedValue,
-          splitDim * config.bytesPerDim,
-          config.bytesPerDim);
+          splitDim * config.bytesPerDim(),
+          config.bytesPerDim());
 
       // recurse
       build(
@@ -1137,17 +1140,17 @@ final class SimpleTextBKDWriter implements Closeable {
 
       int sortedDim = 0;
       int sortedDimCardinality = Integer.MAX_VALUE;
-      FixedBitSet[] usedBytes = new FixedBitSet[config.numDims];
-      for (int dim = 0; dim < config.numDims; ++dim) {
-        if (commonPrefixLengths[dim] < config.bytesPerDim) {
+      FixedBitSet[] usedBytes = new FixedBitSet[config.numDims()];
+      for (int dim = 0; dim < config.numDims(); ++dim) {
+        if (commonPrefixLengths[dim] < config.bytesPerDim()) {
           usedBytes[dim] = new FixedBitSet(256);
         }
       }
       // Find the dimension to compress
-      for (int dim = 0; dim < config.numDims; dim++) {
+      for (int dim = 0; dim < config.numDims(); dim++) {
         int prefix = commonPrefixLengths[dim];
-        if (prefix < config.bytesPerDim) {
-          int offset = dim * config.bytesPerDim;
+        if (prefix < config.bytesPerDim()) {
+          int offset = dim * config.bytesPerDim();
           for (int i = 0; i < heapSource.count(); ++i) {
             PointValue value = heapSource.getPackedValueSlice(i);
             BytesRef packedValue = value.packedValue();
@@ -1190,7 +1193,7 @@ final class SimpleTextBKDWriter implements Closeable {
             final BytesRef scratch = new BytesRef();
 
             {
-              scratch.length = config.packedBytesLength;
+              scratch.length = config.packedBytesLength();
             }
 
             @Override
@@ -1207,7 +1210,7 @@ final class SimpleTextBKDWriter implements Closeable {
       // Inner node: partition/recurse
 
       int splitDim;
-      if (config.numIndexDims > 1) {
+      if (config.numIndexDims() > 1) {
         splitDim = split(minPackedValue, maxPackedValue);
       } else {
         splitDim = 0;
@@ -1223,13 +1226,13 @@ final class SimpleTextBKDWriter implements Closeable {
       int commonPrefixLen =
           Arrays.mismatch(
               minPackedValue,
-              splitDim * config.bytesPerDim,
-              splitDim * config.bytesPerDim + config.bytesPerDim,
+              splitDim * config.bytesPerDim(),
+              splitDim * config.bytesPerDim() + config.bytesPerDim(),
               maxPackedValue,
-              splitDim * config.bytesPerDim,
-              splitDim * config.bytesPerDim + config.bytesPerDim);
+              splitDim * config.bytesPerDim(),
+              splitDim * config.bytesPerDim() + config.bytesPerDim());
       if (commonPrefixLen == -1) {
-        commonPrefixLen = config.bytesPerDim;
+        commonPrefixLen = config.bytesPerDim();
       }
 
       BKDRadixSelector.PathSlice[] pathSlices = new BKDRadixSelector.PathSlice[2];
@@ -1244,20 +1247,28 @@ final class SimpleTextBKDWriter implements Closeable {
               splitDim,
               commonPrefixLen);
 
-      int address = nodeID * (1 + config.bytesPerDim);
+      int address = nodeID * (1 + config.bytesPerDim());
       splitPackedValues[address] = (byte) splitDim;
-      System.arraycopy(splitValue, 0, splitPackedValues, address + 1, config.bytesPerDim);
+      System.arraycopy(splitValue, 0, splitPackedValues, address + 1, config.bytesPerDim());
 
-      byte[] minSplitPackedValue = new byte[config.packedIndexBytesLength];
-      System.arraycopy(minPackedValue, 0, minSplitPackedValue, 0, config.packedIndexBytesLength);
+      byte[] minSplitPackedValue = new byte[config.packedIndexBytesLength()];
+      System.arraycopy(minPackedValue, 0, minSplitPackedValue, 0, config.packedIndexBytesLength());
 
-      byte[] maxSplitPackedValue = new byte[config.packedIndexBytesLength];
-      System.arraycopy(maxPackedValue, 0, maxSplitPackedValue, 0, config.packedIndexBytesLength);
+      byte[] maxSplitPackedValue = new byte[config.packedIndexBytesLength()];
+      System.arraycopy(maxPackedValue, 0, maxSplitPackedValue, 0, config.packedIndexBytesLength());
 
       System.arraycopy(
-          splitValue, 0, minSplitPackedValue, splitDim * config.bytesPerDim, config.bytesPerDim);
+          splitValue,
+          0,
+          minSplitPackedValue,
+          splitDim * config.bytesPerDim(),
+          config.bytesPerDim());
       System.arraycopy(
-          splitValue, 0, maxSplitPackedValue, splitDim * config.bytesPerDim, config.bytesPerDim);
+          splitValue,
+          0,
+          maxSplitPackedValue,
+          splitDim * config.bytesPerDim(),
+          config.bytesPerDim());
 
       // Recurse on left tree:
       build(
@@ -1289,30 +1300,30 @@ final class SimpleTextBKDWriter implements Closeable {
   }
 
   private void computeCommonPrefixLength(HeapPointWriter heapPointWriter, byte[] commonPrefix) {
-    Arrays.fill(commonPrefixLengths, config.bytesPerDim);
+    Arrays.fill(commonPrefixLengths, config.bytesPerDim());
     PointValue value = heapPointWriter.getPackedValueSlice(0);
     BytesRef packedValue = value.packedValue();
-    for (int dim = 0; dim < config.numDims; dim++) {
+    for (int dim = 0; dim < config.numDims(); dim++) {
       System.arraycopy(
           packedValue.bytes,
-          packedValue.offset + dim * config.bytesPerDim,
+          packedValue.offset + dim * config.bytesPerDim(),
           commonPrefix,
-          dim * config.bytesPerDim,
-          config.bytesPerDim);
+          dim * config.bytesPerDim(),
+          config.bytesPerDim());
     }
     for (int i = 1; i < heapPointWriter.count(); i++) {
       value = heapPointWriter.getPackedValueSlice(i);
       packedValue = value.packedValue();
-      for (int dim = 0; dim < config.numDims; dim++) {
+      for (int dim = 0; dim < config.numDims(); dim++) {
         if (commonPrefixLengths[dim] != 0) {
           int j =
               Arrays.mismatch(
                   commonPrefix,
-                  dim * config.bytesPerDim,
-                  dim * config.bytesPerDim + commonPrefixLengths[dim],
+                  dim * config.bytesPerDim(),
+                  dim * config.bytesPerDim() + commonPrefixLengths[dim],
                   packedValue.bytes,
-                  packedValue.offset + dim * config.bytesPerDim,
-                  packedValue.offset + dim * config.bytesPerDim + commonPrefixLengths[dim]);
+                  packedValue.offset + dim * config.bytesPerDim(),
+                  packedValue.offset + dim * config.bytesPerDim() + commonPrefixLengths[dim]);
           if (j != -1) {
             commonPrefixLengths[dim] = j;
           }
@@ -1331,11 +1342,11 @@ final class SimpleTextBKDWriter implements Closeable {
       int[] docs,
       int docsOffset)
       throws IOException {
-    byte[] lastPackedValue = new byte[config.packedBytesLength];
+    byte[] lastPackedValue = new byte[config.packedBytesLength()];
     int lastDoc = -1;
     for (int i = 0; i < count; i++) {
       BytesRef packedValue = values.apply(i);
-      assert packedValue.length == config.packedBytesLength;
+      assert packedValue.length == config.packedBytesLength();
       assert valueInOrder(
           i,
           sortedDim,
@@ -1361,43 +1372,43 @@ final class SimpleTextBKDWriter implements Closeable {
       int packedValueOffset,
       int doc,
       int lastDoc) {
-    int dimOffset = sortedDim * config.bytesPerDim;
+    int dimOffset = sortedDim * config.bytesPerDim();
     if (ord > 0) {
       int cmp =
           Arrays.compareUnsigned(
               lastPackedValue,
               dimOffset,
-              dimOffset + config.bytesPerDim,
+              dimOffset + config.bytesPerDim(),
               packedValue,
               packedValueOffset + dimOffset,
-              packedValueOffset + dimOffset + config.bytesPerDim);
+              packedValueOffset + dimOffset + config.bytesPerDim());
       if (cmp > 0) {
         throw new AssertionError(
             "values out of order: last value="
                 + new BytesRef(lastPackedValue)
                 + " current value="
-                + new BytesRef(packedValue, packedValueOffset, config.packedBytesLength)
+                + new BytesRef(packedValue, packedValueOffset, config.packedBytesLength())
                 + " ord="
                 + ord
                 + " sortedDim="
                 + sortedDim);
       }
-      if (cmp == 0 && config.numDims > config.numIndexDims) {
-        int dataOffset = config.numIndexDims * config.bytesPerDim;
+      if (cmp == 0 && config.numDims() > config.numIndexDims()) {
+        int dataOffset = config.numIndexDims() * config.bytesPerDim();
         cmp =
             Arrays.compareUnsigned(
                 lastPackedValue,
                 dataOffset,
-                config.packedBytesLength,
+                config.packedBytesLength(),
                 packedValue,
                 packedValueOffset + dataOffset,
-                packedValueOffset + config.packedBytesLength);
+                packedValueOffset + config.packedBytesLength());
         if (cmp > 0) {
           throw new AssertionError(
               "data values out of order: last value="
                   + new BytesRef(lastPackedValue)
                   + " current value="
-                  + new BytesRef(packedValue, packedValueOffset, config.packedBytesLength)
+                  + new BytesRef(packedValue, packedValueOffset, config.packedBytesLength())
                   + " ord="
                   + ord);
         }
@@ -1414,7 +1425,8 @@ final class SimpleTextBKDWriter implements Closeable {
                 + sortedDim);
       }
     }
-    System.arraycopy(packedValue, packedValueOffset, lastPackedValue, 0, config.packedBytesLength);
+    System.arraycopy(
+        packedValue, packedValueOffset, lastPackedValue, 0, config.packedBytesLength());
     return true;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDConfig.java
@@ -102,7 +102,7 @@ public record BKDConfig(
     }
     if (packedIndexBytesLength != numIndexDims * bytesPerDim) {
       throw new IllegalArgumentException(
-          "packedBytesLength must be "
+          "packedIndexBytesLength must be "
               + (numIndexDims * bytesPerDim)
               + " (got: "
               + packedIndexBytesLength

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDConfig.java
@@ -26,18 +26,8 @@ import org.apache.lucene.util.ArrayUtil;
  * @param numIndexDims How many dimensions we are indexing in the internal nodes
  * @param bytesPerDim How many bytes each value in each dimension takes.
  * @param maxPointsInLeafNode max points allowed on a Leaf block
- * @param packedBytesLength numDataDims * bytesPerDim
- * @param packedIndexBytesLength numIndexDims * bytesPerDim
- * @param bytesPerDoc (numDims * bytesPerDim) + Integer.BYTES (packedBytesLength plus docID size)
  */
-public record BKDConfig(
-    int numDims,
-    int numIndexDims,
-    int bytesPerDim,
-    int maxPointsInLeafNode,
-    int packedBytesLength,
-    int packedIndexBytesLength,
-    int bytesPerDoc) {
+public record BKDConfig(int numDims, int numIndexDims, int bytesPerDim, int maxPointsInLeafNode) {
 
   /** Default maximum number of point in each leaf block */
   public static final int DEFAULT_MAX_POINTS_IN_LEAF_NODE = 512;
@@ -47,22 +37,6 @@ public record BKDConfig(
 
   /** Maximum number of index dimensions */
   public static final int MAX_INDEX_DIMS = 8;
-
-  /** Constructor that populates the derived input parameters. */
-  public BKDConfig(
-      final int numDims,
-      final int numIndexDims,
-      final int bytesPerDim,
-      final int maxPointsInLeafNode) {
-    this(
-        numDims,
-        numIndexDims,
-        bytesPerDim,
-        maxPointsInLeafNode,
-        numDims * bytesPerDim,
-        numIndexDims * bytesPerDim,
-        numDims * bytesPerDim + Integer.BYTES);
-  }
 
   public BKDConfig {
     // Check inputs are on bounds
@@ -92,29 +66,20 @@ public record BKDConfig(
               + "); got "
               + maxPointsInLeafNode);
     }
-    if (packedBytesLength != numDims * bytesPerDim) {
-      throw new IllegalArgumentException(
-          "packedBytesLength must be "
-              + (numDims * bytesPerDim)
-              + " (got: "
-              + packedBytesLength
-              + ")");
-    }
-    if (packedIndexBytesLength != numIndexDims * bytesPerDim) {
-      throw new IllegalArgumentException(
-          "packedIndexBytesLength must be "
-              + (numIndexDims * bytesPerDim)
-              + " (got: "
-              + packedIndexBytesLength
-              + ")");
-    }
-    if (bytesPerDoc != packedBytesLength + Integer.BYTES) {
-      throw new IllegalArgumentException(
-          "bytesPerDoc must be "
-              + (packedBytesLength + Integer.BYTES)
-              + " (got: "
-              + bytesPerDoc
-              + ")");
-    }
+  }
+
+  /** numDims * bytesPerDim */
+  public int packedBytesLength() {
+    return numDims * bytesPerDim;
+  }
+
+  /** numIndexDims * bytesPerDim */
+  public int packedIndexBytesLength() {
+    return numIndexDims * bytesPerDim;
+  }
+
+  /** (numDims * bytesPerDim) + Integer.BYTES (packedBytesLength plus docID size) */
+  public int bytesPerDoc() {
+    return packedBytesLength() + Integer.BYTES;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDConfig.java
@@ -19,8 +19,25 @@ package org.apache.lucene.util.bkd;
 
 import org.apache.lucene.util.ArrayUtil;
 
-/** Basic parameters for indexing points on the BKD tree. */
-public final class BKDConfig {
+/**
+ * Basic parameters for indexing points on the BKD tree.
+ *
+ * @param numDims How many dimensions we are storing at the leaf (data) node
+ * @param numIndexDims How many dimensions we are indexing in the internal nodes
+ * @param bytesPerDim How many bytes each value in each dimension takes.
+ * @param maxPointsInLeafNode max points allowed on a Leaf block
+ * @param packedBytesLength numDataDims * bytesPerDim
+ * @param packedIndexBytesLength numIndexDims * bytesPerDim
+ * @param bytesPerDoc (numDims * bytesPerDim) + Integer.BYTES (packedBytesLength plus docID size)
+ */
+public record BKDConfig(
+    int numDims,
+    int numIndexDims,
+    int bytesPerDim,
+    int maxPointsInLeafNode,
+    int packedBytesLength,
+    int packedIndexBytesLength,
+    int bytesPerDoc) {
 
   /** Default maximum number of point in each leaf block */
   public static final int DEFAULT_MAX_POINTS_IN_LEAF_NODE = 512;
@@ -31,48 +48,23 @@ public final class BKDConfig {
   /** Maximum number of index dimensions */
   public static final int MAX_INDEX_DIMS = 8;
 
-  /** How many dimensions we are storing at the leaf (data) nodes */
-  public final int numDims;
-
-  /** How many dimensions we are indexing in the internal nodes */
-  public final int numIndexDims;
-
-  /** How many bytes each value in each dimension takes. */
-  public final int bytesPerDim;
-
-  /** max points allowed on a Leaf block */
-  public final int maxPointsInLeafNode;
-
-  /** numDataDims * bytesPerDim */
-  public final int packedBytesLength;
-
-  /** numIndexDims * bytesPerDim */
-  public final int packedIndexBytesLength;
-
-  /** packedBytesLength plus docID size */
-  public final int bytesPerDoc;
-
+  /** Constructor that populates the derived input parameters. */
   public BKDConfig(
       final int numDims,
       final int numIndexDims,
       final int bytesPerDim,
       final int maxPointsInLeafNode) {
-    verifyParams(numDims, numIndexDims, bytesPerDim, maxPointsInLeafNode);
-    this.numDims = numDims;
-    this.numIndexDims = numIndexDims;
-    this.bytesPerDim = bytesPerDim;
-    this.maxPointsInLeafNode = maxPointsInLeafNode;
-    this.packedIndexBytesLength = numIndexDims * bytesPerDim;
-    this.packedBytesLength = numDims * bytesPerDim;
-    // dimensional values (numDims * bytesPerDim) + docID (int)
-    this.bytesPerDoc = this.packedBytesLength + Integer.BYTES;
+    this(
+        numDims,
+        numIndexDims,
+        bytesPerDim,
+        maxPointsInLeafNode,
+        numDims * bytesPerDim,
+        numIndexDims * bytesPerDim,
+        numDims * bytesPerDim + Integer.BYTES);
   }
 
-  private static void verifyParams(
-      final int numDims,
-      final int numIndexDims,
-      final int bytesPerDim,
-      final int maxPointsInLeafNode) {
+  public BKDConfig {
     // Check inputs are on bounds
     if (numDims < 1 || numDims > MAX_DIMS) {
       throw new IllegalArgumentException(

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDConfig.java
@@ -92,5 +92,29 @@ public record BKDConfig(
               + "); got "
               + maxPointsInLeafNode);
     }
+    if (packedBytesLength != numDims * bytesPerDim) {
+      throw new IllegalArgumentException(
+          "packedBytesLength must be "
+              + (numDims * bytesPerDim)
+              + " (got: "
+              + packedBytesLength
+              + ")");
+    }
+    if (packedIndexBytesLength != numIndexDims * bytesPerDim) {
+      throw new IllegalArgumentException(
+          "packedBytesLength must be "
+              + (numIndexDims * bytesPerDim)
+              + " (got: "
+              + packedIndexBytesLength
+              + ")");
+    }
+    if (bytesPerDoc != packedBytesLength + Integer.BYTES) {
+      throw new IllegalArgumentException(
+          "bytesPerDoc must be "
+              + (packedBytesLength + Integer.BYTES)
+              + " (got: "
+              + bytesPerDoc
+              + ")");
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDRadixSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDRadixSelector.java
@@ -39,7 +39,7 @@ public final class BKDRadixSelector {
   private static final int MAX_SIZE_OFFLINE_BUFFER = 1024 * 8;
   // histogram array
   private final long[] histogram;
-  // number of bytes to be sorted: config.bytesPerDim + Integer.BYTES
+  // number of bytes to be sorted: config.bytesPerDim() + Integer.BYTES
   private final int bytesSorted;
   // flag to when we are moving to sort on heap
   private final int maxPointsSortInHeap;
@@ -69,11 +69,11 @@ public final class BKDRadixSelector {
     // equal
     // we tie-break on the docID. Here we account for all bytes used in the process.
     this.bytesSorted =
-        config.bytesPerDim
-            + (config.numDims - config.numIndexDims) * config.bytesPerDim
+        config.bytesPerDim()
+            + (config.numDims() - config.numIndexDims()) * config.bytesPerDim()
             + Integer.BYTES;
-    final int numberOfPointsOffline = MAX_SIZE_OFFLINE_BUFFER / config.bytesPerDoc;
-    this.offlineBuffer = new byte[numberOfPointsOffline * config.bytesPerDoc];
+    final int numberOfPointsOffline = MAX_SIZE_OFFLINE_BUFFER / config.bytesPerDoc();
+    this.offlineBuffer = new byte[numberOfPointsOffline * config.bytesPerDoc()];
     this.partitionBucket = new int[bytesSorted];
     this.histogram = new long[HISTOGRAM_SIZE];
     this.scratch = new byte[bytesSorted];
@@ -147,7 +147,7 @@ public final class BKDRadixSelector {
       throws IOException {
     // find common prefix
     int commonPrefixPosition = bytesSorted;
-    final int offset = dim * config.bytesPerDim;
+    final int offset = dim * config.bytesPerDim();
     try (OfflinePointReader reader = points.getReader(from, to - from, offlineBuffer)) {
       assert commonPrefixPosition > dimCommonPrefix;
       reader.next();
@@ -155,14 +155,18 @@ public final class BKDRadixSelector {
       BytesRef packedValueDocID = pointValue.packedValueDocIDBytes();
       // copy dimension
       System.arraycopy(
-          packedValueDocID.bytes, packedValueDocID.offset + offset, scratch, 0, config.bytesPerDim);
+          packedValueDocID.bytes,
+          packedValueDocID.offset + offset,
+          scratch,
+          0,
+          config.bytesPerDim());
       // copy data dimensions and docID
       System.arraycopy(
           packedValueDocID.bytes,
-          packedValueDocID.offset + config.packedIndexBytesLength,
+          packedValueDocID.offset + config.packedIndexBytesLength(),
           scratch,
-          config.bytesPerDim,
-          (config.numDims - config.numIndexDims) * config.bytesPerDim + Integer.BYTES);
+          config.bytesPerDim(),
+          (config.numDims() - config.numIndexDims()) * config.bytesPerDim() + Integer.BYTES);
 
       for (long i = from + 1; i < to; i++) {
         reader.next();
@@ -179,8 +183,8 @@ public final class BKDRadixSelector {
           break;
         } else {
           // Check common prefix and adjust histogram
-          final int startIndex = Math.min(dimCommonPrefix, config.bytesPerDim);
-          final int endIndex = Math.min(commonPrefixPosition, config.bytesPerDim);
+          final int startIndex = Math.min(dimCommonPrefix, config.bytesPerDim());
+          final int endIndex = Math.min(commonPrefixPosition, config.bytesPerDim());
           packedValueDocID = pointValue.packedValueDocIDBytes();
           int j =
               Arrays.mismatch(
@@ -191,20 +195,20 @@ public final class BKDRadixSelector {
                   packedValueDocID.offset + offset + startIndex,
                   packedValueDocID.offset + offset + endIndex);
           if (j == -1) {
-            if (commonPrefixPosition > config.bytesPerDim) {
+            if (commonPrefixPosition > config.bytesPerDim()) {
               // Tie-break on data dimensions + docID
-              final int startTieBreak = config.packedIndexBytesLength;
-              final int endTieBreak = startTieBreak + commonPrefixPosition - config.bytesPerDim;
+              final int startTieBreak = config.packedIndexBytesLength();
+              final int endTieBreak = startTieBreak + commonPrefixPosition - config.bytesPerDim();
               int k =
                   Arrays.mismatch(
                       scratch,
-                      config.bytesPerDim,
+                      config.bytesPerDim(),
                       commonPrefixPosition,
                       packedValueDocID.bytes,
                       packedValueDocID.offset + startTieBreak,
                       packedValueDocID.offset + endTieBreak);
               if (k != -1) {
-                commonPrefixPosition = config.bytesPerDim + k;
+                commonPrefixPosition = config.bytesPerDim() + k;
                 Arrays.fill(histogram, 0);
                 histogram[scratch[commonPrefixPosition] & 0xff] = i - from;
               }
@@ -230,7 +234,7 @@ public final class BKDRadixSelector {
 
   private int getBucket(int offset, int commonPrefixPosition, PointValue pointValue) {
     int bucket;
-    if (commonPrefixPosition < config.bytesPerDim) {
+    if (commonPrefixPosition < config.bytesPerDim()) {
       BytesRef packedValue = pointValue.packedValue();
       bucket = packedValue.bytes[packedValue.offset + offset + commonPrefixPosition] & 0xff;
     } else {
@@ -239,9 +243,9 @@ public final class BKDRadixSelector {
           packedValueDocID
                   .bytes[
                   packedValueDocID.offset
-                      + config.packedIndexBytesLength
+                      + config.packedIndexBytesLength()
                       + commonPrefixPosition
-                      - config.bytesPerDim]
+                      - config.bytesPerDim()]
               & 0xff;
     }
     return bucket;
@@ -341,7 +345,7 @@ public final class BKDRadixSelector {
       long numDocsTiebreak)
       throws IOException {
     assert bytePosition == bytesSorted - 1 || deltaPoints != null;
-    int offset = dim * config.bytesPerDim;
+    int offset = dim * config.bytesPerDim();
     long tiebreakCounter = 0;
     try (OfflinePointReader reader = points.getReader(from, to - from, offlineBuffer)) {
       while (reader.next()) {
@@ -372,8 +376,8 @@ public final class BKDRadixSelector {
   }
 
   private byte[] partitionPointFromCommonPrefix() {
-    byte[] partition = new byte[config.bytesPerDim];
-    for (int i = 0; i < config.bytesPerDim; i++) {
+    byte[] partition = new byte[config.bytesPerDim()];
+    for (int i = 0; i < config.bytesPerDim(); i++) {
       partition[i] = (byte) partitionBucket[i];
     }
     return partition;
@@ -408,9 +412,9 @@ public final class BKDRadixSelector {
       int to,
       int partitionPoint,
       int commonPrefixLength) {
-    final int dimOffset = dim * config.bytesPerDim + commonPrefixLength;
-    final int dimCmpBytes = config.bytesPerDim - commonPrefixLength;
-    final int dataOffset = config.packedIndexBytesLength - dimCmpBytes;
+    final int dimOffset = dim * config.bytesPerDim() + commonPrefixLength;
+    final int dimCmpBytes = config.bytesPerDim() - commonPrefixLength;
+    final int dataOffset = config.packedIndexBytesLength() - dimCmpBytes;
     new RadixSelector(bytesSorted - commonPrefixLength) {
 
       @Override
@@ -427,7 +431,7 @@ public final class BKDRadixSelector {
       @Override
       protected Selector getFallbackSelector(int d) {
         final int skypedBytes = d + commonPrefixLength;
-        final int dimStart = dim * config.bytesPerDim;
+        final int dimStart = dim * config.bytesPerDim();
         return new IntroSelector() {
 
           @Override
@@ -437,15 +441,15 @@ public final class BKDRadixSelector {
 
           @Override
           protected void setPivot(int i) {
-            if (skypedBytes < config.bytesPerDim) {
+            if (skypedBytes < config.bytesPerDim()) {
               points.copyDim(i, dimStart, scratch, 0);
             }
-            points.copyDataDimsAndDoc(i, scratch, config.bytesPerDim);
+            points.copyDataDimsAndDoc(i, scratch, config.bytesPerDim());
           }
 
           @Override
           protected int compare(int i, int j) {
-            if (skypedBytes < config.bytesPerDim) {
+            if (skypedBytes < config.bytesPerDim()) {
               int cmp = points.compareDim(i, j, dimStart);
               if (cmp != 0) {
                 return cmp;
@@ -456,36 +460,36 @@ public final class BKDRadixSelector {
 
           @Override
           protected int comparePivot(int j) {
-            if (skypedBytes < config.bytesPerDim) {
+            if (skypedBytes < config.bytesPerDim()) {
               int cmp = points.compareDim(j, scratch, 0, dimStart);
               if (cmp != 0) {
                 return cmp;
               }
             }
-            return points.compareDataDimsAndDoc(j, scratch, config.bytesPerDim);
+            return points.compareDataDimsAndDoc(j, scratch, config.bytesPerDim());
           }
         };
       }
     }.select(from, to, partitionPoint);
 
-    byte[] partition = new byte[config.bytesPerDim];
+    byte[] partition = new byte[config.bytesPerDim()];
     PointValue pointValue = points.getPackedValueSlice(partitionPoint);
     BytesRef packedValue = pointValue.packedValue();
     System.arraycopy(
         packedValue.bytes,
-        packedValue.offset + dim * config.bytesPerDim,
+        packedValue.offset + dim * config.bytesPerDim(),
         partition,
         0,
-        config.bytesPerDim);
+        config.bytesPerDim());
     return partition;
   }
 
   /** Sort the heap writer by the specified dim. It is used to sort the leaves of the tree */
   public void heapRadixSort(
       final HeapPointWriter points, int from, int to, int dim, int commonPrefixLength) {
-    final int dimOffset = dim * config.bytesPerDim + commonPrefixLength;
-    final int dimCmpBytes = config.bytesPerDim - commonPrefixLength;
-    final int dataOffset = config.packedIndexBytesLength - dimCmpBytes;
+    final int dimOffset = dim * config.bytesPerDim() + commonPrefixLength;
+    final int dimCmpBytes = config.bytesPerDim() - commonPrefixLength;
+    final int dataOffset = config.packedIndexBytesLength() - dimCmpBytes;
     new MSBRadixSorter(bytesSorted - commonPrefixLength) {
 
       @Override
@@ -502,7 +506,7 @@ public final class BKDRadixSelector {
       @Override
       protected Sorter getFallbackSorter(int k) {
         final int skypedBytes = k + commonPrefixLength;
-        final int dimStart = dim * config.bytesPerDim;
+        final int dimStart = dim * config.bytesPerDim();
         return new IntroSorter() {
 
           @Override
@@ -512,15 +516,15 @@ public final class BKDRadixSelector {
 
           @Override
           protected void setPivot(int i) {
-            if (skypedBytes < config.bytesPerDim) {
+            if (skypedBytes < config.bytesPerDim()) {
               points.copyDim(i, dimStart, scratch, 0);
             }
-            points.copyDataDimsAndDoc(i, scratch, config.bytesPerDim);
+            points.copyDataDimsAndDoc(i, scratch, config.bytesPerDim());
           }
 
           @Override
           protected int compare(int i, int j) {
-            if (skypedBytes < config.bytesPerDim) {
+            if (skypedBytes < config.bytesPerDim()) {
               final int cmp = points.compareDim(i, j, dimStart);
               if (cmp != 0) {
                 return cmp;
@@ -531,13 +535,13 @@ public final class BKDRadixSelector {
 
           @Override
           protected int comparePivot(int j) {
-            if (skypedBytes < config.bytesPerDim) {
+            if (skypedBytes < config.bytesPerDim()) {
               int cmp = points.compareDim(j, scratch, 0, dimStart);
               if (cmp != 0) {
                 return cmp;
               }
             }
-            return points.compareDataDimsAndDoc(j, scratch, config.bytesPerDim);
+            return points.compareDataDimsAndDoc(j, scratch, config.bytesPerDim());
           }
         };
       }

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -72,16 +72,19 @@ public class BKDReader extends PointValues {
     numLeaves = metaIn.readVInt();
     assert numLeaves > 0;
 
-    minPackedValue = new byte[config.packedIndexBytesLength];
-    maxPackedValue = new byte[config.packedIndexBytesLength];
+    minPackedValue = new byte[config.packedIndexBytesLength()];
+    maxPackedValue = new byte[config.packedIndexBytesLength()];
 
-    metaIn.readBytes(minPackedValue, 0, config.packedIndexBytesLength);
-    metaIn.readBytes(maxPackedValue, 0, config.packedIndexBytesLength);
+    metaIn.readBytes(minPackedValue, 0, config.packedIndexBytesLength());
+    metaIn.readBytes(maxPackedValue, 0, config.packedIndexBytesLength());
     final ArrayUtil.ByteArrayComparator comparator =
-        ArrayUtil.getUnsignedComparator(config.bytesPerDim);
-    for (int dim = 0; dim < config.numIndexDims; dim++) {
+        ArrayUtil.getUnsignedComparator(config.bytesPerDim());
+    for (int dim = 0; dim < config.numIndexDims(); dim++) {
       if (comparator.compare(
-              minPackedValue, dim * config.bytesPerDim, maxPackedValue, dim * config.bytesPerDim)
+              minPackedValue,
+              dim * config.bytesPerDim(),
+              maxPackedValue,
+              dim * config.bytesPerDim())
           > 0) {
         throw new CorruptIndexException(
             "minPackedValue "
@@ -118,7 +121,7 @@ public class BKDReader extends PointValues {
       // since lucene 8.6 all trees are unbalanced.
       return false;
     }
-    if (config.numDims > 1) {
+    if (config.numDims() > 1) {
       // high dimensional tree in pre-8.6 indices are balanced.
       assert 1 << MathUtil.log(numLeaves, 2) == numLeaves;
       return true;
@@ -128,7 +131,7 @@ public class BKDReader extends PointValues {
       return false;
     }
     // count of the last node for unbalanced trees
-    final int lastLeafNodePointCount = Math.toIntExact(pointCount % config.maxPointsInLeafNode);
+    final int lastLeafNodePointCount = Math.toIntExact(pointCount % config.maxPointsInLeafNode());
     // navigate to last node
     PointTree pointTree = getPointTree();
     do {
@@ -244,11 +247,11 @@ public class BKDReader extends PointValues {
           1,
           minPackedValue,
           maxPackedValue,
-          new BKDReaderDocIDSetIterator(config.maxPointsInLeafNode),
-          new byte[config.packedBytesLength],
-          new byte[config.packedIndexBytesLength],
-          new byte[config.packedIndexBytesLength],
-          new int[config.numDims],
+          new BKDReaderDocIDSetIterator(config.maxPointsInLeafNode()),
+          new byte[config.packedBytesLength()],
+          new byte[config.packedIndexBytesLength()],
+          new byte[config.packedIndexBytesLength()],
+          new int[config.numDims()],
           isTreeBalanced);
       // read root node
       readNodeData(false);
@@ -286,18 +289,18 @@ public class BKDReader extends PointValues {
       int treeDepth = getTreeDepth(numLeaves);
       splitDimValueStack = new byte[treeDepth][];
       splitValuesStack = new byte[treeDepth][];
-      splitValuesStack[0] = new byte[config.packedIndexBytesLength];
+      splitValuesStack[0] = new byte[config.packedIndexBytesLength()];
       leafBlockFPStack = new long[treeDepth + 1];
       readNodeDataPositions = new int[treeDepth + 1];
       rightNodePositions = new int[treeDepth];
       splitDimsPos = new int[treeDepth];
-      negativeDeltas = new boolean[config.numIndexDims * treeDepth];
+      negativeDeltas = new boolean[config.numIndexDims() * treeDepth];
       // information about the unbalance of the tree so we can report the exact size below a node
       this.pointCount = pointCount;
       rightMostLeafNode = (1 << treeDepth - 1) - 1;
-      int lastLeafNodePointCount = Math.toIntExact(pointCount % config.maxPointsInLeafNode);
+      int lastLeafNodePointCount = Math.toIntExact(pointCount % config.maxPointsInLeafNode());
       this.lastLeafNodePointCount =
-          lastLeafNodePointCount == 0 ? config.maxPointsInLeafNode : lastLeafNodePointCount;
+          lastLeafNodePointCount == 0 ? config.maxPointsInLeafNode() : lastLeafNodePointCount;
       // scratch objects, reused between clones so NN search are not creating those objects
       // in every clone.
       this.scratchIterator = scratchIterator;
@@ -336,10 +339,10 @@ public class BKDReader extends PointValues {
         index.splitValuesStack[index.level] = splitValuesStack[level].clone();
         System.arraycopy(
             negativeDeltas,
-            level * config.numIndexDims,
+            level * config.numIndexDims(),
             index.negativeDeltas,
-            level * config.numIndexDims,
-            config.numIndexDims);
+            level * config.numIndexDims(),
+            config.numIndexDims());
         index.splitDimsPos[level] = splitDimsPos[level];
       }
       return index;
@@ -375,25 +378,25 @@ public class BKDReader extends PointValues {
     private void pushBoundsLeft() {
       final int splitDimPos = splitDimsPos[level];
       if (splitDimValueStack[level] == null) {
-        splitDimValueStack[level] = new byte[config.bytesPerDim];
+        splitDimValueStack[level] = new byte[config.bytesPerDim()];
       }
       // save the dimension we are going to change
       System.arraycopy(
-          maxPackedValue, splitDimPos, splitDimValueStack[level], 0, config.bytesPerDim);
-      assert ArrayUtil.getUnsignedComparator(config.bytesPerDim)
+          maxPackedValue, splitDimPos, splitDimValueStack[level], 0, config.bytesPerDim());
+      assert ArrayUtil.getUnsignedComparator(config.bytesPerDim())
                   .compare(maxPackedValue, splitDimPos, splitValuesStack[level], splitDimPos)
               >= 0
-          : "config.bytesPerDim="
-              + config.bytesPerDim
+          : "config.bytesPerDim()="
+              + config.bytesPerDim()
               + " splitDimPos="
               + splitDimsPos[level]
-              + " config.numIndexDims="
-              + config.numIndexDims
-              + " config.numDims="
-              + config.numDims;
+              + " config.numIndexDims()="
+              + config.numIndexDims()
+              + " config.numDims()="
+              + config.numDims();
       // add the split dim value:
       System.arraycopy(
-          splitValuesStack[level], splitDimPos, maxPackedValue, splitDimPos, config.bytesPerDim);
+          splitValuesStack[level], splitDimPos, maxPackedValue, splitDimPos, config.bytesPerDim());
     }
 
     private void pushLeft() throws IOException {
@@ -408,21 +411,21 @@ public class BKDReader extends PointValues {
       assert splitDimValueStack[level] != null;
       // save the dimension we are going to change
       System.arraycopy(
-          minPackedValue, splitDimPos, splitDimValueStack[level], 0, config.bytesPerDim);
-      assert ArrayUtil.getUnsignedComparator(config.bytesPerDim)
+          minPackedValue, splitDimPos, splitDimValueStack[level], 0, config.bytesPerDim());
+      assert ArrayUtil.getUnsignedComparator(config.bytesPerDim())
                   .compare(minPackedValue, splitDimPos, splitValuesStack[level], splitDimPos)
               <= 0
-          : "config.bytesPerDim="
-              + config.bytesPerDim
+          : "config.bytesPerDim()="
+              + config.bytesPerDim()
               + " splitDimPos="
               + splitDimsPos[level]
-              + " config.numIndexDims="
-              + config.numIndexDims
-              + " config.numDims="
-              + config.numDims;
+              + " config.numIndexDims()="
+              + config.numIndexDims()
+              + " config.numDims()="
+              + config.numDims();
       // add the split dim value:
       System.arraycopy(
-          splitValuesStack[level], splitDimPos, minPackedValue, splitDimPos, config.bytesPerDim);
+          splitValuesStack[level], splitDimPos, minPackedValue, splitDimPos, config.bytesPerDim());
     }
 
     private void pushRight() throws IOException {
@@ -456,7 +459,7 @@ public class BKDReader extends PointValues {
     private void popBounds(byte[] packedValue) {
       // restore the split dimension
       System.arraycopy(
-          splitDimValueStack[level], 0, packedValue, splitDimsPos[level], config.bytesPerDim);
+          splitDimValueStack[level], 0, packedValue, splitDimsPos[level], config.bytesPerDim());
     }
 
     @Override
@@ -517,14 +520,14 @@ public class BKDReader extends PointValues {
       }
       // size for an unbalanced tree.
       return rightMostLeafNode == this.rightMostLeafNode
-          ? (long) (numLeaves - 1) * config.maxPointsInLeafNode + lastLeafNodePointCount
-          : (long) numLeaves * config.maxPointsInLeafNode;
+          ? (long) (numLeaves - 1) * config.maxPointsInLeafNode() + lastLeafNodePointCount
+          : (long) numLeaves * config.maxPointsInLeafNode();
     }
 
     private long sizeFromBalancedTree(int leftMostLeafNode, int rightMostLeafNode) {
       // number of points that need to be distributed between leaves, one per leaf
       final int extraPoints =
-          Math.toIntExact(((long) config.maxPointsInLeafNode * this.leafNodeOffset) - pointCount);
+          Math.toIntExact(((long) config.maxPointsInLeafNode() * this.leafNodeOffset) - pointCount);
       assert extraPoints < leafNodeOffset : "point excess should be lower than leafNodeOffset";
       // offset where we stop adding one point to the leaves
       final int nodeOffset = leafNodeOffset - extraPoints;
@@ -532,9 +535,9 @@ public class BKDReader extends PointValues {
       for (int node = leftMostLeafNode; node <= rightMostLeafNode; node++) {
         // offsetPosition provides which extra point will be added to this node
         if (balanceTreeNodePosition(0, leafNodeOffset, node - leafNodeOffset, 0, 0) < nodeOffset) {
-          count += config.maxPointsInLeafNode;
+          count += config.maxPointsInLeafNode();
         } else {
-          count += config.maxPointsInLeafNode - 1;
+          count += config.maxPointsInLeafNode() - 1;
         }
       }
       return count;
@@ -664,12 +667,12 @@ public class BKDReader extends PointValues {
       if (isLeafNode() == false) {
         System.arraycopy(
             negativeDeltas,
-            (level - 1) * config.numIndexDims,
+            (level - 1) * config.numIndexDims(),
             negativeDeltas,
-            level * config.numIndexDims,
-            config.numIndexDims);
+            level * config.numIndexDims(),
+            config.numIndexDims());
         negativeDeltas[
-                level * config.numIndexDims + (splitDimsPos[level - 1] / config.bytesPerDim)] =
+                level * config.numIndexDims() + (splitDimsPos[level - 1] / config.bytesPerDim())] =
             isLeft;
 
         if (splitValuesStack[level] == null) {
@@ -680,20 +683,20 @@ public class BKDReader extends PointValues {
               0,
               splitValuesStack[level],
               0,
-              config.packedIndexBytesLength);
+              config.packedIndexBytesLength());
         }
 
         // read split dim, prefix, firstDiffByteDelta encoded as int:
         int code = innerNodes.readVInt();
-        final int splitDim = code % config.numIndexDims;
-        splitDimsPos[level] = splitDim * config.bytesPerDim;
-        code /= config.numIndexDims;
-        final int prefix = code % (1 + config.bytesPerDim);
-        final int suffix = config.bytesPerDim - prefix;
+        final int splitDim = code % config.numIndexDims();
+        splitDimsPos[level] = splitDim * config.bytesPerDim();
+        code /= config.numIndexDims();
+        final int prefix = code % (1 + config.bytesPerDim());
+        final int suffix = config.bytesPerDim() - prefix;
 
         if (suffix > 0) {
-          int firstDiffByteDelta = code / (1 + config.bytesPerDim);
-          if (negativeDeltas[level * config.numIndexDims + splitDim]) {
+          int firstDiffByteDelta = code / (1 + config.bytesPerDim());
+          if (negativeDeltas[level * config.numIndexDims() + splitDim]) {
             firstDiffByteDelta = -firstDiffByteDelta;
           }
           final int startPos = splitDimsPos[level] + prefix;
@@ -737,13 +740,13 @@ public class BKDReader extends PointValues {
         PointValues.IntersectVisitor visitor)
         throws IOException {
       readCommonPrefixes(commonPrefixLengths, scratchDataPackedValue, in);
-      if (config.numIndexDims != 1 && version >= BKDWriter.VERSION_LEAF_STORES_BOUNDS) {
+      if (config.numIndexDims() != 1 && version >= BKDWriter.VERSION_LEAF_STORES_BOUNDS) {
         byte[] minPackedValue = scratchMinIndexPackedValue;
         System.arraycopy(
-            scratchDataPackedValue, 0, minPackedValue, 0, config.packedIndexBytesLength);
+            scratchDataPackedValue, 0, minPackedValue, 0, config.packedIndexBytesLength());
         byte[] maxPackedValue = scratchMaxIndexPackedValue;
         // Copy common prefixes before reading adjusted box
-        System.arraycopy(minPackedValue, 0, maxPackedValue, 0, config.packedIndexBytesLength);
+        System.arraycopy(minPackedValue, 0, maxPackedValue, 0, config.packedIndexBytesLength());
         readMinMax(commonPrefixLengths, minPackedValue, maxPackedValue, in);
 
         // The index gives us range of values for each dimension, but the actual range of values
@@ -801,13 +804,13 @@ public class BKDReader extends PointValues {
         visitor.grow(count);
         visitUniqueRawDocValues(scratchDataPackedValue, scratchIterator, count, visitor);
       } else {
-        if (config.numIndexDims != 1) {
+        if (config.numIndexDims() != 1) {
           byte[] minPackedValue = scratchMinIndexPackedValue;
           System.arraycopy(
-              scratchDataPackedValue, 0, minPackedValue, 0, config.packedIndexBytesLength);
+              scratchDataPackedValue, 0, minPackedValue, 0, config.packedIndexBytesLength());
           byte[] maxPackedValue = scratchMaxIndexPackedValue;
           // Copy common prefixes before reading adjusted box
-          System.arraycopy(minPackedValue, 0, maxPackedValue, 0, config.packedIndexBytesLength);
+          System.arraycopy(minPackedValue, 0, maxPackedValue, 0, config.packedIndexBytesLength());
           readMinMax(commonPrefixLengths, minPackedValue, maxPackedValue, in);
 
           // The index gives us range of values for each dimension, but the actual range of values
@@ -853,12 +856,12 @@ public class BKDReader extends PointValues {
     private void readMinMax(
         int[] commonPrefixLengths, byte[] minPackedValue, byte[] maxPackedValue, IndexInput in)
         throws IOException {
-      for (int dim = 0; dim < config.numIndexDims; dim++) {
+      for (int dim = 0; dim < config.numIndexDims(); dim++) {
         int prefix = commonPrefixLengths[dim];
         in.readBytes(
-            minPackedValue, dim * config.bytesPerDim + prefix, config.bytesPerDim - prefix);
+            minPackedValue, dim * config.bytesPerDim() + prefix, config.bytesPerDim() - prefix);
         in.readBytes(
-            maxPackedValue, dim * config.bytesPerDim + prefix, config.bytesPerDim - prefix);
+            maxPackedValue, dim * config.bytesPerDim() + prefix, config.bytesPerDim() - prefix);
       }
     }
 
@@ -874,10 +877,12 @@ public class BKDReader extends PointValues {
       int i;
       for (i = 0; i < count; ) {
         int length = in.readVInt();
-        for (int dim = 0; dim < config.numDims; dim++) {
+        for (int dim = 0; dim < config.numDims(); dim++) {
           int prefix = commonPrefixLengths[dim];
           in.readBytes(
-              scratchPackedValue, dim * config.bytesPerDim + prefix, config.bytesPerDim - prefix);
+              scratchPackedValue,
+              dim * config.bytesPerDim() + prefix,
+              config.bytesPerDim() - prefix);
         }
         scratchIterator.reset(i, length);
         visitor.visit(scratchIterator, scratchPackedValue);
@@ -912,17 +917,19 @@ public class BKDReader extends PointValues {
       // the byte at `compressedByteOffset` is compressed using run-length compression,
       // other suffix bytes are stored verbatim
       final int compressedByteOffset =
-          compressedDim * config.bytesPerDim + commonPrefixLengths[compressedDim];
+          compressedDim * config.bytesPerDim() + commonPrefixLengths[compressedDim];
       commonPrefixLengths[compressedDim]++;
       int i;
       for (i = 0; i < count; ) {
         scratchPackedValue[compressedByteOffset] = in.readByte();
         final int runLen = Byte.toUnsignedInt(in.readByte());
         for (int j = 0; j < runLen; ++j) {
-          for (int dim = 0; dim < config.numDims; dim++) {
+          for (int dim = 0; dim < config.numDims(); dim++) {
             int prefix = commonPrefixLengths[dim];
             in.readBytes(
-                scratchPackedValue, dim * config.bytesPerDim + prefix, config.bytesPerDim - prefix);
+                scratchPackedValue,
+                dim * config.bytesPerDim() + prefix,
+                config.bytesPerDim() - prefix);
           }
           visitor.visit(scratchIterator.docIDs[i + j], scratchPackedValue);
         }
@@ -937,7 +944,7 @@ public class BKDReader extends PointValues {
     private int readCompressedDim(IndexInput in) throws IOException {
       int compressedDim = in.readByte();
       if (compressedDim < -2
-          || compressedDim >= config.numDims
+          || compressedDim >= config.numDims()
           || (version < BKDWriter.VERSION_LOW_CARDINALITY_LEAVES && compressedDim == -2)) {
         throw new CorruptIndexException("Got compressedDim=" + compressedDim, in);
       }
@@ -946,11 +953,11 @@ public class BKDReader extends PointValues {
 
     private void readCommonPrefixes(
         int[] commonPrefixLengths, byte[] scratchPackedValue, IndexInput in) throws IOException {
-      for (int dim = 0; dim < config.numDims; dim++) {
+      for (int dim = 0; dim < config.numDims(); dim++) {
         int prefix = in.readVInt();
         commonPrefixLengths[dim] = prefix;
         if (prefix > 0) {
-          in.readBytes(scratchPackedValue, dim * config.bytesPerDim, prefix);
+          in.readBytes(scratchPackedValue, dim * config.bytesPerDim(), prefix);
         }
         // System.out.println("R: " + dim + " of " + numDims + " prefix=" + prefix);
       }
@@ -974,17 +981,17 @@ public class BKDReader extends PointValues {
 
   @Override
   public int getNumDimensions() throws IOException {
-    return config.numDims;
+    return config.numDims();
   }
 
   @Override
   public int getNumIndexDimensions() throws IOException {
-    return config.numIndexDims;
+    return config.numIndexDims();
   }
 
   @Override
   public int getBytesPerDimension() throws IOException {
-    return config.bytesPerDim;
+    return config.bytesPerDim();
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -60,19 +60,19 @@ import org.apache.lucene.util.bkd.BKDUtil.ByteArrayPredicate;
 /**
  * Recursively builds a block KD-tree to assign all incoming points in N-dim space to smaller and
  * smaller N-dim rectangles (cells) until the number of points in a given rectangle is &lt;= <code>
- * config.maxPointsInLeafNode</code>. The tree is partially balanced, which means the leaf nodes
- * will have the requested <code>config.maxPointsInLeafNode</code> except one that might have less.
- * Leaf nodes may straddle the two bottom levels of the binary tree. Values that fall exactly on a
- * cell boundary may be in either cell.
+ * config.maxPointsInLeafNode()</code>. The tree is partially balanced, which means the leaf nodes
+ * will have the requested <code>config.maxPointsInLeafNode()</code> except one that might have
+ * less. Leaf nodes may straddle the two bottom levels of the binary tree. Values that fall exactly
+ * on a cell boundary may be in either cell.
  *
  * <p>The number of dimensions can be 1 to 8, but every byte[] value is fixed length.
  *
  * <p>This consumes heap during writing: it allocates a <code>Long[numLeaves]</code>, a <code>
- * byte[numLeaves*(1+config.bytesPerDim)]</code> and then uses up to the specified {@code
+ * byte[numLeaves*(1+config.bytesPerDim())]</code> and then uses up to the specified {@code
  * maxMBSortInHeap} heap space for writing.
  *
- * <p><b>NOTE</b>: This can write at most Integer.MAX_VALUE * <code>config.maxPointsInLeafNode
- * </code> / config.bytesPerDim total points.
+ * <p><b>NOTE</b>: This can write at most Integer.MAX_VALUE * <code>config.maxPointsInLeafNode()
+ * </code> / config.bytesPerDim() total points.
  *
  * @lucene.experimental
  */
@@ -150,31 +150,31 @@ public class BKDWriter implements Closeable {
     this.maxDoc = maxDoc;
 
     this.config = config;
-    this.comparator = ArrayUtil.getUnsignedComparator(config.bytesPerDim);
-    this.equalsPredicate = BKDUtil.getEqualsPredicate(config.bytesPerDim);
-    this.commonPrefixComparator = BKDUtil.getPrefixLengthComparator(config.bytesPerDim);
+    this.comparator = ArrayUtil.getUnsignedComparator(config.bytesPerDim());
+    this.equalsPredicate = BKDUtil.getEqualsPredicate(config.bytesPerDim());
+    this.commonPrefixComparator = BKDUtil.getPrefixLengthComparator(config.bytesPerDim());
 
     docsSeen = new FixedBitSet(maxDoc);
 
-    scratchDiff = new byte[config.bytesPerDim];
-    scratch = new byte[config.packedBytesLength];
-    commonPrefixLengths = new int[config.numDims];
+    scratchDiff = new byte[config.bytesPerDim()];
+    scratch = new byte[config.packedBytesLength()];
+    commonPrefixLengths = new int[config.numDims()];
 
-    minPackedValue = new byte[config.packedIndexBytesLength];
-    maxPackedValue = new byte[config.packedIndexBytesLength];
+    minPackedValue = new byte[config.packedIndexBytesLength()];
+    maxPackedValue = new byte[config.packedIndexBytesLength()];
 
     // Maximum number of points we hold in memory at any time
-    maxPointsSortInHeap = (int) ((maxMBSortInHeap * 1024 * 1024) / (config.bytesPerDoc));
-    docIdsWriter = new DocIdsWriter(config.maxPointsInLeafNode);
+    maxPointsSortInHeap = (int) ((maxMBSortInHeap * 1024 * 1024) / (config.bytesPerDoc()));
+    docIdsWriter = new DocIdsWriter(config.maxPointsInLeafNode());
     // Finally, we must be able to hold at least the leaf node in heap during build:
-    if (maxPointsSortInHeap < config.maxPointsInLeafNode) {
+    if (maxPointsSortInHeap < config.maxPointsInLeafNode()) {
       throw new IllegalArgumentException(
           "maxMBSortInHeap="
               + maxMBSortInHeap
               + " only allows for maxPointsSortInHeap="
               + maxPointsSortInHeap
               + ", but this is less than maxPointsInLeafNode="
-              + config.maxPointsInLeafNode
+              + config.maxPointsInLeafNode()
               + "; "
               + "either increase maxMBSortInHeap or decrease maxPointsInLeafNode");
     }
@@ -204,10 +204,10 @@ public class BKDWriter implements Closeable {
   }
 
   public void add(byte[] packedValue, int docID) throws IOException {
-    if (packedValue.length != config.packedBytesLength) {
+    if (packedValue.length != config.packedBytesLength()) {
       throw new IllegalArgumentException(
           "packedValue should be length="
-              + config.packedBytesLength
+              + config.packedBytesLength()
               + " (got: "
               + packedValue.length
               + ")");
@@ -222,15 +222,15 @@ public class BKDWriter implements Closeable {
     }
     if (pointCount == 0) {
       initPointWriter();
-      System.arraycopy(packedValue, 0, minPackedValue, 0, config.packedIndexBytesLength);
-      System.arraycopy(packedValue, 0, maxPackedValue, 0, config.packedIndexBytesLength);
+      System.arraycopy(packedValue, 0, minPackedValue, 0, config.packedIndexBytesLength());
+      System.arraycopy(packedValue, 0, maxPackedValue, 0, config.packedIndexBytesLength());
     } else {
-      for (int dim = 0; dim < config.numIndexDims; dim++) {
-        int offset = dim * config.bytesPerDim;
+      for (int dim = 0; dim < config.numIndexDims(); dim++) {
+        int offset = dim * config.bytesPerDim();
         if (comparator.compare(packedValue, offset, minPackedValue, offset) < 0) {
-          System.arraycopy(packedValue, offset, minPackedValue, offset, config.bytesPerDim);
+          System.arraycopy(packedValue, offset, minPackedValue, offset, config.bytesPerDim());
         } else if (comparator.compare(packedValue, offset, maxPackedValue, offset) > 0) {
-          System.arraycopy(packedValue, offset, maxPackedValue, offset, config.bytesPerDim);
+          System.arraycopy(packedValue, offset, maxPackedValue, offset, config.bytesPerDim());
         }
       }
     }
@@ -431,7 +431,7 @@ public class BKDWriter implements Closeable {
       String fieldName,
       MutablePointTree reader)
       throws IOException {
-    if (config.numDims == 1) {
+    if (config.numDims() == 1) {
       return writeField1Dim(metaOut, indexOut, dataOut, fieldName, reader);
     } else {
       return writeFieldNDims(metaOut, indexOut, dataOut, fieldName, reader);
@@ -450,14 +450,14 @@ public class BKDWriter implements Closeable {
     }
     values.getValue(from, scratch);
     System.arraycopy(
-        scratch.bytes, scratch.offset, minPackedValue, 0, config.packedIndexBytesLength);
+        scratch.bytes, scratch.offset, minPackedValue, 0, config.packedIndexBytesLength());
     System.arraycopy(
-        scratch.bytes, scratch.offset, maxPackedValue, 0, config.packedIndexBytesLength);
+        scratch.bytes, scratch.offset, maxPackedValue, 0, config.packedIndexBytesLength());
     for (int i = from + 1; i < to; ++i) {
       values.getValue(i, scratch);
-      for (int dim = 0; dim < config.numIndexDims; dim++) {
-        final int startOffset = dim * config.bytesPerDim;
-        final int endOffset = startOffset + config.bytesPerDim;
+      for (int dim = 0; dim < config.numIndexDims(); dim++) {
+        final int startOffset = dim * config.bytesPerDim();
+        final int endOffset = startOffset + config.bytesPerDim();
         if (Arrays.compareUnsigned(
                 scratch.bytes,
                 scratch.offset + startOffset,
@@ -471,7 +471,7 @@ public class BKDWriter implements Closeable {
               scratch.offset + startOffset,
               minPackedValue,
               startOffset,
-              config.bytesPerDim);
+              config.bytesPerDim());
         } else if (Arrays.compareUnsigned(
                 scratch.bytes,
                 scratch.offset + startOffset,
@@ -485,7 +485,7 @@ public class BKDWriter implements Closeable {
               scratch.offset + startOffset,
               maxPackedValue,
               startOffset,
-              config.bytesPerDim);
+              config.bytesPerDim());
         }
       }
     }
@@ -519,12 +519,13 @@ public class BKDWriter implements Closeable {
     }
 
     final int numLeaves =
-        Math.toIntExact((pointCount + config.maxPointsInLeafNode - 1) / config.maxPointsInLeafNode);
+        Math.toIntExact(
+            (pointCount + config.maxPointsInLeafNode() - 1) / config.maxPointsInLeafNode());
     final int numSplits = numLeaves - 1;
 
     checkMaxLeafNodeCount(numLeaves);
 
-    final byte[] splitPackedValues = new byte[Math.multiplyExact(numSplits, config.bytesPerDim)];
+    final byte[] splitPackedValues = new byte[Math.multiplyExact(numSplits, config.bytesPerDim())];
     final byte[] splitDimensionValues = new byte[numSplits];
     final long[] leafBlockFPs = new long[numLeaves];
 
@@ -536,7 +537,7 @@ public class BKDWriter implements Closeable {
     }
 
     final long dataStartFP = dataOut.getFilePointer();
-    final int[] parentSplits = new int[config.numIndexDims];
+    final int[] parentSplits = new int[config.numIndexDims()];
     build(
         0,
         numLeaves,
@@ -550,10 +551,10 @@ public class BKDWriter implements Closeable {
         splitPackedValues,
         splitDimensionValues,
         leafBlockFPs,
-        new int[config.maxPointsInLeafNode]);
-    assert Arrays.equals(parentSplits, new int[config.numIndexDims]);
+        new int[config.maxPointsInLeafNode()]);
+    assert Arrays.equals(parentSplits, new int[config.numIndexDims()]);
 
-    scratchBytesRef1.length = config.bytesPerDim;
+    scratchBytesRef1.length = config.bytesPerDim();
     scratchBytesRef1.bytes = splitPackedValues;
 
     return makeWriter(metaOut, indexOut, splitDimensionValues, leafBlockFPs, dataStartFP);
@@ -609,13 +610,13 @@ public class BKDWriter implements Closeable {
       throws IOException {
     assert docMaps == null || readers.size() == docMaps.size();
 
-    BKDMergeQueue queue = new BKDMergeQueue(config.bytesPerDim, readers.size());
+    BKDMergeQueue queue = new BKDMergeQueue(config.bytesPerDim(), readers.size());
 
     for (int i = 0; i < readers.size(); i++) {
       PointValues pointValues = readers.get(i);
-      assert pointValues.getNumDimensions() == config.numDims
-          && pointValues.getBytesPerDimension() == config.bytesPerDim
-          && pointValues.getNumIndexDimensions() == config.numIndexDims;
+      assert pointValues.getNumDimensions() == config.numDims()
+          && pointValues.getBytesPerDimension() == config.bytesPerDim()
+          && pointValues.getNumIndexDimensions() == config.numIndexDims();
       MergeState.DocMap docMap;
       if (docMaps == null) {
         docMap = null;
@@ -653,16 +654,16 @@ public class BKDWriter implements Closeable {
     final long dataStartFP;
     final LongArrayList leafBlockFPs = new LongArrayList();
     final List<byte[]> leafBlockStartValues = new ArrayList<>();
-    final byte[] leafValues = new byte[config.maxPointsInLeafNode * config.packedBytesLength];
-    final int[] leafDocs = new int[config.maxPointsInLeafNode];
+    final byte[] leafValues = new byte[config.maxPointsInLeafNode() * config.packedBytesLength()];
+    final int[] leafDocs = new int[config.maxPointsInLeafNode()];
     private long valueCount;
     private int leafCount;
     private int leafCardinality;
 
     OneDimensionBKDWriter(IndexOutput metaOut, IndexOutput indexOut, IndexOutput dataOut) {
-      if (config.numIndexDims != 1) {
+      if (config.numIndexDims() != 1) {
         throw new UnsupportedOperationException(
-            "config.numIndexDims must be 1 but got " + config.numIndexDims);
+            "config.numIndexDims() must be 1 but got " + config.numIndexDims());
       }
       if (pointCount != 0) {
         throw new IllegalStateException("cannot mix add and merge");
@@ -681,7 +682,7 @@ public class BKDWriter implements Closeable {
       this.dataOut = dataOut;
       this.dataStartFP = dataOut.getFilePointer();
 
-      lastPackedValue = new byte[config.packedBytesLength];
+      lastPackedValue = new byte[config.packedBytesLength()];
     }
 
     // for asserts
@@ -693,7 +694,8 @@ public class BKDWriter implements Closeable {
           config, valueCount + leafCount, 0, lastPackedValue, packedValue, 0, docID, lastDocID);
 
       if (leafCount == 0
-          || equalsPredicate.test(leafValues, (leafCount - 1) * config.bytesPerDim, packedValue, 0)
+          || equalsPredicate.test(
+                  leafValues, (leafCount - 1) * config.bytesPerDim(), packedValue, 0)
               == false) {
         leafCardinality++;
       }
@@ -701,8 +703,8 @@ public class BKDWriter implements Closeable {
           packedValue,
           0,
           leafValues,
-          leafCount * config.packedBytesLength,
-          config.packedBytesLength);
+          leafCount * config.packedBytesLength(),
+          config.packedBytesLength());
       leafDocs[leafCount] = docID;
       docsSeen.set(docID);
       leafCount++;
@@ -716,7 +718,7 @@ public class BKDWriter implements Closeable {
                 + " values");
       }
 
-      if (leafCount == config.maxPointsInLeafNode) {
+      if (leafCount == config.maxPointsInLeafNode()) {
         // We write a block once we hit exactly the max count ... this is different from
         // when we write N > 1 dimensional points where we write between max/2 and max per leaf
         // block
@@ -741,7 +743,7 @@ public class BKDWriter implements Closeable {
 
       pointCount = valueCount;
 
-      scratchBytesRef1.length = config.bytesPerDim;
+      scratchBytesRef1.length = config.bytesPerDim();
       scratchBytesRef1.offset = 0;
       assert leafBlockStartValues.size() + 1 == leafBlockFPs.size();
       BKDTreeLeafNodes leafNodes =
@@ -768,28 +770,29 @@ public class BKDWriter implements Closeable {
             }
           };
       return () -> {
-        writeIndex(metaOut, indexOut, config.maxPointsInLeafNode, leafNodes, dataStartFP);
+        writeIndex(metaOut, indexOut, config.maxPointsInLeafNode(), leafNodes, dataStartFP);
       };
     }
 
     private void writeLeafBlock(int leafCardinality) throws IOException {
       assert leafCount != 0;
       if (valueCount == 0) {
-        System.arraycopy(leafValues, 0, minPackedValue, 0, config.packedIndexBytesLength);
+        System.arraycopy(leafValues, 0, minPackedValue, 0, config.packedIndexBytesLength());
       }
       System.arraycopy(
           leafValues,
-          (leafCount - 1) * config.packedBytesLength,
+          (leafCount - 1) * config.packedBytesLength(),
           maxPackedValue,
           0,
-          config.packedIndexBytesLength);
+          config.packedIndexBytesLength());
 
       valueCount += leafCount;
 
       if (leafBlockFPs.size() > 0) {
         // Save the first (minimum) value in each leaf block except the first, to build the split
         // value index in the end:
-        leafBlockStartValues.add(ArrayUtil.copyOfSubArray(leafValues, 0, config.packedBytesLength));
+        leafBlockStartValues.add(
+            ArrayUtil.copyOfSubArray(leafValues, 0, config.packedBytesLength()));
       }
       leafBlockFPs.add(dataOut.getFilePointer());
       checkMaxLeafNodeCount(leafBlockFPs.size());
@@ -797,28 +800,28 @@ public class BKDWriter implements Closeable {
       // Find per-dim common prefix:
       commonPrefixLengths[0] =
           commonPrefixComparator.compare(
-              leafValues, 0, leafValues, (leafCount - 1) * config.packedBytesLength);
+              leafValues, 0, leafValues, (leafCount - 1) * config.packedBytesLength());
 
       writeLeafBlockDocs(dataOut, leafDocs, 0, leafCount);
       writeCommonPrefixes(dataOut, commonPrefixLengths, leafValues);
 
-      scratchBytesRef1.length = config.packedBytesLength;
+      scratchBytesRef1.length = config.packedBytesLength();
       scratchBytesRef1.bytes = leafValues;
 
       final IntFunction<BytesRef> packedValues =
           i -> {
-            scratchBytesRef1.offset = config.packedBytesLength * i;
+            scratchBytesRef1.offset = config.packedBytesLength() * i;
             return scratchBytesRef1;
           };
       assert valuesInOrderAndBounds(
           config,
           leafCount,
           0,
-          ArrayUtil.copyOfSubArray(leafValues, 0, config.packedBytesLength),
+          ArrayUtil.copyOfSubArray(leafValues, 0, config.packedBytesLength()),
           ArrayUtil.copyOfSubArray(
               leafValues,
-              (leafCount - 1) * config.packedBytesLength,
-              leafCount * config.packedBytesLength),
+              (leafCount - 1) * config.packedBytesLength(),
+              leafCount * config.packedBytesLength()),
           packedValues,
           leafDocs,
           0);
@@ -857,7 +860,7 @@ public class BKDWriter implements Closeable {
       int count = 0;
       while (r.next()) {
         byte[] v = r.packedValue();
-        System.out.println("      " + count + ": " + new BytesRef(v, dim*config.bytesPerDim, config.bytesPerDim));
+        System.out.println("      " + count + ": " + new BytesRef(v, dim*config.bytesPerDim(), config.bytesPerDim()));
         count++;
         if (count == slice.count) {
           break;
@@ -868,10 +871,10 @@ public class BKDWriter implements Closeable {
   */
 
   private void checkMaxLeafNodeCount(int numLeaves) {
-    if (config.bytesPerDim * (long) numLeaves > ArrayUtil.MAX_ARRAY_LENGTH) {
+    if (config.bytesPerDim() * (long) numLeaves > ArrayUtil.MAX_ARRAY_LENGTH) {
       throw new IllegalStateException(
-          "too many nodes; increase config.maxPointsInLeafNode (currently "
-              + config.maxPointsInLeafNode
+          "too many nodes; increase config.maxPointsInLeafNode() (currently "
+              + config.maxPointsInLeafNode()
               + ") and reindex");
     }
   }
@@ -907,7 +910,8 @@ public class BKDWriter implements Closeable {
     pointWriter = null;
 
     final int numLeaves =
-        Math.toIntExact((pointCount + config.maxPointsInLeafNode - 1) / config.maxPointsInLeafNode);
+        Math.toIntExact(
+            (pointCount + config.maxPointsInLeafNode() - 1) / config.maxPointsInLeafNode());
     final int numSplits = numLeaves - 1;
 
     checkMaxLeafNodeCount(numLeaves);
@@ -918,7 +922,7 @@ public class BKDWriter implements Closeable {
 
     // Indexed by nodeID, but first (root) nodeID is 1.  We do 1+ because the lead byte at each
     // recursion says which dim we split on.
-    byte[] splitPackedValues = new byte[Math.multiplyExact(numSplits, config.bytesPerDim)];
+    byte[] splitPackedValues = new byte[Math.multiplyExact(numSplits, config.bytesPerDim())];
     byte[] splitDimensionValues = new byte[numSplits];
 
     // +1 because leaf count is power of 2 (e.g. 8), and innerNodeCount is power of 2 minus 1 (e.g.
@@ -926,13 +930,13 @@ public class BKDWriter implements Closeable {
     long[] leafBlockFPs = new long[numLeaves];
 
     // Make sure the math above "worked":
-    assert pointCount / numLeaves <= config.maxPointsInLeafNode
+    assert pointCount / numLeaves <= config.maxPointsInLeafNode()
         : "pointCount="
             + pointCount
             + " numLeaves="
             + numLeaves
-            + " config.maxPointsInLeafNode="
-            + config.maxPointsInLeafNode;
+            + " config.maxPointsInLeafNode()="
+            + config.maxPointsInLeafNode();
 
     // We re-use the selector so we do not need to create an object every time.
     BKDRadixSelector radixSelector =
@@ -942,7 +946,7 @@ public class BKDWriter implements Closeable {
     boolean success = false;
     try {
 
-      final int[] parentSplits = new int[config.numIndexDims];
+      final int[] parentSplits = new int[config.numIndexDims()];
       build(
           0,
           numLeaves,
@@ -955,8 +959,8 @@ public class BKDWriter implements Closeable {
           splitPackedValues,
           splitDimensionValues,
           leafBlockFPs,
-          new int[config.maxPointsInLeafNode]);
-      assert Arrays.equals(parentSplits, new int[config.numIndexDims]);
+          new int[config.maxPointsInLeafNode()]);
+      assert Arrays.equals(parentSplits, new int[config.numIndexDims()]);
 
       // If no exception, we should have cleaned everything up:
       assert tempDir.getCreatedFiles().isEmpty();
@@ -971,7 +975,7 @@ public class BKDWriter implements Closeable {
     }
 
     scratchBytesRef1.bytes = splitPackedValues;
-    scratchBytesRef1.length = config.bytesPerDim;
+    scratchBytesRef1.length = config.bytesPerDim();
     return makeWriter(metaOut, indexOut, splitDimensionValues, leafBlockFPs, dataStartFP);
   }
 
@@ -990,7 +994,7 @@ public class BKDWriter implements Closeable {
 
           @Override
           public BytesRef getSplitValue(int index) {
-            scratchBytesRef1.offset = index * config.bytesPerDim;
+            scratchBytesRef1.offset = index * config.bytesPerDim();
             return scratchBytesRef1;
           }
 
@@ -1007,7 +1011,7 @@ public class BKDWriter implements Closeable {
 
     return () -> {
       // Write index:
-      writeIndex(metaOut, indexOut, config.maxPointsInLeafNode, leafNodes, dataStartFP);
+      writeIndex(metaOut, indexOut, config.maxPointsInLeafNode(), leafNodes, dataStartFP);
     };
   }
 
@@ -1021,7 +1025,7 @@ public class BKDWriter implements Closeable {
 
     // This is the "file" we append the byte[] to:
     List<byte[]> blocks = new ArrayList<>();
-    byte[] lastSplitValues = new byte[config.bytesPerDim * config.numIndexDims];
+    byte[] lastSplitValues = new byte[config.bytesPerDim() * config.numIndexDims()];
     // System.out.println("\npack index");
     int totalSize =
         recursePackIndex(
@@ -1030,7 +1034,7 @@ public class BKDWriter implements Closeable {
             0l,
             blocks,
             lastSplitValues,
-            new boolean[config.numIndexDims],
+            new boolean[config.numIndexDims()],
             false,
             0,
             leafNodes.numLeaves());
@@ -1104,25 +1108,25 @@ public class BKDWriter implements Closeable {
       int address = splitValue.offset;
 
       // System.out.println("recursePack inner nodeID=" + nodeID + " splitDim=" + splitDim + "
-      // splitValue=" + new BytesRef(splitPackedValues, address, config.bytesPerDim));
+      // splitValue=" + new BytesRef(splitPackedValues, address, config.bytesPerDim()));
 
       // find common prefix with last split value in this dim:
       int prefix =
           commonPrefixComparator.compare(
-              splitValue.bytes, address, lastSplitValues, splitDim * config.bytesPerDim);
+              splitValue.bytes, address, lastSplitValues, splitDim * config.bytesPerDim());
 
       // System.out.println("writeNodeData nodeID=" + nodeID + " splitDim=" + splitDim + " numDims="
-      // + numDims + " config.bytesPerDim=" + config.bytesPerDim + " prefix=" + prefix);
+      // + numDims + " config.bytesPerDim()=" + config.bytesPerDim() + " prefix=" + prefix);
 
       int firstDiffByteDelta;
-      if (prefix < config.bytesPerDim) {
+      if (prefix < config.bytesPerDim()) {
         // System.out.println("  delta byte cur=" +
         // Integer.toHexString(splitPackedValues[address+prefix]&0xFF) + " prev=" +
-        // Integer.toHexString(lastSplitValues[splitDim * config.bytesPerDim + prefix]&0xFF) + "
+        // Integer.toHexString(lastSplitValues[splitDim * config.bytesPerDim() + prefix]&0xFF) + "
         // negated?=" + negativeDeltas[splitDim]);
         firstDiffByteDelta =
             (splitValue.bytes[address + prefix] & 0xFF)
-                - (lastSplitValues[splitDim * config.bytesPerDim + prefix] & 0xFF);
+                - (lastSplitValues[splitDim * config.bytesPerDim() + prefix] & 0xFF);
         if (negativeDeltas[splitDim]) {
           firstDiffByteDelta = -firstDiffByteDelta;
         }
@@ -1134,16 +1138,17 @@ public class BKDWriter implements Closeable {
 
       // pack the prefix, splitDim and delta first diff byte into a single vInt:
       int code =
-          (firstDiffByteDelta * (1 + config.bytesPerDim) + prefix) * config.numIndexDims + splitDim;
+          (firstDiffByteDelta * (1 + config.bytesPerDim()) + prefix) * config.numIndexDims()
+              + splitDim;
 
       // System.out.println("  code=" + code);
       // System.out.println("  splitValue=" + new BytesRef(splitPackedValues, address,
-      // config.bytesPerDim));
+      // config.bytesPerDim()));
 
       writeBuffer.writeVInt(code);
 
       // write the split value, prefix coded vs. our parent's split value:
-      int suffix = config.bytesPerDim - prefix;
+      int suffix = config.bytesPerDim() - prefix;
       byte[] savSplitValue = new byte[suffix];
       if (suffix > 1) {
         writeBuffer.writeBytes(splitValue.bytes, address + prefix + 1, suffix - 1);
@@ -1152,14 +1157,14 @@ public class BKDWriter implements Closeable {
       byte[] cmp = lastSplitValues.clone();
 
       System.arraycopy(
-          lastSplitValues, splitDim * config.bytesPerDim + prefix, savSplitValue, 0, suffix);
+          lastSplitValues, splitDim * config.bytesPerDim() + prefix, savSplitValue, 0, suffix);
 
       // copy our split value into lastSplitValues for our children to prefix-code against
       System.arraycopy(
           splitValue.bytes,
           address + prefix,
           lastSplitValues,
-          splitDim * config.bytesPerDim + prefix,
+          splitDim * config.bytesPerDim() + prefix,
           suffix);
 
       int numBytes = appendBlock(writeBuffer, blocks);
@@ -1213,7 +1218,7 @@ public class BKDWriter implements Closeable {
 
       // restore lastSplitValues to what caller originally passed us:
       System.arraycopy(
-          savSplitValue, 0, lastSplitValues, splitDim * config.bytesPerDim + prefix, suffix);
+          savSplitValue, 0, lastSplitValues, splitDim * config.bytesPerDim() + prefix, suffix);
 
       assert Arrays.equals(lastSplitValues, cmp);
 
@@ -1241,15 +1246,15 @@ public class BKDWriter implements Closeable {
       long dataStartFP)
       throws IOException {
     CodecUtil.writeHeader(metaOut, CODEC_NAME, VERSION_CURRENT);
-    metaOut.writeVInt(config.numDims);
-    metaOut.writeVInt(config.numIndexDims);
+    metaOut.writeVInt(config.numDims());
+    metaOut.writeVInt(config.numIndexDims());
     metaOut.writeVInt(countPerLeaf);
-    metaOut.writeVInt(config.bytesPerDim);
+    metaOut.writeVInt(config.bytesPerDim());
 
     assert numLeaves > 0;
     metaOut.writeVInt(numLeaves);
-    metaOut.writeBytes(minPackedValue, 0, config.packedIndexBytesLength);
-    metaOut.writeBytes(maxPackedValue, 0, config.packedIndexBytesLength);
+    metaOut.writeBytes(minPackedValue, 0, config.packedIndexBytesLength());
+    metaOut.writeBytes(maxPackedValue, 0, config.packedIndexBytesLength());
 
     metaOut.writeVLong(pointCount);
     metaOut.writeVInt(docsSeen.cardinality());
@@ -1264,7 +1269,7 @@ public class BKDWriter implements Closeable {
 
   private void writeLeafBlockDocs(DataOutput out, int[] docIDs, int start, int count)
       throws IOException {
-    assert count > 0 : "config.maxPointsInLeafNode=" + config.maxPointsInLeafNode;
+    assert count > 0 : "config.maxPointsInLeafNode()=" + config.maxPointsInLeafNode();
     out.writeVInt(count);
     docIdsWriter.writeDocIds(docIDs, start, count, out);
   }
@@ -1278,13 +1283,13 @@ public class BKDWriter implements Closeable {
       int leafCardinality)
       throws IOException {
     int prefixLenSum = Arrays.stream(commonPrefixLengths).sum();
-    if (prefixLenSum == config.packedBytesLength) {
+    if (prefixLenSum == config.packedBytesLength()) {
       // all values in this block are equal
       out.writeByte((byte) -1);
     } else {
-      assert commonPrefixLengths[sortedDim] < config.bytesPerDim;
+      assert commonPrefixLengths[sortedDim] < config.bytesPerDim();
       // estimate if storing the values with cardinality is cheaper than storing all values.
-      int compressedByteOffset = sortedDim * config.bytesPerDim + commonPrefixLengths[sortedDim];
+      int compressedByteOffset = sortedDim * config.bytesPerDim() + commonPrefixLengths[sortedDim];
       int highCardinalityCost;
       int lowCardinalityCost;
       if (count == leafCardinality) {
@@ -1303,9 +1308,9 @@ public class BKDWriter implements Closeable {
         }
         // Add cost of runLen compression
         highCardinalityCost =
-            count * (config.packedBytesLength - prefixLenSum - 1) + 2 * numRunLens;
+            count * (config.packedBytesLength() - prefixLenSum - 1) + 2 * numRunLens;
         // +1 is the byte needed for storing the cardinality
-        lowCardinalityCost = leafCardinality * (config.packedBytesLength - prefixLenSum + 1);
+        lowCardinalityCost = leafCardinality * (config.packedBytesLength() - prefixLenSum + 1);
       }
       if (lowCardinalityCost <= highCardinalityCost) {
         out.writeByte((byte) -2);
@@ -1321,38 +1326,38 @@ public class BKDWriter implements Closeable {
   private void writeLowCardinalityLeafBlockPackedValues(
       DataOutput out, int[] commonPrefixLengths, int count, IntFunction<BytesRef> packedValues)
       throws IOException {
-    if (config.numIndexDims != 1) {
+    if (config.numIndexDims() != 1) {
       writeActualBounds(out, commonPrefixLengths, count, packedValues);
     }
     BytesRef value = packedValues.apply(0);
-    System.arraycopy(value.bytes, value.offset, scratch, 0, config.packedBytesLength);
+    System.arraycopy(value.bytes, value.offset, scratch, 0, config.packedBytesLength());
     int cardinality = 1;
     for (int i = 1; i < count; i++) {
       value = packedValues.apply(i);
-      for (int dim = 0; dim < config.numDims; dim++) {
-        final int start = dim * config.bytesPerDim;
+      for (int dim = 0; dim < config.numDims(); dim++) {
+        final int start = dim * config.bytesPerDim();
         if (equalsPredicate.test(value.bytes, value.offset + start, scratch, start) == false) {
           out.writeVInt(cardinality);
-          for (int j = 0; j < config.numDims; j++) {
+          for (int j = 0; j < config.numDims(); j++) {
             out.writeBytes(
                 scratch,
-                j * config.bytesPerDim + commonPrefixLengths[j],
-                config.bytesPerDim - commonPrefixLengths[j]);
+                j * config.bytesPerDim() + commonPrefixLengths[j],
+                config.bytesPerDim() - commonPrefixLengths[j]);
           }
-          System.arraycopy(value.bytes, value.offset, scratch, 0, config.packedBytesLength);
+          System.arraycopy(value.bytes, value.offset, scratch, 0, config.packedBytesLength());
           cardinality = 1;
           break;
-        } else if (dim == config.numDims - 1) {
+        } else if (dim == config.numDims() - 1) {
           cardinality++;
         }
       }
     }
     out.writeVInt(cardinality);
-    for (int i = 0; i < config.numDims; i++) {
+    for (int i = 0; i < config.numDims(); i++) {
       out.writeBytes(
           scratch,
-          i * config.bytesPerDim + commonPrefixLengths[i],
-          config.bytesPerDim - commonPrefixLengths[i]);
+          i * config.bytesPerDim() + commonPrefixLengths[i],
+          config.bytesPerDim() - commonPrefixLengths[i]);
     }
   }
 
@@ -1364,7 +1369,7 @@ public class BKDWriter implements Closeable {
       IntFunction<BytesRef> packedValues,
       int compressedByteOffset)
       throws IOException {
-    if (config.numIndexDims != 1) {
+    if (config.numIndexDims() != 1) {
       writeActualBounds(out, commonPrefixLengths, count, packedValues);
     }
     commonPrefixLengths[sortedDim]++;
@@ -1385,13 +1390,13 @@ public class BKDWriter implements Closeable {
   private void writeActualBounds(
       DataOutput out, int[] commonPrefixLengths, int count, IntFunction<BytesRef> packedValues)
       throws IOException {
-    for (int dim = 0; dim < config.numIndexDims; ++dim) {
+    for (int dim = 0; dim < config.numIndexDims(); ++dim) {
       int commonPrefixLength = commonPrefixLengths[dim];
-      int suffixLength = config.bytesPerDim - commonPrefixLength;
+      int suffixLength = config.bytesPerDim() - commonPrefixLength;
       if (suffixLength > 0) {
         BytesRef[] minMax =
             computeMinMax(
-                count, packedValues, dim * config.bytesPerDim + commonPrefixLength, suffixLength);
+                count, packedValues, dim * config.bytesPerDim() + commonPrefixLength, suffixLength);
         BytesRef min = minMax[0];
         BytesRef max = minMax[1];
         out.writeBytes(min.bytes, min.offset, min.length);
@@ -1446,12 +1451,14 @@ public class BKDWriter implements Closeable {
       throws IOException {
     for (int i = start; i < end; ++i) {
       BytesRef ref = packedValues.apply(i);
-      assert ref.length == config.packedBytesLength;
+      assert ref.length == config.packedBytesLength();
 
-      for (int dim = 0; dim < config.numDims; dim++) {
+      for (int dim = 0; dim < config.numDims(); dim++) {
         int prefix = commonPrefixLengths[dim];
         out.writeBytes(
-            ref.bytes, ref.offset + dim * config.bytesPerDim + prefix, config.bytesPerDim - prefix);
+            ref.bytes,
+            ref.offset + dim * config.bytesPerDim() + prefix,
+            config.bytesPerDim() - prefix);
       }
     }
   }
@@ -1473,10 +1480,10 @@ public class BKDWriter implements Closeable {
 
   private void writeCommonPrefixes(DataOutput out, int[] commonPrefixes, byte[] packedValue)
       throws IOException {
-    for (int dim = 0; dim < config.numDims; dim++) {
+    for (int dim = 0; dim < config.numDims(); dim++) {
       out.writeVInt(commonPrefixes[dim]);
-      // System.out.println(commonPrefixes[dim] + " of " + config.bytesPerDim);
-      out.writeBytes(packedValue, dim * config.bytesPerDim, commonPrefixes[dim]);
+      // System.out.println(commonPrefixes[dim] + " of " + config.bytesPerDim());
+      out.writeBytes(packedValue, dim * config.bytesPerDim(), commonPrefixes[dim]);
     }
   }
 
@@ -1535,8 +1542,8 @@ public class BKDWriter implements Closeable {
     for (int numSplits : parentSplits) {
       maxNumSplits = Math.max(maxNumSplits, numSplits);
     }
-    for (int dim = 0; dim < config.numIndexDims; ++dim) {
-      final int offset = dim * config.bytesPerDim;
+    for (int dim = 0; dim < config.numIndexDims(); ++dim) {
+      final int offset = dim * config.bytesPerDim();
       if (parentSplits[dim] < maxNumSplits / 2
           && comparator.compare(minPackedValue, offset, maxPackedValue, offset) != 0) {
         return dim;
@@ -1545,10 +1552,10 @@ public class BKDWriter implements Closeable {
 
     // Find which dim has the largest span so we can split on it:
     int splitDim = -1;
-    for (int dim = 0; dim < config.numIndexDims; dim++) {
-      NumericUtils.subtract(config.bytesPerDim, dim, maxPackedValue, minPackedValue, scratchDiff);
+    for (int dim = 0; dim < config.numIndexDims(); dim++) {
+      NumericUtils.subtract(config.bytesPerDim(), dim, maxPackedValue, minPackedValue, scratchDiff);
       if (splitDim == -1 || comparator.compare(scratchDiff, 0, scratch, 0) > 0) {
-        System.arraycopy(scratchDiff, 0, scratch, 0, config.bytesPerDim);
+        System.arraycopy(scratchDiff, 0, scratch, 0, config.bytesPerDim());
         splitDim = dim;
       }
     }
@@ -1595,15 +1602,15 @@ public class BKDWriter implements Closeable {
     if (numLeaves == 1) {
       // leaf node
       final int count = to - from;
-      assert count <= config.maxPointsInLeafNode;
+      assert count <= config.maxPointsInLeafNode();
 
       // Compute common prefixes
-      Arrays.fill(commonPrefixLengths, config.bytesPerDim);
+      Arrays.fill(commonPrefixLengths, config.bytesPerDim());
       reader.getValue(from, scratchBytesRef1);
       for (int i = from + 1; i < to; ++i) {
         reader.getValue(i, scratchBytesRef2);
-        for (int dim = 0; dim < config.numDims; dim++) {
-          final int offset = dim * config.bytesPerDim;
+        for (int dim = 0; dim < config.numDims(); dim++) {
+          final int offset = dim * config.bytesPerDim();
           int dimensionPrefixLength = commonPrefixLengths[dim];
           commonPrefixLengths[dim] =
               Math.min(
@@ -1617,23 +1624,23 @@ public class BKDWriter implements Closeable {
       }
 
       // Find the dimension that has the least number of unique bytes at commonPrefixLengths[dim]
-      FixedBitSet[] usedBytes = new FixedBitSet[config.numDims];
-      for (int dim = 0; dim < config.numDims; ++dim) {
-        if (commonPrefixLengths[dim] < config.bytesPerDim) {
+      FixedBitSet[] usedBytes = new FixedBitSet[config.numDims()];
+      for (int dim = 0; dim < config.numDims(); ++dim) {
+        if (commonPrefixLengths[dim] < config.bytesPerDim()) {
           usedBytes[dim] = new FixedBitSet(256);
         }
       }
       for (int i = from + 1; i < to; ++i) {
-        for (int dim = 0; dim < config.numDims; dim++) {
+        for (int dim = 0; dim < config.numDims(); dim++) {
           if (usedBytes[dim] != null) {
-            byte b = reader.getByteAt(i, dim * config.bytesPerDim + commonPrefixLengths[dim]);
+            byte b = reader.getByteAt(i, dim * config.bytesPerDim() + commonPrefixLengths[dim]);
             usedBytes[dim].set(Byte.toUnsignedInt(b));
           }
         }
       }
       int sortedDim = 0;
       int sortedDimCardinality = Integer.MAX_VALUE;
-      for (int dim = 0; dim < config.numDims; ++dim) {
+      for (int dim = 0; dim < config.numDims(); ++dim) {
         if (usedBytes[dim] != null) {
           final int cardinality = usedBytes[dim].cardinality();
           if (cardinality < sortedDimCardinality) {
@@ -1660,8 +1667,8 @@ public class BKDWriter implements Closeable {
       int leafCardinality = 1;
       for (int i = from + 1; i < to; ++i) {
         reader.getValue(i, collector);
-        for (int dim = 0; dim < config.numDims; dim++) {
-          final int start = dim * config.bytesPerDim;
+        for (int dim = 0; dim < config.numDims(); dim++) {
+          final int start = dim * config.bytesPerDim();
           if (equalsPredicate.test(
                   collector.bytes,
                   collector.offset + start,
@@ -1690,7 +1697,7 @@ public class BKDWriter implements Closeable {
       // Write the common prefixes:
       reader.getValue(from, scratchBytesRef1);
       System.arraycopy(
-          scratchBytesRef1.bytes, scratchBytesRef1.offset, scratch, 0, config.packedBytesLength);
+          scratchBytesRef1.bytes, scratchBytesRef1.offset, scratch, 0, config.packedBytesLength());
       writeCommonPrefixes(out, commonPrefixLengths, scratch);
 
       // Write the full values:
@@ -1708,7 +1715,7 @@ public class BKDWriter implements Closeable {
 
       final int splitDim;
       // compute the split dimension and partition around it
-      if (config.numIndexDims == 1) {
+      if (config.numIndexDims() == 1) {
         splitDim = 0;
       } else {
         // for dimensions > 2 we recompute the bounds for the current inner node to help the
@@ -1717,7 +1724,7 @@ public class BKDWriter implements Closeable {
         // bounds is given
         // by SPLITS_BEFORE_EXACT_BOUNDS.
         if (numLeaves != leafBlockFPs.length
-            && config.numIndexDims > 2
+            && config.numIndexDims() > 2
             && Arrays.stream(parentSplits).sum() % SPLITS_BEFORE_EXACT_BOUNDS == 0) {
           computePackedValueBounds(
               reader, from, to, minPackedValue, maxPackedValue, scratchBytesRef1);
@@ -1728,14 +1735,14 @@ public class BKDWriter implements Closeable {
       // How many leaves will be in the left tree:
       int numLeftLeafNodes = getNumLeftLeafNodes(numLeaves);
       // How many points will be in the left tree:
-      final int mid = from + numLeftLeafNodes * config.maxPointsInLeafNode;
+      final int mid = from + numLeftLeafNodes * config.maxPointsInLeafNode();
 
       final int commonPrefixLen =
           commonPrefixComparator.compare(
               minPackedValue,
-              splitDim * config.bytesPerDim,
+              splitDim * config.bytesPerDim(),
               maxPackedValue,
-              splitDim * config.bytesPerDim);
+              splitDim * config.bytesPerDim());
 
       MutablePointTreeReaderUtils.partition(
           config,
@@ -1752,32 +1759,32 @@ public class BKDWriter implements Closeable {
       final int rightOffset = leavesOffset + numLeftLeafNodes;
       final int splitOffset = rightOffset - 1;
       // set the split value
-      final int address = splitOffset * config.bytesPerDim;
+      final int address = splitOffset * config.bytesPerDim();
       splitDimensionValues[splitOffset] = (byte) splitDim;
       reader.getValue(mid, scratchBytesRef1);
       System.arraycopy(
           scratchBytesRef1.bytes,
-          scratchBytesRef1.offset + splitDim * config.bytesPerDim,
+          scratchBytesRef1.offset + splitDim * config.bytesPerDim(),
           splitPackedValues,
           address,
-          config.bytesPerDim);
+          config.bytesPerDim());
 
       byte[] minSplitPackedValue =
-          ArrayUtil.copyOfSubArray(minPackedValue, 0, config.packedIndexBytesLength);
+          ArrayUtil.copyOfSubArray(minPackedValue, 0, config.packedIndexBytesLength());
       byte[] maxSplitPackedValue =
-          ArrayUtil.copyOfSubArray(maxPackedValue, 0, config.packedIndexBytesLength);
+          ArrayUtil.copyOfSubArray(maxPackedValue, 0, config.packedIndexBytesLength());
       System.arraycopy(
           scratchBytesRef1.bytes,
-          scratchBytesRef1.offset + splitDim * config.bytesPerDim,
+          scratchBytesRef1.offset + splitDim * config.bytesPerDim(),
           minSplitPackedValue,
-          splitDim * config.bytesPerDim,
-          config.bytesPerDim);
+          splitDim * config.bytesPerDim(),
+          config.bytesPerDim());
       System.arraycopy(
           scratchBytesRef1.bytes,
-          scratchBytesRef1.offset + splitDim * config.bytesPerDim,
+          scratchBytesRef1.offset + splitDim * config.bytesPerDim(),
           maxSplitPackedValue,
-          splitDim * config.bytesPerDim,
-          config.bytesPerDim);
+          splitDim * config.bytesPerDim(),
+          config.bytesPerDim());
 
       // recurse
       parentSplits[splitDim]++;
@@ -1821,12 +1828,14 @@ public class BKDWriter implements Closeable {
         return;
       }
       BytesRef value = reader.pointValue().packedValue();
-      System.arraycopy(value.bytes, value.offset, minPackedValue, 0, config.packedIndexBytesLength);
-      System.arraycopy(value.bytes, value.offset, maxPackedValue, 0, config.packedIndexBytesLength);
+      System.arraycopy(
+          value.bytes, value.offset, minPackedValue, 0, config.packedIndexBytesLength());
+      System.arraycopy(
+          value.bytes, value.offset, maxPackedValue, 0, config.packedIndexBytesLength());
       while (reader.next()) {
         value = reader.pointValue().packedValue();
-        for (int dim = 0; dim < config.numIndexDims; dim++) {
-          final int startOffset = dim * config.bytesPerDim;
+        for (int dim = 0; dim < config.numIndexDims(); dim++) {
+          final int startOffset = dim * config.bytesPerDim();
           if (comparator.compare(
                   value.bytes, value.offset + startOffset, minPackedValue, startOffset)
               < 0) {
@@ -1835,7 +1844,7 @@ public class BKDWriter implements Closeable {
                 value.offset + startOffset,
                 minPackedValue,
                 startOffset,
-                config.bytesPerDim);
+                config.bytesPerDim());
           } else if (comparator.compare(
                   value.bytes, value.offset + startOffset, maxPackedValue, startOffset)
               > 0) {
@@ -1844,7 +1853,7 @@ public class BKDWriter implements Closeable {
                 value.offset + startOffset,
                 maxPackedValue,
                 startOffset,
-                config.bytesPerDim);
+                config.bytesPerDim());
           }
         }
       }
@@ -1893,17 +1902,17 @@ public class BKDWriter implements Closeable {
 
       int sortedDim = 0;
       int sortedDimCardinality = Integer.MAX_VALUE;
-      FixedBitSet[] usedBytes = new FixedBitSet[config.numDims];
-      for (int dim = 0; dim < config.numDims; ++dim) {
-        if (commonPrefixLengths[dim] < config.bytesPerDim) {
+      FixedBitSet[] usedBytes = new FixedBitSet[config.numDims()];
+      for (int dim = 0; dim < config.numDims(); ++dim) {
+        if (commonPrefixLengths[dim] < config.bytesPerDim()) {
           usedBytes[dim] = new FixedBitSet(256);
         }
       }
       // Find the dimension to compress
-      for (int dim = 0; dim < config.numDims; dim++) {
+      for (int dim = 0; dim < config.numDims(); dim++) {
         int prefix = commonPrefixLengths[dim];
-        if (prefix < config.bytesPerDim) {
-          int offset = dim * config.bytesPerDim;
+        if (prefix < config.bytesPerDim()) {
+          int offset = dim * config.bytesPerDim();
           for (int i = from; i < to; ++i) {
             PointValue value = heapSource.getPackedValueSlice(i);
             BytesRef packedValue = value.packedValue();
@@ -1958,7 +1967,7 @@ public class BKDWriter implements Closeable {
       // Inner node: partition/recurse
 
       final int splitDim;
-      if (config.numIndexDims == 1) {
+      if (config.numIndexDims() == 1) {
         splitDim = 0;
       } else {
         // for dimensions > 2 we recompute the bounds for the current inner node to help the
@@ -1967,7 +1976,7 @@ public class BKDWriter implements Closeable {
         // bounds is given
         // by SPLITS_BEFORE_EXACT_BOUNDS.
         if (numLeaves != leafBlockFPs.length
-            && config.numIndexDims > 2
+            && config.numIndexDims() > 2
             && Arrays.stream(parentSplits).sum() % SPLITS_BEFORE_EXACT_BOUNDS == 0) {
           computePackedValueBounds(points, minPackedValue, maxPackedValue);
         }
@@ -1980,16 +1989,16 @@ public class BKDWriter implements Closeable {
       // How many leaves will be in the left tree:
       final int numLeftLeafNodes = getNumLeftLeafNodes(numLeaves);
       // How many points will be in the left tree:
-      final long leftCount = numLeftLeafNodes * (long) config.maxPointsInLeafNode;
+      final long leftCount = numLeftLeafNodes * (long) config.maxPointsInLeafNode();
 
       BKDRadixSelector.PathSlice[] slices = new BKDRadixSelector.PathSlice[2];
 
       final int commonPrefixLen =
           commonPrefixComparator.compare(
               minPackedValue,
-              splitDim * config.bytesPerDim,
+              splitDim * config.bytesPerDim(),
               maxPackedValue,
-              splitDim * config.bytesPerDim);
+              splitDim * config.bytesPerDim());
 
       byte[] splitValue =
           radixSelector.select(
@@ -2005,19 +2014,27 @@ public class BKDWriter implements Closeable {
       final int splitValueOffset = rightOffset - 1;
 
       splitDimensionValues[splitValueOffset] = (byte) splitDim;
-      int address = splitValueOffset * config.bytesPerDim;
-      System.arraycopy(splitValue, 0, splitPackedValues, address, config.bytesPerDim);
+      int address = splitValueOffset * config.bytesPerDim();
+      System.arraycopy(splitValue, 0, splitPackedValues, address, config.bytesPerDim());
 
-      byte[] minSplitPackedValue = new byte[config.packedIndexBytesLength];
-      System.arraycopy(minPackedValue, 0, minSplitPackedValue, 0, config.packedIndexBytesLength);
+      byte[] minSplitPackedValue = new byte[config.packedIndexBytesLength()];
+      System.arraycopy(minPackedValue, 0, minSplitPackedValue, 0, config.packedIndexBytesLength());
 
-      byte[] maxSplitPackedValue = new byte[config.packedIndexBytesLength];
-      System.arraycopy(maxPackedValue, 0, maxSplitPackedValue, 0, config.packedIndexBytesLength);
+      byte[] maxSplitPackedValue = new byte[config.packedIndexBytesLength()];
+      System.arraycopy(maxPackedValue, 0, maxSplitPackedValue, 0, config.packedIndexBytesLength());
 
       System.arraycopy(
-          splitValue, 0, minSplitPackedValue, splitDim * config.bytesPerDim, config.bytesPerDim);
+          splitValue,
+          0,
+          minSplitPackedValue,
+          splitDim * config.bytesPerDim(),
+          config.bytesPerDim());
       System.arraycopy(
-          splitValue, 0, maxSplitPackedValue, splitDim * config.bytesPerDim, config.bytesPerDim);
+          splitValue,
+          0,
+          maxSplitPackedValue,
+          splitDim * config.bytesPerDim(),
+          config.bytesPerDim());
 
       parentSplits[splitDim]++;
       // Recurse on left tree:
@@ -2056,30 +2073,30 @@ public class BKDWriter implements Closeable {
 
   private void computeCommonPrefixLength(
       HeapPointWriter heapPointWriter, byte[] commonPrefix, int from, int to) {
-    Arrays.fill(commonPrefixLengths, config.bytesPerDim);
+    Arrays.fill(commonPrefixLengths, config.bytesPerDim());
     PointValue value = heapPointWriter.getPackedValueSlice(from);
     BytesRef packedValue = value.packedValue();
-    for (int dim = 0; dim < config.numDims; dim++) {
+    for (int dim = 0; dim < config.numDims(); dim++) {
       System.arraycopy(
           packedValue.bytes,
-          packedValue.offset + dim * config.bytesPerDim,
+          packedValue.offset + dim * config.bytesPerDim(),
           commonPrefix,
-          dim * config.bytesPerDim,
-          config.bytesPerDim);
+          dim * config.bytesPerDim(),
+          config.bytesPerDim());
     }
     for (int i = from + 1; i < to; i++) {
       value = heapPointWriter.getPackedValueSlice(i);
       packedValue = value.packedValue();
-      for (int dim = 0; dim < config.numDims; dim++) {
+      for (int dim = 0; dim < config.numDims(); dim++) {
         if (commonPrefixLengths[dim] != 0) {
           commonPrefixLengths[dim] =
               Math.min(
                   commonPrefixLengths[dim],
                   commonPrefixComparator.compare(
                       commonPrefix,
-                      dim * config.bytesPerDim,
+                      dim * config.bytesPerDim(),
                       packedValue.bytes,
-                      packedValue.offset + dim * config.bytesPerDim));
+                      packedValue.offset + dim * config.bytesPerDim()));
         }
       }
     }
@@ -2095,11 +2112,11 @@ public class BKDWriter implements Closeable {
       IntFunction<BytesRef> values,
       int[] docs,
       int docsOffset) {
-    byte[] lastPackedValue = new byte[config.packedBytesLength];
+    byte[] lastPackedValue = new byte[config.packedBytesLength()];
     int lastDoc = -1;
     for (int i = 0; i < count; i++) {
       BytesRef packedValue = values.apply(i);
-      assert packedValue.length == config.packedBytesLength;
+      assert packedValue.length == config.packedBytesLength();
       assert valueInOrder(
           config,
           i,
@@ -2127,40 +2144,40 @@ public class BKDWriter implements Closeable {
       int packedValueOffset,
       int doc,
       int lastDoc) {
-    int dimOffset = sortedDim * config.bytesPerDim;
+    int dimOffset = sortedDim * config.bytesPerDim();
     if (ord > 0) {
       int cmp =
           Arrays.compareUnsigned(
               lastPackedValue,
               dimOffset,
-              dimOffset + config.bytesPerDim,
+              dimOffset + config.bytesPerDim(),
               packedValue,
               packedValueOffset + dimOffset,
-              packedValueOffset + dimOffset + config.bytesPerDim);
+              packedValueOffset + dimOffset + config.bytesPerDim());
       if (cmp > 0) {
         throw new AssertionError(
             "values out of order: last value="
                 + new BytesRef(lastPackedValue)
                 + " current value="
-                + new BytesRef(packedValue, packedValueOffset, config.packedBytesLength)
+                + new BytesRef(packedValue, packedValueOffset, config.packedBytesLength())
                 + " ord="
                 + ord);
       }
-      if (cmp == 0 && config.numDims > config.numIndexDims) {
+      if (cmp == 0 && config.numDims() > config.numIndexDims()) {
         cmp =
             Arrays.compareUnsigned(
                 lastPackedValue,
-                config.packedIndexBytesLength,
-                config.packedBytesLength,
+                config.packedIndexBytesLength(),
+                config.packedBytesLength(),
                 packedValue,
-                packedValueOffset + config.packedIndexBytesLength,
-                packedValueOffset + config.packedBytesLength);
+                packedValueOffset + config.packedIndexBytesLength(),
+                packedValueOffset + config.packedBytesLength());
         if (cmp > 0) {
           throw new AssertionError(
               "data values out of order: last value="
                   + new BytesRef(lastPackedValue)
                   + " current value="
-                  + new BytesRef(packedValue, packedValueOffset, config.packedBytesLength)
+                  + new BytesRef(packedValue, packedValueOffset, config.packedBytesLength())
                   + " ord="
                   + ord);
         }
@@ -2170,32 +2187,33 @@ public class BKDWriter implements Closeable {
             "docs out of order: last doc=" + lastDoc + " current doc=" + doc + " ord=" + ord);
       }
     }
-    System.arraycopy(packedValue, packedValueOffset, lastPackedValue, 0, config.packedBytesLength);
+    System.arraycopy(
+        packedValue, packedValueOffset, lastPackedValue, 0, config.packedBytesLength());
     return true;
   }
 
   // only called from assert
   private static boolean valueInBounds(
       BKDConfig config, BytesRef packedValue, byte[] minPackedValue, byte[] maxPackedValue) {
-    for (int dim = 0; dim < config.numIndexDims; dim++) {
-      int offset = config.bytesPerDim * dim;
+    for (int dim = 0; dim < config.numIndexDims(); dim++) {
+      int offset = config.bytesPerDim() * dim;
       if (Arrays.compareUnsigned(
               packedValue.bytes,
               packedValue.offset + offset,
-              packedValue.offset + offset + config.bytesPerDim,
+              packedValue.offset + offset + config.bytesPerDim(),
               minPackedValue,
               offset,
-              offset + config.bytesPerDim)
+              offset + config.bytesPerDim())
           < 0) {
         return false;
       }
       if (Arrays.compareUnsigned(
               packedValue.bytes,
               packedValue.offset + offset,
-              packedValue.offset + offset + config.bytesPerDim,
+              packedValue.offset + offset + config.bytesPerDim(),
               maxPackedValue,
               offset,
-              offset + config.bytesPerDim)
+              offset + config.bytesPerDim())
           > 0) {
         return false;
       }

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointReader.java
@@ -56,7 +56,7 @@ public final class OfflinePointReader implements PointReader {
       throws IOException {
     this.config = config;
 
-    if ((start + length) * config.bytesPerDoc + CodecUtil.footerLength()
+    if ((start + length) * config.bytesPerDoc() + CodecUtil.footerLength()
         > tempDir.fileLength(tempFileName)) {
       throw new IllegalArgumentException(
           "requested slice is beyond the length of this file: start="
@@ -64,7 +64,7 @@ public final class OfflinePointReader implements PointReader {
               + " length="
               + length
               + " bytesPerDoc="
-              + config.bytesPerDoc
+              + config.bytesPerDoc()
               + " fileLength="
               + tempDir.fileLength(tempFileName)
               + " tempFileName="
@@ -73,15 +73,15 @@ public final class OfflinePointReader implements PointReader {
     if (reusableBuffer == null) {
       throw new IllegalArgumentException("[reusableBuffer] cannot be null");
     }
-    if (reusableBuffer.length < config.bytesPerDoc) {
+    if (reusableBuffer.length < config.bytesPerDoc()) {
       throw new IllegalArgumentException(
-          "Length of [reusableBuffer] must be bigger than " + config.bytesPerDoc);
+          "Length of [reusableBuffer] must be bigger than " + config.bytesPerDoc());
     }
 
-    this.maxPointOnHeap = reusableBuffer.length / config.bytesPerDoc;
+    this.maxPointOnHeap = reusableBuffer.length / config.bytesPerDoc();
     // Best-effort checksumming:
     if (start == 0
-        && length * config.bytesPerDoc
+        && length * config.bytesPerDoc()
             == tempDir.fileLength(tempFileName) - CodecUtil.footerLength()) {
       // If we are going to read the entire file, e.g. because BKDWriter is now
       // partitioning it, we open with checksums:
@@ -96,7 +96,7 @@ public final class OfflinePointReader implements PointReader {
 
     name = tempFileName;
 
-    long seekFP = start * config.bytesPerDoc;
+    long seekFP = start * config.bytesPerDoc();
     in.seek(seekFP);
     countLeft = length;
     this.onHeapBuffer = reusableBuffer;
@@ -113,11 +113,11 @@ public final class OfflinePointReader implements PointReader {
       }
       try {
         if (countLeft > maxPointOnHeap) {
-          in.readBytes(onHeapBuffer, 0, maxPointOnHeap * config.bytesPerDoc);
+          in.readBytes(onHeapBuffer, 0, maxPointOnHeap * config.bytesPerDoc());
           pointsInBuffer = maxPointOnHeap - 1;
           countLeft -= maxPointOnHeap;
         } else {
-          in.readBytes(onHeapBuffer, 0, (int) countLeft * config.bytesPerDoc);
+          in.readBytes(onHeapBuffer, 0, (int) countLeft * config.bytesPerDoc());
           pointsInBuffer = Math.toIntExact(countLeft - 1);
           countLeft = 0;
         }
@@ -130,7 +130,7 @@ public final class OfflinePointReader implements PointReader {
       }
     } else {
       this.pointsInBuffer--;
-      this.offset += config.bytesPerDoc;
+      this.offset += config.bytesPerDoc();
     }
     return true;
   }
@@ -162,9 +162,9 @@ public final class OfflinePointReader implements PointReader {
     final int packedValueLength;
 
     OfflinePointValue(BKDConfig config, byte[] value) {
-      this.packedValueLength = config.packedBytesLength;
+      this.packedValueLength = config.packedBytesLength();
       this.packedValue = new BytesRef(value, 0, packedValueLength);
-      this.packedValueDocID = new BytesRef(value, 0, config.bytesPerDoc);
+      this.packedValueDocID = new BytesRef(value, 0, config.bytesPerDoc());
     }
 
     /** Sets a new value by changing the offset. */

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/OfflinePointWriter.java
@@ -56,9 +56,9 @@ public final class OfflinePointWriter implements PointWriter {
   @Override
   public void append(byte[] packedValue, int docID) throws IOException {
     assert closed == false : "Point writer is already closed";
-    assert packedValue.length == config.packedBytesLength
+    assert packedValue.length == config.packedBytesLength()
         : "[packedValue] must have length ["
-            + config.packedBytesLength
+            + config.packedBytesLength()
             + "] but was ["
             + packedValue.length
             + "]";
@@ -75,9 +75,9 @@ public final class OfflinePointWriter implements PointWriter {
   public void append(PointValue pointValue) throws IOException {
     assert closed == false : "Point writer is already closed";
     BytesRef packedValueDocID = pointValue.packedValueDocIDBytes();
-    assert packedValueDocID.length == config.bytesPerDoc
+    assert packedValueDocID.length == config.bytesPerDoc()
         : "[packedValue and docID] must have length ["
-            + (config.bytesPerDoc)
+            + (config.bytesPerDoc())
             + "] but was ["
             + packedValueDocID.length
             + "]";
@@ -89,7 +89,7 @@ public final class OfflinePointWriter implements PointWriter {
 
   @Override
   public PointReader getReader(long start, long length) throws IOException {
-    byte[] buffer = new byte[config.bytesPerDoc];
+    byte[] buffer = new byte[config.bytesPerDoc()];
     return getReader(start, length, buffer);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
@@ -954,22 +954,22 @@ public class TestBKD extends LuceneTestCase {
       @Override
       public void visit(int docID, byte[] packedValue) {
         // System.out.println("visit check docID=" + docID);
-        for (int dim = 0; dim < config.numIndexDims; dim++) {
+        for (int dim = 0; dim < config.numIndexDims(); dim++) {
           if (Arrays.compareUnsigned(
                       packedValue,
-                      dim * config.bytesPerDim,
-                      dim * config.bytesPerDim + config.bytesPerDim,
+                      dim * config.bytesPerDim(),
+                      dim * config.bytesPerDim() + config.bytesPerDim(),
                       queryMin[dim],
                       0,
-                      config.bytesPerDim)
+                      config.bytesPerDim())
                   < 0
               || Arrays.compareUnsigned(
                       packedValue,
-                      dim * config.bytesPerDim,
-                      dim * config.bytesPerDim + config.bytesPerDim,
+                      dim * config.bytesPerDim(),
+                      dim * config.bytesPerDim() + config.bytesPerDim(),
                       queryMax[dim],
                       0,
-                      config.bytesPerDim)
+                      config.bytesPerDim())
                   > 0) {
             // System.out.println("  no");
             return;
@@ -1005,39 +1005,39 @@ public class TestBKD extends LuceneTestCase {
       @Override
       public Relation compare(byte[] minPacked, byte[] maxPacked) {
         boolean crosses = false;
-        for (int dim = 0; dim < config.numIndexDims; dim++) {
+        for (int dim = 0; dim < config.numIndexDims(); dim++) {
           if (Arrays.compareUnsigned(
                       maxPacked,
-                      dim * config.bytesPerDim,
-                      dim * config.bytesPerDim + config.bytesPerDim,
+                      dim * config.bytesPerDim(),
+                      dim * config.bytesPerDim() + config.bytesPerDim(),
                       queryMin[dim],
                       0,
-                      config.bytesPerDim)
+                      config.bytesPerDim())
                   < 0
               || Arrays.compareUnsigned(
                       minPacked,
-                      dim * config.bytesPerDim,
-                      dim * config.bytesPerDim + config.bytesPerDim,
+                      dim * config.bytesPerDim(),
+                      dim * config.bytesPerDim() + config.bytesPerDim(),
                       queryMax[dim],
                       0,
-                      config.bytesPerDim)
+                      config.bytesPerDim())
                   > 0) {
             return Relation.CELL_OUTSIDE_QUERY;
           } else if (Arrays.compareUnsigned(
                       minPacked,
-                      dim * config.bytesPerDim,
-                      dim * config.bytesPerDim + config.bytesPerDim,
+                      dim * config.bytesPerDim(),
+                      dim * config.bytesPerDim() + config.bytesPerDim(),
                       queryMin[dim],
                       0,
-                      config.bytesPerDim)
+                      config.bytesPerDim())
                   < 0
               || Arrays.compareUnsigned(
                       maxPacked,
-                      dim * config.bytesPerDim,
-                      dim * config.bytesPerDim + config.bytesPerDim,
+                      dim * config.bytesPerDim(),
+                      dim * config.bytesPerDim() + config.bytesPerDim(),
                       queryMax[dim],
                       0,
-                      config.bytesPerDim)
+                      config.bytesPerDim())
                   > 0) {
             crosses = true;
           }

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKDConfig.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKDConfig.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.bkd;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.ArrayUtil;
+
+public class TestBKDConfig extends LuceneTestCase {
+
+  public void testInvalidNumDims() {
+    IllegalArgumentException ex =
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new BKDConfig(0, 0, 8, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE));
+    assertTrue(ex.getMessage().contains("numDims must be 1 .. " + BKDConfig.MAX_DIMS));
+  }
+
+  public void testInvalidNumIndexedDims() {
+    {
+      IllegalArgumentException ex =
+          expectThrows(
+              IllegalArgumentException.class,
+              () -> new BKDConfig(1, 0, 8, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE));
+      assertTrue(ex.getMessage().contains("numIndexDims must be 1 .. " + BKDConfig.MAX_INDEX_DIMS));
+    }
+    {
+      IllegalArgumentException ex =
+          expectThrows(
+              IllegalArgumentException.class,
+              () -> new BKDConfig(1, 2, 8, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE));
+      assertTrue(ex.getMessage().contains("numIndexDims cannot exceed numDims"));
+    }
+  }
+
+  public void testInvalidBytesPerDim() {
+    IllegalArgumentException ex =
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new BKDConfig(1, 1, 0, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE));
+    assertTrue(ex.getMessage().contains("bytesPerDim must be > 0"));
+  }
+
+  public void testInvalidMaxPointsPerLeafNode() {
+    {
+      IllegalArgumentException ex =
+          expectThrows(IllegalArgumentException.class, () -> new BKDConfig(1, 1, 8, -1));
+      assertTrue(ex.getMessage().contains("maxPointsInLeafNode must be > 0"));
+    }
+    {
+      IllegalArgumentException ex =
+          expectThrows(
+              IllegalArgumentException.class,
+              () -> new BKDConfig(1, 1, 8, ArrayUtil.MAX_ARRAY_LENGTH + 1));
+      assertTrue(
+          ex.getMessage().contains("maxPointsInLeafNode must be <= ArrayUtil.MAX_ARRAY_LENGTH"));
+    }
+  }
+
+  public void testInvalidPackedBytesLength() {
+    IllegalArgumentException ex =
+        expectThrows(IllegalArgumentException.class, () -> new BKDConfig(1, 1, 8, 1024, 0, 0, 0));
+    assertTrue(ex.getMessage().contains("packedBytesLength must be 8"));
+  }
+
+  public void testInvalidPackedIndexBytesLength() {
+    IllegalArgumentException ex =
+        expectThrows(IllegalArgumentException.class, () -> new BKDConfig(1, 1, 8, 1024, 8, 0, 0));
+    assertTrue(ex.getMessage().contains("packedIndexBytesLength must be 8"));
+  }
+
+  public void testInvalidBytesPerDoc() {
+    IllegalArgumentException ex =
+        expectThrows(IllegalArgumentException.class, () -> new BKDConfig(1, 1, 8, 1024, 8, 8, 0));
+    assertTrue(ex.getMessage().contains("bytesPerDoc must be 12"));
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKDConfig.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKDConfig.java
@@ -70,22 +70,4 @@ public class TestBKDConfig extends LuceneTestCase {
           ex.getMessage().contains("maxPointsInLeafNode must be <= ArrayUtil.MAX_ARRAY_LENGTH"));
     }
   }
-
-  public void testInvalidPackedBytesLength() {
-    IllegalArgumentException ex =
-        expectThrows(IllegalArgumentException.class, () -> new BKDConfig(1, 1, 8, 1024, 0, 0, 0));
-    assertTrue(ex.getMessage().contains("packedBytesLength must be 8"));
-  }
-
-  public void testInvalidPackedIndexBytesLength() {
-    IllegalArgumentException ex =
-        expectThrows(IllegalArgumentException.class, () -> new BKDConfig(1, 1, 8, 1024, 8, 0, 0));
-    assertTrue(ex.getMessage().contains("packedIndexBytesLength must be 8"));
-  }
-
-  public void testInvalidBytesPerDoc() {
-    IllegalArgumentException ex =
-        expectThrows(IllegalArgumentException.class, () -> new BKDConfig(1, 1, 8, 1024, 8, 8, 0));
-    assertTrue(ex.getMessage().contains("bytesPerDoc must be 12"));
-  }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKDRadixSelector.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKDRadixSelector.java
@@ -37,7 +37,7 @@ public class TestBKDRadixSelector extends LuceneTestCase {
         new BKDConfig(
             dimensions, dimensions, bytesPerDimensions, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE);
     PointWriter points = getRandomPointWriter(config, dir, values);
-    byte[] value = new byte[config.packedBytesLength];
+    byte[] value = new byte[config.packedBytesLength()];
     NumericUtils.intToSortableBytes(1, value, 0);
     points.append(value, 0);
     NumericUtils.intToSortableBytes(2, value, 0);
@@ -81,7 +81,7 @@ public class TestBKDRadixSelector extends LuceneTestCase {
     int partitionPoint = TestUtil.nextInt(random(), start + 1, end - 1);
     int sortedOnHeap = random().nextInt(5000);
     PointWriter points = getRandomPointWriter(config, dir, values);
-    byte[] value = new byte[config.packedBytesLength];
+    byte[] value = new byte[config.packedBytesLength()];
     for (int i = 0; i < values; i++) {
       random().nextBytes(value);
       points.append(value, i);
@@ -102,7 +102,7 @@ public class TestBKDRadixSelector extends LuceneTestCase {
     int partitionPoint = random().nextInt(values);
     int sortedOnHeap = random().nextInt(5000);
     PointWriter points = getRandomPointWriter(config, dir, values);
-    byte[] value = new byte[config.packedBytesLength];
+    byte[] value = new byte[config.packedBytesLength()];
     random().nextBytes(value);
     for (int i = 0; i < values; i++) {
       if (random().nextBoolean()) {
@@ -123,7 +123,7 @@ public class TestBKDRadixSelector extends LuceneTestCase {
     int sortedOnHeap = random().nextInt(5000);
     BKDConfig config = getRandomConfig();
     PointWriter points = getRandomPointWriter(config, dir, values);
-    byte[] value = new byte[config.packedBytesLength];
+    byte[] value = new byte[config.packedBytesLength()];
     random().nextBytes(value);
     for (int i = 0; i < values; i++) {
       if (random().nextBoolean()) {
@@ -144,7 +144,7 @@ public class TestBKDRadixSelector extends LuceneTestCase {
     int sortedOnHeap = random().nextInt(5000);
     BKDConfig config = getRandomConfig();
     PointWriter points = getRandomPointWriter(config, dir, values);
-    byte[] value = new byte[config.packedBytesLength];
+    byte[] value = new byte[config.packedBytesLength()];
     random().nextBytes(value);
     for (int i = 0; i < values; i++) {
       points.append(value, 0);
@@ -162,7 +162,7 @@ public class TestBKDRadixSelector extends LuceneTestCase {
     int sortedOnHeap = random().nextInt(5000);
     PointWriter points = getRandomPointWriter(config, dir, values);
     int numberValues = random().nextInt(8) + 2;
-    byte[][] differentValues = new byte[numberValues][config.packedBytesLength];
+    byte[][] differentValues = new byte[numberValues][config.packedBytesLength()];
     for (int i = 0; i < numberValues; i++) {
       random().nextBytes(differentValues[i]);
     }
@@ -181,9 +181,9 @@ public class TestBKDRadixSelector extends LuceneTestCase {
     int partitionPoint = random().nextInt(values);
     int sortedOnHeap = random().nextInt(5000);
     PointWriter points = getRandomPointWriter(config, dir, values);
-    byte[] value = new byte[config.packedBytesLength];
-    int dataOnlyDims = config.numDims - config.numIndexDims;
-    byte[] dataValue = new byte[dataOnlyDims * config.bytesPerDim];
+    byte[] value = new byte[config.packedBytesLength()];
+    int dataOnlyDims = config.numDims() - config.numIndexDims();
+    byte[] dataValue = new byte[dataOnlyDims * config.bytesPerDim()];
     random().nextBytes(value);
     for (int i = 0; i < values; i++) {
       random().nextBytes(dataValue);
@@ -191,8 +191,8 @@ public class TestBKDRadixSelector extends LuceneTestCase {
           dataValue,
           0,
           value,
-          config.numIndexDims * config.bytesPerDim,
-          dataOnlyDims * config.bytesPerDim);
+          config.numIndexDims() * config.bytesPerDim(),
+          dataOnlyDims * config.bytesPerDim());
       points.append(value, i);
     }
     points.close();
@@ -210,9 +210,9 @@ public class TestBKDRadixSelector extends LuceneTestCase {
       int sortedOnHeap)
       throws IOException {
     BKDRadixSelector radixSelector = new BKDRadixSelector(config, sortedOnHeap, dir, "test");
-    int dataOnlyDims = config.numDims - config.numIndexDims;
+    int dataOnlyDims = config.numDims() - config.numIndexDims();
     // we only split by indexed dimension so we check for each only those dimension
-    for (int splitDim = 0; splitDim < config.numIndexDims; splitDim++) {
+    for (int splitDim = 0; splitDim < config.numIndexDims(); splitDim++) {
       // We need to make a copy of the data as it is deleted in the process
       BKDRadixSelector.PathSlice inputSlice =
           new BKDRadixSelector.PathSlice(copyPoints(config, dir, points), 0, points.count());
@@ -226,7 +226,7 @@ public class TestBKDRadixSelector extends LuceneTestCase {
       // check that left and right slices contain the correct points
       byte[] max = getMax(config, slices[0], splitDim);
       byte[] min = getMin(config, slices[1], splitDim);
-      int cmp = Arrays.compareUnsigned(max, 0, config.bytesPerDim, min, 0, config.bytesPerDim);
+      int cmp = Arrays.compareUnsigned(max, 0, config.bytesPerDim(), min, 0, config.bytesPerDim());
       assertTrue(cmp <= 0);
       if (cmp == 0) {
         byte[] maxDataDim = getMaxDataDimension(config, slices[0], max, splitDim);
@@ -235,10 +235,10 @@ public class TestBKDRadixSelector extends LuceneTestCase {
             Arrays.compareUnsigned(
                 maxDataDim,
                 0,
-                dataOnlyDims * config.bytesPerDim,
+                dataOnlyDims * config.bytesPerDim(),
                 minDataDim,
                 0,
-                dataOnlyDims * config.bytesPerDim);
+                dataOnlyDims * config.bytesPerDim());
         assertTrue(cmp <= 0);
         if (cmp == 0) {
           int maxDocID = getMaxDocId(config, slices[0], splitDim, partitionPoint, maxDataDim);
@@ -270,9 +270,9 @@ public class TestBKDRadixSelector extends LuceneTestCase {
     byte[] pointsMax = getMax(config, inputSlice, splitDim);
     byte[] pointsMin = getMin(config, inputSlice, splitDim);
     int commonPrefixLength =
-        Arrays.mismatch(pointsMin, 0, config.bytesPerDim, pointsMax, 0, config.bytesPerDim);
+        Arrays.mismatch(pointsMin, 0, config.bytesPerDim(), pointsMax, 0, config.bytesPerDim());
     if (commonPrefixLength == -1) {
-      commonPrefixLength = config.bytesPerDim;
+      commonPrefixLength = config.bytesPerDim();
     }
     return (random().nextBoolean())
         ? commonPrefixLength
@@ -300,22 +300,23 @@ public class TestBKDRadixSelector extends LuceneTestCase {
 
   private byte[] getMin(BKDConfig config, BKDRadixSelector.PathSlice pathSlice, int dimension)
       throws IOException {
-    byte[] min = new byte[config.bytesPerDim];
+    byte[] min = new byte[config.bytesPerDim()];
     Arrays.fill(min, (byte) 0xff);
     try (PointReader reader = pathSlice.writer.getReader(pathSlice.start, pathSlice.count)) {
-      byte[] value = new byte[config.bytesPerDim];
+      byte[] value = new byte[config.bytesPerDim()];
 
       while (reader.next()) {
         PointValue pointValue = reader.pointValue();
         BytesRef packedValue = pointValue.packedValue();
         System.arraycopy(
             packedValue.bytes,
-            packedValue.offset + dimension * config.bytesPerDim,
+            packedValue.offset + dimension * config.bytesPerDim(),
             value,
             0,
-            config.bytesPerDim);
-        if (Arrays.compareUnsigned(min, 0, config.bytesPerDim, value, 0, config.bytesPerDim) > 0) {
-          System.arraycopy(value, 0, min, 0, config.bytesPerDim);
+            config.bytesPerDim());
+        if (Arrays.compareUnsigned(min, 0, config.bytesPerDim(), value, 0, config.bytesPerDim())
+            > 0) {
+          System.arraycopy(value, 0, min, 0, config.bytesPerDim());
         }
       }
     }
@@ -334,16 +335,16 @@ public class TestBKDRadixSelector extends LuceneTestCase {
       while (reader.next()) {
         PointValue pointValue = reader.pointValue();
         BytesRef packedValue = pointValue.packedValue();
-        int offset = dimension * config.bytesPerDim;
-        int dataOffset = config.packedIndexBytesLength;
-        int dataLength = (config.numDims - config.numIndexDims) * config.bytesPerDim;
+        int offset = dimension * config.bytesPerDim();
+        int dataOffset = config.packedIndexBytesLength();
+        int dataLength = (config.numDims() - config.numIndexDims()) * config.bytesPerDim();
         if (Arrays.compareUnsigned(
                     packedValue.bytes,
                     packedValue.offset + offset,
-                    packedValue.offset + offset + config.bytesPerDim,
+                    packedValue.offset + offset + config.bytesPerDim(),
                     partitionPoint,
                     0,
-                    config.bytesPerDim)
+                    config.bytesPerDim())
                 == 0
             && Arrays.compareUnsigned(
                     packedValue.bytes,
@@ -366,38 +367,38 @@ public class TestBKDRadixSelector extends LuceneTestCase {
   private byte[] getMinDataDimension(
       BKDConfig config, BKDRadixSelector.PathSlice p, byte[] minDim, int splitDim)
       throws IOException {
-    final int numDataDims = config.numDims - config.numIndexDims;
-    byte[] min = new byte[numDataDims * config.bytesPerDim];
+    final int numDataDims = config.numDims() - config.numIndexDims();
+    byte[] min = new byte[numDataDims * config.bytesPerDim()];
     Arrays.fill(min, (byte) 0xff);
-    int offset = splitDim * config.bytesPerDim;
+    int offset = splitDim * config.bytesPerDim();
     try (PointReader reader = p.writer.getReader(p.start, p.count)) {
-      byte[] value = new byte[numDataDims * config.bytesPerDim];
+      byte[] value = new byte[numDataDims * config.bytesPerDim()];
       while (reader.next()) {
         PointValue pointValue = reader.pointValue();
         BytesRef packedValue = pointValue.packedValue();
         if (Arrays.mismatch(
                 minDim,
                 0,
-                config.bytesPerDim,
+                config.bytesPerDim(),
                 packedValue.bytes,
                 packedValue.offset + offset,
-                packedValue.offset + offset + config.bytesPerDim)
+                packedValue.offset + offset + config.bytesPerDim())
             == -1) {
           System.arraycopy(
               packedValue.bytes,
-              packedValue.offset + config.numIndexDims * config.bytesPerDim,
+              packedValue.offset + config.numIndexDims() * config.bytesPerDim(),
               value,
               0,
-              numDataDims * config.bytesPerDim);
+              numDataDims * config.bytesPerDim());
           if (Arrays.compareUnsigned(
                   min,
                   0,
-                  numDataDims * config.bytesPerDim,
+                  numDataDims * config.bytesPerDim(),
                   value,
                   0,
-                  numDataDims * config.bytesPerDim)
+                  numDataDims * config.bytesPerDim())
               > 0) {
-            System.arraycopy(value, 0, min, 0, numDataDims * config.bytesPerDim);
+            System.arraycopy(value, 0, min, 0, numDataDims * config.bytesPerDim());
           }
         }
       }
@@ -407,21 +408,22 @@ public class TestBKDRadixSelector extends LuceneTestCase {
 
   private byte[] getMax(BKDConfig config, BKDRadixSelector.PathSlice p, int dimension)
       throws IOException {
-    byte[] max = new byte[config.bytesPerDim];
+    byte[] max = new byte[config.bytesPerDim()];
     Arrays.fill(max, (byte) 0);
     try (PointReader reader = p.writer.getReader(p.start, p.count)) {
-      byte[] value = new byte[config.bytesPerDim];
+      byte[] value = new byte[config.bytesPerDim()];
       while (reader.next()) {
         PointValue pointValue = reader.pointValue();
         BytesRef packedValue = pointValue.packedValue();
         System.arraycopy(
             packedValue.bytes,
-            packedValue.offset + dimension * config.bytesPerDim,
+            packedValue.offset + dimension * config.bytesPerDim(),
             value,
             0,
-            config.bytesPerDim);
-        if (Arrays.compareUnsigned(max, 0, config.bytesPerDim, value, 0, config.bytesPerDim) < 0) {
-          System.arraycopy(value, 0, max, 0, config.bytesPerDim);
+            config.bytesPerDim());
+        if (Arrays.compareUnsigned(max, 0, config.bytesPerDim(), value, 0, config.bytesPerDim())
+            < 0) {
+          System.arraycopy(value, 0, max, 0, config.bytesPerDim());
         }
       }
     }
@@ -431,38 +433,38 @@ public class TestBKDRadixSelector extends LuceneTestCase {
   private byte[] getMaxDataDimension(
       BKDConfig config, BKDRadixSelector.PathSlice p, byte[] maxDim, int splitDim)
       throws IOException {
-    final int numDataDims = config.numDims - config.numIndexDims;
-    byte[] max = new byte[numDataDims * config.bytesPerDim];
+    final int numDataDims = config.numDims() - config.numIndexDims();
+    byte[] max = new byte[numDataDims * config.bytesPerDim()];
     Arrays.fill(max, (byte) 0);
-    int offset = splitDim * config.bytesPerDim;
+    int offset = splitDim * config.bytesPerDim();
     try (PointReader reader = p.writer.getReader(p.start, p.count)) {
-      byte[] value = new byte[numDataDims * config.bytesPerDim];
+      byte[] value = new byte[numDataDims * config.bytesPerDim()];
       while (reader.next()) {
         PointValue pointValue = reader.pointValue();
         BytesRef packedValue = pointValue.packedValue();
         if (Arrays.mismatch(
                 maxDim,
                 0,
-                config.bytesPerDim,
+                config.bytesPerDim(),
                 packedValue.bytes,
                 packedValue.offset + offset,
-                packedValue.offset + offset + config.bytesPerDim)
+                packedValue.offset + offset + config.bytesPerDim())
             == -1) {
           System.arraycopy(
               packedValue.bytes,
-              packedValue.offset + config.packedIndexBytesLength,
+              packedValue.offset + config.packedIndexBytesLength(),
               value,
               0,
-              numDataDims * config.bytesPerDim);
+              numDataDims * config.bytesPerDim());
           if (Arrays.compareUnsigned(
                   max,
                   0,
-                  numDataDims * config.bytesPerDim,
+                  numDataDims * config.bytesPerDim(),
                   value,
                   0,
-                  numDataDims * config.bytesPerDim)
+                  numDataDims * config.bytesPerDim())
               < 0) {
-            System.arraycopy(value, 0, max, 0, numDataDims * config.bytesPerDim);
+            System.arraycopy(value, 0, max, 0, numDataDims * config.bytesPerDim());
           }
         }
       }
@@ -482,16 +484,16 @@ public class TestBKDRadixSelector extends LuceneTestCase {
       while (reader.next()) {
         PointValue pointValue = reader.pointValue();
         BytesRef packedValue = pointValue.packedValue();
-        int offset = dimension * config.bytesPerDim;
-        int dataOffset = config.packedIndexBytesLength;
-        int dataLength = (config.numDims - config.numIndexDims) * config.bytesPerDim;
+        int offset = dimension * config.bytesPerDim();
+        int dataOffset = config.packedIndexBytesLength();
+        int dataLength = (config.numDims() - config.numIndexDims()) * config.bytesPerDim();
         if (Arrays.compareUnsigned(
                     packedValue.bytes,
                     packedValue.offset + offset,
-                    packedValue.offset + offset + config.bytesPerDim,
+                    packedValue.offset + offset + config.bytesPerDim(),
                     partitionPoint,
                     0,
-                    config.bytesPerDim)
+                    config.bytesPerDim())
                 == 0
             && Arrays.compareUnsigned(
                     packedValue.bytes,

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKDRadixSort.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKDRadixSort.java
@@ -30,7 +30,7 @@ public class TestBKDRadixSort extends LuceneTestCase {
     BKDConfig config = getRandomConfig();
     int numPoints = TestUtil.nextInt(random(), 1, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE);
     HeapPointWriter points = new HeapPointWriter(config, numPoints);
-    byte[] value = new byte[config.packedBytesLength];
+    byte[] value = new byte[config.packedBytesLength()];
     for (int i = 0; i < numPoints; i++) {
       random().nextBytes(value);
       points.append(value, i);
@@ -42,7 +42,7 @@ public class TestBKDRadixSort extends LuceneTestCase {
     BKDConfig config = getRandomConfig();
     int numPoints = TestUtil.nextInt(random(), 1, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE);
     HeapPointWriter points = new HeapPointWriter(config, numPoints);
-    byte[] value = new byte[config.packedBytesLength];
+    byte[] value = new byte[config.packedBytesLength()];
     random().nextBytes(value);
     for (int i = 0; i < numPoints; i++) {
       points.append(value, random().nextInt(numPoints));
@@ -54,7 +54,7 @@ public class TestBKDRadixSort extends LuceneTestCase {
     BKDConfig config = getRandomConfig();
     int numPoints = TestUtil.nextInt(random(), 1, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE);
     HeapPointWriter points = new HeapPointWriter(config, numPoints);
-    byte[] value = new byte[config.packedBytesLength];
+    byte[] value = new byte[config.packedBytesLength()];
     random().nextBytes(value);
     for (int i = 0; i < numPoints; i++) {
       if (random().nextBoolean()) {
@@ -71,7 +71,7 @@ public class TestBKDRadixSort extends LuceneTestCase {
     int numPoints = TestUtil.nextInt(random(), 1, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE);
     HeapPointWriter points = new HeapPointWriter(config, numPoints);
     int numberValues = random().nextInt(8) + 2;
-    byte[][] differentValues = new byte[numberValues][config.packedBytesLength];
+    byte[][] differentValues = new byte[numberValues][config.packedBytesLength()];
     for (int i = 0; i < numberValues; i++) {
       random().nextBytes(differentValues[i]);
     }
@@ -85,9 +85,9 @@ public class TestBKDRadixSort extends LuceneTestCase {
     BKDConfig config = getRandomConfig();
     int numPoints = TestUtil.nextInt(random(), 1, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE);
     HeapPointWriter points = new HeapPointWriter(config, numPoints);
-    byte[] value = new byte[config.packedBytesLength];
-    int totalDataDimension = config.numDims - config.numIndexDims;
-    byte[] dataDimensionValues = new byte[totalDataDimension * config.bytesPerDim];
+    byte[] value = new byte[config.packedBytesLength()];
+    int totalDataDimension = config.numDims() - config.numIndexDims();
+    byte[] dataDimensionValues = new byte[totalDataDimension * config.bytesPerDim()];
     random().nextBytes(value);
     for (int i = 0; i < numPoints; i++) {
       random().nextBytes(dataDimensionValues);
@@ -95,8 +95,8 @@ public class TestBKDRadixSort extends LuceneTestCase {
           dataDimensionValues,
           0,
           value,
-          config.packedIndexBytesLength,
-          totalDataDimension * config.bytesPerDim);
+          config.packedIndexBytesLength(),
+          totalDataDimension * config.bytesPerDim());
       points.append(value, random().nextInt(numPoints));
     }
     verifySort(config, points, 0, numPoints);
@@ -107,17 +107,17 @@ public class TestBKDRadixSort extends LuceneTestCase {
     Directory dir = newDirectory();
     BKDRadixSelector radixSelector = new BKDRadixSelector(config, 1000, dir, "test");
     // we check for each dimension
-    for (int splitDim = 0; splitDim < config.numDims; splitDim++) {
+    for (int splitDim = 0; splitDim < config.numDims(); splitDim++) {
       radixSelector.heapRadixSort(
           points,
           start,
           end,
           splitDim,
           getRandomCommonPrefix(config, points, start, end, splitDim));
-      byte[] previous = new byte[config.packedBytesLength];
+      byte[] previous = new byte[config.packedBytesLength()];
       int previousDocId = -1;
       Arrays.fill(previous, (byte) 0);
-      int dimOffset = splitDim * config.bytesPerDim;
+      int dimOffset = splitDim * config.bytesPerDim();
       for (int j = start; j < end; j++) {
         PointValue pointValue = points.getPackedValueSlice(j);
         BytesRef value = pointValue.packedValue();
@@ -125,27 +125,27 @@ public class TestBKDRadixSort extends LuceneTestCase {
             Arrays.compareUnsigned(
                 value.bytes,
                 value.offset + dimOffset,
-                value.offset + dimOffset + config.bytesPerDim,
+                value.offset + dimOffset + config.bytesPerDim(),
                 previous,
                 dimOffset,
-                dimOffset + config.bytesPerDim);
+                dimOffset + config.bytesPerDim());
         assertTrue(cmp >= 0);
         if (cmp == 0) {
-          int dataOffset = config.numIndexDims * config.bytesPerDim;
+          int dataOffset = config.numIndexDims() * config.bytesPerDim();
           cmp =
               Arrays.compareUnsigned(
                   value.bytes,
                   value.offset + dataOffset,
-                  value.offset + config.packedBytesLength,
+                  value.offset + config.packedBytesLength(),
                   previous,
                   dataOffset,
-                  config.packedBytesLength);
+                  config.packedBytesLength());
           assertTrue(cmp >= 0);
         }
         if (cmp == 0) {
           assertTrue(pointValue.docID() >= previousDocId);
         }
-        System.arraycopy(value.bytes, value.offset, previous, 0, config.packedBytesLength);
+        System.arraycopy(value.bytes, value.offset, previous, 0, config.packedBytesLength());
         previousDocId = pointValue.docID();
       }
     }
@@ -155,12 +155,12 @@ public class TestBKDRadixSort extends LuceneTestCase {
   /** returns a common prefix length equal or lower than the current one */
   private int getRandomCommonPrefix(
       BKDConfig config, HeapPointWriter points, int start, int end, int sortDim) {
-    int commonPrefixLength = config.bytesPerDim;
+    int commonPrefixLength = config.bytesPerDim();
     PointValue value = points.getPackedValueSlice(start);
     BytesRef bytesRef = value.packedValue();
-    byte[] firstValue = new byte[config.bytesPerDim];
-    int offset = sortDim * config.bytesPerDim;
-    System.arraycopy(bytesRef.bytes, bytesRef.offset + offset, firstValue, 0, config.bytesPerDim);
+    byte[] firstValue = new byte[config.bytesPerDim()];
+    int offset = sortDim * config.bytesPerDim();
+    System.arraycopy(bytesRef.bytes, bytesRef.offset + offset, firstValue, 0, config.bytesPerDim());
     for (int i = start + 1; i < end; i++) {
       value = points.getPackedValueSlice(i);
       bytesRef = value.packedValue();
@@ -168,10 +168,10 @@ public class TestBKDRadixSort extends LuceneTestCase {
           Arrays.mismatch(
               bytesRef.bytes,
               bytesRef.offset + offset,
-              bytesRef.offset + offset + config.bytesPerDim,
+              bytesRef.offset + offset + config.bytesPerDim(),
               firstValue,
               0,
-              config.bytesPerDim);
+              config.bytesPerDim());
       if (diff != -1 && commonPrefixLength > diff) {
         if (diff == 0) {
           return diff;

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestMutablePointTreeReaderUtils.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestMutablePointTreeReaderUtils.java
@@ -87,10 +87,10 @@ public class TestMutablePointTreeReaderUtils extends LuceneTestCase {
   private void doTestSortByDim() {
     BKDConfig config = createRandomConfig();
     final int maxDoc = TestUtil.nextInt(random(), 1, 1 << random().nextInt(30));
-    int[] commonPrefixLengths = new int[config.numDims];
+    int[] commonPrefixLengths = new int[config.numDims()];
     Point[] points = createRandomPoints(config, maxDoc, commonPrefixLengths, false);
     DummyPointsReader reader = new DummyPointsReader(points);
-    final int sortedDim = random().nextInt(config.numIndexDims);
+    final int sortedDim = random().nextInt(config.numIndexDims());
     MutablePointTreeReaderUtils.sortByDim(
         config,
         sortedDim,
@@ -101,20 +101,20 @@ public class TestMutablePointTreeReaderUtils extends LuceneTestCase {
         new BytesRef(),
         new BytesRef());
     for (int i = 1; i < points.length; ++i) {
-      final int offset = sortedDim * config.bytesPerDim;
+      final int offset = sortedDim * config.bytesPerDim();
       BytesRef previousValue = reader.points[i - 1].packedValue;
       BytesRef currentValue = reader.points[i].packedValue;
       int cmp =
           Arrays.compareUnsigned(
               previousValue.bytes,
               previousValue.offset + offset,
-              previousValue.offset + offset + config.bytesPerDim,
+              previousValue.offset + offset + config.bytesPerDim(),
               currentValue.bytes,
               currentValue.offset + offset,
-              currentValue.offset + offset + config.bytesPerDim);
+              currentValue.offset + offset + config.bytesPerDim());
       if (cmp == 0) {
-        int dataDimOffset = config.packedIndexBytesLength;
-        int dataDimsLength = (config.numDims - config.numIndexDims) * config.bytesPerDim;
+        int dataDimOffset = config.packedIndexBytesLength();
+        int dataDimsLength = (config.numDims() - config.numIndexDims()) * config.bytesPerDim();
         cmp =
             Arrays.compareUnsigned(
                 previousValue.bytes,
@@ -139,10 +139,10 @@ public class TestMutablePointTreeReaderUtils extends LuceneTestCase {
 
   private void doTestPartition() {
     BKDConfig config = createRandomConfig();
-    int[] commonPrefixLengths = new int[config.numDims];
+    int[] commonPrefixLengths = new int[config.numDims()];
     final int maxDoc = TestUtil.nextInt(random(), 1, 1 << random().nextInt(30));
     Point[] points = createRandomPoints(config, maxDoc, commonPrefixLengths, false);
-    final int splitDim = random().nextInt(config.numIndexDims);
+    final int splitDim = random().nextInt(config.numIndexDims());
     DummyPointsReader reader = new DummyPointsReader(points);
     final int pivot = TestUtil.nextInt(random(), 0, points.length - 1);
     MutablePointTreeReaderUtils.partition(
@@ -157,20 +157,20 @@ public class TestMutablePointTreeReaderUtils extends LuceneTestCase {
         new BytesRef(),
         new BytesRef());
     BytesRef pivotValue = reader.points[pivot].packedValue;
-    int offset = splitDim * config.bytesPerDim;
+    int offset = splitDim * config.bytesPerDim();
     for (int i = 0; i < points.length; ++i) {
       BytesRef value = reader.points[i].packedValue;
       int cmp =
           Arrays.compareUnsigned(
               value.bytes,
               value.offset + offset,
-              value.offset + offset + config.bytesPerDim,
+              value.offset + offset + config.bytesPerDim(),
               pivotValue.bytes,
               pivotValue.offset + offset,
-              pivotValue.offset + offset + config.bytesPerDim);
+              pivotValue.offset + offset + config.bytesPerDim());
       if (cmp == 0) {
-        int dataDimOffset = config.packedIndexBytesLength;
-        int dataDimsLength = (config.numDims - config.numIndexDims) * config.bytesPerDim;
+        int dataDimOffset = config.packedIndexBytesLength();
+        int dataDimsLength = (config.numDims() - config.numIndexDims()) * config.bytesPerDim();
         cmp =
             Arrays.compareUnsigned(
                 value.bytes,
@@ -203,24 +203,24 @@ public class TestMutablePointTreeReaderUtils extends LuceneTestCase {
 
   private static Point[] createRandomPoints(
       BKDConfig config, int maxDoc, int[] commonPrefixLengths, boolean isDocIdIncremental) {
-    assertTrue(commonPrefixLengths.length == config.numDims);
+    assertTrue(commonPrefixLengths.length == config.numDims());
     final int numPoints = TestUtil.nextInt(random(), 1, 100000);
     Point[] points = new Point[numPoints];
     if (random().nextInt(10) != 0) {
       for (int i = 0; i < numPoints; ++i) {
-        byte[] value = new byte[config.packedBytesLength];
+        byte[] value = new byte[config.packedBytesLength()];
         random().nextBytes(value);
         points[i] =
             new Point(
                 value, isDocIdIncremental ? Math.min(i, maxDoc - 1) : random().nextInt(maxDoc));
       }
-      for (int i = 0; i < config.numDims; ++i) {
-        commonPrefixLengths[i] = TestUtil.nextInt(random(), 0, config.bytesPerDim);
+      for (int i = 0; i < config.numDims(); ++i) {
+        commonPrefixLengths[i] = TestUtil.nextInt(random(), 0, config.bytesPerDim());
       }
       BytesRef firstValue = points[0].packedValue;
       for (int i = 1; i < points.length; ++i) {
-        for (int dim = 0; dim < config.numDims; ++dim) {
-          int offset = dim * config.bytesPerDim;
+        for (int dim = 0; dim < config.numDims(); ++dim) {
+          int offset = dim * config.bytesPerDim();
           BytesRef packedValue = points[i].packedValue;
           System.arraycopy(
               firstValue.bytes,
@@ -232,30 +232,34 @@ public class TestMutablePointTreeReaderUtils extends LuceneTestCase {
       }
     } else {
       // index dim are equal, data dims different
-      int numDataDims = config.numDims - config.numIndexDims;
-      byte[] indexDims = new byte[config.packedIndexBytesLength];
+      int numDataDims = config.numDims() - config.numIndexDims();
+      byte[] indexDims = new byte[config.packedIndexBytesLength()];
       random().nextBytes(indexDims);
-      byte[] dataDims = new byte[numDataDims * config.bytesPerDim];
+      byte[] dataDims = new byte[numDataDims * config.bytesPerDim()];
       for (int i = 0; i < numPoints; ++i) {
-        byte[] value = new byte[config.packedBytesLength];
-        System.arraycopy(indexDims, 0, value, 0, config.packedIndexBytesLength);
+        byte[] value = new byte[config.packedBytesLength()];
+        System.arraycopy(indexDims, 0, value, 0, config.packedIndexBytesLength());
         random().nextBytes(dataDims);
         System.arraycopy(
-            dataDims, 0, value, config.packedIndexBytesLength, numDataDims * config.bytesPerDim);
+            dataDims,
+            0,
+            value,
+            config.packedIndexBytesLength(),
+            numDataDims * config.bytesPerDim());
         points[i] =
             new Point(
                 value, isDocIdIncremental ? Math.min(i, maxDoc - 1) : random().nextInt(maxDoc));
       }
-      for (int i = 0; i < config.numIndexDims; ++i) {
-        commonPrefixLengths[i] = config.bytesPerDim;
+      for (int i = 0; i < config.numIndexDims(); ++i) {
+        commonPrefixLengths[i] = config.bytesPerDim();
       }
-      for (int i = config.numIndexDims; i < config.numDims; ++i) {
-        commonPrefixLengths[i] = TestUtil.nextInt(random(), 0, config.bytesPerDim);
+      for (int i = config.numIndexDims(); i < config.numDims(); ++i) {
+        commonPrefixLengths[i] = TestUtil.nextInt(random(), 0, config.bytesPerDim());
       }
       BytesRef firstValue = points[0].packedValue;
       for (int i = 1; i < points.length; ++i) {
-        for (int dim = config.numIndexDims; dim < config.numDims; ++dim) {
-          int offset = dim * config.bytesPerDim;
+        for (int dim = config.numIndexDims(); dim < config.numDims(); ++dim) {
+          int offset = dim * config.bytesPerDim();
           BytesRef packedValue = points[i].packedValue;
           System.arraycopy(
               firstValue.bytes,

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
@@ -308,7 +308,7 @@ public class RandomCodec extends AssertingCodec {
     protected int split(byte[] minPackedValue, byte[] maxPackedValue, int[] parentDims) {
       // BKD normally defaults by the widest dimension, to try to make as squarish cells as
       // possible, but we just pick a random one ;)
-      return random.nextInt(config.numIndexDims);
+      return random.nextInt(config.numIndexDims());
     }
   }
 }


### PR DESCRIPTION
BKDConfig holds the configuration of a BKD tree and it can benefit of being represented as a record. The only annoying thing is that we cannot hide the canonical constructor but I don't think that's a big issue.

relates https://github.com/apache/lucene/issues/13207
