### PR TITLE
Deprecate BulkScorer#score(LeafReaderContext, Bits)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -30,6 +30,11 @@ API Changes
 * GITHUB#13735: Add CollectorManager#forSequentialExecution to make CollectorManager creation more convenient
   for users of the deprecated IndexSearcher#search(Query, Collector). (Greg Miller)
 
+* GITHUB#?????: Deprecate BulkScorer#score(LeafCollector collector, Bits acceptDocs) in favour of
+  BulkScorer#score(LeafCollector collector, Bits acceptDocs, int min, int max). The method will be removed in the next
+  major version. Replace usages with the latter, providing 0 as min and DocIdSetIterator.NO_MORE_DOCS as max in case
+  the entire segment should be scored. (Luca Cavanna)
+
 New Features
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -30,10 +30,11 @@ API Changes
 * GITHUB#13735: Add CollectorManager#forSequentialExecution to make CollectorManager creation more convenient
   for users of the deprecated IndexSearcher#search(Query, Collector). (Greg Miller)
 
-* GITHUB#?????: Deprecate BulkScorer#score(LeafCollector collector, Bits acceptDocs) in favour of
+* GITHUB#13794: Deprecate BulkScorer#score(LeafCollector collector, Bits acceptDocs) in favour of
   BulkScorer#score(LeafCollector collector, Bits acceptDocs, int min, int max). The method will be removed in the next
   major version. Replace usages with the latter, providing 0 as min and DocIdSetIterator.NO_MORE_DOCS as max in case
-  the entire segment should be scored. (Luca Cavanna)
+  the entire segment should be scored. Subclasses that override the method should instead override its replacement.
+  (Luca Cavanna)
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/BulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BulkScorer.java
@@ -34,7 +34,8 @@ public abstract class BulkScorer {
    * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
    *     if they are all allowed to match.
    * @deprecated in favour of {@link #score(LeafCollector, Bits, int, int)}. Callers should instead
-   *     call the method variant that takes min and max as arguments. Subclasses that override it
+   *     call the method variant that takes min and max as arguments, providing 0 and {@link
+   *     DocIdSetIterator#NO_MORE_DOCS} to score the entire segment. Subclasses that override it
    *     should instead override its replacement.
    */
   @Deprecated

--- a/lucene/core/src/java/org/apache/lucene/search/BulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BulkScorer.java
@@ -33,7 +33,11 @@ public abstract class BulkScorer {
    * @param collector The collector to which all matching documents are passed.
    * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
    *     if they are all allowed to match.
+   * @deprecated in favour of {@link #score(LeafCollector, Bits, int, int)}. Callers should instead
+   *     call the method variant that takes min and max as arguments. Subclasses that override it
+   *     should instead override its replacement.
    */
+  @Deprecated
   public void score(LeafCollector collector, Bits acceptDocs) throws IOException {
     final int next = score(collector, acceptDocs, 0, DocIdSetIterator.NO_MORE_DOCS);
     assert next == DocIdSetIterator.NO_MORE_DOCS;


### PR DESCRIPTION
We have removed BulkScorer#score(LeafReaderContext, Bits) in main in favour of BulkScorer#score(LeafCollector collector, Bits acceptDocs, int min, int max) as part of #13542. This commit deprecates the method in 9.x. Internal usages of it are left untouched as there may be subclasses that override it, which we don't want to break in a minor release.
