### PR TITLE
Make DirectMonotonicReader.Meta more compact

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/packed/DirectWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/DirectWriter.java
@@ -153,6 +153,18 @@ public final class DirectWriter {
     // for every number of bits per value, we want to be able to read the entire value in a single
     // read e.g. for 20 bits per value, we want to be able to read values using ints so we need
     // 32 - 20 = 12 bits of padding
+    int paddingBitsNeeded = paddingBitsNeeded(bitsPerValue);
+    assert paddingBitsNeeded >= 0;
+    final int paddingBytesNeeded = (paddingBitsNeeded + Byte.SIZE - 1) / Byte.SIZE;
+    assert paddingBytesNeeded <= 3;
+
+    for (int i = 0; i < paddingBytesNeeded; i++) {
+      output.writeByte((byte) 0);
+    }
+    finished = true;
+  }
+
+  public static int paddingBitsNeeded(int bitsPerValue) {
     int paddingBitsNeeded;
     if (bitsPerValue > Integer.SIZE) {
       paddingBitsNeeded = Long.SIZE - bitsPerValue;
@@ -163,14 +175,7 @@ public final class DirectWriter {
     } else {
       paddingBitsNeeded = 0;
     }
-    assert paddingBitsNeeded >= 0;
-    final int paddingBytesNeeded = (paddingBitsNeeded + Byte.SIZE - 1) / Byte.SIZE;
-    assert paddingBytesNeeded <= 3;
-
-    for (int i = 0; i < paddingBytesNeeded; i++) {
-      output.writeByte((byte) 0);
-    }
-    finished = true;
+    return paddingBitsNeeded;
   }
 
   /** Returns an instance suitable for encoding {@code numValues} using {@code bitsPerValue} */


### PR DESCRIPTION
Even with the all-zero bit-length optimization recently introduced, these `Meta` instances tend to consume a non-trivial amount of heap still. We can do away with almost 40% of their size by removing the offsets array that can be calculated on the fly when creating the readers which translates into tens of MB of heap or more for some ES use cases with high segment + field count.
Also added a singleton `DirectMonotonicReader` instance for the common all-zero-values that we have a `Meta` singleton for already.