### PR TITLE
lucene-monitor: make static DocumentBatch.of package scope

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/DocumentBatch.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/DocumentBatch.java
@@ -41,7 +41,7 @@ abstract class DocumentBatch implements Closeable, Supplier<LeafReader> {
    * @param doc the document to add
    * @return the batch containing the input document
    */
-  public static DocumentBatch of(Analyzer analyzer, Document doc) {
+  static DocumentBatch of(Analyzer analyzer, Document doc) {
     return new SingletonDocumentBatch(analyzer, doc);
   }
 
@@ -52,7 +52,7 @@ abstract class DocumentBatch implements Closeable, Supplier<LeafReader> {
    *     collection.
    * @return the batch containing the input documents
    */
-  public static DocumentBatch of(Analyzer analyzer, Document... docs) {
+  static DocumentBatch of(Analyzer analyzer, Document... docs) {
     if (docs.length == 0) {
       throw new IllegalArgumentException("A DocumentBatch must contain at least one document");
     } else if (docs.length == 1) {


### PR DESCRIPTION
Alternative to #13993 i.e. visibility of `of` to match visibility of the class itself.