### PR TITLE
[DRAFT] Change vector input from IndexInput to RandomAccessInput

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/store/EndiannessReverserIndexInput.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/store/EndiannessReverserIndexInput.java
@@ -63,8 +63,7 @@ final class EndiannessReverserIndexInput extends FilterIndexInput {
   public void readFloats(float[] dst, int offset, int length) throws IOException {
     in.readFloats(dst, offset, length);
     for (int i = 0; i < length; ++i) {
-      dst[offset + i] =
-          Float.intBitsToFloat(Integer.reverseBytes(Float.floatToRawIntBits(dst[offset + i])));
+      dst[offset + i] = revertFloat(dst[offset + i]);
     }
   }
 
@@ -107,6 +106,14 @@ final class EndiannessReverserIndexInput extends FilterIndexInput {
     }
 
     @Override
+    public void readFloats(long pos, float[] floats, int offset, int length) throws IOException {
+      in.readFloats(pos, floats, offset, length);
+      for (int i = 0; i < length; ++i) {
+        floats[offset + i] = revertFloat(floats[offset + i]);
+      }
+    }
+
+    @Override
     public short readShort(long pos) throws IOException {
       return Short.reverseBytes(in.readShort(pos));
     }
@@ -120,5 +127,19 @@ final class EndiannessReverserIndexInput extends FilterIndexInput {
     public long readLong(long pos) throws IOException {
       return Long.reverseBytes(in.readLong(pos));
     }
+
+    @Override
+    public Object clone() {
+      try {
+        return super.clone();
+      } catch (CloneNotSupportedException e) {
+        throw new Error(
+            "This cannot happen: Failing to clone EndiannessReverserRandomAccessInput", e);
+      }
+    }
+  }
+
+  private static float revertFloat(float value) {
+    return Float.intBitsToFloat(Integer.reverseBytes(Float.floatToRawIntBits(value)));
   }
 }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -450,7 +450,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                     new OffHeapByteVectorValues.DenseOffHeapVectorValues(
                         fieldInfo.getVectorDimension(),
                         docsWithField.cardinality(),
-                        vectorDataInput,
+                        vectorDataInput.toRandomAccessInput(),
                         byteSize,
                         defaultFlatVectorScorer,
                         fieldInfo.getVectorSimilarityFunction()));
