### PR TITLE
Remove broken .toArray from Long/CharObjectHashMap entirely

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -53,6 +53,7 @@ Bug Fixes
 ---------------------
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended
   when they were not sorted by startOffset. (Seunghan Jung)
+* GITHUB#13884: Remove broken .toArray from Long/CharObjectHashMap entirely. (Pan Guixin)
 
 Build
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/internal/hppc/CharObjectHashMap.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/hppc/CharObjectHashMap.java
@@ -574,15 +574,6 @@ public class CharObjectHashMap<VType>
     public int size() {
       return CharObjectHashMap.this.size();
     }
-
-    public VType[] toArray() {
-      VType[] array = (VType[]) new Object[size()];
-      int i = 0;
-      for (ObjectCursor<VType> cursor : this) {
-        array[i++] = cursor.value;
-      }
-      return array;
-    }
   }
 
   /** An iterator over the set of assigned values. */

--- a/lucene/core/src/java/org/apache/lucene/internal/hppc/LongObjectHashMap.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/hppc/LongObjectHashMap.java
@@ -562,15 +562,6 @@ public class LongObjectHashMap<VType>
     public int size() {
       return LongObjectHashMap.this.size();
     }
-
-    public VType[] toArray() {
-      VType[] array = (VType[]) new Object[size()];
-      int i = 0;
-      for (ObjectCursor<VType> cursor : this) {
-        array[i++] = cursor.value;
-      }
-      return array;
-    }
   }
 
   /** An iterator over the set of assigned values. */

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharObjectHashMap.java
@@ -70,13 +70,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
     assertArrayEquals(elements, array);
   }
 
-  /** Check if the array's content is identical to a given sequence of elements. */
-  private static void assertSortedListEquals(Object[] array, Object... elements) {
-    assertEquals(elements.length, array.length);
-    Arrays.sort(array);
-    assertArrayEquals(elements, array);
-  }
-
   private final int value0 = vcast(0);
   private final int value1 = vcast(1);
   private final int value2 = vcast(2);

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharObjectHashMap.java
@@ -17,6 +17,8 @@
 
 package org.apache.lucene.internal.hppc;
 
+import static org.apache.lucene.internal.hppc.TestIntObjectHashMap.toList;
+
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -24,6 +26,8 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Test;
 
@@ -603,13 +607,15 @@ public class TestCharObjectHashMap extends LuceneTestCase {
     map.put(key1, value3);
     map.put(key2, value2);
     map.put(key3, value1);
-    assertSortedListEquals(map.values().toArray(), value1, value2, value3);
+    MatcherAssert.assertThat(
+        toList(map.values()), Matchers.containsInAnyOrder(value1, value2, value3));
 
     map.clear();
     map.put(key1, value1);
     map.put(key2, value2);
     map.put(key3, value2);
-    assertSortedListEquals(map.values().toArray(), value1, value2, value2);
+    MatcherAssert.assertThat(
+        toList(map.values()), Matchers.containsInAnyOrder(value1, value2, value2));
   }
 
   /* */

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
@@ -594,7 +594,7 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     assertSortedListEquals(toList(map.values()), value1, value2, value2);
   }
 
-  private static <T> List<T> toList(Iterable<ObjectCursor<T>> values) {
+  static <T> List<T> toList(Iterable<ObjectCursor<T>> values) {
     ArrayList<T> list = new ArrayList<>();
     for (var c : values) {
       list.add(c.value);

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongObjectHashMap.java
@@ -69,13 +69,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
     assertArrayEquals(elements, array);
   }
 
-  /** Check if the array's content is identical to a given sequence of elements. */
-  private static void assertSortedListEquals(Object[] array, Object... elements) {
-    assertEquals(elements.length, array.length);
-    Arrays.sort(array);
-    assertArrayEquals(elements, array);
-  }
-
   private final int value0 = vcast(0);
   private final int value1 = vcast(1);
   private final int value2 = vcast(2);

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongObjectHashMap.java
@@ -17,6 +17,8 @@
 
 package org.apache.lucene.internal.hppc;
 
+import static org.apache.lucene.internal.hppc.TestIntObjectHashMap.toList;
+
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -24,6 +26,8 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
@@ -585,13 +589,15 @@ public class TestLongObjectHashMap extends LuceneTestCase {
     map.put(key1, value3);
     map.put(key2, value2);
     map.put(key3, value1);
-    assertSortedListEquals(map.values().toArray(), value1, value2, value3);
+    MatcherAssert.assertThat(
+        toList(map.values()), Matchers.containsInAnyOrder(value1, value2, value3));
 
     map.clear();
     map.put(key1, value1);
     map.put(key2, value2);
     map.put(key3, value2);
-    assertSortedListEquals(map.values().toArray(), value1, value2, value2);
+    MatcherAssert.assertThat(
+        toList(map.values()), Matchers.containsInAnyOrder(value1, value2, value2));
   }
 
   /* */


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
Fixes #13761