### PR TITLE
Fix TestShapeDocValues.testLatLonPolygonBBox

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/document/TestShapeDocValues.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestShapeDocValues.java
@@ -56,12 +56,14 @@ public class TestShapeDocValues extends LuceneTestCase {
 
   public void testLatLonPolygonBBox() {
     Polygon p = GeoTestUtil.nextPolygon();
-    Rectangle expected = (Rectangle) computeBoundingBox(p);
-    LatLonShapeDocValuesField dv = LatLonShape.createDocValueField(FIELD_NAME, p);
-    assertEquals(expected.minLat, dv.getBoundingBox().minLat, TOLERANCE);
-    assertEquals(expected.maxLat, dv.getBoundingBox().maxLat, TOLERANCE);
-    assertEquals(expected.minLon, dv.getBoundingBox().minLon, TOLERANCE);
-    assertEquals(expected.maxLon, dv.getBoundingBox().maxLon, TOLERANCE);
+    if (area(p) != 0) {
+      Rectangle expected = (Rectangle) computeBoundingBox(p);
+      LatLonShapeDocValuesField dv = LatLonShape.createDocValueField(FIELD_NAME, p);
+      assertEquals(expected.minLat, dv.getBoundingBox().minLat, TOLERANCE);
+      assertEquals(expected.maxLat, dv.getBoundingBox().maxLat, TOLERANCE);
+      assertEquals(expected.minLon, dv.getBoundingBox().minLon, TOLERANCE);
+      assertEquals(expected.maxLon, dv.getBoundingBox().maxLon, TOLERANCE);
+    }
   }
 
   public void testXYPolygonBBox() {
@@ -254,5 +256,10 @@ public class TestShapeDocValues extends LuceneTestCase {
       tess.add(d);
     }
     return tess;
+  }
+
+  /** Compute signed area of rectangle */
+  private static double area(Polygon p) {
+    return (p.maxLon - p.minLon) * (p.maxLat - p.minLat);
   }
 }


### PR DESCRIPTION
### Description

With the culprit seed (`C6E272EBEF02886F`) the generated polygon or triangle have extremely close coordinates(`[(0.0,1.757358717152938E-241), (-4.0378026254892873E-84, 0.0), (-4.0378026254892873E-84, 1.757358717152938E-241)]`) causing the area to overflow the double range (i.e. `4.9E-324` to `1.79E308`).

Closes #13531

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
