### PR TITLE
Fix integer overflow in GeoEncodingUtils#Grid implementations

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -410,6 +410,9 @@ Bug Fixes
 
 * GITHUB#13691: Fix incorrect exponent value in explain of SigmoidFunction. (Owais Kazi)
 
+* GITHUB#13703: Fix bug in LatLonPoint queries where narrow polygons close to latitude 90 don't
+  match any points due to an Integer overflow. (Ignacio Vera)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/geo/GeoEncodingUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/GeoEncodingUtils.java
@@ -363,7 +363,7 @@ public final class GeoEncodingUtils {
      */
     public boolean test(int lat, int lon) {
       final int lat2 = ((lat - Integer.MIN_VALUE) >>> latShift);
-      if (lat2 < latBase || lat2 >= latBase + maxLatDelta) {
+      if (lat2 < latBase || lat2 - latBase >= maxLatDelta) {
         return false;
       }
       int lon2 = ((lon - Integer.MIN_VALUE) >>> lonShift);
@@ -411,7 +411,7 @@ public final class GeoEncodingUtils {
      */
     public boolean test(int lat, int lon) {
       final int lat2 = ((lat - Integer.MIN_VALUE) >>> latShift);
-      if (lat2 < latBase || lat2 >= latBase + maxLatDelta) {
+      if (lat2 < latBase || lat2 - latBase >= maxLatDelta) {
         return false;
       }
       int lon2 = ((lon - Integer.MIN_VALUE) >>> lonShift);


### PR DESCRIPTION
While checking the latitude bounds we are doing the following `lat2 >= latBase + maxLatDelta` which can overflow. On the other hand when checking the longitude we are doing `lon2 - lonBase >= maxLonDelta`. This explain why we are seeing an issue for big latitudes but not for big longitudes.

This PR proposes to change the check to `lat2 - maxLatDelta >= latBase` in order to avoid the integer overflow.

fixes https://github.com/apache/lucene/issues/13703