### PR TITLE
Support multi-tenant RAM buffers for IndexWriter

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestIndexUpgradeBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestIndexUpgradeBackwardsCompatibility.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexUpgrader;
@@ -131,7 +132,7 @@ public class TestIndexUpgradeBackwardsCompatibility extends BackwardsCompatibili
     // add dummy segments (which are all in current
     // version) to single segment index
     MergePolicy mp = random().nextBoolean() ? newLogMergePolicy() : newTieredMergePolicy();
-    IndexWriterConfig iwc = new IndexWriterConfig(null).setMergePolicy(mp);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null).setMergePolicy(mp);
     IndexWriter w = new IndexWriter(directory, iwc);
     w.addIndexes(ramDir);
     try (w) {

--- a/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/tasks/TestAddIndexesTask.java
+++ b/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/tasks/TestAddIndexesTask.java
@@ -18,6 +18,7 @@ package org.apache.lucene.benchmark.byTask.tasks;
 
 import java.nio.file.Path;
 import java.util.Properties;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.benchmark.BenchmarkTestCase;
 import org.apache.lucene.benchmark.byTask.PerfRunData;
 import org.apache.lucene.benchmark.byTask.utils.Config;
@@ -45,7 +46,7 @@ public class TestAddIndexesTask extends BenchmarkTestCase {
     inputDir = testDir.resolve("input");
     Directory tmpDir = newFSDirectory(inputDir);
     try {
-      IndexWriter writer = new IndexWriter(tmpDir, new IndexWriterConfig(null));
+      IndexWriter writer = new IndexWriter(tmpDir, new IndexWriterConfig((Analyzer) null));
       for (int i = 0; i < 10; i++) {
         writer.addDocument(new Document());
       }

--- a/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.index;
 
+import java.io.IOException;
+
 /**
  * Default {@link FlushPolicy} implementation that flushes new segments based on RAM used and
  * document count depending on the IndexWriter's {@link IndexWriterConfig}. It also applies pending
@@ -49,6 +51,17 @@ class FlushByRamOrCountsPolicy extends FlushPolicy {
       } else if (activeRam + deletesRam >= limit && perThread != null) {
         flushActiveBytes(control, perThread);
       }
+    }
+  }
+
+  @Override
+  public void flushWriter(
+      IndexWriterRAMManager ramManager,
+      IndexWriterRAMManager.PerWriterIndexWriterRAMManager perWriterRamManager)
+      throws IOException {
+    long totalBytes = perWriterRamManager.getTotalBufferBytesUsed();
+    if (totalBytes > ramManager.getRamBufferSizeMB() * 1024 * 1024) {
+      ramManager.flushRoundRobin();
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
@@ -57,7 +57,8 @@ class FlushByRamOrCountsPolicy extends FlushPolicy {
   @Override
   public void flushRamManager(IndexWriter writer) throws IOException {
     IndexWriterRAMManager ramManager = writer.getConfig().indexWriterRAMManager;
-    if (ramManager.getRamBufferSizeMB() != IndexWriterConfig.DISABLE_AUTO_FLUSH) {
+    if (ramManager.getRamBufferSizeMB() != IndexWriterConfig.DISABLE_AUTO_FLUSH
+        && ramManager.getWriterCount() > 1) {
       long totalBytes = ramManager.updateAndGetCurrentBytesUsed(writer.ramManagerId);
       if (totalBytes > ramManager.getRamBufferSizeMB() * 1024 * 1024) {
         ramManager.flushRoundRobin();

--- a/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FlushByRamOrCountsPolicy.java
@@ -55,13 +55,13 @@ class FlushByRamOrCountsPolicy extends FlushPolicy {
   }
 
   @Override
-  public void flushWriter(
-      IndexWriterRAMManager ramManager,
-      IndexWriterRAMManager.PerWriterIndexWriterRAMManager perWriterRamManager)
-      throws IOException {
-    long totalBytes = perWriterRamManager.getTotalBufferBytesUsed();
-    if (totalBytes > ramManager.getRamBufferSizeMB() * 1024 * 1024) {
-      ramManager.flushRoundRobin();
+  public void flushRamManager(IndexWriter writer) throws IOException {
+    IndexWriterRAMManager ramManager = writer.getConfig().indexWriterRAMManager;
+    if (ramManager.getRamBufferSizeMB() != IndexWriterConfig.DISABLE_AUTO_FLUSH) {
+      long totalBytes = ramManager.updateAndGetCurrentBytesUsed(writer.ramManagerId);
+      if (totalBytes > ramManager.getRamBufferSizeMB() * 1024 * 1024) {
+        ramManager.flushRoundRobin();
+      }
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FlushPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FlushPolicy.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.index;
 
+import java.io.IOException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.InfoStream;
 
@@ -56,6 +57,17 @@ abstract class FlushPolicy {
    */
   public abstract void onChange(
       DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread);
+
+  /**
+   * Chooses which writer should be flushed. Default implementation chooses the writer with most RAM
+   * usage
+   *
+   * @param ramManager the {@link IndexWriterRAMManager} being used to actually flush the writers
+   */
+  public abstract void flushWriter(
+      IndexWriterRAMManager ramManager,
+      IndexWriterRAMManager.PerWriterIndexWriterRAMManager perWriterRamManager)
+      throws IOException;
 
   /** Called by DocumentsWriter to initialize the FlushPolicy */
   protected synchronized void init(LiveIndexWriterConfig indexWriterConfig) {

--- a/lucene/core/src/java/org/apache/lucene/index/FlushPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FlushPolicy.java
@@ -59,15 +59,11 @@ abstract class FlushPolicy {
       DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread);
 
   /**
-   * Chooses which writer should be flushed. Default implementation chooses the writer with most RAM
-   * usage
-   *
-   * @param ramManager the {@link IndexWriterRAMManager} being used to actually flush the writers
+   * Flushed a writer according to the FlushPolicy. NOTE: this doesn't necessarily mean the passed
+   * in writer will be flushed, and in most cases, this will actually be the case as the default
+   * policy is a round-robin policy
    */
-  public abstract void flushWriter(
-      IndexWriterRAMManager ramManager,
-      IndexWriterRAMManager.PerWriterIndexWriterRAMManager perWriterRamManager)
-      throws IOException;
+  public abstract void flushRamManager(IndexWriter writer) throws IOException;
 
   /** Called by DocumentsWriter to initialize the FlushPolicy */
   protected synchronized void init(LiveIndexWriterConfig indexWriterConfig) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexUpgrader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexUpgrader.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.CommandLineUtil;
@@ -135,7 +136,7 @@ public final class IndexUpgrader {
    * {@code matchVersion}. The tool refuses to upgrade indexes with multiple commit points.
    */
   public IndexUpgrader(Directory dir) {
-    this(dir, new IndexWriterConfig(null), false);
+    this(dir, new IndexWriterConfig((Analyzer) null), false);
   }
 
   /**
@@ -145,7 +146,7 @@ public final class IndexUpgrader {
    * be sent to this stream.
    */
   public IndexUpgrader(Directory dir, InfoStream infoStream, boolean deletePriorCommits) {
-    this(dir, new IndexWriterConfig(null), deletePriorCommits);
+    this(dir, new IndexWriterConfig((Analyzer) null), deletePriorCommits);
     if (null != infoStream) {
       this.iwc.setInfoStream(infoStream);
     }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -2451,6 +2451,7 @@ public class IndexWriter
     // Ensure that only one thread actually gets to do the
     // closing, and make sure no commit is also in progress:
     if (shouldClose(true)) {
+      indexWriterRAMManager.removeWriter();
       rollbackInternal();
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
@@ -142,7 +142,21 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
    * problem you should switch to {@link LogByteSizeMergePolicy} or {@link LogDocMergePolicy}.
    */
   public IndexWriterConfig(Analyzer analyzer) {
-    super(analyzer);
+    this(analyzer, new IndexWriterRAMManager(IndexWriterConfig.DEFAULT_RAM_BUFFER_SIZE_MB));
+  }
+
+  /**
+   * Creates a new config with the provided {@link IndexWriterRAMManager}. If you want to share a
+   * buffer between multiple {@link IndexWriter}, you will need to use this constructor as {@link
+   * IndexWriterConfig} maintains a 1:1 relationship with {@link IndexWriter}
+   */
+  public IndexWriterConfig(IndexWriterRAMManager indexWriterRAMManager) {
+    this(new StandardAnalyzer(), indexWriterRAMManager);
+  }
+
+  /** Creates a new config with the provided {@link Analyzer} and {@link IndexWriterRAMManager} */
+  public IndexWriterConfig(Analyzer analyzer, IndexWriterRAMManager indexWriterRAMManager) {
+    super(analyzer, indexWriterRAMManager);
   }
 
   /**
@@ -391,6 +405,11 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
   @Override
   public double getRAMBufferSizeMB() {
     return super.getRAMBufferSizeMB();
+  }
+
+  @Override
+  public IndexWriterRAMManager getIndexWriterRAMManager() {
+    return super.getIndexWriterRAMManager();
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterRAMManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterRAMManager.java
@@ -63,7 +63,7 @@ public class IndexWriterRAMManager {
     return idToWriter.flushRoundRobin();
   }
 
-  /** Registers a writer and returns the associated ID, protected for testing */
+  /** Registers a writer can returns the associated ID */
   protected int registerWriter(IndexWriter writer) {
     int id = idGenerator.incrementAndGet();
     idToWriter.addWriter(writer, id);
@@ -75,42 +75,12 @@ public class IndexWriterRAMManager {
     idToWriter.removeWriter(id);
   }
 
-  private void flushIfNecessary(
-      FlushPolicy flushPolicy, PerWriterIndexWriterRAMManager perWriterRAMManager)
-      throws IOException {
-    if (ramBufferSizeMB != IndexWriterConfig.DISABLE_AUTO_FLUSH) {
-      flushPolicy.flushWriter(this, perWriterRAMManager);
-    }
-  }
-
-  private long updateAndGetCurrentBytesUsed(int id) {
-    return idToWriter.getTotalRamTracker(id);
-  }
-
   /**
-   * For use in {@link IndexWriter}, manages communication with the {@link IndexWriterRAMManager}
+   * Will call {@link IndexWriter#ramBytesUsed()} for the writer id passed in, and then updates the
+   * total ram using that value and returns it
    */
-  public static class PerWriterIndexWriterRAMManager {
-
-    private final int id;
-    private final IndexWriterRAMManager manager;
-
-    PerWriterIndexWriterRAMManager(IndexWriter writer, IndexWriterRAMManager manager) {
-      id = manager.registerWriter(writer);
-      this.manager = manager;
-    }
-
-    void removeWriter() {
-      manager.removeWriter(id);
-    }
-
-    void flushIfNecessary(FlushPolicy flushPolicy) throws IOException {
-      manager.flushIfNecessary(flushPolicy, this);
-    }
-
-    long getTotalBufferBytesUsed() {
-      return manager.updateAndGetCurrentBytesUsed(id);
-    }
+  public long updateAndGetCurrentBytesUsed(int id) {
+    return idToWriter.getTotalRamTracker(id);
   }
 
   private static class LinkedIdToWriter {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterRAMManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterRAMManager.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * For managing multiple instances of {@link IndexWriter} sharing the same buffer (configured by
+ * {@link IndexWriterConfig#setRAMBufferSizeMB})
+ */
+public class IndexWriterRAMManager {
+
+  private final IndexWriterConfig config;
+  private final Map<Integer, IndexWriter> idToWriter = new ConcurrentHashMap<>();
+  private final AtomicInteger idGenerator = new AtomicInteger();
+
+  /**
+   * Default constructor
+   *
+   * @param config the index writer config containing the max RAM buffer size
+   */
+  public IndexWriterRAMManager(IndexWriterConfig config) {
+    this.config = config;
+  }
+
+  private int registerWriter(IndexWriter writer) {
+    int id = idGenerator.incrementAndGet();
+    idToWriter.put(id, writer);
+    return id;
+  }
+
+  private void removeWriter(int id) {
+    if (idToWriter.containsKey(id) == false) {
+      throw new IllegalArgumentException(
+          "Writer " + id + " has not been registered or has been removed already");
+    }
+    idToWriter.remove(id);
+  }
+
+  private void flushIfNecessary(int id) throws IOException {
+    if (idToWriter.containsKey(id) == false) {
+      throw new IllegalArgumentException(
+          "Writer " + id + " has not been registered or has been removed already");
+    }
+    long totalRam = 0L;
+    for (IndexWriter writer : idToWriter.values()) {
+      totalRam += writer.ramBytesUsed();
+    }
+    if (totalRam >= config.getRAMBufferSizeMB() * 1024 * 1024) {
+      IndexWriter writerToFlush = chooseWriterToFlush(idToWriter.values(), idToWriter.get(id));
+      writerToFlush.flushNextBuffer();
+    }
+  }
+
+  /**
+   * Chooses which writer should be flushed. Default implementation chooses the writer with most RAM
+   * usage
+   *
+   * @param writers list of writers registered with this {@link IndexWriterRAMManager}
+   * @param callingWriter the writer calling {@link IndexWriterRAMManager#flushIfNecessary}
+   * @return the IndexWriter to flush
+   */
+  protected static IndexWriter chooseWriterToFlush(
+      Collection<IndexWriter> writers, IndexWriter callingWriter) {
+    IndexWriter highestBufferWriter = null;
+    long highestRam = 0L;
+    for (IndexWriter writer : writers) {
+      long writerRamBytes = writer.ramBytesUsed();
+      if (writerRamBytes > highestRam) {
+        highestRam = writerRamBytes;
+        highestBufferWriter = writer;
+      }
+    }
+    return highestBufferWriter;
+  }
+
+  /**
+   * For use in {@link IndexWriter}, manages communication with the {@link IndexWriterRAMManager}
+   */
+  public static class PerWriterIndexWriterRAMManager {
+
+    private final int id;
+    private final IndexWriterRAMManager manager;
+
+    PerWriterIndexWriterRAMManager(IndexWriter writer, IndexWriterRAMManager manager) {
+      id = manager.registerWriter(writer);
+      this.manager = manager;
+    }
+
+    void removeWriter() {
+      manager.removeWriter(id);
+    }
+
+    void flushIfNecessary() throws IOException {
+      manager.flushIfNecessary(id);
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterRAMManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterRAMManager.java
@@ -37,7 +37,7 @@ public class IndexWriterRAMManager {
    * @param ramBufferSizeMB the RAM buffer size to use between all registered {@link IndexWriter}
    *     instances
    */
-  IndexWriterRAMManager(double ramBufferSizeMB) {
+  public IndexWriterRAMManager(double ramBufferSizeMB) {
     if (ramBufferSizeMB != IndexWriterConfig.DISABLE_AUTO_FLUSH && ramBufferSizeMB <= 0.0) {
       throw new IllegalArgumentException("ramBufferSize should be > 0.0 MB when enabled");
     }
@@ -61,6 +61,11 @@ public class IndexWriterRAMManager {
    */
   public int flushRoundRobin() throws IOException {
     return idToWriter.flushRoundRobin();
+  }
+
+  /** Gets the number of writers registered with this ram manager */
+  public int getWriterCount() {
+    return idToWriter.size();
   }
 
   /** Registers a writer can returns the associated ID */
@@ -167,6 +172,12 @@ public class IndexWriterRAMManager {
         idToWriterNode.get(id).ram = newRAMBytesUsed;
         totalRamTracker += newRAMBytesUsed - oldRAMBytesUsed;
         return totalRamTracker;
+      }
+    }
+
+    int size() {
+      synchronized (lock) {
+        return idToWriterNode.size();
       }
     }
 

--- a/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
+++ b/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
@@ -184,7 +185,7 @@ public class TestMergeSchedulerExternal extends LuceneTestCase {
     // compiles. But ensure that it can be used as well, e.g., no other hidden
     // dependencies or something. Therefore, don't use any random API !
     Directory dir = new ByteBuffersDirectory();
-    IndexWriterConfig conf = new IndexWriterConfig(null);
+    IndexWriterConfig conf = new IndexWriterConfig((Analyzer) null);
     conf.setMergeScheduler(new ReportingMergeScheduler());
     IndexWriter writer = new IndexWriter(dir, conf);
     writer.addDocument(new Document());

--- a/lucene/core/src/test/org/apache/lucene/index/Test2BPostingsBytes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/Test2BPostingsBytes.java
@@ -19,6 +19,7 @@ package org.apache.lucene.index;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.codecs.Codec;
@@ -46,9 +47,9 @@ import org.apache.lucene.tests.util.TestUtil;
 public class Test2BPostingsBytes extends LuceneTestCase {
 
   public void test() throws Exception {
-    IndexWriterConfig defaultConfig = new IndexWriterConfig(null);
+    IndexWriterConfig defaultConfig = new IndexWriterConfig((Analyzer) null);
     Codec defaultCodec = defaultConfig.getCodec();
-    if ((new IndexWriterConfig(null)).getCodec() instanceof CompressingCodec) {
+    if ((new IndexWriterConfig((Analyzer) null)).getCodec() instanceof CompressingCodec) {
       Pattern regex = Pattern.compile("maxDocsPerChunk=(\\d+), blockSize=(\\d+)");
       Matcher matcher = regex.matcher(defaultCodec.toString());
       assertTrue(
@@ -116,7 +117,7 @@ public class Test2BPostingsBytes extends LuceneTestCase {
     if (dir2 instanceof MockDirectoryWrapper) {
       ((MockDirectoryWrapper) dir2).setThrottling(MockDirectoryWrapper.Throttling.NEVER);
     }
-    IndexWriter w2 = new IndexWriter(dir2, new IndexWriterConfig(null));
+    IndexWriter w2 = new IndexWriter(dir2, new IndexWriterConfig((Analyzer) null));
     TestUtil.addIndexesSlowly(w2, subReaders);
     w2.forceMerge(1);
     w2.close();
@@ -129,7 +130,7 @@ public class Test2BPostingsBytes extends LuceneTestCase {
     if (dir3 instanceof MockDirectoryWrapper) {
       ((MockDirectoryWrapper) dir3).setThrottling(MockDirectoryWrapper.Throttling.NEVER);
     }
-    IndexWriter w3 = new IndexWriter(dir3, new IndexWriterConfig(null));
+    IndexWriter w3 = new IndexWriter(dir3, new IndexWriterConfig((Analyzer) null));
     TestUtil.addIndexesSlowly(w3, subReaders);
     w3.forceMerge(1);
     w3.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldReuse.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldReuse.java
@@ -108,7 +108,7 @@ public class TestFieldReuse extends BaseTokenStreamTestCase {
 
   public void testIndexWriterActuallyReuses() throws IOException {
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     IndexWriter iw = new IndexWriter(dir, iwc);
     final MyField field1 = new MyField();
     iw.addDocument(Collections.singletonList(field1));

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexFileDeleter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexFileDeleter.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.codecs.simpletext.SimpleTextCodec;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -238,14 +239,14 @@ public class TestIndexFileDeleter extends LuceneTestCase {
     TestUtil.disableVirusChecker(dir);
 
     // add empty commit
-    new IndexWriter(dir, new IndexWriterConfig(null)).close();
+    new IndexWriter(dir, new IndexWriterConfig((Analyzer) null)).close();
     // add a trash unreferenced file
     dir.createOutput("_0.si", IOContext.DEFAULT).close();
 
     // start virus scanner
     TestUtil.enableVirusChecker(dir);
 
-    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     iw.addDocument(new Document());
     // stop virus scanner
     TestUtil.disableVirusChecker(dir);
@@ -258,7 +259,7 @@ public class TestIndexFileDeleter extends LuceneTestCase {
     Directory dir = newMockDirectory();
 
     // empty commit
-    new IndexWriter(dir, new IndexWriterConfig(null)).close();
+    new IndexWriter(dir, new IndexWriterConfig((Analyzer) null)).close();
 
     SegmentInfos sis = SegmentInfos.readLatestCommit(dir);
     assertEquals(1, sis.getGeneration());
@@ -275,7 +276,7 @@ public class TestIndexFileDeleter extends LuceneTestCase {
     dir.setCheckIndexOnClose(false); // TODO: allow falling back more than one commit
 
     // empty commit
-    new IndexWriter(dir, new IndexWriterConfig(null)).close();
+    new IndexWriter(dir, new IndexWriterConfig((Analyzer) null)).close();
 
     SegmentInfos sis = SegmentInfos.readLatestCommit(dir);
     assertEquals(1, sis.getGeneration());
@@ -299,7 +300,7 @@ public class TestIndexFileDeleter extends LuceneTestCase {
     MockDirectoryWrapper dir = newMockDirectory();
 
     // empty commit
-    new IndexWriter(dir, new IndexWriterConfig(null)).close();
+    new IndexWriter(dir, new IndexWriterConfig((Analyzer) null)).close();
 
     SegmentInfos sis = SegmentInfos.readLatestCommit(dir);
     assertEquals(0, sis.counter);
@@ -321,7 +322,7 @@ public class TestIndexFileDeleter extends LuceneTestCase {
     assertEquals(4, sis.counter);
 
     // ensure we write _4 segment next
-    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     iw.addDocument(new Document());
     iw.commit();
     iw.close();
@@ -336,7 +337,7 @@ public class TestIndexFileDeleter extends LuceneTestCase {
     MockDirectoryWrapper dir = newMockDirectory();
 
     // initial commit
-    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     iw.addDocument(new Document());
     iw.commit();
     iw.close();
@@ -365,7 +366,7 @@ public class TestIndexFileDeleter extends LuceneTestCase {
     dir.setCheckIndexOnClose(false); // TODO: maybe handle such trash better elsewhere...
 
     // empty commit
-    new IndexWriter(dir, new IndexWriterConfig(null)).close();
+    new IndexWriter(dir, new IndexWriterConfig((Analyzer) null)).close();
 
     SegmentInfos sis = SegmentInfos.readLatestCommit(dir);
     assertEquals(1, sis.getGeneration());
@@ -384,7 +385,7 @@ public class TestIndexFileDeleter extends LuceneTestCase {
     MockDirectoryWrapper dir = newMockDirectory();
 
     // initial commit
-    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     iw.addDocument(new Document());
     iw.commit();
     iw.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -2054,7 +2054,7 @@ public class TestIndexWriter extends LuceneTestCase {
 
   public void testGetCommitDataFromOldSnapshot() throws Exception {
     Directory dir = newDirectory();
-    IndexWriter writer = new IndexWriter(dir, newSnapshotIndexWriterConfig(null));
+    IndexWriter writer = new IndexWriter(dir, newSnapshotIndexWriterConfig((Analyzer) null));
     writer.setLiveCommitData(
         new HashMap<String, String>() {
           {
@@ -2069,7 +2069,7 @@ public class TestIndexWriter extends LuceneTestCase {
     writer.close();
 
     // Modify the commit data and commit on close so the most recent commit data is different
-    writer = new IndexWriter(dir, newSnapshotIndexWriterConfig(null));
+    writer = new IndexWriter(dir, newSnapshotIndexWriterConfig((Analyzer) null));
     writer.setLiveCommitData(
         new HashMap<String, String>() {
           {
@@ -2084,7 +2084,7 @@ public class TestIndexWriter extends LuceneTestCase {
     writer =
         new IndexWriter(
             dir,
-            newSnapshotIndexWriterConfig(null)
+            newSnapshotIndexWriterConfig((Analyzer) null)
                 .setOpenMode(OpenMode.APPEND)
                 .setIndexCommit(indexCommit));
     assertEquals("value", getLiveCommitData(writer).get("key"));
@@ -2620,7 +2620,7 @@ public class TestIndexWriter extends LuceneTestCase {
     final CountDownLatch finishCommit = new CountDownLatch(1);
 
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     // use an InfoStream that "takes a long time" to commit
     final IndexWriter iw =
         RandomIndexWriter.mockIndexWriter(
@@ -3216,6 +3216,12 @@ public class TestIndexWriter extends LuceneTestCase {
                 control.setApplyAllDeletes();
               }
             }
+
+            @Override
+            public void flushWriter(
+                IndexWriterRAMManager ramManager,
+                IndexWriterRAMManager.PerWriterIndexWriterRAMManager perWriterRamManager)
+                throws IOException {}
           });
       try (IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
         assertEquals(0, w.docWriter.flushControl.getDeleteBytesUsed());

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -3218,10 +3218,7 @@ public class TestIndexWriter extends LuceneTestCase {
             }
 
             @Override
-            public void flushWriter(
-                IndexWriterRAMManager ramManager,
-                IndexWriterRAMManager.PerWriterIndexWriterRAMManager perWriterRamManager)
-                throws IOException {}
+            public void flushRamManager(IndexWriter writer) throws IOException {}
           });
       try (IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
         assertEquals(0, w.docWriter.flushControl.getDeleteBytesUsed());

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterConfig.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterConfig.java
@@ -88,6 +88,7 @@ public class TestIndexWriterConfig extends LuceneTestCase {
     getters.add("getUseCompoundFile");
     getters.add("isCheckPendingFlushOnUpdate");
     getters.add("getSoftDeletesField");
+    getters.add("getIndexWriterRAMManager");
 
     for (Method m : IndexWriterConfig.class.getDeclaredMethods()) {
       if (m.getDeclaringClass() == IndexWriterConfig.class && m.getName().startsWith("get")) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
@@ -1994,7 +1994,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
         };
 
     Directory dir = newMockDirectory(); // we want to ensure we don't leak any locks or file handles
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     iwc.setInfoStream(evilInfoStream);
     // TODO: cutover to RandomIndexWriter.mockIndexWriter?
     IndexWriter iw =
@@ -2067,7 +2067,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
             }
           });
 
-      IndexWriterConfig iwc = new IndexWriterConfig(null);
+      IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
       IndexWriter iw = new IndexWriter(dir, iwc);
       Document doc = new Document();
       for (int i = 0; i < 10; i++) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.search.IndexSearcher;
@@ -47,7 +48,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
   @Monster("takes over two hours")
   public void testExactlyAtTrueLimit() throws Exception {
     Directory dir = newFSDirectory(createTempDir("2BDocs3"));
-    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     Document doc = new Document();
     doc.add(newStringField("field", "text", Field.Store.NO));
     for (int i = 0; i < IndexWriter.MAX_DOCS; i++) {
@@ -93,7 +94,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(10);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       for (int i = 0; i < 10; i++) {
         w.addDocument(new Document());
       }
@@ -116,7 +117,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(10);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       for (int i = 0; i < 10; i++) {
         w.addDocument(new Document());
       }
@@ -139,7 +140,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(10);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       for (int i = 0; i < 10; i++) {
         w.addDocument(new Document());
       }
@@ -162,7 +163,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(10);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       for (int i = 0; i < 10; i++) {
         w.addDocument(new Document());
       }
@@ -185,7 +186,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(10);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       for (int i = 0; i < 10; i++) {
         Document doc = new Document();
         doc.add(newStringField("id", "" + i, Field.Store.NO));
@@ -226,7 +227,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(10);
     try {
       Directory dir = newDirectory();
-      IndexWriterConfig iwc = new IndexWriterConfig(null);
+      IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
       iwc.setMergePolicy(NoMergePolicy.INSTANCE);
       IndexWriter w = new IndexWriter(dir, iwc);
       for (int i = 0; i < 10; i++) {
@@ -271,14 +272,14 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(10);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       for (int i = 0; i < 10; i++) {
         w.addDocument(new Document());
       }
       w.close();
 
       Directory dir2 = newDirectory();
-      IndexWriter w2 = new IndexWriter(dir2, new IndexWriterConfig(null));
+      IndexWriter w2 = new IndexWriter(dir2, new IndexWriterConfig((Analyzer) null));
       w2.addDocument(new Document());
       expectThrows(
           IllegalArgumentException.class,
@@ -307,7 +308,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
   public void testMultiReaderExactLimit() throws Exception {
     Directory dir = newDirectory();
     Document doc = new Document();
-    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     for (int i = 0; i < 100000; i++) {
       w.addDocument(doc);
     }
@@ -315,7 +316,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
 
     int remainder = IndexWriter.MAX_DOCS % 100000;
     Directory dir2 = newDirectory();
-    w = new IndexWriter(dir2, new IndexWriterConfig(null));
+    w = new IndexWriter(dir2, new IndexWriterConfig((Analyzer) null));
     for (int i = 0; i < remainder; i++) {
       w.addDocument(doc);
     }
@@ -342,7 +343,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
   public void testMultiReaderBeyondLimit() throws Exception {
     Directory dir = newDirectory();
     Document doc = new Document();
-    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     for (int i = 0; i < 100000; i++) {
       w.addDocument(doc);
     }
@@ -354,7 +355,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     remainder++;
 
     Directory dir2 = newDirectory();
-    w = new IndexWriter(dir2, new IndexWriterConfig(null));
+    w = new IndexWriter(dir2, new IndexWriterConfig((Analyzer) null));
     for (int i = 0; i < remainder; i++) {
       w.addDocument(doc);
     }
@@ -387,7 +388,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     // we cheat and add the same one over again... IW wants a write lock on each
     Directory dir = newDirectory(random(), NoLockFactory.INSTANCE);
     Document doc = new Document();
-    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     for (int i = 0; i < 100000; i++) {
       w.addDocument(doc);
     }
@@ -397,7 +398,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
 
     // wrap this with disk full, so test fails faster and doesn't fill up real disks.
     MockDirectoryWrapper dir2 = newMockDirectory();
-    w = new IndexWriter(dir2, new IndexWriterConfig(null));
+    w = new IndexWriter(dir2, new IndexWriterConfig((Analyzer) null));
     w.commit(); // don't confuse checkindex
     dir2.setMaxSizeInBytes(dir2.sizeInBytes() + 65536); // 64KB
     Directory[] dirs = new Directory[1 + (IndexWriter.MAX_DOCS / 100000)];
@@ -437,7 +438,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     // we cheat and add the same one over again... IW wants a write lock on each
     Directory dir = newDirectory(random(), NoLockFactory.INSTANCE);
     Document doc = new Document();
-    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     for (int i = 0; i < 100000; i++) {
       w.addDocument(doc);
     }
@@ -447,7 +448,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
 
     // wrap this with disk full, so test fails faster and doesn't fill up real disks.
     MockDirectoryWrapper dir2 = newMockDirectory();
-    w = new IndexWriter(dir2, new IndexWriterConfig(null));
+    w = new IndexWriter(dir2, new IndexWriterConfig((Analyzer) null));
     w.commit(); // don't confuse checkindex
     dir2.setMaxSizeInBytes(dir2.sizeInBytes() + 65536); // 64KB
     IndexReader r = DirectoryReader.open(dir);
@@ -498,7 +499,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(1);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       w.addDocument(new Document());
       expectThrows(
           IllegalArgumentException.class,
@@ -526,7 +527,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(2);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       w.addDocument(new Document());
       DirectoryReader.open(w).close();
       w.addDocument(new Document());
@@ -557,7 +558,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(2);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       w.addDocument(new Document());
       w.commit();
       w.addDocument(new Document());
@@ -589,7 +590,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(limit);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
 
       CountDownLatch startingGun = new CountDownLatch(1);
       Thread[] threads = new Thread[limit];
@@ -643,11 +644,11 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(2);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       w.addDocument(new Document());
       w.close();
 
-      IndexWriter w2 = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w2 = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       w2.addDocument(new Document());
       expectThrows(
           IllegalArgumentException.class,
@@ -676,10 +677,10 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     setIndexWriterMaxDocs(1);
     try {
       Directory dir = newDirectory();
-      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       w.addDocument(new Document());
       w.close();
-      IndexWriter w2 = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter w2 = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       expectThrows(
           IllegalArgumentException.class,
           () -> {
@@ -696,7 +697,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
   // LUCENE-6299
   public void testCorruptIndexExceptionTooLarge() throws Exception {
     Directory dir = newDirectory();
-    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     w.addDocument(new Document());
     w.addDocument(new Document());
     w.close();
@@ -718,7 +719,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
   // LUCENE-6299
   public void testCorruptIndexExceptionTooLargeWriter() throws Exception {
     Directory dir = newDirectory();
-    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     w.addDocument(new Document());
     w.addDocument(new Document());
     w.close();
@@ -728,7 +729,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
       expectThrows(
           CorruptIndexException.class,
           () -> {
-            new IndexWriter(dir, new IndexWriterConfig(null));
+            new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
           });
     } finally {
       restoreIndexWriterMaxDocs();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterRAMManager.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterRAMManager.java
@@ -321,6 +321,13 @@ public class TestIndexWriterRAMManager extends LuceneTestCase {
         while (removedWriters.contains(maxValidWriter)) {
           maxValidWriter--;
         }
+        while (removedWriters.contains(lastFlush)) {
+          if (lastFlush == 1) {
+            lastFlush = maxValidWriter;
+          } else {
+            lastFlush--;
+          }
+        }
       } else if (event.event.equals(TestEventRecordingIndexWriterRAMManager.TestEvent.ADD)) {
         if (event.id > maxValidWriter) {
           maxValidWriter = event.id;
@@ -382,7 +389,13 @@ public class TestIndexWriterRAMManager extends LuceneTestCase {
       FLUSH;
     }
 
-    record TestEventAndId(TestEvent event, int id) {}
+    record TestEventAndId(TestEvent event, int id) {
+
+      @Override
+      public String toString() {
+        return event + " " + id;
+      }
+    }
 
     ConcurrentLinkedQueue<TestEventAndId> events = new ConcurrentLinkedQueue<>();
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterRAMManager.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterRAMManager.java
@@ -1,0 +1,422 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestIndexWriterRAMManager extends LuceneTestCase {
+
+  private static final FieldType storedTextType = new FieldType(TextField.TYPE_NOT_STORED);
+
+  public void testSingleWriter() throws IOException {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig indexWriterConfig = new IndexWriterConfig();
+      TestFlushPolicy flushPolicy = new TestFlushPolicy();
+      indexWriterConfig.setFlushPolicy(flushPolicy);
+      indexWriterConfig.setRAMBufferSizeMB(1);
+      try (IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
+        assertEquals(0, w.ramBytesUsed());
+        int i = 0;
+        int errorLimit = 100000; // prevents loop from iterating forever
+        while (flushPolicy.flushedWriters.isEmpty()) {
+          Document doc = new Document();
+          doc.add(newField("id", String.valueOf(i), storedTextType));
+          w.addDocument(doc);
+          i += 1;
+          if (i == errorLimit) {
+            fail("Writer has not flushed when expected");
+          }
+        }
+        assertEquals(1, flushPolicy.flushedWriters.size());
+        // suppresses null pointer warning in the next line, this will always return true
+        assert flushPolicy.flushedWriters.size() == 1;
+        assertEquals(1, (int) flushPolicy.flushedWriters.poll());
+      }
+    }
+  }
+
+  public void testMultipleWriters() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (Directory dir2 = newDirectory()) {
+        IndexWriterRAMManager indexWriterRAMManager = new IndexWriterRAMManager(1);
+        // Writers share the same buffer, so we pass in the same ram manager
+        IndexWriterConfig indexWriterConfig = new IndexWriterConfig(indexWriterRAMManager);
+        TestFlushPolicy flushPolicy = new TestFlushPolicy();
+        indexWriterConfig.setFlushPolicy(flushPolicy);
+        IndexWriterConfig indexWriterConfig2 = new IndexWriterConfig(indexWriterRAMManager);
+        indexWriterConfig2.setFlushPolicy(flushPolicy);
+
+        try (IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
+          try (IndexWriter w2 = new IndexWriter(dir2, indexWriterConfig2)) {
+            assertEquals(0, w.ramBytesUsed());
+            assertEquals(0, w2.ramBytesUsed());
+            int i = 0;
+            int errorLimit = 100000; // prevents loop from iterating forever
+            boolean addToWriter1 = true;
+            while (flushPolicy.flushedWriters.size() < 2) {
+              Document doc = new Document();
+              doc.add(newField("id", String.valueOf(i), storedTextType));
+              if (addToWriter1) {
+                w.addDocument(doc);
+              } else {
+                w2.addDocument(doc);
+              }
+              addToWriter1 = !addToWriter1;
+              i += 1;
+              if (i == errorLimit) {
+                fail("Writers have not flushed when expected");
+              }
+            }
+            assertEquals(2, flushPolicy.flushedWriters.size());
+            assert flushPolicy.flushedWriters.size() == 2;
+            assertEquals(1, (int) flushPolicy.flushedWriters.poll());
+            assert flushPolicy.flushedWriters.size() == 1;
+            assertEquals(2, (int) flushPolicy.flushedWriters.poll());
+          }
+        }
+      }
+    }
+  }
+
+  public void testMultipleWritersWithRemoval() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (Directory dir2 = newDirectory()) {
+        IndexWriterRAMManager indexWriterRAMManager = new IndexWriterRAMManager(1);
+        // Writers share the same buffer, so we pass in the same ram manager
+        IndexWriterConfig indexWriterConfig = new IndexWriterConfig(indexWriterRAMManager);
+        TestFlushPolicy flushPolicy = new TestFlushPolicy();
+        indexWriterConfig.setFlushPolicy(flushPolicy);
+        IndexWriterConfig indexWriterConfig2 = new IndexWriterConfig(indexWriterRAMManager);
+        indexWriterConfig2.setFlushPolicy(flushPolicy);
+
+        IndexWriter w = new IndexWriter(dir, indexWriterConfig);
+        IndexWriter w2 = new IndexWriter(dir2, indexWriterConfig2);
+        assertEquals(0, w.ramBytesUsed());
+        assertEquals(0, w2.ramBytesUsed());
+        int i = 0;
+        int errorLimit = 100000; // prevents loop from iterating forever
+        boolean addToWriter1 = true;
+        boolean w2Close = false;
+        while (flushPolicy.flushedWriters.size() < 4) {
+          if (w2Close == false && flushPolicy.flushedWriters.size() == 2) {
+            w2.close();
+            w2Close = true;
+          }
+          Document doc = new Document();
+          doc.add(newField("id", String.valueOf(i), storedTextType));
+          if (addToWriter1 || w2Close) {
+            w.addDocument(doc);
+          } else {
+            w2.addDocument(doc);
+          }
+          addToWriter1 = !addToWriter1;
+          i += 1;
+          if (i == errorLimit) {
+            if (w.isOpen()) {
+              w.close();
+              ;
+            }
+            if (w2.isOpen()) {
+              w2.close();
+            }
+            w2.close();
+            fail("Writers have not flushed when expected");
+          }
+        }
+        if (w.isOpen()) {
+          w.close();
+          ;
+        }
+        if (w2.isOpen()) {
+          w2.close();
+        }
+        // we expect 1 flushed, then 2, then 1 then 1 since 2 was removed
+        assertEquals(4, flushPolicy.flushedWriters.size());
+        assert flushPolicy.flushedWriters.size() == 4;
+        assertEquals(1, (int) flushPolicy.flushedWriters.poll());
+        assert flushPolicy.flushedWriters.size() == 3;
+        assertEquals(2, (int) flushPolicy.flushedWriters.poll());
+        assert flushPolicy.flushedWriters.size() == 2;
+        assertEquals(1, (int) flushPolicy.flushedWriters.poll());
+        assert flushPolicy.flushedWriters.size() == 1;
+        assertEquals(1, (int) flushPolicy.flushedWriters.poll());
+      }
+    }
+  }
+
+  public void testMultipleWritersWithAdding() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (Directory dir2 = newDirectory()) {
+        try (Directory dir3 = newDirectory()) {
+          IndexWriterRAMManager indexWriterRAMManager = new IndexWriterRAMManager(1);
+          // Writers share the same buffer, so we pass in the same ram manager
+          IndexWriterConfig indexWriterConfig = new IndexWriterConfig(indexWriterRAMManager);
+          TestFlushPolicy flushPolicy = new TestFlushPolicy();
+          indexWriterConfig.setFlushPolicy(flushPolicy);
+          IndexWriterConfig indexWriterConfig2 = new IndexWriterConfig(indexWriterRAMManager);
+          indexWriterConfig2.setFlushPolicy(flushPolicy);
+          IndexWriterConfig indexWriterConfig3 = new IndexWriterConfig(indexWriterRAMManager);
+          indexWriterConfig3.setFlushPolicy(flushPolicy);
+
+          IndexWriter w = new IndexWriter(dir, indexWriterConfig);
+          IndexWriter w2 = new IndexWriter(dir2, indexWriterConfig2);
+          IndexWriter w3 = null; // don't init this right now
+          assertEquals(0, w.ramBytesUsed());
+          assertEquals(0, w2.ramBytesUsed());
+          int i = 0;
+          int errorLimit = 100000; // prevents loop from iterating forever
+          while (flushPolicy.flushedWriters.size() < 5) {
+            if (w3 == null && flushPolicy.flushedWriters.size() == 3) {
+              w3 = new IndexWriter(dir3, indexWriterConfig3);
+              assertEquals(0, w3.ramBytesUsed());
+            }
+            Document doc = new Document();
+            doc.add(newField("id", String.valueOf(i), storedTextType));
+            if (i % 3 == 0) {
+              w.addDocument(doc);
+            } else if (i % 3 == 1) {
+              w2.addDocument(doc);
+            } else if (w3 != null) {
+              w3.addDocument(doc);
+            }
+            i += 1;
+            if (i == errorLimit) {
+              if (w.isOpen()) {
+                w.close();
+                ;
+              }
+              if (w2.isOpen()) {
+                w2.close();
+              }
+              if (w3 != null && w3.isOpen()) {
+                w3.close();
+              }
+              w2.close();
+              fail("Writers have not flushed when expected");
+            }
+          }
+          if (w.isOpen()) {
+            w.close();
+            ;
+          }
+          if (w2.isOpen()) {
+            w2.close();
+          }
+          if (w3 != null && w3.isOpen()) {
+            w3.close();
+          }
+          // we expect 1 flushed, then 2, then 1, then 2, then 3 since 3 was added
+          assertEquals(5, flushPolicy.flushedWriters.size());
+          assert flushPolicy.flushedWriters.size() == 5;
+          assertEquals(1, (int) flushPolicy.flushedWriters.poll());
+          assert flushPolicy.flushedWriters.size() == 4;
+          assertEquals(2, (int) flushPolicy.flushedWriters.poll());
+          assert flushPolicy.flushedWriters.size() == 3;
+          assertEquals(1, (int) flushPolicy.flushedWriters.poll());
+          assert flushPolicy.flushedWriters.size() == 2;
+          assertEquals(2, (int) flushPolicy.flushedWriters.poll());
+          assert flushPolicy.flushedWriters.size() == 1;
+          assertEquals(3, (int) flushPolicy.flushedWriters.poll());
+        }
+      }
+    }
+  }
+
+  public void testRandom() throws IOException {
+    for (int i = 0; i < 20; i++) {
+      randomTest();
+    }
+  }
+
+  private static void randomTest() throws IOException {
+    int numWriters = random().nextInt(1, 100);
+    double ramBufferSize = random().nextDouble();
+    List<Directory> directories = new ArrayList<>();
+    List<IndexWriterConfig> configs = new ArrayList<>();
+    List<IndexWriter> writers = new ArrayList<>();
+    TestFlushPolicy flushPolicy = new TestFlushPolicy();
+    TestEventRecordingIndexWriterRAMManager ramManager =
+        new TestEventRecordingIndexWriterRAMManager(ramBufferSize);
+    for (int i = 0; i < numWriters; i++) {
+      directories.add(newDirectory());
+      configs.add(new IndexWriterConfig(ramManager));
+      configs.get(i).setFlushPolicy(flushPolicy);
+      writers.add(new IndexWriter(directories.get(i), configs.get(i)));
+      assertEquals(0, writers.get(i).ramBytesUsed());
+    }
+
+    int flushedLimit = numWriters * 2;
+    int docId = 0;
+    while (ramManager.flushCount.get() < flushedLimit) {
+      boolean changeWriters = random().nextDouble() < 0.2;
+      if (changeWriters) {
+        boolean addWriter = random().nextBoolean();
+        if (addWriter) {
+          directories.add(newDirectory());
+          configs.add(new IndexWriterConfig(ramManager).setFlushPolicy(flushPolicy));
+          writers.add(new IndexWriter(directories.getLast(), configs.getLast()));
+        } else {
+          int closeWriter = random().nextInt(writers.size());
+          if (writers.get(closeWriter).isOpen()) {
+            writers.get(closeWriter).close();
+            directories.get(closeWriter).close();
+          }
+        }
+      } else {
+        Document doc = new Document();
+        doc.add(newField("id", String.valueOf(docId++), storedTextType));
+        int addDocWriter = random().nextInt(writers.size());
+        if (writers.get(addDocWriter).isOpen()) {
+          writers.get(addDocWriter).addDocument(doc);
+        }
+      }
+    }
+
+    verifyEvents(ramManager.events);
+
+    for (int i = 0; i < writers.size(); i++) {
+      if (writers.get(i).isOpen()) {
+        writers.get(i).close();
+        directories.get(i).close();
+      }
+    }
+  }
+
+  private static void verifyEvents(
+      Queue<TestEventRecordingIndexWriterRAMManager.TestEventAndId> events) {
+
+    TestEventRecordingIndexWriterRAMManager.TestEventAndId event = events.poll();
+    int lastFlush = -1;
+    int maxValidWriter = 1;
+    Set<Integer> removedWriters = new HashSet<>();
+    while (event != null) {
+      if (event.event.equals(TestEventRecordingIndexWriterRAMManager.TestEvent.REMOVE)) {
+        removedWriters.add(event.id);
+        while (removedWriters.contains(maxValidWriter)) {
+          maxValidWriter--;
+        }
+      } else if (event.event.equals(TestEventRecordingIndexWriterRAMManager.TestEvent.ADD)) {
+        if (event.id > maxValidWriter) {
+          maxValidWriter = event.id;
+        }
+      } else if (event.event.equals(TestEventRecordingIndexWriterRAMManager.TestEvent.FLUSH)) {
+        int flushedId = event.id;
+        assertFalse("Flushed ID after removing it", removedWriters.contains(flushedId));
+        if (lastFlush == -1) {
+          if (removedWriters.contains(1) == false) {
+            assertEquals("Must start flushing at the first id", 1, flushedId);
+          }
+        } else {
+          int nextValidFlush = lastFlush + 1;
+          while (removedWriters.contains(nextValidFlush) || nextValidFlush > maxValidWriter) {
+            if (nextValidFlush > maxValidWriter) {
+              nextValidFlush = 1;
+            } else {
+              nextValidFlush++;
+            }
+          }
+
+          assertEquals("Flushed in the wrong order", nextValidFlush, event.id);
+        }
+        lastFlush = flushedId;
+      }
+      event = events.poll();
+    }
+  }
+
+  /**
+   * Flush policy used for testing that keeps track of all the writers that were flushed and what
+   * order they were flushed in
+   */
+  private static class TestFlushPolicy extends FlushPolicy {
+
+    ConcurrentLinkedQueue<Integer> flushedWriters = new ConcurrentLinkedQueue<>();
+
+    @Override
+    public void onChange(DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread) {}
+
+    @Override
+    public void flushWriter(
+        IndexWriterRAMManager ramManager,
+        IndexWriterRAMManager.PerWriterIndexWriterRAMManager perWriterRamManager)
+        throws IOException {
+      long totalBytes = perWriterRamManager.getTotalBufferBytesUsed();
+      if (totalBytes > ramManager.getRamBufferSizeMB() * 1024 * 1024) {
+        int flushedId = ramManager.flushRoundRobin();
+        flushedWriters.add(flushedId);
+      }
+    }
+  }
+
+  private static class TestEventRecordingIndexWriterRAMManager extends IndexWriterRAMManager {
+
+    public enum TestEvent {
+      ADD,
+      REMOVE,
+      FLUSH;
+    }
+
+    record TestEventAndId(TestEvent event, int id) {}
+
+    ConcurrentLinkedQueue<TestEventAndId> events = new ConcurrentLinkedQueue<>();
+
+    AtomicInteger flushCount = new AtomicInteger();
+
+    /**
+     * Default constructor
+     *
+     * @param ramBufferSizeMB the RAM buffer size to use between all registered {@link IndexWriter}
+     *     instances
+     */
+    TestEventRecordingIndexWriterRAMManager(double ramBufferSizeMB) {
+      super(ramBufferSizeMB);
+    }
+
+    @Override
+    public int flushRoundRobin() throws IOException {
+      int flushed = super.flushRoundRobin();
+      events.add(new TestEventAndId(TestEvent.FLUSH, flushed));
+      flushCount.incrementAndGet();
+      return flushed;
+    }
+
+    @Override
+    protected int registerWriter(IndexWriter writer) {
+      int id = super.registerWriter(writer);
+      events.add(new TestEventAndId(TestEvent.ADD, id));
+      return id;
+    }
+
+    @Override
+    protected void removeWriter(int id) {
+      super.removeWriter(id);
+      events.add(new TestEventAndId(TestEvent.REMOVE, id));
+    }
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterRAMManager.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterRAMManager.java
@@ -369,11 +369,9 @@ public class TestIndexWriterRAMManager extends LuceneTestCase {
     public void onChange(DocumentsWriterFlushControl control, DocumentsWriterPerThread perThread) {}
 
     @Override
-    public void flushWriter(
-        IndexWriterRAMManager ramManager,
-        IndexWriterRAMManager.PerWriterIndexWriterRAMManager perWriterRamManager)
-        throws IOException {
-      long totalBytes = perWriterRamManager.getTotalBufferBytesUsed();
+    public void flushRamManager(IndexWriter writer) throws IOException {
+      IndexWriterRAMManager ramManager = writer.getConfig().indexWriterRAMManager;
+      long totalBytes = ramManager.updateAndGetCurrentBytesUsed(writer.ramManagerId);
       if (totalBytes > ramManager.getRamBufferSizeMB() * 1024 * 1024) {
         int flushedId = ramManager.flushRoundRobin();
         flushedWriters.add(flushedId);
@@ -420,7 +418,7 @@ public class TestIndexWriterRAMManager extends LuceneTestCase {
     }
 
     @Override
-    protected int registerWriter(IndexWriter writer) {
+    public int registerWriter(IndexWriter writer) {
       int id = super.registerWriter(writer);
       events.add(new TestEventAndId(TestEvent.ADD, id));
       return id;

--- a/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -29,7 +30,7 @@ public class TestInfoStream extends LuceneTestCase {
   /** we shouldn't have test points unless we ask */
   public void testTestPointsOff() throws Exception {
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     iwc.setInfoStream(
         new InfoStream() {
           @Override
@@ -55,7 +56,7 @@ public class TestInfoStream extends LuceneTestCase {
   /** but they should work when we need */
   public void testTestPointsOn() throws Exception {
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     AtomicBoolean seenTestPoint = new AtomicBoolean();
     iwc.setInfoStream(
         new InfoStream() {

--- a/lucene/core/src/test/org/apache/lucene/index/TestPointValues.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPointValues.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.document.BinaryPoint;
 import org.apache.lucene.document.Document;
@@ -566,7 +567,7 @@ public class TestPointValues extends LuceneTestCase {
 
   public void testPointsFieldMissingFromOneSegment() throws Exception {
     Directory dir = FSDirectory.open(createTempDir());
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     IndexWriter w = new IndexWriter(dir, iwc);
     Document doc = new Document();
     doc.add(new StringField("id", "0", Field.Store.NO));
@@ -631,7 +632,7 @@ public class TestPointValues extends LuceneTestCase {
 
   public void testCheckIndexIncludesPoints() throws Exception {
     Directory dir = new ByteBuffersDirectory();
-    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     Document doc = new Document();
     doc.add(new IntPoint("int1", 17));
     w.addDocument(doc);
@@ -669,7 +670,8 @@ public class TestPointValues extends LuceneTestCase {
   public void testMergedStatsOneSegmentWithoutPoints() throws IOException {
     Directory dir = new ByteBuffersDirectory();
     IndexWriter w =
-        new IndexWriter(dir, new IndexWriterConfig(null).setMergePolicy(NoMergePolicy.INSTANCE));
+        new IndexWriter(
+            dir, new IndexWriterConfig((Analyzer) null).setMergePolicy(NoMergePolicy.INSTANCE));
     w.addDocument(new Document());
     DirectoryReader.open(w).close();
     Document doc = new Document();
@@ -690,7 +692,7 @@ public class TestPointValues extends LuceneTestCase {
 
   public void testMergedStatsAllPointsDeleted() throws IOException {
     Directory dir = new ByteBuffersDirectory();
-    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     w.addDocument(new Document());
     Document doc = new Document();
     doc.add(new IntPoint("field", Integer.MIN_VALUE));
@@ -728,7 +730,7 @@ public class TestPointValues extends LuceneTestCase {
     final int numDims = TestUtil.nextInt(random(), 1, 8);
     final int numBytesPerDim = TestUtil.nextInt(random(), 1, 16);
     Directory dir = new ByteBuffersDirectory();
-    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter w = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     final int numDocs = TestUtil.nextInt(random(), 10, 20);
     for (int i = 0; i < numDocs; ++i) {
       Document doc = new Document();

--- a/lucene/core/src/test/org/apache/lucene/search/TestControlledRealTimeReopenThread.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestControlledRealTimeReopenThread.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.TextField;
@@ -469,7 +470,7 @@ public class TestControlledRealTimeReopenThread extends ThreadedIndexingAndSearc
 
   public void testListenerCalled() throws Exception {
     Directory dir = newDirectory();
-    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     final AtomicBoolean afterRefreshCalled = new AtomicBoolean(false);
     SearcherManager sm = new SearcherManager(iw, new SearcherFactory());
     sm.addListener(

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
@@ -321,7 +322,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
   public void testCloseTwice() throws Exception {
     // test that we can close SM twice (per Closeable's contract).
     Directory dir = newDirectory();
-    new IndexWriter(dir, new IndexWriterConfig(null)).close();
+    new IndexWriter(dir, new IndexWriterConfig((Analyzer) null)).close();
     SearcherManager sm = new SearcherManager(dir, null);
     sm.close();
     sm.close();
@@ -362,7 +363,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
 
   public void testEnsureOpen() throws Exception {
     Directory dir = newDirectory();
-    new IndexWriter(dir, new IndexWriterConfig(null)).close();
+    new IndexWriter(dir, new IndexWriterConfig((Analyzer) null)).close();
     SearcherManager sm = new SearcherManager(dir, null);
     IndexSearcher s = sm.acquire();
     sm.close();
@@ -389,7 +390,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
 
   public void testListenerCalled() throws Exception {
     Directory dir = newDirectory();
-    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     final AtomicBoolean afterRefreshCalled = new AtomicBoolean(false);
     SearcherManager sm = new SearcherManager(iw, false, false, new SearcherFactory());
     sm.addListener(

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/DirectoryTaxonomyWriter.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/DirectoryTaxonomyWriter.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -237,7 +238,7 @@ public class DirectoryTaxonomyWriter implements TaxonomyWriter {
 
     // Make sure we use a MergePolicy which always merges adjacent segments and thus
     // keeps the doc IDs ordered as well (this is crucial for the taxonomy index).
-    return new IndexWriterConfig(null)
+    return new IndexWriterConfig((Analyzer) null)
         .setOpenMode(openMode)
         .setMergePolicy(new LogByteSizeMergePolicy());
   }

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyWriter.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyWriter.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.facet.DrillDownQuery;
 import org.apache.lucene.facet.FacetField;
@@ -274,7 +275,7 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     Directory dir = newDirectory();
 
     // create an empty index first, so that DirTaxoWriter initializes indexEpoch to 1.
-    new IndexWriter(dir, new IndexWriterConfig(null)).close();
+    new IndexWriter(dir, new IndexWriterConfig((Analyzer) null)).close();
 
     DirectoryTaxonomyWriter taxoWriter =
         new DirectoryTaxonomyWriter(dir, OpenMode.CREATE_OR_APPEND, NO_OP_CACHE);

--- a/lucene/misc/src/java/org/apache/lucene/misc/IndexMergeTool.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/IndexMergeTool.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.misc;
 
 import java.nio.file.Paths;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
@@ -48,7 +49,7 @@ public class IndexMergeTool {
   static class Options {
     String mergedIndexPath;
     String[] indexPaths;
-    IndexWriterConfig config = new IndexWriterConfig(null).setOpenMode(OpenMode.CREATE);
+    IndexWriterConfig config = new IndexWriterConfig((Analyzer) null).setOpenMode(OpenMode.CREATE);
     int maxSegments = 0;
 
     static Options parse(String[] args) throws ReflectiveOperationException {

--- a/lucene/misc/src/java/org/apache/lucene/misc/index/MultiPassIndexSplitter.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/index/MultiPassIndexSplitter.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.BaseCompositeReader;
 import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
@@ -106,7 +107,8 @@ public class MultiPassIndexSplitter {
         }
       }
       IndexWriter w =
-          new IndexWriter(outputs[i], new IndexWriterConfig(null).setOpenMode(OpenMode.CREATE));
+          new IndexWriter(
+              outputs[i], new IndexWriterConfig((Analyzer) null).setOpenMode(OpenMode.CREATE));
       System.err.println("Writing part " + (i + 1) + " ...");
       // pass the subreaders directly, as our wrapper's numDocs/hasDeletetions are not up-to-date
       final List<? extends FakeDeleteLeafIndexReader> sr = input.getSequentialSubReadersWrapper();

--- a/lucene/misc/src/java/org/apache/lucene/misc/index/PKIndexSplitter.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/index/PKIndexSplitter.java
@@ -18,6 +18,7 @@ package org.apache.lucene.misc.index;
 
 import java.io.IOException;
 import java.util.List;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FilterCodecReader;
@@ -57,7 +58,7 @@ public class PKIndexSplitter {
   }
 
   private static IndexWriterConfig newDefaultConfig() {
-    return new IndexWriterConfig(null).setOpenMode(OpenMode.CREATE);
+    return new IndexWriterConfig((Analyzer) null).setOpenMode(OpenMode.CREATE);
   }
 
   public PKIndexSplitter(

--- a/lucene/misc/src/test/org/apache/lucene/misc/index/TestBinaryDocValueSelector.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/index/TestBinaryDocValueSelector.java
@@ -18,6 +18,7 @@
 package org.apache.lucene.misc.index;
 
 import java.io.IOException;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -93,7 +94,7 @@ public class TestBinaryDocValueSelector extends LuceneTestCase {
   }
 
   private static IndexWriterConfig getIndexWriterConfig() {
-    return new IndexWriterConfig(null)
+    return new IndexWriterConfig((Analyzer) null)
         .setOpenMode(IndexWriterConfig.OpenMode.CREATE)
         .setMergePolicy(NoMergePolicy.INSTANCE)
         .setIndexSort(new Sort(new SortField("ord", SortField.Type.INT)));

--- a/lucene/misc/src/test/org/apache/lucene/misc/index/TestIndexRearranger.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/index/TestIndexRearranger.java
@@ -20,6 +20,7 @@ package org.apache.lucene.misc.index;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -207,7 +208,7 @@ public class TestIndexRearranger extends LuceneTestCase {
   }
 
   private static IndexWriterConfig getIndexWriterConfig() {
-    return new IndexWriterConfig(null)
+    return new IndexWriterConfig((Analyzer) null)
         .setOpenMode(IndexWriterConfig.OpenMode.CREATE)
         .setMergePolicy(NoMergePolicy.INSTANCE)
         .setIndexSort(new Sort(new SortField("ord", SortField.Type.INT)));

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestFunctionRangeQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestFunctionRangeQuery.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.queries.function;
 
 import java.io.IOException;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
@@ -100,7 +101,7 @@ public class TestFunctionRangeQuery extends FunctionTestSetup {
   private void doTestDeleted(ValueSource valueSource) throws IOException {
     // We delete doc with #3. Note we don't commit it to disk; we search using a near real-time
     // reader.
-    IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(null));
+    IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
     try {
       writer.deleteDocuments(
           new FunctionRangeQuery(valueSource, 3, 3, true, true)); // delete the one with #3

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestSpatialExample.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestSpatialExample.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.spatial;
 
 import java.io.IOException;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -97,7 +98,7 @@ public class TestSpatialExample extends LuceneTestCase {
   }
 
   private void indexPoints() throws Exception {
-    IndexWriterConfig iwConfig = new IndexWriterConfig(null);
+    IndexWriterConfig iwConfig = new IndexWriterConfig((Analyzer) null);
     IndexWriter indexWriter = new IndexWriter(directory, iwConfig);
 
     // Spatial4j is x-y order for arguments

--- a/lucene/suggest/src/java/org/apache/lucene/search/spell/SpellChecker.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/spell/SpellChecker.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -158,7 +159,7 @@ public class SpellChecker implements java.io.Closeable {
     synchronized (modifyCurrentIndexLock) {
       ensureOpen();
       if (!DirectoryReader.indexExists(spellIndexDir)) {
-        IndexWriter writer = new IndexWriter(spellIndexDir, new IndexWriterConfig(null));
+        IndexWriter writer = new IndexWriter(spellIndexDir, new IndexWriterConfig((Analyzer) null));
         writer.close();
       }
       swapSearcher(spellIndexDir);
@@ -453,7 +454,7 @@ public class SpellChecker implements java.io.Closeable {
       ensureOpen();
       final Directory dir = this.spellIndex;
       final IndexWriter writer =
-          new IndexWriter(dir, new IndexWriterConfig(null).setOpenMode(OpenMode.CREATE));
+          new IndexWriter(dir, new IndexWriterConfig((Analyzer) null).setOpenMode(OpenMode.CREATE));
       writer.close();
       swapSearcher(dir);
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BasePostingsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BasePostingsFormatTestCase.java
@@ -752,7 +752,7 @@ public abstract class BasePostingsFormatTestCase extends BaseIndexFileFormatTest
 
   public void testPostingsEnumDocsOnly() throws Exception {
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     IndexWriter iw = new IndexWriter(dir, iwc);
     Document doc = new Document();
     doc.add(new StringField("foo", "bar", Field.Store.NO));
@@ -1269,7 +1269,7 @@ public abstract class BasePostingsFormatTestCase extends BaseIndexFileFormatTest
 
   public void testPostingsEnumPayloads() throws Exception {
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     IndexWriter iw = new IndexWriter(dir, iwc);
     Document doc = new Document();
     Token token1 = new Token("bar", 0, 3);
@@ -1474,7 +1474,7 @@ public abstract class BasePostingsFormatTestCase extends BaseIndexFileFormatTest
 
   public void testPostingsEnumAll() throws Exception {
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     IndexWriter iw = new IndexWriter(dir, iwc);
     Document doc = new Document();
     Token token1 = new Token("bar", 0, 3);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseStoredFieldsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseStoredFieldsFormatTestCase.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.simpletext.SimpleTextCodec;
@@ -832,7 +833,7 @@ public abstract class BaseStoredFieldsFormatTestCase extends BaseIndexFileFormat
     Directory[] dirs = new Directory[10];
     for (int i = 0; i < dirs.length; i++) {
       Directory dir = newDirectory();
-      IndexWriterConfig iwc = new IndexWriterConfig(null);
+      IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
       IndexWriter iw = new IndexWriter(dir, iwc);
       Document doc = new Document();
       for (int j = 0; j < 10; j++) {
@@ -849,7 +850,7 @@ public abstract class BaseStoredFieldsFormatTestCase extends BaseIndexFileFormat
         reader = new MismatchedDirectoryReader(reader, random());
       }
       dirs[i] = newDirectory();
-      IndexWriter adder = new IndexWriter(dirs[i], new IndexWriterConfig(null));
+      IndexWriter adder = new IndexWriter(dirs[i], new IndexWriterConfig((Analyzer) null));
       TestUtil.addIndexesSlowly(adder, reader);
       adder.commit();
       adder.close();
@@ -858,7 +859,7 @@ public abstract class BaseStoredFieldsFormatTestCase extends BaseIndexFileFormat
     }
 
     Directory everything = newDirectory();
-    IndexWriter iw = new IndexWriter(everything, new IndexWriterConfig(null));
+    IndexWriter iw = new IndexWriter(everything, new IndexWriterConfig((Analyzer) null));
     iw.addIndexes(dirs);
     iw.forceMerge(1);
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
@@ -1484,7 +1484,7 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
 
   public void testPostingsEnumPayloads() throws Exception {
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     IndexWriter iw = new IndexWriter(dir, iwc);
     Document doc = new Document();
     Token token1 = new Token("bar", 0, 3);
@@ -1686,7 +1686,7 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
 
   public void testPostingsEnumAll() throws Exception {
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     IndexWriter iw = new IndexWriter(dir, iwc);
     Document doc = new Document();
     Token token1 = new Token("bar", 0, 3);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/LegacyBaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/LegacyBaseDocValuesFormatTestCase.java
@@ -3179,7 +3179,7 @@ public abstract class LegacyBaseDocValuesFormatTestCase extends BaseIndexFileFor
 
   public void testOneSortedNumberOneMissing() throws IOException {
     Directory directory = newDirectory();
-    IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(null));
+    IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig((Analyzer) null));
     Document doc = new Document();
     doc.add(new SortedNumericDocValuesField("dv", 5));
     writer.addDocument(doc);
@@ -3273,7 +3273,7 @@ public abstract class LegacyBaseDocValuesFormatTestCase extends BaseIndexFileFor
 
   public void testTwoSortedNumberOneMissing() throws IOException {
     Directory directory = newDirectory();
-    IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(null));
+    IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig((Analyzer) null));
     Document doc = new Document();
     doc.add(new SortedNumericDocValuesField("dv", 11));
     doc.add(new SortedNumericDocValuesField("dv", -5));
@@ -3297,7 +3297,7 @@ public abstract class LegacyBaseDocValuesFormatTestCase extends BaseIndexFileFor
 
   public void testSortedNumberMerge() throws IOException {
     Directory directory = newDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
     iwc.setMergePolicy(newLogMergePolicy());
     IndexWriter writer = new IndexWriter(directory, iwc);
     Document doc = new Document();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockDirectoryWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockDirectoryWrapper.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexWriter;
@@ -929,7 +930,7 @@ public class MockDirectoryWrapper extends BaseDirectoryWrapper {
           // now look for unreferenced files: discount ones that we tried to delete but could not
           Set<String> allFiles = new HashSet<>(Arrays.asList(listAll()));
           String[] startFiles = allFiles.toArray(new String[0]);
-          IndexWriterConfig iwc = new IndexWriterConfig(null);
+          IndexWriterConfig iwc = new IndexWriterConfig((Analyzer) null);
           iwc.setIndexDeletionPolicy(NoDeletionPolicy.INSTANCE);
 
           // We must do this before opening writer otherwise writer will be angry if there are
@@ -983,7 +984,8 @@ public class MockDirectoryWrapper extends BaseDirectoryWrapper {
           int numDocs1 = ir1.numDocs();
           ir1.close();
           // Don't commit on close, so that no merges will be scheduled.
-          new IndexWriter(this, new IndexWriterConfig(null).setCommitOnClose(false)).close();
+          new IndexWriter(this, new IndexWriterConfig((Analyzer) null).setCommitOnClose(false))
+              .close();
           DirectoryReader ir2 = DirectoryReader.open(this);
           int numDocs2 = ir2.numDocs();
           ir2.close();

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestFailIfUnreferencedFiles.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestFailIfUnreferencedFiles.java
@@ -18,6 +18,7 @@ package org.apache.lucene.tests.util;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import java.util.Collections;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -40,7 +41,7 @@ public class TestFailIfUnreferencedFiles extends WithNestedTests {
     public void testDummy() throws Exception {
       MockDirectoryWrapper dir = LuceneTestCase.newMockDirectory();
       dir.setAssertNoUnrefencedFilesOnClose(true);
-      IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(null));
+      IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig((Analyzer) null));
       iw.addDocument(new Document());
       iw.close();
       IndexOutput output = dir.createOutput("_hello.world", IOContext.DEFAULT);


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

Draft PR to outline my initial approach. I introduced `IndexWriterRamManager` to control writer flushes. I also have a function `IndexWriterRamManager#chooseWriterToFlush` that lets the user choose which writer they specifically want to be flushed, sort of like a simple flush policy. Currently it defaults to just choosing the writer with the most RAM usage. 

One thing I wanted to avoid was starting another thread to just poll the IndexWriter memory usage, so I just added a listener in `IndexWriter#maybeProcessEvents` which is called whenever docs are updated or deleted (`IndexWriterRamManager#flushIfNecessary`). I wanted this method to be called whenever `FlushPolicy#onChange` was called, as I believe they both kinda do the same thing

No unit tests yet, but will add them! I just wanted to have my approach sanity checked for now

### Revision 2
* Failing some unit tests but changed the general approach to address some of the feedback I received
* Still need to write new unit tests to test this code
* Now this will always create a `IndexWriterRAMManager` that is tied to the `IndexWriterConfig`. The user can either pass in their own if they want multiple `IndexWriter` instances to share a single buffer or just let the `IndexWriterRAMManager` be created per `IndexWriter`

### Revision 3
* Fixed unit tests

### Revision 4
* Added unit tests and fixed some bugs