### PR TITLE
Account for 0 graph size when initializing HNSW graph

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java
@@ -121,6 +121,10 @@ public class IncrementalHnswGraphMerger implements HnswGraphMerger {
     }
 
     HnswGraph initializerGraph = ((HnswGraphProvider) initReader).getGraph(fieldInfo.name);
+    if (initializerGraph.size() == 0) {
+      return HnswGraphBuilder.create(
+          scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed, maxOrd);
+    }
 
     BitSet initializedNodes = new FixedBitSet(maxOrd);
     int[] oldToNewOrdinalMap = getNewOrdMapping(mergedVectorValues, initializedNodes);


### PR DESCRIPTION
When initializing a joint graph from one of the segments' graphs,
 we always assume that a segment's graph is present. But later we want
 to explore an option where some segments will not have graphs (#13447).

This change allows to account for missing graphs.