### PR TITLE
Have value and count in LabelAndValue only for TaxonomyFacets

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -118,6 +118,10 @@ API Changes
   argument with a `FacetsCollectorManager` and update the return type to include both `TopDocs` results as well as
   facets results. (Luca Cavanna)
 
+* GITHUB#11282: Remove `count` from `LabelAndValue` and introduce `ValueAndCount` which can be used as the `value` in
+  `LabelAndValue`. `TaxonomyFacets` will always have `ValueAndCount` in the results, while other faceting
+  implementations will return a simple `Number`, as before GITHUB#13414. (Stefan Vodita)
+
 New Features
 ---------------------
 

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/AssociationsFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/AssociationsFacetsExample.java
@@ -172,7 +172,8 @@ public class AssociationsFacetsExample {
     System.out.println("Counts per label are also available:");
     for (FacetResult facetResult : results) {
       for (LabelAndValue lv : facetResult.labelValues) {
-        System.out.println("\t" + lv.label + ": " + lv.count);
+        System.out.println(
+            "\t" + lv.label + ": " + ((LabelAndValue.ValueAndCount) lv.value).getCount());
       }
     }
   }

--- a/lucene/facet/src/java/org/apache/lucene/facet/LabelAndValue.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/LabelAndValue.java
@@ -24,21 +24,10 @@ public final class LabelAndValue {
   /** Value associated with this label. */
   public final Number value;
 
-  /** Number of occurrences for this label. */
-  public final int count;
-
   /** Constructor with unspecified count, we assume the value is a count. */
   public LabelAndValue(String label, Number value) {
     this.label = label;
     this.value = value;
-    this.count = value.intValue();
-  }
-
-  /** Constructor with value and count. */
-  public LabelAndValue(String label, Number value, int count) {
-    this.label = label;
-    this.value = value;
-    this.count = count;
   }
 
   @Override
@@ -52,11 +41,81 @@ public final class LabelAndValue {
       return false;
     }
     LabelAndValue other = (LabelAndValue) _other;
-    return label.equals(other.label) && value.equals(other.value);
+    if (label.equals(other.label) == false) {
+      return false;
+    }
+    // value and other.value could be Number and ValueAndCount.
+    // We need the equals in ValueAndCount to be called.
+    if (value instanceof ValueAndCount) {
+      return value.equals(other.value);
+    }
+    return other.value.equals(value);
   }
 
   @Override
   public int hashCode() {
     return label.hashCode() + 1439 * value.hashCode();
+  }
+
+  /**
+   * Is a {@link Number} while holding a {@link Number} and a count. Meant as a value for {@link
+   * LabelAndValue}.
+   */
+  public static class ValueAndCount extends Number {
+    Number value;
+    int count;
+
+    /** All args constructor. */
+    public ValueAndCount(Number value, int count) {
+      this.value = value;
+      this.count = count;
+    }
+
+    /** Get the count. */
+    public int getCount() {
+      return count;
+    }
+
+    @Override
+    public int intValue() {
+      return value.intValue();
+    }
+
+    @Override
+    public long longValue() {
+      return value.longValue();
+    }
+
+    @Override
+    public float floatValue() {
+      return value.floatValue();
+    }
+
+    @Override
+    public double doubleValue() {
+      return value.doubleValue();
+    }
+
+    @Override
+    public boolean equals(Object _other) {
+      if (_other instanceof ValueAndCount) {
+        return value.equals(((ValueAndCount) _other).value)
+            && count == ((ValueAndCount) _other).count;
+      }
+      if (_other instanceof Number) {
+        return value.equals(_other);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return value.toString();
+    }
   }
 }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -334,7 +334,8 @@ abstract class TaxonomyFacets extends Facets {
       TopOrdAndNumberQueue.OrdAndValue ordAndValue = q.pop();
       assert ordAndValue != null;
       ordinals[i] = ordAndValue.ord;
-      values[i] = ordAndValue.getValue();
+      values[i] =
+          new LabelAndValue.ValueAndCount(ordAndValue.getValue(), getCount(ordAndValue.ord));
     }
 
     FacetLabel[] bulkPath = taxoReader.getBulkPath(ordinals);
