### PR TITLE
Replace branch_9x references with branch_10x in workflows

### DIFF
--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'branch_9x'
+      - 'branch_10x'
 
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}

--- a/.github/workflows/run-checks-gradle-upgrade.yml
+++ b/.github/workflows/run-checks-gradle-upgrade.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - 'main'
-      - 'branch_9x'
+      - 'branch_10x'
     paths:
       - '.github/workflows/run-checks-gradle-upgrade.yml'
       - 'gradle/wrapper/**'
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'branch_9x'
+      - 'branch_10x'
     paths:
       - '.github/workflows/run-checks-gradle-upgrade.yml'
       - 'gradle/wrapper/**'

--- a/.github/workflows/run-checks-mod-analysis-common.yml
+++ b/.github/workflows/run-checks-mod-analysis-common.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - 'main'
-      - 'branch_9x'
+      - 'branch_10x'
     paths:
       - '.github/workflows/run-checks-mod-analysis-common.yml'
       - 'lucene/analysis/common/**'
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'branch_9x'
+      - 'branch_10x'
     paths:
       - '.github/workflows/run-checks-mod-analysis-common.yml'
       - 'lucene/analysis/common/**'

--- a/.github/workflows/run-checks-mod-distribution.tests.yml
+++ b/.github/workflows/run-checks-mod-distribution.tests.yml
@@ -6,12 +6,12 @@ on:
   pull_request:
     branches:
       - 'main'
-      - 'branch_9x'
+      - 'branch_10x'
 
   push:
     branches:
       - 'main'
-      - 'branch_9x'
+      - 'branch_10x'
 
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}

--- a/dev-docs/working-between-major-versions.adoc
+++ b/dev-docs/working-between-major-versions.adoc
@@ -51,7 +51,7 @@ cd lucene
 git clone git@github.com:apache/lucene.git main
 cd main
 # For each branch that you want a separate directory created for, add a worktree
-git worktree add ../9x branch_9x
+git worktree add ../10x branch_10x
 ----
 
 === Using the Worktrees


### PR DESCRIPTION
With the move of the main branch to 11, and the upcoming sunsetting of 9x, we need to replace branch_9x references with branch_10x in workflows.