### PR TITLE
Speed up top-k retrieval on filtered conjunctions.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -89,6 +89,9 @@ Optimizations
   longs that would pack two integers. We are now moving back to integers to be
   able to take advantage of 2x more lanes with the vector API. (Adrien Grand)
 
+* GITHUB#13994: Speed up top-k retrieval of filtered conjunctions.
+  (Adrien Grand)
+
 Bug Fixes
 ---------------------
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -563,28 +563,28 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
       BooleanQuery.Builder builder = new BooleanQuery.Builder();
       builder.setMinimumNumberShouldMatch(minimumNumberShouldMatch);
       boolean actuallyRewritten = false;
-      for (BooleanClause clause : clauses) {
-        if (clause.isRequired() && clause.query() instanceof BooleanQuery innerQuery) {
+      for (BooleanClause outerClause : clauses) {
+        if (outerClause.isRequired() && outerClause.query() instanceof BooleanQuery innerQuery) {
           if (innerQuery.getMinimumNumberShouldMatch() == 0
               && innerQuery.getClauses(Occur.SHOULD).isEmpty()) {
             actuallyRewritten = true;
             for (BooleanClause innerClause : innerQuery) {
-              Occur occur = innerClause.occur();
-              if (occur == Occur.FILTER
-                  || occur == Occur.MUST_NOT
-                  || clause.occur() == Occur.MUST) {
+              Occur innerOccur = innerClause.occur();
+              if (innerOccur == Occur.FILTER
+                  || innerOccur == Occur.MUST_NOT
+                  || outerClause.occur() == Occur.MUST) {
                 builder.add(innerClause);
               } else {
-                assert clause.occur() == Occur.FILTER && occur == Occur.MUST;
+                assert outerClause.occur() == Occur.FILTER && innerOccur == Occur.MUST;
                 // In this case we need to change the occur of the inner query from MUST to FILTER.
                 builder.add(innerClause.query(), Occur.FILTER);
               }
             }
           } else {
-            builder.add(clause);
+            builder.add(outerClause);
           }
         } else {
-          builder.add(clause);
+          builder.add(outerClause);
         }
       }
       if (actuallyRewritten) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanRewrites.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanRewrites.java
@@ -330,8 +330,8 @@ public class TestBooleanRewrites extends LuceneTestCase {
     int depth = TestUtil.nextInt(random(), 10, 30);
     TestRewriteQuery rewriteQueryExpected = new TestRewriteQuery();
     TestRewriteQuery rewriteQuery = new TestRewriteQuery();
-    Query expectedQuery =
-        new BooleanQuery.Builder().add(rewriteQueryExpected, Occur.FILTER).build();
+    BooleanQuery.Builder expectedQueryBuilder =
+        new BooleanQuery.Builder().add(rewriteQueryExpected, Occur.FILTER);
     Query deepBuilder =
         new BooleanQuery.Builder()
             .add(rewriteQuery, Occur.SHOULD)
@@ -345,21 +345,19 @@ public class TestBooleanRewrites extends LuceneTestCase {
               .add(tq, Occur.SHOULD)
               .add(deepBuilder, Occur.SHOULD);
       deepBuilder = bq.build();
-      BooleanQuery.Builder expectedBq = new BooleanQuery.Builder().add(tq, Occur.FILTER);
+      expectedQueryBuilder.add(tq, Occur.FILTER);
       if (i == depth) {
-        expectedBq.add(rewriteQuery, Occur.FILTER);
-      } else {
-        expectedBq.add(expectedQuery, Occur.FILTER);
+        expectedQueryBuilder.add(rewriteQuery, Occur.FILTER);
       }
-      expectedQuery = expectedBq.build();
     }
     BooleanQuery bq = new BooleanQuery.Builder().add(deepBuilder, Occur.FILTER).build();
-    expectedQuery = new BoostQuery(new ConstantScoreQuery(expectedQuery), 0.0f);
+    Query expectedQuery =
+        new BoostQuery(new ConstantScoreQuery(expectedQueryBuilder.build()), 0.0f);
     Query rewritten = searcher.rewrite(bq);
     assertEquals(expectedQuery, rewritten);
     // the SHOULD clauses cause more rewrites because they incrementally change to `MUST` and then
-    // `FILTER`
-    assertEquals("Depth=" + depth, depth + 1, rewriteQuery.numRewrites);
+    // `FILTER`, plus the flattening of required clauses
+    assertEquals("Depth=" + depth, depth * 2, rewriteQuery.numRewrites);
   }
 
   public void testDeeplyNestedBooleanRewrite() throws IOException {
@@ -369,27 +367,26 @@ public class TestBooleanRewrites extends LuceneTestCase {
     int depth = TestUtil.nextInt(random(), 10, 30);
     TestRewriteQuery rewriteQueryExpected = new TestRewriteQuery();
     TestRewriteQuery rewriteQuery = new TestRewriteQuery();
-    Query expectedQuery =
-        new BooleanQuery.Builder().add(rewriteQueryExpected, Occur.FILTER).build();
+    BooleanQuery.Builder expectedQueryBuilder =
+        new BooleanQuery.Builder().add(rewriteQueryExpected, Occur.FILTER);
     Query deepBuilder = new BooleanQuery.Builder().add(rewriteQuery, Occur.MUST).build();
     for (int i = depth; i > 0; i--) {
       TermQuery tq = termQueryFunction.apply(i);
       BooleanQuery.Builder bq =
           new BooleanQuery.Builder().add(tq, Occur.MUST).add(deepBuilder, Occur.MUST);
       deepBuilder = bq.build();
-      BooleanQuery.Builder expectedBq = new BooleanQuery.Builder().add(tq, Occur.FILTER);
+      expectedQueryBuilder.add(tq, Occur.FILTER);
       if (i == depth) {
-        expectedBq.add(rewriteQuery, Occur.FILTER);
-      } else {
-        expectedBq.add(expectedQuery, Occur.FILTER);
+        expectedQueryBuilder.add(rewriteQuery, Occur.FILTER);
       }
-      expectedQuery = expectedBq.build();
     }
     BooleanQuery bq = new BooleanQuery.Builder().add(deepBuilder, Occur.FILTER).build();
-    expectedQuery = new BoostQuery(new ConstantScoreQuery(expectedQuery), 0.0f);
+    Query expectedQuery =
+        new BoostQuery(new ConstantScoreQuery(expectedQueryBuilder.build()), 0.0f);
     Query rewritten = searcher.rewrite(bq);
     assertEquals(expectedQuery, rewritten);
-    assertEquals("Depth=" + depth, 1, rewriteQuery.numRewrites);
+    // `depth` rewrites because of the flattening
+    assertEquals("Depth=" + depth, depth, rewriteQuery.numRewrites);
   }
 
   public void testRemoveMatchAllFilter() throws IOException {
@@ -689,6 +686,110 @@ public class TestBooleanRewrites extends LuceneTestCase {
             .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
             .build();
     assertSame(query, searcher.rewrite(query));
+  }
+
+  public void testFlattenInnerConjunctions() throws IOException {
+    IndexSearcher searcher = newSearcher(new MultiReader());
+
+    Query inner =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+            .add(new TermQuery(new Term("foo", "quux")), Occur.MUST)
+            .build();
+    Query query =
+        new BooleanQuery.Builder()
+            .add(inner, Occur.MUST)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.FILTER)
+            .build();
+    Query expectedRewritten =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+            .add(new TermQuery(new Term("foo", "quux")), Occur.MUST)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.FILTER)
+            .build();
+    assertEquals(expectedRewritten, searcher.rewrite(query));
+
+    query =
+        new BooleanQuery.Builder()
+            .setMinimumNumberShouldMatch(0)
+            .add(inner, Occur.MUST)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
+            .build();
+    expectedRewritten =
+        new BooleanQuery.Builder()
+            .setMinimumNumberShouldMatch(0)
+            .add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+            .add(new TermQuery(new Term("foo", "quux")), Occur.MUST)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
+            .build();
+    assertEquals(expectedRewritten, searcher.rewrite(query));
+
+    query =
+        new BooleanQuery.Builder()
+            .add(inner, Occur.MUST)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.MUST_NOT)
+            .build();
+    expectedRewritten =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+            .add(new TermQuery(new Term("foo", "quux")), Occur.MUST)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.MUST_NOT)
+            .build();
+    assertEquals(expectedRewritten, searcher.rewrite(query));
+
+    inner =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+            .add(new TermQuery(new Term("foo", "quux")), Occur.FILTER)
+            .build();
+    query =
+        new BooleanQuery.Builder()
+            .add(inner, Occur.MUST)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.MUST)
+            .build();
+    expectedRewritten =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+            .add(new TermQuery(new Term("foo", "quux")), Occur.FILTER)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.MUST)
+            .build();
+    assertEquals(expectedRewritten, searcher.rewrite(query));
+
+    inner =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+            .add(new TermQuery(new Term("foo", "quux")), Occur.FILTER)
+            .build();
+    query =
+        new BooleanQuery.Builder()
+            .add(inner, Occur.FILTER)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.MUST)
+            .build();
+    expectedRewritten =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("foo", "bar")), Occur.FILTER)
+            .add(new TermQuery(new Term("foo", "quux")), Occur.FILTER)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.MUST)
+            .build();
+    assertEquals(expectedRewritten, searcher.rewrite(query));
+
+    inner =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+            .add(new TermQuery(new Term("foo", "quux")), Occur.MUST_NOT)
+            .build();
+    query =
+        new BooleanQuery.Builder()
+            .add(inner, Occur.FILTER)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.MUST)
+            .build();
+    expectedRewritten =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("foo", "bar")), Occur.FILTER)
+            .add(new TermQuery(new Term("foo", "quux")), Occur.MUST_NOT)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.MUST)
+            .build();
+    assertEquals(expectedRewritten, searcher.rewrite(query));
   }
 
   public void testDiscardShouldClauses() throws IOException {


### PR DESCRIPTION
A while back we added an optimized bulk scorer that implements block-max AND, this yielded a good speedup on nightly benchmarks, see annotation `FP` at https://benchmarks.mikemccandless.com/AndHighHigh.html. With this PR, filtered conjunctions now also run through this optimized bulk scorer by doing two things:
 - It flattens inner conjunctions. This makes queries initially written as something like `+(+term1 +term2) #filter` rewritten to `+term1 +term2 #filter`.
 - It evaluates queries that have a mix of MUST and FILTER clauses evaluated through `BlockMaxConjunctionBulkScorer` by treating FILTER clauses as scoring clauses that produce a score of 0.
