### PR TITLE
Introduce multiSelect for ScalarQuantizer

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
@@ -616,16 +616,17 @@ public final class ArrayUtil {
   }
 
   /**
-   * Reorganize {@code arr[from:to[} so that the elements at the offsets included in {@code k} are at the same position as if
-   * {@code arr[from:to]} was sorted, and all elements on their left are less than or equal to them, and
-   * all elements on their right are greater than or equal to them.
+   * Reorganize {@code arr[from:to[} so that the elements at the offsets included in {@code k} are
+   * at the same position as if {@code arr[from:to]} was sorted, and all elements on their left are
+   * less than or equal to them, and all elements on their right are greater than or equal to them.
    *
    * <p>This runs in linear time on average and in {@code n log(n)} time in the worst case.
    *
    * @param arr Array to be re-organized.
    * @param from Starting index for re-organization. Elements before this index will be left as is.
    * @param to Ending index. Elements after this index will be left as is.
-   * @param k Array containing the Indexes of elements to sort from. Values must be less than 'to' and greater than or equal to 'from'. This list will be sorted during the call.
+   * @param k Array containing the Indexes of elements to sort from. Values must be less than 'to'
+   *     and greater than or equal to 'from'. This list will be sorted during the call.
    * @param comparator Comparator to use for sorting
    */
   public static <T> void multiSelect(

--- a/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
@@ -615,6 +615,42 @@ public final class ArrayUtil {
     }.select(from, to, k);
   }
 
