### PR TITLE
Removing the deprecated parameters, -fast, -slow, -crossCheckTermVectors from CheckIndex.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,7 +7,7 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
-(No changes)
+* GITHUB#11023: Removing deprecated parameters from CheckIndex. (Jakub Slowinski)
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -4284,21 +4284,8 @@ public final class CheckIndex implements Closeable {
         int level = Integer.parseInt(args[i]);
         Level.checkIfLevelInBounds(level);
         opts.level = level;
-      } else if ("-fast".equals(arg)) {
-        // Deprecated. Remove in Lucene 11.
-        System.err.println(
-            "-fast is deprecated, use '-level 1' for explicitly verifying file checksums only. This is also now the default "
-                + "behaviour!");
-      } else if ("-slow".equals(arg)) {
-        // Deprecated. Remove in Lucene 11.
-        System.err.println("-slow is deprecated, use '-level 3' instead for slow checks");
-        opts.level = Level.MIN_LEVEL_FOR_SLOW_CHECKS;
       } else if ("-exorcise".equals(arg)) {
         opts.doExorcise = true;
-      } else if ("-crossCheckTermVectors".equals(arg)) {
-        // Deprecated. Remove in Lucene 11.
-        System.err.println("-crossCheckTermVectors is deprecated, use '-level 3' instead");
-        opts.level = Level.MAX_VALUE;
       } else if (arg.equals("-verbose")) {
         opts.verbose = true;
       } else if (arg.equals("-segment")) {


### PR DESCRIPTION
Removing the deprecated parameters, -fast, -slow, -crossCheckTermVectors from CheckIndex.
Their usage is replaced with `-level` with respective values of `1`, `3`, `3`.

Follow-up on the deprecation done in #11023.