@@ -342,9 +343,7 @@ abstract class TaxonomyFacets extends Facets {
     // add 1 here to also account for the dim:
     int childComponentIdx = path.length + 1;
     for (int i = 0; i < labelValues.length; i++) {
-      labelValues[i] =
-          new LabelAndValue(
-              bulkPath[i].components[childComponentIdx], values[i], getCount(ordinals[i]));
+      labelValues[i] = new LabelAndValue(bulkPath[i].components[childComponentIdx], values[i]);
     }
 
     return new FacetResult(
@@ -379,7 +378,7 @@ abstract class TaxonomyFacets extends Facets {
           aggregatedCount += count;
           aggregatedValue = aggregate(aggregatedValue, value);
           ordinals.add(ord);
-          ordValues.add(value);
+          ordValues.add(new LabelAndValue.ValueAndCount(value, count));
         }
       }
     } else {
@@ -393,7 +392,7 @@ abstract class TaxonomyFacets extends Facets {
           aggregatedCount += count;
           aggregatedValue = aggregate(aggregatedValue, value);
           ordinals.add(ord);
-          ordValues.add(value);
+          ordValues.add(new LabelAndValue.ValueAndCount(value, count));
         }
         ord = siblings.get(ord);
       }
@@ -420,9 +419,7 @@ abstract class TaxonomyFacets extends Facets {
 
     LabelAndValue[] labelValues = new LabelAndValue[ordValues.size()];
     for (int i = 0; i < ordValues.size(); i++) {
-      labelValues[i] =
-          new LabelAndValue(
-              bulkPath[i].components[cp.length], ordValues.get(i), getCount(ordinals.get(i)));
+      labelValues[i] = new LabelAndValue(bulkPath[i].components[cp.length], ordValues.get(i));
     }
     return new FacetResult(dim, path, aggregatedValue, labelValues, ordinals.size());
   }

