### PR TITLE
Optimize DFS while marking connected components

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
@@ -163,6 +163,10 @@ public class HnswUtil {
       throws IOException {
     // Start at entry point and search all nodes on this level
     // System.out.println("markRooted level=" + level + " entryPoint=" + entryPoint);
+    if (connectedNodes.get(entryPoint)) {
+      return new Component(entryPoint, 0);
+    }
+    FixedBitSet nodesInStack = new FixedBitSet(hnswGraph.size());
     Deque<Integer> stack = new ArrayDeque<>();
     stack.push(entryPoint);
     int count = 0;
@@ -178,7 +182,10 @@ public class HnswUtil {
       int friendCount = 0;
       while ((friendOrd = hnswGraph.nextNeighbor()) != NO_MORE_DOCS) {
         ++friendCount;
-        stack.push(friendOrd);
+        if (connectedNodes.get(friendOrd) == false && nodesInStack.get(friendOrd) == false) {
+          stack.push(friendOrd);
+          nodesInStack.set(friendOrd);
+        }
       }
       if (friendCount < maxConn && notFullyConnected != null) {
         notFullyConnected.set(node);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
@@ -106,7 +106,9 @@ public class HnswUtil {
     } else {
       entryPoint = connectedNodes.nextSetBit(0);
     }
-    components.add(new Component(entryPoint, total));
+    if (total > 0) {
+      components.add(new Component(entryPoint, total));
+    }
     if (level == 0) {
       int nextClear = nextClearBit(connectedNodes, 0);
       while (nextClear != NO_MORE_DOCS) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
@@ -29,6 +29,7 @@ import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.internal.hppc.IntHashSet;
 import org.apache.lucene.util.FixedBitSet;
 
 /** Utilities for use in tests involving HNSW graphs */
@@ -166,7 +167,7 @@ public class HnswUtil {
     if (connectedNodes.get(entryPoint)) {
       return new Component(entryPoint, 0);
     }
-    FixedBitSet nodesInStack = new FixedBitSet(hnswGraph.size());
+    IntHashSet nodesInStack = new IntHashSet();
     Deque<Integer> stack = new ArrayDeque<>();
     stack.push(entryPoint);
     int count = 0;
@@ -182,9 +183,9 @@ public class HnswUtil {
       int friendCount = 0;
       while ((friendOrd = hnswGraph.nextNeighbor()) != NO_MORE_DOCS) {
         ++friendCount;
-        if (connectedNodes.get(friendOrd) == false && nodesInStack.get(friendOrd) == false) {
+        if (connectedNodes.get(friendOrd) == false && nodesInStack.contains(friendOrd) == false) {
           stack.push(friendOrd);
-          nodesInStack.set(friendOrd);
+          nodesInStack.add(friendOrd);
         }
       }
       if (friendCount < maxConn && notFullyConnected != null) {


### PR DESCRIPTION
Part of #14002 

Stack depth was growing more than it should causing excessive allocations. This should help reduce them, and may potentially speed up process.

Benchmark while indexing 100k docs:

```
cat max_stack_depth_optimized.txt | grep maxStackDepth | sort -t= -k2 -n | tail
maxStackDepth=8592
maxStackDepth=8605
maxStackDepth=8666
maxStackDepth=8738
maxStackDepth=8779
maxStackDepth=8825
maxStackDepth=9084
maxStackDepth=39925
maxStackDepth=67764
maxStackDepth=68239
```
```
cat max_stack_depth_optimized.txt | tail


Results:
recall  latency (ms)    nDoc  topK  fanout  maxConn  beamWidth  quantized  index s  index docs/s  force merge s  num segments  index size (MB)  vec disk (MB)  vec RAM (MB)
 0.532         0.224  100000   100      50       16        250     4 bits     3.56      28129.40           6.71             1            47.82         42.915         4.768
 0.661         0.206  100000   100      50       16        250     7 bits     3.42      29231.22           6.35             1            50.85         47.684         9.537
 0.830         0.263  100000   100      50       16        250         no     3.16      31665.61           5.40             1            42.36         38.147        38.147

BUILD SUCCESSFUL in 34s
2 actionable tasks: 1 executed, 1 up-to-date
```
```
cat max_stack_depth_non_optimized.txt | grep maxStackDepth | sort -t= -k2 -n | tail
maxStackDepth=138439
maxStackDepth=139713
maxStackDepth=140014
maxStackDepth=140365
maxStackDepth=140955
maxStackDepth=147255
maxStackDepth=152292
maxStackDepth=618303
maxStackDepth=1128533
maxStackDepth=1505067
```
```
cat max_stack_depth_non_optimized.txt | tail


Results:
recall  latency (ms)    nDoc  topK  fanout  maxConn  beamWidth  quantized  index s  index docs/s  force merge s  num segments  index size (MB)  vec disk (MB)  vec RAM (MB)
 0.532         0.244  100000   100      50       16        250     4 bits     3.52      28376.84           8.04             1            47.85         42.915         4.768
 0.662         0.309  100000   100      50       16        250     7 bits     3.54      28288.54           7.64             1            50.86         47.684         9.537
 0.810         0.271  100000   100      50       16        250         no     3.20      31230.48           5.65             1            41.99         38.147        38.147

BUILD SUCCESSFUL in 37s
2 actionable tasks: 1 executed, 1 up-to-date
```

cc: @msokolov @vigyasharma 