### PR TITLE
Fix ord-to-doc mapping when searching Lucene 9.0.0 hnsw indices

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,7 +7,8 @@ http://s.apache.org/luceneversions
 
 Bug Fixes
 ---------------------
-(No changes)
+
+* GITHUB#13947: Fix ord-to-doc mapping when searching Lucene 9.0.0 hnsw indices (Michael Sokolov, Ben Trent)
 
 ======================== Lucene 9.12.0 =======================
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -276,7 +276,7 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
       int node = results.topNode();
       float minSimilarity = results.topScore();
       results.pop();
-      knnCollector.collect(node, minSimilarity);
+      knnCollector.collect(vectorValues.ordToDoc(node), minSimilarity);
     }
   }
 


### PR DESCRIPTION
Bug discovered in https://github.com/apache/lucene/pull/13910

This corrects the logic so that users in lucene 9.12.1 will be able to correctly read from Lucene 9.0.0 HNSW indices. Previously, if they created an index in lucene 9.0.0 and not all documents contained a vector, reading in 9.8+ would produce non-sensical scores.