### PR TITLE
Add prefetching support to term vectors.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/BaseCompositeReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BaseCompositeReader.java
@@ -118,6 +118,15 @@ public abstract class BaseCompositeReader<R extends IndexReader> extends Composi
     TermVectors[] subVectors = new TermVectors[subReaders.length];
     return new TermVectors() {
       @Override
+      public void prefetch(int docID) throws IOException {
+        final int i = readerIndex(docID); // find subreader num
+        if (subVectors[i] == null) {
+          subVectors[i] = subReaders[i].termVectors();
+        }
+        subVectors[i].prefetch(docID - starts[i]);
+      }
+
+      @Override
       public Fields get(int docID) throws IOException {
         final int i = readerIndex(docID); // find subreader num
         // dispatch to subreader, reusing if possible

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -3810,6 +3810,9 @@ public final class CheckIndex implements Closeable {
       if (vectorsReader != null) {
         vectorsReader = vectorsReader.getMergeInstance();
         for (int j = 0; j < reader.maxDoc(); ++j) {
+          if ((j & 0x03) == 0) {
+            vectorsReader.prefetch(j);
+          }
           // Intentionally pull/visit (but don't count in
           // stats) deleted documents to make sure they too
           // are not corrupt:

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -48,6 +48,7 @@ import org.apache.lucene.util.Version;
  * behavior</em>.
  */
 public class ParallelLeafReader extends LeafReader {
+
   private final FieldInfos fieldInfos;
   private final LeafReader[] parallelReaders, storedFieldsReaders;
   private final Set<LeafReader> completeReaderSet =
@@ -325,14 +326,32 @@ public class ParallelLeafReader extends LeafReader {
   @Override
   public TermVectors termVectors() throws IOException {
     ensureOpen();
-    // TODO: optimize
+
+    Map<LeafReader, TermVectors> readerToTermVectors = new IdentityHashMap<>();
+    for (LeafReader reader : parallelReaders) {
+      if (reader.getFieldInfos().hasVectors()) {
+        TermVectors termVectors = reader.termVectors();
+        readerToTermVectors.put(reader, termVectors);
+      }
+    }
+
     return new TermVectors() {
+      @Override
+      public void prefetch(int docID) throws IOException {
+        // Prefetch all vectors. Note that this may be wasteful if the consumer doesn't need to read
+        // all the fields but we have no way to know what fields the consumer needs.
+        for (TermVectors termVectors : readerToTermVectors.values()) {
+          termVectors.prefetch(docID);
+        }
+      }
+
       @Override
       public Fields get(int docID) throws IOException {
         ParallelFields fields = null;
         for (Map.Entry<String, LeafReader> ent : tvFieldToReader.entrySet()) {
           String fieldName = ent.getKey();
-          Terms vector = ent.getValue().termVectors().get(docID, fieldName);
+          TermVectors termVectors = readerToTermVectors.get(ent.getValue());
+          Terms vector = termVectors.get(docID, fieldName);
           if (vector != null) {
             if (fields == null) {
               fields = new ParallelFields();

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
@@ -297,6 +297,11 @@ public final class SlowCodecReaderWrapper {
     }
     return new TermVectorsReader() {
       @Override
+      public void prefetch(int docID) throws IOException {
+        termVectors.prefetch(docID);
+      }
+
+      @Override
       public Fields get(int docID) throws IOException {
         return termVectors.get(docID);
       }

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
@@ -245,6 +245,15 @@ final class SlowCompositeCodecReaderWrapper extends CodecReader {
     }
 
     @Override
+    public void prefetch(int doc) throws IOException {
+      int readerId = docIdToReaderId(doc);
+      TermVectorsReader reader = readers[readerId];
+      if (reader != null) {
+        reader.prefetch(doc - docStarts[readerId]);
+      }
+    }
+
+    @Override
     public Fields get(int doc) throws IOException {
       int readerId = docIdToReaderId(doc);
       TermVectorsReader reader = readers[readerId];

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -656,6 +656,11 @@ public final class SortingCodecReader extends FilterCodecReader {
   private TermVectorsReader newTermVectorsReader(TermVectorsReader delegate) {
     return new TermVectorsReader() {
       @Override
+      public void prefetch(int doc) throws IOException {
+        delegate.prefetch(docMap.newToOld(doc));
+      }
+
+      @Override
       public Fields get(int doc) throws IOException {
         return delegate.get(docMap.newToOld(doc));
       }

--- a/lucene/core/src/java/org/apache/lucene/index/TermVectors.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermVectors.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute; // javadocs
+import org.apache.lucene.store.IndexInput;
 
 /**
  * API for reading term vectors.
@@ -29,6 +30,18 @@ public abstract class TermVectors {
 
   /** Sole constructor. (For invocation by subclass constructors, typically implicit.) */
   protected TermVectors() {}
+
+  /**
+   * Optional method: Give a hint to this {@link TermVectors} instance that the given document will
+   * be read in the near future. This typically delegates to {@link IndexInput#prefetch} and is
+   * useful to parallelize I/O across multiple documents.
+   *
+   * <p>NOTE: This API is expected to be called on a small enough set of doc IDs that they could all
+   * fit in the page cache. If you plan on retrieving a very large number of documents, it may be a
+   * good idea to perform calls to {@link #prefetch} and {@link #get} in batches instead of
+   * prefetching all documents up-front.
+   */
+  public void prefetch(int docID) throws IOException {}
 
   /**
    * Returns term vectors for this document, or null if term vectors were not indexed.

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90TermVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90TermVectorsFormat.java
@@ -16,7 +16,24 @@
  */
 package org.apache.lucene.codecs.lucene90;
 
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.TermVectors;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.tests.codecs.compressing.dummy.DummyCompressingCodec;
 import org.apache.lucene.tests.index.BaseTermVectorsFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 
@@ -24,5 +41,85 @@ public class TestLucene90TermVectorsFormat extends BaseTermVectorsFormatTestCase
   @Override
   protected Codec getCodec() {
     return TestUtil.getDefaultCodec();
+  }
+
+  private static class CountingPrefetchDirectory extends FilterDirectory {
+
+    private final AtomicInteger counter;
+
+    CountingPrefetchDirectory(Directory in, AtomicInteger counter) {
+      super(in);
+      this.counter = counter;
+    }
+
+    @Override
+    public IndexInput openInput(String name, IOContext context) throws IOException {
+      return new CountingPrefetchIndexInput(super.openInput(name, context), counter);
+    }
+  }
+
+  private static class CountingPrefetchIndexInput extends FilterIndexInput {
+
+    private final AtomicInteger counter;
+
+    public CountingPrefetchIndexInput(IndexInput input, AtomicInteger counter) {
+      super(input.toString(), input);
+      this.counter = counter;
+    }
+
+    @Override
+    public void prefetch(long offset, long length) throws IOException {
+      in.prefetch(offset, length);
+      counter.incrementAndGet();
+    }
+
+    @Override
+    public IndexInput clone() {
+      return new CountingPrefetchIndexInput(in.clone(), counter);
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+      return new CountingPrefetchIndexInput(in.slice(sliceDescription, offset, length), counter);
+    }
+  }
+
+  public void testSkipRedundantPrefetches() throws IOException {
+    // Use the "dummy" codec, which has the same base class as Lucene90StoredFieldsFormat but allows
+    // configuring the number of docs per chunk.
+    Codec codec = new DummyCompressingCodec(1 << 10, 2, false, 16);
+    try (Directory origDir = newDirectory()) {
+      AtomicInteger counter = new AtomicInteger();
+      Directory dir = new CountingPrefetchDirectory(origDir, counter);
+      try (IndexWriter w = new IndexWriter(dir, new IndexWriterConfig().setCodec(codec))) {
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setStoreTermVectors(true);
+        for (int i = 0; i < 100; ++i) {
+          Document doc = new Document();
+          doc.add(new Field("content", Integer.toString(i), ft));
+          w.addDocument(doc);
+        }
+        w.forceMerge(1);
+      }
+
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        TermVectors termVectors = reader.termVectors();
+        counter.set(0);
+        assertEquals(0, counter.get());
+        termVectors.prefetch(0);
+        assertEquals(1, counter.get());
+        termVectors.prefetch(1);
+        // This format has 2 docs per block, so the second prefetch is skipped
+        assertEquals(1, counter.get());
+        termVectors.prefetch(15);
+        assertEquals(2, counter.get());
+        termVectors.prefetch(14);
+        // 14 is in the same block as 15, so the prefetch was skipped
+        assertEquals(2, counter.get());
+        // Already prefetched in the past, so skipped again
+        termVectors.prefetch(1);
+        assertEquals(2, counter.get());
+      }
+    }
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -154,6 +154,12 @@ public class AssertingLeafReader extends FilterLeafReader {
     }
 
     @Override
+    public void prefetch(int docID) throws IOException {
+      assertThread("TermVectors", creationThread);
+      in.prefetch(docID);
+    }
+
+    @Override
     public Fields get(int doc) throws IOException {
       assertThread("TermVectors", creationThread);
       Fields fields = in.get(doc);


### PR DESCRIPTION
This follows the same approach that we used for stored fields.