### PR TITLE
Fix bug where off-heap scorer would kick on even for float vectors

### DIFF
--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorer.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorer.java
@@ -19,6 +19,7 @@ package org.apache.lucene.internal.vectorization;
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
 import java.util.Optional;
+import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.FilterIndexInput;
@@ -40,6 +41,7 @@ abstract sealed class Lucene99MemorySegmentByteVectorScorer
    */
   public static Optional<Lucene99MemorySegmentByteVectorScorer> create(
       VectorSimilarityFunction type, IndexInput input, KnnVectorValues values, byte[] queryVector) {
+    assert values instanceof ByteVectorValues;
     input = FilterIndexInput.unwrapOnlyTest(input);
     if (!(input instanceof MemorySegmentAccessInput msInput)) {
       return Optional.empty();

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorerSupplier.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorerSupplier.java
@@ -19,6 +19,7 @@ package org.apache.lucene.internal.vectorization;
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
 import java.util.Optional;
+import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.FilterIndexInput;
@@ -42,6 +43,7 @@ public abstract sealed class Lucene99MemorySegmentByteVectorScorerSupplier
    */
   static Optional<RandomVectorScorerSupplier> create(
       VectorSimilarityFunction type, IndexInput input, KnnVectorValues values) {
+    assert values instanceof ByteVectorValues;
     input = FilterIndexInput.unwrapOnlyTest(input);
     if (!(input instanceof MemorySegmentAccessInput msInput)) {
       return Optional.empty();

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFlatVectorsScorer.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFlatVectorsScorer.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import org.apache.lucene.codecs.hnsw.DefaultFlatVectorScorer;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
+import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
@@ -43,7 +44,8 @@ public class Lucene99MemorySegmentFlatVectorsScorer implements FlatVectorsScorer
     // a quantized values here is a wrapping or delegation issue
     assert !(vectorValues instanceof QuantizedByteVectorValues);
     // currently only supports binary vectors
-    if (vectorValues instanceof HasIndexSlice byteVectorValues
+    if (vectorValues instanceof ByteVectorValues bvv
+        && bvv instanceof HasIndexSlice byteVectorValues
         && byteVectorValues.getSlice() != null) {
       var scorer =
           Lucene99MemorySegmentByteVectorScorerSupplier.create(
@@ -70,7 +72,8 @@ public class Lucene99MemorySegmentFlatVectorsScorer implements FlatVectorsScorer
     checkDimensions(queryVector.length, vectorValues.dimension());
     // a quantized values here is a wrapping or delegation issue
     assert !(vectorValues instanceof QuantizedByteVectorValues);
-    if (vectorValues instanceof HasIndexSlice byteVectorValues
+    if (vectorValues instanceof ByteVectorValues bvv
+        && bvv instanceof HasIndexSlice byteVectorValues
         && byteVectorValues.getSlice() != null) {
       var scorer =
           Lucene99MemorySegmentByteVectorScorer.create(


### PR DESCRIPTION
introduced in the major refactor https://github.com/apache/lucene/pull/13779

Off-heap scoring is only present for `byte[]` vectors, and it isn't enough to verify that the vector provider also satisfies the `HasIndexSlice` interface. The vectors need to be byte vectors otherwise, the slice iterations and scoring are completely nonsensical leading to HNSW graph building to run until the heat-death of the universe.