### PR TITLE
Reassign the knn values iterator in TestSortingCodecReader

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
@@ -255,6 +255,7 @@ public class TestSortingCodecReader extends LuceneTestCase {
                 sorted_set_dv = leaf.getSortedSetDocValues("sorted_set_dv");
                 binary_sorted_dv = leaf.getSortedDocValues("binary_sorted_dv");
                 vectorValues = leaf.getFloatVectorValues("vector");
+                valuesIterator = vectorValues.iterator();
                 prevValue = -1;
               }
               assertTrue(prevValue + " < " + ids.longValue(), prevValue < ids.longValue());


### PR DESCRIPTION
This caused a reproducible test failure, here is the repro line:

```
gradlew :lucene:core:test --tests "org.apache.lucene.index.TestSortingCodecReader.testSortOnAddIndicesRandom" -Ptests.jvms=10 "-Ptests.jvmargs=-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1" -Ptests.seed=D6987AB46172F996 -Ptests.nightly=true -Ptests.gui=true -Ptests.file.encoding=UTF-8 -Ptests.vectorsize=128 -Ptests.forceintegervectors=true
```

The fix addresses it.