### PR TITLE
Fix TestPrefixRandom failures when intra-segment concurrency is enabled

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestPrefixRandom.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPrefixRandom.java
@@ -43,6 +43,7 @@ public class TestPrefixRandom extends LuceneTestCase {
   private IndexSearcher searcher;
   private IndexReader reader;
   private Directory dir;
+  private int numDocs;
 
   @Override
   public void setUp() throws Exception {
@@ -59,8 +60,8 @@ public class TestPrefixRandom extends LuceneTestCase {
     Field field = newStringField("field", "", Field.Store.NO);
     doc.add(field);
 
-    int num = atLeast(1000);
-    for (int i = 0; i < num; i++) {
+    numDocs = atLeast(1000);
+    for (int i = 0; i < numDocs; i++) {
       field.setStringValue(TestUtil.randomUnicodeString(random(), 10));
       writer.addDocument(doc);
     }
@@ -134,8 +135,8 @@ public class TestPrefixRandom extends LuceneTestCase {
     PrefixQuery smart = new PrefixQuery(new Term("field", prefix));
     DumbPrefixQuery dumb = new DumbPrefixQuery(new Term("field", prefix));
 
-    TopDocs smartDocs = searcher.search(smart, 25);
-    TopDocs dumbDocs = searcher.search(dumb, 25);
+    TopDocs smartDocs = searcher.search(smart, numDocs);
+    TopDocs dumbDocs = searcher.search(dumb, numDocs);
     CheckHits.checkEqual(smart, smartDocs.scoreDocs, dumbDocs.scoreDocs);
   }
 }


### PR DESCRIPTION
The order in which documents are processed is not a guarantee, hence we may return a different set of documents when early terminating the search. Those are not incorrect results though.

I opted for increasing the number of hits so that we never early terminate the search for this test.

I believe this test should have failed with inter-segment concurrency as well, and intra-segment concurrency makes it more likely to fail (although not so frequently).