### PR TITLE
Fix Flaky Test In TestBlockJoinBulkScorer

### DIFF
--- a/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinBulkScorer.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinBulkScorer.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -303,16 +304,9 @@ public class TestBlockJoinBulkScorer extends LuceneTestCase {
   private static void assertEqualsToOneOf(List<?> expectedList, Object actual) {
     boolean foundMatch = false;
     for (Object expected : expectedList) {
-      if (expected == null) {
-        if (actual == null) {
-          foundMatch = true;
-          break;
-        }
-      } else {
-        foundMatch = expected.equals(actual);
-        if (foundMatch) {
-          break;
-        }
+      if (Objects.equals(expected, actual)) {
+        foundMatch = true;
+        break;
       }
     }
 

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinBulkScorer.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinBulkScorer.java
@@ -292,7 +292,12 @@ public class TestBlockJoinBulkScorer extends LuceneTestCase {
         null,
         0,
         NO_MORE_DOCS);
-    assertEqualsToOneOf(expectedScoresList, actualScores);
+
+    if (expectedScoresList.size() == 1) {
+      assertEquals(expectedScoresList.getFirst(), actualScores);
+    } else {
+      assertEqualsToOneOf(expectedScoresList, actualScores);
+    }
   }
 
   private static void assertEqualsToOneOf(List<?> expectedList, Object actual) {


### PR DESCRIPTION
Fix the `testSetMinCompetitiveScoreWithScoreModeMax` test, which sometimes failed due to randomizations in how the docs were scored. This fix should also be backported to `branch_9x`.