### PR TITLE
Adjust command to remove uploaded artifacts upon respin

### DIFF
--- a/dev-tools/scripts/releaseWizard.py
+++ b/dev-tools/scripts/releaseWizard.py
@@ -239,7 +239,7 @@ def maybe_remove_rc_from_svn():
                  logfile="svn_rm.log",
                  tee=True,
                  vars={
-                     'dist_folder': """lucene-{{ release_version }}-RC{{ rc_number }}-rev{{ build_rc.git_rev | default("<git_rev>", True) }}""",
+                     'dist_folder': """lucene-{{ release_version }}-RC{{ rc_number }}-rev-{{ build_rc.git_rev | default("<git_rev>", True) }}""",
                      'dist_url': "{{ dist_url_base }}/{{ dist_folder }}"
                  }
              )],


### PR DESCRIPTION
The command to remove uploaded artifacts from svn is missing a dash, hence it fails as it does not match the name of the artifacts uploaded at the previous steps.