### PR TITLE
Reduce TaskExecutor overhead

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -18,9 +18,10 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
@@ -30,7 +31,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.ThreadInterruptedException;
@@ -73,15 +73,68 @@ public final class TaskExecutor {
   /**
    * Execute all the callables provided as an argument, wait for them to complete and return the
    * obtained results. If an exception is thrown by more than one callable, the subsequent ones will
-   * be added as suppressed exceptions to the first one that was caught.
+   * be added as suppressed exceptions to the first one that was caught. Additionally, if one task
+   * throws an exception, all other tasks from the same group are cancelled, to avoid needless
+   * computation as their results would not be exposed anyways.
    *
    * @param callables the callables to execute
    * @return a list containing the results from the tasks execution
    * @param <T> the return type of the task execution
    */
   public <T> List<T> invokeAll(Collection<Callable<T>> callables) throws IOException {
-    TaskGroup<T> taskGroup = new TaskGroup<>(callables);
-    return taskGroup.invokeAll(executor);
+    List<RunnableFuture<T>> futures = new ArrayList<>(callables.size());
+    for (Callable<T> callable : callables) {
+      futures.add(new Task<>(callable, futures));
+    }
+    final int count = futures.size();
+    // taskId provides the first index of an un-executed task in #futures
+    final AtomicInteger taskId = new AtomicInteger(0);
+    // we fork execution count - 1 tasks to execute at least one task on the current thread to
+    // minimize needless forking and blocking of the current thread
+    if (count > 1) {
+      final Runnable work =
+          () -> {
+            int id = taskId.getAndIncrement();
+            if (id < count) {
+              futures.get(id).run();
+            }
+          };
+      for (int j = 0; j < count - 1; j++) {
+        executor.execute(work);
+      }
+    }
+    // try to execute as many tasks as possible on the current thread to minimize context
+    // switching in case of long running concurrent
+    // tasks as well as dead-locking if the current thread is part of #executor for executors that
+    // have limited or no parallelism
+    int id;
+    while ((id = taskId.getAndIncrement()) < count) {
+      futures.get(id).run();
+      if (id >= count - 1) {
+        // save redundant CAS in case this was the last task
+        break;
+      }
+    }
+    return collectResults(futures);
+  }
+
+  private static <T> List<T> collectResults(List<RunnableFuture<T>> futures) throws IOException {
+    Throwable exc = null;
+    List<T> results = new ArrayList<>(futures.size());
+    for (Future<T> future : futures) {
+      try {
+        results.add(future.get());
+      } catch (InterruptedException e) {
+        exc = IOUtils.useOrSuppress(exc, new ThreadInterruptedException(e));
+      } catch (ExecutionException e) {
+        exc = IOUtils.useOrSuppress(exc, e.getCause());
+      }
+    }
+    assert assertAllFuturesCompleted(futures) : "Some tasks are still running?";
+    if (exc != null) {
+      throw IOUtils.rethrowAlways(exc);
+    }
+    return results;
   }
 
   @Override
@@ -89,128 +142,74 @@ public final class TaskExecutor {
     return "TaskExecutor(" + "executor=" + executor + ')';
   }
 
-  /**
-   * Holds all the sub-tasks that a certain operation gets split into as it gets parallelized and
-   * exposes the ability to invoke such tasks and wait for them all to complete their execution and
-   * provide their results. Additionally, if one task throws an exception, all other tasks from the
-   * same group are cancelled, to avoid needless computation as their results would not be exposed
-   * anyways. Creates one {@link FutureTask} for each {@link Callable} provided
-   *
-   * @param <T> the return type of all the callables
-   */
-  private static final class TaskGroup<T> {
-    private final List<RunnableFuture<T>> futures;
-
-    TaskGroup(Collection<Callable<T>> callables) {
-      List<RunnableFuture<T>> tasks = new ArrayList<>(callables.size());
-      for (Callable<T> callable : callables) {
-        tasks.add(createTask(callable));
+  private static boolean assertAllFuturesCompleted(Collection<? extends Future<?>> futures) {
+    for (Future<?> future : futures) {
+      if (future.isDone() == false) {
+        return false;
       }
-      this.futures = Collections.unmodifiableList(tasks);
+    }
+    return true;
+  }
+
+  private static <T> void cancelAll(Collection<? extends Future<T>> futures) {
+    for (Future<?> future : futures) {
+      future.cancel(false);
+    }
+  }
+
+  private static class Task<T> extends FutureTask<T> {
+
+    @SuppressWarnings("unused") // only accessed via #STARTED_OR_CANCELLED
+    private volatile boolean startedOrCancelled;
+
+    private static final VarHandle STARTED_OR_CANCELLED;
+
+    static {
+      try {
+        STARTED_OR_CANCELLED =
+            MethodHandles.lookup().findVarHandle(Task.class, "startedOrCancelled", boolean.class);
+      } catch (Exception e) {
+        throw new ExceptionInInitializerError(e);
+      }
     }
 
-    RunnableFuture<T> createTask(Callable<T> callable) {
-      return new FutureTask<>(callable) {
+    private final Collection<? extends Future<T>> futures;
 
-        private final AtomicBoolean startedOrCancelled = new AtomicBoolean(false);
-
-        @Override
-        public void run() {
-          if (startedOrCancelled.compareAndSet(false, true)) {
-            super.run();
-          }
-        }
-
-        @Override
-        protected void setException(Throwable t) {
-          super.setException(t);
-          cancelAll();
-        }
-
-        @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
-          assert mayInterruptIfRunning == false
-              : "cancelling tasks that are running is not supported";
-          /*
-          Future#get (called in invokeAll) throws CancellationException when invoked against a running task that has been cancelled but
-          leaves the task running. We rather want to make sure that invokeAll does not leave any running tasks behind when it returns.
-          Overriding cancel ensures that tasks that are already started will complete normally once cancelled, and Future#get will
-          wait for them to finish instead of throwing CancellationException. A cleaner way would have been to override FutureTask#get and
-          make it wait for cancelled tasks, but FutureTask#awaitDone is private. Tasks that are cancelled before they are started will be no-op.
-           */
-          if (startedOrCancelled.compareAndSet(false, true)) {
-            // task is cancelled hence it has no results to return. That's fine: they would be
-            // ignored anyway.
-            set(null);
-            return true;
-          }
-          return false;
-        }
-      };
+    public Task(Callable<T> callable, Collection<? extends Future<T>> futures) {
+      super(callable);
+      this.futures = futures;
     }
 
-    List<T> invokeAll(Executor executor) throws IOException {
-      final int count = futures.size();
-      // taskId provides the first index of an un-executed task in #futures
-      final AtomicInteger taskId = new AtomicInteger(0);
-      // we fork execution count - 1 tasks to execute at least one task on the current thread to
-      // minimize needless forking and blocking of the current thread
-      if (count > 1) {
-        final Runnable work =
-            () -> {
-              int id = taskId.getAndIncrement();
-              if (id < count) {
-                futures.get(id).run();
-              }
-            };
-        for (int j = 0; j < count - 1; j++) {
-          executor.execute(work);
-        }
+    @Override
+    public void run() {
+      if (STARTED_OR_CANCELLED.compareAndSet(this, false, true)) {
+        super.run();
       }
-      // try to execute as many tasks as possible on the current thread to minimize context
-      // switching in case of long running concurrent
-      // tasks as well as dead-locking if the current thread is part of #executor for executors that
-      // have limited or no parallelism
-      int id;
-      while ((id = taskId.getAndIncrement()) < count) {
-        futures.get(id).run();
-        if (id >= count - 1) {
-          // save redundant CAS in case this was the last task
-          break;
-        }
-      }
-      Throwable exc = null;
-      List<T> results = new ArrayList<>(count);
-      for (int i = 0; i < count; i++) {
-        Future<T> future = futures.get(i);
-        try {
-          results.add(future.get());
-        } catch (InterruptedException e) {
-          exc = IOUtils.useOrSuppress(exc, new ThreadInterruptedException(e));
-        } catch (ExecutionException e) {
-          exc = IOUtils.useOrSuppress(exc, e.getCause());
-        }
-      }
-      assert assertAllFuturesCompleted() : "Some tasks are still running?";
-      if (exc != null) {
-        throw IOUtils.rethrowAlways(exc);
-      }
-      return results;
     }
 
-    private boolean assertAllFuturesCompleted() {
-      for (RunnableFuture<T> future : futures) {
-        if (future.isDone() == false) {
-          return false;
-        }
-      }
-      return true;
+    @Override
+    protected void setException(Throwable t) {
+      super.setException(t);
+      cancelAll(futures);
     }
 
-    private void cancelAll() {
-      for (Future<T> future : futures) {
-        future.cancel(false);
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+      assert mayInterruptIfRunning == false : "cancelling tasks that are running is not supported";
+      /*
+      Future#get (called in #collectResults) throws CancellationException when invoked against a running task that has been cancelled but
+      leaves the task running. We rather want to make sure that invokeAll does not leave any running tasks behind when it returns.
+      Overriding cancel ensures that tasks that are already started will complete normally once cancelled, and Future#get will
+      wait for them to finish instead of throwing CancellationException. A cleaner way would have been to override FutureTask#get and
+      make it wait for cancelled tasks, but FutureTask#awaitDone is private. Tasks that are cancelled before they are started will be no-op.
+       */
+      if (STARTED_OR_CANCELLED.compareAndSet(this, false, true)) {
+        // task is cancelled hence it has no results to return. That's fine: they would be
+        // ignored anyway.
+        set(null);
+        return true;
       }
+      return false;
     }
   }
 }


### PR DESCRIPTION
The `TaskGroup` class is redundant, the futures list can be a local variable shared by the tasks (this also removes any need for making it read-only). Also, the tasks can be made a little more lightweight too by using a var handle instead of an atomic and being explicit about the fact that they need a reference to the list of other tasks.

Similar to #13860 a small but not insignificant improvement here + reducing the noise in this code now sets up cleaner benchmarking for potential solutions to the small task overhead problems we ran into here and there:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
           BrowseMonthTaxoFacets       12.82     (23.1%)       12.65     (29.1%)   -1.3% ( -43% -   66%) 0.819
                         LowTerm      846.91      (5.6%)      846.92      (5.9%)    0.0% ( -10% -   12%) 0.999
               HighTermMonthSort     1525.55      (5.2%)     1529.85      (6.6%)    0.3% ( -10% -   12%) 0.832
                      OrHighHigh      193.59      (9.9%)      194.63      (5.3%)    0.5% ( -13% -   17%) 0.762
                     AndHighHigh      135.09      (9.6%)      135.88      (7.1%)    0.6% ( -14% -   19%) 0.756
                    OrNotHighLow     1787.14      (5.4%)     1798.09      (4.5%)    0.6% (  -8% -   11%) 0.581
                       OrHighLow      714.69      (3.6%)      720.59      (3.9%)    0.8% (  -6% -    8%) 0.325
                        HighTerm      439.29      (9.9%)      443.35      (9.2%)    0.9% ( -16% -   22%) 0.665
            BrowseDateSSDVFacets        1.24      (6.9%)        1.26      (9.2%)    1.0% ( -14% -   18%) 0.585
                         MedTerm      582.73      (7.8%)      588.53      (8.6%)    1.0% ( -14% -   18%) 0.586
                    OrHighNotLow      517.51      (7.3%)      524.34      (5.7%)    1.3% ( -10% -   15%) 0.366
                         Prefix3     1737.96      (5.1%)     1761.79      (5.8%)    1.4% (  -9% -   12%) 0.260
                       MedPhrase      121.93      (8.9%)      123.89      (7.2%)    1.6% ( -13% -   19%) 0.374
                   OrHighNotHigh      601.29      (6.1%)      611.36      (5.1%)    1.7% (  -8% -   13%) 0.180
                       OrHighMed      222.29      (3.2%)      226.23      (3.8%)    1.8% (  -5% -    9%) 0.024
                          IntNRQ      141.25      (4.9%)      143.76      (4.4%)    1.8% (  -7% -   11%) 0.089
                      AndHighLow     1629.97      (6.3%)     1659.01      (6.8%)    1.8% ( -10% -   15%) 0.226
                          Fuzzy1       78.77      (2.9%)       80.21      (3.4%)    1.8% (  -4% -    8%) 0.011
            HighTermTitleBDVSort       31.60      (4.0%)       32.18      (5.3%)    1.8% (  -7% -   11%) 0.080
         AndHighMedDayTaxoFacets       92.22      (2.6%)       93.92      (3.1%)    1.8% (  -3% -    7%) 0.004
     BrowseRandomLabelTaxoFacets        4.34      (4.2%)        4.42      (4.5%)    1.9% (  -6% -   11%) 0.054
        AndHighHighDayTaxoFacets       27.25      (3.4%)       27.80      (3.1%)    2.0% (  -4% -    8%) 0.006
                    HighSpanNear       11.45      (4.9%)       11.68      (7.3%)    2.0% (  -9% -   14%) 0.145
                        PKLookup      240.33      (2.7%)      245.34      (2.3%)    2.1% (  -2% -    7%) 0.000
                    OrHighNotMed      654.03      (6.4%)      668.14      (6.2%)    2.2% (  -9% -   15%) 0.125
                    OrNotHighMed      359.60      (4.8%)      367.38      (3.6%)    2.2% (  -5% -   11%) 0.022
               HighTermTitleSort       67.09      (4.2%)       68.63      (4.8%)    2.3% (  -6% -   11%) 0.023
            MedTermDayTaxoFacets       22.07      (3.4%)       22.63      (4.1%)    2.5% (  -4% -   10%) 0.003
          OrHighMedDayTaxoFacets        6.41      (5.0%)        6.59      (5.4%)    2.7% (  -7% -   13%) 0.020
                          Fuzzy2       83.73      (2.6%)       86.05      (2.2%)    2.8% (  -1% -    7%) 0.000
            HighIntervalsOrdered       20.50      (4.9%)       21.10      (5.5%)    2.9% (  -7% -   14%) 0.012
       BrowseDayOfYearTaxoFacets        5.13      (5.7%)        5.29      (9.3%)    3.0% ( -11% -   19%) 0.084
                HighSloppyPhrase        8.16      (5.3%)        8.41      (4.8%)    3.0% (  -6% -   13%) 0.007
                         Respell       54.78      (1.5%)       56.47      (1.5%)    3.1% (   0% -    6%) 0.000
            BrowseDateTaxoFacets        5.05      (5.9%)        5.21      (9.4%)    3.1% ( -11% -   19%) 0.079
                   OrNotHighHigh      181.76      (7.3%)      187.49      (5.6%)    3.2% (  -9% -   17%) 0.030
             LowIntervalsOrdered       17.54      (4.6%)       18.11      (4.5%)    3.3% (  -5% -   12%) 0.001
                      TermDTSort      153.46      (6.0%)      158.55      (4.9%)    3.3% (  -7% -   15%) 0.007
                     MedSpanNear       27.38      (2.1%)       28.30      (2.2%)    3.4% (   0% -    7%) 0.000
                       LowPhrase       23.26      (5.1%)       24.05      (5.4%)    3.4% (  -6% -   14%) 0.004
                      AndHighMed      176.55      (6.1%)      182.49      (5.3%)    3.4% (  -7% -   15%) 0.008
                 LowSloppyPhrase       90.89      (4.5%)       94.02      (5.0%)    3.4% (  -5% -   13%) 0.001
                     LowSpanNear       31.44      (2.2%)       32.54      (2.4%)    3.5% (  -1% -    8%) 0.000
             MedIntervalsOrdered       44.12      (3.9%)       45.69      (3.8%)    3.6% (  -4% -   11%) 0.000
                      HighPhrase       84.47      (5.7%)       87.81      (5.3%)    4.0% (  -6% -   15%) 0.001
     BrowseRandomLabelSSDVFacets        3.28      (2.7%)        3.41      (4.9%)    4.1% (  -3% -   12%) 0.000
       BrowseDayOfYearSSDVFacets        4.49     (10.1%)        4.68     (10.4%)    4.1% ( -14% -   27%) 0.073
           BrowseMonthSSDVFacets        4.39      (7.3%)        4.59      (8.0%)    4.4% ( -10% -   21%) 0.009
                 MedSloppyPhrase       28.27      (4.7%)       29.52      (7.1%)    4.4% (  -6% -   17%) 0.001
                        Wildcard      214.34      (6.1%)      224.66      (6.0%)    4.8% (  -6% -   17%) 0.000
           HighTermDayOfYearSort      323.67      (8.6%)      339.53      (7.7%)    4.9% ( -10% -   23%) 0.007
```