### PR TITLE
Add IndexInput isLoaded

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
@@ -18,6 +18,7 @@ package org.apache.lucene.store;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Optional;
 import org.apache.lucene.codecs.CompoundFormat;
 
 /**
@@ -226,4 +227,17 @@ public abstract class IndexInput extends DataInput implements Closeable {
    * @param length the number of bytes to prefetch
    */
   public void prefetch(long offset, long length) throws IOException {}
+
+  /**
+   * Returns a hint whether all the contents of this input are resident in physical memory. It's a
+   * hint because the operating system may have paged out some of the data by the time this method
+   * returns. If the optional is true, then it's likely that the contents of this input are resident
+   * in physical memory. A value of false does not imply that the contents are not resident in
+   * physical memory. An empty optional is returned if it is not possible to determine.
+   *
+   * <p>The default implementation returns an empty optional.
+   */
+  public Optional<Boolean> isLoaded() {
+    return Optional.empty();
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
@@ -235,6 +235,8 @@ public abstract class IndexInput extends DataInput implements Closeable {
    * in physical memory. A value of false does not imply that the contents are not resident in
    * physical memory. An empty optional is returned if it is not possible to determine.
    *
+   * <p>This runs in linear time with the {@link #length()} of this input / page size.
+   *
    * <p>The default implementation returns an empty optional.
    */
   public Optional<Boolean> isLoaded() {

--- a/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
@@ -17,6 +17,8 @@
 package org.apache.lucene.store;
 
 import java.io.IOException;
+import java.util.Optional;
+
 import org.apache.lucene.util.BitUtil; // javadocs
 
 /**
@@ -77,4 +79,13 @@ public interface RandomAccessInput {
    * @see IndexInput#prefetch
    */
   default void prefetch(long offset, long length) throws IOException {}
+
+  /**
+   * Returns a hint whether all the contents of this input are resident in physical memory.
+   *
+   * @see IndexInput#isLoaded()
+   */
+  default Optional<Boolean> isLoaded() {
+    return Optional.empty();
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
@@ -18,7 +18,6 @@ package org.apache.lucene.store;
 
 import java.io.IOException;
 import java.util.Optional;
-
 import org.apache.lucene.util.BitUtil; // javadocs
 
 /**

--- a/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -407,11 +407,12 @@ abstract class MemorySegmentIndexInput extends IndexInput
   }
 
   public Optional<Boolean> isLoaded() {
-    boolean loaded = true;
     for (MemorySegment seg : segments) {
-      loaded = loaded && seg.isLoaded();
+      if (seg.isLoaded() == false) {
+        return Optional.of(Boolean.FALSE);
+      }
     }
-    return Optional.of(loaded);
+    return Optional.of(Boolean.TRUE);
   }
 
   @Override

--- a/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -406,6 +406,14 @@ abstract class MemorySegmentIndexInput extends IndexInput
     }
   }
 
+  public Optional<Boolean> isLoaded() {
+    boolean loaded = true;
+    for (MemorySegment seg : segments) {
+      loaded = loaded && seg.isLoaded();
+    }
+    return Optional.of(loaded);
+  }
+
   @Override
   public byte readByte(long pos) throws IOException {
     try {

--- a/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -406,6 +406,7 @@ abstract class MemorySegmentIndexInput extends IndexInput
     }
   }
 
+  @Override
   public Optional<Boolean> isLoaded() {
     for (MemorySegment seg : segments) {
       if (seg.isLoaded() == false) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
@@ -1605,7 +1605,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
   }
 
   public void testIsLoaded() throws IOException {
-    doTestPrefetch(0);
+    testIsLoaded(0);
   }
 
   public void testIsLoadedOnSlice() throws IOException {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
@@ -50,6 +50,7 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
@@ -1632,7 +1633,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
           in = orig.slice("slice", startOffset, totalLength - startOffset);
         }
         var loaded = in.isLoaded();
-        if (dir instanceof MMapDirectory) {
+        if (FilterDirectory.unwrap(dir) instanceof MMapDirectory) {
           assertTrue(loaded.isPresent());
           assertTrue(loaded.get());
         } else {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
@@ -1633,7 +1633,9 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
           in = orig.slice("slice", startOffset, totalLength - startOffset);
         }
         var loaded = in.isLoaded();
-        if (FilterDirectory.unwrap(dir) instanceof MMapDirectory) {
+        if (FilterDirectory.unwrap(dir) instanceof MMapDirectory
+            // direct IO wraps MMap but does not support isLoaded
+            && !(dir.getClass().getName().contains("DirectIO"))) {
           assertTrue(loaded.isPresent());
           assertTrue(loaded.get());
         } else {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
@@ -1649,7 +1649,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
 
   private void testIsLoaded(int startOffset) throws IOException {
     try (Directory dir = getDirectory(createTempDir())) {
-      if (dir instanceof MMapDirectory mMapDirectory) {
+      if (FilterDirectory.unwrap(dir) instanceof MMapDirectory mMapDirectory) {
         mMapDirectory.setPreload(MMapDirectory.ALL_FILES);
       }
       final int totalLength = startOffset + TestUtil.nextInt(random(), 16384, 65536);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
@@ -53,6 +53,7 @@ import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.tests.mockfile.ExtrasFS;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -1598,6 +1599,44 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
                       arr, startOffset + offset, startOffset + offset + readLength),
                   ArrayUtil.copyOfSubArray(temp, 0, readLength));
           }
+        }
+      }
+    }
+  }
+
+  public void testIsLoaded() throws IOException {
+    doTestPrefetch(0);
+  }
+
+  public void testIsLoadedOnSlice() throws IOException {
+    testIsLoaded(TestUtil.nextInt(random(), 1, 1024));
+  }
+
+  private void testIsLoaded(int startOffset) throws IOException {
+    try (Directory dir = getDirectory(createTempDir())) {
+      if (dir instanceof MMapDirectory mMapDirectory) {
+        mMapDirectory.setPreload(MMapDirectory.ALL_FILES);
+      }
+      final int totalLength = startOffset + TestUtil.nextInt(random(), 16384, 65536);
+      byte[] arr = new byte[totalLength];
+      random().nextBytes(arr);
+      try (IndexOutput out = dir.createOutput("temp.bin", IOContext.DEFAULT)) {
+        out.writeBytes(arr, arr.length);
+      }
+
+      try (IndexInput orig = dir.openInput("temp.bin", IOContext.DEFAULT)) {
+        IndexInput in;
+        if (startOffset == 0) {
+          in = orig.clone();
+        } else {
+          in = orig.slice("slice", startOffset, totalLength - startOffset);
+        }
+        var loaded = in.isLoaded();
+        if (dir instanceof MMapDirectory) {
+          assertTrue(loaded.isPresent());
+          assertTrue(loaded.get());
+        } else {
+          assertFalse(loaded.isPresent());
         }
       }
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockIndexInputWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockIndexInputWrapper.java
@@ -19,6 +19,7 @@ package org.apache.lucene.tests.store;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.store.FilterIndexInput;
@@ -182,6 +183,13 @@ public class MockIndexInputWrapper extends FilterIndexInput {
     ensureOpen();
     ensureAccessible();
     in.prefetch(offset, length);
+  }
+
+  @Override
+  public Optional<Boolean> isLoaded() {
+    ensureOpen();
+    ensureAccessible();
+    return in.isLoaded();
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.tests.store;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.atomic.LongAdder;
 import org.apache.lucene.internal.hppc.LongHashSet;
 import org.apache.lucene.store.ChecksumIndexInput;
@@ -205,6 +206,11 @@ public class SerialIOCountingDirectory extends FilterDirectory {
     public IndexInput clone() {
       IndexInput clone = in.clone();
       return new SerializedIOCountingIndexInput(clone, readAdvice, sliceOffset, sliceLength);
+    }
+
+    @Override
+    public Optional<Boolean> isLoaded() {
+      return in.isLoaded();
     }
   }
 }


### PR DESCRIPTION
This commit adds `IndexInput::isLoaded` to help determine if the contents of an input is resident in physical memory.

The intent of this new method is to help build inspection and diagnostic infrastructure on top. The initial requirement is to help understand if vector data and more specifically the HNSW graph are in memory. For search use cases, performance drops off significantly if, at least, the graph is not resident.  This is not a perfect API, more of a hint, but along with read advice like MADV_WILLNEED may be used to determine perf issues searching vectors