### PR TITLE
FVH BaseFragmentsBuilder does not properly support colored pre/post tags

### DIFF
--- a/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/BaseFragmentsBuilder.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/BaseFragmentsBuilder.java
@@ -405,12 +405,10 @@ public abstract class BaseFragmentsBuilder implements FragmentsBuilder {
   }
 
   protected String getPreTag(String[] preTags, int num) {
-    int n = num % preTags.length;
-    return preTags[n];
+    return preTags[num];
   }
 
   protected String getPostTag(String[] postTags, int num) {
-    int n = num % postTags.length;
-    return postTags[n];
+    return postTags[num];
   }
 }


### PR DESCRIPTION
### FVH BaseFragmentsBuilder does not properly support colored pre/post tags

Details and discussion about the problem can be found  in this issue: [FVH BaseFragmentsBuilder does not properly support colored pre/post tags #13933](https://github.com/apache/lucene/issues/13933)

This PR is still work in progress, I will add more tests and improve the solution.