### PR TITLE
Make some BooleanQuery methods public and a new `#add(Collection)` method for BQ builder

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -36,6 +36,8 @@ API Changes
 
 * GITHUB#13859: Allow open-ended ranges in Intervals range queries. (Mayya Sharipova)
 
+* GITHUB#13950: Make BooleanQuery#getClauses public and add #add(Collection<BooleanClause>) to BQ builder. (Shubham Chaudhary)
+
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -88,20 +88,14 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
     }
 
     /**
-     * Add a collection of BooleanClause's to this {@link Builder}. Note that the order in which
+     * Add a collection of BooleanClauses to this {@link Builder}. Note that the order in which
      * clauses are added does not have any impact on matching documents or query performance.
      *
      * @throws IndexSearcher.TooManyClauses if the new number of clauses exceeds the maximum clause
      *     number
      */
     public Builder add(Collection<BooleanClause> collection) {
-      // We do the final deep check for max clauses count limit during
-      // <code>IndexSearcher.rewrite</code> but do this check to short
-      // circuit in case a single query holds more than numClauses
-      //
-      // NOTE: this is not just an early check for optimization -- it's
-      // neccessary to prevent run-away 'rewriting' of bad queries from
-      // creating BQ objects that might eat up all the Heap.
+      // see #addClause(BooleanClause)
       if ((clauses.size() + collection.size()) > IndexSearcher.maxClauseCount) {
         throw new IndexSearcher.TooManyClauses();
       }
@@ -166,12 +160,12 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
    * Whether this query is a pure disjunction, ie. it only has SHOULD clauses and it is enough for a
    * single clause to match for this boolean query to match.
    */
-  public boolean isPureDisjunction() {
+  boolean isPureDisjunction() {
     return clauses.size() == getClauses(Occur.SHOULD).size() && minimumNumberShouldMatch <= 1;
   }
 
   /** Whether this query is a two clause disjunction with two term query clauses. */
-  public boolean isTwoClausePureDisjunctionWithTerms() {
+  boolean isTwoClausePureDisjunctionWithTerms() {
     return clauses.size() == 2
         && isPureDisjunction()
         && clauses.get(0).query() instanceof TermQuery


### PR DESCRIPTION
### Description

Changes in this PR :

1. Makes `getClauses(Occur occur` method public to get the collection of one type of clauses. Without public I had to call `getClauses` and then iterate to store this info whereas `BoolenQuery` is [already storing this info in clauseSets](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java#L111) which seems like a good candidate to be exposed for reuse this method. This would also simplify not having checks like eg: [1](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java#L366-L370), [2](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java#L461-L465), [3](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java#L530-L532), [4](https://github.com/apache/lucene/blob/main/lucene/monitor/src/java/org/apache/lucene/monitor/QueryAnalyzer.java#L86-L87) etc along with the `add(Collection)` method(point 3 below). 
2. Similarly makes `#isPureDisjunction` and `isTwoClausePureDisjunctionWithTerms` public which looks could be something useful and right thing to be exposed by the `BooleanQuery` class.
3. Adds an `add(Collection<BooleanClause> collection)` method to `BooleanQuery.Builder`. While doing some query manipulation I had to insert a set of clause but one by one. I'd be useful if there was a `add(Collection<BooleanClause> collection)` to add the to the maintained list of clauses and simplify it for cases where users are manipulating the BQ. I see some places in code that could be refactored to avoid looping to insert the list of clauses as mentioned in point 1.

I'd love to hear thoughts and suggestions. I don't know if there are any rationale of not having these methods public earlier(or a previous attempt) but would love to know.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
