### PR TITLE
Parse escaped brackets and spaces in range queries

### DIFF
--- a/lucene/queryparser/src/generated/checksums/javaccParserClassic.json
+++ b/lucene/queryparser/src/generated/checksums/javaccParserClassic.json
@@ -1,9 +1,9 @@
 {
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/ParseException.java": "7a8a8fd5b2ea78f9a17f54cbae8b0e4496e8988e",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.java": "a2b7d21092d21cbac290cb1ddde5ac161824fb83",
-    "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.jj": "ed9f248e1a48cadeeab8f0a79e77e986e34ff721",
+    "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.jj": "64bc53b09c0665afd281f1d85a2db802e5f75266",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserConstants.java": "e59a3fd38b66a3d56779c55955c1e014225a1f50",
-    "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserTokenManager.java": "dc99a1083bfa50e429d40e114fabe7dd5d434693",
+    "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserTokenManager.java": "b83ebcc6c97618f1986573cb294d6180f1943f77",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/Token.java": "310665ba37d982327fcb55cc3523d629ef29ef54",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/TokenMgrError.java": "7e2dd6ab7489048bb70f3077ca9fed90f925ec33"
 }

--- a/lucene/queryparser/src/generated/checksums/javaccParserClassic.json
+++ b/lucene/queryparser/src/generated/checksums/javaccParserClassic.json
@@ -1,7 +1,7 @@
 {
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/ParseException.java": "7a8a8fd5b2ea78f9a17f54cbae8b0e4496e8988e",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.java": "a2b7d21092d21cbac290cb1ddde5ac161824fb83",
-    "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.jj": "64bc53b09c0665afd281f1d85a2db802e5f75266",
+    "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.jj": "7cac819b393e10a0cfd3ef4e9a5c28d53dc03331",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserConstants.java": "e59a3fd38b66a3d56779c55955c1e014225a1f50",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserTokenManager.java": "b83ebcc6c97618f1986573cb294d6180f1943f77",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/Token.java": "310665ba37d982327fcb55cc3523d629ef29ef54",

--- a/lucene/queryparser/src/generated/checksums/javaccParserFlexible.json
+++ b/lucene/queryparser/src/generated/checksums/javaccParserFlexible.json
@@ -1,9 +1,9 @@
 {
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/ParseException.java": "984cd645fdbad92dd3c8811785e1d48e582bacc5",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/StandardSyntaxParser.java": "dcf92073340d1c38d01905a307f49fc89e094e76",
-    "lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/StandardSyntaxParser.jj": "77ebf56c78a8614a82532ca6bdf69378afd44b8f",
+    "lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/StandardSyntaxParser.jj": "c8f8c491a819197643f5e224bfcf3f72994190bd",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/StandardSyntaxParserConstants.java": "4ad426d4f4b7577f4af4e9057de32c65c83b1812",
-    "lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/StandardSyntaxParserTokenManager.java": "c264cc500a3964751827a9567ac230eda9783d9f",
+    "lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/StandardSyntaxParserTokenManager.java": "4fab6d6f05db84083e1ab8b572844c94a6a5ecc6",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/Token.java": "f4cb9d01587279dba30e549ce4867e4381bbd9d7",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/TokenMgrError.java": "ff4008e6f76aa09dd48ff7c35190d7326bcf9849"
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.jj
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.jj
@@ -223,7 +223,7 @@ PARSER_END(QueryParser)
 | <RANGEIN_END:  "]"> : DEFAULT
 | <RANGEEX_END:  "}"> : DEFAULT
 | <RANGE_QUOTED: "\"" (~["\""] | "\\\"")+ "\"">
-| <RANGE_GOOP:   (~[ " ", "]", "}" ])+ >
+| <RANGE_GOOP:   (~[ "\\", " ", "]", "}" ] | "\\" ~[])+ >
 }
 
 // *   Query  ::= ( Clause )*

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserTokenManager.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserTokenManager.java
@@ -721,7 +721,7 @@ private final int jjStopStringLiteralDfa_1(int pos, long active0){
          if ((active0 & 0x10000000L) != 0L)
          {
             jjmatchedKind = 32;
-            return 6;
+            return 9;
          }
          return -1;
       default :
@@ -754,7 +754,7 @@ private int jjMoveStringLiteralDfa1_1(long active0){
    {
       case 79:
          if ((active0 & 0x10000000L) != 0L)
-            return jjStartNfaWithStates_1(1, 28, 6);
+            return jjStartNfaWithStates_1(1, 28, 9);
          break;
       default :
          break;
@@ -772,7 +772,7 @@ private int jjStartNfaWithStates_1(int pos, int kind, int state)
 private int jjMoveNfa_1(int startState, int curPos)
 {
    int startsAt = 0;
-   jjnewStateCnt = 7;
+   jjnewStateCnt = 9;
    int i = 1;
    jjstateSet[0] = startState;
    int kind = 0x7fffffff;
@@ -792,7 +792,7 @@ private int jjMoveNfa_1(int startState, int curPos)
                   {
                      if (kind > 32)
                         kind = 32;
-                     { jjCheckNAdd(6); }
+                     { jjCheckNAddTwoStates(6, 7); }
                   }
                   if ((0x100002600L & l) != 0L)
                   {
@@ -801,6 +801,14 @@ private int jjMoveNfa_1(int startState, int curPos)
                   }
                   else if (curChar == 34)
                      { jjCheckNAddTwoStates(2, 4); }
+                  break;
+               case 9:
+               case 6:
+                  if ((0xfffffffeffffffffL & l) == 0L)
+                     break;
+                  if (kind > 32)
+                     kind = 32;
+                  { jjCheckNAddTwoStates(6, 7); }
                   break;
                case 1:
                   if (curChar == 34)
@@ -818,12 +826,10 @@ private int jjMoveNfa_1(int startState, int curPos)
                   if (curChar == 34 && kind > 31)
                      kind = 31;
                   break;
-               case 6:
-                  if ((0xfffffffeffffffffL & l) == 0L)
-                     break;
+               case 8:
                   if (kind > 32)
                      kind = 32;
-                  { jjCheckNAdd(6); }
+                  { jjCheckNAddTwoStates(6, 7); }
                   break;
                default : break;
             }
@@ -837,12 +843,24 @@ private int jjMoveNfa_1(int startState, int curPos)
             switch(jjstateSet[--i])
             {
                case 0:
-               case 6:
-                  if ((0xdfffffffdfffffffL & l) == 0L)
-                     break;
-                  if (kind > 32)
-                     kind = 32;
-                  { jjCheckNAdd(6); }
+                  if ((0xdfffffffcfffffffL & l) != 0L)
+                  {
+                     if (kind > 32)
+                        kind = 32;
+                     { jjCheckNAddTwoStates(6, 7); }
+                  }
+                  else if (curChar == 92)
+                     jjstateSet[jjnewStateCnt++] = 8;
+                  break;
+               case 9:
+                  if ((0xdfffffffcfffffffL & l) != 0L)
+                  {
+                     if (kind > 32)
+                        kind = 32;
+                     { jjCheckNAddTwoStates(6, 7); }
+                  }
+                  else if (curChar == 92)
+                     jjstateSet[jjnewStateCnt++] = 8;
                   break;
                case 2:
                   { jjAddStates(29, 31); }
@@ -850,6 +868,22 @@ private int jjMoveNfa_1(int startState, int curPos)
                case 4:
                   if (curChar == 92)
                      jjstateSet[jjnewStateCnt++] = 3;
+                  break;
+               case 6:
+                  if ((0xdfffffffcfffffffL & l) == 0L)
+                     break;
+                  if (kind > 32)
+                     kind = 32;
+                  { jjCheckNAddTwoStates(6, 7); }
+                  break;
+               case 7:
+                  if (curChar == 92)
+                     jjstateSet[jjnewStateCnt++] = 8;
+                  break;
+               case 8:
+                  if (kind > 32)
+                     kind = 32;
+                  { jjCheckNAddTwoStates(6, 7); }
                   break;
                default : break;
             }
@@ -876,19 +910,21 @@ private int jjMoveNfa_1(int startState, int curPos)
                   {
                      if (kind > 32)
                         kind = 32;
-                     { jjCheckNAdd(6); }
+                     { jjCheckNAddTwoStates(6, 7); }
                   }
                   break;
-               case 2:
-                  if (jjCanMove_1(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(29, 31); }
-                  break;
+               case 9:
                case 6:
+               case 8:
                   if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 32)
                      kind = 32;
-                  { jjCheckNAdd(6); }
+                  { jjCheckNAddTwoStates(6, 7); }
+                  break;
+               case 2:
+                  if (jjCanMove_1(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(29, 31); }
                   break;
                default : if (i1 == 0 || l1 == 0 || i2 == 0 ||  l2 == 0) break; else break;
             }
@@ -901,7 +937,7 @@ private int jjMoveNfa_1(int startState, int curPos)
          kind = 0x7fffffff;
       }
       ++curPos;
-      if ((i = jjnewStateCnt) == (startsAt = 7 - (jjnewStateCnt = startsAt)))
+      if ((i = jjnewStateCnt) == (startsAt = 9 - (jjnewStateCnt = startsAt)))
          return curPos;
       try { curChar = input_stream.readChar(); }
       catch(java.io.IOException e) { return curPos; }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/StandardSyntaxParser.jj
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/StandardSyntaxParser.jj
@@ -198,7 +198,7 @@ PARSER_END(StandardSyntaxParser)
     | <RANGEIN_END:  "]"> : DEFAULT
     | <RANGEEX_END:  "}"> : DEFAULT
     | <RANGE_QUOTED: "\"" (~["\""] | "\\\"")+ "\"">
-    | <RANGE_GOOP:   (~[ " ", "]", "}" ])+ >
+    | <RANGE_GOOP:   (~[ "\\", " ", "]", "}" ] | "\\" ~[])+ >
 }
 
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/StandardSyntaxParserTokenManager.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/StandardSyntaxParserTokenManager.java
@@ -1786,7 +1786,7 @@ private final int jjStopStringLiteralDfa_1(int pos, long active0){
          if ((active0 & 0x8000000000000L) != 0L)
          {
             jjmatchedKind = 55;
-            return 6;
+            return 9;
          }
          return -1;
       default :
@@ -1819,7 +1819,7 @@ private int jjMoveStringLiteralDfa1_1(long active0){
    {
       case 79:
          if ((active0 & 0x8000000000000L) != 0L)
-            return jjStartNfaWithStates_1(1, 51, 6);
+            return jjStartNfaWithStates_1(1, 51, 9);
          break;
       default :
          break;
@@ -1837,7 +1837,7 @@ private int jjStartNfaWithStates_1(int pos, int kind, int state)
 private int jjMoveNfa_1(int startState, int curPos)
 {
    int startsAt = 0;
-   jjnewStateCnt = 7;
+   jjnewStateCnt = 9;
    int i = 1;
    jjstateSet[0] = startState;
    int kind = 0x7fffffff;
@@ -1852,12 +1852,20 @@ private int jjMoveNfa_1(int startState, int curPos)
          {
             switch(jjstateSet[--i])
             {
+               case 9:
+               case 6:
+                  if ((0xfffffffeffffffffL & l) == 0L)
+                     break;
+                  if (kind > 55)
+                     kind = 55;
+                  { jjCheckNAddTwoStates(6, 7); }
+                  break;
                case 0:
                   if ((0xfffffffeffffffffL & l) != 0L)
                   {
                      if (kind > 55)
                         kind = 55;
-                     { jjCheckNAdd(6); }
+                     { jjCheckNAddTwoStates(6, 7); }
                   }
                   if ((0x100002600L & l) != 0L)
                   {
@@ -1883,12 +1891,10 @@ private int jjMoveNfa_1(int startState, int curPos)
                   if (curChar == 34 && kind > 54)
                      kind = 54;
                   break;
-               case 6:
-                  if ((0xfffffffeffffffffL & l) == 0L)
-                     break;
+               case 8:
                   if (kind > 55)
                      kind = 55;
-                  { jjCheckNAdd(6); }
+                  { jjCheckNAddTwoStates(6, 7); }
                   break;
                default : break;
             }
@@ -1901,13 +1907,25 @@ private int jjMoveNfa_1(int startState, int curPos)
          {
             switch(jjstateSet[--i])
             {
+               case 9:
+                  if ((0xdfffffffcfffffffL & l) != 0L)
+                  {
+                     if (kind > 55)
+                        kind = 55;
+                     { jjCheckNAddTwoStates(6, 7); }
+                  }
+                  else if (curChar == 92)
+                     jjstateSet[jjnewStateCnt++] = 8;
+                  break;
                case 0:
-               case 6:
-                  if ((0xdfffffffdfffffffL & l) == 0L)
-                     break;
-                  if (kind > 55)
-                     kind = 55;
-                  { jjCheckNAdd(6); }
+                  if ((0xdfffffffcfffffffL & l) != 0L)
+                  {
+                     if (kind > 55)
+                        kind = 55;
+                     { jjCheckNAddTwoStates(6, 7); }
+                  }
+                  else if (curChar == 92)
+                     jjstateSet[jjnewStateCnt++] = 8;
                   break;
                case 2:
                   { jjAddStates(26, 28); }
@@ -1915,6 +1933,22 @@ private int jjMoveNfa_1(int startState, int curPos)
                case 4:
                   if (curChar == 92)
                      jjstateSet[jjnewStateCnt++] = 3;
+                  break;
+               case 6:
+                  if ((0xdfffffffcfffffffL & l) == 0L)
+                     break;
+                  if (kind > 55)
+                     kind = 55;
+                  { jjCheckNAddTwoStates(6, 7); }
+                  break;
+               case 7:
+                  if (curChar == 92)
+                     jjstateSet[jjnewStateCnt++] = 8;
+                  break;
+               case 8:
+                  if (kind > 55)
+                     kind = 55;
+                  { jjCheckNAddTwoStates(6, 7); }
                   break;
                default : break;
             }
@@ -1931,6 +1965,15 @@ private int jjMoveNfa_1(int startState, int curPos)
          {
             switch(jjstateSet[--i])
             {
+               case 9:
+               case 6:
+               case 8:
+                  if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
+                     break;
+                  if (kind > 55)
+                     kind = 55;
+                  { jjCheckNAddTwoStates(6, 7); }
+                  break;
                case 0:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                   {
@@ -1941,19 +1984,12 @@ private int jjMoveNfa_1(int startState, int curPos)
                   {
                      if (kind > 55)
                         kind = 55;
-                     { jjCheckNAdd(6); }
+                     { jjCheckNAddTwoStates(6, 7); }
                   }
                   break;
                case 2:
                   if (jjCanMove_1(hiByte, i1, i2, l1, l2))
                      { jjAddStates(26, 28); }
-                  break;
-               case 6:
-                  if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
-                     break;
-                  if (kind > 55)
-                     kind = 55;
-                  { jjCheckNAdd(6); }
                   break;
                default : if (i1 == 0 || l1 == 0 || i2 == 0 ||  l2 == 0) break; else break;
             }
@@ -1966,7 +2002,7 @@ private int jjMoveNfa_1(int startState, int curPos)
          kind = 0x7fffffff;
       }
       ++curPos;
-      if ((i = jjnewStateCnt) == (startsAt = 7 - (jjnewStateCnt = startsAt)))
+      if ((i = jjnewStateCnt) == (startsAt = 9 - (jjnewStateCnt = startsAt)))
          return curPos;
       try { curChar = input_stream.readChar(); }
       catch(java.io.IOException e) { return curPos; }


### PR DESCRIPTION
### Description

[This issue](https://github.com/apache/lucene/issues/13234) raises a question about the QueryParser's ability to handle escaped brackets in a range query's terms.

```
queryParser.parse( "[ a\\[i\\] TO b\\[i\\] ]" );

/* 
org.apache.lucene.queryparser.classic.ParseException: Cannot parse '[a\[i\] TO b\[i\]]': Encountered " "]" "] "" at line 1, column 6.
Was expecting:
    "TO" ...
 */
```

I discovered a workaround highlighted in [a previous PR](https://github.com/apache/lucene/pull/13323). However, I think that escaped special characters (notably: closing brackets and spaces) should be allowed in a range term, so I've updated the JavaCC token definition.

### Backwards Compatibility

There are two JavaCC changes:  
1. **Addition of `| "\\" ~[]`** - by nature of the `|` this should not fail to parse anything that was parsed before. 
2. **Addition of `"\\"` in the negation set: `~[ "\\", " ", "]", "}" ]`** - if the `"\\"` is followed by another character, it will be parsed by change 1. If it's followed by EOF, it would have thrown a `ParseException` for "Term can not end with escape character."

By this logic, nothing that was parsed before the changes will fail to parse after the changes. The one break in backwards compatibility is the message of the `ParseException` in some cases, for example:

`queryParser.parse("[\\ TO abc]");` 
- Before: `org.apache.lucene.queryparser.classic.ParseException: Cannot parse '[\ TO abc]': Term can not end with escape character.`
- After: `org.apache.lucene.queryparser.classic.ParseException: Cannot parse '[\ TO abc]': Encountered " <RANGE_GOOP> "\\] "" at line 1, column 6.
Was expecting:
    "TO" ...`
  - This is to be expected as escaped spaces are now allowed, so the first term parsed is `" TO"`.

---

### Question: other QueryParsers

In previous changes to QueryParser.jj/StandardSyntaxParser.jj, I noticed authors also changed Solr's [QueryParser.jj](https://github.com/apache/solr/blob/main/solr/core/src/java/org/apache/solr/parser/QueryParser.jj). I imagine I'd want to do the same here, but wanted to check with maintainers first.