### PR TITLE
Update lastDoc in ScoreCachingWrappingScorer

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/ScoreCachingWrappingScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScoreCachingWrappingScorer.java
@@ -84,7 +84,7 @@ public final class ScoreCachingWrappingScorer extends Scorable {
   public float score() throws IOException {
     if (lastDoc != curDoc) {
       curScore = in.score();
-      curDoc = lastDoc;
+      lastDoc = curDoc;
     }
 
     return curScore;

--- a/lucene/core/src/test/org/apache/lucene/search/TestPositiveScoresOnlyCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPositiveScoresOnlyCollector.java
@@ -114,8 +114,9 @@ public class TestPositiveScoresOnlyCollector extends LuceneTestCase {
     Collector c = new PositiveScoresOnlyCollector(tdc);
     LeafCollector ac = c.getLeafCollector(ir.leaves().get(0));
     ac.setScorer(s);
-    while (s.iterator().nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-      ac.collect(0);
+    int docId;
+    while ((docId = s.iterator().nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+      ac.collect(docId);
     }
     TopDocs td = tdc.topDocs();
     ScoreDoc[] sd = td.scoreDocs;

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -359,7 +359,7 @@ public class TestTopFieldCollector extends LuceneTestCase {
       leafCollector.collect(1);
 
       scorer.score = 4;
-      leafCollector.collect(1);
+      leafCollector.collect(2);
 
       TopDocs topDocs = collector.topDocs();
       assertEquals(totalHitsThreshold < 4, scorer.minCompetitiveScore != null);


### PR DESCRIPTION
### Description

I noticed that ScoreCachingWrappingScorer never updates lastDoc, so it's always -1. Technically, it's probably fine, since it still ends up returning the same score for multiple score() calls between collect calls, but I think this change better reflects the intended logic. (In particular, if the same doc was somehow collected multiple times, then the score would get recalculated.)