### PR TITLE
Run filtered disjunctions with MaxScoreBulkScorer.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -110,6 +110,9 @@ Optimizations
 * GITHUB#14021: WANDScorer now computes scores on the fly, which helps prevent
   advancing "tail" clauses in many cases. (Adrien Grand)
 
+* GITHUB#14014: Filtered disjunctions now get executed via `MaxScoreBulkScorer`.
+  (Adrien Grand)
+
 Bug Fixes
 ---------------------
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
@@ -183,7 +183,8 @@ final class BooleanScorerSupplier extends ScorerSupplier {
 
   BulkScorer booleanScorer() throws IOException {
     final int numOptionalClauses = subs.get(Occur.SHOULD).size();
-    final int numRequiredClauses = subs.get(Occur.MUST).size() + subs.get(Occur.FILTER).size();
+    final int numMustClauses = subs.get(Occur.MUST).size();
+    final int numRequiredClauses = numMustClauses + subs.get(Occur.FILTER).size();
 
     BulkScorer positiveScorer;
     if (numRequiredClauses == 0) {
@@ -209,6 +210,8 @@ final class BooleanScorerSupplier extends ScorerSupplier {
       }
 
       positiveScorer = optionalBulkScorer();
+    } else if (numMustClauses == 0 && numOptionalClauses > 1 && minShouldMatch >= 1) {
+      positiveScorer = filteredOptionalBulkScorer();
     } else if (numRequiredClauses > 0 && numOptionalClauses == 0 && minShouldMatch == 0) {
       positiveScorer = requiredBulkScorer();
     } else {
@@ -286,7 +289,7 @@ final class BooleanScorerSupplier extends ScorerSupplier {
         optionalScorers.add(ss.get(Long.MAX_VALUE));
       }
 
-      return new MaxScoreBulkScorer(maxDoc, optionalScorers);
+      return new MaxScoreBulkScorer(maxDoc, optionalScorers, null);
     }
 
     List<Scorer> optional = new ArrayList<Scorer>();
@@ -295,6 +298,32 @@ final class BooleanScorerSupplier extends ScorerSupplier {
     }
 
     return new BooleanScorer(optional, Math.max(1, minShouldMatch), scoreMode.needsScores());
+  }
+
+  BulkScorer filteredOptionalBulkScorer() throws IOException {
+    if (subs.get(Occur.MUST).isEmpty() == false
+        || subs.get(Occur.FILTER).isEmpty()
+        || scoreMode != ScoreMode.TOP_SCORES
+        || subs.get(Occur.SHOULD).size() <= 1
+        || minShouldMatch > 1) {
+      return null;
+    }
+    long cost = cost();
+    List<Scorer> optionalScorers = new ArrayList<>();
+    for (ScorerSupplier ss : subs.get(Occur.SHOULD)) {
+      optionalScorers.add(ss.get(cost));
+    }
+    List<Scorer> filters = new ArrayList<>();
+    for (ScorerSupplier ss : subs.get(Occur.FILTER)) {
+      filters.add(ss.get(cost));
+    }
+    Scorer filterScorer;
+    if (filters.size() == 1) {
+      filterScorer = filters.iterator().next();
+    } else {
+      filterScorer = new ConjunctionScorer(filters, Collections.emptySet());
+    }
+    return new MaxScoreBulkScorer(maxDoc, optionalScorers, filterScorer);
   }
 
   // Return a BulkScorer for the required clauses only

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
@@ -192,8 +192,9 @@ final class MaxScoreBulkScorer extends BulkScorer {
         } while (top.doc < filter.doc);
       } else {
         int doc = top.doc;
-        boolean match = (acceptDocs == null || acceptDocs.get(doc))
-            && (filter.twoPhaseView == null || filter.twoPhaseView.matches());
+        boolean match =
+            (acceptDocs == null || acceptDocs.get(doc))
+                && (filter.twoPhaseView == null || filter.twoPhaseView.matches());
         double score = 0;
         do {
           if (match) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestMaxScoreBulkScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMaxScoreBulkScorer.java
@@ -85,7 +85,8 @@ public class TestMaxScoreBulkScorer extends LuceneTestCase {
                 .scorer(context);
 
         BulkScorer scorer =
-            new MaxScoreBulkScorer(context.reader().maxDoc(), Arrays.asList(scorer1, scorer2));
+            new MaxScoreBulkScorer(
+                context.reader().maxDoc(), Arrays.asList(scorer1, scorer2), null);
 
         scorer.score(
             new LeafCollector() {
@@ -134,6 +135,141 @@ public class TestMaxScoreBulkScorer extends LuceneTestCase {
     }
   }
 
+  public void testFilteredDisjunction() throws Exception {
+    try (Directory dir = newDirectory()) {
+      writeDocuments(dir);
+
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        IndexSearcher searcher = newSearcher(reader);
+
+        Query clause1 =
+            new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2);
+        Query clause2 = new ConstantScoreQuery(new TermQuery(new Term("foo", "C")));
+        Query filter = new TermQuery(new Term("foo", "B"));
+        LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
+        Scorer scorer1 =
+            searcher
+                .createWeight(searcher.rewrite(clause1), ScoreMode.TOP_SCORES, 1f)
+                .scorer(context);
+        Scorer scorer2 =
+            searcher
+                .createWeight(searcher.rewrite(clause2), ScoreMode.TOP_SCORES, 1f)
+                .scorer(context);
+        Scorer filterScorer =
+            searcher
+                .createWeight(searcher.rewrite(filter), ScoreMode.TOP_SCORES, 1f)
+                .scorer(context);
+
+        BulkScorer scorer =
+            new MaxScoreBulkScorer(
+                context.reader().maxDoc(), Arrays.asList(scorer1, scorer2), filterScorer);
+
+        scorer.score(
+            new LeafCollector() {
+
+              private int i;
+              private Scorable scorer;
+
+              @Override
+              public void setScorer(Scorable scorer) throws IOException {
+                this.scorer = scorer;
+              }
+
+              @Override
+              public void collect(int doc) throws IOException {
+                switch (i++) {
+                  case 0:
+                    assertEquals(0, doc);
+                    assertEquals(2, scorer.score(), 0);
+                    break;
+                  case 1:
+                    assertEquals(12288, doc);
+                    assertEquals(2 + 1, scorer.score(), 0);
+                    break;
+                  case 2:
+                    assertEquals(20480, doc);
+                    assertEquals(1, scorer.score(), 0);
+                    break;
+                  default:
+                    fail();
+                    break;
+                }
+              }
+            },
+            null,
+            0,
+            DocIdSetIterator.NO_MORE_DOCS);
+      }
+    }
+  }
+
+  public void testFilteredDisjunctionWithSkipping() throws Exception {
+    try (Directory dir = newDirectory()) {
+      writeDocuments(dir);
+
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        IndexSearcher searcher = newSearcher(reader);
+
+        Query clause1 =
+            new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2);
+        Query clause2 = new ConstantScoreQuery(new TermQuery(new Term("foo", "C")));
+        Query filter = new TermQuery(new Term("foo", "B"));
+        LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
+        Scorer scorer1 =
+            searcher
+                .createWeight(searcher.rewrite(clause1), ScoreMode.TOP_SCORES, 1f)
+                .scorer(context);
+        Scorer scorer2 =
+            searcher
+                .createWeight(searcher.rewrite(clause2), ScoreMode.TOP_SCORES, 1f)
+                .scorer(context);
+        Scorer filterScorer =
+            searcher
+                .createWeight(searcher.rewrite(filter), ScoreMode.TOP_SCORES, 1f)
+                .scorer(context);
+
+        BulkScorer scorer =
+            new MaxScoreBulkScorer(
+                context.reader().maxDoc(), Arrays.asList(scorer1, scorer2), filterScorer);
+
+        scorer.score(
+            new LeafCollector() {
+
+              private int i;
+              private Scorable scorer;
+
+              @Override
+              public void setScorer(Scorable scorer) throws IOException {
+                this.scorer = scorer;
+              }
+
+              @Override
+              public void collect(int doc) throws IOException {
+                switch (i++) {
+                  case 0:
+                    assertEquals(0, doc);
+                    assertEquals(2, scorer.score(), 0);
+                    scorer.setMinCompetitiveScore(Math.nextUp(2));
+                    break;
+                  case 1:
+                    assertEquals(12288, doc);
+                    assertEquals(2 + 1, scorer.score(), 0);
+                    scorer.setMinCompetitiveScore(Math.nextUp(2 + 1));
+                    break;
+                  default:
+                    System.out.println(i);
+                    fail();
+                    break;
+                }
+              }
+            },
+            null,
+            0,
+            DocIdSetIterator.NO_MORE_DOCS);
+      }
+    }
+  }
+
   public void testBasicsWithTwoDisjunctionClausesAndSkipping() throws Exception {
     try (Directory dir = newDirectory()) {
       writeDocuments(dir);
@@ -155,7 +291,8 @@ public class TestMaxScoreBulkScorer extends LuceneTestCase {
                 .scorer(context);
 
         BulkScorer scorer =
-            new MaxScoreBulkScorer(context.reader().maxDoc(), Arrays.asList(scorer1, scorer2));
+            new MaxScoreBulkScorer(
+                context.reader().maxDoc(), Arrays.asList(scorer1, scorer2), null);
 
         scorer.score(
             new LeafCollector() {
@@ -227,7 +364,7 @@ public class TestMaxScoreBulkScorer extends LuceneTestCase {
 
         BulkScorer scorer =
             new MaxScoreBulkScorer(
-                context.reader().maxDoc(), Arrays.asList(scorer1, scorer2, scorer3));
+                context.reader().maxDoc(), Arrays.asList(scorer1, scorer2, scorer3), null);
 
         scorer.score(
             new LeafCollector() {
@@ -304,7 +441,7 @@ public class TestMaxScoreBulkScorer extends LuceneTestCase {
 
         BulkScorer scorer =
             new MaxScoreBulkScorer(
-                context.reader().maxDoc(), Arrays.asList(scorer1, scorer2, scorer3));
+                context.reader().maxDoc(), Arrays.asList(scorer1, scorer2, scorer3), null);
 
         scorer.score(
             new LeafCollector() {
@@ -505,7 +642,8 @@ public class TestMaxScoreBulkScorer extends LuceneTestCase {
     fox.cost = 900;
     fox.maxScore = 1.1f;
 
-    MaxScoreBulkScorer scorer = new MaxScoreBulkScorer(10_000, Arrays.asList(the, quick, fox));
+    MaxScoreBulkScorer scorer =
+        new MaxScoreBulkScorer(10_000, Arrays.asList(the, quick, fox), null);
     the.docID = 4;
     the.maxScoreUpTo = 130;
     quick.docID = 4;


### PR DESCRIPTION
Running filtered disjunctions with a specialized bulk scorer seems to yield a good speedup. For what it's worth, I also tried to implement a MAXSCORE-based scorer to see if it had to do with the `BulkScorer` specialization or the algorithm, but it didn't help.

To work properly, I had to add a rewrite rule to inline disjunctions in a MUST clause.

As a next step, it would be interesting to see if we can further optimize this by loading the filter into a bitset and applying it like live docs.