### PR TITLE
Update QueryUtils to use CollectorManager

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
@@ -512,7 +512,7 @@ public class QueryUtils {
 
                     @Override
                     public LeafReader getLastReader() {
-                      return null;
+                      return lastReader;
                     }
                   };
                 }
@@ -522,7 +522,9 @@ public class QueryUtils {
                     Collection<SimpleCollectorWithLastReader> collectors) {
                   List<LeafReader> lastReaders = new ArrayList<>();
                   for (SimpleCollectorWithLastReader collector : collectors) {
-                    lastReaders.add(collector.getLastReader());
+                    if (collector.getLastReader() != null) {
+                      lastReaders.add(collector.getLastReader());
+                    }
                   }
                   return lastReaders;
                 }
@@ -692,7 +694,9 @@ public class QueryUtils {
               public List<LeafReader> reduce(Collection<SimpleCollectorWithLastReader> collectors) {
                 List<LeafReader> lastReaders = new ArrayList<>();
                 for (SimpleCollectorWithLastReader collector : collectors) {
-                  lastReaders.add(collector.getLastReader());
+                  if (collector.getLastReader() != null) {
+                    lastReaders.add(collector.getLastReader());
+                  }
                 }
                 return lastReaders;
               }


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

Relates to https://github.com/apache/lucene/issues/12892

We introduce a new `SimpleCollectorWithLastReader` class to help keep context of LastReader per thread. This way calling `CollectorManager#reduce` can work with an executor. 

The diff makes it look big, but in reality we just wrap SimpleCollector inside a CollectorManager.