+  /**
+   * Reorganize {@code arr[from:to[} so that the elements at the offsets included in {@code k} are at the same position as if
+   * {@code arr[from:to]} was sorted, and all elements on their left are less than or equal to them, and
+   * all elements on their right are greater than or equal to them.
+   *
+   * <p>This runs in linear time on average and in {@code n log(n)} time in the worst case.
+   *
+   * @param arr Array to be re-organized.
+   * @param from Starting index for re-organization. Elements before this index will be left as is.
+   * @param to Ending index. Elements after this index will be left as is.
+   * @param k Array containing the Indexes of elements to sort from. Values must be less than 'to' and greater than or equal to 'from'. This list will be sorted during the call.
+   * @param comparator Comparator to use for sorting
+   */
+  public static <T> void multiSelect(
+      T[] arr, int from, int to, int[] k, Comparator<? super T> comparator) {
+    new IntroSelector() {
+
+      T pivot;
+
+      @Override
+      protected void swap(int i, int j) {
+        ArrayUtil.swap(arr, i, j);
+      }
+
+      @Override
+      protected void setPivot(int i) {
+        pivot = arr[i];
+      }
+
+      @Override
+      protected int comparePivot(int j) {
+        return comparator.compare(pivot, arr[j]);
+      }
+    }.multiSelect(from, to, k);
+  }
+
   /** Copies an array into a new array. */
   public static byte[] copyArray(byte[] array) {
     return copyOfSubArray(array, 0, array.length);

--- a/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
@@ -46,9 +46,9 @@ public abstract class IntroSelector extends Selector {
   }
 
   @Override
-  public final void select(int from, int to, int[] k) {
-    checkArgs(from, to, k);
-    select(from, to, k, 0, k.length, 2 * MathUtil.log(to - from, 2));
+  public final void multiSelect(int from, int to, int[] k, int kFrom, int kTo) {
+    checkMultiArgs(from, to, k, kFrom, kTo);
+    multiSelect(from, to, k, kFrom, kTo, 2 * MathUtil.log(to - from, 2));
   }
 
   // Visible for testing.
@@ -153,8 +153,8 @@ public abstract class IntroSelector extends Selector {
   }
 
   // Visible for testing.
-  void select(int from, int to, int[] k, int kFrom, int kTo, int maxDepth) {
-    // If there is only 1 k value to select in this group, then use the single-k select method
+  void multiSelect(int from, int to, int[] k, int kFrom, int kTo, int maxDepth) {
+    // If there is only 1 k value to select in this group, then use the single-k select method, which does not do recursion
     if (kTo - kFrom == 1) {
       select(from, to, k[kFrom], maxDepth);
       return;
@@ -251,11 +251,11 @@ public abstract class IntroSelector extends Selector {
       }
       // Recursively select the relevant k-values from the bottom group, if there are any k-values to select there
       if (bottomKTo > kFrom) {
-        select(from, j + 1, k, kFrom, bottomKTo, maxDepth);
+        multiSelect(from, j + 1, k, kFrom, bottomKTo, maxDepth);
       }
       // Recursively select the relevant k-values from the top group, if there are any k-values to select there
       if (topKFrom < kTo) {
-        select(i, to, k, topKFrom, kTo, maxDepth);
+        multiSelect(i, to, k, topKFrom, kTo, maxDepth);
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
@@ -46,8 +46,7 @@ public abstract class IntroSelector extends Selector {
   }
 
   @Override
-  public final void multiSelect(int from, int to, int[] k, int kFrom, int kTo) {
-    checkMultiArgs(from, to, k, kFrom, kTo);
+  protected final void multiSelect(int from, int to, int[] k, int kFrom, int kTo) {
     multiSelect(from, to, k, kFrom, kTo, 2 * MathUtil.log(to - from, 2));
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
@@ -154,7 +154,8 @@ public abstract class IntroSelector extends Selector {
 
   // Visible for testing.
   void multiSelect(int from, int to, int[] k, int kFrom, int kTo, int maxDepth) {
-    // If there is only 1 k value to select in this group, then use the single-k select method, which does not do recursion
+    // If there is only 1 k value to select in this group, then use the single-k select method,
+    // which does not do recursion
     if (kTo - kFrom == 1) {
       select(from, to, k[kFrom], maxDepth);
       return;
@@ -240,7 +241,7 @@ public abstract class IntroSelector extends Selector {
       // Select the K values contained in the bottom and top partitions.
       int topKFrom = kTo;
       int bottomKTo = kFrom;
-      for (int ki = kTo-1; ki >= kFrom; ki--) {
+      for (int ki = kTo - 1; ki >= kFrom; ki--) {
         if (k[ki] >= i) {
           topKFrom = ki;
         }
@@ -249,11 +250,13 @@ public abstract class IntroSelector extends Selector {
           break;
         }
       }
-      // Recursively select the relevant k-values from the bottom group, if there are any k-values to select there
+      // Recursively select the relevant k-values from the bottom group, if there are any k-values
+      // to select there
       if (bottomKTo > kFrom) {
         multiSelect(from, j + 1, k, kFrom, bottomKTo, maxDepth);
       }
-      // Recursively select the relevant k-values from the top group, if there are any k-values to select there
+      // Recursively select the relevant k-values from the top group, if there are any k-values to
+      // select there
       if (topKFrom < kTo) {
         multiSelect(i, to, k, topKFrom, kTo, maxDepth);
       }

--- a/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
@@ -224,12 +224,14 @@ public abstract class RadixSelector extends Selector {
       }
       final int bucketTo = bucketFrom + histogram[bucket];
       int bucketKTo = bucketKFrom;
-      // Move the right-side of the k-window up until the k-value is no longer in the current histogram bucket
+      // Move the right-side of the k-window up until the k-value is no longer in the current
+      // histogram bucket
       while (bucketKTo < kTo && k[bucketKTo] < bucketTo) {
         bucketKTo++;
       }
 
-      // If there are any k-values captured in this histogram, continue down this path with those k-values
+      // If there are any k-values captured in this histogram, continue down this path with those
+      // k-values
       if (bucketKFrom < bucketKTo) {
         partition(from, to, bucket, bucketFrom, bucketTo, d);
 

--- a/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
@@ -126,8 +126,7 @@ public abstract class RadixSelector extends Selector {
   }
 
   @Override
-  public void multiSelect(int from, int to, int[] k, int kFrom, int kTo) {
-    checkMultiArgs(from, to, k, kFrom, kTo);
+  protected void multiSelect(int from, int to, int[] k, int kFrom, int kTo) {
     multiSelect(from, to, k, kFrom, kTo, 0, 0);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
  * Radix selector.
  *
  * <p>This implementation works similarly to a MSB radix sort except that it only recurses into the
- * sub partition that contains the desired value.
+ * sub partition that contains the desired value(s).
  *
  * @lucene.internal
  */

--- a/lucene/core/src/java/org/apache/lucene/util/Selector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Selector.java
@@ -33,22 +33,23 @@ public abstract class Selector {
   public abstract void select(int from, int to, int k);
 
   /**
-   * Reorder elements so that the elements at all positions in {@code k} are the same as if all elements were
-   * sorted and all other elements are partitioned around it: {@code [from, k[n])} only contains
-   * elements that are less than or equal to {@code k[n]} and {@code (k[n], to)} only contains elements
-   * that are greater than or equal to {@code k[n]}.
+   * Reorder elements so that the elements at all positions in {@code k} are the same as if all
+   * elements were sorted and all other elements are partitioned around it: {@code [from, k[n])}
+   * only contains elements that are less than or equal to {@code k[n]} and {@code (k[n], to)} only
+   * contains elements that are greater than or equal to {@code k[n]}.
    */
   public void multiSelect(int from, int to, int[] k) {
     multiSelect(from, to, k, 0, k.length);
   }
 
   /**
-   * Reorder elements so that the elements at all positions in {@code k} are the same as if all elements were
-   * sorted and all other elements are partitioned around it: {@code [from, k[n])} only contains
-   * elements that are less than or equal to {@code k[n]} and {@code (k[n], to)} only contains elements
-   * that are greater than or equal to {@code k[n]}.
+   * Reorder elements so that the elements at all positions in {@code k} are the same as if all
+   * elements were sorted and all other elements are partitioned around it: {@code [from, k[n])}
+   * only contains elements that are less than or equal to {@code k[n]} and {@code (k[n], to)} only
+   * contains elements that are greater than or equal to {@code k[n]}.
    *
-   * The array {@code k} will be sorted, so {@code kFrom} and {@code kTo} must be referring to the sorted order.
+   * <p>The array {@code k} will be sorted, so {@code kFrom} and {@code kTo} must be referring to
+   * the sorted order.
    */
   public void multiSelect(int from, int to, int[] k, int kFrom, int kTo) {
     // Default implementation only uses select(), so it is not optimal

--- a/lucene/core/src/java/org/apache/lucene/util/Selector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Selector.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.util;
 
+import java.util.Arrays;
+
 /**
  * An implementation of a selection algorithm, ie. computing the k-th greatest value from a
  * collection.
@@ -39,6 +41,7 @@ public abstract class Selector {
   public void multiSelect(int from, int to, int[] k) {
     // k needs to be sorted, so copy the array
     k = ArrayUtil.copyArray(k);
+    Arrays.sort(k);
     checkMultiArgs(from, to, k);
     multiSelect(from, to, k, 0, k.length);
   }

--- a/lucene/core/src/java/org/apache/lucene/util/Selector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Selector.java
@@ -39,6 +39,9 @@ public abstract class Selector {
    * contains elements that are greater than or equal to {@code k[n]}.
    */
   public void multiSelect(int from, int to, int[] k) {
+    // k needs to be sorted, so copy the array
+    k = Arrays.copyOf(k, k.length);
+    checkMultiArgs(from, to, k);
     multiSelect(from, to, k, 0, k.length);
   }
 
@@ -48,12 +51,11 @@ public abstract class Selector {
    * only contains elements that are less than or equal to {@code k[n]} and {@code (k[n], to)} only
    * contains elements that are greater than or equal to {@code k[n]}.
    *
-   * <p>The array {@code k} will be sorted, so {@code kFrom} and {@code kTo} must be referring to
+   * <p>The array {@code k} must be sorted, and {@code kFrom} and {@code kTo} must be referring to
    * the sorted order.
    */
-  public void multiSelect(int from, int to, int[] k, int kFrom, int kTo) {
+  protected void multiSelect(int from, int to, int[] k, int kFrom, int kTo) {
     // Default implementation only uses select(), so it is not optimal
-    checkMultiArgs(from, to, k, kFrom, kTo);
     int nextFrom = from;
     for (int i = kFrom; i < kTo; i++) {
       int currentK = k[i];
@@ -75,18 +77,14 @@ public abstract class Selector {
     }
   }
 
-  void checkMultiArgs(int from, int to, int[] k, int kFrom, int kTo) {
-    if (kFrom < 0) {
-      throw new IllegalArgumentException("kFrom must be >= 0");
+  void checkMultiArgs(int from, int to, int[] k) {
+    if (k.length == 0) {
+      throw new IllegalArgumentException("k must not be empty");
     }
-    if (kTo > k.length) {
-      throw new IllegalArgumentException("kFrom must be <= k.length");
-    }
-    Arrays.sort(k);
-    if (k[kFrom] < from) {
+    if (k[0] < from) {
       throw new IllegalArgumentException("All k must be >= from");
     }
-    if (k[kTo - 1] >= to) {
+    if (k[k.length - 1] >= to) {
       throw new IllegalArgumentException("All k must be < to");
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/util/Selector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Selector.java
@@ -38,8 +38,31 @@ public abstract class Selector {
    * elements that are less than or equal to {@code k[n]} and {@code (k[n], to)} only contains elements
    * that are greater than or equal to {@code k[n]}.
    */
-  public void select(int from, int to, int[] k) {
-    select(from, to, k[0]);
+  public void multiSelect(int from, int to, int[] k) {
+    multiSelect(from, to, k, 0, k.length);
+  }
+
+  /**
+   * Reorder elements so that the elements at all positions in {@code k} are the same as if all elements were
+   * sorted and all other elements are partitioned around it: {@code [from, k[n])} only contains
+   * elements that are less than or equal to {@code k[n]} and {@code (k[n], to)} only contains elements
+   * that are greater than or equal to {@code k[n]}.
+   *
+   * The array {@code k} will be sorted, so {@code kFrom} and {@code kTo} must be referring to the sorted order.
+   */
+  public void multiSelect(int from, int to, int[] k, int kFrom, int kTo) {
+    // Default implementation only uses select(), so it is not optimal
+    checkMultiArgs(from, to, k, kFrom, kTo);
+    int nextFrom = from;
+    for (int i = kFrom; i < kTo; i++) {
+      int currentK = k[i];
+      if (currentK < nextFrom) {
+        // This is a duplicate k
+        continue;
+      }
+      select(nextFrom, to, currentK);
+      nextFrom = currentK + 1;
+    }
   }
 
   void checkArgs(int from, int to, int k) {
@@ -51,15 +74,18 @@ public abstract class Selector {
     }
   }
 
-  void checkArgs(int from, int to, int[] k) {
-    if (k.length < 1) {
-      throw new IllegalArgumentException("There must be at least one k to select, none given");
+  void checkMultiArgs(int from, int to, int[] k, int kFrom, int kTo) {
+    if (kFrom < 0) {
+      throw new IllegalArgumentException("kFrom must be >= 0");
+    }
+    if (kTo > k.length) {
+      throw new IllegalArgumentException("kFrom must be <= k.length");
     }
     Arrays.sort(k);
-    if (k[0] < from) {
+    if (k[kFrom] < from) {
       throw new IllegalArgumentException("All k must be >= from");
     }
-    if (k[k.length - 1] >= to) {
+    if (k[kTo - 1] >= to) {
       throw new IllegalArgumentException("All k must be < to");
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/util/Selector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Selector.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.util;
 
+import java.util.Arrays;
+
 /**
  * An implementation of a selection algorithm, ie. computing the k-th greatest value from a
  * collection.
@@ -30,12 +32,35 @@ public abstract class Selector {
    */
   public abstract void select(int from, int to, int k);
 
+  /**
+   * Reorder elements so that the elements at all positions in {@code k} are the same as if all elements were
+   * sorted and all other elements are partitioned around it: {@code [from, k[n])} only contains
+   * elements that are less than or equal to {@code k[n]} and {@code (k[n], to)} only contains elements
+   * that are greater than or equal to {@code k[n]}.
+   */
+  public void select(int from, int to, int[] k) {
+    select(from, to, k[0]);
+  }
+
   void checkArgs(int from, int to, int k) {
     if (k < from) {
       throw new IllegalArgumentException("k must be >= from");
     }
     if (k >= to) {
       throw new IllegalArgumentException("k must be < to");
+    }
+  }
+
+  void checkArgs(int from, int to, int[] k) {
+    if (k.length < 1) {
+      throw new IllegalArgumentException("There must be at least one k to select, none given");
+    }
+    Arrays.sort(k);
+    if (k[0] < from) {
+      throw new IllegalArgumentException("All k must be >= from");
+    }
+    if (k[k.length - 1] >= to) {
+      throw new IllegalArgumentException("All k must be < to");
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/Selector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Selector.java
@@ -16,8 +16,6 @@
  */
 package org.apache.lucene.util;
 
-import java.util.Arrays;
-
 /**
  * An implementation of a selection algorithm, ie. computing the k-th greatest value from a
  * collection.
@@ -40,7 +38,7 @@ public abstract class Selector {
    */
   public void multiSelect(int from, int to, int[] k) {
     // k needs to be sorted, so copy the array
-    k = Arrays.copyOf(k, k.length);
+    k = ArrayUtil.copyArray(k);
     checkMultiArgs(from, to, k);
     multiSelect(from, to, k, 0, k.length);
   }

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizer.java
@@ -439,7 +439,8 @@ public class ScalarQuantizer {
       double[] lowerSum) {
     assert confidenceIntervals.length == upperSum.length
         && confidenceIntervals.length == lowerSum.length;
-    float[][] upperAndLowerQuantiles = getUpperAndLowerQuantiles(quantileGatheringScratch, confidenceIntervals);
+    float[][] upperAndLowerQuantiles =
+        getUpperAndLowerQuantiles(quantileGatheringScratch, confidenceIntervals);
     for (int i = 0; i < confidenceIntervals.length; i++) {
       upperSum[i] += upperAndLowerQuantiles[i][1];
       lowerSum[i] += upperAndLowerQuantiles[i][0];
@@ -591,8 +592,8 @@ public class ScalarQuantizer {
 
     // After the selection process, pick out the given quantile values
     for (int i = 0; i < confidenceIntervals.length; i++) {
-      minAndMaxPerInterval[i][0] = arr[selectorIndexes[2*i]];
-      minAndMaxPerInterval[i][1] = arr[selectorIndexes[2*i + 1]];
+      minAndMaxPerInterval[i][0] = arr[selectorIndexes[2 * i]];
+      minAndMaxPerInterval[i][1] = arr[selectorIndexes[2 * i + 1]];
     }
     return minAndMaxPerInterval;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizer.java
@@ -587,7 +587,7 @@ public class ScalarQuantizer {
       selectorIndexes[2 * i + 1] = arr.length - selectorIndex - 1;
     }
     Selector selector = new FloatSelector(arr);
-    selector.select(0, arr.length, selectorIndexes);
+    selector.multiSelect(0, arr.length, selectorIndexes);
 
     // After the selection process, pick out the given quantile values
     for (int i = 0; i < confidenceIntervals.length; i++) {

--- a/lucene/core/src/test/org/apache/lucene/util/TestIntroSelector.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestIntroSelector.java
@@ -80,5 +80,30 @@ public class TestIntroSelector extends LuceneTestCase {
         assertTrue(actual[i] >= actual[k]);
       }
     }
+
+    final int[] kArr = new int[TestUtil.nextInt(random, 1, 10)];
+    for (int i = 0; i < kArr.length; i++) {
+      kArr[i] = TestUtil.nextInt(random, from, to - 1);
+    }
+    selector.multiSelect(from, to, kArr);
+
+    int nextKIdx = 0;
+    Arrays.sort(kArr);
+    for (int i = 0; i < actual.length; ++i) {
+      if (i < from || i >= to) {
+        assertSame(arr[i], actual[i]);
+      } else if (nextKIdx < kArr.length) {
+        if (i == kArr[nextKIdx]) {
+          assertEquals(expected[i], actual[i]);
+          while (nextKIdx < kArr.length && i == kArr[nextKIdx]) {
+            nextKIdx++;
+          }
+        } else {
+          assertTrue(actual[i].compareTo(expected[kArr[nextKIdx]]) <= 0);
+        }
+      } else {
+        assertTrue(actual[i].compareTo(expected[kArr[kArr.length - 1]]) >= 0);
+      }
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestRadixSelector.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRadixSelector.java
@@ -108,5 +108,30 @@ public class TestRadixSelector extends LuceneTestCase {
         assertTrue(actual[i].compareTo(actual[k]) >= 0);
       }
     }
+
+    final int[] kArr = new int[TestUtil.nextInt(random(), 1, 10)];
+    for (int i = 0; i < kArr.length; i++) {
+      kArr[i] = TestUtil.nextInt(random(), from, to - 1);
+    }
+    selector.multiSelect(from, to, kArr);
+
+    int nextKIdx = 0;
+    Arrays.sort(kArr);
+    for (int i = 0; i < actual.length; ++i) {
+      if (i < from || i >= to) {
+        assertSame(arr[i], actual[i]);
+      } else if (nextKIdx < kArr.length) {
+        if (i == kArr[nextKIdx]) {
+          assertEquals(expected[i], actual[i]);
+          while (nextKIdx < kArr.length && i == kArr[nextKIdx]) {
+            nextKIdx++;
+          }
+        } else {
+          assertTrue(actual[i].compareTo(expected[kArr[nextKIdx]]) <= 0);
+        }
+      } else {
+        assertTrue(actual[i].compareTo(expected[kArr[kArr.length - 1]]) >= 0);
+      }
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizer.java
+++ b/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizer.java
@@ -195,7 +195,7 @@ public class TestScalarQuantizer extends LuceneTestCase {
 
   public void testFromVectorsAutoInterval4Bit() throws IOException {
     int dims = 128;
-    int numVecs = 1000;
+    int numVecs = 100;
     VectorSimilarityFunction similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
 
     float[][] floats = randomFloats(numVecs, dims);

--- a/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizer.java
+++ b/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizer.java
@@ -125,22 +125,23 @@ public class TestScalarQuantizer extends LuceneTestCase {
       percs[i] = (float) i;
     }
     shuffleArray(percs);
-    float[][] upperAndLower = ScalarQuantizer.getUpperAndLowerQuantiles(percs, new float[]{0.9f});
+    float[][] upperAndLower = ScalarQuantizer.getUpperAndLowerQuantiles(percs, new float[] {0.9f});
     assertEquals(50f, upperAndLower[0][0], 1e-7);
     assertEquals(949f, upperAndLower[0][1], 1e-7);
     shuffleArray(percs);
-    upperAndLower = ScalarQuantizer.getUpperAndLowerQuantiles(percs, new float[]{0.95f});
+    upperAndLower = ScalarQuantizer.getUpperAndLowerQuantiles(percs, new float[] {0.95f});
     assertEquals(25f, upperAndLower[0][0], 1e-7);
     assertEquals(974f, upperAndLower[0][1], 1e-7);
     shuffleArray(percs);
-    upperAndLower = ScalarQuantizer.getUpperAndLowerQuantiles(percs, new float[]{0.99f});
+    upperAndLower = ScalarQuantizer.getUpperAndLowerQuantiles(percs, new float[] {0.99f});
     assertEquals(5f, upperAndLower[0][0], 1e-7);
     assertEquals(994f, upperAndLower[0][1], 1e-7);
   }
 
   public void testEdgeCase() {
     float[][] upperAndLower =
-        ScalarQuantizer.getUpperAndLowerQuantiles(new float[] {1.0f, 1.0f, 1.0f, 1.0f, 1.0f}, new float[]{0.9f});
+        ScalarQuantizer.getUpperAndLowerQuantiles(
+            new float[] {1.0f, 1.0f, 1.0f, 1.0f, 1.0f}, new float[] {0.9f});
     assertEquals(1f, upperAndLower[0][0], 1e-7f);
     assertEquals(1f, upperAndLower[0][1], 1e-7f);
   }
@@ -194,7 +195,7 @@ public class TestScalarQuantizer extends LuceneTestCase {
 
   public void testFromVectorsAutoInterval4Bit() throws IOException {
     int dims = 128;
-    int numVecs = 100;
+    int numVecs = 1000;
     VectorSimilarityFunction similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
 
     float[][] floats = randomFloats(numVecs, dims);

--- a/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizer.java
+++ b/lucene/core/src/test/org/apache/lucene/util/quantization/TestScalarQuantizer.java
@@ -125,24 +125,24 @@ public class TestScalarQuantizer extends LuceneTestCase {
       percs[i] = (float) i;
     }
     shuffleArray(percs);
-    float[] upperAndLower = ScalarQuantizer.getUpperAndLowerQuantile(percs, 0.9f);
-    assertEquals(50f, upperAndLower[0], 1e-7);
-    assertEquals(949f, upperAndLower[1], 1e-7);
+    float[][] upperAndLower = ScalarQuantizer.getUpperAndLowerQuantiles(percs, new float[]{0.9f});
+    assertEquals(50f, upperAndLower[0][0], 1e-7);
+    assertEquals(949f, upperAndLower[0][1], 1e-7);
     shuffleArray(percs);
-    upperAndLower = ScalarQuantizer.getUpperAndLowerQuantile(percs, 0.95f);
-    assertEquals(25f, upperAndLower[0], 1e-7);
-    assertEquals(974f, upperAndLower[1], 1e-7);
+    upperAndLower = ScalarQuantizer.getUpperAndLowerQuantiles(percs, new float[]{0.95f});
+    assertEquals(25f, upperAndLower[0][0], 1e-7);
+    assertEquals(974f, upperAndLower[0][1], 1e-7);
     shuffleArray(percs);
-    upperAndLower = ScalarQuantizer.getUpperAndLowerQuantile(percs, 0.99f);
-    assertEquals(5f, upperAndLower[0], 1e-7);
-    assertEquals(994f, upperAndLower[1], 1e-7);
+    upperAndLower = ScalarQuantizer.getUpperAndLowerQuantiles(percs, new float[]{0.99f});
+    assertEquals(5f, upperAndLower[0][0], 1e-7);
+    assertEquals(994f, upperAndLower[0][1], 1e-7);
   }
 
   public void testEdgeCase() {
-    float[] upperAndLower =
-        ScalarQuantizer.getUpperAndLowerQuantile(new float[] {1.0f, 1.0f, 1.0f, 1.0f, 1.0f}, 0.9f);
-    assertEquals(1f, upperAndLower[0], 1e-7f);
-    assertEquals(1f, upperAndLower[1], 1e-7f);
+    float[][] upperAndLower =
+        ScalarQuantizer.getUpperAndLowerQuantiles(new float[] {1.0f, 1.0f, 1.0f, 1.0f, 1.0f}, new float[]{0.9f});
+    assertEquals(1f, upperAndLower[0][0], 1e-7f);
+    assertEquals(1f, upperAndLower[0][1], 1e-7f);
   }
 
   public void testScalarWithSampling() throws IOException {


### PR DESCRIPTION
Resolves #13918 

### Description

This introduces a `multiSelect(from, to, k[])` method on the `Selector` abstract class, and gives implementations of the method for both `Selector` implementations, `IntroSelector` and `RadixSelector`.

This is really only used so far in the `ScalarQuantizer`, which uses `IntroSelector`, to find confidence intervals (quantiles) for lists of vectors. This code was refactored to find all quantiles at once. `ScalarQuantizer.fromVectors()` does 1 confidence interval (2 quantiles), and `ScalarQuantizer.fromVectorsAutoInterval()` does 2 confidence intervals (4 quantiles).

### multiSelect details

For both `RadixSelector` and `IntroSelector`, the `multiSelect()` code is not too dissimilar from the `select()` code, however all paths are taken that could lead to one of the `k` values. In each path, only the relevant `k` values are checked. If a path has only 1 `k` value, then `select()` is called instead of `multiSelect()`.

One difference in `RadixSelector` is that recursive calls are not done in-place, rather kept in a list to do after checking all path-options, so that we don't have to keep a stack of histograms. This should not be expensive, because the list that contains these recursive-call-path-options, is capped at the number of valid `k` values for that path, which will likely be small most of the time.

Also I provided a default `Selector.multiSelect()` call that is not optimized, because `Selector` is a public class that people might have made custom implementations of?

### Benchmarking

~~Real benchmarking still needs to be done, but using IntelliJ's profiler on `TestScalarQuantizer.testFromVectorsAutoInterval4Bit()`, I have seen a **>20% speed improvement** in the call to `ScalarQuantizer.fromVectorsAutoInterval()` when using 1028 dimensions (310 ms -> 240 ms). This speedup holds when using 1000 vectors instead of 100  (3200 ms -> 2500 ms) and when using 1000 vectors and a smaller dimension of 128 (480 ms -> 370 ms).~~  
Oops, bad results

I'd love to make benchmarks that fit with the way Lucene does them. Are there already vector benchmarks that I could build off of, or do I need to start from scratch?