### PR TITLE
Remove IOException from MultiTermQuery#getTermsCount

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -313,7 +313,7 @@ public abstract class MultiTermQuery extends Query {
    * Return the number of unique terms contained in this query, if known up-front. If not known, -1
    * will be returned.
    */
-  public long getTermsCount() throws IOException {
+  public long getTermsCount() {
     return -1;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -137,7 +137,7 @@ public class TermInSetQuery extends MultiTermQuery implements Accountable {
   }
 
   @Override
-  public long getTermsCount() throws IOException {
+  public long getTermsCount() {
     return termData.size();
   }
 

--- a/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/TermsQuery.java
@@ -95,7 +95,7 @@ class TermsQuery extends MultiTermQuery implements Accountable {
   }
 
   @Override
-  public long getTermsCount() throws IOException {
+  public long getTermsCount() {
     return terms.size();
   }
 


### PR DESCRIPTION
Neither this method nor any of the two overrides can throw an IOException. This change removes the throws clauses from this method in order simplify not have to handle them on the callers side.