### PR TITLE
Ensure doc order for TestCommonTermsQuery#testMinShouldMatch

### DIFF
--- a/lucene/queries/src/test/org/apache/lucene/queries/TestCommonTermsQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/TestCommonTermsQuery.java
@@ -194,7 +194,12 @@ public class TestCommonTermsQuery extends LuceneTestCase {
   public void testMinShouldMatch() throws IOException {
     Directory dir = newDirectory();
     MockAnalyzer analyzer = new MockAnalyzer(random());
-    RandomIndexWriter w = new RandomIndexWriter(random(), dir, analyzer);
+    RandomIndexWriter w =
+        new RandomIndexWriter(
+            random(),
+            dir,
+            LuceneTestCase.newIndexWriterConfig(analyzer)
+                .setMergePolicy(LuceneTestCase.newMergePolicy(random(), false)));
     String[] docs =
         new String[] {
           "this is the end of the world right",


### PR DESCRIPTION
Need to ensure doc order as some docs have scores that are exactly the same.

closes: https://github.com/apache/lucene/issues/13946