### PR TITLE
Deprecate FacetsCollector#search utility methods

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -24,6 +24,9 @@ API Changes
 * GITHUB#13568: Add DrillSideways#search method that supports any CollectorManagers for drill-sideways dimensions
   or drill-down. (Egor Potemkin)
 
+* GITHUB#13737: Deprecate the FacetsCollector#search utility methods and add new corresponding method to
+  FacetsCollectorManager that accept a FacetsCollectorManager as last argument in place of a Collector. (Luca Cavanna)
+
 New Features
 ---------------------
 

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/AssociationsFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/AssociationsFacetsExample.java
@@ -25,6 +25,7 @@ import org.apache.lucene.facet.DrillDownQuery;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.facet.taxonomy.AssociationAggregationFunction;
@@ -97,12 +98,13 @@ public class AssociationsFacetsExample {
     IndexSearcher searcher = new IndexSearcher(indexReader);
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
 
-    FacetsCollector fc = new FacetsCollector();
-
     // MatchAllDocsQuery is for "browsing" (counts facets
     // for all non-deleted docs in the index); normally
     // you'd use a "normal" query:
-    FacetsCollector.search(searcher, new MatchAllDocsQuery(), 10, fc);
+    FacetsCollectorManager.FacetsResult facetsResult =
+        FacetsCollectorManager.search(
+            searcher, new MatchAllDocsQuery(), 10, new FacetsCollectorManager());
+    FacetsCollector fc = facetsResult.facetsCollector();
 
     Facets tags =
         new TaxonomyFacetIntAssociations(
@@ -133,8 +135,8 @@ public class AssociationsFacetsExample {
 
     // Now user drills down on Publish Date/2010:
     q.add("tags", "solr");
-    FacetsCollector fc = new FacetsCollector();
-    FacetsCollector.search(searcher, q, 10, fc);
+    FacetsCollectorManager fcm = new FacetsCollectorManager();
+    FacetsCollector fc = FacetsCollectorManager.search(searcher, q, 10, fcm).facetsCollector();
 
     // Retrieve results
     Facets facets =

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/ExpressionAggregationFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/ExpressionAggregationFacetsExample.java
@@ -30,6 +30,7 @@ import org.apache.lucene.facet.FacetField;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.taxonomy.AssociationAggregationFunction;
 import org.apache.lucene.facet.taxonomy.TaxonomyFacetFloatAssociations;
@@ -97,12 +98,13 @@ public class ExpressionAggregationFacetsExample {
         DoubleValuesSource.fromLongField("popularity")); // the value of the 'popularity' field
 
     // Aggregates the facet values
-    FacetsCollector fc = new FacetsCollector(true);
+    FacetsCollectorManager fcm = new FacetsCollectorManager(true);
 
     // MatchAllDocsQuery is for "browsing" (counts facets
     // for all non-deleted docs in the index); normally
     // you'd use a "normal" query:
-    FacetsCollector.search(searcher, new MatchAllDocsQuery(), 10, fc);
+    FacetsCollector fc =
+        FacetsCollectorManager.search(searcher, new MatchAllDocsQuery(), 10, fcm).facetsCollector();
 
     // Retrieve results
     Facets facets =

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/MultiCategoryListsFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/MultiCategoryListsFacetsExample.java
@@ -25,6 +25,7 @@ import org.apache.lucene.facet.FacetField;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts;
 import org.apache.lucene.facet.taxonomy.TaxonomyReader;
@@ -97,12 +98,13 @@ public class MultiCategoryListsFacetsExample {
     IndexSearcher searcher = new IndexSearcher(indexReader);
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
 
-    FacetsCollector fc = new FacetsCollector();
+    FacetsCollectorManager fcm = new FacetsCollectorManager();
 
     // MatchAllDocsQuery is for "browsing" (counts facets
     // for all non-deleted docs in the index); normally
     // you'd use a "normal" query:
-    FacetsCollector.search(searcher, new MatchAllDocsQuery(), 10, fc);
+    FacetsCollector fc =
+        FacetsCollectorManager.search(searcher, new MatchAllDocsQuery(), 10, fcm).facetsCollector();
 
     // Retrieve results
     List<FacetResult> results = new ArrayList<>();

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/RangeFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/RangeFacetsExample.java
@@ -27,6 +27,7 @@ import org.apache.lucene.facet.DrillSideways;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.range.LongRange;
 import org.apache.lucene.facet.range.LongRangeFacetCounts;
@@ -86,13 +87,13 @@ public class RangeFacetsExample implements Closeable {
   /** User runs a query and counts facets. */
   public FacetResult search() throws IOException {
 
-    // Aggregates the facet counts
-    FacetsCollector fc = new FacetsCollector();
-
     // MatchAllDocsQuery is for "browsing" (counts facets
     // for all non-deleted docs in the index); normally
     // you'd use a "normal" query:
-    FacetsCollector.search(searcher, new MatchAllDocsQuery(), 10, fc);
+    FacetsCollector fc =
+        FacetsCollectorManager.search(
+                searcher, new MatchAllDocsQuery(), 10, new FacetsCollectorManager())
+            .facetsCollector();
 
     Facets facets = new LongRangeFacetCounts("timestamp", fc, PAST_HOUR, PAST_SIX_HOURS, PAST_DAY);
     return facets.getTopChildren(10, "timestamp");

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleFacetsExample.java
@@ -99,12 +99,13 @@ public class SimpleFacetsExample {
     IndexSearcher searcher = new IndexSearcher(indexReader);
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
 
-    FacetsCollector fc = new FacetsCollector();
+    FacetsCollectorManager fcm = new FacetsCollectorManager();
 
     // MatchAllDocsQuery is for "browsing" (counts facets
     // for all non-deleted docs in the index); normally
     // you'd use a "normal" query:
-    FacetsCollector.search(searcher, new MatchAllDocsQuery(), 10, fc);
+    FacetsCollector fc =
+        FacetsCollectorManager.search(searcher, new MatchAllDocsQuery(), 10, fcm).facetsCollector();
 
     // Retrieve results
     List<FacetResult> results = new ArrayList<>();
@@ -156,8 +157,8 @@ public class SimpleFacetsExample {
 
     // Now user drills down on Publish Date/2010:
     q.add("Publish Date", "2010");
-    FacetsCollector fc = new FacetsCollector();
-    FacetsCollector.search(searcher, q, 10, fc);
+    FacetsCollectorManager fcm = new FacetsCollectorManager();
+    FacetsCollector fc = FacetsCollectorManager.search(searcher, q, 10, fcm).facetsCollector();
 
     // Retrieve results
     Facets facets = new FastTaxonomyFacetCounts(taxoReader, config, fc);

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleSortedSetFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/SimpleSortedSetFacetsExample.java
@@ -25,6 +25,7 @@ import org.apache.lucene.facet.DrillDownQuery;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.sortedset.DefaultSortedSetDocValuesReaderState;
 import org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetCounts;
@@ -92,12 +93,13 @@ public class SimpleSortedSetFacetsExample {
         new DefaultSortedSetDocValuesReaderState(indexReader, config);
 
     // Aggregates the facet counts
-    FacetsCollector fc = new FacetsCollector();
+    FacetsCollectorManager fcm = new FacetsCollectorManager();
 
     // MatchAllDocsQuery is for "browsing" (counts facets
     // for all non-deleted docs in the index); normally
     // you'd use a "normal" query:
-    FacetsCollector.search(searcher, new MatchAllDocsQuery(), 10, fc);
+    FacetsCollector fc =
+        FacetsCollectorManager.search(searcher, new MatchAllDocsQuery(), 10, fcm).facetsCollector();
 
     // Retrieve results
     Facets facets = new SortedSetDocValuesFacetCounts(state, fc);
@@ -120,8 +122,8 @@ public class SimpleSortedSetFacetsExample {
     // Now user drills down on Publish Year/2010:
     DrillDownQuery q = new DrillDownQuery(config);
     q.add("Publish Year", "2010");
-    FacetsCollector fc = new FacetsCollector();
-    FacetsCollector.search(searcher, q, 10, fc);
+    FacetsCollectorManager fcm = new FacetsCollectorManager();
+    FacetsCollector fc = FacetsCollectorManager.search(searcher, q, 10, fcm).facetsCollector();
 
     // Retrieve results
     Facets facets = new SortedSetDocValuesFacetCounts(state, fc);

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/StringValueFacetCountsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/StringValueFacetCountsExample.java
@@ -27,6 +27,7 @@ import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.StringDocValuesReaderState;
 import org.apache.lucene.facet.StringValueFacetCounts;
@@ -96,12 +97,13 @@ public class StringValueFacetCountsExample {
         new StringDocValuesReaderState(indexReader, "Publish Year");
 
     // Aggregates the facet counts
-    FacetsCollector fc = new FacetsCollector();
+    FacetsCollectorManager fcm = new FacetsCollectorManager();
 
     // MatchAllDocsQuery is for "browsing" (counts facets
     // for all non-deleted docs in the index); normally
     // you'd use a "normal" query:
-    FacetsCollector.search(searcher, new MatchAllDocsQuery(), 10, fc);
+    FacetsCollector fc =
+        FacetsCollectorManager.search(searcher, new MatchAllDocsQuery(), 10, fcm).facetsCollector();
 
     // Retrieve results
     Facets authorFacets = new StringValueFacetCounts(authorState, fc);

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/package-info.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/package-info.java
@@ -198,9 +198,9 @@
  * org.apache.lucene.search.Collector}, and as such can be passed to the search() method of Lucene's
  * {@link org.apache.lucene.search.IndexSearcher}. In case the application also needs to collect
  * documents (in addition to accumulating/collecting facets), you can use one of {@link
- * org.apache.lucene.facet.FacetsCollector#search(org.apache.lucene.search.IndexSearcher,
- * org.apache.lucene.search.Query, int, org.apache.lucene.search.Collector)
- * FacetsCollector.search(...)} utility methods.
+ * org.apache.lucene.facet.FacetsCollectorManager#search(org.apache.lucene.search.IndexSearcher,
+ * org.apache.lucene.search.Query, int, org.apache.lucene.facet.FacetsCollectorManager)
+ * FacetsCollectorManager.search(...)} utility methods.
  *
  * <p>There is a facets collecting code example in {@link
  * org.apache.lucene.demo.facet.SimpleFacetsExample#facetsWithSearch()}, see <a

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollector.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollector.java
@@ -155,13 +155,25 @@ public class FacetsCollector extends SimpleCollector {
     context = null;
   }
 
-  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  /**
+   * Utility method, to search and also collect all hits into the provided {@link Collector}.
+   *
+   * @deprecated use {@link FacetsCollectorManager#search(IndexSearcher, Query, int,
+   *     FacetsCollectorManager)} instead.
+   */
+  @Deprecated
   public static TopDocs search(IndexSearcher searcher, Query q, int n, Collector fc)
       throws IOException {
     return doSearch(searcher, null, q, n, null, false, fc);
   }
 
-  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  /**
+   * Utility method, to search and also collect all hits into the provided {@link Collector}.
+   *
+   * @deprecated use {@link FacetsCollectorManager#search(IndexSearcher, Query, int, Sort,
+   *     FacetsCollectorManager)} instead.
+   */
+  @Deprecated
   public static TopFieldDocs search(IndexSearcher searcher, Query q, int n, Sort sort, Collector fc)
       throws IOException {
     if (sort == null) {
@@ -170,7 +182,13 @@ public class FacetsCollector extends SimpleCollector {
     return (TopFieldDocs) doSearch(searcher, null, q, n, sort, false, fc);
   }
 
-  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  /**
+   * Utility method, to search and also collect all hits into the provided {@link Collector}.
+   *
+   * @deprecated use {@link FacetsCollectorManager#search(IndexSearcher, Query, int, Sort, boolean,
+   *     FacetsCollectorManager)} instead.
+   */
+  @Deprecated
   public static TopFieldDocs search(
       IndexSearcher searcher, Query q, int n, Sort sort, boolean doDocScores, Collector fc)
       throws IOException {
@@ -180,13 +198,25 @@ public class FacetsCollector extends SimpleCollector {
     return (TopFieldDocs) doSearch(searcher, null, q, n, sort, doDocScores, fc);
   }
 
-  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  /**
+   * Utility method, to search and also collect all hits into the provided {@link Collector}.
+   *
+   * @deprecated use {@link FacetsCollectorManager#searchAfter(IndexSearcher, ScoreDoc, Query, int,
+   *     FacetsCollectorManager)} instead.
+   */
+  @Deprecated
   public static TopDocs searchAfter(
       IndexSearcher searcher, ScoreDoc after, Query q, int n, Collector fc) throws IOException {
     return doSearch(searcher, after, q, n, null, false, fc);
   }
 
-  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  /**
+   * Utility method, to search and also collect all hits into the provided {@link Collector}.
+   *
+   * @deprecated use {@link FacetsCollectorManager#searchAfter(IndexSearcher, ScoreDoc, Query, int,
+   *     Sort, FacetsCollectorManager)} instead.
+   */
+  @Deprecated
   public static TopDocs searchAfter(
       IndexSearcher searcher, ScoreDoc after, Query q, int n, Sort sort, Collector fc)
       throws IOException {
@@ -196,7 +226,13 @@ public class FacetsCollector extends SimpleCollector {
     return doSearch(searcher, after, q, n, sort, false, fc);
   }
 
-  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  /**
+   * Utility method, to search and also collect all hits into the provided {@link Collector}.
+   *
+   * @deprecated use {@link FacetsCollectorManager#searchAfter(IndexSearcher, ScoreDoc, Query, int,
+   *     Sort, boolean, FacetsCollectorManager)} instead.
+   */
+  @Deprecated
   public static TopDocs searchAfter(
       IndexSearcher searcher,
       ScoreDoc after,

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollectorManager.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollectorManager.java
@@ -19,7 +19,20 @@ package org.apache.lucene.facet;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MultiCollectorManager;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopFieldCollector;
+import org.apache.lucene.search.TopFieldCollectorManager;
+import org.apache.lucene.search.TopScoreDocCollectorManager;
+import org.apache.lucene.search.TotalHitCountCollectorManager;
+import org.apache.lucene.search.TotalHits;
 
 /**
  * A {@link CollectorManager} implementation which produces FacetsCollector and produces a merged
@@ -27,12 +40,24 @@ import org.apache.lucene.search.CollectorManager;
  */
 public class FacetsCollectorManager implements CollectorManager<FacetsCollector, FacetsCollector> {
 
+  private final boolean keepScores;
+
   /** Sole constructor. */
-  public FacetsCollectorManager() {}
+  public FacetsCollectorManager() {
+    this(false);
+  }
+
+  /**
+   * Creates a new collector manager that in turn creates {@link FacetsCollector} using the provided
+   * {@code keepScores} flag. hits.
+   */
+  public FacetsCollectorManager(boolean keepScores) {
+    this.keepScores = keepScores;
+  }
 
   @Override
   public FacetsCollector newCollector() throws IOException {
-    return new FacetsCollector();
+    return new FacetsCollector(keepScores);
   }
 
   @Override
@@ -52,6 +77,169 @@ public class FacetsCollectorManager implements CollectorManager<FacetsCollector,
       final List<MatchingDocs> matchingDocs = this.getMatchingDocs();
       facetsCollectors.forEach(
           facetsCollector -> matchingDocs.addAll(facetsCollector.getMatchingDocs()));
+    }
+  }
+
+  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  public static FacetsResult search(
+      IndexSearcher searcher, Query q, int n, FacetsCollectorManager fcm) throws IOException {
+    return doSearch(searcher, null, q, n, null, false, fcm);
+  }
+
+  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  public static FacetsResult search(
+      IndexSearcher searcher, Query q, int n, Sort sort, FacetsCollectorManager fcm)
+      throws IOException {
+    if (sort == null) {
+      throw new IllegalArgumentException("sort must not be null");
+    }
+    return doSearch(searcher, null, q, n, sort, false, fcm);
+  }
+
+  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  public static FacetsResult search(
+      IndexSearcher searcher,
+      Query q,
+      int n,
+      Sort sort,
+      boolean doDocScores,
+      FacetsCollectorManager fcm)
+      throws IOException {
+    if (sort == null) {
+      throw new IllegalArgumentException("sort must not be null");
+    }
+    return doSearch(searcher, null, q, n, sort, doDocScores, fcm);
+  }
+
+  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  public static FacetsResult searchAfter(
+      IndexSearcher searcher, ScoreDoc after, Query q, int n, FacetsCollectorManager fcm)
+      throws IOException {
+    return doSearch(searcher, after, q, n, null, false, fcm);
+  }
+
+  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  public static FacetsResult searchAfter(
+      IndexSearcher searcher, ScoreDoc after, Query q, int n, Sort sort, FacetsCollectorManager fcm)
+      throws IOException {
+    if (sort == null) {
+      throw new IllegalArgumentException("sort must not be null");
+    }
+    return doSearch(searcher, after, q, n, sort, false, fcm);
+  }
+
+  /** Utility method, to search and also collect all hits into the provided {@link Collector}. */
+  public static FacetsResult searchAfter(
+      IndexSearcher searcher,
+      ScoreDoc after,
+      Query q,
+      int n,
+      Sort sort,
+      boolean doDocScores,
+      FacetsCollectorManager fcm)
+      throws IOException {
+    if (sort == null) {
+      throw new IllegalArgumentException("sort must not be null");
+    }
+    return doSearch(searcher, after, q, n, sort, doDocScores, fcm);
+  }
+
+  private static FacetsResult doSearch(
+      IndexSearcher searcher,
+      ScoreDoc after,
+      Query q,
+      int n,
+      Sort sort,
+      boolean doDocScores,
+      FacetsCollectorManager fcm)
+      throws IOException {
+
+    int limit = searcher.getIndexReader().maxDoc();
+    if (limit == 0) {
+      limit = 1;
+    }
+    n = Math.min(n, limit);
+
+    if (after != null && after.doc >= limit) {
+      throw new IllegalArgumentException(
+          "after.doc exceeds the number of documents in the reader: after.doc="
+              + after.doc
+              + " limit="
+              + limit);
+    }
+
+    final TopDocs topDocs;
+    final FacetsCollector facetsCollector;
+    if (n == 0) {
+      TotalHitCountCollectorManager hitCountCollectorManager = new TotalHitCountCollectorManager();
+      MultiCollectorManager multiCollectorManager =
+          new MultiCollectorManager(hitCountCollectorManager, fcm);
+      Object[] result = searcher.search(q, multiCollectorManager);
+      topDocs =
+          new TopDocs(
+              new TotalHits((Integer) result[0], TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+      facetsCollector = (FacetsCollector) result[1];
+    } else {
+      final MultiCollectorManager multiCollectorManager;
+      if (sort != null) {
+        if (after != null && !(after instanceof FieldDoc)) {
+          // TODO: if we fix type safety of TopFieldDocs we can
+          // remove this
+          throw new IllegalArgumentException("after must be a FieldDoc; got " + after);
+        }
+        TopFieldCollectorManager topFieldCollectorManager =
+            new TopFieldCollectorManager(sort, n, (FieldDoc) after, Integer.MAX_VALUE, true);
+        multiCollectorManager = new MultiCollectorManager(topFieldCollectorManager, fcm);
+      } else {
+        TopScoreDocCollectorManager topScoreDocCollectorManager =
+            new TopScoreDocCollectorManager(n, after, Integer.MAX_VALUE, true);
+        multiCollectorManager = new MultiCollectorManager(topScoreDocCollectorManager, fcm);
+      }
+      Object[] result = searcher.search(q, multiCollectorManager);
+      topDocs = (TopDocs) result[0];
+      if (doDocScores) {
+        TopFieldCollector.populateScores(topDocs.scoreDocs, searcher, q);
+      }
+      facetsCollector = (FacetsCollector) result[1];
+    }
+    return new FacetsResult(topDocs, facetsCollector);
+  }
+
+  /**
+   * Holds results of a search run via static utility methods exposed by this class. Those include
+   * {@link TopDocs} as well as facets result included in the returned {@link FacetsCollector}
+   */
+  public static class FacetsResult {
+    private final TopDocs topDocs;
+    private final FacetsCollector facetsCollector;
+
+    /**
+     * Create a new instance of this class.
+     *
+     * @param topDocs the top docs
+     * @param facetsCollector the facets result included in a {@link FacetsCollector} instance
+     */
+    public FacetsResult(TopDocs topDocs, FacetsCollector facetsCollector) {
+      this.topDocs = topDocs;
+      this.facetsCollector = facetsCollector;
+    }
+
+    /**
+     * Exposed the {@link TopDocs}
+     *
+     * @return the top docs returned from the search
+     */
+    public TopDocs topDocs() {
+      return topDocs;
+    }
+
+    /**
+     * Exposes the facet results
+     *
+     * @return the facet results via a reduced {@link FacetsCollector}
+     */
+    public FacetsCollector facetsCollector() {
+      return facetsCollector;
     }
   }
 }

--- a/lucene/facet/src/java/org/apache/lucene/facet/package-info.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/package-info.java
@@ -47,8 +47,8 @@
  * all methods implement a common {@link org.apache.lucene.facet.Facets} base API that you use to
  * obtain specific facet counts.
  *
- * <p>The various {@link org.apache.lucene.facet.FacetsCollector#search} utility methods are useful
- * for doing an "ordinary" search (sorting by score, or by a specified Sort) but also collecting
- * into a {@link org.apache.lucene.facet.FacetsCollector} for subsequent faceting.
+ * <p>The various {@link org.apache.lucene.facet.FacetsCollectorManager#search} utility methods are
+ * useful for doing an "ordinary" search (sorting by score, or by a specified Sort) but also
+ * collecting into a {@link org.apache.lucene.facet.FacetsCollectorManager} for subsequent faceting.
  */
 package org.apache.lucene.facet;

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillDownQuery.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillDownQuery.java
@@ -189,8 +189,10 @@ public class TestDrillDownQuery extends FacetTestCase {
     DrillDownQuery q = new DrillDownQuery(config);
     q.add("b", "1");
     int limit = 0;
-    FacetsCollector facetCollector = new FacetsCollector();
-    FacetsCollector.search(searcher, q, limit, facetCollector);
+
+    FacetsCollector facetCollector =
+        FacetsCollectorManager.search(searcher, q, limit, new FacetsCollectorManager())
+            .facetsCollector();
     Facets facets =
         getTaxonomyFacetCounts(
             taxo, config, facetCollector, config.getDimConfig("b").indexFieldName);

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestMultipleIndexFields.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestMultipleIndexFields.java
@@ -331,9 +331,9 @@ public class TestMultipleIndexFields extends FacetTestCase {
   }
 
   private FacetsCollector performSearch(IndexSearcher searcher) throws IOException {
-    FacetsCollector fc = new FacetsCollector();
-    FacetsCollector.search(searcher, new MatchAllDocsQuery(), 10, fc);
-    return fc;
+    return FacetsCollectorManager.search(
+            searcher, new MatchAllDocsQuery(), 10, new FacetsCollectorManager())
+        .facetsCollector();
   }
 
   private void seedIndex(TaxonomyWriter tw, RandomIndexWriter iw, FacetsConfig config)

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -1398,9 +1398,13 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               if (VERBOSE) {
                 System.out.println("\nTEST: iter content=" + searchToken);
               }
-              FacetsCollector fc = new FacetsCollector();
-              FacetsCollector.search(
-                  searcher, new TermQuery(new Term("content", searchToken)), 10, fc);
+              FacetsCollector fc =
+                  FacetsCollectorManager.search(
+                          searcher,
+                          new TermQuery(new Term("content", searchToken)),
+                          10,
+                          new FacetsCollectorManager())
+                      .facetsCollector();
               Facets facets;
               if (exec != null) {
                 facets = new ConcurrentSortedSetDocValuesFacetCounts(state, fc, exec);
@@ -1546,9 +1550,13 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               if (VERBOSE) {
                 System.out.println("\nTEST: iter content=" + searchToken);
               }
-              FacetsCollector fc = new FacetsCollector();
-              FacetsCollector.search(
-                  searcher, new TermQuery(new Term("content", searchToken)), 10, fc);
+              FacetsCollector fc =
+                  FacetsCollectorManager.search(
+                          searcher,
+                          new TermQuery(new Term("content", searchToken)),
+                          10,
+                          new FacetsCollectorManager())
+                      .facetsCollector();
               Facets facets;
               if (exec != null) {
                 facets = new ConcurrentSortedSetDocValuesFacetCounts(state, fc, exec);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestOrdinalMappingLeafReader.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestOrdinalMappingLeafReader.java
@@ -24,6 +24,7 @@ import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
@@ -89,8 +90,10 @@ public class TestOrdinalMappingLeafReader extends FacetTestCase {
     DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
     IndexSearcher searcher = newSearcher(indexReader);
 
-    FacetsCollector collector = new FacetsCollector();
-    FacetsCollector.search(searcher, new MatchAllDocsQuery(), 10, collector);
+    FacetsCollector collector =
+        FacetsCollectorManager.search(
+                searcher, new MatchAllDocsQuery(), 10, new FacetsCollectorManager())
+            .facetsCollector();
 
     // tag facets
     Facets tagFacets = new FastTaxonomyFacetCounts("$tags", taxoReader, facetConfig, collector);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -1068,8 +1068,13 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
       if (VERBOSE) {
         System.out.println("\nTEST: iter content=" + searchToken);
       }
-      FacetsCollector fc = new FacetsCollector();
-      FacetsCollector.search(searcher, new TermQuery(new Term("content", searchToken)), 10, fc);
+      FacetsCollector fc =
+          FacetsCollectorManager.search(
+                  searcher,
+                  new TermQuery(new Term("content", searchToken)),
+                  10,
+                  new FacetsCollectorManager())
+              .facetsCollector();
       Facets facets = getTaxonomyFacetCounts(tr, config, fc);
 
       // Slow, yet hopefully bug-free, faceting:

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
@@ -325,10 +325,12 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
     DirectoryReader r = DirectoryReader.open(iw);
     DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
 
-    FacetsCollector fc = new FacetsCollector(true);
     BoostQuery csq = new BoostQuery(new ConstantScoreQuery(new MatchAllDocsQuery()), 2f);
 
-    TopDocs td = FacetsCollector.search(newSearcher(r), csq, 10, fc);
+    FacetsCollectorManager.FacetsResult facetsResult =
+        FacetsCollectorManager.search(newSearcher(r), csq, 10, new FacetsCollectorManager(true));
+    TopDocs td = facetsResult.topDocs();
+    FacetsCollector fc = facetsResult.facetsCollector();
 
     // Test SUM:
     Facets facets =
@@ -435,11 +437,12 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
     DirectoryReader r = DirectoryReader.open(iw);
     DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
 
-    FacetsCollector fc = new FacetsCollector(true);
     // score documents by their 'price' field - makes asserting the correct counts for the
     // categories easier
     Query q = new FunctionQuery(new LongFieldSource("price"));
-    FacetsCollector.search(newSearcher(r), q, 10, fc);
+    FacetsCollector fc =
+        FacetsCollectorManager.search(newSearcher(r), q, 10, new FacetsCollectorManager(true))
+            .facetsCollector();
 
     // Test SUM:
     Facets facets =
@@ -588,8 +591,10 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
     DirectoryReader r = DirectoryReader.open(iw);
     DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
 
-    FacetsCollector fc = new FacetsCollector(true);
-    FacetsCollector.search(newSearcher(r), new MatchAllDocsQuery(), 10, fc);
+    FacetsCollector fc =
+        FacetsCollectorManager.search(
+                newSearcher(r), new MatchAllDocsQuery(), 10, new FacetsCollectorManager(true))
+            .facetsCollector();
 
     Facets facets1 = getTaxonomyFacetCounts(taxoReader, config, fc);
     Facets facets2;
@@ -657,8 +662,13 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
       if (VERBOSE) {
         System.out.println("\nTEST: iter content=" + searchToken);
       }
-      FacetsCollector fc = new FacetsCollector();
-      FacetsCollector.search(searcher, new TermQuery(new Term("content", searchToken)), 10, fc);
+      FacetsCollector fc =
+          FacetsCollectorManager.search(
+                  searcher,
+                  new TermQuery(new Term("content", searchToken)),
+                  10,
+                  new FacetsCollectorManager())
+              .facetsCollector();
 
       checkResults(
           numDims,


### PR DESCRIPTION
These can now be replaced by the corresponding methods added to FacetsCollectorManager that accept a FacetsCollectorManager as last argument in place of a Collector

This is the backport #13733 , minus the removal of the static methods which get instead deprecated in the 9x branch.

Relates to #11041