--- a/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
@@ -254,7 +254,6 @@ public abstract class FacetTestCase extends LuceneTestCase {
   }
 
   protected void assertNumericValuesEquals(Number a, Number b) {
-    assertTrue(a.getClass().isInstance(b));
     if (a instanceof Float) {
       assertEquals(a.floatValue(), b.floatValue(), a.floatValue() / 1e5);
     } else if (a instanceof Double) {
@@ -292,7 +291,8 @@ public abstract class FacetTestCase extends LuceneTestCase {
         result, expectedDim, expectedPath, expectedChildCount, expectedValue, expectedChildren);
     assertEquals(result.labelValues.length, countPerLabel.size());
     for (LabelAndValue lv : result.labelValues) {
-      assertEquals(lv.count, (int) countPerLabel.get(lv.label));
+      assertEquals(
+          ((LabelAndValue.ValueAndCount) lv.value).getCount(), (int) countPerLabel.get(lv.label));
     }
   }
 }

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestFacetsConfig.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestFacetsConfig.java
@@ -78,7 +78,7 @@ public class TestFacetsConfig extends FacetTestCase {
     Facets facets = getTaxonomyFacetCounts(taxoReader, facetsConfig, fc);
     FacetResult res = facets.getTopChildren(10, "a");
     assertEquals(1, res.labelValues.length);
-    assertEquals(2, res.labelValues[0].value);
+    assertEquals(2, res.labelValues[0].value.intValue());
     IOUtils.close(indexReader, taxoReader);
 
     IOUtils.close(indexDir, taxoDir);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts2.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts2.java
@@ -277,12 +277,14 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     FacetResult result = facets.getTopChildren(NUM_CHILDREN_CP_A, CP_A);
     assertEquals(-1, result.value.intValue());
     for (LabelAndValue labelValue : result.labelValues) {
-      assertEquals(termExpectedCounts.get(CP_A + "/" + labelValue.label), labelValue.value);
+      assertEquals(
+          (int) termExpectedCounts.get(CP_A + "/" + labelValue.label), labelValue.value.intValue());
     }
     result = facets.getTopChildren(NUM_CHILDREN_CP_B, CP_B);
     assertEquals(termExpectedCounts.get(CP_B), result.value);
     for (LabelAndValue labelValue : result.labelValues) {
-      assertEquals(termExpectedCounts.get(CP_B + "/" + labelValue.label), labelValue.value);
+      assertEquals(
+          (int) termExpectedCounts.get(CP_B + "/" + labelValue.label), labelValue.value.intValue());
     }
 
     IOUtils.close(indexReader, taxoReader);
@@ -302,7 +304,8 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     assertEquals(-1, result.value.intValue());
     int prevValue = Integer.MAX_VALUE;
     for (LabelAndValue labelValue : result.labelValues) {
-      assertEquals(allExpectedCounts.get(CP_A + "/" + labelValue.label), labelValue.value);
+      assertEquals(
+          (int) allExpectedCounts.get(CP_A + "/" + labelValue.label), labelValue.value.intValue());
       assertTrue(
           "wrong sort order of sub results: labelValue.value="
               + labelValue.value
@@ -316,7 +319,8 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     assertEquals(allExpectedCounts.get(CP_B), result.value);
     prevValue = Integer.MAX_VALUE;
     for (LabelAndValue labelValue : result.labelValues) {
-      assertEquals(allExpectedCounts.get(CP_B + "/" + labelValue.label), labelValue.value);
+      assertEquals(
+          (int) allExpectedCounts.get(CP_B + "/" + labelValue.label), labelValue.value.intValue());
       assertTrue(
           "wrong sort order of sub results: labelValue.value="
               + labelValue.value
@@ -342,12 +346,14 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     FacetResult result = facets.getTopChildren(Integer.MAX_VALUE, CP_A);
     assertEquals(-1, result.value.intValue());
     for (LabelAndValue labelValue : result.labelValues) {
-      assertEquals(allExpectedCounts.get(CP_A + "/" + labelValue.label), labelValue.value);
+      assertEquals(
+          (int) allExpectedCounts.get(CP_A + "/" + labelValue.label), labelValue.value.intValue());
     }
     result = facets.getTopChildren(Integer.MAX_VALUE, CP_B);
     assertEquals(allExpectedCounts.get(CP_B), result.value);
     for (LabelAndValue labelValue : result.labelValues) {
-      assertEquals(allExpectedCounts.get(CP_B + "/" + labelValue.label), labelValue.value);
+      assertEquals(
+          (int) allExpectedCounts.get(CP_B + "/" + labelValue.label), labelValue.value.intValue());
     }
 
     IOUtils.close(indexReader, taxoReader);
@@ -366,12 +372,14 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     FacetResult result = facets.getTopChildren(NUM_CHILDREN_CP_C, CP_C);
     assertEquals(allExpectedCounts.get(CP_C), result.value);
     for (LabelAndValue labelValue : result.labelValues) {
-      assertEquals(allExpectedCounts.get(CP_C + "/" + labelValue.label), labelValue.value);
+      assertEquals(
+          (int) allExpectedCounts.get(CP_C + "/" + labelValue.label), labelValue.value.intValue());
     }
     result = facets.getTopChildren(NUM_CHILDREN_CP_D, CP_D);
     assertEquals(allExpectedCounts.get(CP_C), result.value);
     for (LabelAndValue labelValue : result.labelValues) {
-      assertEquals(allExpectedCounts.get(CP_D + "/" + labelValue.label), labelValue.value);
+      assertEquals(
+          (int) allExpectedCounts.get(CP_D + "/" + labelValue.label), labelValue.value.intValue());
     }
 
     IOUtils.close(indexReader, taxoReader);


### PR DESCRIPTION
#13414 in we added a `count` to `LabelAndValue` as a non-breaking solution to the problem of counts not being available from facets that also do other aggregations (#11282) despite being computed (#12966).

This time we break API and make it so only `TaxonomyFacets` output two values, a count and an optional additional value. All other (single value) facets work as they did before #13414.

This isn't a great solution either.
1. Not all `TaxonomyFacets` have two values.
2. What if we want more than two in the future (#12546)?
3. To avoid breaking too many of the assumptions, comparing `LabelAndValue`s is weird. A `ValueAndCount` can be equal to a `Number`.
4. A user of `TaxonomyFacets` has to cast `LabelAndValue.value` to access the actual value and count.

There are other ideas in #13414. I'm not sure if I like this better than what we currently have. It's better for non-`TaxonomyFacets` not to use the extra memory, but it makes using `TaxonomyFacets` more complicated, and it makes `LabelAndValue` complicated.

If we go ahead with this for Lucene 10, I'd separately deprecate `LabelAndValue.count` in 9.12.
