### PR TITLE
Copy stored fields during flush with index sort

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
@@ -507,8 +507,7 @@ public final class Lucene90CompressingStoredFieldsWriter extends StoredFieldsWri
     BULK_MERGE_ENABLED = v;
   }
 
-  private void copyOneDoc(Lucene90CompressingStoredFieldsReader reader, int docID)
-      throws IOException {
+  void copyOneDoc(Lucene90CompressingStoredFieldsReader reader, int docID) throws IOException {
     assert reader.getVersion() == VERSION_CURRENT;
     SerializedDocument doc = reader.serializedDocument(docID);
     startDocument();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90SortingStoredFieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90SortingStoredFieldsConsumer.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene90.compressing;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.StoredFieldsFormat;
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.codecs.StoredFieldsWriter;
+import org.apache.lucene.codecs.compressing.CompressionMode;
+import org.apache.lucene.codecs.compressing.Compressor;
+import org.apache.lucene.codecs.compressing.Decompressor;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Sorter;
+import org.apache.lucene.index.SortingStoredFieldsConsumer;
+import org.apache.lucene.store.ByteBuffersDataInput;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+
+/** A {@link SortingStoredFieldsConsumer} using Lucene90StoredFields format. */
+public final class Lucene90SortingStoredFieldsConsumer extends SortingStoredFieldsConsumer {
+  /** A mode that appends bytes without applying compression. */
+  public static final CompressionMode NO_COMPRESSION =
+      new CompressionMode() {
+        @Override
+        public Compressor newCompressor() {
+          return new Compressor() {
+            @Override
+            public void close() {}
+
+            @Override
+            public void compress(ByteBuffersDataInput buffersInput, DataOutput out)
+                throws IOException {
+              out.copyBytes(buffersInput, buffersInput.length());
+            }
+          };
+        }
+
+        @Override
+        public Decompressor newDecompressor() {
+          return new Decompressor() {
+            @Override
+            public void decompress(
+                DataInput in, int originalLength, int offset, int length, BytesRef bytes)
+                throws IOException {
+              bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, length);
+              in.skipBytes(offset);
+              in.readBytes(bytes.bytes, 0, length);
+              bytes.offset = 0;
+              bytes.length = length;
+            }
+
+            @Override
+            public Decompressor clone() {
+              return this;
+            }
+          };
+        }
+      };
+
+  private static final StoredFieldsFormat LUCENE90_NO_COMPRESSION_STORED_FIELDS_FORMAT =
+      new Lucene90CompressingStoredFieldsFormat(
+          "Lucene90TempStoredFields", NO_COMPRESSION, 128 * 1024, 1, 10);
+
+  public Lucene90SortingStoredFieldsConsumer(Codec codec, Directory directory, SegmentInfo info) {
+    super(codec, LUCENE90_NO_COMPRESSION_STORED_FIELDS_FORMAT, directory, info);
+  }
+
+  @Override
+  protected void copyDocs(
+      SegmentWriteState state,
+      Sorter.DocMap sortMap,
+      StoredFieldsWriter writer,
+      StoredFieldsReader reader)
+      throws IOException {
+    if (reader instanceof Lucene90CompressingStoredFieldsReader compressReader
+        && compressReader.getVersion() == Lucene90CompressingStoredFieldsWriter.VERSION_CURRENT) {
+      if (writer instanceof Lucene90CompressingStoredFieldsWriter compressWriter) {
+        for (int docID = 0; docID < state.segmentInfo.maxDoc(); docID++) {
+          compressWriter.copyOneDoc(
+              compressReader, sortMap == null ? docID : sortMap.newToOld(docID));
+        }
+        return;
+      }
+    } else {
+      assert false : "the temp stored fields format wasn't used?";
+    }
+    super.copyDocs(state, sortMap, writer, reader);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -39,6 +39,7 @@ import org.apache.lucene.codecs.NormsFormat;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsFormat;
 import org.apache.lucene.codecs.PointsWriter;
+import org.apache.lucene.codecs.lucene90.compressing.Lucene90SortingStoredFieldsConsumer;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.InvertableType;
 import org.apache.lucene.document.KnnByteVectorField;
@@ -127,7 +128,8 @@ final class IndexingChain implements Accountable {
               indexWriterConfig.getCodec());
     } else {
       storedFieldsConsumer =
-          new SortingStoredFieldsConsumer(indexWriterConfig.getCodec(), directory, segmentInfo);
+          new Lucene90SortingStoredFieldsConsumer(
+              indexWriterConfig.getCodec(), directory, segmentInfo);
       termVectorsWriter =
           new SortingTermVectorsConsumer(
               intBlockAllocator,

--- a/lucene/core/src/java/org/apache/lucene/index/SortingTermVectorsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingTermVectorsConsumer.java
@@ -25,6 +25,7 @@ import org.apache.lucene.codecs.TermVectorsFormat;
 import org.apache.lucene.codecs.TermVectorsReader;
 import org.apache.lucene.codecs.TermVectorsWriter;
 import org.apache.lucene.codecs.lucene90.compressing.Lucene90CompressingTermVectorsFormat;
+import org.apache.lucene.codecs.lucene90.compressing.Lucene90SortingStoredFieldsConsumer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FlushInfo;
@@ -38,7 +39,12 @@ final class SortingTermVectorsConsumer extends TermVectorsConsumer {
 
   private static final TermVectorsFormat TEMP_TERM_VECTORS_FORMAT =
       new Lucene90CompressingTermVectorsFormat(
-          "TempTermVectors", "", SortingStoredFieldsConsumer.NO_COMPRESSION, 8 * 1024, 128, 10);
+          "TempTermVectors",
+          "",
+          Lucene90SortingStoredFieldsConsumer.NO_COMPRESSION,
+          8 * 1024,
+          128,
+          10);
   TrackingTmpOutputDirectoryWrapper tmpDirectory;
 
   SortingTermVectorsConsumer(


### PR DESCRIPTION
This change avoids copying stored fields individually when flushing with index sorting. This optimization can reduce flushing time, especially in cases with many stored fields.