### PR TITLE
Lower number of hits in TestLargeNumHitsTopDocsCollector

### DIFF
--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/LargeNumHitsTopDocsCollector.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/LargeNumHitsTopDocsCollector.java
@@ -137,7 +137,7 @@ public final class LargeNumHitsTopDocsCollector implements Collector {
     }
 
     // Total number of hits collected were less than requestedHitCount
-    assert totalHits < requestedHitCount;
+    assert totalHits <= requestedHitCount;
     Collections.sort(
         hits,
         Comparator.comparing((ScoreDoc scoreDoc) -> scoreDoc.score)

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/LargeNumHitsTopDocsCollector.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/LargeNumHitsTopDocsCollector.java
@@ -129,7 +129,7 @@ public final class LargeNumHitsTopDocsCollector implements Collector {
    */
   protected void populateResults(ScoreDoc[] results, int howMany) {
     if (pq != null) {
-      assert totalHits >= requestedHitCount;
+      assert totalHits > requestedHitCount;
       for (int i = howMany - 1; i >= 0; i--) {
         results[i] = pq.pop();
       }

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestLargeNumHitsTopDocsCollector.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestLargeNumHitsTopDocsCollector.java
@@ -103,9 +103,9 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
 
   public void testNoPQBuild() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
-    LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(2000);
+    LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(250_000);
     TopScoreDocCollectorManager regularCollectorManager =
-        new TopScoreDocCollectorManager(2000, Integer.MAX_VALUE);
+        new TopScoreDocCollectorManager(reader.numDocs(), Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
     TopDocs topDocs = searcher.search(testQuery, regularCollectorManager);
@@ -133,9 +133,9 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
 
   public void testNoPQHitsOrder() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
-    LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(2000);
+    LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(250_000);
     TopScoreDocCollectorManager regularCollectorManager =
-        new TopScoreDocCollectorManager(2000, Integer.MAX_VALUE);
+        new TopScoreDocCollectorManager(reader.numDocs(), Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
     TopDocs topDocs = searcher.search(testQuery, regularCollectorManager);

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestLargeNumHitsTopDocsCollector.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestLargeNumHitsTopDocsCollector.java
@@ -103,9 +103,9 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
 
   public void testNoPQBuild() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
-    LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(250_000);
+    LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(2000);
     TopScoreDocCollectorManager regularCollectorManager =
-        new TopScoreDocCollectorManager(250_000, Integer.MAX_VALUE);
+        new TopScoreDocCollectorManager(2000, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
     TopDocs topDocs = searcher.search(testQuery, regularCollectorManager);
@@ -133,9 +133,9 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
 
   public void testNoPQHitsOrder() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
-    LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(250_000);
+    LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(2000);
     TopScoreDocCollectorManager regularCollectorManager =
-        new TopScoreDocCollectorManager(250_000, Integer.MAX_VALUE);
+        new TopScoreDocCollectorManager(2000, Integer.MAX_VALUE);
 
     searcher.search(testQuery, largeCollector);
     TopDocs topDocs = searcher.search(testQuery, regularCollectorManager);


### PR DESCRIPTION
There's two tests where we use 250_000 as number of collected hits, but we only ever index max 2000 docs. That makes use create a priority queue of size 250_000 for each segment partition which causes out of memory errors when the number of partitions is higher than a few.

With this commit I propose that we lower the threshold to 2000 for those tests that need a high number of collected hits. The assumption that a priority queue is not built within the LargeNumHitsTopDocsCollector still holds so this change should not defeat the purpose of the tests.