### PR TITLE
Speedup MaxScoreCache.computeMaxScore

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/Impacts.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Impacts.java
@@ -40,7 +40,8 @@ public abstract class Impacts {
   /**
    * Return impacts on the given level. These impacts are sorted by increasing frequency and
    * increasing unsigned norm, and only valid until the doc ID returned by {@link
-   * #getDocIdUpTo(int)} for the same level, included. The returned list is never empty. NOTE: There
+   * #getDocIdUpTo(int)} for the same level, included. The returned list is never empty and should
+   * implement {@link java.util.RandomAccess} if it contains more than a single element. NOTE: There
    * is no guarantee that these impacts actually appear in postings, only that they trigger scores
    * that are greater than or equal to the impacts that actually appear in postings.
    */

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreCache.java
@@ -19,7 +19,6 @@ package org.apache.lucene.search;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.RandomAccess;
 import org.apache.lucene.index.Impact;
 import org.apache.lucene.index.Impacts;
 import org.apache.lucene.index.ImpactsSource;
@@ -71,21 +70,10 @@ public final class MaxScoreCache {
   }
 
   private float computeMaxScore(List<Impact> impacts) {
-    if (impacts instanceof RandomAccess) {
-      float maxScore = 0;
-      var scorer = this.scorer;
-      for (int i = 0, length = impacts.size(); i < length; i++) {
-        Impact impact = impacts.get(i);
-        maxScore = Math.max(scorer.score(impact.freq, impact.norm), maxScore);
-      }
-      return maxScore;
-    }
-    return maxScoreSlowList(impacts);
-  }
-
-  private float maxScoreSlowList(List<Impact> impacts) {
     float maxScore = 0;
-    for (Impact impact : impacts) {
+    var scorer = this.scorer;
+    for (int i = 0, length = impacts.size(); i < length; i++) {
+      Impact impact = impacts.get(i);
       maxScore = Math.max(scorer.score(impact.freq, impact.norm), maxScore);
     }
     return maxScore;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.RandomAccess;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesSkipIndexType;
@@ -700,7 +701,10 @@ public class AssertingLeafReader extends FilterLeafReader {
     public List<Impact> getImpacts(int level) {
       assert validFor == Math.max(impactsEnum.docID(), impactsEnum.lastShallowTarget)
           : "Cannot reuse impacts after advancing the iterator";
-      return in.getImpacts(level);
+      List<Impact> impacts = in.getImpacts(level);
+      assert impacts.size() <= 1 || impacts instanceof RandomAccess
+          : "impact lists longer than 1 should implement RandomAccess but saw impacts = " + impacts;
+      return impacts;
     }
   }
 


### PR DESCRIPTION
This shows up as allocating tens of GB for iterators in the nightly benchmarks. We should go the zero-allocation route for RandomAccess lists which I'd expect 100% of them will be here for a bit of a speedup.

Deals with spots like this one:

```
0.95%         9914M         java.util.AbstractList#iterator() [Inlined code]
                              at org.apache.lucene.search.MaxScoreCache#computeMaxScore() [Inlined code]
                              at org.apache.lucene.search.MaxScoreCache#getMaxScoreForLevel() [Inlined code]
                              at org.apache.lucene.search.MaxScoreCache#getMaxScore() [Inlined code]
                              at org.apache.lucene.search.TermScorer#getMaxScore() [JIT compiled code]
                              at org.apache.lucene.search.MaxScoreBulkScorer#updateMaxWindowScores() [Inlined code]
                              at org.apache.lucene.search.MaxScoreBulkScorer#score() [JIT compiled code]
                              at org.apache.lucene.search.IndexSearcher#searchLeaf() [Inlined code]
                              at org.apache.lucene.search.IndexSearcher#search() [Inlined code]
                              at org.apache.lucene.search.IndexSearcher#lambda$search$2() [Inlined code]
                              at org.apache.lucene.search.IndexSearcher$$Lambda+0x00007ff7491c1208.712410791#call() [JIT compiled code]
```

No big wins in wikimedium as expected but some small but significant ones still:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
           BrowseMonthTaxoFacets       12.21     (33.1%)       11.34     (36.9%)   -7.1% ( -57% -   94%) 0.363
                      AndHighLow     1351.38      (3.2%)     1349.23      (4.5%)   -0.2% (  -7% -    7%) 0.856
                        Wildcard      148.01      (4.0%)      148.30      (4.6%)    0.2% (  -8% -    9%) 0.840
                    OrNotHighLow     1225.79      (3.5%)     1229.78      (4.2%)    0.3% (  -7% -    8%) 0.709
               HighTermMonthSort     1593.19      (4.3%)     1603.01      (4.6%)    0.6% (  -7% -    9%) 0.537
                          Fuzzy1      124.84      (1.9%)      125.83      (2.1%)    0.8% (  -3% -    4%) 0.078
       BrowseDayOfYearTaxoFacets        5.49     (10.1%)        5.53     (10.1%)    0.8% ( -17% -   23%) 0.718
                          IntNRQ       85.67      (8.9%)       86.38      (7.5%)    0.8% ( -14% -   18%) 0.651
                       OrHighMed      247.21      (5.2%)      249.32      (5.1%)    0.9% (  -9% -   11%) 0.462
                         LowTerm      778.48      (6.0%)      785.47      (5.2%)    0.9% (  -9% -   12%) 0.473
            BrowseDateTaxoFacets        5.42     (10.4%)        5.47     (10.0%)    0.9% ( -17% -   23%) 0.686
                       OrHighLow      861.35      (3.0%)      869.35      (3.5%)    0.9% (  -5% -    7%) 0.200
                      TermDTSort      154.51      (5.2%)      156.11      (5.2%)    1.0% (  -8% -   12%) 0.373
                        PKLookup      241.50      (1.8%)      244.05      (2.3%)    1.1% (  -3% -    5%) 0.023
     BrowseRandomLabelTaxoFacets        4.53      (9.2%)        4.58      (9.0%)    1.1% ( -15% -   21%) 0.601
         AndHighMedDayTaxoFacets      180.40      (2.7%)      182.41      (2.8%)    1.1% (  -4% -    6%) 0.067
                       LowPhrase      240.05      (3.9%)      242.78      (3.6%)    1.1% (  -6% -    9%) 0.179
            BrowseDateSSDVFacets        1.28      (6.3%)        1.29      (7.0%)    1.1% ( -11% -   15%) 0.444
            MedTermDayTaxoFacets       37.21      (2.6%)       37.73      (2.6%)    1.4% (  -3% -    6%) 0.018
                          Fuzzy2       78.93      (2.1%)       80.12      (2.3%)    1.5% (  -2% -    6%) 0.002
            HighTermTitleBDVSort       19.57      (7.5%)       19.87      (9.6%)    1.5% ( -14% -   20%) 0.431
        AndHighHighDayTaxoFacets       42.57      (3.2%)       43.25      (3.3%)    1.6% (  -4% -    8%) 0.032
               HighTermTitleSort       69.00      (3.9%)       70.10      (4.2%)    1.6% (  -6% -   10%) 0.078
                 LowSloppyPhrase      179.21      (4.7%)      182.12      (3.7%)    1.6% (  -6% -   10%) 0.085
                     LowSpanNear       46.63      (2.2%)       47.40      (1.8%)    1.7% (  -2% -    5%) 0.000
           BrowseMonthSSDVFacets        4.56     (10.3%)        4.64      (7.4%)    1.7% ( -14% -   21%) 0.399
                      AndHighMed      379.00      (4.9%)      385.43      (4.4%)    1.7% (  -7% -   11%) 0.102
                         Respell       41.39      (1.2%)       42.12      (1.2%)    1.8% (   0% -    4%) 0.000
             LowIntervalsOrdered       33.80      (4.1%)       34.45      (5.2%)    1.9% (  -7% -   11%) 0.065
                   OrHighNotHigh      375.88      (9.9%)      383.33      (9.1%)    2.0% ( -15% -   23%) 0.351
                 MedSloppyPhrase       25.78      (3.9%)       26.30      (2.8%)    2.0% (  -4% -    9%) 0.008
                         Prefix3      965.50      (3.2%)      985.63      (3.2%)    2.1% (  -4% -    8%) 0.004
                    HighSpanNear       18.13      (5.8%)       18.51      (8.2%)    2.1% ( -11% -   17%) 0.179
                    OrNotHighMed      323.77      (5.7%)      330.79      (4.4%)    2.2% (  -7% -   12%) 0.056
                      HighPhrase      125.98      (6.3%)      128.95      (7.5%)    2.4% ( -10% -   17%) 0.128
                      OrHighHigh      116.07      (8.0%)      118.87      (7.7%)    2.4% ( -12% -   19%) 0.169
                       MedPhrase      106.85      (4.0%)      109.63      (4.3%)    2.6% (  -5% -   11%) 0.005
             MedIntervalsOrdered      110.26      (8.7%)      113.19      (9.5%)    2.7% ( -14% -   22%) 0.193
                     MedSpanNear      112.49      (2.1%)      115.50      (1.9%)    2.7% (  -1% -    6%) 0.000
                         MedTerm      607.30      (6.3%)      624.17      (5.5%)    2.8% (  -8% -   15%) 0.035
          OrHighMedDayTaxoFacets       12.10      (4.0%)       12.45      (3.9%)    2.8% (  -4% -   11%) 0.001
                    OrHighNotLow      426.78      (5.9%)      439.68      (5.6%)    3.0% (  -8% -   15%) 0.019
           HighTermDayOfYearSort      396.15      (5.8%)      408.49      (6.9%)    3.1% (  -9% -   16%) 0.029
                HighSloppyPhrase       28.22      (7.6%)       29.10      (6.4%)    3.1% ( -10% -   18%) 0.047
       BrowseDayOfYearSSDVFacets        4.60      (7.0%)        4.75     (10.5%)    3.2% ( -13% -   22%) 0.109
                        HighTerm      688.69      (7.0%)      711.75      (5.8%)    3.3% (  -8% -   17%) 0.020
                     AndHighHigh      122.44      (3.1%)      126.70      (3.7%)    3.5% (  -3% -   10%) 0.000
            HighIntervalsOrdered       47.94      (9.1%)       49.64      (9.0%)    3.5% ( -13% -   23%) 0.081
                   OrNotHighHigh      451.85      (3.3%)      468.01      (3.8%)    3.6% (  -3% -   11%) 0.000
     BrowseRandomLabelSSDVFacets        3.36      (3.9%)        3.48      (5.2%)    3.7% (  -5% -   13%) 0.000
                    OrHighNotMed      640.39      (5.7%)      666.69      (4.9%)    4.1% (  -6% -   15%) 0.001

```