### PR TITLE
Add mergeProgress into MergeState for abort in mergeMiddle

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldMergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldMergeState.java
@@ -69,7 +69,8 @@ final class PerFieldMergeState {
         in.maxDocs,
         in.infoStream,
         in.intraMergeTaskExecutor,
-        in.needsIndexSort);
+        in.needsIndexSort,
+        in.mergeProgress);
   }
 
   private static class FilterFieldInfos extends FieldInfos {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3453,7 +3453,8 @@ public class IndexWriter
             trackingDir,
             globalFieldNumberMap,
             context,
-            intraMergeExecutor);
+            intraMergeExecutor,
+            merge.getMergeProgress());
 
     if (!merger.shouldMerge()) {
       return;
@@ -5254,7 +5255,8 @@ public class IndexWriter
               dirWrapper,
               globalFieldNumberMap,
               context,
-              intraMergeExecutor);
+              intraMergeExecutor,
+              merge.getMergeProgress());
       merge.info.setSoftDelCount(Math.toIntExact(softDeleteCount.get()));
       merge.checkAborted();
 

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -91,17 +91,22 @@ public class MergeState {
   /** Indicates if the index needs to be sorted * */
   public boolean needsIndexSort;
 
+  /** Progress and state for an executing merge. */
+  public final MergePolicy.OneMergeProgress mergeProgress;
+
   /** Sole constructor. */
   MergeState(
       List<CodecReader> readers,
       SegmentInfo segmentInfo,
       InfoStream infoStream,
-      Executor intraMergeTaskExecutor)
+      Executor intraMergeTaskExecutor,
+      MergePolicy.OneMergeProgress mergeProgress)
       throws IOException {
     verifyIndexSort(readers, segmentInfo);
     this.infoStream = infoStream;
     int numReaders = readers.size();
     this.intraMergeTaskExecutor = intraMergeTaskExecutor;
+    this.mergeProgress = mergeProgress;
 
     maxDocs = new int[numReaders];
     fieldsProducers = new FieldsProducer[numReaders];
@@ -284,7 +289,8 @@ public class MergeState {
       int[] maxDocs,
       InfoStream infoStream,
       Executor intraMergeTaskExecutor,
-      boolean needsIndexSort) {
+      boolean needsIndexSort,
+      MergePolicy.OneMergeProgress mergeProgress) {
     this.docMaps = docMaps;
     this.segmentInfo = segmentInfo;
     this.mergeFieldInfos = mergeFieldInfos;
@@ -301,5 +307,6 @@ public class MergeState {
     this.infoStream = infoStream;
     this.intraMergeTaskExecutor = intraMergeTaskExecutor;
     this.needsIndexSort = needsIndexSort;
+    this.mergeProgress = mergeProgress;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentMerger.java
@@ -59,13 +59,15 @@ final class SegmentMerger {
       Directory dir,
       FieldInfos.FieldNumbers fieldNumbers,
       IOContext context,
-      Executor intraMergeTaskExecutor)
+      Executor intraMergeTaskExecutor,
+      MergePolicy.OneMergeProgress mergeProgress)
       throws IOException {
     if (context.context() != IOContext.Context.MERGE) {
       throw new IllegalArgumentException(
           "IOContext.context should be MERGE; got: " + context.context());
     }
-    mergeState = new MergeState(readers, segmentInfo, infoStream, intraMergeTaskExecutor);
+    mergeState =
+        new MergeState(readers, segmentInfo, infoStream, intraMergeTaskExecutor, mergeProgress);
     mergeStateCreationThread = Thread.currentThread();
     directory = dir;
     this.codec = segmentInfo.getCodec();

--- a/lucene/core/src/test/org/apache/lucene/index/TestDoc.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDoc.java
@@ -230,7 +230,6 @@ public class TestDoc extends LuceneTestCase {
             StringHelper.randomId(),
             new HashMap<>(),
             null);
-
     SegmentMerger merger =
         new SegmentMerger(
             Arrays.<CodecReader>asList(r1, r2),
@@ -239,8 +238,8 @@ public class TestDoc extends LuceneTestCase {
             trackingDir,
             new FieldInfos.FieldNumbers(null, null),
             context,
-            new SameThreadExecutorService());
-
+            new SameThreadExecutorService(),
+            new MergePolicy.OneMergeProgress());
     merger.merge();
     r1.close();
     r2.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentMerger.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentMerger.java
@@ -107,7 +107,8 @@ public class TestSegmentMerger extends LuceneTestCase {
             mergedDir,
             new FieldInfos.FieldNumbers(null, null),
             newIOContext(random(), new IOContext(new MergeInfo(-1, -1, false, -1))),
-            new SameThreadExecutorService());
+            new SameThreadExecutorService(),
+            new MergePolicy.OneMergeProgress());
     MergeState mergeState = merger.merge();
     int docsMerged = mergeState.segmentInfo.maxDoc();
     assertTrue(docsMerged == 2);


### PR DESCRIPTION
### Description

we see the scenarios like #13354, it would make abort waiting for merge finished, like #13354 and https://github.com/elastic/elasticsearch/issues/107513 elasticsearch #`removeIndex` or `stop shard`. Athough we can make close shard async, when there is a long time merge like hnsw graph build, it would take a long time to build graph and eventually we just want to remove the index.

the abort waiting on
```
	at java.lang.Object.wait(java.base@17.0.2/Native Method)
	- waiting on <no object reference available>
	at org.apache.lucene.index.IndexWriter.doWait(IndexWriter.java:5410)
	- locked <0x0000001022b0abe8> (a org.apache.lucene.index.IndexWriter)
	at org.apache.lucene.index.IndexWriter.abortMerges(IndexWriter.java:2721)
	- locked <0x0000001022b0abe8> (a org.apache.lucene.index.IndexWriter)
	at org.apache.lucene.index.IndexWriter.rollbackInternalNoCommit(IndexWriter.java:2469)
	- locked <0x0000001022b0abe8> (a org.apache.lucene.index.IndexWriter)
	at org.apache.lucene.index.IndexWriter.rollbackInternal(IndexWriter.java:2449)
	- locked <0x0000001022bae6d0> (a java.lang.Object)
```

and lucene is doing hnsw merge build graph
```
	at org.apache.lucene.codecs.lucene95.OffHeapFloatVectorValues.vectorValue(OffHeapFloatVectorValues.java:61)
	at org.apache.lucene.codecs.lucene95.OffHeapFloatVectorValues$DenseOffHeapVectorValues.vectorValue(OffHeapFloatVectorValues.java:86)
	at org.apache.lucene.util.hnsw.HnswGraphSearcher.compare(HnswGraphSearcher.java:333)
	at org.apache.lucene.util.hnsw.HnswGraphSearcher.searchLevel(HnswGraphSearcher.java:310)
	at org.apache.lucene.util.hnsw.HnswGraphSearcher.searchLevel(HnswGraphSearcher.java:251)
	at org.apache.lucene.util.hnsw.HnswGraphBuilder.addGraphNode(HnswGraphBuilder.java:289)
	at org.apache.lucene.util.hnsw.HnswGraphBuilder.addGraphNode(HnswGraphBuilder.java:297)
	at org.apache.lucene.util.hnsw.HnswGraphBuilder.addVectors(HnswGraphBuilder.java:246)
	at org.apache.lucene.util.hnsw.HnswGraphBuilder.build(HnswGraphBuilder.java:171)
```

### ISSUE 
#13354

### Proposal

i think we can pass the MergePolicy.OneMergeProgress into MergeState which `OneMergeProgress#aborted` is volatile variable, and every heavy merge processing codec can add some probe in the process, and verify the status to throw `MergeAbortedException` 

this pr only pass the progress into state.

And sample like `Lucene90CompressingStoredFieldsWriter` we can add probe code like 
```
public int merge(MergeState mergeState) throws IOException {
   ...
   while (sub != null) {
       ...processing storefield compressing for one sub...

      //probe for check progress is aborted
      if (mergeState.mergeProgress.isAborted()) {
        throw new MergePolicy.MergeAbortedException("Merge aborted.");
      }
   }
}
```


