### PR TITLE
Add a few toString methods for HNSW scoring classes

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/ProfileResults.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/ProfileResults.java
@@ -156,7 +156,12 @@ public class ProfileResults {
 
   /** Process all the JFR files passed in args and print a merged summary. */
   public static void printReport(
-      List<String> files, String mode, int stacksize, int count, boolean lineNumbers, boolean frameTypes)
+      List<String> files,
+      String mode,
+      int stacksize,
+      int count,
+      boolean lineNumbers,
+      boolean frameTypes)
       throws IOException {
     if (!"cpu".equals(mode) && !"heap".equals(mode)) {
       throw new IllegalArgumentException("tests.profile.mode must be one of (cpu,heap)");

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/DefaultFlatVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/DefaultFlatVectorScorer.java
@@ -116,6 +116,11 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
     public RandomVectorScorerSupplier copy() throws IOException {
       return new ByteScoringSupplier(vectors, similarityFunction);
     }
+
+    @Override
+    public String toString() {
+      return "ByteScoringSupplier(similarityFunction=" + similarityFunction + ")";
+    }
   }
 
   /** RandomVectorScorerSupplier for Float vector */
@@ -147,6 +152,11 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
     @Override
     public RandomVectorScorerSupplier copy() throws IOException {
       return new FloatScoringSupplier(vectors, similarityFunction);
+    }
+
+    @Override
+    public String toString() {
+      return "FloatScoringSupplier(similarityFunction=" + similarityFunction + ")";
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
@@ -170,5 +170,12 @@ public class ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       return new ScalarQuantizedRandomVectorScorerSupplier(
           similarity, vectorSimilarityFunction, values.copy());
     }
+
+    @Override
+    public String toString() {
+      return "ScalarQuantizedRandomVectorScorerSupplier(vectorSimilarityFunction="
+          + vectorSimilarityFunction
+          + ")";
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
@@ -301,5 +301,12 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     public ScalarQuantizedRandomVectorScorerSupplier copy() throws IOException {
       return new ScalarQuantizedRandomVectorScorerSupplier(values.copy(), vectorSimilarityFunction);
     }
+
+    @Override
+    public String toString() {
+      return "ScalarQuantizedRandomVectorScorerSupplier(vectorSimilarityFunction="
+          + vectorSimilarityFunction
+          + ")";
+    }
   }
 }


### PR DESCRIPTION
I was trying to debug whether the distance metric I had requested using `luceneutil`'s `knnPerfTest.py` was properly working its way all the way down that stack, and found a few `toString` methods to help in my journey.

I also ran `./gradlew tidy` which brought in an unrelated and whitespace-only change to `build-tools/build-infra/src/main/java/org/apache/lucene/gradle/ProfileResults.java`.