### PR TITLE
Use range optimizations for "slow" MultiTermQueries when terms happen to be contiguous

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -16,19 +16,11 @@
  */
 package org.apache.lucene.document;
 
-import java.io.IOException;
-import java.util.Objects;
-import java.util.function.LongPredicate;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesSkipper;
-import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
-import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
-import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.DocValuesRangeIterator;
 import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -36,11 +28,12 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
-import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortedSetDocValuesRangeScorer;
-import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+import java.util.Objects;
 
 final class SortedSetDocValuesRangeQuery extends Query {
 
@@ -155,76 +148,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
               }
             }
 
-            return new SortedSetDocValuesRangeScorer(values, minOrd, maxOrd, scoreMode, score(), skipper);
-
-            /**
-            // no terms matched in this segment
-            if (minOrd > maxOrd
-                || (skipper != null
-                    && (minOrd > skipper.maxValue() || maxOrd < skipper.minValue()))) {
-              return new ConstantScoreScorer(score(), scoreMode, DocIdSetIterator.empty());
-            }
-
-            // all terms matched in this segment
-            if (skipper != null
-                && skipper.docCount() == context.reader().maxDoc()
-                && skipper.minValue() >= minOrd
-                && skipper.maxValue() <= maxOrd) {
-              return new ConstantScoreScorer(
-                  score(), scoreMode, DocIdSetIterator.all(skipper.docCount()));
-            }
-
-            final SortedDocValues singleton = DocValues.unwrapSingleton(values);
-            TwoPhaseIterator iterator;
-            if (singleton != null) {
-              if (skipper != null) {
-                final DocIdSetIterator psIterator =
-                    getDocIdSetIteratorOrNullForPrimarySort(
-                        context.reader(), singleton, skipper, minOrd, maxOrd);
-                if (psIterator != null) {
-                  return new ConstantScoreScorer(score(), scoreMode, psIterator);
-                }
-              }
-              iterator =
-                  new TwoPhaseIterator(singleton) {
-                    @Override
-                    public boolean matches() throws IOException {
-                      final long ord = singleton.ordValue();
-                      return ord >= minOrd && ord <= maxOrd;
-                    }
-
-                    @Override
-                    public float matchCost() {
-                      return 2; // 2 comparisons
-                    }
-                  };
-            } else {
-              iterator =
-                  new TwoPhaseIterator(values) {
-                    @Override
-                    public boolean matches() throws IOException {
-                      for (int i = 0; i < values.docValueCount(); i++) {
-                        long ord = values.nextOrd();
-                        if (ord < minOrd) {
-                          continue;
-                        }
-                        // Values are sorted, so the first ord that is >= minOrd is our best
-                        // candidate
-                        return ord <= maxOrd;
-                      }
-                      return false; // all ords were < minOrd
-                    }
-
-                    @Override
-                    public float matchCost() {
-                      return 2; // 2 comparisons
-                    }
-                  };
-            }
-            if (skipper != null) {
-              iterator = new DocValuesRangeIterator(iterator, skipper, minOrd, maxOrd, false);
-            }
-            return new ConstantScoreScorer(score(), scoreMode, iterator);
+            return new SortedSetDocValuesRangeScorer(field, values, minOrd, maxOrd, scoreMode, score(), skipper, context);
           }
 
           @Override
@@ -232,7 +156,6 @@ final class SortedSetDocValuesRangeQuery extends Query {
             return values.cost();
           }
         };
-          **/
       }
 
       @Override
@@ -240,70 +163,5 @@ final class SortedSetDocValuesRangeQuery extends Query {
         return DocValues.isCacheable(ctx, field);
       }
     };
