### PR TITLE
Only consider clauses whose cost is less than the lead cost to compute block boundaries in WANDScorer.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -96,6 +96,9 @@ Optimizations
 * GITHUB#13994: Speed up top-k retrieval of filtered conjunctions.
   (Adrien Grand)
 
+* GITHUB#14000: Speed up top-k retrieval of filtered disjunctions.
+  (Adrien Grand)
+
 Bug Fixes
 ---------------------
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
@@ -478,7 +478,7 @@ final class BooleanScorerSupplier extends ScorerSupplier {
       // However, as WANDScorer uses more complex algorithm and data structure, we would like to
       // still use DisjunctionSumScorer to handle exhaustive pure disjunctions, which may be faster
       if ((scoreMode == ScoreMode.TOP_SCORES && topLevelScoringClause) || minShouldMatch > 1) {
-        return new WANDScorer(optionalScorers, minShouldMatch, scoreMode);
+        return new WANDScorer(optionalScorers, minShouldMatch, scoreMode, leadCost);
       } else {
         return new DisjunctionSumScorer(optionalScorers, scoreMode);
       }

--- a/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
@@ -407,12 +407,8 @@ final class WANDScorer extends Scorer {
     // per-window max scores over and over again. In the event when this makes us compute upTo as
     // NO_MORE_DOCS, this scorer will effectively implement WAND rather than block-max WAND.
     for (DisiWrapper w : head) {
-      if (w.doc <= newUpTo) {
-        // Note: it's important to call advanceShallow since it has side-effects.
-        int clauseUpto = w.scorer.advanceShallow(w.doc);
-        if (w.cost <= leadCost) {
-          newUpTo = Math.min(clauseUpto, newUpTo);
-        }
+      if (w.doc <= newUpTo && w.cost <= leadCost) {
+        newUpTo = Math.min(w.scorer.advanceShallow(w.doc), newUpTo);
       }
     }
     // Only look at the tail if none of the `head` clauses had a block we could reuse and if its

--- a/lucene/core/src/test/org/apache/lucene/search/TestWANDScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestWANDScorer.java
@@ -119,7 +119,8 @@ public class TestWANDScorer extends LuceneTestCase {
                 .add(
                     new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "C"))), 3),
                     Occur.SHOULD)
-                .build());
+                .build(),
+            random().nextBoolean());
 
     Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.TOP_SCORES, 1);
     ScorerSupplier ss = weight.scorerSupplier(searcher.getIndexReader().leaves().get(0));
@@ -180,7 +181,8 @@ public class TestWANDScorer extends LuceneTestCase {
                         .add(
                             new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
                             Occur.SHOULD)
-                        .build()),
+                        .build(),
+                    random().nextBoolean()),
                 Occur.MUST)
             .add(new TermQuery(new Term("foo", "C")), Occur.FILTER)
             .build();
@@ -222,7 +224,8 @@ public class TestWANDScorer extends LuceneTestCase {
                         .add(
                             new ConstantScoreQuery(new TermQuery(new Term("foo", "B"))),
                             Occur.SHOULD)
-                        .build()),
+                        .build(),
+                    random().nextBoolean()),
                 Occur.MUST)
             .add(new TermQuery(new Term("foo", "C")), Occur.MUST_NOT)
             .build();
@@ -297,7 +300,8 @@ public class TestWANDScorer extends LuceneTestCase {
                             new ConstantScoreQuery(new TermQuery(new Term("foo", "C"))), 3),
                         Occur.SHOULD)
                     .setMinimumNumberShouldMatch(2)
-                    .build());
+                    .build(),
+                random().nextBoolean());
 
         Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.TOP_SCORES, 1);
         ScorerSupplier ss = weight.scorerSupplier(searcher.getIndexReader().leaves().get(0));
@@ -377,7 +381,8 @@ public class TestWANDScorer extends LuceneTestCase {
                     .add(new TermQuery(new Term("foo", "B")), Occur.SHOULD)
                     .add(new TermQuery(new Term("foo", "C")), Occur.SHOULD)
                     .setMinimumNumberShouldMatch(2)
-                    .build());
+                    .build(),
+                random().nextBoolean());
 
         Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.TOP_SCORES, 1);
         ScorerSupplier ss = weight.scorerSupplier(searcher.getIndexReader().leaves().get(0));
@@ -431,7 +436,8 @@ public class TestWANDScorer extends LuceneTestCase {
                             new ConstantScoreQuery(new TermQuery(new Term("foo", "C"))), 3),
                         Occur.SHOULD)
                     .setMinimumNumberShouldMatch(2)
-                    .build());
+                    .build(),
+                random().nextBoolean());
 
         Scorer scorer =
             searcher
@@ -489,7 +495,8 @@ public class TestWANDScorer extends LuceneTestCase {
                                     new ConstantScoreQuery(new TermQuery(new Term("foo", "D"))), 4),
                                 Occur.SHOULD)
                             .setMinimumNumberShouldMatch(2)
