### PR TITLE
Speed up PostingsEnum when reading positions.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -119,6 +119,9 @@ Optimizations
 * GITHUB#14023: Make JVM inlining decisions more predictable in our main
   queries. (Adrien Grand)
 
+* GITHUB#14032: Speed up PostingsEnum when positions are requested.
+  (Adrien Grand)
+
 Bug Fixes
 ---------------------
 * GITHUB#13832: Fixed an issue where the DefaultPassageFormatter.format method did not format passages as intended


### PR DESCRIPTION
This PR changes the following:
 - As much work as possible is moved from `nextDoc()`/`advance()` to `nextPosition()`. This helps only pay the overhead of reading positions when all query terms agree on a candidate.
 - Frequencies are read lazily. Again, this helps in case a document is needed in a block, but clauses do not agree on a common candidate match, so frequencies are never decoded.
 - A few other minor optimizations.