### PR TITLE
Fix flakiness issues with TestTieredMergePolicy.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -438,7 +438,10 @@ public class TieredMergePolicy extends MergePolicy {
     }
     // allowedSegCount may occasionally be less than segsPerTier
     // if segment sizes are below the floor size
-    allowedSegCount = Math.max(allowedSegCount, Math.max(segsPerTier, targetSearchConcurrency));
+    allowedSegCount = Math.max(allowedSegCount, segsPerTier);
+    // No need to merge if the total number of segments (including too big segments) is less than or
+    // equal to the target search concurrency.
+    allowedSegCount = Math.max(allowedSegCount, targetSearchConcurrency - tooBigCount);
     int allowedDocCount = getMaxAllowedDocs(totalMaxDoc, totalDelDocs);
 
     if (verbose(mergeContext) && tooBigCount > 0) {


### PR DESCRIPTION
The two seeds at #13818 had different root causes:
 - The test allows the number of segments to go above the limit, only if none of the merges are legal. But there are multiple reasons why a merge may be illegal: because it exceeds the max doc count or because it is too imbalanced. However these two things were checked independently, so you could run into cases when the test would think that there are legal merges from the doc count perspective and from the balance perspective, but all legal merges from the doc count perspective are illegal from the balance perspective and vice-versa. The test now checks that there are merges that are good wrt these two criteria at once.
 - `TieredMergePolicy` allows at least `targetSearchConcurrency` segments in an index. There was a bug in `TieredMergePolicy` where this condition is applied after "too big" segments have been removed, so it effectively allowed more segments than necessary in the index.

Closes #13818
