### PR TITLE
update EdgeNGramTokenizer.DEFAULT_MAX_NGRAM_SIZE to be practical

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/EdgeNGramTokenizer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/EdgeNGramTokenizer.java
@@ -28,7 +28,7 @@ import org.apache.lucene.util.AttributeFactory;
  * pre-tokenization} and correctly handles supplementary characters.
  */
 public class EdgeNGramTokenizer extends NGramTokenizer {
-  public static final int DEFAULT_MAX_GRAM_SIZE = 1;
+  public static final int DEFAULT_MAX_GRAM_SIZE = 2;
   public static final int DEFAULT_MIN_GRAM_SIZE = 1;
 
   /**


### PR DESCRIPTION
issue : https://github.com/apache/lucene/issues/13802

- Many libraries(git code: [Elasticsearch](https://github.com/elastic/elasticsearch/blob/main/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java#L511), [OpenSearch](https://github.com/opensearch-project/OpenSearch/blob/main/modules/analysis-common/src/main/java/org/opensearch/analysis/common/EdgeNGramTokenizerFactory.java#L54)) based on Lucene use NGramTokenizer.DEFAULT_MAX_NGRAM_SIZE instead of EdgeNGramTokenizer's when configuring an **EdgeNGramTokenizer**.
- By the above reason, it's NOT practical to keep sticking DEFAULT_MAX_NGRAM_SIZE of EdgeNGramTokenizer to be ONE. 
