### PR TITLE
lucene-monitor: make abstract DocumentBatch public

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/DocumentBatch.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/DocumentBatch.java
@@ -33,6 +33,9 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.IOUtils;
 
+/**
+ * Abstract for a DocumentBatch containing a single or a set of documents.
+ */
 public abstract class DocumentBatch implements Closeable, Supplier<LeafReader> {
 
   /**

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/DocumentBatch.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/DocumentBatch.java
@@ -33,7 +33,7 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.IOUtils;
 
-abstract class DocumentBatch implements Closeable, Supplier<LeafReader> {
+public abstract class DocumentBatch implements Closeable, Supplier<LeafReader> {
 
   /**
    * Create a DocumentBatch containing a single InputDocument

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/DocumentBatch.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/DocumentBatch.java
@@ -33,9 +33,7 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.IOUtils;
 
-/**
- * Abstract for a DocumentBatch containing a single or a set of documents.
- */
+/** Abstraction for a DocumentBatch containing a single or a set of documents. */
 public abstract class DocumentBatch implements Closeable, Supplier<LeafReader> {
 
   /**


### PR DESCRIPTION
### Description

The static `DocumentBatch.of` methods are already public, if the class itself was public too that would allow applications -- e.g. see @kotman12's https://github.com/apache/solr/pull/2382 -- to refer to the class e.g. in a visitor.
