### PR TITLE
Suppressing "automatic module" warning for benchmark-jmh

### DIFF
--- a/lucene/benchmark-jmh/src/java/module-info.java
+++ b/lucene/benchmark-jmh/src/java/module-info.java
@@ -16,6 +16,9 @@
  */
 
 /** Lucene JMH benchmarks. */
+
+// jmh.core is not modularized and causes a warning. Suppressing it until it is modularized.
+@SuppressWarnings("requires-automatic")
 module org.apache.lucene.benchmark.jmh {
   requires jmh.core;
   requires jdk.unsupported;


### PR DESCRIPTION
jmh.core is not modularized resulting in this error. The other modules seem fine though.

Probably can be removed once jmh updates the module-info.

Closes #13992 