### PR TITLE
Override iterator in Empty off-heap vector values

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/OffHeapFloatVectorValues.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/OffHeapFloatVectorValues.java
@@ -250,6 +250,11 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues {
     }
 
     @Override
+    public DocIndexIterator iterator() {
+      return createDenseIterator();
+    }
+
+    @Override
     public Bits getAcceptOrds(Bits acceptDocs) {
       return null;
     }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapByteVectorValues.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapByteVectorValues.java
@@ -264,6 +264,11 @@ abstract class OffHeapByteVectorValues extends ByteVectorValues {
     }
 
     @Override
+    public DocIndexIterator iterator() {
+      return createDenseIterator();
+    }
+
+    @Override
     public Bits getAcceptOrds(Bits acceptDocs) {
       return null;
     }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapFloatVectorValues.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapFloatVectorValues.java
@@ -263,6 +263,11 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues {
     }
 
     @Override
+    public DocIndexIterator iterator() {
+      return createDenseIterator();
+    }
+
+    @Override
     public Bits getAcceptOrds(Bits acceptDocs) {
       return null;
     }


### PR DESCRIPTION
This commit override the iterator method in the empty off-heap vector values. The implementation is just the dense iterator, which handles empty values just fine. We use it elsewhere for similar too.