### PR TITLE
Speedup PriorityQueue a little

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
@@ -117,13 +117,13 @@ public abstract class PriorityQueue<T> implements Iterable<T> {
    * ArrayIndexOutOfBoundsException} is thrown.
    */
   public void addAll(Collection<T> elements) {
-    int s = size;
-    if (s + elements.size() > this.maxSize) {
+    int size = this.size;
+    if (size + elements.size() > this.maxSize) {
       throw new ArrayIndexOutOfBoundsException(
           "Cannot add "
               + elements.size()
               + " elements to a queue with remaining capacity: "
-              + (maxSize - s));
+              + (maxSize - size));
     }
 
     // Heap with size S always takes first S elements of the array,
@@ -131,15 +131,15 @@ public abstract class PriorityQueue<T> implements Iterable<T> {
     Iterator<T> iterator = elements.iterator();
     var heap = this.heap;
     while (iterator.hasNext()) {
-      heap[s + 1] = iterator.next();
-      s++;
+      heap[size + 1] = iterator.next();
+      size++;
     }
 
     // The loop goes down to 1 as heap is 1-based not 0-based.
-    for (int i = (s >>> 1); i >= 1; i--) {
-      downHeap(i, heap, s);
+    for (int i = (size >>> 1); i >= 1; i--) {
+      downHeap(i, heap, size);
     }
-    this.size = s;
+    this.size = size;
   }
 
   /**


### PR DESCRIPTION
Saving some field accesses results in small but visible savings:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                         LowTerm      617.46      (8.2%)      615.47      (7.4%)   -0.3% ( -14% -   16%) 0.855
                    OrHighNotLow      488.90      (9.5%)      491.20      (7.8%)    0.5% ( -15% -   19%) 0.808
                    OrHighNotMed      384.07      (7.9%)      386.54      (6.4%)    0.6% ( -12% -   16%) 0.688
                       OrHighMed      269.60      (4.9%)      271.50      (4.5%)    0.7% (  -8% -   10%) 0.504
                         Prefix3      397.59      (7.4%)      401.40      (6.8%)    1.0% ( -12% -   16%) 0.546
                      AndHighMed      156.59      (4.2%)      158.14      (4.2%)    1.0% (  -7% -    9%) 0.290
                      AndHighLow     1711.42      (7.5%)     1729.95      (6.7%)    1.1% ( -12% -   16%) 0.496
                       OrHighLow      564.40      (4.6%)      570.66      (5.3%)    1.1% (  -8% -   11%) 0.315
             LowIntervalsOrdered      255.12      (5.7%)      258.02      (7.6%)    1.1% ( -11% -   15%) 0.448
                        HighTerm      688.93      (6.5%)      697.31      (6.4%)    1.2% ( -10% -   15%) 0.400
                        PKLookup      242.28      (1.5%)      245.33      (2.5%)    1.3% (  -2% -    5%) 0.006
            HighTermTitleBDVSort       37.87      (3.3%)       38.37      (3.3%)    1.3% (  -5% -    8%) 0.073
             MedIntervalsOrdered       48.08      (5.5%)       48.72      (6.7%)    1.3% ( -10% -   14%) 0.335
                   OrHighNotHigh      419.24      (6.8%)      424.98      (6.3%)    1.4% ( -10% -   15%) 0.350
                         MedTerm      668.97      (7.0%)      678.42      (5.4%)    1.4% ( -10% -   14%) 0.311
               HighTermTitleSort       76.23      (6.0%)       77.32      (5.0%)    1.4% (  -9% -   13%) 0.254
                    OrNotHighLow      993.21      (7.3%)     1007.93      (5.6%)    1.5% ( -10% -   15%) 0.310
                      TermDTSort      207.44      (3.7%)      210.59      (4.2%)    1.5% (  -6% -    9%) 0.086
                          IntNRQ      216.19      (6.9%)      219.48      (7.3%)    1.5% ( -11% -   16%) 0.340
                          Fuzzy1       98.73      (2.1%)      100.28      (2.7%)    1.6% (  -3% -    6%) 0.004
            BrowseDateTaxoFacets        5.31      (8.6%)        5.40      (7.8%)    1.7% ( -13% -   19%) 0.368
            MedTermDayTaxoFacets       34.37      (4.4%)       34.94      (4.2%)    1.7% (  -6% -   10%) 0.086
       BrowseDayOfYearTaxoFacets        5.39      (8.4%)        5.48      (7.9%)    1.7% ( -13% -   19%) 0.343
                      OrHighHigh       79.75      (7.3%)       81.16      (5.7%)    1.8% ( -10% -   15%) 0.227
                   OrNotHighHigh      355.03      (6.4%)      361.39      (5.8%)    1.8% (  -9% -   14%) 0.188
                    OrNotHighMed      384.05      (6.4%)      391.18      (7.6%)    1.9% ( -11% -   16%) 0.237
            HighIntervalsOrdered       34.09      (4.9%)       34.76      (6.3%)    2.0% (  -8% -   13%) 0.118
               HighTermMonthSort     1504.80      (6.1%)     1537.64      (6.1%)    2.2% (  -9% -   15%) 0.111
                       LowPhrase      144.85      (4.6%)      148.15      (4.7%)    2.3% (  -6% -   12%) 0.029
           HighTermDayOfYearSort      359.83      (6.6%)      368.10      (6.9%)    2.3% ( -10% -   16%) 0.127
         AndHighMedDayTaxoFacets       22.54      (3.7%)       23.08      (4.0%)    2.4% (  -5% -   10%) 0.006
     BrowseRandomLabelTaxoFacets        4.41      (3.4%)        4.52      (3.8%)    2.4% (  -4% -    9%) 0.003
                HighSloppyPhrase       27.97      (5.9%)       28.70      (6.2%)    2.6% (  -9% -   15%) 0.055
                     LowSpanNear       18.23      (7.2%)       18.71      (8.1%)    2.7% ( -11% -   19%) 0.120
                      HighPhrase      279.12      (7.9%)      286.62      (7.2%)    2.7% ( -11% -   19%) 0.112
                 MedSloppyPhrase        5.58      (4.1%)        5.73      (4.9%)    2.7% (  -6% -   12%) 0.007
                     AndHighHigh       61.57      (4.6%)       63.31      (4.2%)    2.8% (  -5% -   12%) 0.004
           BrowseMonthTaxoFacets       12.23     (28.7%)       12.58     (31.2%)    2.8% ( -44% -   88%) 0.672
                        Wildcard       84.87      (3.2%)       87.37      (3.0%)    2.9% (  -3% -    9%) 0.000
                         Respell       56.85      (1.9%)       58.60      (2.4%)    3.1% (  -1% -    7%) 0.000
            BrowseDateSSDVFacets        1.24      (6.0%)        1.28      (6.4%)    3.2% (  -8% -   16%) 0.020
                          Fuzzy2       69.18      (3.5%)       71.42      (3.4%)    3.2% (  -3% -   10%) 0.000
                    HighSpanNear       18.56      (6.8%)       19.19      (6.9%)    3.4% (  -9% -   18%) 0.028
          OrHighMedDayTaxoFacets        8.58      (7.4%)        8.88      (7.0%)    3.5% ( -10% -   19%) 0.031
                 LowSloppyPhrase       20.16      (8.0%)       20.88      (9.9%)    3.5% ( -13% -   23%) 0.079
                     MedSpanNear       30.28      (2.6%)       31.46      (4.4%)    3.9% (  -3% -   11%) 0.000
        AndHighHighDayTaxoFacets        8.28      (5.8%)        8.60      (5.9%)    3.9% (  -7% -   16%) 0.003
           BrowseMonthSSDVFacets        4.48      (9.6%)        4.66      (9.1%)    4.1% ( -13% -   25%) 0.048
                       MedPhrase       32.89      (4.5%)       34.28      (6.1%)    4.3% (  -6% -   15%) 0.000
     BrowseRandomLabelSSDVFacets        3.29      (3.8%)        3.43      (5.4%)    4.4% (  -4% -   14%) 0.000
       BrowseDayOfYearSSDVFacets        4.41      (4.2%)        4.65      (6.5%)    5.5% (  -5% -   16%) 0.000

```