### PR TITLE
Make MaxScoreAccumulator use primitive long instead Object return

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreAccumulator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreAccumulator.java
@@ -35,8 +35,8 @@ final class MaxScoreAccumulator {
   }
 
   /**
-   * Return the max encoded DocAndScore in a way that is consistent with {@link
-   * DocAndScore#compareTo}.
+   * Return the max encoded docId and score found in the two longs, following the encoding in {@link
+   * #accumulate}.
    */
   private static long maxEncode(long v1, long v2) {
     float score1 = Float.intBitsToFloat((int) (v1 >> 32));
@@ -57,26 +57,15 @@ final class MaxScoreAccumulator {
     acc.accumulate(encode);
   }
 
-  DocAndScore get() {
-    long value = acc.get();
-    if (value == Long.MIN_VALUE) {
-      return null;
-    }
-    float score = Float.intBitsToFloat((int) (value >> 32));
-    int docId = (int) value;
-    return new DocAndScore(docId, score);
+  public static float toScore(long value) {
+    return Float.intBitsToFloat((int) (value >> 32));
   }
 
-  record DocAndScore(int docId, float score) implements Comparable<DocAndScore> {
+  public static int docId(long value) {
+    return (int) value;
+  }
 
-    @Override
-    public int compareTo(DocAndScore o) {
-      int cmp = Float.compare(score, o.score);
-      if (cmp == 0) {
-        // tie-break on doc id, lower id has the priority
-        return Integer.compare(o.docId, docId);
-      }
-      return cmp;
-    }
+  long getRaw() {
+    return acc.get();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.search.FieldValueHitQueue.Entry;
-import org.apache.lucene.search.MaxScoreAccumulator.DocAndScore;
 import org.apache.lucene.search.TotalHits.Relation;
 
 /**
@@ -366,10 +365,12 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
       // we can start checking the global maximum score even
       // if the local queue is not full because the threshold
       // is reached.
-      DocAndScore maxMinScore = minScoreAcc.get();
-      if (maxMinScore != null && maxMinScore.score() > minCompetitiveScore) {
-        scorer.setMinCompetitiveScore(maxMinScore.score());
-        minCompetitiveScore = maxMinScore.score();
+      long maxMinScore = minScoreAcc.getRaw();
+      float score;
+      if (maxMinScore != Long.MIN_VALUE
+          && (score = MaxScoreAccumulator.toScore(maxMinScore)) > minCompetitiveScore) {
+        scorer.setMinCompetitiveScore(score);
+        minCompetitiveScore = score;
         totalHitsRelation = TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestMaxScoreAccumulator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMaxScoreAccumulator.java
@@ -23,44 +23,28 @@ public class TestMaxScoreAccumulator extends LuceneTestCase {
   public void testSimple() {
     MaxScoreAccumulator acc = new MaxScoreAccumulator();
     acc.accumulate(0, 0f);
-    assertEquals(0f, acc.get().score(), 0);
-    assertEquals(0, acc.get().docId(), 0);
+    assertEquals(0f, MaxScoreAccumulator.toScore(acc.getRaw()), 0);
+    assertEquals(0, MaxScoreAccumulator.docId(acc.getRaw()), 0);
     acc.accumulate(10, 0f);
-    assertEquals(0f, acc.get().score(), 0);
-    assertEquals(0, acc.get().docId(), 0);
+    assertEquals(0f, MaxScoreAccumulator.toScore(acc.getRaw()), 0);
+    assertEquals(0, MaxScoreAccumulator.docId(acc.getRaw()), 0);
     acc.accumulate(100, 1000f);
-    assertEquals(1000f, acc.get().score(), 0);
-    assertEquals(100, acc.get().docId(), 0);
+    assertEquals(1000f, MaxScoreAccumulator.toScore(acc.getRaw()), 0);
+    assertEquals(100, MaxScoreAccumulator.docId(acc.getRaw()), 0);
     acc.accumulate(1000, 5f);
-    assertEquals(1000f, acc.get().score(), 0);
-    assertEquals(100, acc.get().docId(), 0);
+    assertEquals(1000f, MaxScoreAccumulator.toScore(acc.getRaw()), 0);
+    assertEquals(100, MaxScoreAccumulator.docId(acc.getRaw()), 0);
     acc.accumulate(99, 1000f);
-    assertEquals(1000f, acc.get().score(), 0);
-    assertEquals(99, acc.get().docId(), 0);
+    assertEquals(1000f, MaxScoreAccumulator.toScore(acc.getRaw()), 0);
+    assertEquals(99, MaxScoreAccumulator.docId(acc.getRaw()), 0);
     acc.accumulate(1000, 1001f);
-    assertEquals(1001f, acc.get().score(), 0);
-    assertEquals(1000, acc.get().docId(), 0);
+    assertEquals(1001f, MaxScoreAccumulator.toScore(acc.getRaw()), 0);
+    assertEquals(1000, MaxScoreAccumulator.docId(acc.getRaw()), 0);
     acc.accumulate(10, 1001f);
-    assertEquals(1001f, acc.get().score(), 0);
-    assertEquals(10, acc.get().docId(), 0);
+    assertEquals(1001f, MaxScoreAccumulator.toScore(acc.getRaw()), 0);
+    assertEquals(10, MaxScoreAccumulator.docId(acc.getRaw()), 0);
     acc.accumulate(100, 1001f);
-    assertEquals(1001f, acc.get().score(), 0);
-    assertEquals(10, acc.get().docId(), 0);
-  }
-
-  public void testRandom() {
-    MaxScoreAccumulator acc = new MaxScoreAccumulator();
-    int numDocs = atLeast(100);
-    int maxDocs = atLeast(10000);
-    MaxScoreAccumulator.DocAndScore max = new MaxScoreAccumulator.DocAndScore(-1, -1);
-    for (int i = 0; i < numDocs; i++) {
-      MaxScoreAccumulator.DocAndScore res =
-          new MaxScoreAccumulator.DocAndScore(random().nextInt(maxDocs), random().nextFloat());
-      acc.accumulate(res.docId(), res.score());
-      if (res.compareTo(max) > 0) {
-        max = res;
-      }
-    }
-    assertEquals(max, acc.get());
+    assertEquals(1001f, MaxScoreAccumulator.toScore(acc.getRaw()), 0);
+    assertEquals(10, MaxScoreAccumulator.docId(acc.getRaw()), 0);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -519,47 +519,47 @@ public class TestTopDocsCollector extends LuceneTestCase {
 
     scorer.score = 3;
     leafCollector.collect(0);
-    assertNull(minValueChecker.get());
+    assertEquals(Long.MIN_VALUE, minValueChecker.getRaw());
     assertNull(scorer.minCompetitiveScore);
 
     scorer2.score = 6;
     leafCollector2.collect(0);
-    assertNull(minValueChecker.get());
+    assertEquals(Long.MIN_VALUE, minValueChecker.getRaw());
     assertNull(scorer2.minCompetitiveScore);
 
     scorer.score = 2;
     leafCollector.collect(1);
-    assertEquals(2f, minValueChecker.get().score(), 0f);
+    assertEquals(2f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(Math.nextUp(2f), scorer.minCompetitiveScore, 0f);
     assertNull(scorer2.minCompetitiveScore);
 
     scorer2.score = 9;
     leafCollector2.collect(1);
-    assertEquals(6f, minValueChecker.get().score(), 0f);
+    assertEquals(6f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(Math.nextUp(2f), scorer.minCompetitiveScore, 0f);
     assertEquals(Math.nextUp(6f), scorer2.minCompetitiveScore, 0f);
 
     scorer2.score = 7;
     leafCollector2.collect(2);
-    assertEquals(minValueChecker.get().score(), 7f, 0f);
+    assertEquals(MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 7f, 0f);
     assertEquals(Math.nextUp(2f), scorer.minCompetitiveScore, 0f);
     assertEquals(Math.nextUp(7f), scorer2.minCompetitiveScore, 0f);
 
     scorer2.score = 1;
     leafCollector2.collect(3);
-    assertEquals(minValueChecker.get().score(), 7f, 0f);
+    assertEquals(MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 7f, 0f);
     assertEquals(Math.nextUp(2f), scorer.minCompetitiveScore, 0f);
     assertEquals(Math.nextUp(7f), scorer2.minCompetitiveScore, 0f);
 
     scorer.score = 10;
     leafCollector.collect(2);
-    assertEquals(minValueChecker.get().score(), 7f, 0f);
+    assertEquals(MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 7f, 0f);
     assertEquals(7f, scorer.minCompetitiveScore, 0f);
     assertEquals(Math.nextUp(7f), scorer2.minCompetitiveScore, 0f);
 
     scorer.score = 11;
     leafCollector.collect(3);
-    assertEquals(minValueChecker.get().score(), 10, 0f);
+    assertEquals(MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 10, 0f);
     assertEquals(Math.nextUp(10f), scorer.minCompetitiveScore, 0f);
     assertEquals(Math.nextUp(7f), scorer2.minCompetitiveScore, 0f);
 
@@ -571,19 +571,19 @@ public class TestTopDocsCollector extends LuceneTestCase {
 
     scorer3.score = 1f;
     leafCollector3.collect(0);
-    assertEquals(10f, minValueChecker.get().score(), 0f);
+    assertEquals(10f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(Math.nextUp(10f), scorer3.minCompetitiveScore, 0f);
 
     scorer.score = 11;
     leafCollector.collect(4);
-    assertEquals(11f, minValueChecker.get().score(), 0f);
+    assertEquals(11f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(Math.nextUp(11f), scorer.minCompetitiveScore, 0f);
     assertEquals(Math.nextUp(7f), scorer2.minCompetitiveScore, 0f);
     assertEquals(Math.nextUp(10f), scorer3.minCompetitiveScore, 0f);
 
     scorer3.score = 2f;
     leafCollector3.collect(1);
-    assertEquals(minValueChecker.get().score(), 11f, 0f);
+    assertEquals(MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 11f, 0f);
     assertEquals(Math.nextUp(11f), scorer.minCompetitiveScore, 0f);
     assertEquals(Math.nextUp(7f), scorer2.minCompetitiveScore, 0f);
     assertEquals(Math.nextUp(11f), scorer3.minCompetitiveScore, 0f);

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -577,47 +577,47 @@ public class TestTopFieldCollector extends LuceneTestCase {
 
     scorer.score = 3;
     leafCollector.collect(0);
-    assertNull(minValueChecker.get());
+    assertEquals(Long.MIN_VALUE, minValueChecker.getRaw());
     assertNull(scorer.minCompetitiveScore);
 
     scorer2.score = 6;
     leafCollector2.collect(0);
-    assertNull(minValueChecker.get());
+    assertEquals(Long.MIN_VALUE, minValueChecker.getRaw());
     assertNull(scorer2.minCompetitiveScore);
 
     scorer.score = 2;
     leafCollector.collect(1);
-    assertEquals(2f, minValueChecker.get().score(), 0f);
+    assertEquals(2f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(2f, scorer.minCompetitiveScore, 0f);
     assertNull(scorer2.minCompetitiveScore);
 
     scorer2.score = 9;
     leafCollector2.collect(1);
-    assertEquals(6f, minValueChecker.get().score(), 0f);
+    assertEquals(6f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(2f, scorer.minCompetitiveScore, 0f);
     assertEquals(6f, scorer2.minCompetitiveScore, 0f);
 
     scorer2.score = 7;
     leafCollector2.collect(2);
-    assertEquals(7f, minValueChecker.get().score(), 0f);
+    assertEquals(7f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(2f, scorer.minCompetitiveScore, 0f);
     assertEquals(7f, scorer2.minCompetitiveScore, 0f);
 
     scorer2.score = 1;
     leafCollector2.collect(3);
-    assertEquals(7f, minValueChecker.get().score(), 0f);
+    assertEquals(7f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(2f, scorer.minCompetitiveScore, 0f);
     assertEquals(7f, scorer2.minCompetitiveScore, 0f);
 
     scorer.score = 10;
     leafCollector.collect(2);
-    assertEquals(7f, minValueChecker.get().score(), 0f);
+    assertEquals(7f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(7f, scorer.minCompetitiveScore, 0f);
     assertEquals(7f, scorer2.minCompetitiveScore, 0f);
 
     scorer.score = 11;
     leafCollector.collect(3);
-    assertEquals(10f, minValueChecker.get().score(), 0f);
+    assertEquals(10f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(10f, scorer.minCompetitiveScore, 0f);
     assertEquals(7f, scorer2.minCompetitiveScore, 0f);
 
@@ -629,19 +629,19 @@ public class TestTopFieldCollector extends LuceneTestCase {
 
     scorer3.score = 1f;
     leafCollector3.collect(0);
-    assertEquals(10f, minValueChecker.get().score(), 0f);
+    assertEquals(10f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(10f, scorer3.minCompetitiveScore, 0f);
 
     scorer.score = 11;
     leafCollector.collect(4);
-    assertEquals(11f, minValueChecker.get().score(), 0f);
+    assertEquals(11f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(11f, scorer.minCompetitiveScore, 0f);
     assertEquals(7f, scorer2.minCompetitiveScore, 0f);
     assertEquals(10f, scorer3.minCompetitiveScore, 0f);
 
     scorer3.score = 2f;
     leafCollector3.collect(1);
-    assertEquals(11f, minValueChecker.get().score(), 0f);
+    assertEquals(11f, MaxScoreAccumulator.toScore(minValueChecker.getRaw()), 0f);
     assertEquals(11f, scorer.minCompetitiveScore, 0f);
     assertEquals(7f, scorer2.minCompetitiveScore, 0f);
     assertEquals(11f, scorer3.minCompetitiveScore, 0f);


### PR DESCRIPTION
An object return inside hot code like this is needlessly wasteful. Escape analysis doesn't catch this one and we end up allocating many GB of throwaway objects during benchmark runs. We might as well use two utility methods and accumulate the raw value.

Small but statistically significant improvement in e.g. wikimedium:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
           BrowseMonthTaxoFacets       12.30     (27.3%)       11.33     (35.8%)   -7.9% ( -55% -   75%) 0.267
                 LowSloppyPhrase      216.04      (8.4%)      214.34     (10.0%)   -0.8% ( -17% -   19%) 0.704
                          IntNRQ      143.96      (6.1%)      143.04      (7.2%)   -0.6% ( -13% -   13%) 0.667
               HighTermTitleSort       70.06      (5.1%)       70.59      (4.5%)    0.8% (  -8% -   10%) 0.485
                    OrHighNotMed      341.64      (6.8%)      345.69      (6.8%)    1.2% ( -11% -   15%) 0.436
           HighTermDayOfYearSort      363.12      (9.3%)      367.59     (11.3%)    1.2% ( -17% -   24%) 0.594
                   OrNotHighHigh      573.71      (6.5%)      580.89      (6.4%)    1.3% ( -10% -   15%) 0.386
                         LowTerm      722.35      (5.9%)      732.47      (6.9%)    1.4% ( -10% -   15%) 0.331
                   OrHighNotHigh      271.00      (7.0%)      275.08      (6.3%)    1.5% ( -11% -   15%) 0.312
               HighTermMonthSort     1386.74      (8.3%)     1409.12      (7.8%)    1.6% ( -13% -   19%) 0.368
                        PKLookup      239.12      (2.0%)      243.02      (2.0%)    1.6% (  -2% -    5%) 0.000
                 MedSloppyPhrase      144.63      (5.4%)      147.04      (6.5%)    1.7% (  -9% -   14%) 0.213
                      AndHighMed      279.04      (5.1%)      283.73      (6.5%)    1.7% (  -9% -   14%) 0.198
                          Fuzzy1       80.09      (6.3%)       81.47      (5.0%)    1.7% (  -9% -   13%) 0.175
                      AndHighLow     1243.25      (9.0%)     1264.92      (8.8%)    1.7% ( -14% -   21%) 0.382
                    OrNotHighMed      367.10      (7.8%)      373.61      (9.3%)    1.8% ( -14% -   20%) 0.354
                       MedPhrase      329.04      (7.2%)      335.14      (4.3%)    1.9% (  -8% -   14%) 0.161
                       LowPhrase      117.16      (4.9%)      119.40      (4.4%)    1.9% (  -6% -   11%) 0.064
                      TermDTSort      163.92      (6.1%)      167.35      (7.3%)    2.1% ( -10% -   16%) 0.164
             LowIntervalsOrdered       36.71      (6.4%)       37.48      (6.2%)    2.1% (  -9% -   15%) 0.137
            HighTermTitleBDVSort       27.44      (4.5%)       28.03      (5.7%)    2.1% (  -7% -   12%) 0.061
                    HighSpanNear        4.74      (1.5%)        4.84      (3.4%)    2.2% (  -2% -    7%) 0.000
                      HighPhrase      277.60      (7.2%)      283.63      (6.1%)    2.2% ( -10% -   16%) 0.145
                       OrHighLow      758.57      (6.3%)      775.09      (5.6%)    2.2% (  -9% -   14%) 0.100
                         Respell       57.65      (1.7%)       58.95      (2.0%)    2.3% (  -1% -    6%) 0.000
                    OrNotHighLow     1186.64      (6.2%)     1217.06      (8.0%)    2.6% ( -10% -   17%) 0.109
                     MedSpanNear       29.76      (4.4%)       30.54      (3.4%)    2.6% (  -4% -   10%) 0.003
     BrowseRandomLabelTaxoFacets        4.35      (4.0%)        4.46      (4.7%)    2.6% (  -5% -   11%) 0.007
           BrowseMonthSSDVFacets        4.57     (13.2%)        4.69     (12.6%)    2.7% ( -20% -   32%) 0.353
        AndHighHighDayTaxoFacets        8.14      (6.9%)        8.35      (6.0%)    2.7% (  -9% -   16%) 0.063
                       OrHighMed      207.74      (7.7%)      213.31      (5.3%)    2.7% (  -9% -   16%) 0.068
                         MedTerm      619.73      (8.4%)      636.42      (8.3%)    2.7% ( -12% -   21%) 0.148
            MedTermDayTaxoFacets       25.14      (3.7%)       25.84      (3.6%)    2.8% (  -4% -   10%) 0.001
                        Wildcard       44.99      (5.5%)       46.25      (5.4%)    2.8% (  -7% -   14%) 0.022
                      OrHighHigh       94.80      (6.9%)       97.49      (7.0%)    2.8% ( -10% -   17%) 0.067
             MedIntervalsOrdered        6.95      (5.9%)        7.16      (5.2%)    3.0% (  -7% -   14%) 0.017
     BrowseRandomLabelSSDVFacets        3.27      (4.9%)        3.37      (5.3%)    3.0% (  -6% -   13%) 0.008
         AndHighMedDayTaxoFacets      117.88      (4.9%)      121.46      (5.9%)    3.0% (  -7% -   14%) 0.013
            HighIntervalsOrdered        8.08      (6.8%)        8.33      (5.7%)    3.2% (  -8% -   16%) 0.023
                    OrHighNotLow      513.35      (7.9%)      529.80      (7.4%)    3.2% ( -11% -   20%) 0.060
       BrowseDayOfYearTaxoFacets        5.23      (9.6%)        5.41     (11.3%)    3.3% ( -16% -   26%) 0.161
                          Fuzzy2       71.90      (5.3%)       74.30      (5.3%)    3.3% (  -6% -   14%) 0.005
                HighSloppyPhrase       17.90      (5.2%)       18.51      (6.5%)    3.4% (  -7% -   15%) 0.010
                        HighTerm      374.19      (7.7%)      387.17      (7.8%)    3.5% ( -11% -   20%) 0.046
          OrHighMedDayTaxoFacets       13.06      (3.6%)       13.53      (3.2%)    3.6% (  -3% -   10%) 0.000
                         Prefix3      264.02      (7.6%)      273.73      (7.9%)    3.7% ( -10% -   20%) 0.034
            BrowseDateTaxoFacets        5.16      (9.6%)        5.35     (11.9%)    3.7% ( -16% -   27%) 0.124
            BrowseDateSSDVFacets        1.25      (4.2%)        1.29      (4.4%)    3.7% (  -4% -   12%) 0.000
       BrowseDayOfYearSSDVFacets        4.42      (8.4%)        4.59      (7.1%)    3.8% ( -10% -   21%) 0.030
                     LowSpanNear       36.34      (7.6%)       37.84      (7.9%)    4.1% ( -10% -   21%) 0.018
                     AndHighHigh       76.32      (9.4%)       80.33     (11.2%)    5.3% ( -14% -   28%) 0.023

```