### PR TITLE
Misc cleanups postings codec

### DIFF
--- a/lucene/core/src/generated/checksums/generateForDeltaUtil.json
+++ b/lucene/core/src/generated/checksums/generateForDeltaUtil.json
@@ -1,4 +1,4 @@
 {
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForDeltaUtil.java": "5115b12ac31537ce31d73c0a279df92060749a3a",
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForDeltaUtil.py": "db6154406e68b80d2c90116b5d0bfa9ba220762a"
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForDeltaUtil.java": "f561578ccb6a95364bb62c5ed86b38ff0b4a009d",
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForDeltaUtil.py": "eea1a71be9da8a13fdd979354dc4a8c6edf21be1"
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForDeltaUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForDeltaUtil.java
@@ -23,7 +23,6 @@ import static org.apache.lucene.codecs.lucene912.ForUtil.*;
 import java.io.IOException;
 import org.apache.lucene.internal.vectorization.PostingDecodingUtil;
 import org.apache.lucene.store.DataOutput;
-import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.packed.PackedInts;
 
 /**
@@ -280,11 +279,6 @@ public final class ForDeltaUtil {
     } else {
       decodeAndPrefixSum(bitsPerValue, pdu, base, longs);
     }
-  }
-
-  void skip(IndexInput in) throws IOException {
-    final int bitsPerValue = Byte.toUnsignedInt(in.readByte());
-    in.skipBytes(numBytes(bitsPerValue));
   }
 
   /** Delta-decode 128 integers into {@code longs}. */

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -1498,12 +1498,9 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
             level--;
           }
 
-          if (level1LastDocID != NO_MORE_DOCS) {
-            if (level == 0) {
-              return level1LastDocID;
-            }
+          if (level1LastDocID != NO_MORE_DOCS && level == 0) {
+            return level1LastDocID;
           }
-
           return NO_MORE_DOCS;
         }
 
@@ -1518,12 +1515,10 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
             level--;
           }
 
-          if (level1LastDocID != NO_MORE_DOCS) {
-            if (level == 0) {
-              scratch.reset(level1SerializedImpacts.bytes, 0, level1SerializedImpacts.length);
-              readImpacts(scratch, level1Impacts);
-              return level1Impacts;
-            }
+          if (level1LastDocID != NO_MORE_DOCS && level == 0) {
+            scratch.reset(level1SerializedImpacts.bytes, 0, level1SerializedImpacts.length);
+            readImpacts(scratch, level1Impacts);
+            return level1Impacts;
           }
 
           return Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
@@ -1834,10 +1829,8 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
             level--;
           }
 
-          if (level1LastDocID != NO_MORE_DOCS) {
-            if (level == 0) {
-              return level1LastDocID;
-            }
+          if (level1LastDocID != NO_MORE_DOCS && level == 0) {
+            return level1LastDocID;
           }
 
           return NO_MORE_DOCS;
@@ -1854,12 +1847,10 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
             level--;
           }
 
-          if (level1LastDocID != NO_MORE_DOCS) {
-            if (level == 0) {
-              scratch.reset(level1SerializedImpacts.bytes(), 0, level1SerializedImpacts.length());
-              readImpacts(scratch, level1Impacts);
-              return level1Impacts;
-            }
+          if (level1LastDocID != NO_MORE_DOCS && level == 0) {
+            scratch.reset(level1SerializedImpacts.bytes(), 0, level1SerializedImpacts.length());
+            readImpacts(scratch, level1Impacts);
+            return level1Impacts;
           }
 
           return Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -1498,7 +1498,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
             level--;
           }
 
