### PR TITLE
Make CombinedFieldQuery eligible for WAND/MAXSCORE.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -99,6 +99,9 @@ Optimizations
 * GITHUB#13985: Introduces IndexInput#updateReadAdvice to change the ReadAdvice
   while merging vectors. (Tejas Shah)
 
+* GITHUB#13999: CombinedFieldQuery now returns non-infinite maximum scores,
+  making it eligible to dynamic pruning. (Adrien Grand)
+
 Bug Fixes
 ---------------------
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CombinedFieldQuery.java
@@ -438,12 +438,14 @@ public final class CombinedFieldQuery extends Query implements Accountable {
     private final DisiPriorityQueue queue;
     private final DocIdSetIterator iterator;
     private final MultiNormsLeafSimScorer simScorer;
+    private final float maxScore;
 
     CombinedFieldScorer(
         DisiPriorityQueue queue, DocIdSetIterator iterator, MultiNormsLeafSimScorer simScorer) {
       this.queue = queue;
       this.iterator = iterator;
       this.simScorer = simScorer;
+      this.maxScore = simScorer.getSimScorer().score(Float.POSITIVE_INFINITY, 1L);
     }
 
     @Override
@@ -475,7 +477,7 @@ public final class CombinedFieldQuery extends Query implements Accountable {
 
     @Override
     public float getMaxScore(int upTo) throws IOException {
-      return Float.POSITIVE_INFINITY;
+      return maxScore;
     }
   }
 }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiNormsLeafSimScorer.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiNormsLeafSimScorer.java
@@ -90,6 +90,10 @@ final class MultiNormsLeafSimScorer {
     }
   }
 
+  SimScorer getSimScorer() {
+    return scorer;
+  }
+
   private long getNormValue(int doc) throws IOException {
     if (norms != null) {
       boolean found = norms.advanceExact(doc);


### PR DESCRIPTION
`CombinedFieldQuery` currently returns an infinite maximum score. We can do better by returning the maximum score that the sim scorer can return, which in the case of BM25 is bounded by the IDF. This makes CombinedFieldQuery eligible for WAND/MAXSCORE (not their block-max variants though, since we return the same score upper bound for the whole index).