### PR TITLE
Remove broken .toArray from IntObjectHashMap entirely

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/internal/hppc/IntObjectHashMap.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/hppc/IntObjectHashMap.java
@@ -562,15 +562,6 @@ public class IntObjectHashMap<VType>
     public int size() {
       return IntObjectHashMap.this.size();
     }
-
-    public VType[] toArray() {
-      VType[] array = (VType[]) new Object[size()];
-      int i = 0;
-      for (ObjectCursor<VType> cursor : this) {
-        array[i++] = cursor.value;
-      }
-      return array;
-    }
   }
 
   /** An iterator over the set of assigned values. */

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
@@ -18,12 +18,17 @@
 package org.apache.lucene.internal.hppc;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -66,10 +71,8 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /** Check if the array's content is identical to a given sequence of elements. */
-  private static void assertSortedListEquals(Object[] array, Object... elements) {
-    assertEquals(elements.length, array.length);
-    Arrays.sort(array);
-    assertArrayEquals(elements, array);
+  private static void assertSortedListEquals(List<Object> array, Object... elements) {
+    Assert.assertEquals(array.stream().sorted().toList(), Arrays.asList(elements));
   }
 
   private final int value0 = vcast(0);
@@ -584,13 +587,22 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     map.put(key1, value3);
     map.put(key2, value2);
     map.put(key3, value1);
-    assertSortedListEquals(map.values().toArray(), value1, value2, value3);
+    assertSortedListEquals(toList(map.values()), value1, value2, value3);
 
     map.clear();
     map.put(key1, value1);
     map.put(key2, value2);
     map.put(key3, value2);
-    assertSortedListEquals(map.values().toArray(), value1, value2, value2);
+    MatcherAssert.assertThat(
+        toList(map.values()), Matchers.containsInAnyOrder(value1, value2, value2));
+  }
+
+  private static <T> List<T> toList(Iterable<ObjectCursor<T>> values) {
+    ArrayList<T> list = new ArrayList<>();
+    for (var c : values) {
+      list.add(c.value);
+    }
+    return list;
   }
 
   /* */

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
@@ -70,7 +70,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
 
   /** Check if the array's content is identical to a given sequence of elements. */
   private static void assertSortedListEquals(List<Object> array, Object... elements) {
-    Assert.assertEquals(array.stream().sorted().toList(), Arrays.asList(elements));
+    Assert.assertEquals(Arrays.asList(elements), array.stream().sorted().toList());
   }
 
   private final int value0 = vcast(0);

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -593,8 +591,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     map.put(key1, value1);
     map.put(key2, value2);
     map.put(key3, value2);
-    MatcherAssert.assertThat(
-        toList(map.values()), Matchers.containsInAnyOrder(value1, value2, value2));
+    assertSortedListEquals(toList(map.values()), value1, value2, value2);
   }
 
   private static <T> List<T> toList(Iterable<ObjectCursor<T>> values) {


### PR DESCRIPTION
This method is only used in tests. I moved the toList collection utility to the test class to minimize surface API. 
Fixes #13761
