### PR TITLE
Simplify PForUtil construction and cleanup its code gen a little

### DIFF
--- a/lucene/core/src/generated/checksums/generateForDeltaUtil.json
+++ b/lucene/core/src/generated/checksums/generateForDeltaUtil.json
@@ -1,4 +1,4 @@
 {
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForDeltaUtil.java": "f561578ccb6a95364bb62c5ed86b38ff0b4a009d",
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForDeltaUtil.py": "eea1a71be9da8a13fdd979354dc4a8c6edf21be1"
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForDeltaUtil.java": "b662da5848b0decc8bceb4225f433875ae9e3c11",
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForDeltaUtil.py": "01787b97bbe79edb7703498cef8ddb85901a6b1e"
 }

--- a/lucene/core/src/generated/checksums/generateForUtil.json
+++ b/lucene/core/src/generated/checksums/generateForUtil.json
@@ -1,4 +1,4 @@
 {
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForUtil.java": "159e82388346fde147924d5e15ca65df4dd63b9a",
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForUtil.py": "66dc8813160feae2a37d8b50474f5f9830b6cb22"
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForUtil.java": "02e0c8c290e65d0314664fde24c9331bdec44925",
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForUtil.py": "d7850f37e52a16c6592322950d0f6219cad23a33"
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForDeltaUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForDeltaUtil.java
@@ -286,11 +286,11 @@ public final class ForDeltaUtil {
       throws IOException {
     switch (bitsPerValue) {
       case 1:
-        decode1(pdu, tmp, longs);
+        decode1(pdu, longs);
         prefixSum8(longs, base);
         break;
       case 2:
-        decode2(pdu, tmp, longs);
+        decode2(pdu, longs);
         prefixSum8(longs, base);
         break;
       case 3:
@@ -298,7 +298,7 @@ public final class ForDeltaUtil {
         prefixSum8(longs, base);
         break;
       case 4:
-        decode4(pdu, tmp, longs);
+        decode4(pdu, longs);
         prefixSum8(longs, base);
         break;
       case 5:
@@ -314,7 +314,7 @@ public final class ForDeltaUtil {
         prefixSum16(longs, base);
         break;
       case 8:
-        decode8To16(pdu, tmp, longs);
+        decode8To16(pdu, longs);
         prefixSum16(longs, base);
         break;
       case 9:
@@ -346,7 +346,7 @@ public final class ForDeltaUtil {
         prefixSum32(longs, base);
         break;
       case 16:
-        decode16To32(pdu, tmp, longs);
+        decode16To32(pdu, longs);
         prefixSum32(longs, base);
         break;
       case 17:
@@ -431,8 +431,7 @@ public final class ForDeltaUtil {
     }
   }
 
-  private static void decode8To16(PostingDecodingUtil pdu, long[] tmp, long[] longs)
-      throws IOException {
+  private static void decode8To16(PostingDecodingUtil pdu, long[] longs) throws IOException {
     pdu.splitLongs(16, longs, 8, 8, MASK16_8, longs, 16, MASK16_8);
   }
 
@@ -522,8 +521,7 @@ public final class ForDeltaUtil {
     }
   }
 
-  private static void decode16To32(PostingDecodingUtil pdu, long[] tmp, long[] longs)
-      throws IOException {
+  private static void decode16To32(PostingDecodingUtil pdu, long[] longs) throws IOException {
     pdu.splitLongs(32, longs, 16, 16, MASK32_16, longs, 32, MASK32_16);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/ForUtil.java
@@ -291,11 +291,11 @@ public final class ForUtil {
   void decode(int bitsPerValue, PostingDecodingUtil pdu, long[] longs) throws IOException {
     switch (bitsPerValue) {
       case 1:
-        decode1(pdu, tmp, longs);
+        decode1(pdu, longs);
         expand8(longs);
         break;
       case 2:
-        decode2(pdu, tmp, longs);
+        decode2(pdu, longs);
         expand8(longs);
         break;
       case 3:
@@ -303,7 +303,7 @@ public final class ForUtil {
         expand8(longs);
         break;
       case 4:
-        decode4(pdu, tmp, longs);
+        decode4(pdu, longs);
         expand8(longs);
         break;
       case 5:
@@ -319,7 +319,7 @@ public final class ForUtil {
         expand8(longs);
         break;
       case 8:
-        decode8(pdu, tmp, longs);
+        decode8(pdu, longs);
         expand8(longs);
         break;
       case 9:
@@ -351,7 +351,7 @@ public final class ForUtil {
         expand16(longs);
         break;
       case 16:
-        decode16(pdu, tmp, longs);
+        decode16(pdu, longs);
         expand16(longs);
         break;
       case 17:
@@ -393,11 +393,11 @@ public final class ForUtil {
     }
   }
 
-  static void decode1(PostingDecodingUtil pdu, long[] tmp, long[] longs) throws IOException {
+  static void decode1(PostingDecodingUtil pdu, long[] longs) throws IOException {
     pdu.splitLongs(2, longs, 7, 1, MASK8_1, longs, 14, MASK8_1);
   }
 
-  static void decode2(PostingDecodingUtil pdu, long[] tmp, long[] longs) throws IOException {
+  static void decode2(PostingDecodingUtil pdu, long[] longs) throws IOException {
     pdu.splitLongs(4, longs, 6, 2, MASK8_2, longs, 12, MASK8_2);
   }
 
@@ -413,7 +413,7 @@ public final class ForUtil {
     }
   }
 
-  static void decode4(PostingDecodingUtil pdu, long[] tmp, long[] longs) throws IOException {
+  static void decode4(PostingDecodingUtil pdu, long[] longs) throws IOException {
     pdu.splitLongs(8, longs, 4, 4, MASK8_4, longs, 8, MASK8_4);
   }
 
@@ -457,7 +457,7 @@ public final class ForUtil {
     }
   }
 
-  static void decode8(PostingDecodingUtil pdu, long[] tmp, long[] longs) throws IOException {
+  static void decode8(PostingDecodingUtil pdu, long[] longs) throws IOException {
     pdu.in.readLongs(longs, 0, 16);
   }
 
@@ -601,7 +601,7 @@ public final class ForUtil {
     }
   }
 
-  static void decode16(PostingDecodingUtil pdu, long[] tmp, long[] longs) throws IOException {
+  static void decode16(PostingDecodingUtil pdu, long[] longs) throws IOException {
     pdu.in.readLongs(longs, 0, 32);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -427,7 +427,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     public PostingsEnum reset(IntBlockTermState termState, int flags) throws IOException {
       resetIndexInput(termState);
       if (pforUtil == null && docFreq >= BLOCK_SIZE) {
-        pforUtil = new PForUtil(new ForUtil());
+        pforUtil = new PForUtil();
         forDeltaUtil = new ForDeltaUtil();
       }
       totalTermFreq = indexHasFreq ? termState.totalTermFreq : docFreq;
@@ -727,7 +727,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
       }
       totalTermFreq = termState.totalTermFreq;
       if (pforUtil == null && totalTermFreq >= BLOCK_SIZE) {
-        pforUtil = new PForUtil(new ForUtil());
+        pforUtil = new PForUtil();
       }
       // Where this term's postings start in the .pos file:
       final long posTermStartFP = termState.posStartFP;
@@ -1142,7 +1142,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
   private abstract class BlockImpactsEnum extends ImpactsEnum {
 
     protected final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
-    protected final PForUtil pforUtil = new PForUtil(new ForUtil());
+    protected final PForUtil pforUtil = new PForUtil();
 
     protected final long[] docBuffer = new long[BLOCK_SIZE + 1];
     protected final long[] freqBuffer = new long[BLOCK_SIZE];

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsWriter.java
@@ -142,9 +142,8 @@ public class Lucene912PostingsWriter extends PushPostingsWriterBase {
           metaOut, META_CODEC, VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
       CodecUtil.writeIndexHeader(
           docOut, DOC_CODEC, VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
-      final ForUtil forUtil = new ForUtil();
       forDeltaUtil = new ForDeltaUtil();
-      pforUtil = new PForUtil(forUtil);
+      pforUtil = new PForUtil();
       if (state.fieldInfos.hasProx()) {
         posDeltaBuffer = new long[BLOCK_SIZE];
         String posFileName =

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForDeltaUtil.py
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForDeltaUtil.py
@@ -361,7 +361,10 @@ def writeRemainder(bpv, next_primitive, remaining_bits_per_long, o, num_values, 
   
 def writeDecode(bpv, f):
   next_primitive = primitive_size_for_bpv(bpv)
-  f.write('  private static void decode%dTo%d(PostingDecodingUtil pdu, long[] tmp, long[] longs) throws IOException {\n' %(bpv, next_primitive))
+  if next_primitive % bpv == 0:
+    f.write('  private static void decode%dTo%d(PostingDecodingUtil pdu, long[] longs) throws IOException {\n' %(bpv, next_primitive))
+  else:
+    f.write('  private static void decode%dTo%d(PostingDecodingUtil pdu, long[] tmp, long[] longs) throws IOException {\n' %(bpv, next_primitive))
   if bpv == next_primitive:
     f.write('    pdu.in.readLongs(longs, 0, %d);\n' %(bpv*2))
   else:
@@ -390,9 +393,15 @@ if __name__ == '__main__':
     primitive_size = primitive_size_for_bpv(bpv)
     f.write('    case %d:\n' %bpv)
     if next_primitive(bpv) == primitive_size:
-      f.write('        decode%d(pdu, tmp, longs);\n' %bpv)
+      if primitive_size % bpv == 0:
+        f.write('        decode%d(pdu, longs);\n' %bpv)
+      else:
+        f.write('        decode%d(pdu, tmp, longs);\n' %bpv)
     else:
-      f.write('        decode%dTo%d(pdu, tmp, longs);\n' %(bpv, primitive_size))
+      if primitive_size % bpv == 0:
+        f.write('        decode%dTo%d(pdu, longs);\n' %(bpv, primitive_size))
+      else:
+        f.write('        decode%dTo%d(pdu, tmp, longs);\n' %(bpv, primitive_size))
     f.write('      prefixSum%d(longs, base);\n' %primitive_size)
     f.write('      break;\n')
   f.write('    default:\n')

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForUtil.py
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/gen_ForUtil.py
@@ -287,8 +287,8 @@ def writeDecode(bpv, f):
     next_primitive = 8
   elif bpv <= 16:
     next_primitive = 16
-  f.write('  static void decode%d(PostingDecodingUtil pdu, long[] tmp, long[] longs) throws IOException {\n' %bpv)
   if bpv == next_primitive:
+    f.write('  static void decode%d(PostingDecodingUtil pdu, long[] longs) throws IOException {\n' %bpv)
     f.write('    pdu.in.readLongs(longs, 0, %d);\n' %(bpv*2))
   else:
     num_values_per_long = 64 / next_primitive
@@ -296,8 +296,10 @@ def writeDecode(bpv, f):
     num_iters = (next_primitive - 1) // bpv
     o = 2 * bpv * num_iters
     if remaining_bits == 0:
+      f.write('  static void decode%d(PostingDecodingUtil pdu, long[] longs) throws IOException {\n' %bpv)
       f.write('    pdu.splitLongs(%d, longs, %d, %d, MASK%d_%d, longs, %d, MASK%d_%d);\n' %(bpv*2, next_primitive - bpv, bpv, next_primitive, bpv, o, next_primitive, next_primitive - num_iters * bpv))
     else:
+      f.write('  static void decode%d(PostingDecodingUtil pdu, long[] tmp, long[] longs) throws IOException {\n' %bpv)
       f.write('    pdu.splitLongs(%d, longs, %d, %d, MASK%d_%d, tmp, 0, MASK%d_%d);\n' %(bpv*2, next_primitive - bpv, bpv, next_primitive, bpv, next_primitive, next_primitive - num_iters * bpv))
       writeRemainder(bpv, next_primitive, remaining_bits, o, 128/num_values_per_long - o, f)
   f.write('  }\n')
@@ -334,7 +336,10 @@ if __name__ == '__main__':
     elif bpv <= 16:
       next_primitive = 16
     f.write('      case %d:\n' %bpv)
-    f.write('        decode%d(pdu, tmp, longs);\n' %bpv)
+    if next_primitive % bpv == 0:
+      f.write('        decode%d(pdu, longs);\n' %bpv)
+    else:
+      f.write('        decode%d(pdu, tmp, longs);\n' %bpv)
     f.write('        expand%d(longs);\n' %next_primitive)
     f.write('        break;\n')
   f.write('      default:\n')

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestPForUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene912/TestPForUtil.java
@@ -39,11 +39,10 @@ public class TestPForUtil extends LuceneTestCase {
     final Directory d = new ByteBuffersDirectory();
     final long endPointer = encodeTestData(iterations, values, d);
 
-    ForUtil forUtil = new ForUtil();
     IndexInput in = d.openInput("test.bin", IOContext.READONCE);
     PostingDecodingUtil pdu =
         Lucene912PostingsReader.VECTORIZATION_PROVIDER.newPostingDecodingUtil(in);
-    final PForUtil pforUtil = new PForUtil(forUtil);
+    final PForUtil pforUtil = new PForUtil();
     for (int i = 0; i < iterations; ++i) {
       if (random().nextInt(5) == 0) {
         PForUtil.skip(in);
@@ -91,7 +90,7 @@ public class TestPForUtil extends LuceneTestCase {
 
   private long encodeTestData(int iterations, int[] values, Directory d) throws IOException {
     IndexOutput out = d.createOutput("test.bin", IOContext.DEFAULT);
-    final PForUtil pforUtil = new PForUtil(new ForUtil());
+    final PForUtil pforUtil = new PForUtil();
 
     for (int i = 0; i < iterations; ++i) {
       long[] source = new long[ForUtil.BLOCK_SIZE];


### PR DESCRIPTION
Generate cleaner code for PForUtil that has no dead parameters.

Also:
PForUtil instances always create their own `ForUtil`, so we can inline that into the field declaration. Also, we can save cycles for accessing the input on PostingsDecodingUtil.

Surprisingly, the combination of these cleanups yields a small but statistically fully visible speedup that the compiler isn't able to get to on its own it seems. For wikimedium with 40 task repeats and 40 JVMs I get:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                    OrHighNotLow     1031.61      (5.0%)     1039.33      (4.8%)    0.7% (  -8% -   11%) 0.494
                      TermDTSort      182.64      (6.8%)      184.65      (5.8%)    1.1% ( -10% -   14%) 0.437
           HighTermDayOfYearSort      357.56      (6.4%)      361.83      (7.4%)    1.2% ( -11% -   16%) 0.440
            MedTermDayTaxoFacets       33.24      (2.7%)       33.65      (2.7%)    1.2% (  -4% -    6%) 0.042
               HighTermTitleSort       62.22      (2.9%)       63.03      (3.0%)    1.3% (  -4% -    7%) 0.048
                       OrHighMed      343.75      (5.2%)      348.33      (4.3%)    1.3% (  -7% -   11%) 0.213
                    OrNotHighLow     1597.43      (5.1%)     1620.18      (5.2%)    1.4% (  -8% -   12%) 0.219
     BrowseRandomLabelSSDVFacets        3.34      (5.1%)        3.39      (4.0%)    1.5% (  -7% -   11%) 0.151
                         LowTerm      653.68      (5.1%)      663.51      (5.0%)    1.5% (  -8% -   12%) 0.186
                        PKLookup      241.00      (1.8%)      244.97      (2.1%)    1.6% (  -2% -    5%) 0.000
         AndHighMedDayTaxoFacets       46.25      (2.1%)       47.10      (2.4%)    1.8% (  -2% -    6%) 0.000
                    OrHighNotMed      610.05      (5.7%)      621.53      (5.6%)    1.9% (  -8% -   14%) 0.138
               HighTermMonthSort     1488.88      (4.7%)     1517.64      (5.3%)    1.9% (  -7% -   12%) 0.085
        AndHighHighDayTaxoFacets       25.76      (3.5%)       26.26      (3.7%)    2.0% (  -5% -    9%) 0.015
                         Prefix3      507.94      (5.0%)      517.90      (4.9%)    2.0% (  -7% -   12%) 0.075
            BrowseDateTaxoFacets        5.16      (9.7%)        5.26      (9.1%)    2.1% ( -15% -   23%) 0.326
           BrowseMonthSSDVFacets        4.45      (8.4%)        4.54      (4.6%)    2.1% ( -10% -   16%) 0.167
                     AndHighHigh      112.67      (4.3%)      115.05      (3.8%)    2.1% (  -5% -   10%) 0.019
                        Wildcard      400.35      (4.0%)      408.87      (3.9%)    2.1% (  -5% -   10%) 0.017
                       OrHighLow      591.02      (2.9%)      603.62      (3.3%)    2.1% (  -3% -    8%) 0.002
            BrowseDateSSDVFacets        1.26      (4.8%)        1.29      (6.7%)    2.2% (  -8% -   14%) 0.098
                      AndHighMed      271.86      (3.8%)      277.78      (3.2%)    2.2% (  -4% -    9%) 0.006
             LowIntervalsOrdered      170.07      (5.5%)      173.79      (4.5%)    2.2% (  -7% -   12%) 0.052
                      AndHighLow     1876.44      (4.3%)     1918.82      (4.7%)    2.3% (  -6% -   11%) 0.026
                         MedTerm      640.37      (7.2%)      655.21      (6.3%)    2.3% ( -10% -   17%) 0.125
       BrowseDayOfYearTaxoFacets        5.23      (9.8%)        5.36      (8.5%)    2.4% ( -14% -   22%) 0.247
     BrowseRandomLabelTaxoFacets        4.39      (4.1%)        4.50      (4.4%)    2.4% (  -5% -   11%) 0.011
                   OrHighNotHigh      340.64      (5.8%)      349.08      (5.0%)    2.5% (  -7% -   14%) 0.041
                       MedPhrase      828.87      (3.5%)      849.87      (4.8%)    2.5% (  -5% -   11%) 0.007
            HighIntervalsOrdered       38.15      (5.4%)       39.14      (4.6%)    2.6% (  -7% -   13%) 0.022
                      HighPhrase      150.20      (3.3%)      154.11      (4.5%)    2.6% (  -4% -   10%) 0.003
                     MedSpanNear      106.92      (5.3%)      109.71      (3.7%)    2.6% (  -6% -   12%) 0.011
          OrHighMedDayTaxoFacets        1.94      (5.9%)        2.00      (5.0%)    2.6% (  -7% -   14%) 0.031
                    OrNotHighMed      393.61      (4.4%)      404.39      (4.0%)    2.7% (  -5% -   11%) 0.004
                          Fuzzy2       66.62      (3.5%)       68.49      (2.5%)    2.8% (  -3% -    9%) 0.000
                       LowPhrase       27.05      (5.4%)       27.82      (4.8%)    2.9% (  -6% -   13%) 0.012
                HighSloppyPhrase       29.60      (6.8%)       30.45      (3.8%)    2.9% (  -7% -   14%) 0.018
             MedIntervalsOrdered       35.98      (3.7%)       37.02      (4.0%)    2.9% (  -4% -   11%) 0.001
                         Respell       44.27      (2.0%)       45.56      (1.9%)    2.9% (   0% -    6%) 0.000
                      OrHighHigh      100.77      (5.2%)      103.85      (6.2%)    3.1% (  -7% -   15%) 0.017
                   OrNotHighHigh      530.63      (4.1%)      547.05      (3.7%)    3.1% (  -4% -   11%) 0.000
                          Fuzzy1      114.15      (3.7%)      118.04      (2.4%)    3.4% (  -2% -    9%) 0.000
                     LowSpanNear       43.15      (5.5%)       44.63      (4.7%)    3.4% (  -6% -   14%) 0.003
            HighTermTitleBDVSort       16.19      (3.8%)       16.75      (3.8%)    3.4% (  -3% -   11%) 0.000
                          IntNRQ       73.96      (5.4%)       76.51      (8.6%)    3.4% (  -9% -   18%) 0.032
                    HighSpanNear       20.01      (5.4%)       20.74      (5.1%)    3.6% (  -6% -   14%) 0.002
                 MedSloppyPhrase       19.62      (4.5%)       20.33      (3.9%)    3.6% (  -4% -   12%) 0.000
       BrowseDayOfYearSSDVFacets        4.56      (9.3%)        4.73     (10.5%)    3.7% ( -14% -   26%) 0.092
                        HighTerm      596.70      (7.0%)      619.46      (7.8%)    3.8% ( -10% -   19%) 0.021
                 LowSloppyPhrase       24.74      (4.6%)       25.72      (5.8%)    4.0% (  -6% -   15%) 0.001
           BrowseMonthTaxoFacets       11.38     (37.0%)       12.99     (32.5%)   14.1% ( -40% -  132%) 0.070
```