### PR TITLE
Fix ToParentBlockJoinQuery child doc == parent doc error checking when score mode is None

### DIFF
--- a/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinQuery.java
@@ -242,6 +242,7 @@ public class ToParentBlockJoinQuery extends Query {
 
     @Override
     public int advance(int target) throws IOException {
+      // Look backwards to see if the current child doc matches the previous parent
       final int prevParent =
           target == 0 ? -1 : parentBits.prevSetBit(Math.min(target, parentBits.length()) - 1);
 
@@ -265,6 +266,10 @@ public class ToParentBlockJoinQuery extends Query {
       if (childDoc >= parentBits.length()) {
         return doc = NO_MORE_DOCS;
       }
+
+      // Get the current parent, starting at the current child doc. We do this to handle the case
+      // where the current child doc is also the current parent. When advance is next called, this
+      // will be detected and an exception will be thrown.
       return doc = parentBits.nextSetBit(childDoc);
     }
 

--- a/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinQuery.java
@@ -242,14 +242,25 @@ public class ToParentBlockJoinQuery extends Query {
 
     @Override
     public int advance(int target) throws IOException {
-      if (target >= parentBits.length()) {
-        return doc = NO_MORE_DOCS;
-      }
-      final int firstChildTarget = target == 0 ? 0 : parentBits.prevSetBit(target - 1) + 1;
+      final int prevParent =
+          target == 0 ? 0 : parentBits.prevSetBit(Math.min(target, parentBits.length()) - 1);
+
       int childDoc = childApproximation.docID();
-      if (childDoc < firstChildTarget) {
-        childDoc = childApproximation.advance(firstChildTarget);
+      if (childDoc < prevParent) {
+        childDoc = childApproximation.advance(prevParent);
       }
+
+      // TODO: Can we assume that doc 0 is never a real parent that also matches the child query?
+      if (prevParent != 0 && childDoc == prevParent) {
+        throw new IllegalStateException(
+            "Child query must not match same docs with parent filter. "
+                + "Combine them as must clauses (+) to find a problem doc. "
+                + "docId="
+                + childDoc
+                + ", "
+                + this.getClass());
+      }
+
       if (childDoc >= parentBits.length() - 1) {
         return doc = NO_MORE_DOCS;
       }
@@ -429,20 +440,6 @@ public class ToParentBlockJoinQuery extends Query {
         }
 
         score = parentScore.score();
-      }
-
-      // TODO: When score mode is None, this check is broken because the child approximation is not
-      // advanced and will therefore never match the parent approximation at this point in
-      // execution. Fix this error check when score mode is None.
-      if (childApproximation.docID() == parentApproximation.docID()
-          && (childTwoPhase == null || childTwoPhase.matches())) {
-        throw new IllegalStateException(
-            "Child query must not match same docs with parent filter. "
-                + "Combine them as must clauses (+) to find a problem doc. "
-                + "docId="
-                + parentApproximation.docID()
-                + ", "
-                + childScorer.getClass());
       }
 
       return score;

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinScorer.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinScorer.java
@@ -34,7 +34,6 @@ import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
@@ -61,6 +60,7 @@ public class TestBlockJoinScorer extends LuceneTestCase {
       docs.clear();
       for (int j = 0; j < i; j++) {
         Document child = new Document();
+        child.add(newStringField("docType", "child", Field.Store.NO));
         child.add(newStringField("value", Integer.toString(j), Field.Store.YES));
         docs.add(child);
       }
@@ -81,7 +81,7 @@ public class TestBlockJoinScorer extends LuceneTestCase {
         new QueryBitSetProducer(new TermQuery(new Term("docType", "parent")));
     CheckJoinIndex.check(reader, parentsFilter);
 
-    Query childQuery = new MatchAllDocsQuery();
+    Query childQuery = new TermQuery(new Term("docType", "child"));
     ToParentBlockJoinQuery query =
         new ToParentBlockJoinQuery(childQuery, parentsFilter, ScoreMode.None);
 

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinValidation.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinValidation.java
@@ -82,16 +82,12 @@ public class TestBlockJoinValidation extends LuceneTestCase {
   }
 
   public void testNextDocValidationForToParentBjq() throws Exception {
-    // TODO: This test is broken when score mode is None because BlockJoinScorer#scoreChildDocs does
-    // not advance the child approximation. Adjust this test once that is fixed.
-    final List<ScoreMode> validScoreModes =
-        List.of(ScoreMode.Avg, ScoreMode.Max, ScoreMode.Total, ScoreMode.Min);
     Query parentQueryWithRandomChild = createChildrenQueryWithOneParent(getRandomChildNumber(0));
     ToParentBlockJoinQuery blockJoinQuery =
         new ToParentBlockJoinQuery(
             parentQueryWithRandomChild,
             parentsFilter,
-            RandomPicks.randomFrom(LuceneTestCase.random(), validScoreModes));
+            RandomPicks.randomFrom(LuceneTestCase.random(), ScoreMode.values()));
     IllegalStateException expected =
         expectThrows(
             IllegalStateException.class,


### PR DESCRIPTION
Fix the child doc == parent doc error-checking gap that currently exists in `ToParentBlockJoinQuery` when the score mode is `ScoreMode.None`.

As written, this approach _almost_ works, but fails when a two-phase iterator is required. Best I can tell, I think the solution lies in fully encapsulating the two-phase iterator details in `parentApproximation` & `childApproximation` so that `ParentTwoPhase#matches` is only called within `ToParentBlockJoinQuery`.
