### PR TITLE
Include java21 source folders to gradle source sets

### DIFF
--- a/gradle/java/folder-layout.gradle
+++ b/gradle/java/folder-layout.gradle
@@ -19,7 +19,7 @@
 allprojects {
   plugins.withType(JavaPlugin) {
     sourceSets {
-      main.java.srcDirs = ['src/java']
+      main.java.srcDirs = ['src/java', 'src/java21']
       main.resources.srcDirs = ['src/resources']
       test.java.srcDirs = ['src/test']
       test.resources.srcDirs = ['src/test-files']


### PR DESCRIPTION
This makes it so that IDEs automatically add java files under java21 as source files.
