### PR TITLE
Speed up advancing within a block.

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/ProfileResults.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/ProfileResults.java
@@ -156,7 +156,12 @@ public class ProfileResults {
 
   /** Process all the JFR files passed in args and print a merged summary. */
   public static void printReport(
-      List<String> files, String mode, int stacksize, int count, boolean lineNumbers, boolean frameTypes)
+      List<String> files,
+      String mode,
+      int stacksize,
+      int count,
+      boolean lineNumbers,
+      boolean frameTypes)
       throws IOException {
     if (!"cpu".equals(mode) && !"heap".equals(mode)) {
       throw new IllegalArgumentException("tests.profile.mode must be one of (cpu,heap)");

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/AdvanceBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/AdvanceBenchmark.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(
+    value = 1,
+    jvmArgsAppend = {"-Xmx1g", "-Xms1g", "-XX:+AlwaysPreTouch"})
+public class AdvanceBenchmark {
+
+  private final long[] values = new long[129];
+  private final int[] startIndexes = new int[1_000];
+  private final long[] targets = new long[startIndexes.length];
+
+  @Setup(Level.Trial)
+  public void setup() throws Exception {
+    for (int i = 0; i < 128; ++i) {
+      values[i] = i;
+    }
+    values[128] = DocIdSetIterator.NO_MORE_DOCS;
+    Random r = new Random(0);
+    for (int i = 0; i < startIndexes.length; ++i) {
+      startIndexes[i] = r.nextInt(64);
+      targets[i] = startIndexes[i] + 1 + r.nextInt(1 << r.nextInt(7));
+    }
+  }
+
+  @Benchmark
+  public void binarySearch() {
+    for (int i = 0; i < startIndexes.length; ++i) {
+      binarySearch(values, targets[i], startIndexes[i]);
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private static int binarySearch(long[] values, long target, int startIndex) {
+    // Standard binary search
+    int i = Arrays.binarySearch(values, startIndex, values.length, target);
+    if (i < 0) {
+      i = -1 - i;
+    }
+    return i;
+  }
+
+  @Benchmark
+  public void binarySearch2() {
+    for (int i = 0; i < startIndexes.length; ++i) {
+      binarySearch2(values, targets[i], startIndexes[i]);
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private static int binarySearch2(long[] values, long target, int startIndex) {
+    // Try to help the compiler by providing predictable start/end offsets.
+    int i = Arrays.binarySearch(values, 0, 128, target);
+    if (i < 0) {
+      i = -1 - i;
+    }
+    return i;
+  }
+
+  @Benchmark
+  public void binarySearch3() {
+    for (int i = 0; i < startIndexes.length; ++i) {
+      binarySearch3(values, targets[i], startIndexes[i]);
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private static int binarySearch3(long[] values, long target, int startIndex) {
+    // Organize code the same way as suggested in https://quickwit.io/blog/search-a-sorted-block,
+    // which proved to help with LLVM.
+    int start = 0;
+    int length = 128;
+
+    while (length > 1) {
+      length /= 2;
+      if (values[start + length - 1] < target) {
+        start += length;
+      }
+    }
+    return start;
+  }
+
+  @Benchmark
+  public void binarySearch4() {
+    for (int i = 0; i < startIndexes.length; ++i) {
+      binarySearch4(values, targets[i], startIndexes[i]);
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private static int binarySearch4(long[] values, long target, int startIndex) {
+    // Explicitly inline the binary-search logic to see if it helps the compiler.
+    int start = 0;
+
+    start += values[63] < target ? 64 : 0;
+    start += values[start + 31] < target ? 32 : 0;
+    start += values[start + 15] < target ? 16 : 0;
+    start += values[start + 7] < target ? 8 : 0;
+    start += values[start + 3] < target ? 4 : 0;
+    start += values[start + 1] < target ? 2 : 0;
+    start += values[start] < target ? 1 : 0;
+
+    return start;
+  }
+
+  @Benchmark
+  public void binarySearch5() {
+    for (int i = 0; i < startIndexes.length; ++i) {
+      binarySearch5(values, targets[i], startIndexes[i]);
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private static int binarySearch5(long[] values, long target, int startIndex) {
+    // Other way to write a binary search
+    int start = 0;
+
+    for (int shift = 6; shift >= 0; --shift) {
+      int halfRange = 1 << shift;
+      if (values[start + halfRange - 1] < target) {
+        start += halfRange;
+      }
+    }
+
+    return start;
+  }
+
+  @Benchmark
+  public void binarySearch6() {
+    for (int i = 0; i < startIndexes.length; ++i) {
+      binarySearch6(values, targets[i], startIndexes[i]);
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private static int binarySearch6(long[] values, long target, int startIndex) {
+    // Other way to write a binary search
+    int start = 0;
+
+    for (int halfRange = 64; halfRange > 0; halfRange >>= 1) {
+      if (values[start + halfRange - 1] < target) {
+        start += halfRange;
+      }
+    }
+
+    return start;
+  }
+
+  @Benchmark
+  public void linearSearch() {
+    for (int i = 0; i < startIndexes.length; ++i) {
+      linearSearch(values, targets[i], startIndexes[i]);
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private static int linearSearch(long[] values, long target, int startIndex) {
+    // Naive linear search.
+    for (int i = startIndex; i < values.length; ++i) {
+      if (values[i] >= target) {
+        return i;
+      }
+    }
+    return values.length;
+  }
+
+  @Benchmark
+  public void bruteForceSearch() {
+    for (int i = 0; i < startIndexes.length; ++i) {
+      bruteForceSearch(values, targets[i], startIndexes[i]);
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private static int bruteForceSearch(long[] values, long target, int startIndex) {
+    // Linear search with predictable start/end offsets to see if it helps the compiler.
+    for (int i = 0; i < 128; ++i) {
+      if (values[i] >= target) {
+        return i;
+      }
+    }
+    return values.length;
+  }
+
+  @Benchmark
+  public void linearSearch2() {
+    for (int i = 0; i < startIndexes.length; ++i) {
+      linearSearch2(values, targets[i], startIndexes[i]);
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private static int linearSearch2(long[] values, long target, int startIndex) {
+    // Two-level linear search, first checking every 8-th value, then values within an 8-value range
+    int rangeEnd = values.length;
+
+    for (int i = startIndex + 7; i < values.length; i += 8) {
+      if (values[i] >= target) {
+        rangeEnd = i;
+        break;
+      }
+    }
+
+    for (int i = rangeEnd - 7; i < rangeEnd; ++i) {
+      if (values[i] >= target) {
+        return i;
+      }
+    }
+
+    return rangeEnd;
+  }
+
+  @Benchmark
+  public void linearSearch3() {
+    for (int i = 0; i < startIndexes.length; ++i) {
+      linearSearch3(values, targets[i], startIndexes[i]);
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private static int linearSearch3(long[] values, long target, int startIndex) {
+    // Iteration over linearSearch that tries to reduce branches
+    while (startIndex + 4 <= values.length) {
+      int count = values[startIndex] < target ? 1 : 0;
+      if (values[startIndex+1] < target) {
+        count++;
+      }
+      if (values[startIndex+2] < target) {
+        count++;
+      }
+      if (values[startIndex+3] < target) {
+        count++;
+      }
+      if (count != 4) {
+        return startIndex + count;
+      }
+      startIndex += 4;
+    }
+
+    for (int i = startIndex; i < values.length; ++i) {
+      if (values[i] >= target) {
+        return i;
+      }
+    }
+
+    return values.length;
+  }
+
+  @Benchmark
+  public void hybridSearch() {
+    for (int i = 0; i < startIndexes.length; ++i) {
+      hybridSearch(values, targets[i], startIndexes[i]);
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private static int hybridSearch(long[] values, long target, int startIndex) {
+    // Two-level linear search, first checking every 8-th value, then values within an 8-value range
+    int rangeEnd = values.length;
+
+    for (int i = startIndex + 7; i < values.length; i += 8) {
+      if (values[i] >= target) {
+        rangeEnd = i;
+        break;
+      }
+    }
+
+    return binarySearchHelper8(values, target, rangeEnd - 7);
+  }
+
+  // Compiles to a branchless binary search.
+  private static int binarySearchHelper8(long[] values, long target, int start) {
+    for (int shift = 2; shift >= 0; --shift) {
+      int halfRange = 1 << shift;
+      if (values[start + halfRange - 1] < target) {
+        start += halfRange;
+      }
+    }
+    return start;
+  }
+
+  private static void assertEquals(int expected, int actual) {
+    if (expected != actual) {
+      throw new AssertionError("Expected: " + expected + ", got " + actual);
+    }
+  }
+
+  public static void main(String[] args) {
+    // For testing purposes
+    long[] values = new long[129];
+    for (int i = 0; i < 128; ++i) {
+      values[i] = i;
+    }
+    values[128] = DocIdSetIterator.NO_MORE_DOCS;
+    for (int start = 0; start < 128; ++start) {
+      for (int targetIndex = start; targetIndex < 128; ++targetIndex) {
+        int actualIndex = binarySearch(values, values[targetIndex], start);
+        assertEquals(targetIndex, actualIndex);
+        actualIndex = binarySearch2(values, values[targetIndex], start);
+        assertEquals(targetIndex, actualIndex);
+        actualIndex = binarySearch3(values, values[targetIndex], start);
+        assertEquals(targetIndex, actualIndex);
+        actualIndex = binarySearch4(values, values[targetIndex], start);
+        assertEquals(targetIndex, actualIndex);
+        actualIndex = binarySearch5(values, values[targetIndex], start);
+        assertEquals(targetIndex, actualIndex);
+        actualIndex = binarySearch6(values, values[targetIndex], start);
+        assertEquals(targetIndex, actualIndex);
+        actualIndex = bruteForceSearch(values, values[targetIndex], start);
+        assertEquals(targetIndex, actualIndex);
+        actualIndex = hybridSearch(values, values[targetIndex], start);
+        assertEquals(targetIndex, actualIndex);
+        actualIndex = linearSearch(values, values[targetIndex], start);
+        assertEquals(targetIndex, actualIndex);
+        actualIndex = linearSearch2(values, values[targetIndex], start);
+        assertEquals(targetIndex, actualIndex);
+        actualIndex = linearSearch3(values, values[targetIndex], start);
+        assertEquals(targetIndex, actualIndex);
+      }
+    }
+  }
+}

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/AdvanceBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/AdvanceBenchmark.java
@@ -243,22 +243,22 @@ public class AdvanceBenchmark {
   @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   private static int linearSearch2(long[] values, long target, int startIndex) {
     // Two-level linear search, first checking every 8-th value, then values within an 8-value range
-    int rangeEnd = values.length;
+    int rangeStart = values.length - 8;
 
-    for (int i = startIndex + 7; i < values.length; i += 8) {
-      if (values[i] >= target) {
-        rangeEnd = i;
+    for (int i = startIndex; i + 8 <= values.length; i += 8) {
+      if (values[i + 7] >= target) {
+        rangeStart = i;
         break;
       }
     }
 
-    for (int i = rangeEnd - 7; i < rangeEnd; ++i) {
-      if (values[i] >= target) {
-        return i;
+    for (int i = 0; i < 8; ++i) {
+      if (values[rangeStart + i] >= target) {
+        return rangeStart + i;
       }
     }
 
-    return rangeEnd;
+    return values.length;
   }
 
   @Benchmark
@@ -307,16 +307,16 @@ public class AdvanceBenchmark {
   @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   private static int hybridSearch(long[] values, long target, int startIndex) {
     // Two-level linear search, first checking every 8-th value, then values within an 8-value range
-    int rangeEnd = values.length;
+    int rangeStart = values.length - 8;
 
-    for (int i = startIndex + 7; i < values.length; i += 8) {
-      if (values[i] >= target) {
-        rangeEnd = i;
+    for (int i = startIndex; i + 8 <= values.length; i += 8) {
+      if (values[i + 7] >= target) {
+        rangeStart = i;
         break;
       }
     }
 
-    return binarySearchHelper8(values, target, rangeEnd - 7);
+    return binarySearchHelper8(values, target, rangeStart);
   }
 
   // branchless binary search over 8 values

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/AdvanceBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/AdvanceBenchmark.java
@@ -129,13 +129,27 @@ public class AdvanceBenchmark {
     // Explicitly inline the binary-search logic to see if it helps the compiler.
     int start = 0;
 
-    start += values[63] < target ? 64 : 0;
-    start += values[start + 31] < target ? 32 : 0;
-    start += values[start + 15] < target ? 16 : 0;
-    start += values[start + 7] < target ? 8 : 0;
-    start += values[start + 3] < target ? 4 : 0;
-    start += values[start + 1] < target ? 2 : 0;
-    start += values[start] < target ? 1 : 0;
+    if (values[63] < target) {
+      start += 64;
+    }
+    if (values[start + 31] < target) {
+      start += 32;
+    }
+    if (values[start + 15] < target) {
+      start += 16;
+    }
+    if (values[start + 7] < target) {
+      start += 8;
+    }
+    if (values[start + 3] < target) {
+      start += 4;
+    }
+    if (values[start + 1] < target) {
+      start += 2;
+    }
+    if (values[start] < target) {
+      start += 1;
+    }
 
     return start;
   }
@@ -305,13 +319,16 @@ public class AdvanceBenchmark {
     return binarySearchHelper8(values, target, rangeEnd - 7);
   }
 
-  // Compiles to a branchless binary search.
+  // branchless binary search over 8 values
   private static int binarySearchHelper8(long[] values, long target, int start) {
-    for (int shift = 2; shift >= 0; --shift) {
-      int halfRange = 1 << shift;
-      if (values[start + halfRange - 1] < target) {
-        start += halfRange;
-      }
+    if (values[start + 3] < target) {
+      start += 4;
+    }
+    if (values[start + 1] < target) {
+      start += 2;
+    }
+    if (values[start] < target) {
+      start += 1;
     }
     return start;
   }

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/AdvanceBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/AdvanceBenchmark.java
@@ -259,13 +259,13 @@ public class AdvanceBenchmark {
     // Iteration over linearSearch that tries to reduce branches
     while (startIndex + 4 <= values.length) {
       int count = values[startIndex] < target ? 1 : 0;
-      if (values[startIndex+1] < target) {
+      if (values[startIndex + 1] < target) {
         count++;
       }
-      if (values[startIndex+2] < target) {
+      if (values[startIndex + 2] < target) {
         count++;
       }
-      if (values[startIndex+3] < target) {
+      if (values[startIndex + 3] < target) {
         count++;
       }
       if (count != 4) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -250,11 +250,11 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
    */
   private static int binarySearch4(long[] values, long target, int start) {
     // This code is organized in a way that compiles to a branchless binary search.
-    for (int shift = 1; shift >= 0; --shift) {
-      int halfRange = 1 << shift;
-      if (values[start + halfRange - 1] < target) {
-        start += halfRange;
-      }
+    if (values[start + 1] < target) {
+      start += 2;
+    }
+    if (values[start] < target) {
+      start += 1;
     }
     return start;
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -238,7 +238,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
   }
 
   /**
-   * Return the first index in sorted array {@code buffer} whose value is greater than or equal to
+   * Return the first index in sorted array {@code values} whose value is greater than or equal to
    * {@code target}. For correctness, it requires the last 4 values to be set to {@code
    * NO_MORE_DOCS}.
    */

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestLucene912PostingsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestLucene912PostingsFormat.java
@@ -157,11 +157,12 @@ public class TestLucene912PostingsFormat extends BasePostingsFormatTestCase {
   }
 
   public void testFindNextGEQ() {
-    long[] values = new long[ForUtil.BLOCK_SIZE + 1];
+    long[] values =
+        new long[ForUtil.BLOCK_SIZE + Lucene912PostingsReader.BINARY_SEARCH_WINDOW_SIZE];
     for (int i = 0; i < ForUtil.BLOCK_SIZE; ++i) {
       values[i] = i * 2;
     }
-    values[ForUtil.BLOCK_SIZE] = DocIdSetIterator.NO_MORE_DOCS;
+    Arrays.fill(values, ForUtil.BLOCK_SIZE, values.length, DocIdSetIterator.NO_MORE_DOCS);
     for (int i = 0; i < ForUtil.BLOCK_SIZE; ++i) {
       for (int start = 0; start <= i; ++start) {
         assertEquals(i, Lucene912PostingsReader.findNextGEQ(values, i * 2, start));

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestLucene912PostingsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestLucene912PostingsFormat.java
@@ -31,6 +31,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.Impact;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.store.Directory;
@@ -151,6 +152,20 @@ public class TestLucene912PostingsFormat extends BasePostingsFormatTestCase {
                 new ByteArrayDataInput(b),
                 new MutableImpactList(impacts.size() + random().nextInt(3)));
         assertEquals(impacts, impacts2);
+      }
+    }
+  }
+
+  public void testFindNextGEQ() {
+    long[] values = new long[ForUtil.BLOCK_SIZE + 1];
+    for (int i = 0; i < ForUtil.BLOCK_SIZE; ++i) {
+      values[i] = i * 2;
+    }
+    values[ForUtil.BLOCK_SIZE] = DocIdSetIterator.NO_MORE_DOCS;
+    for (int i = 0; i < ForUtil.BLOCK_SIZE; ++i) {
+      for (int start = 0; start <= i; ++start) {
+        assertEquals(i, Lucene912PostingsReader.findNextGEQ(values, i * 2, start));
+        assertEquals(i + 1, Lucene912PostingsReader.findNextGEQ(values, i * 2 + 1, start));
       }
     }
   }


### PR DESCRIPTION
Advancing within a block consists of finding the first index within an array of 128 values whose value is greater than or equal a target. Given the small size, it's not obvious whether it's better to perform a linear search, a binary search or something else... It is surprisingly hard to beat the linear search that we are using today.

Experiments suggested that the following approach works in practice:
 - First check if the next item in the array is greater than or equal to the target.
 - Then find the first 4-values interval that contains our target.
 - Then perform a branchless binary search within this interval of 4 values.

This approach still biases heavily towards the case when the target is very close to the current index, only a bit less than a linear search.