### PR TITLE
Speedup OrderedIntervalsSource

### DIFF
--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/OrderedIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/OrderedIntervalsSource.java
@@ -124,38 +124,54 @@ class OrderedIntervalsSource extends MinimizingConjunctionIntervalsSource {
       start = end = slop = IntervalIterator.NO_MORE_INTERVALS;
       int lastStart = Integer.MAX_VALUE;
       boolean minimizing = false;
+      final var subIterators = this.subIterators;
+      int currentIndex = i;
       while (true) {
         while (true) {
-          if (subIterators.get(i - 1).end() >= lastStart) {
+          var prev = subIterators.get(currentIndex - 1);
+          if (prev.end() >= lastStart) {
+            i = currentIndex;
             return start;
           }
-          if (i == subIterators.size()
-              || (minimizing && subIterators.get(i).start() > subIterators.get(i - 1).end())) {
+          if (currentIndex == subIterators.size()) {
+            break;
+          }
+          final IntervalIterator current = subIterators.get(currentIndex);
+          if (minimizing && (current.start() > prev.end())) {
             break;
           }
           do {
-            if (subIterators.get(i).end() >= lastStart
-                || subIterators.get(i).nextInterval() == IntervalIterator.NO_MORE_INTERVALS) {
+            if (current.end() >= lastStart
+                || current.nextInterval() == IntervalIterator.NO_MORE_INTERVALS) {
+              i = currentIndex;
               return start;
             }
-          } while (subIterators.get(i).start() <= subIterators.get(i - 1).end());
-          i++;
+          } while (current.start() <= prev.end());
+          currentIndex++;
         }
-        start = subIterators.get(0).start();
+        var first = subIterators.getFirst();
+        final int start = first.start();
+        this.start = start;
         if (start == NO_MORE_INTERVALS) {
+          i = currentIndex;
           return end = NO_MORE_INTERVALS;
         }
-        end = subIterators.get(subIterators.size() - 1).end();
-        slop = end - start + 1;
+        var last = subIterators.getLast();
+
+        final int end = last.end();
+        this.end = end;
+        int slop = end - start + 1;
         for (IntervalIterator subIterator : subIterators) {
           slop -= subIterator.width();
         }
+        this.slop = slop;
         onMatch.onMatch();
-        lastStart = subIterators.get(subIterators.size() - 1).start();
-        i = 1;
-        if (subIterators.get(0).nextInterval() == IntervalIterator.NO_MORE_INTERVALS) {
+        currentIndex = 1;
+        if (first.nextInterval() == IntervalIterator.NO_MORE_INTERVALS) {
+          i = currentIndex;
           return start;
         }
+        lastStart = last.start();
         minimizing = true;
       }
     }


### PR DESCRIPTION
Looking up the same indices out of a list is very costly, also better keep things in local variables (likely registers) where possible. Benchmarks show this clearly helps interval runs:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
            BrowseDateTaxoFacets        5.70     (22.5%)        5.53     (10.8%)   -3.0% ( -29% -   39%) 0.444
       BrowseDayOfYearTaxoFacets        5.74     (21.0%)        5.61     (11.3%)   -2.3% ( -28% -   37%) 0.535
     BrowseRandomLabelTaxoFacets        4.65     (21.9%)        4.58      (3.9%)   -1.4% ( -22% -   31%) 0.690
                          IntNRQ       92.77      (7.4%)       92.96      (6.6%)    0.2% ( -12% -   15%) 0.899
                      TermDTSort      166.60      (5.3%)      167.22      (6.3%)    0.4% ( -10% -   12%) 0.779
                      AndHighMed      577.41      (3.7%)      583.19      (4.1%)    1.0% (  -6% -    9%) 0.252
                      AndHighLow     1408.99      (4.0%)     1423.18      (4.6%)    1.0% (  -7% -    9%) 0.296
                    OrHighNotLow      649.27      (6.0%)      656.72      (5.9%)    1.1% ( -10% -   13%) 0.390
                   OrNotHighHigh      345.92      (5.2%)      349.97      (5.0%)    1.2% (  -8% -   11%) 0.304
           BrowseMonthTaxoFacets       10.20     (45.0%)       10.33     (46.1%)    1.2% ( -61% -  167%) 0.904
                       OrHighMed      232.61      (4.5%)      235.71      (4.1%)    1.3% (  -6% -   10%) 0.163
                   OrHighNotHigh      369.46      (4.8%)      374.61      (3.9%)    1.4% (  -6% -   10%) 0.152
            BrowseDateSSDVFacets        1.25      (8.6%)        1.27      (9.1%)    1.5% ( -14% -   21%) 0.439
                    OrNotHighLow     1607.37      (3.7%)     1632.12      (4.8%)    1.5% (  -6% -   10%) 0.107
                        PKLookup      241.49      (2.1%)      245.26      (2.3%)    1.6% (  -2% -    6%) 0.002
                          Fuzzy1       92.30      (2.1%)       93.76      (2.6%)    1.6% (  -3% -    6%) 0.003
                          Fuzzy2       99.26      (2.3%)      100.88      (1.6%)    1.6% (  -2% -    5%) 0.000
                     AndHighHigh       86.30      (5.4%)       87.74      (4.8%)    1.7% (  -8% -   12%) 0.144
                    OrNotHighMed      472.61      (4.6%)      480.64      (4.8%)    1.7% (  -7% -   11%) 0.107
                         MedTerm      666.11      (5.9%)      677.51      (5.8%)    1.7% (  -9% -   14%) 0.190
         AndHighMedDayTaxoFacets       50.17      (2.6%)       51.06      (2.5%)    1.8% (  -3% -    7%) 0.002
               HighTermMonthSort     1567.45      (5.2%)     1599.30      (4.7%)    2.0% (  -7% -   12%) 0.068
        AndHighHighDayTaxoFacets       35.86      (3.5%)       36.63      (3.2%)    2.1% (  -4% -    9%) 0.004
                    OrHighNotMed      874.94      (6.4%)      893.82      (5.8%)    2.2% (  -9% -   15%) 0.117
            MedTermDayTaxoFacets       29.38      (3.6%)       30.03      (3.4%)    2.2% (  -4% -    9%) 0.005
                        HighTerm      624.07      (5.7%)      638.02      (6.6%)    2.2% (  -9% -   15%) 0.105
            HighTermTitleBDVSort       20.23      (7.4%)       20.72      (8.2%)    2.4% ( -12% -   19%) 0.174
                       OrHighLow      825.14      (4.3%)      844.87      (3.8%)    2.4% (  -5% -   11%) 0.009
                         Respell       56.91      (1.8%)       58.27      (1.3%)    2.4% (   0% -    5%) 0.000
                 LowSloppyPhrase      140.38      (3.4%)      143.75      (3.7%)    2.4% (  -4% -    9%) 0.002
           HighTermDayOfYearSort      422.09      (6.8%)      432.22      (6.9%)    2.4% ( -10% -   17%) 0.116
                       MedPhrase       81.60      (4.7%)       83.60      (5.3%)    2.5% (  -7% -   13%) 0.028
                     MedSpanNear       97.44      (2.6%)       99.91      (2.0%)    2.5% (  -2% -    7%) 0.000
                         LowTerm      712.67      (4.7%)      730.77      (4.6%)    2.5% (  -6% -   12%) 0.014
                    HighSpanNear       65.55      (2.5%)       67.23      (2.6%)    2.6% (  -2% -    7%) 0.000
     BrowseRandomLabelSSDVFacets        3.37      (3.5%)        3.46      (4.3%)    2.7% (  -5% -   10%) 0.003
                 MedSloppyPhrase      103.46      (3.4%)      106.31      (3.0%)    2.8% (  -3% -    9%) 0.000
                     LowSpanNear       45.18      (2.6%)       46.45      (3.8%)    2.8% (  -3% -    9%) 0.000
                        Wildcard      198.73      (5.0%)      204.43      (4.8%)    2.9% (  -6% -   13%) 0.009
                         Prefix3      264.48      (4.0%)      272.14      (3.8%)    2.9% (  -4% -   11%) 0.001
               HighTermTitleSort       63.44      (2.2%)       65.31      (2.2%)    2.9% (  -1% -    7%) 0.000
                      OrHighHigh      134.68      (6.2%)      138.67      (7.3%)    3.0% (  -9% -   17%) 0.049
          OrHighMedDayTaxoFacets       10.98      (5.3%)       11.33      (6.5%)    3.2% (  -8% -   15%) 0.015
                      HighPhrase       74.65      (7.4%)       77.20      (9.6%)    3.4% ( -12% -   22%) 0.076
           BrowseMonthSSDVFacets        4.49      (4.4%)        4.65      (8.0%)    3.5% (  -8% -   16%) 0.015
                HighSloppyPhrase       49.70      (3.7%)       51.47      (3.5%)    3.6% (  -3% -   11%) 0.000
                       LowPhrase       87.42      (7.4%)       90.81      (7.5%)    3.9% ( -10% -   20%) 0.020
       BrowseDayOfYearSSDVFacets        4.58      (6.8%)        4.83     (10.6%)    5.4% ( -11% -   24%) 0.007
            HighIntervalsOrdered       28.21     (10.3%)       32.38     (10.4%)   14.8% (  -5% -   39%) 0.000
             LowIntervalsOrdered      116.91      (6.0%)      134.70      (5.9%)   15.2% (   3% -   28%) 0.000
             MedIntervalsOrdered       21.96      (9.1%)       25.85      (9.4%)   17.7% (   0% -   39%) 0.000
```