-          if (level1LastDocID != NO_MORE_DOCS && level == 0) {
+          if (level == 0) {
             return level1LastDocID;
           }
           return NO_MORE_DOCS;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -77,8 +77,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
   private final int maxNumImpactsAtLevel1;
   private final int maxImpactNumBytesAtLevel1;
 
-  private final int version;
-
   /** Sole constructor. */
   public Lucene912PostingsReader(SegmentReadState state) throws IOException {
     String metaName =
@@ -87,6 +85,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     final long expectedDocFileLength, expectedPosFileLength, expectedPayFileLength;
     ChecksumIndexInput metaIn = null;
     boolean success = false;
+    int version;
     try {
       metaIn = state.directory.openChecksumInput(metaName);
       version =
@@ -344,16 +343,13 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
   final class BlockDocsEnum extends PostingsEnum {
 
-    final ForUtil forUtil = new ForUtil();
     final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
-    final PForUtil pforUtil = new PForUtil(forUtil);
+    final PForUtil pforUtil = new PForUtil(new ForUtil());
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];
     private final long[] freqBuffer = new long[BLOCK_SIZE];
 
     private int docBufferUpto;
-
-    final IndexInput startDocIn;
 
     IndexInput docIn;
     PostingDecodingUtil docInUtil;
@@ -378,8 +374,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     private int singletonDocID; // docid when there is a single pulsed posting, otherwise -1
     private long freqFP;
 
-    public BlockDocsEnum(FieldInfo fieldInfo) throws IOException {
-      this.startDocIn = Lucene912PostingsReader.this.docIn;
+    public BlockDocsEnum(FieldInfo fieldInfo) {
       this.docIn = null;
       indexHasFreq = fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) >= 0;
       indexHasPos =
@@ -396,7 +391,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     }
 
     public boolean canReuse(IndexInput docIn, FieldInfo fieldInfo) {
-      return docIn == startDocIn
+      return docIn == Lucene912PostingsReader.this.docIn
           && indexHasFreq
               == (fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) >= 0)
           && indexHasPos
@@ -417,7 +412,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
       if (docFreq > 1) {
         if (docIn == null) {
           // lazy init
-          docIn = startDocIn.clone();
+          docIn = Lucene912PostingsReader.this.docIn.clone();
           docInUtil = VECTORIZATION_PROVIDER.newPostingDecodingUtil(docIn);
         }
         prefetchPostings(docIn, termState);
@@ -460,22 +455,22 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     }
 
     @Override
-    public int nextPosition() throws IOException {
+    public int nextPosition() {
       return -1;
     }
 
     @Override
-    public int startOffset() throws IOException {
+    public int startOffset() {
       return -1;
     }
 
     @Override
-    public int endOffset() throws IOException {
+    public int endOffset() {
       return -1;
     }
 
     @Override
-    public BytesRef getPayload() throws IOException {
+    public BytesRef getPayload() {
       return null;
     }
 
@@ -493,7 +488,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
         if (needsFreq) {
           freqFP = docIn.getFilePointer();
         }
-        pforUtil.skip(docIn);
+        PForUtil.skip(docIn);
       }
       docCountUpto += BLOCK_SIZE;
       prevDocID = docBuffer[BLOCK_SIZE - 1];
@@ -629,9 +624,8 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
   final class EverythingEnum extends PostingsEnum {
 
-    final ForUtil forUtil = new ForUtil();
     final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
-    final PForUtil pforUtil = new PForUtil(forUtil);
+    final PForUtil pforUtil = new PForUtil(new ForUtil());
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];
     private final long[] freqBuffer = new long[BLOCK_SIZE + 1];
@@ -651,8 +645,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
     private int docBufferUpto;
     private int posBufferUpto;
-
-    final IndexInput startDocIn;
 
     IndexInput docIn;
     PostingDecodingUtil docInUtil;
@@ -680,13 +672,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     // skip these to "catch up":
     private long posPendingCount;
 
-    // Where this term's postings start in the .pos file:
-    private long posTermStartFP;
-
-    // Where this term's payloads/offsets start in the .pay
-    // file:
-    private long payTermStartFP;
-
     // File pointer where the last (vInt encoded) pos delta
     // block is.  We need this to know whether to bulk
     // decode vs vInt decode the block:
@@ -713,7 +698,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     private int singletonDocID; // docid when there is a single pulsed posting, otherwise -1
 
     public EverythingEnum(FieldInfo fieldInfo) throws IOException {
-      this.startDocIn = Lucene912PostingsReader.this.docIn;
       this.docIn = null;
       indexHasFreq = fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) >= 0;
       indexHasPos =
@@ -761,7 +745,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     }
 
     public boolean canReuse(IndexInput docIn, FieldInfo fieldInfo) {
-      return docIn == startDocIn
+      return docIn == Lucene912PostingsReader.this.docIn
           && indexHasOffsets
               == (fieldInfo
                       .getIndexOptions()
@@ -772,14 +756,17 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
     public PostingsEnum reset(IntBlockTermState termState, int flags) throws IOException {
       docFreq = termState.docFreq;
-      posTermStartFP = termState.posStartFP;
-      payTermStartFP = termState.payStartFP;
+      // Where this term's postings start in the .pos file:
+      final long posTermStartFP = termState.posStartFP;
+      // Where this term's payloads/offsets start in the .pay
+      // file:
+      final long payTermStartFP = termState.payStartFP;
       totalTermFreq = termState.totalTermFreq;
       singletonDocID = termState.singletonDocID;
       if (docFreq > 1) {
         if (docIn == null) {
           // lazy init
-          docIn = startDocIn.clone();
+          docIn = Lucene912PostingsReader.this.docIn.clone();
           docInUtil = VECTORIZATION_PROVIDER.newPostingDecodingUtil(docIn);
         }
         prefetchPostings(docIn, termState);
@@ -829,7 +816,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     }
 
     @Override
-    public int freq() throws IOException {
+    public int freq() {
       return freq;
     }
 
@@ -1054,11 +1041,11 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
         toSkip -= leftInBlock;
         while (toSkip >= BLOCK_SIZE) {
           assert posIn.getFilePointer() != lastPosBlockFP;
-          pforUtil.skip(posIn);
+          PForUtil.skip(posIn);
 
           if (indexHasPayloads) {
             // Skip payloadLength block:
-            pforUtil.skip(payIn);
+            PForUtil.skip(payIn);
 
             // Skip payloadBytes block:
             int numBytes = payIn.readVInt();
@@ -1066,14 +1053,13 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
           }
 
           if (indexHasOffsets) {
-            pforUtil.skip(payIn);
-            pforUtil.skip(payIn);
+            PForUtil.skip(payIn);
+            PForUtil.skip(payIn);
           }
           toSkip -= BLOCK_SIZE;
         }
         refillPositions();
         payloadByteUpto = 0;
-        posBufferUpto = 0;
         final int toSkipInt = (int) toSkip;
         if (indexHasPayloads) {
           for (int i = 0; i < toSkipInt; ++i) {
@@ -1137,7 +1123,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
           } else {
             // this works, because when writing a vint block we always force the first length to be
             // written
-            pforUtil.skip(payIn); // skip over lengths
+            PForUtil.skip(payIn); // skip over lengths
             int numBytes = payIn.readVInt(); // read length of payloadBytes
             payIn.seek(payIn.getFilePointer() + numBytes); // skip over payloadBytes
           }
@@ -1151,8 +1137,8 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
           } else {
             // this works, because when writing a vint block we always force the first length to be
             // written
-            pforUtil.skip(payIn); // skip over starts
-            pforUtil.skip(payIn); // skip over lengths
+            PForUtil.skip(payIn); // skip over starts
+            PForUtil.skip(payIn); // skip over lengths
           }
         }
       }
@@ -1219,16 +1205,13 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
   final class BlockImpactsDocsEnum extends ImpactsEnum {
 
-    final ForUtil forUtil = new ForUtil();
     final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
-    final PForUtil pforUtil = new PForUtil(forUtil);
+    final PForUtil pforUtil = new PForUtil(new ForUtil());
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];
     private final long[] freqBuffer = new long[BLOCK_SIZE];
 
     private int docBufferUpto;
-
-    final IndexInput startDocIn;
 
     final IndexInput docIn;
     final PostingDecodingUtil docInUtil;
@@ -1236,7 +1219,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     final boolean indexHasPos;
     final boolean indexHasOffsetsOrPayloads;
 
-    private int docFreq; // number of docs in this posting list
+    private final int docFreq; // number of docs in this posting list
     private int docCountUpto; // number of docs in or before the current block
     private int doc; // doc we last read
     private long prevDocID; // last doc ID of the previous block
@@ -1245,23 +1228,22 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     // true if we shallow-advanced to a new block that we have not decoded yet
     private boolean needsRefilling;
 
+    private final ByteArrayDataInput scratch = new ByteArrayDataInput();
+
     // level 0 skip data
     private int level0LastDocID;
     private long level0DocEndFP;
     private final BytesRef level0SerializedImpacts;
-    private final ByteArrayDataInput level0SerializedImpactsIn = new ByteArrayDataInput();
     private final MutableImpactList level0Impacts;
     // level 1 skip data
     private int level1LastDocID;
     private long level1DocEndFP;
     private int level1DocCountUpto;
     private final BytesRef level1SerializedImpacts;
-    private final ByteArrayDataInput level1SerializedImpactsIn = new ByteArrayDataInput();
     private final MutableImpactList level1Impacts;
 
     public BlockImpactsDocsEnum(FieldInfo fieldInfo, IntBlockTermState termState)
         throws IOException {
-      this.startDocIn = Lucene912PostingsReader.this.docIn;
       indexHasFreq = fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) >= 0;
       indexHasPos =
           fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;
@@ -1277,7 +1259,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
       docFreq = termState.docFreq;
       if (docFreq > 1) {
-        docIn = startDocIn.clone();
+        docIn = Lucene912PostingsReader.this.docIn.clone();
         docInUtil = VECTORIZATION_PROVIDER.newPostingDecodingUtil(docIn);
         prefetchPostings(docIn, termState);
       } else {
@@ -1323,22 +1305,22 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     }
 
     @Override
-    public int nextPosition() throws IOException {
+    public int nextPosition() {
       return -1;
     }
 
     @Override
-    public int startOffset() throws IOException {
+    public int startOffset() {
       return -1;
     }
 
     @Override
-    public int endOffset() throws IOException {
+    public int endOffset() {
       return -1;
     }
 
     @Override
-    public BytesRef getPayload() throws IOException {
+    public BytesRef getPayload() {
       return null;
     }
 
@@ -1356,7 +1338,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
         if (indexHasFreq) {
           freqFP = docIn.getFilePointer();
-          pforUtil.skip(docIn);
+          PForUtil.skip(docIn);
         }
         docCountUpto += BLOCK_SIZE;
       } else {
@@ -1502,7 +1484,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     }
 
     @Override
-    public Impacts getImpacts() throws IOException {
+    public Impacts getImpacts() {
       return new Impacts() {
 
         @Override
@@ -1533,7 +1515,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
             if (level == 0) {
               return level1LastDocID;
             }
-            level--;
           }
 
           return NO_MORE_DOCS;
@@ -1543,9 +1524,8 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
         public List<Impact> getImpacts(int level) {
           if (level0LastDocID != NO_MORE_DOCS) {
             if (level == 0) {
-              level0SerializedImpactsIn.reset(
-                  level0SerializedImpacts.bytes, 0, level0SerializedImpacts.length);
-              readImpacts(level0SerializedImpactsIn, level0Impacts);
+              scratch.reset(level0SerializedImpacts.bytes, 0, level0SerializedImpacts.length);
+              readImpacts(scratch, level0Impacts);
               return level0Impacts;
             }
             level--;
@@ -1553,12 +1533,10 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
           if (level1LastDocID != NO_MORE_DOCS) {
             if (level == 0) {
-              level1SerializedImpactsIn.reset(
-                  level1SerializedImpacts.bytes, 0, level1SerializedImpacts.length);
-              readImpacts(level1SerializedImpactsIn, level1Impacts);
+              scratch.reset(level1SerializedImpacts.bytes, 0, level1SerializedImpacts.length);
+              readImpacts(scratch, level1Impacts);
               return level1Impacts;
             }
-            level--;
           }
 
           return Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
@@ -1574,9 +1552,8 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
   final class BlockImpactsPostingsEnum extends ImpactsEnum {
 
-    final ForUtil forUtil = new ForUtil();
     final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
-    final PForUtil pforUtil = new PForUtil(forUtil);
+    final PForUtil pforUtil = new PForUtil(new ForUtil());
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];
     private final long[] freqBuffer = new long[BLOCK_SIZE];
@@ -1585,21 +1562,19 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     private int docBufferUpto;
     private int posBufferUpto;
 
-    final IndexInput startDocIn;
-
     final IndexInput docIn;
     final PostingDecodingUtil docInUtil;
     final IndexInput posIn;
     final PostingDecodingUtil posInUtil;
 
     final boolean indexHasFreq;
-    final boolean indexHasPos;
     final boolean indexHasOffsets;
     final boolean indexHasPayloads;
     final boolean indexHasOffsetsOrPayloads;
 
-    private int docFreq; // number of docs in this posting list
-    private long totalTermFreq; // sum of freqBuffer in this posting list (or docFreq when omitted)
+    private final int docFreq; // number of docs in this posting list
+    private final long
+        totalTermFreq; // sum of freqBuffer in this posting list (or docFreq when omitted)
     private int docCountUpto; // number of docs in or before the current block
     private int doc; // doc we last read
     private long prevDocID; // last doc ID of the previous block
@@ -1610,16 +1585,15 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     // skip these to "catch up":
     private long posPendingCount;
 
-    // Where this term's postings start in the .pos file:
-    private long posTermStartFP;
-
     // File pointer where the last (vInt encoded) pos delta
     // block is.  We need this to know whether to bulk
     // decode vs vInt decode the block:
-    private long lastPosBlockFP;
+    private final long lastPosBlockFP;
 
     // true if we shallow-advanced to a new block that we have not decoded yet
     private boolean needsRefilling;
+
+    private final ByteArrayDataInput scratch = new ByteArrayDataInput();
 
     // level 0 skip data
     private int level0LastDocID;
@@ -1627,7 +1601,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     private long level0PosEndFP;
     private int level0BlockPosUpto;
     private final BytesRefBuilder level0SerializedImpacts = new BytesRefBuilder();
-    private final ByteArrayDataInput level0SerializedImpactsIn = new ByteArrayDataInput();
     private final MutableImpactList level0Impacts;
     // level 1 skip data
     private int level1LastDocID;
@@ -1636,17 +1609,13 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     private long level1PosEndFP;
     private int level1BlockPosUpto;
     private final BytesRefBuilder level1SerializedImpacts = new BytesRefBuilder();
-    private final ByteArrayDataInput level1SerializedImpactsIn = new ByteArrayDataInput();
     private final MutableImpactList level1Impacts;
 
-    private int singletonDocID; // docid when there is a single pulsed posting, otherwise -1
+    private final int singletonDocID; // docid when there is a single pulsed posting, otherwise -1
 
     public BlockImpactsPostingsEnum(FieldInfo fieldInfo, IntBlockTermState termState)
         throws IOException {
-      this.startDocIn = Lucene912PostingsReader.this.docIn;
       indexHasFreq = fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) >= 0;
-      indexHasPos =
-          fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;
       indexHasOffsets =
           fieldInfo
                   .getIndexOptions()
@@ -1663,11 +1632,12 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
       docBuffer[BLOCK_SIZE] = NO_MORE_DOCS;
 
       docFreq = termState.docFreq;
-      posTermStartFP = termState.posStartFP;
+      // Where this term's postings start in the .pos file:
+      final long posTermStartFP = termState.posStartFP;
       totalTermFreq = termState.totalTermFreq;
       singletonDocID = termState.singletonDocID;
       if (docFreq > 1) {
-        docIn = startDocIn.clone();
+        docIn = Lucene912PostingsReader.this.docIn.clone();
         docInUtil = VECTORIZATION_PROVIDER.newPostingDecodingUtil(docIn);
         prefetchPostings(docIn, termState);
       } else {
@@ -1710,7 +1680,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     }
 
     @Override
-    public int freq() throws IOException {
+    public int freq() {
       return freq;
     }
 
@@ -1850,7 +1820,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     }
 
     @Override
-    public Impacts getImpacts() throws IOException {
+    public Impacts getImpacts() {
       return new Impacts() {
 
         @Override
@@ -1881,7 +1851,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
             if (level == 0) {
               return level1LastDocID;
             }
-            level--;
           }
 
           return NO_MORE_DOCS;
@@ -1891,9 +1860,8 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
         public List<Impact> getImpacts(int level) {
           if (level0LastDocID != NO_MORE_DOCS) {
             if (level == 0) {
-              level0SerializedImpactsIn.reset(
-                  level0SerializedImpacts.bytes(), 0, level0SerializedImpacts.length());
-              readImpacts(level0SerializedImpactsIn, level0Impacts);
+              scratch.reset(level0SerializedImpacts.bytes(), 0, level0SerializedImpacts.length());
+              readImpacts(scratch, level0Impacts);
               return level0Impacts;
             }
             level--;
@@ -1901,12 +1869,10 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
           if (level1LastDocID != NO_MORE_DOCS) {
             if (level == 0) {
-              level1SerializedImpactsIn.reset(
-                  level1SerializedImpacts.bytes(), 0, level1SerializedImpacts.length());
-              readImpacts(level1SerializedImpactsIn, level1Impacts);
+              scratch.reset(level1SerializedImpacts.bytes(), 0, level1SerializedImpacts.length());
+              readImpacts(scratch, level1Impacts);
               return level1Impacts;
             }
-            level--;
           }
 
           return Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
@@ -1962,7 +1928,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
         toSkip -= leftInBlock;
         while (toSkip >= BLOCK_SIZE) {
           assert posIn.getFilePointer() != lastPosBlockFP;
-          pforUtil.skip(posIn);
+          PForUtil.skip(posIn);
           toSkip -= BLOCK_SIZE;
         }
         refillPositions();
@@ -2067,7 +2033,8 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     }
   }
 
-  private void prefetchPostings(IndexInput docIn, IntBlockTermState state) throws IOException {
+  private static void prefetchPostings(IndexInput docIn, IntBlockTermState state)
+      throws IOException {
     assert state.docFreq > 1; // Singletons are inlined in the terms dict, nothing to prefetch
     if (docIn.getFilePointer() != state.docStartFP) {
       // Don't prefetch if the input is already positioned at the right offset, which suggests that

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -235,13 +235,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
       DataInput in, FieldInfo fieldInfo, BlockTermState _termState, boolean absolute)
       throws IOException {
     final IntBlockTermState termState = (IntBlockTermState) _termState;
-    final boolean fieldHasPositions =
-        fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;
-    final boolean fieldHasOffsets =
-        fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS)
-            >= 0;
-    final boolean fieldHasPayloads = fieldInfo.hasPayloads();
-
     if (absolute) {
       termState.docStartFP = 0;
       termState.posStartFP = 0;
@@ -262,9 +255,13 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
       termState.singletonDocID += BitUtil.zigZagDecode(l >>> 1);
     }
 
-    if (fieldHasPositions) {
+    if (fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0) {
       termState.posStartFP += in.readVLong();
-      if (fieldHasOffsets || fieldHasPayloads) {
+      if (fieldInfo
+                  .getIndexOptions()
+                  .compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS)
+              >= 0
+          || fieldInfo.hasPayloads()) {
         termState.payStartFP += in.readVLong();
       }
       if (termState.totalTermFreq > BLOCK_SIZE) {
@@ -655,7 +652,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     final BytesRef payload;
 
     final boolean indexHasFreq;
-    final boolean indexHasPos;
     final boolean indexHasOffsets;
     final boolean indexHasPayloads;
     final boolean indexHasOffsetsOrPayloads;
@@ -700,8 +696,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     public EverythingEnum(FieldInfo fieldInfo) throws IOException {
       this.docIn = null;
       indexHasFreq = fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) >= 0;
-      indexHasPos =
-          fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;
       indexHasOffsets =
           fieldInfo
                   .getIndexOptions()
@@ -1217,7 +1211,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     final PostingDecodingUtil docInUtil;
     final boolean indexHasFreq;
     final boolean indexHasPos;
-    final boolean indexHasOffsetsOrPayloads;
 
     private final int docFreq; // number of docs in this posting list
     private int docCountUpto; // number of docs in or before the current block
@@ -1247,12 +1240,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
       indexHasFreq = fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) >= 0;
       indexHasPos =
           fieldInfo.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;
-      indexHasOffsetsOrPayloads =
-          fieldInfo
-                      .getIndexOptions()
-                      .compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS)
-                  >= 0
-              || fieldInfo.hasPayloads();
       // We set the last element of docBuffer to NO_MORE_DOCS, it helps save conditionals in
       // advance()
       docBuffer[BLOCK_SIZE] = NO_MORE_DOCS;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsWriter.java
@@ -342,7 +342,7 @@ public class Lucene912PostingsWriter extends PushPostingsWriterBase {
   }
 
   @Override
-  public void finishDoc() throws IOException {
+  public void finishDoc() {
     docBufferUpto++;
     docCount++;
 
@@ -443,7 +443,6 @@ public class Lucene912PostingsWriter extends PushPostingsWriterBase {
 
   private void writeLevel1SkipData() throws IOException {
     docOut.writeVInt(docID - level1LastDocID);
-    long numImpactBytes = scratchOutput.size();
     final long level1End;
     if (writeFreqs) {
       List<Impact> impacts = level1CompetitiveFreqNormAccumulator.getCompetitiveFreqNormPairs();
@@ -451,7 +450,7 @@ public class Lucene912PostingsWriter extends PushPostingsWriterBase {
         maxNumImpactsAtLevel1 = impacts.size();
       }
       writeImpacts(impacts, scratchOutput);
-      numImpactBytes = scratchOutput.size();
+      long numImpactBytes = scratchOutput.size();
       if (numImpactBytes > maxImpactNumBytesAtLevel1) {
         maxImpactNumBytesAtLevel1 = Math.toIntExact(numImpactBytes);
       }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/PForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/PForUtil.java
@@ -121,7 +121,7 @@ final class PForUtil {
   }
 
   /** Skip 128 integers. */
-  void skip(DataInput in) throws IOException {
+  static void skip(DataInput in) throws IOException {
     final int token = Byte.toUnsignedInt(in.readByte());
     final int bitsPerValue = token & 0x1f;
     final int numExceptions = token >>> 5;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForDeltaUtil.py
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForDeltaUtil.py
@@ -308,11 +308,6 @@ public final class ForDeltaUtil {
     }
   }
 
-  void skip(IndexInput in) throws IOException {
-    final int bitsPerValue = Byte.toUnsignedInt(in.readByte());
-    in.skipBytes(numBytes(bitsPerValue));
-  }
-
 """
 
 def primitive_size_for_bpv(bpv):

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
@@ -254,7 +254,7 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
     }
   }
 
-  private class FieldsReader extends DocValuesProducer {
+  private static class FieldsReader extends DocValuesProducer {
 
     private final Map<String, DocValuesProducer> fields = new HashMap<>();
     private final Map<String, DocValuesProducer> formats = new HashMap<>();

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestPForUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestPForUtil.java
@@ -46,7 +46,7 @@ public class TestPForUtil extends LuceneTestCase {
     final PForUtil pforUtil = new PForUtil(forUtil);
     for (int i = 0; i < iterations; ++i) {
       if (random().nextInt(5) == 0) {
-        pforUtil.skip(in);
+        PForUtil.skip(in);
         continue;
       }
       final long[] restored = new long[ForUtil.BLOCK_SIZE];


### PR DESCRIPTION
Removing some obvious dead code, turning some fields into locals that don't need to be fields, making things static and deduplicating duplicate "scratch" field.

Overall a small but measurable performance gain which can probably be attributed to saving field reads/writes + some cycles when creating instances of the impacts where a lot of fields could be saved:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                    OrNotHighLow     1559.88      (4.4%)     1559.66      (4.8%)   -0.0% (  -8% -    9%) 0.989
                        Wildcard      241.64      (4.5%)      243.87      (5.7%)    0.9% (  -8% -   11%) 0.420
               HighTermMonthSort     1608.93      (4.3%)     1629.45      (4.6%)    1.3% (  -7% -   10%) 0.201
                         Prefix3      677.36      (5.0%)      686.11      (3.9%)    1.3% (  -7% -   10%) 0.197
                         LowTerm      710.04      (3.6%)      719.66      (3.9%)    1.4% (  -5% -    9%) 0.106
           BrowseMonthTaxoFacets       11.89     (33.5%)       12.06     (35.3%)    1.4% ( -50% -  105%) 0.857
                        HighTerm      646.33      (5.4%)      655.38      (6.9%)    1.4% ( -10% -   14%) 0.312
                      OrHighHigh      118.45      (6.3%)      120.14      (5.9%)    1.4% ( -10% -   14%) 0.293
                 MedSloppyPhrase      134.50      (4.6%)      136.48      (5.4%)    1.5% (  -8% -   12%) 0.189
                    OrNotHighMed      480.99      (4.6%)      488.16      (4.8%)    1.5% (  -7% -   11%) 0.157
                      AndHighMed      136.46      (3.9%)      138.76      (4.3%)    1.7% (  -6% -   10%) 0.065
                      AndHighLow     1323.61      (4.5%)     1346.00      (5.6%)    1.7% (  -8% -   12%) 0.137
             LowIntervalsOrdered       58.35      (3.3%)       59.35      (3.1%)    1.7% (  -4% -    8%) 0.017
           HighTermDayOfYearSort      372.14      (7.4%)      378.92      (6.3%)    1.8% ( -11% -   16%) 0.237
            HighTermTitleBDVSort       27.43      (5.9%)       27.94      (6.6%)    1.9% ( -10% -   15%) 0.187
     BrowseRandomLabelSSDVFacets        3.36      (4.3%)        3.42      (4.5%)    1.9% (  -6% -   11%) 0.048
            MedTermDayTaxoFacets       12.00      (4.1%)       12.23      (4.2%)    1.9% (  -6% -   10%) 0.036
         AndHighMedDayTaxoFacets       76.82      (3.5%)       78.36      (3.0%)    2.0% (  -4% -    8%) 0.006
                        PKLookup      240.37      (2.2%)      245.17      (1.6%)    2.0% (  -1% -    5%) 0.000
                       OrHighMed      249.18      (3.8%)      254.27      (3.0%)    2.0% (  -4% -    9%) 0.007
                          Fuzzy2      101.61      (2.4%)      103.79      (2.6%)    2.1% (  -2% -    7%) 0.000
                    HighSpanNear       27.78      (4.9%)       28.39      (4.9%)    2.2% (  -7% -   12%) 0.047
           BrowseMonthSSDVFacets        4.47      (7.2%)        4.57      (7.1%)    2.3% ( -11% -   17%) 0.155
                      TermDTSort      154.84      (5.9%)      158.48      (5.2%)    2.3% (  -8% -   14%) 0.059
             MedIntervalsOrdered       89.79      (5.1%)       91.92      (4.0%)    2.4% (  -6% -   12%) 0.021
                    OrHighNotLow      628.00      (6.3%)      642.86      (6.4%)    2.4% (  -9% -   16%) 0.095
                     AndHighHigh      130.16      (3.9%)      133.38      (3.8%)    2.5% (  -4% -   10%) 0.004
                   OrNotHighHigh      548.82      (4.1%)      562.55      (4.1%)    2.5% (  -5% -   11%) 0.007
                    OrHighNotMed      667.58      (3.6%)      684.31      (5.2%)    2.5% (  -6% -   11%) 0.012
                   OrHighNotHigh      424.43      (4.5%)      435.54      (4.8%)    2.6% (  -6% -   12%) 0.012
     BrowseRandomLabelTaxoFacets        4.41      (4.3%)        4.52      (4.4%)    2.7% (  -5% -   11%) 0.006
                          Fuzzy1       95.00      (3.6%)       97.55      (4.0%)    2.7% (  -4% -   10%) 0.002
                     LowSpanNear      146.33      (2.8%)      150.30      (2.4%)    2.7% (  -2% -    8%) 0.000
        AndHighHighDayTaxoFacets       15.64      (4.1%)       16.07      (3.8%)    2.7% (  -4% -   11%) 0.002
                         Respell       39.55      (1.6%)       40.64      (1.7%)    2.8% (   0% -    6%) 0.000
       BrowseDayOfYearSSDVFacets        4.55      (7.4%)        4.68      (7.1%)    2.9% ( -10% -   18%) 0.076
                       LowPhrase      523.23      (4.8%)      538.51      (3.2%)    2.9% (  -4% -   11%) 0.001
                      HighPhrase       34.62      (2.6%)       35.65      (3.5%)    3.0% (  -3% -    9%) 0.000
                       OrHighLow      668.71      (5.1%)      688.65      (4.7%)    3.0% (  -6% -   13%) 0.006
                 LowSloppyPhrase      181.31      (6.4%)      186.78      (5.5%)    3.0% (  -8% -   15%) 0.024
               HighTermTitleSort       73.86      (4.4%)       76.09      (3.8%)    3.0% (  -4% -   11%) 0.001
                       MedPhrase      165.13      (3.2%)      170.62      (4.3%)    3.3% (  -4% -   11%) 0.000
                         MedTerm      613.70      (6.0%)      634.71      (5.4%)    3.4% (  -7% -   15%) 0.008
          OrHighMedDayTaxoFacets        5.88      (6.9%)        6.08      (7.2%)    3.4% (  -9% -   18%) 0.029
            BrowseDateSSDVFacets        1.27      (4.2%)        1.32      (8.1%)    3.7% (  -8% -   16%) 0.010
            BrowseDateTaxoFacets        5.21      (9.6%)        5.43     (10.8%)    4.2% ( -14% -   27%) 0.066
                     MedSpanNear       34.35      (1.6%)       35.84      (2.9%)    4.3% (   0% -    8%) 0.000
       BrowseDayOfYearTaxoFacets        5.28      (9.6%)        5.52     (10.6%)    4.4% ( -14% -   27%) 0.052
                HighSloppyPhrase       26.34      (4.1%)       27.55      (3.8%)    4.6% (  -3% -   13%) 0.000
            HighIntervalsOrdered        8.14      (4.7%)        8.53      (5.0%)    4.8% (  -4% -   15%) 0.000
                          IntNRQ       67.50      (8.6%)       70.99      (7.6%)    5.2% ( -10% -   23%) 0.004
```