### PR TITLE
Avoid performance regression by constructing lazily the PointTree in NumericComparator (#13498)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -218,6 +218,8 @@ Bug Fixes
 * GITHUB#12878: Fix the declared Exceptions of Expression#evaluate() to match those
   of DoubleValues#doubleValue(). (Uwe Schindler)
 
+* GITHUB#13498: Avoid performance regression by constructing lazily the PointTree in NumericComparator, (Ignacio Vera)
+
 Changes in Runtime Behavior
 ---------------------
 


### PR DESCRIPTION
 Forward port of https://github.com/apache/lucene/pull/13498 to address performance issue after reverting https://github.com/apache/lucene/pull/13857. 
