### PR TITLE
Speed up Lucene912PostingsReader nextDoc() impls.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -75,7 +75,7 @@ Optimizations
 * GITHUB#13943: Removed shared `HitsThresholdChecker`, which reduces overhead
   but may delay a bit when dynamic pruning kicks in. (Adrien Grand)
 
-* GITHUB#13963: Speedup nextDoc() implementations in Lucene912PostingsReader.
+* GITHUB#13963: Speed up nextDoc() implementations in Lucene912PostingsReader.
   (Adrien Grand)
 
 Bug Fixes

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -75,6 +75,9 @@ Optimizations
 * GITHUB#13943: Removed shared `HitsThresholdChecker`, which reduces overhead
   but may delay a bit when dynamic pruning kicks in. (Adrien Grand)
 
+* GITHUB#13963: Speedup nextDoc() implementations in Lucene912PostingsReader.
+  (Adrien Grand)
+
 Bug Fixes
 ---------------------
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -1648,10 +1648,9 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     public int nextDoc() throws IOException {
       if (docBufferUpto == BLOCK_SIZE) {
         advanceShallow(doc + 1);
-        if (needsRefilling) {
-          refillDocs();
-          needsRefilling = false;
-        }
+        assert needsRefilling;
+        refillDocs();
+        needsRefilling = false;
       }
 
       doc = (int) docBuffer[docBufferUpto];

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene912/Lucene912PostingsReader.java
@@ -580,7 +580,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
     @Override
     public int nextDoc() throws IOException {
-      if (doc == level0LastDocID) { // advance skip data on level 0
+      if (docBufferUpto == BLOCK_SIZE) { // advance skip data on level 0
         moveToNextLevel0Block();
       }
 
@@ -875,7 +875,7 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
     @Override
     public int nextDoc() throws IOException {
-      if (doc == level0LastDocID) { // advance level 0 skip data
+      if (docBufferUpto == BLOCK_SIZE) { // advance level 0 skip data
         moveToNextLevel0Block();
       }
 
@@ -1417,11 +1417,13 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
     @Override
     public int nextDoc() throws IOException {
-      if (doc == level0LastDocID) {
-        moveToNextLevel0Block();
-      } else if (needsRefilling) {
-        refillDocs();
-        needsRefilling = false;
+      if (docBufferUpto == BLOCK_SIZE) {
+        if (needsRefilling) {
+          refillDocs();
+          needsRefilling = false;
+        } else {
+          moveToNextLevel0Block();
+        }
       }
 
       return this.doc = (int) docBuffer[docBufferUpto++];
@@ -1644,10 +1646,12 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
 
     @Override
     public int nextDoc() throws IOException {
-      advanceShallow(doc + 1);
-      if (needsRefilling) {
-        refillDocs();
-        needsRefilling = false;
+      if (docBufferUpto == BLOCK_SIZE) {
+        advanceShallow(doc + 1);
+        if (needsRefilling) {
+          refillDocs();
+          needsRefilling = false;
+        }
       }
 
       doc = (int) docBuffer[docBufferUpto];


### PR DESCRIPTION
127 times out of 128, nextDoc() returns the next doc ID in the buffer. Currently, we check if the current doc is equal to the last doc ID in the block to know if we need to refill. We can do better by comparing the current index in the block with the block size, which is a bit more efficient since the latter is a constant.