### PR TITLE
Disable exchanging minimum scores across slices for exhaustive evaluation.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -63,6 +63,9 @@ Optimizations
 * GITHUB#13941: Optimized computation of top-hits on disjunctive queries with
   many clauses. (Adrien Grand)
 
+* GITHUB#13954: Disabled exchanging scores across slices for exhaustive
+  top-hits evaluation. (Adrien Grand)
+
 Bug Fixes
 ---------------------
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollectorManager.java
@@ -93,7 +93,10 @@ public class TopFieldCollectorManager implements CollectorManager<TopFieldCollec
         supportsConcurrency
             ? HitsThresholdChecker.createShared(Math.max(totalHitsThreshold, numHits))
             : HitsThresholdChecker.create(Math.max(totalHitsThreshold, numHits));
-    this.minScoreAcc = supportsConcurrency ? new MaxScoreAccumulator() : null;
+    this.minScoreAcc =
+        supportsConcurrency && totalHitsThreshold != Integer.MAX_VALUE
+            ? new MaxScoreAccumulator()
+            : null;
     this.collectors = new ArrayList<>();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollectorManager.java
@@ -75,7 +75,10 @@ public class TopScoreDocCollectorManager
         supportsConcurrency
             ? HitsThresholdChecker.createShared(Math.max(totalHitsThreshold, numHits))
             : HitsThresholdChecker.create(Math.max(totalHitsThreshold, numHits));
-    this.minScoreAcc = supportsConcurrency ? new MaxScoreAccumulator() : null;
+    this.minScoreAcc =
+        supportsConcurrency && totalHitsThreshold != Integer.MAX_VALUE
+            ? new MaxScoreAccumulator()
+            : null;
   }
 
   /**


### PR DESCRIPTION
When `totalHitsThreshold` is `Integer.MAX_VALUE`, dynamic pruning is never used and all hits get evaluated. Thus, the minimum competitive score always stays at zero, and there is nothing to exchange across slices.