### PR TITLE
DrillSideways#search: use bounded wildcard for the list of drill-sideways CollectorManagers

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -293,7 +293,7 @@ API Changes
 * GITHUB#13568: Add DoubleValuesSource#toSortableLongDoubleValuesSource and
   MultiDoubleValuesSource#toSortableMultiLongValuesSource methods. (Shradha Shankar)
 
-* GITHUB#13568: Add DrillSideways#search method that supports any CollectorManagers for drill-sideways dimensions
+* GITHUB#13568, GITHUB#13750: Add DrillSideways#search method that supports any CollectorManagers for drill-sideways dimensions
   or drill-down. (Egor Potemkin)
 
 New Features

--- a/lucene/demo/src/java/org/apache/lucene/demo/facet/SandboxFacetsExample.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/facet/SandboxFacetsExample.java
@@ -43,7 +43,6 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.sandbox.facet.ComparableUtils;
-import org.apache.lucene.sandbox.facet.FacetFieldCollector;
 import org.apache.lucene.sandbox.facet.FacetFieldCollectorManager;
 import org.apache.lucene.sandbox.facet.cutters.TaxonomyFacetsCutter;
 import org.apache.lucene.sandbox.facet.cutters.ranges.LongRangeFacetCutter;
@@ -57,7 +56,6 @@ import org.apache.lucene.sandbox.facet.recorders.CountFacetRecorder;
 import org.apache.lucene.sandbox.facet.recorders.LongAggregationsFacetRecorder;
 import org.apache.lucene.sandbox.facet.recorders.MultiFacetsRecorder;
 import org.apache.lucene.sandbox.facet.recorders.Reducer;
-import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LongValuesSource;
@@ -563,7 +561,7 @@ public class SandboxFacetsExample {
     // FacetFieldCollectorManager anyway, and leaf cutter are not merged or anything like that.
     FacetFieldCollectorManager<CountFacetRecorder> publishDayDimensionCollectorManager =
         new FacetFieldCollectorManager<>(defaultTaxoCutter, publishDayDimensionRecorder);
-    List<CollectorManager<FacetFieldCollector, CountFacetRecorder>> drillSidewaysManagers =
+    List<FacetFieldCollectorManager<CountFacetRecorder>> drillSidewaysManagers =
         List.of(publishDayDimensionCollectorManager);
 
     //// (3) search

--- a/lucene/facet/src/java/org/apache/lucene/facet/DrillSideways.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/DrillSideways.java
@@ -340,7 +340,7 @@ public class DrillSideways {
       mainCollectorManager = hitCollectorManager;
     }
     // Drill sideways dimensions
-    final List<CollectorManager<FacetsCollector, FacetsCollector>> drillSidewaysCollectorManagers;
+    final List<FacetsCollectorManager> drillSidewaysCollectorManagers;
     if (query.getDims().isEmpty() == false) {
       drillSidewaysCollectorManagers = new ArrayList<>(query.getDims().size());
       for (int i = 0; i < query.getDims().size(); i++) {
@@ -408,7 +408,7 @@ public class DrillSideways {
   public <C extends Collector, T, K extends Collector, R> Result<T, R> search(
       DrillDownQuery query,
       CollectorManager<C, T> drillDownCollectorManager,
-      List<CollectorManager<K, R>> drillSidewaysCollectorManagers)
+      List<? extends CollectorManager<K, R>> drillSidewaysCollectorManagers)
       throws IOException {
     if (drillDownCollectorManager == null) {
       throw new IllegalArgumentException(
@@ -443,7 +443,7 @@ public class DrillSideways {
   private <C extends Collector, T, K extends Collector, R> Result<T, R> searchSequentially(
       final DrillDownQuery query,
       final CollectorManager<C, T> drillDownCollectorManager,
-      final List<CollectorManager<K, R>> drillSidewaysCollectorManagers)
+      final List<? extends CollectorManager<K, R>> drillSidewaysCollectorManagers)
       throws IOException {
 
     Map<String, Integer> drillDownDims = query.getDims();
@@ -485,7 +485,7 @@ public class DrillSideways {
   private <C extends Collector, T, K extends Collector, R> Result<T, R> searchConcurrently(
       final DrillDownQuery query,
       final CollectorManager<C, T> drillDownCollectorManager,
-      final List<CollectorManager<K, R>> drillSidewaysCollectorManagers) {
+      final List<? extends CollectorManager<K, R>> drillSidewaysCollectorManagers) {
 
     final Map<String, Integer> drillDownDims = query.getDims();
     final CallableCollector<T> drillDownCallableCollector =

--- a/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysQuery.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/DrillSidewaysQuery.java
@@ -46,7 +46,7 @@ class DrillSidewaysQuery<K extends Collector, R> extends Query {
 
   final Query baseQuery;
 
-  final List<CollectorManager<K, R>> drillSidewaysCollectorManagers;
+  final List<? extends CollectorManager<K, R>> drillSidewaysCollectorManagers;
   final List<List<K>> managedDrillSidewaysCollectors;
 
   final Query[] drillDownQueries;
@@ -59,7 +59,7 @@ class DrillSidewaysQuery<K extends Collector, R> extends Query {
    */
   DrillSidewaysQuery(
       Query baseQuery,
-      List<CollectorManager<K, R>> drillSidewaysCollectorManagers,
+      List<? extends CollectorManager<K, R>> drillSidewaysCollectorManagers,
       Query[] drillDownQueries,
       boolean scoreSubDocsAtOnce) {
     // Note that the "managed" collector lists are synchronized here since bulkScorer()
@@ -80,7 +80,7 @@ class DrillSidewaysQuery<K extends Collector, R> extends Query {
    */
   private DrillSidewaysQuery(
       Query baseQuery,
-      List<CollectorManager<K, R>> drillSidewaysCollectorManagers,
+      List<? extends CollectorManager<K, R>> drillSidewaysCollectorManagers,
       List<List<K>> managedDrillSidewaysCollectors,
       Query[] drillDownQueries,
       boolean scoreSubDocsAtOnce) {


### PR DESCRIPTION
`DrillSideways#search`: use bounded wildcard for the list of drill-sideways CollectorManagers

Lists are invariant, so current API doesn't allow passing something like `List<CollectorManagerImplementation>` where `class CollectorManagerImplementation implements CollectorManager<A, B>`. Invariant makes it so `List<CollectorManagerImplementation>` does not extend `List<CollectorManager<A, B>>`. Using bounded wildcard type allows to overcome that.
