### PR TITLE
Support JDK 23 in Panama Vectorization Provider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
   minJavaVersion = JavaVersion.toVersion(deps.versions.minJava.get())
 
   // also change this in extractor tool: ExtractForeignAPI
-  vectorIncubatorJavaVersions = [ JavaVersion.VERSION_21, JavaVersion.VERSION_22 ] as Set
+  vectorIncubatorJavaVersions = [ JavaVersion.VERSION_21, JavaVersion.VERSION_22, JavaVersion.VERSION_23 ] as Set
 
   // snapshot build marker used in scripts.
   snapshotBuild = version.contains("SNAPSHOT")

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -296,6 +296,8 @@ New Features
 
 * GITHUB#13568: Add sandbox facets module to compute facets while collecting. (Egor Potemkin, Shradha Shankar)
 
+* GITHUB#13678: Add support JDK 23 to the Panama Vectorization Provider. (Chris Hegarty)
+
 Improvements
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -108,7 +108,7 @@ public abstract class VectorizationProvider {
   static VectorizationProvider lookup(boolean testMode) {
     final int runtimeVersion = Runtime.version().feature();
     assert runtimeVersion >= 21;
-    if (runtimeVersion <= 22) {
+    if (runtimeVersion <= 23) {
       // only use vector module with Hotspot VM
       if (!Constants.IS_HOTSPOT_VM) {
         LOG.warning(


### PR DESCRIPTION
This commit updates the Vectorization Provider to support JDK 23. The API has not changed so the changes minimally bump the major JDK check, and enable the incubating API during testing.