### PR TITLE
Fix Gradle build sometimes gives spurious "unreferenced license file" warnings

### DIFF
--- a/gradle/validation/jar-checks.gradle
+++ b/gradle/validation/jar-checks.gradle
@@ -20,6 +20,10 @@
 // 2) notice file
 // 3) checksum validation/ generation.
 
+// WARNING: The tasks in this file share internal state between tasks without using files.
+// Because of this all tasks here must always execute together, so they cannot define task outputs.
+// TODO: Rewrite the internal state to use state files containing the ext.jarInfos and its referencedFiles
+
 // This should be false only for debugging.
 def failOnError = true
 
@@ -194,13 +198,6 @@ subprojects {
     description = "Validate license and notice files of dependencies"
     dependsOn collectJarInfos
 
-    def outputFileName = 'validateJarLicenses'
-    inputs.dir(file(project.rootDir.path + '/lucene/licenses'))
-        .withPropertyName('licenses')
-        .withPathSensitivity(PathSensitivity.RELATIVE)
-    outputs.file(layout.buildDirectory.file(outputFileName))
-        .withPropertyName('validateJarLicensesResult')
-
     doLast {
       def errors = []
       jarInfos.each { dep ->
@@ -246,9 +243,7 @@ subprojects {
           }
         }
       }
-      // Required to take advantage of incremental building and the build cache
-      def f = new File(project.buildDir.path + "/" + outputFileName)
-      f.write(errors.toString(), "UTF-8")
+
       if (errors) {
         def msg = "Certain license/ notice files are missing:\n  - " + errors.join("\n  - ")
         if (failOnError) {

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -405,6 +405,12 @@ Bug Fixes
 
 * GITHUB#13691: Fix incorrect exponent value in explain of SigmoidFunction. (Owais Kazi)
 
+Build
+---------------------
+
+* GITHUB#13695, GITHUB#13696: Fix Gradle build sometimes gives spurious "unreferenced license file" warnings.
+  (Uwe Schindler)
+
 Other
 --------------------
 (No changes)


### PR DESCRIPTION
Revert changes by #12150 in jar-checks.gradle, because tasks in this file shares internal state between tasks without using files. Because of this all tasks here must always execute together, so they cannot define task outputs.

This closes #13695