### PR TITLE
Correct Point file extensions in Codec javadocs

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/package-info.java
@@ -400,8 +400,8 @@
  *       performant encoding that is vectorized.
  *   <li>In version 8.6, index sort serialization is delegated to the sorts themselves, to allow
  *       user-defined sorts to be used
- *   <li>In version 8.6, points fields split the index tree and leaf data into separate files,
- *       to allow for different access patterns to the different data structures</li>
+ *   <li>In version 8.6, points fields split the index tree and leaf data into separate files, to
+ *       allow for different access patterns to the different data structures
  *   <li>In version 8.7, stored fields compression became adaptive to better handle documents with
  *       smaller stored fields.
  *   <li>In version 9.0, vector-valued fields were added.

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/package-info.java
@@ -306,7 +306,7 @@
  * </tr>
  * <tr>
  * <td>{@link org.apache.lucene.codecs.lucene90.Lucene90PointsFormat Point values}</td>
- * <td>.dii, .dim</td>
+ * <td>.kdd, .kdi, .kdm</td>
  * <td>Holds indexed points</td>
  * </tr>
  * <tr>
@@ -400,6 +400,8 @@
  *       performant encoding that is vectorized.
  *   <li>In version 8.6, index sort serialization is delegated to the sorts themselves, to allow
  *       user-defined sorts to be used
+ *   <li>In version 8.6, points fields split the index tree and leaf data into separate files,
+ *       to allow for different access patterns to the different data structures</li>
  *   <li>In version 8.7, stored fields compression became adaptive to better handle documents with
  *       smaller stored fields.
  *   <li>In version 9.0, vector-valued fields were added.


### PR DESCRIPTION
The Points file format was changed back in version 8.6 but we never updated
the Codec javadocs.