@@ -462,7 +462,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                     new OffHeapFloatVectorValues.DenseOffHeapVectorValues(
                         fieldInfo.getVectorDimension(),
                         docsWithField.cardinality(),
-                        vectorDataInput,
+                        vectorDataInput.toRandomAccessInput(),
                         byteSize,
                         defaultFlatVectorScorer,
                         fieldInfo.getVectorSimilarityFunction()));

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorScorerBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorScorerBenchmark.java
@@ -98,7 +98,7 @@ public class VectorScorerBenchmark {
   static KnnVectorValues vectorValues(
       int dims, int size, IndexInput in, VectorSimilarityFunction sim) throws IOException {
     return new OffHeapByteVectorValues.DenseOffHeapVectorValues(
-        dims, size, in.slice("test", 0, in.length()), dims, new ThrowingFlatVectorScorer(), sim);
+        dims, size, in.toRandomAccessInput(), dims, new ThrowingFlatVectorScorer(), sim);
   }
 
   static final class ThrowingFlatVectorScorer implements FlatVectorsScorer {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/HasIndexSlice.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/HasIndexSlice.java
@@ -16,14 +16,14 @@
  */
 package org.apache.lucene.codecs.lucene95;
 
-import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
 
 /**
- * Implementors can return the IndexInput from which their values are read. For use by vector
+ * Implementors can return the RandomAccessInput from which their values are read. For use by vector
  * quantizers.
  */
 public interface HasIndexSlice {
 
-  /** Returns an IndexInput from which to read this instance's values. */
-  IndexInput getSlice();
+  /** Returns a RandomAccessInput from which to read this instance's values. */
+  RandomAccessInput getSlice();
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
@@ -303,7 +303,7 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
                     new OffHeapByteVectorValues.DenseOffHeapVectorValues(
                         fieldInfo.getVectorDimension(),
                         docsWithField.cardinality(),
-                        finalVectorDataInput,
+                        finalVectorDataInput.toRandomAccessInput(),
                         fieldInfo.getVectorDimension() * Byte.BYTES,
                         vectorsScorer,
                         fieldInfo.getVectorSimilarityFunction()));
@@ -313,7 +313,7 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
                     new OffHeapFloatVectorValues.DenseOffHeapVectorValues(
                         fieldInfo.getVectorDimension(),
                         docsWithField.cardinality(),
-                        finalVectorDataInput,
+                        finalVectorDataInput.toRandomAccessInput(),
                         fieldInfo.getVectorDimension() * Float.BYTES,
                         vectorsScorer,
                         fieldInfo.getVectorSimilarityFunction()));

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
@@ -213,8 +213,8 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     public float score(int vectorOrdinal) throws IOException {
       // get compressed vector, in Lucene99, vector values are stored and have a single value for
       // offset correction
-      values.getSlice().seek((long) vectorOrdinal * (values.getVectorByteLength() + Float.BYTES));
-      values.getSlice().readBytes(compressedVector, 0, compressedVector.length);
+      long pos = (long) vectorOrdinal * (values.getVectorByteLength() + Float.BYTES);
+      values.getSlice().readBytes(pos, compressedVector, 0, compressedVector.length);
       float vectorOffset = values.getScoreCorrectionConstant(vectorOrdinal);
       int dotProduct = VectorUtil.int4DotProductPacked(targetBytes, compressedVector);
       // For the current implementation of scalar quantization, all dotproducts should be >= 0;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
@@ -524,7 +524,7 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
                   compress,
                   fieldInfo.getVectorSimilarityFunction(),
                   vectorsScorer,
-                  quantizationDataInput)));
+                  quantizationDataInput.toRandomAccessInput())));
     } finally {
       if (success == false) {
         IOUtils.closeWhileHandlingException(tempQuantizedVectorData, quantizationDataInput);

--- a/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
@@ -259,6 +259,12 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
   }
 
   @Override
+  public void readFloats(long pos, float[] dst, int offset, int len) throws IOException {
+    seek(pos);
+    readFloats(dst, offset, len);
+  }
+
+  @Override
   public void readBytes(long pos, byte[] bytes, int offset, int len) throws IOException {
     if (len <= bufferSize) {
       // the buffer is big enough to satisfy this request

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
@@ -262,6 +262,12 @@ public final class ByteBuffersDataInput extends DataInput
   }
 
   @Override
+  public void readFloats(long pos, float[] floats, int offset, int length) throws IOException {
+    seek(pos);
+    readFloats(floats, offset, length);
+  }
+
+  @Override
   public short readShort(long pos) {
     long absPos = offset + pos;
     int blockOffset = blockOffset(absPos);

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersIndexInput.java
@@ -176,6 +176,12 @@ public final class ByteBuffersIndexInput extends IndexInput implements RandomAcc
   }
 
   @Override
+  public void readFloats(long pos, float[] floats, int offset, int length) throws IOException {
+    ensureOpen();
+    in.readFloats(pos, floats, offset, length);
+  }
+
+  @Override
   public short readShort(long pos) throws IOException {
     ensureOpen();
     return in.readShort(pos);

--- a/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
@@ -185,6 +185,13 @@ public abstract class IndexInput extends DataInput implements Closeable {
         }
 
         @Override
+        public void readFloats(long pos, float[] floats, int offset, int length)
+            throws IOException {
+          slice.seek(pos);
+          slice.readFloats(floats, offset, length);
+        }
+
+        @Override
         public short readShort(long pos) throws IOException {
           slice.seek(pos);
           return slice.readShort();

--- a/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
@@ -152,6 +152,14 @@ public abstract class IndexInput extends DataInput implements Closeable {
     }
   }
 
+  /** Convert this IndexInput a RandomAccessInput. */
+  public RandomAccessInput toRandomAccessInput() throws IOException {
+    if (this instanceof RandomAccessInput) {
+      return (RandomAccessInput) this;
+    }
+    return randomAccessSlice(0, length());
+  }
+
   /**
    * Creates a random-access slice of this index input, with the given offset and length.
    *
@@ -212,6 +220,15 @@ public abstract class IndexInput extends DataInput implements Closeable {
         @Override
         public void prefetch(long offset, long length) throws IOException {
           slice.prefetch(offset, length);
+        }
+
+        @Override
+        public Object clone() {
+          try {
+            return super.clone();
+          } catch (CloneNotSupportedException e) {
+            throw new Error("This cannot happen: Failing to clone RandomAccessInput", e);
+          }
         }
 
         @Override

--- a/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
@@ -23,7 +23,7 @@ import org.apache.lucene.util.BitUtil; // javadocs
  * Random Access Index API. Unlike {@link IndexInput}, this has no concept of file position, all
  * reads are absolute. However, like IndexInput, it is only intended for use by a single thread.
  */
-public interface RandomAccessInput {
+public interface RandomAccessInput extends Cloneable {
 
   /** The number of bytes in the file. */
   long length();
@@ -46,6 +46,14 @@ public interface RandomAccessInput {
       bytes[offset + i] = readByte(pos + i);
     }
   }
+
+  /**
+   * Reads a specified number of floats starting at a given position into an array at the specified
+   * offset.
+   *
+   * @see DataInput#readFloats
+   */
+  void readFloats(long pos, float[] floats, int offset, int length) throws IOException;
 
   /**
    * Reads a short (LE byte order) at the given position in the file
@@ -77,4 +85,6 @@ public interface RandomAccessInput {
    * @see IndexInput#prefetch
    */
   default void prefetch(long offset, long length) throws IOException {}
+
+  Object clone();
 }

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/QuantizedByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/QuantizedByteVectorValues.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.search.VectorScorer;
-import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
 
 /**
  * A version of {@link ByteVectorValues}, but additionally retrieving score correction offset for
@@ -52,7 +52,7 @@ public abstract class QuantizedByteVectorValues extends ByteVectorValues impleme
   }
 
   @Override
-  public IndexInput getSlice() {
+  public RandomAccessInput getSlice() {
     return null;
   }
 }

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorer.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorer.java
@@ -25,6 +25,7 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.FilterIndexInput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.MemorySegmentAccessInput;
+import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 
 abstract sealed class Lucene99MemorySegmentByteVectorScorer
@@ -40,8 +41,14 @@ abstract sealed class Lucene99MemorySegmentByteVectorScorer
    * returned.
    */
   public static Optional<Lucene99MemorySegmentByteVectorScorer> create(
-      VectorSimilarityFunction type, IndexInput input, KnnVectorValues values, byte[] queryVector) {
+      VectorSimilarityFunction type,
+      RandomAccessInput slice,
+      KnnVectorValues values,
+      byte[] queryVector) {
     assert values instanceof ByteVectorValues;
+    if (!(slice instanceof IndexInput input)) {
+      return Optional.empty();
+    }
     input = FilterIndexInput.unwrapOnlyTest(input);
     if (!(input instanceof MemorySegmentAccessInput msInput)) {
       return Optional.empty();

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorerSupplier.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorerSupplier.java
@@ -25,6 +25,7 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.FilterIndexInput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.MemorySegmentAccessInput;
+import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 
@@ -42,8 +43,11 @@ public abstract sealed class Lucene99MemorySegmentByteVectorScorerSupplier
    * optional is returned.
    */
   static Optional<RandomVectorScorerSupplier> create(
-      VectorSimilarityFunction type, IndexInput input, KnnVectorValues values) {
+      VectorSimilarityFunction type, RandomAccessInput slice, KnnVectorValues values) {
     assert values instanceof ByteVectorValues;
+    if (!(slice instanceof IndexInput input)) {
+      return Optional.empty();
+    }
     input = FilterIndexInput.unwrapOnlyTest(input);
     if (!(input instanceof MemorySegmentAccessInput msInput)) {
       return Optional.empty();

--- a/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -233,6 +233,12 @@ abstract class MemorySegmentIndexInput extends IndexInput
   }
 
   @Override
+  public void readFloats(long pos, float[] dst, int offset, int len) throws IOException {
+    seek(pos);
+    readFloats(dst, offset, len);
+  }
+
+  @Override
   public void readFloats(float[] dst, int offset, int length) throws IOException {
     try {
       MemorySegment.copy(curSegment, LAYOUT_LE_FLOAT, curPosition, dst, offset, length);

--- a/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestFlatVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestFlatVectorScorer.java
@@ -178,18 +178,13 @@ public class TestFlatVectorScorer extends LuceneTestCase {
   ByteVectorValues byteVectorValues(int dims, int size, IndexInput in, VectorSimilarityFunction sim)
       throws IOException {
     return new OffHeapByteVectorValues.DenseOffHeapVectorValues(
-        dims, size, in.slice("byteValues", 0, in.length()), dims, flatVectorsScorer, sim);
+        dims, size, in.toRandomAccessInput(), dims, flatVectorsScorer, sim);
   }
 
   FloatVectorValues floatVectorValues(
       int dims, int size, IndexInput in, VectorSimilarityFunction sim) throws IOException {
     return new OffHeapFloatVectorValues.DenseOffHeapVectorValues(
-        dims,
-        size,
-        in.slice("floatValues", 0, in.length()),
-        dims * Float.BYTES,
-        flatVectorsScorer,
-        sim);
+        dims, size, in.toRandomAccessInput(), dims * Float.BYTES, flatVectorsScorer, sim);
   }
 
   /** Concatenates float arrays as byte[]. */

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestLucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestLucene99ScalarQuantizedVectorScorer.java
@@ -43,6 +43,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
@@ -133,8 +134,12 @@ public class TestLucene99ScalarQuantizedVectorScorer extends LuceneTestCase {
               }
 
               @Override
-              public IndexInput getSlice() {
-                return in;
+              public RandomAccessInput getSlice() {
+                try {
+                  return in.randomAccessSlice(0, in.length());
+                } catch (IOException e) {
+                  throw new RuntimeException(e);
+                }
               }
 
               @Override

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorScorer.java
@@ -381,13 +381,13 @@ public class TestVectorScorer extends LuceneTestCase {
   KnnVectorValues vectorValues(int dims, int size, IndexInput in, VectorSimilarityFunction sim)
       throws IOException {
     return new OffHeapByteVectorValues.DenseOffHeapVectorValues(
-        dims, size, in.slice("byteValues", 0, in.length()), dims, MEMSEG_SCORER, sim);
+        dims, size, in.toRandomAccessInput(), dims, MEMSEG_SCORER, sim);
   }
 
   KnnVectorValues floatVectorValues(int dims, int size, IndexInput in, VectorSimilarityFunction sim)
       throws IOException {
     return new OffHeapFloatVectorValues.DenseOffHeapVectorValues(
-        dims, size, in.slice("floatValues", 0, in.length()), dims, MEMSEG_SCORER, sim);
+        dims, size, in.toRandomAccessInput(), dims, MEMSEG_SCORER, sim);
   }
 
   // creates the vector based on the given ordinal, which is reproducible given the ord and dims

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/quantization/SampleReader.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/quantization/SampleReader.java
@@ -22,7 +22,7 @@ import java.util.Random;
 import java.util.function.IntUnaryOperator;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
-import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.Bits;
 
 /** A reader of vector values that samples a subset of the vectors. */
@@ -53,7 +53,7 @@ public class SampleReader extends FloatVectorValues implements HasIndexSlice {
   }
 
   @Override
-  public IndexInput getSlice() {
+  public RandomAccessInput getSlice() {
     return ((HasIndexSlice) origin).getSlice();
   }
 


### PR DESCRIPTION
### Description

This PR changes the input of vector reader from IndexInput to RandomAccessInput, as we mostly random-access the vectors with seek() followed by readFloats().

One thing I'm uncertain is the need for cloning RandomAccessInput.

TODO:
- Add tests

fixes #13938