### PR TITLE
Remove synchronization from IndexWriter.isClosed

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -5820,7 +5820,7 @@ public class IndexWriter
     return isCurrent;
   }
 
-  synchronized boolean isClosed() {
+  boolean isClosed() {
     return closed;
   }
 


### PR DESCRIPTION
Blocking on this one seems unnecessary as the closed flag is volatile. This tends to block for an extended period in its only production use case `StandardDirectoryWriter.isCurrent()` every now and then which seems unnecessary. Either it's true, in which case it'll stay true and there's no need to wait for anything or it's false in which case the else branch goes into `IndexWriter.nrtIsCurrent` which blocks on the same mutex anyway.
