### PR TITLE
Prevent flattening of ordered and unordered interval sources

### DIFF
--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/BlockIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/BlockIntervalsSource.java
@@ -38,6 +38,7 @@ class BlockIntervalsSource extends ConjunctionIntervalsSource {
     List<IntervalsSource> flattened = new ArrayList<>();
     for (IntervalsSource s : sources) {
       if (s instanceof BlockIntervalsSource) {
+        // Block sources can be flattened because they do not increase the gap (gap = 0)
         flattened.addAll(((BlockIntervalsSource) s).subSources);
       } else {
         flattened.add(s);

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/OrderedIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/OrderedIntervalsSource.java
@@ -30,23 +30,11 @@ class OrderedIntervalsSource extends MinimizingConjunctionIntervalsSource {
     if (sources.size() == 1) {
       return sources.get(0);
     }
-    List<IntervalsSource> rewritten = deduplicate(flatten(sources));
+    List<IntervalsSource> rewritten = deduplicate(sources);
     if (rewritten.size() == 1) {
       return rewritten.get(0);
     }
     return new OrderedIntervalsSource(rewritten);
-  }
-
-  private static List<IntervalsSource> flatten(List<IntervalsSource> sources) {
-    List<IntervalsSource> flattened = new ArrayList<>();
-    for (IntervalsSource s : sources) {
-      if (s instanceof OrderedIntervalsSource) {
-        flattened.addAll(((OrderedIntervalsSource) s).subSources);
-      } else {
-        flattened.add(s);
-      }
-    }
-    return flattened;
   }
 
   private static List<IntervalsSource> deduplicate(List<IntervalsSource> sources) {

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/UnorderedIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/UnorderedIntervalsSource.java
@@ -33,7 +33,7 @@ class UnorderedIntervalsSource extends MinimizingConjunctionIntervalsSource {
     if (sources.size() == 1) {
       return sources.get(0);
     }
-    List<IntervalsSource> rewritten = deduplicate(flatten(sources));
+    List<IntervalsSource> rewritten = deduplicate(sources);
     if (rewritten.size() == 1) {
       return rewritten.get(0);
     }
@@ -53,18 +53,6 @@ class UnorderedIntervalsSource extends MinimizingConjunctionIntervalsSource {
       ((RepeatingIntervalsSource) deduplicated.get(0)).setName("UNORDERED");
     }
     return deduplicated;
-  }
-
-  private static List<IntervalsSource> flatten(List<IntervalsSource> sources) {
-    List<IntervalsSource> flattened = new ArrayList<>();
-    for (IntervalsSource s : sources) {
-      if (s instanceof UnorderedIntervalsSource) {
-        flattened.addAll(((UnorderedIntervalsSource) s).subSources);
-      } else {
-        flattened.add(s);
-      }
-    }
-    return flattened;
   }
 
   private UnorderedIntervalsSource(List<IntervalsSource> sources) {

--- a/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestIntervalQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestIntervalQuery.java
@@ -338,6 +338,21 @@ public class TestIntervalQuery extends LuceneTestCase {
     checkHits(q, new int[] {6, 7});
   }
 
+  public void testUnorderedWithNoGap() throws IOException {
+    Query q =
+            new IntervalQuery(
+                    field,
+                    Intervals.maxgaps(
+                            0,
+                            Intervals.unordered(
+                                    Intervals.term("w3"),
+                                    Intervals.unordered(Intervals.term("w1"), Intervals.term("w5"))
+                            )
+                    )
+            );
+    checkHits(q, new int[] {0});
+  }
+
   public void testOrderedWithGaps() throws IOException {
     Query q =
         new IntervalQuery(
@@ -358,6 +373,21 @@ public class TestIntervalQuery extends LuceneTestCase {
                 Intervals.ordered(
                     Intervals.term("alice"), Intervals.term("bob"), Intervals.term("carl"))));
     checkHits(q, new int[] {12});
+  }
+
+  public void testOrderedWithNoGap() throws IOException {
+    Query q =
+            new IntervalQuery(
+                    field,
+                    Intervals.maxgaps(
+                            0,
+                            Intervals.ordered(
+                                    Intervals.ordered(Intervals.term("w1"), Intervals.term("w4")),
+                                    Intervals.term("w5")
+                            )
+                    )
+            );
+    checkHits(q, new int[] {0});
   }
 
   public void testNestedOrInContainedBy() throws IOException {

--- a/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestIntervalQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestIntervalQuery.java
@@ -340,16 +340,13 @@ public class TestIntervalQuery extends LuceneTestCase {
 
   public void testUnorderedWithNoGap() throws IOException {
     Query q =
-            new IntervalQuery(
-                    field,
-                    Intervals.maxgaps(
-                            0,
-                            Intervals.unordered(
-                                    Intervals.term("w3"),
-                                    Intervals.unordered(Intervals.term("w1"), Intervals.term("w5"))
-                            )
-                    )
-            );
+        new IntervalQuery(
+            field,
+            Intervals.maxgaps(
+                0,
+                Intervals.unordered(
+                    Intervals.term("w3"),
+                    Intervals.unordered(Intervals.term("w1"), Intervals.term("w5")))));
     checkHits(q, new int[] {0});
   }
 
@@ -377,16 +374,13 @@ public class TestIntervalQuery extends LuceneTestCase {
 
   public void testOrderedWithNoGap() throws IOException {
     Query q =
-            new IntervalQuery(
-                    field,
-                    Intervals.maxgaps(
-                            0,
-                            Intervals.ordered(
-                                    Intervals.ordered(Intervals.term("w1"), Intervals.term("w4")),
-                                    Intervals.term("w5")
-                            )
-                    )
-            );
+        new IntervalQuery(
+            field,
+            Intervals.maxgaps(
+                0,
+                Intervals.ordered(
+                    Intervals.ordered(Intervals.term("w1"), Intervals.term("w4")),
+                    Intervals.term("w5"))));
     checkHits(q, new int[] {0});
   }
 


### PR DESCRIPTION
This commit removes the flattening of ordered and unordered interval sources, as it alters the gap that parent intervals see. For example, ordered("a", ordered("b", "c")) should result in a different gap compared to ordered("a", "b", "c").
The flattening that is currently applied prevent some valid queries to match since the computed gap for ordered and unordered sources are not preserved when combining sources.

Phrase/Block operators will continue to flatten their sub-sources since this does not affect the inner gap (which is always 0 in the case of blocks).
