### PR TITLE
Check ahead if we can get the count

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -63,6 +63,8 @@ Optimizations
 * GITHUB#13941: Optimized computation of top-hits on disjunctive queries with
   many clauses. (Adrien Grand)
 
+* GITHUB#13899: Check ahead if we can get the count. (Lu Xugang)
+
 Bug Fixes
 ---------------------
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -186,9 +186,40 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
       @Override
       public int count(LeafReaderContext context) throws IOException {
         if (context.reader().hasDeletions() == false) {
-          IteratorAndCount itAndCount = getDocIdSetIteratorOrNull(context);
+          IteratorAndCount itAndCount = null;
+          LeafReader reader = context.reader();
+
+          // first use bkd optimization if possible
+          SortedNumericDocValues sortedNumericValues = DocValues.getSortedNumeric(reader, field);
+          NumericDocValues numericValues = DocValues.unwrapSingleton(sortedNumericValues);
+          PointValues pointValues = reader.getPointValues(field);
+          if (pointValues != null && pointValues.getDocCount() == reader.maxDoc()) {
+            itAndCount = getDocIdSetIteratorOrNullFromBkd(context, numericValues);
+          }
           if (itAndCount != null && itAndCount.count != -1) {
             return itAndCount.count;
+          }
+
+          // use index sort optimization if possible
+          Sort indexSort = reader.getMetaData().sort();
+          if (indexSort != null
+              && indexSort.getSort().length > 0
+              && indexSort.getSort()[0].getField().equals(field)) {
+            final SortField sortField = indexSort.getSort()[0];
+            final SortField.Type sortFieldType = getSortFieldType(sortField);
+            // The index sort optimization is only supported for Type.INT and Type.LONG
+            if (sortFieldType == Type.INT || sortFieldType == Type.LONG) {
+              Object missingValue = sortField.getMissingValue();
+              final long missingLongValue = missingValue == null ? 0L : (long) missingValue;
+              // all documents have docValues or missing value falls outside the range
+              if ((pointValues != null && pointValues.getDocCount() == reader.maxDoc())
+                  || (missingLongValue < lowerValue || missingLongValue > upperValue)) {
+                itAndCount = getDocIdSetIterator(sortField, sortFieldType, context, numericValues);
+              }
+              if (itAndCount != null && itAndCount.count != -1) {
+                return itAndCount.count;
+              }
+            }
           }
         }
         return fallbackWeight.count(context);

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -186,6 +186,9 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
       @Override
       public int count(LeafReaderContext context) throws IOException {
         if (context.reader().hasDeletions() == false) {
+          if (lowerValue > upperValue) {
+            return 0;
+          }
           IteratorAndCount itAndCount = null;
           LeafReader reader = context.reader();
 

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -185,10 +185,10 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
 
       @Override
       public int count(LeafReaderContext context) throws IOException {
+        if (lowerValue > upperValue) {
+          return 0;
+        }
         if (context.reader().hasDeletions() == false) {
-          if (lowerValue > upperValue) {
-            return 0;
-          }
           IteratorAndCount itAndCount = null;
           LeafReader reader = context.reader();
 

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -185,10 +185,10 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
 
       @Override
       public int count(LeafReaderContext context) throws IOException {
-        if (lowerValue > upperValue) {
-          return 0;
-        }
         if (context.reader().hasDeletions() == false) {
+          if (lowerValue > upperValue) {
+            return 0;
+          }
           IteratorAndCount itAndCount = null;
           LeafReader reader = context.reader();
 


### PR DESCRIPTION
Check whether the IndexSortSortedNumericDocValuesRangeQuery's count can be obtained before traversing the BKD tree or performing binary search using DocValues.

see https://github.com/apache/lucene/issues/13890
