### PR TITLE
Reuse Impacts instances across invocations.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -1221,8 +1221,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     // true if we shallow-advanced to a new block that we have not decoded yet
     private boolean needsRefilling;
 
-    private final ByteArrayDataInput scratch = new ByteArrayDataInput();
-
     // level 0 skip data
     private int level0LastDocID;
     private long level0DocEndFP;
@@ -1470,60 +1468,65 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
       return doc;
     }
 
+    private final Impacts impacts =
+        new Impacts() {
+
+          private final ByteArrayDataInput scratch = new ByteArrayDataInput();
+
+          @Override
+          public int numLevels() {
+            int numLevels = 0;
+            if (level0LastDocID != NO_MORE_DOCS) {
+              numLevels++;
+            }
+            if (level1LastDocID != NO_MORE_DOCS) {
+              numLevels++;
+            }
+            if (numLevels == 0) {
+              numLevels++;
+            }
+            return numLevels;
+          }
+
+          @Override
+          public int getDocIdUpTo(int level) {
+            if (level0LastDocID != NO_MORE_DOCS) {
+              if (level == 0) {
+                return level0LastDocID;
+              }
+              level--;
+            }
+
+            if (level == 0) {
+              return level1LastDocID;
+            }
+            return NO_MORE_DOCS;
+          }
+
+          @Override
+          public List<Impact> getImpacts(int level) {
+            if (level0LastDocID != NO_MORE_DOCS) {
+              if (level == 0) {
+                scratch.reset(level0SerializedImpacts.bytes, 0, level0SerializedImpacts.length);
+                readImpacts(scratch, level0Impacts);
+                return level0Impacts;
+              }
+              level--;
+            }
+
+            if (level1LastDocID != NO_MORE_DOCS && level == 0) {
+              scratch.reset(level1SerializedImpacts.bytes, 0, level1SerializedImpacts.length);
+              readImpacts(scratch, level1Impacts);
+              return level1Impacts;
+            }
+
+            return Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
+          }
+        };
+
     @Override
     public Impacts getImpacts() {
-      return new Impacts() {
-
-        @Override
-        public int numLevels() {
-          int numLevels = 0;
-          if (level0LastDocID != NO_MORE_DOCS) {
-            numLevels++;
-          }
-          if (level1LastDocID != NO_MORE_DOCS) {
-            numLevels++;
-          }
-          if (numLevels == 0) {
-            numLevels++;
-          }
-          return numLevels;
-        }
-
-        @Override
-        public int getDocIdUpTo(int level) {
-          if (level0LastDocID != NO_MORE_DOCS) {
-            if (level == 0) {
-              return level0LastDocID;
-            }
-            level--;
-          }
-
-          if (level == 0) {
-            return level1LastDocID;
-          }
-          return NO_MORE_DOCS;
-        }
-
-        @Override
-        public List<Impact> getImpacts(int level) {
-          if (level0LastDocID != NO_MORE_DOCS) {
-            if (level == 0) {
-              scratch.reset(level0SerializedImpacts.bytes, 0, level0SerializedImpacts.length);
-              readImpacts(scratch, level0Impacts);
-              return level0Impacts;
-            }
-            level--;
-          }
-
-          if (level1LastDocID != NO_MORE_DOCS && level == 0) {
-            scratch.reset(level1SerializedImpacts.bytes, 0, level1SerializedImpacts.length);
-            readImpacts(scratch, level1Impacts);
-            return level1Impacts;
-          }
-
-          return Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
-        }
-      };
+      return impacts;
     }
 
     @Override
@@ -1574,8 +1577,6 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
     // true if we shallow-advanced to a new block that we have not decoded yet
     private boolean needsRefilling;
-
-    private final ByteArrayDataInput scratch = new ByteArrayDataInput();
 
     // level 0 skip data
     private int level0LastDocID;
@@ -1801,61 +1802,66 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
       }
     }
 