-                            .build()),
+                            .build(),
+                        random().nextBoolean()),
                     Occur.MUST)
                 .add(new TermQuery(new Term("foo", "C")), Occur.FILTER)
                 .build();
@@ -565,7 +572,8 @@ public class TestWANDScorer extends LuceneTestCase {
                                     new ConstantScoreQuery(new TermQuery(new Term("foo", "D"))), 4),
                                 Occur.SHOULD)
                             .setMinimumNumberShouldMatch(2)
-                            .build()),
+                            .build(),
+                        random().nextBoolean()),
                     Occur.MUST)
                 .add(new TermQuery(new Term("foo", "C")), Occur.FILTER)
                 .build();
@@ -625,7 +633,8 @@ public class TestWANDScorer extends LuceneTestCase {
                                     new ConstantScoreQuery(new TermQuery(new Term("foo", "D"))), 4),
                                 Occur.SHOULD)
                             .setMinimumNumberShouldMatch(2)
-                            .build()),
+                            .build(),
+                        random().nextBoolean()),
                     Occur.MUST)
                 .add(new TermQuery(new Term("foo", "C")), Occur.MUST_NOT)
                 .build();
@@ -699,7 +708,8 @@ public class TestWANDScorer extends LuceneTestCase {
                                     new ConstantScoreQuery(new TermQuery(new Term("foo", "D"))), 4),
                                 Occur.SHOULD)
                             .setMinimumNumberShouldMatch(2)
-                            .build()),
+                            .build(),
+                        random().nextBoolean()),
                     Occur.MUST)
                 .add(new TermQuery(new Term("foo", "C")), Occur.MUST_NOT)
                 .build();
@@ -744,7 +754,7 @@ public class TestWANDScorer extends LuceneTestCase {
         builder.add(
             maybeWrap(new TermQuery(new Term("foo", Integer.toString(start + i)))), Occur.SHOULD);
       }
-      Query query = new WANDScorerQuery(builder.build());
+      Query query = new WANDScorerQuery(builder.build(), random().nextBoolean());
 
       CheckHits.checkTopScores(random(), query, searcher);
 
@@ -795,7 +805,7 @@ public class TestWANDScorer extends LuceneTestCase {
                     0f)),
             Occur.SHOULD);
       }
-      Query query = new WANDScorerQuery(builder.build());
+      Query query = new WANDScorerQuery(builder.build(), random().nextBoolean());
 
       CheckHits.checkTopScores(random(), query, searcher);
 
@@ -855,7 +865,7 @@ public class TestWANDScorer extends LuceneTestCase {
         }
         builder.add(query, Occur.SHOULD);
       }
-      Query query = new WANDScorerQuery(builder.build());
+      Query query = new WANDScorerQuery(builder.build(), random().nextBoolean());
 
       CheckHits.checkTopScores(random(), query, searcher);
 
@@ -979,11 +989,13 @@ public class TestWANDScorer extends LuceneTestCase {
 
   private static class WANDScorerQuery extends Query {
     private final BooleanQuery query;
+    private final boolean doBlocks;
 
-    private WANDScorerQuery(BooleanQuery query) {
+    private WANDScorerQuery(BooleanQuery query, boolean doBlocks) {
       assert query.clauses().size() == query.getClauses(Occur.SHOULD).size()
           : "This test utility query is only used to create WANDScorer for disjunctions.";
       this.query = query;
+      this.doBlocks = doBlocks;
     }
 
     @Override
@@ -1028,7 +1040,7 @@ public class TestWANDScorer extends LuceneTestCase {
                     optionalScorers,
                     query.getMinimumNumberShouldMatch(),
                     scoreMode,
-                    Long.MAX_VALUE);
+                    doBlocks ? Long.MAX_VALUE : 0L);
           } else {
             scorer = weight.scorer(context);
             if (scorer == null) return null;

--- a/lucene/core/src/test/org/apache/lucene/search/TestWANDScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestWANDScorer.java
@@ -1024,7 +1024,11 @@ public class TestWANDScorer extends LuceneTestCase {
           final Scorer scorer;
           if (optionalScorers.size() > 0) {
             scorer =
-                new WANDScorer(optionalScorers, query.getMinimumNumberShouldMatch(), scoreMode);
+                new WANDScorer(
+                    optionalScorers,
+                    query.getMinimumNumberShouldMatch(),
+                    scoreMode,
+                    Long.MAX_VALUE);
           } else {
             scorer = weight.scorer(context);
             if (scorer == null) return null;


### PR DESCRIPTION
WANDScorer implements block-max WAND and needs to recompute score upper bounds whenever it moves to a different block. Thus it's important for these blocks to be large enough to avoid re-computing score upper bounds over and over again. With this commit, WANDScorer no longer uses clauses whose cost is higher than the cost of the filter to compute block boundaries. This effectively makes blocks larger when the filter is more selective.

This is a fixed version of #14000, plus a test that would have found the bug that nightlies found.