### PR TITLE
Use growNoCopy when copying bytes in BytesRefBuilder

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -53,6 +53,8 @@ Optimizations
 * GITHUB#13800: MaxScoreBulkScorer now recomputes scorer partitions when the
   minimum competitive allows for a more favorable partitioning. (Adrien Grand)
 
+* GITHUB#13930: Use growNoCopy when copying bytes in BytesRefBuilder. (Ignacio Vera)
+
 Bug Fixes
 ---------------------
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefBuilder.java
@@ -100,8 +100,10 @@ public class BytesRefBuilder {
    * #clear()} and then {@link #append(byte[], int, int)}.
    */
   public void copyBytes(byte[] b, int off, int len) {
-    clear();
-    append(b, off, len);
+    assert ref.offset == 0;
+    ref.length = len;
+    growNoCopy(len);
+    System.arraycopy(b, off, ref.bytes, 0, len);
   }
 
   /**
@@ -109,8 +111,7 @@ public class BytesRefBuilder {
    * #clear()} and then {@link #append(BytesRef)}.
    */
   public void copyBytes(BytesRef ref) {
-    clear();
-    append(ref);
+    copyBytes(ref.bytes, ref.offset, ref.length);
   }
 
   /**
@@ -118,8 +119,7 @@ public class BytesRefBuilder {
    * #clear()} and then {@link #append(BytesRefBuilder)}.
    */
   public void copyBytes(BytesRefBuilder builder) {
-    clear();
-    append(builder);
+    copyBytes(builder.get());
   }
 
   /**
@@ -135,7 +135,7 @@ public class BytesRefBuilder {
    * text.
    */
   public void copyChars(CharSequence text, int off, int len) {
-    grow(UnicodeUtil.maxUTF8Length(len));
+    growNoCopy(UnicodeUtil.maxUTF8Length(len));
     ref.length = UnicodeUtil.UTF16toUTF8(text, off, len, ref.bytes);
   }
 
@@ -144,7 +144,7 @@ public class BytesRefBuilder {
    * text.
    */
   public void copyChars(char[] text, int off, int len) {
-    grow(UnicodeUtil.maxUTF8Length(len));
+    growNoCopy(UnicodeUtil.maxUTF8Length(len));
     ref.length = UnicodeUtil.UTF16toUTF8(text, off, len, ref.bytes);
   }
 


### PR DESCRIPTION
I noticed in BytesRefBuilder that we have growNoCopy method, still when calling the methods #copyBytes (reseting the contents on the buffer) we are calling grow. It seems more logical to use in that case growNoCopy so this is what this commit is proposing.