### PR TITLE
Update EdgeNGramTokenizer.DEFAULT_MAX_NGRAM_SIZE to be practical

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/EdgeNGramTokenizer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/EdgeNGramTokenizer.java
@@ -28,7 +28,7 @@ import org.apache.lucene.util.AttributeFactory;
  * pre-tokenization} and correctly handles supplementary characters.
  */
 public class EdgeNGramTokenizer extends NGramTokenizer {
-  public static final int DEFAULT_MAX_GRAM_SIZE = 1;
+  public static final int DEFAULT_MAX_GRAM_SIZE = 2;
   public static final int DEFAULT_MIN_GRAM_SIZE = 1;
 
   /**

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/ngram/TestNGramFilters.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/ngram/TestNGramFilters.java
@@ -90,12 +90,12 @@ public class TestNGramFilters extends BaseTokenStreamFactoryTestCase {
     stream.close();
   }
 
-  /** Test EdgeNGramTokenizerFactory */
+  /** Test EdgeNGramTokenizerFactory with default (after commit '3b442bd3834') */
   public void testEdgeNGramTokenizer() throws Exception {
     Reader reader = new StringReader("test");
     TokenStream stream = tokenizerFactory("EdgeNGram").create();
     ((Tokenizer) stream).setReader(reader);
-    assertTokenStreamContents(stream, new String[] {"t"});
+    assertTokenStreamContents(stream, new String[] {"t", "te"});
   }
 
   /** Test EdgeNGramTokenizerFactory with min and max gram size */
@@ -107,7 +107,7 @@ public class TestNGramFilters extends BaseTokenStreamFactoryTestCase {
     assertTokenStreamContents(stream, new String[] {"t", "te"});
   }
 
-  /** Test EdgeNGramFilterFactory with old defaults */
+  /** Test EdgeNGramFilterFactory with old defaults (before commit '3b442bd3834') */
   public void testEdgeNGramFilter() throws Exception {
     Reader reader = new StringReader("test");
     TokenStream stream = whitespaceMockTokenizer(reader);


### PR DESCRIPTION
issue : https://github.com/apache/lucene/issues/13802

- Many libraries(git code: [Elasticsearch](https://github.com/elastic/elasticsearch/blob/main/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java#L511), [OpenSearch](https://github.com/opensearch-project/OpenSearch/blob/main/modules/analysis-common/src/main/java/org/opensearch/analysis/common/EdgeNGramTokenizerFactory.java#L54)) based on Lucene use NGramTokenizer.DEFAULT_MAX_NGRAM_SIZE(=`2`) instead of EdgeNGramTokenizer's(=`1`) when configuring an **EdgeNGramTokenizer**.
- By the above reason, it's NOT practical to keep sticking DEFAULT_MAX_NGRAM_SIZE of EdgeNGramTokenizer to be `1` so this PR changes it to be `2`.
- If it's necessary to explain this change, I'll add/change explanations by documentation.