### PR TITLE
Make HnswLock and LockedRow final

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswConcurrentMergeBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswConcurrentMergeBuilder.java
@@ -222,7 +222,7 @@ public class HnswConcurrentMergeBuilder implements HnswBuilder {
     @Override
     void graphSeek(HnswGraph graph, int level, int targetNode) {
       try (HnswLock.LockedRow rowLock = hnswLock.read(level, targetNode)) {
-        NeighborArray neighborArray = rowLock.row;
+        NeighborArray neighborArray = rowLock.row();
         if (nodeBuffer == null || nodeBuffer.length < neighborArray.size()) {
           nodeBuffer = new int[neighborArray.size()];
         }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -339,7 +339,7 @@ public class HnswGraphBuilder implements HnswBuilder {
       int nbr = candidates.nodes()[i];
       if (hnswLock != null) {
         try (HnswLock.LockedRow rowLock = hnswLock.write(level, nbr)) {
-          NeighborArray nbrsOfNbr = rowLock.row;
+          NeighborArray nbrsOfNbr = rowLock.row();
           nbrsOfNbr.addAndEnsureDiversity(node, candidates.scores()[i], nbr, scorerSupplier);
         }
       } else {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswLock.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswLock.java
@@ -25,7 +25,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Provide (read-and-write) locked access to rows of an OnHeapHnswGraph. For use by
  * HnswConcurrentMerger and its HnswGraphBuilders.
  */
-class HnswLock {
+final class HnswLock {
   private static final int NUM_LOCKS = 512;
   private final ReentrantReadWriteLock[] locks;
   private final OnHeapHnswGraph graph;
@@ -52,15 +52,7 @@ class HnswLock {
     return new LockedRow(graph.getNeighbors(level, node), lock);
   }
 
-  static class LockedRow implements Closeable {
-    final Lock lock;
-    final NeighborArray row;
-
-    LockedRow(NeighborArray row, Lock lock) {
-      this.lock = lock;
-      this.row = row;
-    }
-
+  record LockedRow(NeighborArray row, Lock lock) implements Closeable {
     @Override
     public void close() {
       lock.unlock();


### PR DESCRIPTION
Trivial commit that makes HnswLock final and LockedRow a record. This is general clean up and helps the JIT a little when reasoning about these types - which show quite a bit in indexing and search profiles.