### PR TITLE
Remove CollectorManager#forSequentialExecution

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -311,9 +311,6 @@ API Changes
 * GITHUB#13568, GITHUB#13750: Add DrillSideways#search method that supports any CollectorManagers for drill-sideways dimensions
   or drill-down. (Egor Potemkin)
 
-* GITHUB#13735: Add CollectorManager#forSequentialExecution to make CollectorManager creation more convenient
-  for users of the deprecated IndexSearcher#search(Query, Collector). (Greg Miller)
-
 New Features
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/CollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CollectorManager.java
@@ -18,8 +18,6 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.concurrent.Executor;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 
 /**
@@ -55,36 +53,4 @@ public interface CollectorManager<C extends Collector, T> {
    * called after collection is finished on all provided collectors.
    */
   T reduce(Collection<C> collectors) throws IOException;
-
-  /**
-   * Wrap a provided {@link Collector} with a thin {@code CollectorManager} wrapper for use with
-   * {@link IndexSearcher#search(Query, CollectorManager)} when doing single-threaded searching. The
-   * wrapping {@code CollectorManager} provides no {@link CollectorManager#reduce(Collection)}
-   * implementation, so the wrapped {@code Collector} needs to do all relevant work while
-   * collecting.
-   *
-   * <p>Note: This is only safe to use when {@code IndexSearcher} is created with no executor (see:
-   * {@link IndexSearcher#IndexSearcher(IndexReader, Executor)}).
-   */
-  static <C extends Collector> CollectorManager<C, ?> forSequentialExecution(C in) {
-    return new CollectorManager<C, Void>() {
-      private boolean newCollectorInvoked;
-
-      @Override
-      public C newCollector() {
-        if (newCollectorInvoked) {
-          throw new IllegalStateException(
-              "newCollector should be invoked at most once. Ensure your IndexSearcher has been created without an Executor.");
-        }
-        newCollectorInvoked = true;
-        return in;
-      }
-
-      @Override
-      public Void reduce(Collection<C> collectors) {
-        assert collectors.size() == 1 : "collectors should contain exactly one collector instance";
-        return null;
-      }
-    };
-  }
 }


### PR DESCRIPTION
We have recently (see #13735) introduced this utility method that creates a collector manager which only works when a searcher does not have an executor set, otherwise it throws exception once we attempt to create a new collector for more than one slice.

While we discussed it should be safe to use in some specific scenarios like the monitor module, we should be careful exposing this utility publicly, because while we'd like to ease migration from the search(Query, Collector) method, we may end up making users life even worse, in that it exposes them to failures whenever an executor is set and there is more than one slice created, which is hard to follow and does not provide a good user experience. What is these users do have an executor set to their searcher and think that this method provides a collector manager that is able to turn off concurrency (like search(Query, Collector) does currently), which is not possible?

My proposal is that we use a similar collector manager locally, where safe and required, but we don't expose it to users. In most places, we should rather expose collector managers that do support search concurrency, rather than working around the lack of those. Even for us committers, it has not been entirely clear when this is safe and when it's not, which indicates that this is something that users will likely struggle with.