### PR TITLE
Taxonomy counts are incorrect due to ordinal sorting (#14008)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -123,6 +123,8 @@ Other
 Bug Fixes
 ---------------------
 
+* GITHUB#14008: Counts provided by taxonomy facets in addition to another aggregation are now returned together with
+  their corresponding ordinals. (Paul King)
 
 ======================= Lucene 10.0.0 =======================
 
@@ -421,6 +423,14 @@ Build
 * GITHUB#13649: Fix eclipse ide settings generation #13649 (Uwe Schindler, Dawid Weiss)
 
 * GITHUB#13698: Upgrade to gradle 8.10 (Dawid Weiss)
+
+======================== Lucene 9.12.1 =======================
+
+Bug Fixes
+---------------------
+
+* GITHUB#14008: Counts provided by taxonomy facets in addition to another aggregation are now returned together with
+  their corresponding ordinals. (Paul King)
 
 ======================== Lucene 9.12.0 =======================
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacets.java
@@ -314,6 +314,7 @@ abstract class TaxonomyFacets extends Facets {
 
     LabelAndValue[] labelValues = new LabelAndValue[q.size()];
     int[] ordinals = new int[labelValues.length];
+    int[] counts = new int[labelValues.length];
     Number[] values = new Number[labelValues.length];
 
     for (int i = labelValues.length - 1; i >= 0; i--) {
@@ -321,6 +322,7 @@ abstract class TaxonomyFacets extends Facets {
       assert ordAndValue != null;
       ordinals[i] = ordAndValue.ord;
       values[i] = ordAndValue.getValue();
+      counts[i] = getCount(ordinals[i]);
     }
 
     FacetLabel[] bulkPath = taxoReader.getBulkPath(ordinals);
@@ -329,8 +331,7 @@ abstract class TaxonomyFacets extends Facets {
     int childComponentIdx = path.length + 1;
     for (int i = 0; i < labelValues.length; i++) {
       labelValues[i] =
-          new LabelAndValue(
-              bulkPath[i].components[childComponentIdx], values[i], getCount(ordinals[i]));
+          new LabelAndValue(bulkPath[i].components[childComponentIdx], values[i], counts[i]);
     }
 
     return new FacetResult(


### PR DESCRIPTION
I just moved collecting the counts to before the sort occurs. Added a test which currently fails but passes after the change.

Closes #14008