### PR TITLE
Reorder checks in LRUQueryCache#count

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -387,6 +387,8 @@ Optimizations
 
 * GITHUB#13587: Use Max WAND optimizations with ToParentBlockJoinQuery when using ScoreMode.Max (Mike Pellegrini)
 
+* GITHUB#13742: Reorder checks in LRUQueryCache#count (Shubham Chaudhary)
+
 Changes in runtime behavior
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -816,15 +816,9 @@ public class LRUQueryCache implements QueryCache, Accountable {
 
     @Override
     public int count(LeafReaderContext context) throws IOException {
-      // If the wrapped weight can count quickly then use that
-      int innerCount = in.count(context);
-      if (innerCount != -1) {
-        return innerCount;
-      }
-
       // Our cache won't have an accurate count if there are deletions
       if (context.reader().hasDeletions()) {
-        return -1;
+        return in.count(context);
       }
 
       // Otherwise check if the count is in the cache
@@ -834,24 +828,24 @@ public class LRUQueryCache implements QueryCache, Accountable {
 
       if (in.isCacheable(context) == false) {
         // this segment is not suitable for caching
-        return -1;
+        return in.count(context);
       }
 
       // Short-circuit: Check whether this segment is eligible for caching
       // before we take a lock because of #get
       if (shouldCache(context) == false) {
-        return -1;
+        return in.count(context);
       }
 
       final IndexReader.CacheHelper cacheHelper = context.reader().getCoreCacheHelper();
       if (cacheHelper == null) {
         // this reader has no cacheHelper
-        return -1;
+        return in.count(context);
       }
 
       // If the lock is already busy, prefer using the uncached version than waiting
       if (readLock.tryLock() == false) {
-        return -1;
+        return in.count(context);
       }
 
       CacheAndCount cached;
@@ -860,11 +854,12 @@ public class LRUQueryCache implements QueryCache, Accountable {
       } finally {
         readLock.unlock();
       }
-      if (cached == null) {
-        // Not cached
-        return -1;
+      if (cached != null) {
+        // cached
+        return cached.count();
       }
-      return cached.count();
+      // Not cached, check if the wrapped weight can count quickly then use that
+      return in.count(context);
     }
 
     @Override


### PR DESCRIPTION
### Description

Reorder the checks in LRUQueryCache#count to first check the cached version. Addresses or closes #13717

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
