### PR TITLE
Disable intra-merge parallelism for all structures but kNN vectors

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -470,6 +470,8 @@ Bug Fixes
   `IndexWriter.forceMerge` or
   `IndexWriter.addIndexes(CodecReader...)`, or reindexing entirely.
 
+* GITHUB#13799: Disable intra-merge parallelism for all structures but kNN vectors. (Ben Trent)
+
 Build
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -41,7 +41,7 @@ import org.apache.lucene.util.packed.PackedLongValues;
  *
  * @lucene.experimental
  */
-public class MergeState implements Cloneable {
+public class MergeState {
 
   /** Maps document IDs from old segments to document IDs in the new segment */
   public final DocMap[] docMaps;
@@ -301,56 +301,5 @@ public class MergeState implements Cloneable {
     this.infoStream = infoStream;
     this.intraMergeTaskExecutor = intraMergeTaskExecutor;
     this.needsIndexSort = needsIndexSort;
-  }
-
-  @Override
-  public MergeState clone() {
-    StoredFieldsReader[] storedFieldsReaders = this.storedFieldsReaders.clone();
-    TermVectorsReader[] termVectorsReaders = this.termVectorsReaders.clone();
-    NormsProducer[] normsProducers = this.normsProducers.clone();
-    DocValuesProducer[] docValuesProducers = this.docValuesProducers.clone();
-    FieldsProducer[] fieldsProducers = this.fieldsProducers.clone();
-    PointsReader[] pointsReaders = this.pointsReaders.clone();
-    KnnVectorsReader[] knnVectorsReaders = this.knnVectorsReaders.clone();
-    for (int i = 0; i < storedFieldsReaders.length; ++i) {
-      if (storedFieldsReaders[i] != null) {
-        storedFieldsReaders[i] = storedFieldsReaders[i].getMergeInstance();
-      }
-      if (termVectorsReaders[i] != null) {
-        termVectorsReaders[i] = termVectorsReaders[i].getMergeInstance();
-      }
-      if (normsProducers[i] != null) {
-        normsProducers[i] = normsProducers[i].getMergeInstance();
-      }
-      if (docValuesProducers[i] != null) {
-        docValuesProducers[i] = docValuesProducers[i].getMergeInstance();
-      }
-      if (fieldsProducers[i] != null) {
-        fieldsProducers[i] = fieldsProducers[i].getMergeInstance();
-      }
-      if (pointsReaders[i] != null) {
-        pointsReaders[i] = pointsReaders[i].getMergeInstance();
-      }
-      if (knnVectorsReaders[i] != null) {
-        knnVectorsReaders[i] = knnVectorsReaders[i].getMergeInstance();
-      }
-    }
-    return new MergeState(
-        docMaps,
-        segmentInfo,
-        mergeFieldInfos,
-        storedFieldsReaders,
-        termVectorsReaders,
-        normsProducers,
-        docValuesProducers,
-        fieldInfos,
-        liveDocs,
-        fieldsProducers,
-        pointsReaders,
-        knnVectorsReaders,
-        maxDocs,
-        infoStream,
-        intraMergeTaskExecutor,
-        needsIndexSort);
   }
 }


### PR DESCRIPTION
After adjusting tests that truly exercise intra-merge parallelism, more issues have arisen. See: https://github.com/apache/lucene/issues/13798

To be risk adverse & due to the soon to be released/freezed Lucene 10 & 9.12, I am reverting all intra-merge parallelism, except for the parallelism when merging HNSW graphs.

Merging other structures was never really enabled in a release (we disabled it in a bugfix for Lucene 9.11). While this is frustrating as it seems like we leaving lots of perf on the floor, I am err'ing on the side of safety here. 

In Lucene 10, we can work on incrementally reenabling intra-merge parallelism.

closes: https://github.com/apache/lucene/issues/13798