### PR TITLE
Remove IndexSearcher#search(List<LeafReaderContext>, Weight, Collector)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -120,6 +120,9 @@ API Changes
 
 * GITHUB#13328: Convert many basic Lucene classes to record classes, including CollectionStatistics, TermStatistics and LeafMetadata. (Shubham Chaudhary)
 
+* GITHUB#13780: Remove `IndexSearcher#search(List<LeafReaderContext>, Weight, Collector)` in favour of the newly
+  introduced `IndexSearcher#search(LeafReaderContextPartition[], Weight, Collector)`
+
 New Features
 ---------------------
 

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -867,3 +867,9 @@ method now supports an additional 4th and last argument to optionally enable cre
 `TotalHitCountCollectorManager` now requires that an array of `LeafSlice`s, retrieved via `IndexSearcher#getSlices`, 
 is provided to its constructor. Depending on whether segment partitions are present among slices, the manager can 
 optimize the type of collectors it creates and exposes via `newCollector`.
+
+### IndexSearcher#search(List<LeafReaderContext, Weight, Collector) removed
+
+The protected `IndexSearcher#search(List<LeafReaderContext leaves, Weight weight, Collector collector)` method has been 
+removed in favour of the newly introduced `search(LeafReaderContextPartition[] partitions, Weight weight, Collector collector)`.
+`IndexSearcher` subclasses that override this method need to instead override the new method.

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -868,8 +868,8 @@ method now supports an additional 4th and last argument to optionally enable cre
 is provided to its constructor. Depending on whether segment partitions are present among slices, the manager can 
 optimize the type of collectors it creates and exposes via `newCollector`.
 
-### IndexSearcher#search(List<LeafReaderContext, Weight, Collector) removed
+### IndexSearcher#search(List<LeafReaderContext>, Weight, Collector) removed
 
-The protected `IndexSearcher#search(List<LeafReaderContext leaves, Weight weight, Collector collector)` method has been 
+The protected `IndexSearcher#search(List<LeafReaderContext> leaves, Weight weight, Collector collector)` method has been 
 removed in favour of the newly introduced `search(LeafReaderContextPartition[] partitions, Weight weight, Collector collector)`.
 `IndexSearcher` subclasses that override this method need to instead override the new method.

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -858,7 +858,7 @@ Subclasses of `IndexSearcher` that call or override the `searchLeaf` method need
 
 ### Signature of static IndexSearch#slices method changed
 
-The static `IndexSearcher#sslices(List<LeafReaderContext> leaves, int maxDocsPerSlice, int maxSegmentsPerSlice)` 
+The static `IndexSearcher#slices(List<LeafReaderContext> leaves, int maxDocsPerSlice, int maxSegmentsPerSlice)` 
 method now supports an additional 4th and last argument to optionally enable creating segment partitions:
 `IndexSearcher#slices(List<LeafReaderContext> leaves, int maxDocsPerSlice, int maxSegmentsPerSlice, boolean allowSegmentPartitions)`
 
@@ -868,7 +868,7 @@ method now supports an additional 4th and last argument to optionally enable cre
 is provided to its constructor. Depending on whether segment partitions are present among slices, the manager can 
 optimize the type of collectors it creates and exposes via `newCollector`.
 
-### IndexSearcher#search(List<LeafReaderContext>, Weight, Collector) removed
+### `IndexSearcher#search(List<LeafReaderContext>, Weight, Collector)` removed
 
 The protected `IndexSearcher#search(List<LeafReaderContext> leaves, Weight weight, Collector collector)` method has been 
 removed in favour of the newly introduced `search(LeafReaderContextPartition[] partitions, Weight weight, Collector collector)`.

--- a/lucene/core/src/java/org/apache/lucene/search/CollectionTerminatedException.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CollectionTerminatedException.java
@@ -21,8 +21,8 @@ package org.apache.lucene.search;
  * the current leaf.
  *
  * <p>Note: IndexSearcher swallows this exception and never re-throws it. As a consequence, you
- * should not catch it when calling {@link IndexSearcher#search} as it is unnecessary and might hide
- * misuse of this exception.
+ * should not catch it when calling the different search methods that {@link IndexSearcher} exposes
+ * as it is unnecessary and might hide misuse of this exception.
  */
 @SuppressWarnings("serial")
 public final class CollectionTerminatedException extends RuntimeException {

--- a/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
@@ -134,7 +134,8 @@ public abstract class FieldComparator<T> {
   /**
    * Sorts by descending relevance. NOTE: if you are sorting only by descending relevance and then
    * secondarily by ascending docID, performance is faster using {@link TopScoreDocCollector}
-   * directly (which {@link IndexSearcher#search} uses when no {@link Sort} is specified).
+   * directly (which {@link IndexSearcher#search(Query, int)} uses when no {@link Sort} is
+   * specified).
    */
   public static final class RelevanceComparator extends FieldComparator<Float>
       implements LeafFieldComparator {

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -1659,10 +1659,11 @@ public class TestDrillSideways extends FacetTestCase {
     }
 
     @Override
-    protected void search(List<LeafReaderContext> leaves, Weight weight, Collector collector)
+    protected void search(
+        LeafReaderContextPartition[] partitions, Weight weight, Collector collector)
         throws IOException {
       AssertingCollector assertingCollector = AssertingCollector.wrap(collector);
-      super.search(leaves, weight, assertingCollector);
+      super.search(partitions, weight, assertingCollector);
       assert assertingCollector.hasFinishedCollectingPreviousLeaf;
     }
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingIndexSearcher.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingIndexSearcher.java
@@ -17,12 +17,10 @@
 package org.apache.lucene.tests.search;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexReaderContext;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -69,15 +67,6 @@ public class AssertingIndexSearcher extends IndexSearcher {
     Query rewritten = super.rewrite(original);
     QueryUtils.check(rewritten);
     return rewritten;
-  }
-
-  @Override
-  protected void search(List<LeafReaderContext> leaves, Weight weight, Collector collector)
-      throws IOException {
-    assert weight instanceof AssertingWeight;
-    AssertingCollector assertingCollector = AssertingCollector.wrap(collector);
-    super.search(leaves, weight, assertingCollector);
-    assert assertingCollector.hasFinishedCollectingPreviousLeaf;
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
@@ -554,9 +554,9 @@ public class CheckHits {
     }
 
     @Override
-    public void search(Query query, Collector results) throws IOException {
+    public void search(Query query, Collector collector) throws IOException {
       checkExplanations(query);
-      super.search(query, results);
+      super.search(query, collector);
     }
 
     @Override


### PR DESCRIPTION
With the introduction of intra-segment concurrency, we have introduced a new protected `search(LeafReaderContextPartition[], Weight, Collector)` method. The previous variant that accepts a list of leaf reader contexts was left deprecated as there is one leftover usages coming from `search(Query, Collector)`. The hope was that the latter was going to be removed soon as well, but there is actually no need to tie the two removals. It is easier to fold this method into its only caller, in order for it to still bypass the collector manager based methods.