### PR TITLE
Speedup GlobalHitsThresholdChecker a little

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/HitsThresholdChecker.java
+++ b/lucene/core/src/java/org/apache/lucene/search/HitsThresholdChecker.java
@@ -46,7 +46,11 @@ abstract class HitsThresholdChecker {
       if (thresholdReached) {
         return true;
       }
-      return thresholdReached = globalHitCount.longValue() > getHitsThreshold();
+      if (globalHitCount.longValue() > getHitsThreshold()) {
+        thresholdReached = true;
+        return true;
+      }
+      return false;
     }
 
     @Override


### PR DESCRIPTION
Even though this field is not `volatile`, writing it isn't free and causes needless cache thrashing at some frequency. We can speed things up by only writing the `true` value and never the `false` value.

At least on x86 this has a small but clearly visible positive impact in wiki-med-all benchmarks:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                      AndHighLow     1320.25      (7.8%)     1303.53     (13.6%)   -1.3% ( -21% -   21%) 0.718
                        HighTerm      855.19      (6.9%)      848.11     (14.1%)   -0.8% ( -20% -   21%) 0.813
         AndHighMedDayTaxoFacets      134.18      (3.8%)      133.19      (4.5%)   -0.7% (  -8% -    7%) 0.580
          OrHighMedDayTaxoFacets        6.73      (5.2%)        6.73      (4.1%)   -0.0% (  -8% -    9%) 0.982
            MedTermDayTaxoFacets       13.45      (3.9%)       13.45      (5.3%)    0.0% (  -8% -    9%) 0.982
           BrowseMonthSSDVFacets        4.49      (8.2%)        4.51      (8.7%)    0.3% ( -15% -   18%) 0.911
                 MedSloppyPhrase       36.33      (7.0%)       36.45      (6.0%)    0.3% ( -11% -   14%) 0.873
                       OrHighMed      224.17      (3.8%)      225.47      (4.9%)    0.6% (  -7% -    9%) 0.675
                     MedSpanNear       96.02      (7.3%)       96.60      (7.2%)    0.6% ( -12% -   16%) 0.790
     BrowseRandomLabelSSDVFacets        3.26      (2.3%)        3.29      (2.6%)    0.9% (  -3% -    5%) 0.227
                    OrNotHighLow     1097.11     (11.4%)     1107.99      (9.6%)    1.0% ( -17% -   24%) 0.766
       BrowseDayOfYearSSDVFacets        4.38      (3.4%)        4.42      (3.9%)    1.0% (  -6% -    8%) 0.377
            HighTermTitleBDVSort       24.30      (7.0%)       24.61      (8.0%)    1.3% ( -12% -   17%) 0.598
                         Prefix3      102.78      (8.3%)      104.17      (8.1%)    1.4% ( -13% -   19%) 0.603
                          Fuzzy1       91.69      (6.5%)       92.98      (5.9%)    1.4% ( -10% -   14%) 0.469
                       LowPhrase       71.06      (5.6%)       72.07      (4.0%)    1.4% (  -7% -   11%) 0.355
                        PKLookup      233.39      (3.5%)      237.05      (3.0%)    1.6% (  -4% -    8%) 0.130
                    HighSpanNear        2.51      (2.2%)        2.56      (2.8%)    1.8% (  -3% -    6%) 0.028
                     AndHighHigh      115.40      (3.9%)      117.54      (3.1%)    1.9% (  -4% -    9%) 0.096
            HighIntervalsOrdered       22.18      (9.8%)       22.62      (7.5%)    2.0% ( -13% -   21%) 0.471
                          IntNRQ      832.49     (11.0%)      849.89     (15.9%)    2.1% ( -22% -   32%) 0.628
                       MedPhrase      327.84      (5.9%)      335.15      (8.0%)    2.2% ( -11% -   17%) 0.316
            BrowseDateSSDVFacets        1.24      (3.4%)        1.27      (4.1%)    2.3% (  -4% -   10%) 0.048
                         Respell       44.23      (2.5%)       45.34      (2.2%)    2.5% (  -2% -    7%) 0.001
                 LowSloppyPhrase       31.93      (8.7%)       32.74      (8.4%)    2.5% ( -13% -   21%) 0.348
                      OrHighHigh       74.05      (6.3%)       76.04      (7.4%)    2.7% ( -10% -   17%) 0.216
                HighSloppyPhrase       33.90     (11.0%)       34.87      (8.9%)    2.8% ( -15% -   25%) 0.368
             MedIntervalsOrdered       27.04      (3.9%)       27.82      (4.7%)    2.9% (  -5% -   12%) 0.034
                    OrHighNotMed      468.83      (6.9%)      484.01      (8.1%)    3.2% ( -11% -   19%) 0.175
        AndHighHighDayTaxoFacets       23.97      (5.4%)       24.77      (4.7%)    3.3% (  -6% -   14%) 0.039
                          Fuzzy2       81.16      (3.1%)       84.04      (3.0%)    3.6% (  -2% -   10%) 0.000
                     LowSpanNear       47.37      (6.6%)       49.13      (4.8%)    3.7% (  -7% -   16%) 0.041
                        Wildcard      193.09     (11.7%)      200.32     (11.6%)    3.7% ( -17% -   30%) 0.309
                      AndHighMed      253.31      (8.0%)      263.49      (5.9%)    4.0% (  -9% -   19%) 0.072
                         LowTerm      586.07      (7.0%)      609.94     (11.3%)    4.1% ( -13% -   24%) 0.171
               HighTermTitleSort       59.11      (6.3%)       61.53      (5.3%)    4.1% (  -7% -   16%) 0.026
                   OrNotHighHigh      323.26      (6.3%)      337.69      (8.2%)    4.5% (  -9% -   20%) 0.055
            BrowseDateTaxoFacets        4.89      (5.3%)        5.11      (6.3%)    4.6% (  -6% -   17%) 0.012
             LowIntervalsOrdered       53.41      (4.9%)       55.90      (5.3%)    4.7% (  -5% -   15%) 0.004
     BrowseRandomLabelTaxoFacets        4.24      (4.1%)        4.44      (3.9%)    4.8% (  -3% -   13%) 0.000
                   OrHighNotHigh      509.58      (8.2%)      534.81      (6.3%)    5.0% (  -8% -   21%) 0.032
                    OrNotHighMed      356.67      (4.8%)      374.35      (6.3%)    5.0% (  -5% -   16%) 0.005
               HighTermMonthSort     1286.76     (10.8%)     1350.90     (11.4%)    5.0% ( -15% -   30%) 0.155
                      TermDTSort      194.58      (6.9%)      204.67      (8.6%)    5.2% (  -9% -   22%) 0.036
                      HighPhrase       19.20      (7.9%)       20.21      (8.0%)    5.2% (  -9% -   22%) 0.038
           HighTermDayOfYearSort      330.05     (11.2%)      347.39     (11.2%)    5.3% ( -15% -   31%) 0.139
                       OrHighLow      447.18      (6.8%)      470.74      (7.2%)    5.3% (  -8% -   20%) 0.017
                         MedTerm      691.26      (7.0%)      727.87      (9.0%)    5.3% (  -9% -   22%) 0.037
                    OrHighNotLow      396.54      (6.5%)      419.54      (9.7%)    5.8% (  -9% -   23%) 0.027
       BrowseDayOfYearTaxoFacets        4.95      (4.7%)        5.25      (6.6%)    5.9% (  -5% -   18%) 0.001
           BrowseMonthTaxoFacets       12.00     (31.4%)       12.91     (29.4%)    7.6% ( -40% -   99%) 0.429
```

