### PR TITLE
Indicate frontier init length in Lucene90BlockTreeTermsWriter#compileIndex.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
@@ -545,6 +545,7 @@ public final class Lucene90BlockTreeTermsWriter extends FieldsConsumer {
               .suffixRAMLimitMB(0d)
               .dataOutput(getOnHeapReaderWriter(pageBits))
               .setVersion(fstVersion)
+              .setInitLength(prefix.length + 1)
               .build();
       // if (DEBUG) {
       //  System.out.println("  compile index for prefix=" + prefix);

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -164,7 +164,8 @@ public class FSTCompiler<T> {
       boolean allowFixedLengthArcs,
       DataOutput dataOutput,
       float directAddressingMaxOversizingFactor,
-      int version) {
+      int version,
+      int initLength) {
     this.allowFixedLengthArcs = allowFixedLengthArcs;
     this.directAddressingMaxOversizingFactor = directAddressingMaxOversizingFactor;
     this.version = version;
@@ -185,7 +186,7 @@ public class FSTCompiler<T> {
     NO_OUTPUT = outputs.getNoOutput();
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    final UnCompiledNode<T>[] f = (UnCompiledNode<T>[]) new UnCompiledNode[10];
+    final UnCompiledNode<T>[] f = (UnCompiledNode<T>[]) new UnCompiledNode[initLength];
     frontier = f;
     for (int idx = 0; idx < frontier.length; idx++) {
       frontier[idx] = new UnCompiledNode<>(this, idx);
@@ -247,6 +248,7 @@ public class FSTCompiler<T> {
     private DataOutput dataOutput;
     private float directAddressingMaxOversizingFactor = DIRECT_ADDRESSING_MAX_OVERSIZING_FACTOR;
     private int version = FST.VERSION_CURRENT;
+    private int initLength = 10;
 
     /**
      * @param inputType The input type (transition labels). Can be anything from {@link INPUT_TYPE}
@@ -346,6 +348,11 @@ public class FSTCompiler<T> {
       return this;
     }
 
+    public Builder<T> setInitLength(int initLength) {
+      this.initLength = initLength;
+      return this;
+    }
+
     /** Creates a new {@link FSTCompiler}. */
     public FSTCompiler<T> build() {
       // create a default DataOutput if not specified
@@ -359,7 +366,8 @@ public class FSTCompiler<T> {
           allowFixedLengthArcs,
           dataOutput,
           directAddressingMaxOversizingFactor,
-          version);
+          version,
+          initLength);
     }
   }
 


### PR DESCRIPTION
### Description

I think it could avoid waste or resize `FSTCompiler.frontier` when building leaf block's FST, which has no `block.subIndices`. 