-  }
-
-  private DocIdSetIterator getDocIdSetIteratorOrNullForPrimarySort(
-      LeafReader reader,
-      SortedDocValues sortedDocValues,
-      DocValuesSkipper skipper,
-      long minOrd,
-      long maxOrd)
-      throws IOException {
-    if (skipper.docCount() != reader.maxDoc()) {
-      return null;
-    }
-    final Sort indexSort = reader.getMetaData().sort();
-    if (indexSort == null
-        || indexSort.getSort().length == 0
-        || indexSort.getSort()[0].getField().equals(field) == false) {
-      return null;
-    }
-
-    final int minDocID;
-    final int maxDocID;
-    if (indexSort.getSort()[0].getReverse()) {
-      if (skipper.maxValue() <= maxOrd) {
-        minDocID = 0;
-      } else {
-        skipper.advance(Long.MIN_VALUE, maxOrd);
-        minDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l <= maxOrd);
-      }
-      if (skipper.minValue() >= minOrd) {
-        maxDocID = skipper.docCount();
-      } else {
-        skipper.advance(Long.MIN_VALUE, minOrd);
-        maxDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l < minOrd);
-      }
-    } else {
-      if (skipper.minValue() >= minOrd) {
-        minDocID = 0;
-      } else {
-        skipper.advance(minOrd, Long.MAX_VALUE);
-        minDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l >= minOrd);
-      }
-      if (skipper.maxValue() <= maxOrd) {
-        maxDocID = skipper.docCount();
-      } else {
-        skipper.advance(maxOrd, Long.MAX_VALUE);
-        maxDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l > maxOrd);
-      }
-    }
-    return minDocID == maxDocID
-        ? DocIdSetIterator.empty()
-        : DocIdSetIterator.range(minDocID, maxDocID);
-  }
-
-  private static int nextDoc(int startDoc, SortedDocValues docValues, LongPredicate predicate)
-      throws IOException {
-    int doc = docValues.docID();
-    if (startDoc > doc) {
-      doc = docValues.advance(startDoc);
-    }
-    for (; doc < DocIdSetIterator.NO_MORE_DOCS; doc = docValues.nextDoc()) {
-      if (predicate.test(docValues.ordValue())) {
-        break;
-      }
-    }
-    return doc;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -37,6 +37,7 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortedSetDocValuesRangeScorer;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
@@ -154,6 +155,9 @@ final class SortedSetDocValuesRangeQuery extends Query {
               }
             }
 
+            return new SortedSetDocValuesRangeScorer(values, minOrd, maxOrd, scoreMode, score(), skipper);
+
+            /**
             // no terms matched in this segment
             if (minOrd > maxOrd
                 || (skipper != null
@@ -228,6 +232,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
             return values.cost();
           }
         };
+          **/
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesRewriteMethod.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesRewriteMethod.java
@@ -195,7 +195,7 @@ public final class DocValuesRewriteMethod extends MultiTermQuery.RewriteMethod {
               }
 
               if (hasGaps == false) {
-                return new SortedSetDocValuesRangeScorer(values, minOrd, maxOrd, scoreMode, score(), skipper);
+                return new SortedSetDocValuesRangeScorer(query.field, values, minOrd, maxOrd, scoreMode, score(), skipper, context);
               }
 
               final SortedDocValues singleton = DocValues.unwrapSingleton(values);

