### PR TITLE
Add migration note about the deprecation of optional RegExp complement syntax

### DIFF
--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -83,13 +83,14 @@ These classes no longer take a `determinizeWorkLimit` and no longer determinize
 behind the scenes. It is the responsibility of the caller to call
 `Operations.determinize()` for DFA execution.
 
-### RegExp no longer supports the optional complement syntax
+### RegExp optional complement syntax has been deprecated
 
-The `RegExp` class no longer supports the optional complement syntax, previously
-supported by the `~` character. When working with automata retrieved from regexp,
-equivalent functionality can be achieved by using `Operations.complement`. For
-example, `new RegExp("~(foo)").toAutomaton()` that matches input that is not
-"foo", can be rewritten as `Operations.complement(new RegExp("(foo)").toAutomaton(), ...)`.
+Support for the optional complement syntax (`~`) has been deprecated.
+The `COMPLEMENT` syntax flag has been removed and replaced by the
+`DEPRECATED_COMPLEMENT` flag. Users wanting to enable the deprecated
+complement support can do so by explicitly passing a syntax flags that
+has `DEPRECATED_COMPLEMENT` when creating a `RegExp`. For example:
+`new RegExp("~(foo)", RegExp.DEPRECATED_COMPLEMENT)`.
 
 Alternatively, and quite commonly, a more simple _complement bracket expression_,
 `[^...]`, may be a suitable replacement, For example, `[^fo]` matches any

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -80,9 +80,14 @@ behaviour as 9.x, clone `PersianAnalyzer` in 9.x or create custom analyzer by us
 ### AutomatonQuery/CompiledAutomaton/RunAutomaton/RegExp no longer determinize (LUCENE-10010)
 
 These classes no longer take a `determinizeWorkLimit` and no longer determinize
-behind the scenes. It is the responsibility of the caller to to call
-`Operations.determinize()` for DFA execution. The `RegExp` class no longer supports
-the optional complement syntax, previously supported by the `~` character.
+behind the scenes. It is the responsibility of the caller to call
+`Operations.determinize()` for DFA execution.
+
+### RegExp no longer supports the optional complement syntax
+
+The `RegExp` class no longer supports the optional complement syntax, previously
+supported by the `~` character. In many cases complement-of-range may be a
+suitable replacement, e.g. `[^a-z]`.
 
 ### DocValuesFieldExistsQuery, NormsFieldExistsQuery and KnnVectorFieldExistsQuery removed in favor of FieldExistsQuery (LUCENE-10436)
 

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -86,8 +86,9 @@ behind the scenes. It is the responsibility of the caller to call
 ### RegExp no longer supports the optional complement syntax
 
 The `RegExp` class no longer supports the optional complement syntax, previously
-supported by the `~` character. In many cases complement-of-range may be a
-suitable replacement, e.g. `[^a-z]`.
+supported by the `~` character. In many cases a _complemented bracket expression_,
+`[^...]`, may be a suitable replacement, For example, `[^awk]` matches any
+character that is not an `a`, `w`, or `k`.
 
 ### DocValuesFieldExistsQuery, NormsFieldExistsQuery and KnnVectorFieldExistsQuery removed in favor of FieldExistsQuery (LUCENE-10436)
 

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -86,9 +86,14 @@ behind the scenes. It is the responsibility of the caller to call
 ### RegExp no longer supports the optional complement syntax
 
 The `RegExp` class no longer supports the optional complement syntax, previously
-supported by the `~` character. In many cases a _complemented bracket expression_,
-`[^...]`, may be a suitable replacement, For example, `[^awk]` matches any
-character that is not an `a`, `w`, or `k`.
+supported by the `~` character. When working with automata retrieved from regexp,
+equivalent functionality can be achieved by using `Operations.complement`. For
+example, `new RegExp("~(foo)").toAutomaton()` that matches input that is not
+"foo", can be rewritten as `Operations.complement(new RegExp("(foo)").toAutomaton(), ...)`.
+
+Alternatively, and quite commonly, a more simple _complement bracket expression_,
+`[^...]`, may be a suitable replacement, For example, `[^fo]` matches any
+character that is not an `f` or `o`.
 
 ### DocValuesFieldExistsQuery, NormsFieldExistsQuery and KnnVectorFieldExistsQuery removed in favor of FieldExistsQuery (LUCENE-10436)
 

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -81,7 +81,8 @@ behaviour as 9.x, clone `PersianAnalyzer` in 9.x or create custom analyzer by us
 
 These classes no longer take a `determinizeWorkLimit` and no longer determinize
 behind the scenes. It is the responsibility of the caller to to call
-`Operations.determinize()` for DFA execution.
+`Operations.determinize()` for DFA execution. The `RegExp` class no longer supports
+the optional complement syntax, previously supported by the `~` character.
 
 ### DocValuesFieldExistsQuery, NormsFieldExistsQuery and KnnVectorFieldExistsQuery removed in favor of FieldExistsQuery (LUCENE-10436)
 


### PR DESCRIPTION
This commit adds a migration note about the deprecation of optional RegExp complement support.