### PR TITLE
Add BytesRefIterator to TermInSetQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -295,6 +295,8 @@ Build
 API Changes
 ---------------------
 
+* GITHUB#13806: Add TermInSetQuery#getBytesRefIterator to be able to iterate over query terms. (Christoph Büscher)
+
 * GITHUB#13469: Expose FlatVectorsFormat as a first-class format; can be configured using a custom Codec. (Michael Sokolov)
 
 * GITHUB#13612: Hunspell: add Suggester#proceedPastRep to avoid losing relevant suggestions. (Peter Gromov)

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -135,6 +135,11 @@ public class TermInSetQuery extends MultiTermQuery implements Accountable {
     return termData.size();
   }
 
+  /**
+   * Get an iterator over the encoded terms for query inspection.
+   *
+   * @lucene.experimental
+   */
   public BytesRefIterator getBytesRefIterator() {
     final TermIterator iterator = this.termData.iterator();
     return () -> iterator.next();

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -27,13 +27,7 @@ import org.apache.lucene.index.PrefixCodedTerms.TermIterator;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.AttributeSource;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.BytesRefComparator;
-import org.apache.lucene.util.RamUsageEstimator;
-import org.apache.lucene.util.StringSorter;
+import org.apache.lucene.util.*;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
@@ -139,6 +133,11 @@ public class TermInSetQuery extends MultiTermQuery implements Accountable {
   @Override
   public long getTermsCount() {
     return termData.size();
+  }
+
+  public BytesRefIterator getBytesRefIterator() {
+    final TermIterator iterator = this.termData.iterator();
+    return () -> iterator.next();
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
@@ -52,6 +52,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.RamUsageTester;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 
@@ -526,5 +527,20 @@ public class TestTermInSetQuery extends LuceneTestCase {
             }
           }
         });
+  }
+
+  public void testTermsIterator() throws IOException {
+    TermInSetQuery empty = new TermInSetQuery("field", Collections.emptyList());
+    BytesRefIterator it = empty.getBytesRefIterator();
+    assertNull(it.next());
+
+    TermInSetQuery query =
+        new TermInSetQuery(
+            "field", List.of(newBytesRef("term1"), newBytesRef("term2"), newBytesRef("term3")));
+    it = query.getBytesRefIterator();
+    assertEquals(newBytesRef("term1"), it.next());
+    assertEquals(newBytesRef("term2"), it.next());
+    assertEquals(newBytesRef("term3"), it.next());
+    assertNull(it.next());
   }
 }


### PR DESCRIPTION
Addresses #13804

TermInSetQuery used to have an accessor to its terms that was removed in #12173 to protect leaking internal encoding details. This introduces an accessor to the term data in the query that doesn't expose internal but merely allows iterating over the decoded BytesRef, making inspection of the querys content possible again.
