### PR TITLE
Remove TODO in FSTCompiler#freezeTail.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -828,7 +828,7 @@ public class FSTCompiler<T> {
       // FSTEnum, Util, etc., have trouble w/ non-final
       // dead-end states:
 
-      // TODO: is node.numArcs == 0 always false?  we no longer prune any nodes from FST:
+      // node.numArcs == 0 happens on last node, but it is final.
       final boolean isFinal = node.isFinal || node.numArcs == 0;
 
       // this node makes it and we now compile it.  first,

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -819,10 +819,14 @@ public class FSTCompiler<T> {
       final UnCompiledNode<T> node = frontier[idx];
       final int prevIdx = idx - 1;
       final UnCompiledNode<T> parent = frontier[prevIdx];
+      // We need use this variable rather than node.output to call replaceLast later, because
+      // compileNode(node) will clear node's state.
       final T nextFinalOutput = node.output;
 
       // If this node has no outgoing arcs, it should be final.
       assert node.numArcs != 0 || node.isFinal;
+      // We need use this variable rather than node.isFinal to call replaceLast later, because
+      // compileNode(node) will clear node's state.
       final boolean isFinal = node.isFinal;
 
       // this node makes it and we now compile it.  first,

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -828,7 +828,8 @@ public class FSTCompiler<T> {
       // FSTEnum, Util, etc., have trouble w/ non-final
       // dead-end states:
 
-      // node.numArcs == 0 happens on last node, but it is final.
+      // node.numArcs == 0 happens on last node. But it is final, we still can remove node.numArcs
+      // == 0.
       final boolean isFinal = node.isFinal || node.numArcs == 0;
 
       // this node makes it and we now compile it.  first,

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTCompiler.java
@@ -819,18 +819,11 @@ public class FSTCompiler<T> {
       final UnCompiledNode<T> node = frontier[idx];
       final int prevIdx = idx - 1;
       final UnCompiledNode<T> parent = frontier[prevIdx];
-
       final T nextFinalOutput = node.output;
 
-      // We "fake" the node as being final if it has no
-      // outgoing arcs; in theory we could leave it
-      // as non-final (the FST can represent this), but
-      // FSTEnum, Util, etc., have trouble w/ non-final
-      // dead-end states:
-
-      // node.numArcs == 0 happens on last node. But it is final, we still can remove node.numArcs
-      // == 0.
-      final boolean isFinal = node.isFinal || node.numArcs == 0;
+      // If this node has no outgoing arcs, it should be final.
+      assert node.numArcs != 0 || node.isFinal;
+      final boolean isFinal = node.isFinal;
 
       // this node makes it and we now compile it.  first,
       // compile any targets that were previously


### PR DESCRIPTION
### Description

`node.numArcs == 0` happens on the last node of a input. But we set it `isFinal`,  so we still can remove `node.numArcs == 0`.
