### PR TITLE
Multireader Support in Searcher Manager

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
@@ -114,8 +114,8 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
   }
 
   /**
-   * Creates and returns a new SearcherManager from an existing {@link IndexReader}.  Note that
-   * this steals the incoming reference.
+   * Creates and returns a new SearcherManager from an existing {@link IndexReader}. Note that this
+   * steals the incoming reference.
    *
    * @param reader the IndexReader.
    * @param searcherFactory An optional {@link SearcherFactory}. Pass <code>null</code> if you don't

--- a/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
@@ -114,16 +114,15 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
   }
 
   /**
-   * Creates and returns a new SearcherManager from an existing {@link DirectoryReader}. Note that
+   * Creates and returns a new SearcherManager from an existing {@link IndexReader}.  Note that
    * this steals the incoming reference.
    *
-   * @param reader the DirectoryReader.
+   * @param reader the IndexReader.
    * @param searcherFactory An optional {@link SearcherFactory}. Pass <code>null</code> if you don't
    *     require the searcher to be warmed before going live or other custom behavior.
    * @throws IOException if there is a low-level I/O error
    */
-  public SearcherManager(DirectoryReader reader, SearcherFactory searcherFactory)
-      throws IOException {
+  public SearcherManager(IndexReader reader, SearcherFactory searcherFactory) throws IOException {
     if (searcherFactory == null) {
       searcherFactory = new SearcherFactory();
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -561,13 +561,13 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
     MultiReader reader = new MultiReader(nrtReader, nrtReader2);
 
     SearcherManager mgr = new SearcherManager(reader, null);
-    for(int i=0;i<10;i++) {
+    for (int i = 0; i < 10; i++) {
       Document d = new Document();
       d.add(new TextField("contents", Integer.toString(i), Field.Store.NO));
       w.addDocument(new Document());
 
       Document d2 = new Document();
-      d2.add(new TextField("contents", Integer.toString(i+10), Field.Store.NO));
+      d2.add(new TextField("contents", Integer.toString(i + 10), Field.Store.NO));
       w2.addDocument(new Document());
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -29,12 +29,21 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.TextField;
-import org.apache.lucene.index.*;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MultiReader;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.apache.lucene.util.English;
 import org.apache.lucene.tests.index.ThreadedIndexingAndSearchingTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
@@ -554,11 +563,11 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
     SearcherManager mgr = new SearcherManager(reader, null);
     for(int i=0;i<10;i++) {
       Document d = new Document();
-      d.add(new TextField("contents", English.intToEnglish(i), Field.Store.NO));
+      d.add(new TextField("contents", Integer.toString(i), Field.Store.NO));
       w.addDocument(new Document());
 
       Document d2 = new Document();
-      d2.add(new TextField("contents", English.intToEnglish(i+10), Field.Store.NO));
+      d2.add(new TextField("contents", Integer.toString(i+10), Field.Store.NO));
       w2.addDocument(new Document());
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -28,20 +28,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.index.ConcurrentMergeScheduler;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.FilterDirectoryReader;
-import org.apache.lucene.index.FilterLeafReader;
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.Term;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.*;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.English;
 import org.apache.lucene.tests.index.ThreadedIndexingAndSearchingTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
@@ -545,7 +538,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
     w.close();
     dir.close();
   }
-  
+
   // LUCENE-13975
   public void testMultiReaderReader() throws Exception {
     Directory dir = newDirectory();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -545,6 +545,43 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
     w.close();
     dir.close();
   }
+  
+  // LUCENE-13975
+  public void testMultiReaderReader() throws Exception {
+    Directory dir = newDirectory();
+    RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+    DirectoryReader nrtReader = w.getReader();
+
+    Directory dir2 = newDirectory();
+    RandomIndexWriter w2 = new RandomIndexWriter(random(), dir2);
+    DirectoryReader nrtReader2 = w2.getReader();
+
+    MultiReader reader = new MultiReader(nrtReader, nrtReader2);
+
+    SearcherManager mgr = new SearcherManager(reader, null);
+    for(int i=0;i<10;i++) {
+      Document d = new Document();
+      d.add(new TextField("contents", English.intToEnglish(i), Field.Store.NO));
+      w.addDocument(new Document());
+
+      Document d2 = new Document();
+      d2.add(new TextField("contents", English.intToEnglish(i+10), Field.Store.NO));
+      w2.addDocument(new Document());
+    }
+
+    mgr.maybeRefresh();
+    IndexSearcher s = mgr.acquire();
+    try {
+      assertTrue(s.getIndexReader() instanceof MultiReader);
+      assertEquals(s.count(new MatchAllDocsQuery()), 20);
+    } finally {
+      mgr.release(s);
+    }
+
+    mgr.close();
+    w.close();
+    dir.close();
+  }
 
   public void testPreviousReaderIsPassed() throws IOException {
     final Directory dir = newDirectory();


### PR DESCRIPTION
### Description

Copied from https://github.com/apache/lucene/issues/13975

I'd like to use MultiReader inside my searcher manager, but currently there is only support for DirectoryReader. Not sure about the context for. why this was the case initially, seems specific to some desired use-case https://issues.apache.org/jira/browse/LUCENE-6087.

Anyway should be a 1-line change here: https://github.com/apache/lucene/blob/9e90fb5bf1807f1d9ccf2cabf74b3235f2431ed4/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java#L125

I found a relevant stack overflow question here:
https://stackoverflow.com/questions/49817453/searchermanager-and-multireader-in-lucene

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