--- a/lucene/core/src/java/org/apache/lucene/search/SortedSetDocValuesRangeScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortedSetDocValuesRangeScorer.java
@@ -1,0 +1,116 @@
+package org.apache.lucene.search;
+
+import org.apache.lucene.document.DocValuesRangeIterator;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class SortedSetDocValuesRangeScorer extends Scorer {
+  final Scorer delegate;
+
+  public SortedSetDocValuesRangeScorer(SortedSetDocValues values, long minOrd, long maxOrd, ScoreMode scoreMode, float score, DocValuesSkipper skipper) throws IOException {
+    delegate = setupScorer(values, minOrd, maxOrd, scoreMode, score, skipper);
+  }
+
+  static Scorer setupScorer(SortedSetDocValues values, long minOrd, long maxOrd, ScoreMode scoreMode, float score, DocValuesSkipper skipper) throws IOException {
+    // no terms matched in this segment
+    if (minOrd > maxOrd
+        || (skipper != null
+        && (minOrd > skipper.maxValue() || maxOrd < skipper.minValue()))) {
+      return new ConstantScoreScorer(score, scoreMode, DocIdSetIterator.empty());
+    }
+
+    final SortedDocValues singleton = DocValues.unwrapSingleton(values);
+    TwoPhaseIterator iterator;
+    if (singleton != null) {
+      iterator =
+          new TwoPhaseIterator(singleton) {
+            @Override
+            public boolean matches() throws IOException {
+              final long ord = singleton.ordValue();
+              return ord >= minOrd && ord <= maxOrd;
+            }
+
+            @Override
+            public float matchCost() {
+              return 2; // 2 comparisons
+            }
+          };
+    } else {
+      iterator =
+          new TwoPhaseIterator(values) {
+            @Override
+            public boolean matches() throws IOException {
+              for (int i = 0; i < values.docValueCount(); i++) {
+                long ord = values.nextOrd();
+                if (ord < minOrd) {
+                  continue;
+                }
+                // Values are sorted, so the first ord that is >= minOrd is our best
+                // candidate
+                return ord <= maxOrd;
+              }
+              return false; // all ords were < minOrd
+            }
+
+            @Override
+            public float matchCost() {
+              return 2; // 2 comparisons
+            }
+          };
+    }
+    if (skipper != null) {
+      iterator = new DocValuesRangeIterator(iterator, skipper, minOrd, maxOrd);
+    }
+    return new ConstantScoreScorer(score, scoreMode, iterator);
+  }
+
+  @Override
+  public int docID() {
+    return delegate.docID();
+  }
+
+  @Override
+  public DocIdSetIterator iterator() {
+    return delegate.iterator();
+  }
+
+  @Override
+  public float getMaxScore(int upTo) throws IOException {
+    return delegate.getMaxScore(upTo);
+  }
+
+  @Override
+  public float score() throws IOException {
+    return delegate.score();
+  }
+
+  @Override
+  public TwoPhaseIterator twoPhaseIterator() {
+    return delegate.twoPhaseIterator();
+  }
+
+  @Override
+  public int advanceShallow(int target) throws IOException {
+    return delegate.advanceShallow(target);
+  }
+
+  @Override
+  public float smoothingScore(int docId) throws IOException {
+    return delegate.smoothingScore(docId);
+  }
+
+  @Override
+  public void setMinCompetitiveScore(float minScore) throws IOException {
+    delegate.setMinCompetitiveScore(minScore);
+  }
+
+  @Override
+  public Collection<ChildScorable> getChildren() throws IOException {
+    return delegate.getChildren();
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/SortedSetDocValuesRangeScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortedSetDocValuesRangeScorer.java
@@ -1,22 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.search;
 
-import org.apache.lucene.document.DocValuesRangeIterator;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.function.LongPredicate;
 
 public class SortedSetDocValuesRangeScorer extends Scorer {
   final Scorer delegate;
 
-  public SortedSetDocValuesRangeScorer(SortedSetDocValues values, long minOrd, long maxOrd, ScoreMode scoreMode, float score, DocValuesSkipper skipper) throws IOException {
-    delegate = setupScorer(values, minOrd, maxOrd, scoreMode, score, skipper);
+  public SortedSetDocValuesRangeScorer(
+      String field,
+      SortedSetDocValues values,
+      long minOrd,
+      long maxOrd,
+      ScoreMode scoreMode,
+      float score,
+      DocValuesSkipper skipper,
+      LeafReaderContext context) throws IOException {
+    delegate = setupScorer(field, values, minOrd, maxOrd, scoreMode, score, skipper, context);
   }
 
-  static Scorer setupScorer(SortedSetDocValues values, long minOrd, long maxOrd, ScoreMode scoreMode, float score, DocValuesSkipper skipper) throws IOException {
+  static Scorer setupScorer(
+      String field,
+      SortedSetDocValues values,
+      long minOrd,
+      long maxOrd,
+      ScoreMode scoreMode,
+      float score,
+      DocValuesSkipper skipper,
+      LeafReaderContext context) throws IOException {
     // no terms matched in this segment
     if (minOrd > maxOrd
         || (skipper != null
@@ -24,9 +58,26 @@ public class SortedSetDocValuesRangeScorer extends Scorer {
       return new ConstantScoreScorer(score, scoreMode, DocIdSetIterator.empty());
     }
 
+    // all terms matched in this segment
+    if (skipper != null
+        && skipper.docCount() == context.reader().maxDoc()
+        && skipper.minValue() >= minOrd
+        && skipper.maxValue() <= maxOrd) {
+      return new ConstantScoreScorer(
+          score, scoreMode, DocIdSetIterator.all(skipper.docCount()));
+    }
+
     final SortedDocValues singleton = DocValues.unwrapSingleton(values);
     TwoPhaseIterator iterator;
     if (singleton != null) {
+      if (skipper != null) {
+        final DocIdSetIterator psIterator =
+            getDocIdSetIteratorOrNullForPrimarySort(
+                context.reader(), field, singleton, skipper, minOrd, maxOrd);
+        if (psIterator != null) {
+          return new ConstantScoreScorer(score, scoreMode, psIterator);
+        }
+      }
       iterator =
           new TwoPhaseIterator(singleton) {
             @Override
@@ -64,7 +115,7 @@ public class SortedSetDocValuesRangeScorer extends Scorer {
           };
     }
     if (skipper != null) {
-      iterator = new DocValuesRangeIterator(iterator, skipper, minOrd, maxOrd);
+      iterator = new DocValuesRangeIterator(iterator, skipper, minOrd, maxOrd, false);
     }
     return new ConstantScoreScorer(score, scoreMode, iterator);
   }
@@ -112,5 +163,71 @@ public class SortedSetDocValuesRangeScorer extends Scorer {
   @Override
   public Collection<ChildScorable> getChildren() throws IOException {
     return delegate.getChildren();
+  }
+
+  private static DocIdSetIterator getDocIdSetIteratorOrNullForPrimarySort(
+      LeafReader reader,
+      String field,
+      SortedDocValues sortedDocValues,
+      DocValuesSkipper skipper,
+      long minOrd,
+      long maxOrd)
+      throws IOException {
+    if (skipper.docCount() != reader.maxDoc()) {
+      return null;
+    }
+    final Sort indexSort = reader.getMetaData().getSort();
+    if (indexSort == null
+        || indexSort.getSort().length == 0
+        || indexSort.getSort()[0].getField().equals(field) == false) {
+      return null;
+    }
+
+    final int minDocID;
+    final int maxDocID;
+    if (indexSort.getSort()[0].getReverse()) {
+      if (skipper.maxValue() <= maxOrd) {
+        minDocID = 0;
+      } else {
+        skipper.advance(Long.MIN_VALUE, maxOrd);
+        minDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l <= maxOrd);
+      }
+      if (skipper.minValue() >= minOrd) {
+        maxDocID = skipper.docCount();
+      } else {
+        skipper.advance(Long.MIN_VALUE, minOrd);
+        maxDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l < minOrd);
+      }
+    } else {
+      if (skipper.minValue() >= minOrd) {
+        minDocID = 0;
+      } else {
+        skipper.advance(minOrd, Long.MAX_VALUE);
+        minDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l >= minOrd);
+      }
+      if (skipper.maxValue() <= maxOrd) {
+        maxDocID = skipper.docCount();
+      } else {
+        skipper.advance(maxOrd, Long.MAX_VALUE);
+        maxDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l > maxOrd);
+      }
+    }
+    return minDocID == maxDocID
+        ? DocIdSetIterator.empty()
+        : DocIdSetIterator.range(minDocID, maxDocID);
+  }
+
+  private static int nextDoc(int startDoc, SortedDocValues docValues, LongPredicate predicate)
+      throws IOException {
+    int doc = docValues.docID();
+    if (startDoc > doc) {
+      doc = docValues.advance(startDoc);
+    }
+    for (; doc < DocIdSetIterator.NO_MORE_DOCS; doc = docValues.nextDoc()) {
+      if (predicate.test(docValues.ordValue())) {
+        break;
+      }
+    }
+    return doc;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/SortedSetDocValuesRangeScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortedSetDocValuesRangeScorer.java
@@ -177,7 +177,7 @@ public class SortedSetDocValuesRangeScorer extends Scorer {
     if (skipper.docCount() != reader.maxDoc()) {
       return null;
     }
-    final Sort indexSort = reader.getMetaData().getSort();
+    final Sort indexSort = reader.getMetaData().sort();
     if (indexSort == null
         || indexSort.getSort().length == 0
         || indexSort.getSort()[0].getField().equals(field) == false) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRewriteMethod.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRewriteMethod.java
@@ -41,10 +41,10 @@ import org.apache.lucene.util.automaton.RegExp;
 
 /** Tests the DocValuesRewriteMethod */
 public class TestDocValuesRewriteMethod extends LuceneTestCase {
-  protected IndexSearcher searcher;
+  private IndexSearcher searcher;
   private IndexReader reader;
   private Directory dir;
-  protected String fieldName;
+  private String fieldName;
 
   @Override
   public void setUp() throws Exception {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
@@ -278,6 +278,41 @@ public class TestTermInSetQuery extends LuceneTestCase {
     dir.close();
   }
 
+  public void testContiguousRangeOptimization() throws IOException {
+    Directory dir = newDirectory();
+    RandomIndexWriter iw = new RandomIndexWriter(random(), dir);
+
+    // Index 100 docs with 10 unique terms from the set {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}:
+    for (int i = 0; i < 100; i++) {
+      Document doc = new Document();
+      BytesRef term = new BytesRef(String.valueOf(i % 10));
+      // Create inverted and doc value fields (with and without skip index):
+      doc.add(new StringField("field", term, Store.NO));
+      doc.add(new SortedSetDocValuesField("field", term));
+      doc.add(SortedSetDocValuesField.indexedField("idx_field", term));
+      iw.addDocument(doc);
+    }
+
+    iw.commit();
+    IndexReader reader = iw.getReader();
+    IndexSearcher searcher = newSearcher(reader);
+    iw.close();
+
+    // Create TermInSet queries that can be optimized into a range since they contain contiguous
+    // values and make sure
+    // they all produce equivalent results (using all three fields we indexed):
+    List<BytesRef> queryTerms = List.of(new BytesRef("0"), new BytesRef("1"), new BytesRef("2"));
+    Query q1 =
+        new TermInSetQuery(MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE, "field", queryTerms);
+    Query q2 = new TermInSetQuery(MultiTermQuery.DOC_VALUES_REWRITE, "field", queryTerms);
+    Query q3 = new TermInSetQuery(MultiTermQuery.DOC_VALUES_REWRITE, "idx_field", queryTerms);
+    assertSameMatches(searcher, q1, q2, false);
+    assertSameMatches(searcher, q2, q3, false);
+
+    reader.close();
+    dir.close();
+  }
+
   private void assertSameMatches(IndexSearcher searcher, Query q1, Query q2, boolean scores)
       throws IOException {
     final int maxDoc = searcher.getIndexReader().maxDoc();


### PR DESCRIPTION
### Description

This is a small optimization that treats "slow" multi-term queries (e.g., TermInSet, RegexpQuery, etc.) as ordinal ranges when the query terms create a contiguous range. This is likely a rare case, but it doesn't seem too hard to optimize, and I think it's worth doing so especially now that we have a doc value index/skipper.