### PR TITLE
Lazy initialize ForDeltaUtil and ForUtil in Lucene912PostingsReader

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -632,7 +632,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
   final class EverythingEnum extends PostingsEnum {
 
     private ForDeltaUtil forDeltaUtil;
-    final PForUtil pforUtil = new PForUtil(new ForUtil());
+    private PForUtil pforUtil;
 
     private final long[] docBuffer = new long[BLOCK_SIZE + 1];
     private final long[] freqBuffer = new long[BLOCK_SIZE + 1];
@@ -760,7 +760,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
     public PostingsEnum reset(IntBlockTermState termState, int flags) throws IOException {
       docFreq = termState.docFreq;
-      if (forDeltaUtil == null && (docFreq >= BLOCK_SIZE)) {
+      if (forDeltaUtil == null && docFreq >= BLOCK_SIZE) {
         forDeltaUtil = new ForDeltaUtil();
       }
       // Where this term's postings start in the .pos file:
@@ -769,6 +769,9 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
       // file:
       final long payTermStartFP = termState.payStartFP;
       totalTermFreq = termState.totalTermFreq;
+      if (pforUtil == null && totalTermFreq >= BLOCK_SIZE) {
+        pforUtil = new PForUtil(new ForUtil());
+      }
       singletonDocID = termState.singletonDocID;
       if (docFreq > 1) {
         if (docIn == null) {


### PR DESCRIPTION
Lazy initialize these fields. They consume/cause a lot of memory/GC because they are allocated frequently (~7% of all allocations in luceneutil's wikimedia medium run for me). This does not cause any measurable slowdown as far as runtime is concerned and since these are not even needed for all instances (in fact they are rarely used in the queries the benchmark explores) save quite a few CPU cycles for collecting and allocating them.

@jpountz I know we talked about reusing these instances, but as far as I can tell this deals with the problem much more fundamentally, we simply often do not need these?