### PR TITLE
Reduce size of queue in TestBoolean2#testRandomQueries

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
@@ -404,10 +404,10 @@ public class TestBoolean2 extends LuceneTestCase {
 
         // test diff (randomized) scorers produce the same results on bigSearcher as well
         hits1 =
-            bigSearcher.search(q1, new TopFieldCollectorManager(sort, 1000 * mulFactor, 1))
+            bigSearcher.search(q1, new TopFieldCollectorManager(sort, mulFactor, 1))
                 .scoreDocs;
         hits2 =
-            bigSearcher.search(q1, new TopFieldCollectorManager(sort, 1000 * mulFactor, 1))
+            bigSearcher.search(q1, new TopFieldCollectorManager(sort, mulFactor, 1))
                 .scoreDocs;
         CheckHits.checkEqual(q1, hits1, hits2);
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
@@ -403,12 +403,8 @@ public class TestBoolean2 extends LuceneTestCase {
             bigSearcher.count(q3.build()));
 
         // test diff (randomized) scorers produce the same results on bigSearcher as well
-        hits1 =
-            bigSearcher.search(q1, new TopFieldCollectorManager(sort, mulFactor, 1))
-                .scoreDocs;
-        hits2 =
-            bigSearcher.search(q1, new TopFieldCollectorManager(sort, mulFactor, 1))
-                .scoreDocs;
+        hits1 = bigSearcher.search(q1, new TopFieldCollectorManager(sort, mulFactor, 1)).scoreDocs;
+        hits2 = bigSearcher.search(q1, new TopFieldCollectorManager(sort, mulFactor, 1)).scoreDocs;
         CheckHits.checkEqual(q1, hits1, hits2);
       }
 


### PR DESCRIPTION
The queue is created as 1000 * mulFactor, but the test succeeds without the 1000 factor. That causes out of memories as the mulFactor can be as high as 4096 in some cases, and then each slice will get a collector with a queue of size 1000 * mulFactor. Only the allocation of such queue makes the test go OOM.

Closes #11754

