### PR TITLE
Added support for highlighting `IndexOrDocValuesQuery`

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -54,6 +54,7 @@ Bug Fixes
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended
   when they were not sorted by startOffset. (Seunghan Jung)
 * GITHUB#13884: Remove broken .toArray from Long/CharObjectHashMap entirely. (Pan Guixin)
+* GITHUB#12686: Added support for highlighting IndexOrDocValuesQuery. (Prudhvi Godithi)
 
 Build
 ---------------------

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
@@ -54,6 +54,7 @@ import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MultiPhraseQuery;
@@ -162,6 +163,11 @@ public class WeightedSpanTermExtractor {
         SpanNearQuery sp =
             new SpanNearQuery(clauses, phraseQuery.getSlop() + positionGaps, inorder);
         extractWeightedSpanTerms(terms, sp, boost);
+      }
+    } else if (query instanceof IndexOrDocValuesQuery) {
+      Query indexQuery = ((IndexOrDocValuesQuery) query).getIndexQuery();
+      if (indexQuery != null) {
+        extract(indexQuery, boost, terms);
       }
     } else if (query instanceof TermQuery || query instanceof SynonymQuery) {
       extractWeightedTerms(terms, query, boost);


### PR DESCRIPTION
### Description

Coming from https://github.com/apache/lucene/issues/12686, added condition to check for `IndexOrDocValuesQuery`. Please take a look and let me know.

Thanks
