### PR TITLE
Make WANDScorer compute scores on the fly.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -105,6 +105,9 @@ Optimizations
 * GITHUB#13999: CombinedFieldQuery now returns non-infinite maximum scores,
   making it eligible to dynamic pruning. (Adrien Grand)
 
+* GITHUB#14021: WANDScorer now computes scores on the fly, which helps prevent
+  advancing "tail" clauses in many cases. (Adrien Grand)
+
 Bug Fixes
 ---------------------
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended

--- a/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
@@ -546,6 +546,7 @@ final class WANDScorer extends Scorer {
 
   @Override
   public float score() throws IOException {
+    // we need to know about all matches
     advanceAllTail();
 
     double leadScore = this.leadScore;


### PR DESCRIPTION
Currently, `WANDSCorer` considers that a hit is a match if the sum of maximum scores across clauses is more than or equal to the minimum competitive score. We can do better by computing scores of leading clauses on the fly. This helps because scores are often lower than the score upper bound, so using actual scores instead of score upper bounds can help skip advancing more clauses.

For reference, we are already doing the same trick in our conjunction (bulk) scorers and in `MaxScoreBulkScorer` (bulk scorer for top-level disjunctions).