### PR TITLE
Release wizard to split clean and check calls to separate calls

### DIFF
--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -112,8 +112,10 @@ def prepare(root, version, pause_before_sign, gpg_key_id, gpg_password, gpg_home
   checkDOAPfiles(version)
 
   if not dev_mode:
-    print('  ./gradlew --stacktrace --no-daemon clean check')
-    run('./gradlew --stacktrace --no-daemon clean check')
+    print('  ./gradlew --stacktrace --no-daemon clean')
+    run('./gradlew --stacktrace --no-daemon clean')
+    print('  ./gradlew --stacktrace --no-daemon check')
+    run('./gradlew --stacktrace --no-daemon check')
   else:
     print('  skipping precommit check due to dev-mode')
 


### PR DESCRIPTION
While preparing Lucene 10 RC1, I had an issue running the release script from branch_10_0. It reproduces on branch_10x as well. The `./gradle clean check` command fails with the following gradle error and some huge tasks dependency output:

```
Unable to make progress running work. There are items queued for execution but none of them can be started
```

@ChrisHegarty confirmed that he could reproduce the same issue on his machine as well. I worked around this by splitting the `clean` and `check` into two separate calls, in which case everything works fine. I [pushed](https://github.com/apache/lucene/commit/f411adfe43163fde25122a88164991369ce3797f) that work-around to `branch_10_0` to unblock the release process, and I am opening this to discuss whether this is a change that we should make to `main` and `branch_10_0`, at least until we have figured out what causes the issue and we have a fix.
