### PR TITLE
Add some basic HNSW graph checks to CheckIndex

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2819,7 +2819,7 @@ public final class CheckIndex implements Closeable {
               "OK [%d fields] [took %.3f sec]",
               status.hnswGraphsStatusByField.size(),
               nsToSec(System.nanoTime() - startNS)));
-      printHnswInfo(status.hnswGraphsStatusByField);
+      printHnswInfo(infoStream, status.hnswGraphsStatusByField);
     } catch (Throwable e) {
       if (failFast) {
         throw IOUtils.rethrowAlways(e);
@@ -2834,18 +2834,25 @@ public final class CheckIndex implements Closeable {
     return status;
   }
 
-  private static void printHnswInfo(Map<String, CheckIndex.Status.HnswGraphStatus> fieldsStatus) {
+  private static void printHnswInfo(
+      PrintStream infoStream, Map<String, CheckIndex.Status.HnswGraphStatus> fieldsStatus) {
     for (Map.Entry<String, CheckIndex.Status.HnswGraphStatus> entry : fieldsStatus.entrySet()) {
       String fieldName = entry.getKey();
       CheckIndex.Status.HnswGraphStatus status = entry.getValue();
-      System.out.println("      hnsw field name: " + fieldName);
+      msg(infoStream, "      hnsw field name: " + fieldName);
 
       int numLevels = Math.min(status.numNodesAtLevel.size(), status.connectednessAtLevel.size());
       for (int level = numLevels - 1; level >= 0; level--) {
         int numNodes = status.numNodesAtLevel.get(level);
         String connectedness = status.connectednessAtLevel.get(level);
-        System.out.printf(
-            "        level %d: %d nodes, %s connected%n", level, numNodes, connectedness);
+        msg(
+            infoStream,
+            String.format(
+                Locale.ROOT,
+                "        level %d: %d nodes, %s connected",
+                level,
+                numNodes,
+                connectedness));
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -251,6 +251,9 @@ public final class CheckIndex implements Closeable {
       /** Status of vectors */
       public VectorValuesStatus vectorValuesStatus;
 
+      /** Status of HNSW graph */
+      public HnswGraphStatus hnswGraphStatus;
+
       /** Status of soft deletes */
       public SoftDeletesStatus softDeletesStatus;
 
@@ -403,6 +406,21 @@ public final class CheckIndex implements Closeable {
 
       /** Total number of fields with vectors. */
       public int totalKnnVectorFields;
+
+      /** Exception thrown during vector values test (null on success) */
+      public Throwable error;
+    }
+
+    /** Status from testing HNSW graph */
+    public static final class HnswGraphStatus {
+
+      HnswGraphStatus() {}
+
+      /** Number of nodes in the graph */
+      public int hnswGraphSize;
+
+      /** Number of levels of the graph */
+      public int hsnwGraphNumLevels;
 
       /** Exception thrown during vector values test (null on success) */
       public Throwable error;
@@ -901,74 +919,6 @@ public final class CheckIndex implements Closeable {
               + result.maxSegmentName);
     }
 
-    try (DirectoryReader reader = DirectoryReader.open(dir)) {
-      for (LeafReaderContext context : reader.leaves()) {
-        LeafReader leafReader = context.reader();
-        KnnVectorsReader vectorsReader =
-            ((PerFieldKnnVectorsFormat.FieldsReader) ((CodecReader) leafReader).getVectorReader())
-                .getFieldReader("knn");
-        HnswGraph knnValues = ((Lucene99HnswVectorsReader) vectorsReader).getGraph("knn");
-        msg(
-            infoStream,
-            String.format(
-                Locale.ROOT, "Leaf %d has %d layers\n", context.ord, knnValues.numLevels()));
-        msg(
-            infoStream,
-            String.format(
-                Locale.ROOT, "Leaf %d has %d documents\n", context.ord, leafReader.maxDoc()));
-        final int numLevels = knnValues.numLevels();
-        for (int level = numLevels - 1; level >= 0; level--) {
-          int count = 0;
-          int min = Integer.MAX_VALUE, max = 0, total = 0;
-          long sumDelta = 0;
-          HnswGraph.NodesIterator nodesIterator = knnValues.getNodesOnLevel(level);
-          while (nodesIterator.hasNext()) {
-            int node = nodesIterator.nextInt();
-            int n = 0;
-            knnValues.seek(level, node);
-            int nbr, lastNeighbor = -1, firstNeighbor = -1;
-            while ((nbr = knnValues.nextNeighbor()) != NO_MORE_DOCS) {
-              if (firstNeighbor == -1) {
-                firstNeighbor = nbr;
-              }
-              // we see repeated neighbor nodes?!
-              assert nbr >= lastNeighbor
-                  : "neighbors out of order for node "
-                      + node
-                      + ": "
-                      + nbr
-                      + "<"
-                      + lastNeighbor
-                      + " 1st="
-                      + firstNeighbor;
-              assert nbr != lastNeighbor
-                      : "there are repeated neighbors of node " + node + " with value " + nbr;
-              lastNeighbor = nbr;
-              ++n;
-            }
-            max = Math.max(max, n);
-            min = Math.min(min, n);
-            if (n > 0) {
-              ++count;
-              total += n;
-              sumDelta += lastNeighbor - firstNeighbor;
-            }
-          }
-          msg(
-              infoStream,
-              String.format(
-                  Locale.ROOT,
-                  "Graphh level=%d size=%d, Fanout min=%d, mean=%.2f, max=%d, meandelta=%.2f\n",
-                  level,
-                  count,
-                  min,
-                  total / (float) count,
-                  max,
-                  sumDelta / (float) total));
-        }
-      }
-    }
-
     if (result.clean) {
       msg(infoStream, "No problems were detected with this index.\n");
     }
@@ -1154,6 +1104,9 @@ public final class CheckIndex implements Closeable {
 
         // Test FloatVectorValues and ByteVectorValues
         segInfoStat.vectorValuesStatus = testVectors(reader, infoStream, failFast);
+
+        // Test HNSW graph
+        segInfoStat.hnswGraphStatus = testHnswGraph(reader, infoStream, failFast);
 
         // Test Index Sort
         if (indexSort != null) {
@@ -2801,6 +2754,71 @@ public final class CheckIndex implements Closeable {
               status.totalKnnVectorFields,
               status.totalVectorValues,
               nsToSec(System.nanoTime() - startNS)));
+
+    } catch (Throwable e) {
+      if (failFast) {
+        throw IOUtils.rethrowAlways(e);
+      }
+      msg(infoStream, "ERROR: " + e);
+      status.error = e;
+      if (infoStream != null) {
+        e.printStackTrace(infoStream);
+      }
+    }
+
+    return status;
+  }
+
+  /** Test the HNSW graph. */
+  public static Status.HnswGraphStatus testHnswGraph(
+          CodecReader reader, PrintStream infoStream, boolean failFast) throws IOException {
+    if (infoStream != null) {
+      infoStream.print("    test: hnsw graph..........");
+    }
+    long startNS = System.nanoTime();
+    KnnVectorsReader vectorsReader = ((PerFieldKnnVectorsFormat.FieldsReader) reader.getVectorReader())
+            .getFieldReader("knn");
+    HnswGraph hnswGraph = ((Lucene99HnswVectorsReader) vectorsReader).getGraph("knn");
+    Status.HnswGraphStatus status = new Status.HnswGraphStatus();
+
+    try {
+      final int numLevels = hnswGraph.numLevels();
+      status.hnswGraphSize = hnswGraph.size();
+      status.hsnwGraphNumLevels = numLevels;
+        for (int level = numLevels - 1; level >= 0; level--) {
+          HnswGraph.NodesIterator nodesIterator = hnswGraph.getNodesOnLevel(level);
+          while (nodesIterator.hasNext()) {
+            int node = nodesIterator.nextInt();
+            hnswGraph.seek(level, node);
+            int nbr, lastNeighbor = -1, firstNeighbor = -1;
+            while ((nbr = hnswGraph.nextNeighbor()) != NO_MORE_DOCS) {
+              if (firstNeighbor == -1) {
+                firstNeighbor = nbr;
+              }
+              if (nbr < lastNeighbor) {
+                throw new CheckIndexException(
+                        "Neighbors out of order for node " + node + ": "+ nbr
+                                + "<"
+                                + lastNeighbor
+                                + " 1st="
+                                + firstNeighbor);
+              } else if (nbr == lastNeighbor) {
+                throw new CheckIndexException(
+                        "There are repeated neighbors of node " + node + " with value " + nbr
+                );
+              }
+              lastNeighbor = nbr;
+            }
+          }
+        }
+      msg(
+              infoStream,
+              String.format(
+                      Locale.ROOT,
+                      "OK [%d nodes, %d levels] [took %.3f sec]",
+                      status.hnswGraphSize,
+                      status.hsnwGraphNumLevels,
+                      nsToSec(System.nanoTime() - startNS)));
 
     } catch (Throwable e) {
       if (failFast) {

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2783,8 +2783,6 @@ public final class CheckIndex implements Closeable {
 
     try {
       final int numLevels = hnswGraph.numLevels();
-      status.hnswGraphSize = hnswGraph.size();
-      status.hsnwGraphNumLevels = numLevels;
       // Perform tests on each level of the HNSW graph
       for (int level = numLevels - 1; level >= 0; level--) {
         HnswGraph.NodesIterator nodesIterator = hnswGraph.getNodesOnLevel(level);
@@ -2812,15 +2810,17 @@ public final class CheckIndex implements Closeable {
             }
             lastNeighbor = nbr;
           }
+          status.hnswGraphSize++;
         }
+        status.hsnwGraphNumLevels++;
       }
       msg(
           infoStream,
           String.format(
               Locale.ROOT,
-              "OK [%d nodes, %d levels] [took %.3f sec]",
-              status.hnswGraphSize,
+              "OK [%d levels, %d nodes (over all levels)] [took %.3f sec]",
               status.hsnwGraphNumLevels,
+              status.hnswGraphSize,
               nsToSec(System.nanoTime() - startNS)));
 
     } catch (Throwable e) {

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2872,6 +2872,7 @@ public final class CheckIndex implements Closeable {
               throw new CheckIndexException(
                   "There are repeated neighbors of node " + node + " with value " + nbr);
             }
+            // TODO: add checks: nodes are within range and neighbors are on the same level
             lastNeighbor = nbr;
           }
           status.hnswGraphsStatusByField.get(fieldName).totalNumNodes++;

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2806,17 +2806,17 @@ public final class CheckIndex implements Closeable {
               }
               if (nbr < lastNeighbor) {
                 throw new CheckIndexException(
-                        "Neighbors out of order for node "
-                                + node
-                                + ": "
-                                + nbr
-                                + "<"
-                                + lastNeighbor
-                                + " 1st="
-                                + firstNeighbor);
+                    "Neighbors out of order for node "
+                        + node
+                        + ": "
+                        + nbr
+                        + "<"
+                        + lastNeighbor
+                        + " 1st="
+                        + firstNeighbor);
               } else if (nbr == lastNeighbor) {
                 throw new CheckIndexException(
-                        "There are repeated neighbors of node " + node + " with value " + nbr);
+                    "There are repeated neighbors of node " + node + " with value " + nbr);
               }
               lastNeighbor = nbr;
             }
@@ -2825,13 +2825,13 @@ public final class CheckIndex implements Closeable {
           status.hsnwGraphNumLevels++;
         }
         msg(
-                infoStream,
-                String.format(
-                        Locale.ROOT,
-                        "OK [%d levels, %d nodes (over all levels)] [took %.3f sec]",
-                        status.hsnwGraphNumLevels,
-                        status.hnswGraphSize,
-                        nsToSec(System.nanoTime() - startNS)));
+            infoStream,
+            String.format(
+                Locale.ROOT,
+                "OK [%d levels, %d nodes (over all levels)] [took %.3f sec]",
+                status.hsnwGraphNumLevels,
+                status.hnswGraphSize,
+                nsToSec(System.nanoTime() - startNS)));
       }
     } catch (Throwable e) {
       if (failFast) {

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -52,7 +52,7 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
-import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader;
+import org.apache.lucene.codecs.hnsw.HnswGraphProvider;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DocumentStoredFieldVisitor;
@@ -2778,7 +2778,7 @@ public final class CheckIndex implements Closeable {
     long startNS = System.nanoTime();
     KnnVectorsReader vectorsReader =
         ((PerFieldKnnVectorsFormat.FieldsReader) reader.getVectorReader()).getFieldReader("knn");
-    HnswGraph hnswGraph = ((Lucene99HnswVectorsReader) vectorsReader).getGraph("knn");
+    HnswGraph hnswGraph = ((HnswGraphProvider) vectorsReader).getGraph("knn");
     Status.HnswGraphStatus status = new Status.HnswGraphStatus();
 
     try {

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -422,9 +422,6 @@ public final class CheckIndex implements Closeable {
 
       /** Number of levels in the HNSW graph */
       public int numLevels;
-
-      /** Exception thrown during vector values test (null on success) */
-      public Throwable error;
     }
 
     /** Status from testing all HNSW graphs */
@@ -2826,9 +2823,9 @@ public final class CheckIndex implements Closeable {
           infoStream,
           String.format(
               Locale.ROOT,
-              "OK [%d fields: %s] [took %.3f sec]",
+              "OK [%d fields%s] [took %.3f sec]",
               status.hnswGraphsStatusByField.size(),
-              hnswGraphResultJoiner,
+              hnswGraphResultJoiner.toString().isEmpty() ? "" : ": " + hnswGraphResultJoiner,
               nsToSec(System.nanoTime() - startNS)));
     } catch (Throwable e) {
       if (failFast) {


### PR DESCRIPTION
### Description

This is a first pass on #13724 - I've added the following checks:
- verify neighbor list is in order 
- verify no duplicate neighbors

The code was adapted from [KnnGraphTester](https://github.com/mikemccand/luceneutil/blob/3a6235c2038de6c6d5d0575d8f58cf06c2836793/src/main/knn/KnnGraphTester.java#L521) in luceneutil.

Here's some test results from an index containing the cohere-wikipedia-docs-768d dataset:
```
    test: open reader.........OK [took 0.010 sec]
    test: check integrity.....OK [took 2.207 sec]
    test: check live docs.....OK [took 0.000 sec]
    test: field infos.........OK [2 fields] [took 0.000 sec]
    test: field norms.........OK [0 fields] [took 0.000 sec]
    test: terms, freq, prox...    test: stored fields.......OK [1500000 total field count; avg 1.0 fields per doc] [took 0.398 sec]
    test: term vectors........OK [0 total term vector count; avg 0.0 term/freq vector fields per doc] [took 0.000 sec]
    test: docvalues...........OK [0 docvalues fields; 0 BINARY; 0 NUMERIC; 0 SORTED; 0 SORTED_NUMERIC; 0 SORTED_SET; 0 SKIPPING INDEX] [took 0.000 sec]
    test: points..............OK [0 fields, 0 points] [took 0.000 sec]
    test: vectors.............OK [1 fields, 1500000 vectors] [took 0.497 sec]
    test: hnsw graph..........OK [4 levels, 1547684 nodes (over all levels)] [took 0.485 sec]

No problems were detected with this index.
```

I manually corrupted some neighbors lists in order to check the failure cases:
```
    test: open reader.........OK [took 0.012 sec]
    test: check integrity.....OK [took 3.633 sec]
    test: check live docs.....OK [took 0.000 sec]
    test: field infos.........OK [2 fields] [took 0.000 sec]
    test: field norms.........OK [0 fields] [took 0.000 sec]
    test: terms, freq, prox...    test: stored fields.......OK [1500000 total field count; avg 1.0 fields per doc] [took 0.393 sec]
    test: term vectors........OK [0 total term vector count; avg 0.0 term/freq vector fields per doc] [took 0.000 sec]
    test: docvalues...........OK [0 docvalues fields; 0 BINARY; 0 NUMERIC; 0 SORTED; 0 SORTED_NUMERIC; 0 SORTED_SET; 0 SKIPPING INDEX] [took 0.000 sec]
    test: points..............OK [0 fields, 0 points] [took 0.000 sec]
    test: vectors.............OK [1 fields, 1500000 vectors] [took 0.504 sec]
    test: hnsw graph..........ERROR: org.apache.lucene.index.CheckIndex$CheckIndexException: Neighbors out of order for node 31142: 839445<1326517 1st=33190
org.apache.lucene.index.CheckIndex$CheckIndexException: Neighbors out of order for node 31142: 839445<1326517 1st=33190
	at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.index.CheckIndex.testHnswGraph(CheckIndex.java:2798)
	at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.index.CheckIndex.testSegment(CheckIndex.java:1109)
	at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.index.CheckIndex.checkIndex(CheckIndex.java:806)
	at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.index.CheckIndex.checkIndex(CheckIndex.java:576)
	at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.index.CheckIndex.doCheck(CheckIndex.java:4479)
	at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.index.CheckIndex.doMain(CheckIndex.java:4316)
	at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.index.CheckIndex.main(CheckIndex.java:4248)
```

I intend to dig into the HNSW creation and think about more checks that would be useful here, but I wanted to start small with these neighbor checks only.