### PR TITLE
Align TestGenerateBwcIndices.java with AddBackcompatindices.py

### DIFF
--- a/dev-tools/scripts/addBackcompatIndexes.py
+++ b/dev-tools/scripts/addBackcompatIndexes.py
@@ -40,7 +40,7 @@ def create_and_add_index(source, indextype, index_version, current_version, temp
       'cfs': 'index',
       'nocfs': 'index',
       'sorted': 'sorted',
-      'int8_hnsw': 'int8_hnsw',
+      'int7_hnsw': 'int7_hnsw',
       'moreterms': 'moreterms',
       'dvupdates': 'dvupdates',
       'emptyIndex': 'empty'
@@ -61,7 +61,7 @@ def create_and_add_index(source, indextype, index_version, current_version, temp
     'cfs': 'testCreateCFS',
     'nocfs': 'testCreateNoCFS',
     'sorted': 'testCreateSortedIndex',
-    'int8_hnsw': 'testCreateInt8HNSWIndices',
+    'int7_hnsw': 'testCreateInt7HNSWIndices',
     'moreterms': 'testCreateMoreTermsIndex',
     'dvupdates': 'testCreateIndexWithDocValuesUpdates',
     'emptyIndex': 'testCreateEmptyIndex'
@@ -206,7 +206,7 @@ def main():
   current_version = scriptutil.Version.parse(scriptutil.find_current_version())
   create_and_add_index(source, 'cfs', c.version, current_version, c.temp_dir)
   create_and_add_index(source, 'nocfs', c.version, current_version, c.temp_dir)
-  create_and_add_index(source, 'int8_hnsw', c.version, current_version, c.temp_dir)
+  create_and_add_index(source, 'int7_hnsw', c.version, current_version, c.temp_dir)
   should_make_sorted =     current_version.is_back_compat_with(c.version) \
                        and (c.version.major > 6 or (c.version.major == 6 and c.version.minor >= 2))
   if should_make_sorted:


### PR DESCRIPTION
We updated TestGenerateBwcIndices to create int7 HNSW indices instead of int8 with #13874. The corresponding python code part of the release wizard needs to be updated accordingly.

This should be good for branch_10_0, as well as branch_10x and main. I just used it to generate backwards indices for the 10.0.0 release branch. See https://github.com/apache/lucene/commit/e821a1b4f87b49008368754e2e0d773572e2b1c0 .

