### PR TITLE
Reduce allocations in ByteBuffersDataOutput.writeString

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import org.apache.lucene.util.BitUtil;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.GroupVIntUtil;
-import org.apache.lucene.util.UnicodeUtil;
 
 /**
  * Abstract base class for performing write operations of Lucene's low-level data types.
@@ -269,10 +269,9 @@ public abstract class DataOutput {
    * @see DataInput#readString()
    */
   public void writeString(String s) throws IOException {
-    final byte[] utf8Result = new byte[UnicodeUtil.calcUTF16toUTF8Length(s, 0, s.length())];
-    UnicodeUtil.UTF16toUTF8(s, 0, s.length(), utf8Result);
+    final BytesRef utf8Result = new BytesRef(s);
     writeVInt(utf8Result.length);
-    writeBytes(utf8Result, 0, utf8Result.length);
+    writeBytes(utf8Result.bytes, utf8Result.offset, utf8Result.length);
   }
 
   private static int COPY_BUFFER_SIZE = 16384;

--- a/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import org.apache.lucene.util.BitUtil;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.GroupVIntUtil;
+import org.apache.lucene.util.UnicodeUtil;
 
 /**
  * Abstract base class for performing write operations of Lucene's low-level data types.
@@ -269,9 +269,10 @@ public abstract class DataOutput {
    * @see DataInput#readString()
    */
   public void writeString(String s) throws IOException {
-    final BytesRef utf8Result = new BytesRef(s);
+    final byte[] utf8Result = new byte[UnicodeUtil.calcUTF16toUTF8Length(s, 0, s.length())];
+    UnicodeUtil.UTF16toUTF8(s, 0, s.length(), utf8Result);
     writeVInt(utf8Result.length);
-    writeBytes(utf8Result.bytes, utf8Result.offset, utf8Result.length);
+    writeBytes(utf8Result, 0, utf8Result.length);
   }
 
   private static int COPY_BUFFER_SIZE = 16384;


### PR DESCRIPTION
Saw this in the nightly benchmark indexing run profiling:

There's no need to allocate a byte array when serializing to heap buffers and the string fits the remaining capacity without further bounds checks. If it doesn't fit we could technically do better than the current `writeLongString` and avoid one round of copying by chunking the string but that might not be worth the complexity.
In either case we can calculate the utf8 length up-front. While this costs extra cycles (in the small case) for iterating the string twice it saves creating an oftentimes 3x oversized byte array, a `BytesRef`, field reads from the `BytesRef`, copying from it to the buffer and the associated GC with cleaning it up. Theory and some quick benchmarking suggests this version is likely faster for any string length than the existing code.
