### PR TITLE
Propagate keepScores to reduced FacetsCollector

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollectorManager.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollectorManager.java
@@ -67,12 +67,14 @@ public class FacetsCollectorManager implements CollectorManager<FacetsCollector,
     if (collectors.size() == 1) {
       return collectors.iterator().next();
     }
-    return new ReducedFacetsCollector(collectors);
+    assert collectors.stream().allMatch(fc -> fc.getKeepScores() == keepScores);
+    return new ReducedFacetsCollector(collectors, keepScores);
   }
 
   private static class ReducedFacetsCollector extends FacetsCollector {
 
-    public ReducedFacetsCollector(final Collection<FacetsCollector> facetsCollectors) {
+    ReducedFacetsCollector(final Collection<FacetsCollector> facetsCollectors, boolean keepScores) {
+      super(keepScores);
       final List<MatchingDocs> matchingDocs = this.getMatchingDocs();
       facetsCollectors.forEach(
           facetsCollector -> matchingDocs.addAll(facetsCollector.getMatchingDocs()));

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetValueSource.java
@@ -315,6 +315,7 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
         FacetsCollectorManager.search(newSearcher(r), csq, 10, new FacetsCollectorManager(true));
     TopDocs td = facetsResult.topDocs();
     FacetsCollector fc = facetsResult.facetsCollector();
+    assertTrue(fc.getKeepScores());
 
     // Test SUM:
     Facets facets =
@@ -411,6 +412,7 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
     FacetsCollector fc =
         FacetsCollectorManager.search(newSearcher(r), q, 10, new FacetsCollectorManager(true))
             .facetsCollector();
+    assertTrue(fc.getKeepScores());
 
     // Test SUM:
     Facets facets =
@@ -547,6 +549,7 @@ public class TestTaxonomyFacetValueSource extends FacetTestCase {
         FacetsCollectorManager.search(
                 newSearcher(r), new MatchAllDocsQuery(), 10, new FacetsCollectorManager(true))
             .facetsCollector();
+    assertTrue(fc.getKeepScores());
 
     Facets facets1 = getTaxonomyFacetCounts(taxoReader, config, fc);
     Facets facets2 =


### PR DESCRIPTION
We recently introduced support for keepScores to FacetsCollectorManager. The returned reduced FacetsCollector instance though does not reflect that in that its inner keepScores flag is always false. This commit fixes that.