+    private final Impacts impacts =
+        new Impacts() {
+
+          private final ByteArrayDataInput scratch = new ByteArrayDataInput();
+
+          @Override
+          public int numLevels() {
+            int numLevels = 0;
+            if (level0LastDocID != NO_MORE_DOCS) {
+              numLevels++;
+            }
+            if (level1LastDocID != NO_MORE_DOCS) {
+              numLevels++;
+            }
+            if (numLevels == 0) {
+              numLevels++;
+            }
+            return numLevels;
+          }
+
+          @Override
+          public int getDocIdUpTo(int level) {
+            if (level0LastDocID != NO_MORE_DOCS) {
+              if (level == 0) {
+                return level0LastDocID;
+              }
+              level--;
+            }
+
+            if (level1LastDocID != NO_MORE_DOCS && level == 0) {
+              return level1LastDocID;
+            }
+
+            return NO_MORE_DOCS;
+          }
+
+          @Override
+          public List<Impact> getImpacts(int level) {
+            if (level0LastDocID != NO_MORE_DOCS) {
+              if (level == 0) {
+                scratch.reset(level0SerializedImpacts.bytes(), 0, level0SerializedImpacts.length());
+                readImpacts(scratch, level0Impacts);
+                return level0Impacts;
+              }
+              level--;
+            }
+
+            if (level1LastDocID != NO_MORE_DOCS && level == 0) {
+              scratch.reset(level1SerializedImpacts.bytes(), 0, level1SerializedImpacts.length());
+              readImpacts(scratch, level1Impacts);
+              return level1Impacts;
+            }
+
+            return Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
+          }
+        };
+
     @Override
     public Impacts getImpacts() {
-      return new Impacts() {
-
-        @Override
-        public int numLevels() {
-          int numLevels = 0;
-          if (level0LastDocID != NO_MORE_DOCS) {
-            numLevels++;
-          }
-          if (level1LastDocID != NO_MORE_DOCS) {
-            numLevels++;
-          }
-          if (numLevels == 0) {
-            numLevels++;
-          }
-          return numLevels;
-        }
-
-        @Override
-        public int getDocIdUpTo(int level) {
-          if (level0LastDocID != NO_MORE_DOCS) {
-            if (level == 0) {
-              return level0LastDocID;
-            }
-            level--;
-          }
-
-          if (level1LastDocID != NO_MORE_DOCS && level == 0) {
-            return level1LastDocID;
-          }
-
-          return NO_MORE_DOCS;
-        }
-
-        @Override
-        public List<Impact> getImpacts(int level) {
-          if (level0LastDocID != NO_MORE_DOCS) {
-            if (level == 0) {
-              scratch.reset(level0SerializedImpacts.bytes(), 0, level0SerializedImpacts.length());
-              readImpacts(scratch, level0Impacts);
-              return level0Impacts;
-            }
-            level--;
-          }
-
-          if (level1LastDocID != NO_MORE_DOCS && level == 0) {
-            scratch.reset(level1SerializedImpacts.bytes(), 0, level1SerializedImpacts.length());
-            readImpacts(scratch, level1Impacts);
-            return level1Impacts;
-          }
-
-          return Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
-        }
-      };
+      return impacts;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -67,6 +67,12 @@ import org.apache.lucene.util.IOUtils;
 public final class Lucene912PostingsReader extends PostingsReaderBase {
 
   static final VectorizationProvider VECTORIZATION_PROVIDER = VectorizationProvider.getInstance();
+  // Dummy impacts, composed of the maximum possible term frequency and the lowest possible
+  // (unsigned) norm value. This is typically used on tail blocks, which don't actually record
+  // impacts as the storage overhead would not be worth any query evaluation speedup, since there's
+  // less than 128 docs left to evaluate anyway.
+  private static final List<Impact> DUMMY_IMPACTS =
+      Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
 
   private final IndexInput docIn;
   private final IndexInput posIn;
@@ -1520,7 +1526,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
               return level1Impacts;
             }
 
-            return Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
+            return DUMMY_IMPACTS;
           }
         };
 
@@ -1855,7 +1861,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
               return level1Impacts;
             }
 
-            return Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
+            return DUMMY_IMPACTS;
           }
         };
 


### PR DESCRIPTION
Our `ImpactsEnum` currently return a new object on every call to `getImpacts()`, which shows up in nightly profiles.