### PR TITLE
Fix comment on compare suffix and target in SegmentTermsEnumFrame.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnumFrame.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/SegmentTermsEnumFrame.java
@@ -598,7 +598,7 @@ final class SegmentTermsEnumFrame {
       startBytePos = suffixesReader.getPosition();
       suffixesReader.skipBytes(suffixLength);
 
-      // Loop over bytes in the suffix, comparing to the target
+      // Compare suffix and target.
       final int cmp =
           Arrays.compareUnsigned(
               suffixBytes,
@@ -686,7 +686,7 @@ final class SegmentTermsEnumFrame {
       nextEnt = mid + 1;
       startBytePos = mid * suffixLength;
 
-      // Binary search bytes in the suffix, comparing to the target.
+      // Compare suffix and target.
       cmp =
           Arrays.compareUnsigned(
               suffixBytes,
@@ -792,6 +792,7 @@ final class SegmentTermsEnumFrame {
         lastSubFP = fp - subCode;
       }
 
+      // Compare suffix and target.
       final int cmp =
           Arrays.compareUnsigned(
               suffixBytes,


### PR DESCRIPTION
### Description

Since we do not loop over bytes (hand-written) in the suffix, to compare to the target anymore.
