### PR TITLE
Address length used to copy array in FacetsCollector to not be out of bounds

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollector.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollector.java
@@ -84,7 +84,7 @@ public class FacetsCollector extends SimpleCollector {
     if (keepScores) {
       if (doc >= scores.length) {
         float[] newScores = new float[ArrayUtil.oversize(doc + 1, 4)];
-        System.arraycopy(scores, 0, newScores, 0, doc);
+        System.arraycopy(scores, 0, newScores, 0, scores.length);
         scores = newScores;
       }
       scores[doc] = scorer.score();


### PR DESCRIPTION
This has caused a few recent test failures with jdk23 and jdk24. It should get fixed replacing the length with the length of the array that we copy from, rather than using the new length.