### PR TITLE
Make Operations#repeat create simpler automata.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
@@ -207,24 +207,17 @@ public final class Operations {
     // Copy the automaton while renumbering states.
     Transition t = new Transition();
     for (int state = 0; state < a.getNumStates(); ++state) {
-      // Any final state is equivalent to the initial state in the repeat automaton.
       int src = stateMap[state];
       int count = a.initTransition(state, t);
       for (int i = 0; i < count; i++) {
         a.getNextTransition(t);
         int dest = stateMap[t.dest];
         builder.addTransition(src, dest, t.min, t.max);
-      }
-    }
-
-    // Now copy outgoing transitions of state 0 (they have already been copied above if state 0 is
-    // final).
-    if (a.isAccept(0) == false) {
-      int count = a.initTransition(0, t);
-      for (int i = 0; i < count; i++) {
-        a.getNextTransition(t);
-        int dest = stateMap[t.dest];
-        builder.addTransition(0, dest, t.min, t.max);
+        if (state == 0 && src != 0) {
+          // We also need to copy outgoing transitions of the initial state of the original
+          // automaton to the new initial state that we created.
+          builder.addTransition(0, dest, t.min, t.max);
+        }
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
@@ -188,73 +188,52 @@ public final class Operations {
       return a;
     }
 
-    boolean acceptStatesHaveNoTransitions = true;
-    for (int acceptState = a.getAcceptStates().nextSetBit(0);
-        acceptState != -1;
-        acceptState = a.getAcceptStates().nextSetBit(acceptState + 1)) {
-      if (a.getNumTransitions(acceptState) != 0) {
-        acceptStatesHaveNoTransitions = false;
-        break;
-      }
-    }
-
     Automaton.Builder builder = new Automaton.Builder();
     // Create the initial state, which is accepted
     builder.createState();
     builder.setAccept(0, true);
     Transition t = new Transition();
 
-    if (acceptStatesHaveNoTransitions) {
-      // In the common case when accept states have no transitions, we can create a simpler repeat
-      // automaton by merging final states into the initial state. The produced automaton has no
-      // dead states if the input automaton doesn't have dead states either. Plus state 0 is the
-      // only accept state, which makes this function idempotent in this case when accept states
-      // have no transitions.
-      int[] stateMap = new int[a.getNumStates()];
-      for (int state = 0; state < a.getNumStates(); ++state) {
-        if (a.isAccept(state)) {
-          // Final states get merged into the initial state.
-          stateMap[state] = 0;
-        } else {
-          stateMap[state] = builder.createState();
-        }
+    int[] stateMap = new int[a.getNumStates()];
+    for (int state = 0; state < a.getNumStates(); ++state) {
+      if (a.isAccept(state) == false) {
+        stateMap[state] = builder.createState();
+      } else if (a.getNumTransitions(state) == 0) {
+        // Accept states that have no transitions get merged into state 0.
+        stateMap[state] = 0;
+      } else {
+        int newState = builder.createState();
+        stateMap[state] = newState;
+        builder.setAccept(newState, true);
       }
-      // Now copy the automaton while renumbering states.
-      for (int state = 0; state < a.getNumStates(); ++state) {
-        int src = stateMap[state];
-        int count = a.initTransition(state, t);
-        for (int i = 0; i < count; i++) {
-          a.getNextTransition(t);
-          int dest = stateMap[t.dest];
-          builder.addTransition(src, dest, t.min, t.max);
-          if (state == 0 && src != 0) {
-            // We also need to copy outgoing transitions of the initial state of the original
-            // automaton to the new initial state that we created.
-            builder.addTransition(0, dest, t.min, t.max);
-          }
-        }
-      }
-    } else {
-      builder.copy(a);
+    }
 
-      int count = a.initTransition(0, t);
+    // Now copy the automaton while renumbering states.
+    for (int state = 0; state < a.getNumStates(); ++state) {
+      int src = stateMap[state];
+      int count = a.initTransition(state, t);
       for (int i = 0; i < count; i++) {
         a.getNextTransition(t);
-        builder.addTransition(0, t.dest + 1, t.min, t.max);
-      }
-
-      for (int s = a.getAcceptStates().nextSetBit(0);
-          s != -1;
-          s = a.getAcceptStates().nextSetBit(s + 1)) {
-        count = a.initTransition(0, t);
-        for (int i = 0; i < count; i++) {
-          a.getNextTransition(t);
-          builder.addTransition(s + 1, t.dest + 1, t.min, t.max);
+        int dest = stateMap[t.dest];
+        builder.addTransition(src, dest, t.min, t.max);
+        if (state == 0 && src != 0) {
+          // Transitions from the initial state need to get copied to our new initial state.
+          builder.addTransition(0, dest, t.min, t.max);
+        }
+        if (dest != 0 && a.isAccept(t.dest)) {
+          // Transitions to an accept state need to be copied as transitions to the initial
+          // state.
+          // Note: this makes the automaton non deterministic.
+          builder.addTransition(src, 0, t.min, t.max);
+        }
+        if (state == 0 && src != 0 && dest != 0 && a.isAccept(t.dest)) {
+          // Combination of the two above conditions.
+          builder.addTransition(0, 0, t.min, t.max);
         }
       }
     }
 
-    return builder.finish();
+    return removeDeadStates(builder.finish());
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
@@ -216,19 +216,26 @@ public final class Operations {
         a.getNextTransition(t);
         int dest = stateMap[t.dest];
         builder.addTransition(src, dest, t.min, t.max);
-        if (state == 0 && src != 0) {
-          // Transitions from the initial state need to get copied to our new initial state.
-          builder.addTransition(0, dest, t.min, t.max);
-        }
-        if (dest != 0 && a.isAccept(t.dest)) {
-          // Transitions to an accept state need to be copied as transitions to the initial
-          // state.
-          // Note: this makes the automaton non deterministic.
-          builder.addTransition(src, 0, t.min, t.max);
-        }
-        if (state == 0 && src != 0 && dest != 0 && a.isAccept(t.dest)) {
-          // Combination of the two above conditions.
-          builder.addTransition(0, 0, t.min, t.max);
+      }
+    }
+
+    // Now copy transitions of the initial state to our new initial state.
+    int count = a.initTransition(0, t);
+    for (int i = 0; i < count; i++) {
+      a.getNextTransition(t);
+      builder.addTransition(0, stateMap[t.dest], t.min, t.max);
+    }
+
+    // Now copy transitions of the initial state to final states to make the automaton repeat
+    // itself.
+    for (int s = a.getAcceptStates().nextSetBit(0);
+        s != -1;
+        s = a.getAcceptStates().nextSetBit(s + 1)) {
+      if (stateMap[s] != 0) {
+        count = a.initTransition(0, t);
+        for (int i = 0; i < count; i++) {
+          a.getNextTransition(t);
+          builder.addTransition(stateMap[s], stateMap[t.dest], t.min, t.max);
         }
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestOperations.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestOperations.java
@@ -288,7 +288,7 @@ public class TestOperations extends LuceneTestCase {
     abs.finishState();
     abs.addTransition(1, 0, 'b');
     abs.finishState();
-    assertTrue(Operations.sameLanguage(abs, Operations.removeDeadStates(Operations.repeat(ab))));
+    assertTrue(Operations.sameLanguage(abs, Operations.repeat(ab)));
     assertSame(abs, Operations.repeat(abs));
 
     Automaton absThenC = Operations.concatenate(abs, Automata.makeChar('c'));
@@ -305,9 +305,7 @@ public class TestOperations extends LuceneTestCase {
     absThenCs.addTransition(2, 1, 'a');
     absThenCs.addTransition(2, 0, 'c');
     absThenCs.finishState();
-    assertTrue(
-        Operations.sameLanguage(
-            absThenCs, Operations.removeDeadStates(Operations.repeat(absThenC))));
+    assertTrue(Operations.sameLanguage(absThenCs, Operations.repeat(absThenC)));
     assertSame(absThenCs, Operations.repeat(absThenCs));
 
     Automaton aThenBs = new Automaton(); // (ab)*a?
@@ -324,7 +322,6 @@ public class TestOperations extends LuceneTestCase {
     aOrBs.addTransition(0, 0, 'a');
     aOrBs.addTransition(0, 0, 'b');
 
-    assertTrue(
-        Operations.sameLanguage(aOrBs, Operations.removeDeadStates(Operations.repeat(aThenBs))));
+    assertTrue(Operations.sameLanguage(aOrBs, Operations.repeat(aThenBs)));
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestOperations.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestOperations.java
@@ -329,11 +329,12 @@ public class TestOperations extends LuceneTestCase {
     aOrAbs.finishState();
     assertTrue(
         Operations.sameLanguage(
-            Operations.determinize(aOrAbs, Integer.MAX_VALUE), Operations.repeat(aOrAb)));
+            Operations.determinize(aOrAbs, Integer.MAX_VALUE),
+            Operations.determinize(Operations.repeat(aOrAb), Integer.MAX_VALUE)));
   }
 
   public void testDuelRepeat() {
-    final int iters = atLeast(1000);
+    final int iters = atLeast(1_000);
     for (int iter = 0; iter < iters; ++iter) {
       Automaton a = AutomatonTestUtil.randomAutomaton(random());
       Automaton repeat1 = Operations.determinize(Operations.repeat(a), Integer.MAX_VALUE);

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestOperations.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestOperations.java
@@ -254,4 +254,77 @@ public class TestOperations extends LuceneTestCase {
     a.finishState();
     return a;
   }
+
+  public void testRepeat() {
+    Automaton emptyLanguage = Automata.makeEmpty();
+    assertSame(emptyLanguage, Operations.repeat(emptyLanguage));
+
+    Automaton emptyString = Automata.makeEmptyString();
+    assertSame(emptyString, Operations.repeat(emptyString));
+
+    Automaton a = Automata.makeChar('a');
+    Automaton as = new Automaton();
+    as.createState();
+    as.setAccept(0, true);
+    as.addTransition(0, 0, 'a');
+    as.finishState();
+    assertTrue(Operations.sameLanguage(as, Operations.repeat(a)));
+    assertSame(as, Operations.repeat(as));
+
+    Automaton aOrEmpty = new Automaton();
+    aOrEmpty.createState();
+    aOrEmpty.setAccept(0, true);
+    aOrEmpty.createState();
+    aOrEmpty.setAccept(1, true);
+    aOrEmpty.addTransition(0, 1, 'a');
+    assertTrue(Operations.sameLanguage(as, Operations.repeat(aOrEmpty)));
+
+    Automaton ab = Automata.makeString("ab");
+    Automaton abs = new Automaton();
+    abs.createState();
+    abs.createState();
+    abs.setAccept(0, true);
+    abs.addTransition(0, 1, 'a');
+    abs.finishState();
+    abs.addTransition(1, 0, 'b');
+    abs.finishState();
+    assertTrue(Operations.sameLanguage(abs, Operations.removeDeadStates(Operations.repeat(ab))));
+    assertSame(abs, Operations.repeat(abs));
+
+    Automaton absThenC = Operations.concatenate(abs, Automata.makeChar('c'));
+    Automaton absThenCs = new Automaton();
+    absThenCs.createState();
+    absThenCs.createState();
+    absThenCs.createState();
+    absThenCs.setAccept(0, true);
+    absThenCs.addTransition(0, 1, 'a');
+    absThenCs.addTransition(0, 0, 'c');
+    absThenCs.finishState();
+    absThenCs.addTransition(1, 2, 'b');
+    absThenCs.finishState();
+    absThenCs.addTransition(2, 1, 'a');
+    absThenCs.addTransition(2, 0, 'c');
+    absThenCs.finishState();
+    assertTrue(
+        Operations.sameLanguage(
+            absThenCs, Operations.removeDeadStates(Operations.repeat(absThenC))));
+    assertSame(absThenCs, Operations.repeat(absThenCs));
+
+    Automaton aThenBs = new Automaton(); // (ab)*a?
+    aThenBs.createState();
+    aThenBs.createState();
+    aThenBs.setAccept(0, true);
+    aThenBs.setAccept(1, true);
+    aThenBs.addTransition(0, 1, 'a');
+    aThenBs.addTransition(1, 0, 'b');
+
+    Automaton aOrBs = new Automaton(); // [ab]*
+    aOrBs.createState();
+    aOrBs.setAccept(0, true);
+    aOrBs.addTransition(0, 0, 'a');
+    aOrBs.addTransition(0, 0, 'b');
+
+    assertTrue(
+        Operations.sameLanguage(aOrBs, Operations.removeDeadStates(Operations.repeat(aThenBs))));
+  }
 }


### PR DESCRIPTION
`Operations#repeat` currently creates an automaton that has one more final state, and 2x more transitions for each of the final states. With this change, the returned automaton has a single final state and only 2x more transitions for state 0.

Currently a draft as I'm still looking into whether this new logic is correct.