### PR TITLE
DocValuesSkipper implementation in IndexSortSorted

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -467,12 +467,14 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
     DocValuesSkipper skipper = context.reader().getDocValuesSkipper(field);
     if (skipper != null) {
       if (skipper.minValue() > upperValue || skipper.maxValue() < lowerValue) {
-        return null;
-      }
-      if (skipper.docCount() == context.reader().maxDoc()
-          && skipper.minValue() >= lowerValue
-          && skipper.maxValue() <= upperValue) {
-        return IteratorAndCount.all(skipper.docCount());
+        // Instead of returning null, act as there's no skipper.
+        skipper = null;
+      } else {
+        if (skipper.docCount() == context.reader().maxDoc()
+            && skipper.minValue() >= lowerValue
+            && skipper.maxValue() <= upperValue) {
+          return IteratorAndCount.all(skipper.docCount());
+        }
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -21,8 +21,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Objects;
 import java.util.function.LongPredicate;
-import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.LeafReader;
@@ -304,8 +302,8 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
     }
   }
 
-  private static int nextDocSkipper(int startDoc, NumericDocValues docValues, LongPredicate predicate)
-      throws IOException {
+  private static int nextDocSkipper(
+      int startDoc, NumericDocValues docValues, LongPredicate predicate) throws IOException {
     int doc = docValues.docID();
     if (startDoc > doc) {
       doc = docValues.advance(startDoc);

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -304,14 +304,14 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
     }
   }
 
-  private static int nextDocSkipper(int startDoc, DocIdSetIterator docValues, LongPredicate predicate)
+  private static int nextDocSkipper(int startDoc, NumericDocValues docValues, LongPredicate predicate)
       throws IOException {
     int doc = docValues.docID();
     if (startDoc > doc) {
       doc = docValues.advance(startDoc);
     }
     for (; doc < DocIdSetIterator.NO_MORE_DOCS; doc = docValues.nextDoc()) {
-      if (predicate.test(docValues.cost())) {
+      if (predicate.test(docValues.longValue())) {
         break;
       }
     }


### PR DESCRIPTION
Fixes #13840 

`IndexSortSortedNumericDocValuesRangeQuery` now implements a similar logic (using `DocValuesSkipper`) as `SortedNumericDocValuesRangeQuery`'s `getDocIdSetIteratorOrNullForPrimarySort` method.

### Description

Since `IndexSortSortedNumericDocValuesRangeQuery` and `SortedNumericDocValuesRangeQuery` share similarities regarding _primarySort_, I updated the first one's logic to utilize the skipper advantages.

I'd say this PR is not _fully_ completed, in the sense that the previous search logic is still there but never used (specifically the methods `nextDoc`, `findNextValue`, `lastDoc`, `matchNone`, `matchAll`, which I want to imagine got 'replaced' by the skipper altogether).

The current changes still comply with the tests, but because of them being _optimization changes_ I couldn't really tell if the method has better performance or not, and so I wanted to hear your takes on this.