### PR TITLE
Ensure stability of clause order for DisjunctionMaxQuery toString

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -70,6 +70,7 @@ Bug Fixes
 * GITHUB#13884: Remove broken .toArray from Long/CharObjectHashMap entirely. (Pan Guixin)
 * GITHUB#12686: Added support for highlighting IndexOrDocValuesQuery. (Prudhvi Godithi)
 * GITHUB#13927: Fix StoredFieldsConsumer finish. (linfn)
+* GITHUB#13944: Ensure deterministic order of clauses for `DisjunctionMaxQuery#toString`. (Laurent Jakubina)
 
 Build
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -68,8 +67,7 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
     }
     this.tieBreakerMultiplier = tieBreakerMultiplier;
     this.disjuncts.addAll(disjuncts);
-    this.orderedQueries = new ArrayList<>(disjuncts);
-    orderedQueries.sort(Comparator.comparing(Query::toString)); // ensure one sort
+    this.orderedQueries = new ArrayList<>(disjuncts); // order from the caller
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.apache.lucene.index.LeafReaderContext;
 
 /**

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
@@ -295,24 +295,20 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
    */
   @Override
   public String toString(String field) {
-    StringBuilder buffer = new StringBuilder();
-    buffer.append("(");
-    Iterator<Query> it = disjuncts.iterator();
-    for (int i = 0; it.hasNext(); i++) {
-      Query subquery = it.next();
-      if (subquery instanceof BooleanQuery) { // wrap sub-bools in parens
-        buffer.append("(");
-        buffer.append(subquery.toString(field));
-        buffer.append(")");
-      } else buffer.append(subquery.toString(field));
-      if (i != disjuncts.size() - 1) buffer.append(" | ");
-    }
-    buffer.append(")");
-    if (tieBreakerMultiplier != 0.0f) {
-      buffer.append("~");
-      buffer.append(tieBreakerMultiplier);
-    }
-    return buffer.toString();
+    return disjuncts.stream()
+            .map(
+                    subquery -> {
+                      if (subquery instanceof BooleanQuery) { // wrap sub-bools in parens
+                        return "(" + subquery.toString(field) + ")";
+                      }
+                      return subquery.toString(field);
+                    })
+            .sorted()
+            .collect(
+                    Collectors.joining(
+                            " | ",
+                            "(",
+                            ")" + ((tieBreakerMultiplier != 0.0f) ? "~" + tieBreakerMultiplier : "")));
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
@@ -296,19 +296,19 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
   @Override
   public String toString(String field) {
     return disjuncts.stream()
-            .map(
-                    subquery -> {
-                      if (subquery instanceof BooleanQuery) { // wrap sub-bools in parens
-                        return "(" + subquery.toString(field) + ")";
-                      }
-                      return subquery.toString(field);
-                    })
-            .sorted()
-            .collect(
-                    Collectors.joining(
-                            " | ",
-                            "(",
-                            ")" + ((tieBreakerMultiplier != 0.0f) ? "~" + tieBreakerMultiplier : "")));
+        .map(
+            subquery -> {
+              if (subquery instanceof BooleanQuery) { // wrap sub-bools in parens
+                return "(" + subquery.toString(field) + ")";
+              }
+              return subquery.toString(field);
+            })
+        .sorted()
+        .collect(
+            Collectors.joining(
+                " | ",
+                "(",
+                ")" + ((tieBreakerMultiplier != 0.0f) ? "~" + tieBreakerMultiplier : "")));
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -489,6 +489,29 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
     assertEquals(q1, q2);
   }
 
+  /* Inspired from TestIntervals.testIntervalDisjunctionToStringStability */
+  public void testToStringOrderMatters() {
+    final int clauseNbr =
+            random().nextInt(22) + 4; // ensure a reasonably large minimum number of clauses
+    final String[] terms = new String[clauseNbr];
+    for (int i = 0; i < clauseNbr; i++) {
+      terms[i] = Character.toString((char) ('a' + i));
+    }
+
+    final String expected =
+            Arrays.stream(terms)
+                    .map((term) -> "test:" + term)
+                    .collect(Collectors.joining(" | ", "(", ")~1.0"));
+
+    Collections.shuffle(Arrays.asList(terms), random()); // Disrupt clause order
+
+    DisjunctionMaxQuery source =
+            new DisjunctionMaxQuery(
+                    Arrays.stream(terms).map((term) -> tq("test", term)).toList(), 1.0f);
+
+    assertEquals(expected, source.toString(""));
+  }
+
   public void testRandomTopDocs() throws Exception {
     doTestRandomTopDocs(2, 0.05f, 0.05f);
     doTestRandomTopDocs(2, 1.0f, 0.05f);

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -504,8 +504,6 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
             .map((term) -> "test:" + term)
             .collect(Collectors.joining(" | ", "(", ")~1.0"));
 
-    Collections.shuffle(Arrays.asList(terms), random()); // Disrupt clause order
-
     DisjunctionMaxQuery source =
         new DisjunctionMaxQuery(
             Arrays.stream(terms).map((term) -> tq("test", term)).toList(), 1.0f);

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -492,22 +492,22 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
   /* Inspired from TestIntervals.testIntervalDisjunctionToStringStability */
   public void testToStringOrderMatters() {
     final int clauseNbr =
-            random().nextInt(22) + 4; // ensure a reasonably large minimum number of clauses
+        random().nextInt(22) + 4; // ensure a reasonably large minimum number of clauses
     final String[] terms = new String[clauseNbr];
     for (int i = 0; i < clauseNbr; i++) {
       terms[i] = Character.toString((char) ('a' + i));
     }
 
     final String expected =
-            Arrays.stream(terms)
-                    .map((term) -> "test:" + term)
-                    .collect(Collectors.joining(" | ", "(", ")~1.0"));
+        Arrays.stream(terms)
+            .map((term) -> "test:" + term)
+            .collect(Collectors.joining(" | ", "(", ")~1.0"));
 
     Collections.shuffle(Arrays.asList(terms), random()); // Disrupt clause order
 
     DisjunctionMaxQuery source =
-            new DisjunctionMaxQuery(
-                    Arrays.stream(terms).map((term) -> tq("test", term)).toList(), 1.0f);
+        new DisjunctionMaxQuery(
+            Arrays.stream(terms).map((term) -> tq("test", term)).toList(), 1.0f);
 
     assertEquals(expected, source.toString(""));
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;


### PR DESCRIPTION
Since https://github.com/apache/lucene/pull/110, the disjuncts elements of DisjunctionMaxQueries don't have an order anymore, which is impacting the `toString` method. In isolation, that does not matter. But, in Solr, when the debug component is needed for a distributed query, every shard can return a different toString representation of the same query... and the different toString keys of the debug response will have an array value, containing those different representations (instead of having one value for one same representation).

Example with the `parsedquery_toString` key (of a json response within Solr):
`parsedquery_toString":["((docIdentifiers:\"Okarandeep Osingh\" docIdentifiers:Otest) | (docTitle:\"Okarandeep Osingh\" docTitle:Otest) | (docBody:\"Okarandeep Osingh\" docBody:Otest))","((docBody:\"Okarandeep Osingh\" docBody:Otest) | (docTitle:\"Okarandeep Osingh\" docTitle:Otest) | (docIdentifiers:\"Okarandeep Osingh\" docIdentifiers:Otest))"]`

When PR110 was merged, Solr adapted its unit tests this way: https://github.com/apache/solr/pull/117 but, later on within Lucene, the toString method of DisjuctionIntervalsSource was adapted in prevision of a potential similar future change: https://github.com/apache/lucene/pull/193. 

I adapted the toString method of DisjunctionMaxQueries similarly to this PR.




