### PR TITLE
Make SegmentInfos#readCommit(Directory, String, int) public

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -125,7 +125,7 @@ Bug Fixes
   in valid polygons. (Ignacio Vera)
 * GITHUB#13990: Added filter to the toString() method of Knn[Float|Byte]VectorQuery
   and DiversifyingChildren[Float|Byte]KnnVectorQuery. (Viswanath Kuchibhotla)
-  
+
 * GITHUB#14027: Make SegmentInfos#readCommit(Directory, String, int) public
 
 Build

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -125,6 +125,8 @@ Bug Fixes
   in valid polygons. (Ignacio Vera)
 * GITHUB#13990: Added filter to the toString() method of Knn[Float|Byte]VectorQuery
   and DiversifyingChildren[Float|Byte]KnnVectorQuery. (Viswanath Kuchibhotla)
+  
+* GITHUB#14027: Make SegmentInfos#readCommit(Directory, String, int) public
 
 Build
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -285,10 +285,11 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
   }
 
   /**
-   * Read a particular segmentFileName, as long as the commit's {@link SegmentInfos#getIndexCreatedVersionMajor()}
-   * is strictly greater than the provided minimum supported major version. If the commit's version is older, an
-   * {@link IndexFormatTooOldException} will be thrown. Note that this may throw an IOException if a commit is in
-   * process.
+   * Read a particular segmentFileName, as long as the commit's {@link
+   * SegmentInfos#getIndexCreatedVersionMajor()} is strictly greater than the provided minimum
+   * supported major version. If the commit's version is older, an {@link
+   * IndexFormatTooOldException} will be thrown. Note that this may throw an IOException if a commit
+   * is in process.
    */
   public static final SegmentInfos readCommit(
       Directory directory, String segmentFileName, int minSupportedMajorVersion)

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -284,7 +284,13 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
     return readCommit(directory, segmentFileName, Version.MIN_SUPPORTED_MAJOR);
   }
 
-  static final SegmentInfos readCommit(
+  /**
+   * Read a particular segmentFileName, as long as the commit's {@link SegmentInfos#getIndexCreatedVersionMajor()}
+   * is strictly greater than the provided minimum supported major version. If the commit's version is older, an
+   * {@link IndexFormatTooOldException} will be thrown. Note that this may throw an IOException if a commit is in
+   * process.
+   */
+  public static final SegmentInfos readCommit(
       Directory directory, String segmentFileName, int minSupportedMajorVersion)
       throws IOException {
 
@@ -307,7 +313,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
   }
 
   /** Read the commit from the provided {@link ChecksumIndexInput}. */
-  static final SegmentInfos readCommit(
+  public static final SegmentInfos readCommit(
       Directory directory, ChecksumIndexInput input, long generation, int minSupportedMajorVersion)
       throws IOException {
     Throwable priorE = null;


### PR DESCRIPTION
The corresponding readLatestCommit method is public and can be used to read segment infos from indices that are older than N - 1. The same should be possible for readCommit, but that requires the method that takes the minimum supported version as an argument to be public.