### PR TITLE
Allow easier verification of the Panama Vectorization provider with newer Java versions

### DIFF
--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -132,8 +132,10 @@ allprojects {
       def v = JavaVersion.toVersion(Integer.parseInt(prop)).majorVersion
       if (rootProject.vectorIncubatorJavaVersions.contains(rootProject.runtimeJavaVersion) ||
           rootProject.runtimeJavaVersion.majorVersion <= v) {
-        systemProperty 'org.apache.lucene.vectorization.upperJavaFeatureVersion', v
         jvmArgs '--add-modules', 'jdk.incubator.vector'
+        if (rootProject.runtimeJavaVersion.majorVersion <= v) {
+          systemProperty 'org.apache.lucene.vectorization.upperJavaFeatureVersion', v
+        }
       }
       
       jvmArgs '--enable-native-access=' + (project.path in [

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -128,12 +128,10 @@ allprojects {
       jvmArgs '--add-modules', 'jdk.management'
 
       // Enable the vector incubator module on supported Java versions:
-      def v = JavaVersion.VERSION_1_1
-      def prop = providers.systemProperty("org.apache.lucene.vectorization.upperJavaFeatureVersion")
-      if (prop.isPresent())
-        v = prop.map(Integer::parseInt).map(JavaVersion::getVersionForMajor).get()
+      def prop = propertyOrDefault("org.apache.lucene.vectorization.upperJavaFeatureVersion", "1") as String
+      def v = JavaVersion.toVersion(Integer.parseInt(prop)).majorVersion
       if (rootProject.vectorIncubatorJavaVersions.contains(rootProject.runtimeJavaVersion) ||
-          rootProject.runtimeJavaVersion <= v) {
+          rootProject.runtimeJavaVersion.majorVersion <= v) {
         systemProperty 'org.apache.lucene.vectorization.upperJavaFeatureVersion', v
         jvmArgs '--add-modules', 'jdk.incubator.vector'
       }

--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -128,7 +128,13 @@ allprojects {
       jvmArgs '--add-modules', 'jdk.management'
 
       // Enable the vector incubator module on supported Java versions:
-      if (rootProject.vectorIncubatorJavaVersions.contains(rootProject.runtimeJavaVersion)) {
+      def v = JavaVersion.VERSION_1_1
+      def prop = providers.systemProperty("org.apache.lucene.vectorization.upperJavaFeatureVersion")
+      if (prop.isPresent())
+        v = prop.map(Integer::parseInt).map(JavaVersion::getVersionForMajor).get()
+      if (rootProject.vectorIncubatorJavaVersions.contains(rootProject.runtimeJavaVersion) ||
+          rootProject.runtimeJavaVersion <= v) {
+        systemProperty 'org.apache.lucene.vectorization.upperJavaFeatureVersion', v
         jvmArgs '--add-modules', 'jdk.incubator.vector'
       }
       

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -47,7 +47,11 @@ New Features
 
 Improvements
 ---------------------
-(No changes)
+
+* GITHUB#13986: Allow easier configuration of the Panama Vectorization provider with
+  newer Java versions. Set the `org.apache.lucene.vectorization.upperJavaFeatureVersion`
+  system property to increase the set of Java versions that Panama Vectorization will
+  provide optimized implementations for. (Chris Hegarty)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -38,12 +38,16 @@ import org.apache.lucene.util.VectorUtil;
  * vectorization modules in the Java runtime this class provides optimized implementations (using
  * SIMD) of several algorithms used throughout Apache Lucene.
  *
+ * <p>Expert: set the {@value #UPPER_JAVA_FEATURE_VERSION_SYSPROP} system property to increase the
+ * set of Java versions this class will provide optimized implementations for.
+ *
  * @lucene.internal
  */
 public abstract class VectorizationProvider {
 
   static final OptionalInt TESTS_VECTOR_SIZE;
   static final boolean TESTS_FORCE_INTEGER_VECTORS;
+  static final int UPPER_JAVA_FEATURE_VERSION = getUpperJavaFeatureVersion();
 
   static {
     var vs = OptionalInt.empty();
@@ -69,6 +73,27 @@ public abstract class VectorizationProvider {
       // ignored
     }
     TESTS_FORCE_INTEGER_VECTORS = enforce;
+  }
+
+  private static final String UPPER_JAVA_FEATURE_VERSION_SYSPROP =
+      "org.apache.lucene.vectorization.upperJavaFeatureVersion";
+  private static final int DEFAULT_UPPER_JAVA_FEATURE_VERSION = 23;
+
+  private static int getUpperJavaFeatureVersion() {
+    int runtimeVersion = DEFAULT_UPPER_JAVA_FEATURE_VERSION;
+    try {
+      String str = System.getProperty(UPPER_JAVA_FEATURE_VERSION_SYSPROP);
+      if (str != null) {
+        runtimeVersion = Math.max(Integer.parseInt(str), runtimeVersion);
+      }
+    } catch (@SuppressWarnings("unused") NumberFormatException | SecurityException ignored) {
+      Logger.getLogger(VectorizationProvider.class.getName())
+          .warning(
+              "Cannot read sysprop "
+                  + UPPER_JAVA_FEATURE_VERSION_SYSPROP
+                  + ", so the default value will be used.");
+    }
+    return runtimeVersion;
   }
 
   /**
@@ -108,7 +133,7 @@ public abstract class VectorizationProvider {
   static VectorizationProvider lookup(boolean testMode) {
     final int runtimeVersion = Runtime.version().feature();
     assert runtimeVersion >= 21;
-    if (runtimeVersion <= 23) {
+    if (runtimeVersion <= UPPER_JAVA_FEATURE_VERSION) {
       // only use vector module with Hotspot VM
       if (!Constants.IS_HOTSPOT_VM) {
         LOG.warning(


### PR DESCRIPTION
This commit allows easier verification of the Panama Vectorization provider with newer Java versions.

The upper bound Java version of the Vectorization provider is hardcoded to the version that has been tested and is known to work. This is a bit inflexible when experimenting with and verifying newer JDK versions. This change proposes to add a new system property that allows to set the upper bound of the range of Java versions supported.

With this change, and the accompanying small gradle change, then one can verify newer JDKs as follows:

```
CI=true; RUNTIME_JAVA_HOME=/Users/chegar/binaries/jdk-24.jdk-ea-b23/Contents/Home
./gradlew :lucene:core:test -Dorg.apache.lucene.vectorization.upperJavaFeatureVersion=24
```

This change helps both testing and verifying with Early Access JDK builds, as well as allowing to override the upper bound when the JDK is known to work fine.