### PR TITLE
Combine all postings enum impls of the default codec into a single class

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -56,6 +56,9 @@ Improvements
   system property to increase the set of Java versions that Panama Vectorization will
   provide optimized implementations for. (Chris Hegarty)
 
+* GITHUB#14033: Combine all postings enum impls of the default codec into a
+  single class. (Adrien Grand)
+
 Optimizations
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
@@ -781,22 +781,26 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
           int docDelta = readVInt15(docIn);
           level0LastDocID += docDelta;
           boolean found = target <= level0LastDocID;
-
           long blockLength = readVLong15(docIn);
           level0DocEndFP = docIn.getFilePointer() + blockLength;
-          if (indexHasFreq) {
-            int numImpactBytes = docIn.readVInt();
-            if (needsImpacts && found) {
-              docIn.readBytes(level0SerializedImpacts.bytes, 0, numImpactBytes);
-              level0SerializedImpacts.length = numImpactBytes;
-            } else {
-              docIn.skipBytes(numImpactBytes);
-            }
 
-            if (needsPos) {
-              readLevel0PosData();
-            } else {
+          if (indexHasFreq) {
+            if (found == false && needsPos == false) {
               docIn.seek(skip0End);
+            } else {
+              int numImpactBytes = docIn.readVInt();
+              if (needsImpacts && found) {
+                docIn.readBytes(level0SerializedImpacts.bytes, 0, numImpactBytes);
+                level0SerializedImpacts.length = numImpactBytes;
+              } else {
+                docIn.skipBytes(numImpactBytes);
+              }
+
+              if (needsPos) {
+                readLevel0PosData();
+              } else {
+                docIn.seek(skip0End);
+              }
             }
           }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
@@ -760,7 +760,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
         if (payIn != null) { // needs payloads or offsets
           assert level0PayEndFP >= payIn.getFilePointer();
           payIn.seek(payFP);
-          payloadByteUpto = payUpto;;
+          payloadByteUpto = payUpto;
         }
         posBufferUpto = BLOCK_SIZE;
       } else {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
@@ -876,7 +876,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
       final int leftInBlock = BLOCK_SIZE - posBufferUpto;
       if (toSkip < leftInBlock) {
         int end = posBufferUpto + toSkip;
-        if (indexHasPayloads) {
+        if (needsPayloads) {
           payloadByteUpto += sumOverRange(payloadLengthBuffer, posBufferUpto, end);
         }
         posBufferUpto = end;
@@ -905,7 +905,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
         }
         refillPositions();
         payloadByteUpto = 0;
-        if (payloadLengthBuffer != null) {
+        if (needsPayloads) {
           payloadByteUpto += sumOverRange(payloadLengthBuffer, 0, toSkip);
         }
         posBufferUpto = toSkip;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.RandomAccess;
+
 import org.apache.lucene.codecs.BlockTermState;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.PostingsReaderBase;
@@ -44,7 +45,6 @@ import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SegmentReadState;
-import org.apache.lucene.index.SlowImpactsEnum;
 import org.apache.lucene.internal.vectorization.PostingDecodingUtil;
 import org.apache.lucene.internal.vectorization.VectorizationProvider;
 import org.apache.lucene.store.ByteArrayDataInput;
@@ -272,35 +272,18 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
   public PostingsEnum postings(
       FieldInfo fieldInfo, BlockTermState termState, PostingsEnum reuse, int flags)
           throws IOException {
-    return (reuse instanceof EverythingEnum everythingEnum
-        && everythingEnum.canReuse(docIn, fieldInfo, flags)
+    return (reuse instanceof BlockPostingsEnum everythingEnum
+        && everythingEnum.canReuse(docIn, fieldInfo, flags, false)
         ? everythingEnum
-            : new EverythingEnum(fieldInfo, flags))
+            : new BlockPostingsEnum(fieldInfo, flags, false))
         .reset((IntBlockTermState) termState, flags);
   }
 
   @Override
   public ImpactsEnum impacts(FieldInfo fieldInfo, BlockTermState state, int flags)
       throws IOException {
-    final IndexOptions options = fieldInfo.getIndexOptions();
-    final boolean indexHasPositions =
-        options.compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;
-
-    if (options.compareTo(IndexOptions.DOCS_AND_FREQS) >= 0
-        && (indexHasPositions == false
-            || PostingsEnum.featureRequested(flags, PostingsEnum.POSITIONS) == false)) {
-      return new BlockImpactsDocsEnum(indexHasPositions, (IntBlockTermState) state);
-    }
-
-    if (indexHasPositions
-        && (options.compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) < 0
-            || PostingsEnum.featureRequested(flags, PostingsEnum.OFFSETS) == false)
-        && (fieldInfo.hasPayloads() == false
-            || PostingsEnum.featureRequested(flags, PostingsEnum.PAYLOADS) == false)) {
-      return new BlockImpactsPostingsEnum(fieldInfo, (IntBlockTermState) state);
-    }
-
-    return new SlowImpactsEnum(postings(fieldInfo, state, null, flags));
+    return new BlockPostingsEnum(fieldInfo, flags, true)
+        .reset((IntBlockTermState) state, flags);
   }
 
   private static long sumOverRange(int[] arr, int start, int end) {
@@ -311,7 +294,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     return res;
   }
 
-  final class EverythingEnum extends PostingsEnum {
+  final class BlockPostingsEnum extends ImpactsEnum {
 
     protected ForDeltaUtil forDeltaUtil;
     protected PForUtil pforUtil;
@@ -322,6 +305,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
 
     // level 0 skip data
     protected int level0LastDocID;
+    private long level0DocEndFP;
 
     // level 1 skip data
     protected int level1LastDocID;
@@ -380,6 +364,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     final boolean needsOffsets;
     final boolean needsPayloads;
     final boolean needsOffsetsOrPayloads;
+    final boolean needsImpacts;
 
     private int position; // current position
 
@@ -392,17 +377,26 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     // decode vs vInt decode the block:
     private long lastPosBlockFP;
 
+    // level 0 skip data
     private long level0PosEndFP;
     private int level0BlockPosUpto;
     private long level0PayEndFP;
     private int level0BlockPayUpto;
+    protected final BytesRef level0SerializedImpacts;
+    protected final MutableImpactList level0Impacts;
 
+    // level 1 skip data
     private long level1PosEndFP;
     private int level1BlockPosUpto;
     private long level1PayEndFP;
     private int level1BlockPayUpto;
+    protected final BytesRef level1SerializedImpacts;
+    protected final MutableImpactList level1Impacts;
 
-    public EverythingEnum(FieldInfo fieldInfo, int flags) throws IOException {
+    // true if we shallow-advanced to a new block that we have not decoded yet
+    protected boolean needsRefilling;
+
+    public BlockPostingsEnum(FieldInfo fieldInfo, int flags, boolean needsImpacts) throws IOException {
       options = fieldInfo.getIndexOptions();
       indexHasFreq = options.compareTo(IndexOptions.DOCS_AND_FREQS) >= 0;
       indexHasPos = options.compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;
@@ -416,6 +410,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
       needsOffsets = indexHasOffsets && PostingsEnum.featureRequested(flags, PostingsEnum.OFFSETS);
       needsPayloads = indexHasPayloads && PostingsEnum.featureRequested(flags, PostingsEnum.PAYLOADS);
       needsOffsetsOrPayloads = needsOffsets || needsPayloads;
+      this.needsImpacts = needsImpacts;
 
       // We set the last element of docBuffer to NO_MORE_DOCS, it helps save conditionals in
       // advance()
@@ -423,6 +418,18 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
 
       if (needsFreq == false) {
         Arrays.fill(freqBuffer, 1);
+      }
+
+      if (needsFreq && needsImpacts) {
+        level0SerializedImpacts = new BytesRef(maxImpactNumBytesAtLevel0);
+        level1SerializedImpacts = new BytesRef(maxImpactNumBytesAtLevel1);
+        level0Impacts = new MutableImpactList(maxNumImpactsAtLevel0);
+        level1Impacts = new MutableImpactList(maxNumImpactsAtLevel1);
+      } else {
+        level0SerializedImpacts = null;
+        level1SerializedImpacts = null;
+        level0Impacts = null;
+        level1Impacts = null;
       }
 
       if (needsPos) {
@@ -433,7 +440,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
         this.posInUtil = null;
       }
 
-      if (needsOffsetsOrPayloads) {
+      if (needsOffsets || needsPayloads) {
         this.payIn = Lucene101PostingsReader.this.payIn.clone();
         payInUtil = VECTORIZATION_PROVIDER.newPostingDecodingUtil(payIn);
       } else {
@@ -462,14 +469,15 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
       }
     }
 
-    public boolean canReuse(IndexInput docIn, FieldInfo fieldInfo, int flags) {
+    public boolean canReuse(IndexInput docIn, FieldInfo fieldInfo, int flags, boolean needsImpacts) {
       return docIn == Lucene101PostingsReader.this.docIn
           && options == fieldInfo.getIndexOptions()
           && indexHasPayloads == fieldInfo.hasPayloads()
-          && this.flags == flags;
+          && this.flags == flags
+          && this.needsImpacts == needsImpacts;
     }
 
-    public PostingsEnum reset(IntBlockTermState termState, int flags) throws IOException {
+    public BlockPostingsEnum reset(IntBlockTermState termState, int flags) throws IOException {
       docFreq = termState.docFreq;
       singletonDocID = termState.singletonDocID;
       if (docFreq > 1) {
@@ -484,7 +492,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
       if (forDeltaUtil == null && docFreq >= BLOCK_SIZE) {
         forDeltaUtil = new ForDeltaUtil();
       }
-      totalTermFreq = termState.totalTermFreq;
+      totalTermFreq = indexHasFreq ? termState.totalTermFreq : termState.docFreq;
       if (needsFreq && pforUtil == null && totalTermFreq >= BLOCK_SIZE) {
         pforUtil = new PForUtil();
       }
@@ -606,7 +614,13 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
 
         if (indexHasFreq) {
           long skip1EndFP = docIn.readShort() + docIn.getFilePointer();
-          docIn.skipBytes(docIn.readShort()); // impacts
+          int numImpactBytes = docIn.readShort();
+          if (needsImpacts) {
+            docIn.readBytes(level1SerializedImpacts.bytes, 0, numImpactBytes);
+            level1SerializedImpacts.length = numImpactBytes;
+          } else {
+            docIn.skipBytes(numImpactBytes);
+          }
           if (indexHasPos) {
             level1PosEndFP += docIn.readVLong();
             level1BlockPosUpto = docIn.readByte();
@@ -633,24 +647,35 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
       prevDocID = level0LastDocID;
 
       assert docBufferUpto == BLOCK_SIZE;
-      if (posIn != null && level0PosEndFP >= posIn.getFilePointer()) {
-        posIn.seek(level0PosEndFP);
-        posPendingCount = level0BlockPosUpto;
-        if (payIn != null) {
-          assert level0PayEndFP >= payIn.getFilePointer();
-          payIn.seek(level0PayEndFP);
-          payloadByteUpto = level0BlockPayUpto;
+      if (posIn != null) {
+        if (level0PosEndFP >= posIn.getFilePointer()) {
+          posIn.seek(level0PosEndFP);
+          posPendingCount = level0BlockPosUpto;
+          if (payIn != null) {
+            assert level0PayEndFP >= payIn.getFilePointer();
+            payIn.seek(level0PayEndFP);
+            payloadByteUpto = level0BlockPayUpto;
+          }
+          posBufferUpto = BLOCK_SIZE;
+        } else {
+          posPendingCount += sumOverRange(freqBuffer, posDocBufferUpto, BLOCK_SIZE);
         }
-        posBufferUpto = BLOCK_SIZE;
       }
 
       if (docFreq - docCountUpto >= BLOCK_SIZE) {
         docIn.readVLong(); // skip0 num bytes
         int docDelta = readVInt15(docIn);
         level0LastDocID += docDelta;
-        readVLong15(docIn); // block length
+        long blockLength = readVLong15(docIn);
+        level0DocEndFP = docIn.getFilePointer() + blockLength;
         if (indexHasFreq) {
-          docIn.skipBytes(docIn.readVLong()); // impacts
+          int numImpactBytes = docIn.readVInt();
+          if (needsImpacts) {
+            docIn.readBytes(level0SerializedImpacts.bytes, 0, numImpactBytes);
+            level0SerializedImpacts.length = numImpactBytes;
+          } else {
+            docIn.skipBytes(numImpactBytes);
+          }
 
           if (indexHasPos) {
             level0PosEndFP += docIn.readVLong();
@@ -666,17 +691,6 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
       }
 
       refillDocs();
-    }
-
-    @Override
-    public int nextDoc() throws IOException {
-      if (docBufferUpto == BLOCK_SIZE) { // advance level 0 skip data
-        moveToNextLevel0Block();
-      }
-
-      this.doc = docBuffer[docBufferUpto];
-      docBufferUpto++;
-      return doc;
     }
 
     private void skipLevel0To(int target) throws IOException {
@@ -708,9 +722,15 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
           level0LastDocID += docDelta;
 
           long blockLength = readVLong15(docIn);
-          long blockEndFP = docIn.getFilePointer() + blockLength;
+          level0DocEndFP = docIn.getFilePointer() + blockLength;
           if (indexHasFreq) {
-            docIn.skipBytes(docIn.readVLong()); // impacts
+            int numImpactBytes = docIn.readVInt();
+            if (needsImpacts) {
+              docIn.readBytes(level0SerializedImpacts.bytes, 0, numImpactBytes);
+              level0SerializedImpacts.length = numImpactBytes;
+            } else {
+              docIn.skipBytes(numImpactBytes);
+            }
 
             if (indexHasPos) {
               level0PosEndFP += docIn.readVLong();
@@ -726,7 +746,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
             break;
           }
 
-          docIn.seek(blockEndFP);
+          docIn.seek(level0DocEndFP);
           docCountUpto += BLOCK_SIZE;
         } else {
           level0LastDocID = NO_MORE_DOCS;
@@ -736,22 +756,48 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     }
 
     @Override
-    public int advance(int target) throws IOException {
+    public void advanceShallow(int target) throws IOException {
       if (target > level0LastDocID) { // advance level 0 skip data
 
-        if (target > level1LastDocID) { // advance level 1 skip data
+        if (target > level1LastDocID) { // advance skip data on level 1
           skipLevel1To(target);
+        } else if (needsRefilling) {
+          docIn.seek(level0DocEndFP);
+          docCountUpto += BLOCK_SIZE;
         }
 
         skipLevel0To(target);
 
+        needsRefilling = true;
+      }
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      if (docBufferUpto == BLOCK_SIZE) {
+        if (needsRefilling) {
+          refillDocs();
+          needsRefilling = false;
+        } else {
+          moveToNextLevel0Block();
+        }
+      }
+
+      return this.doc = docBuffer[docBufferUpto++];
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+      if (target > level0LastDocID || needsRefilling) {
+        advanceShallow(target);
         refillDocs();
+        needsRefilling = false;
       }
 
       int next = VectorUtil.findNextGEQ(docBuffer, target, docBufferUpto, docBufferSize);
-      this.docBufferUpto = next + 1;
-
-      return this.doc = docBuffer[next];
+      this.doc = docBuffer[next];
+      docBufferUpto = next + 1;
+      return doc;
     }
 
     private void skipPositions(int freq) throws IOException {
@@ -877,6 +923,35 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
       }
     }
 
+    private void accumulatePendingPositions() throws IOException {
+      posPendingCount += sumOverRange(freqBuffer, posDocBufferUpto, docBufferUpto);
+      posDocBufferUpto = docBufferUpto;
+
+      assert posPendingCount > 0;
+
+      int freq = freq();
+      if (posPendingCount > freq) {
+        skipPositions(freq);
+        posPendingCount = freq;
+      }
+    }
+
+    private void accumulateOffsetsAndPayloads() {
+      if (needsPayloads) {
+        payloadLength = payloadLengthBuffer[posBufferUpto];
+        payload.bytes = payloadBytes;
+        payload.offset = payloadByteUpto;
+        payload.length = payloadLength;
+        payloadByteUpto += payloadLength;
+      }
+
+      if (needsOffsets) { // needs offsets
+        startOffset = lastStartOffset + offsetStartDeltaBuffer[posBufferUpto];
+        endOffset = startOffset + offsetLengthBuffer[posBufferUpto];
+        lastStartOffset = startOffset;
+      }
+    }
+
     @Override
     public int nextPosition() throws IOException {
       if (needsPos == false) {
@@ -886,17 +961,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
       assert posDocBufferUpto <= docBufferUpto;
       if (posDocBufferUpto != docBufferUpto) {
         // First position we're reading on this doc
-        posPendingCount += sumOverRange(freqBuffer, posDocBufferUpto, docBufferUpto);
-        posDocBufferUpto = docBufferUpto;
-
-        assert posPendingCount > 0;
-
-        int freq = freq();
-        if (posPendingCount > freq) {
-          skipPositions(freq);
-          posPendingCount = freq;
-        }
-
+        accumulatePendingPositions();
         position = 0;
         lastStartOffset = 0;
       }
@@ -907,18 +972,8 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
       }
       position += posDeltaBuffer[posBufferUpto];
 
-      if (payloadLengthBuffer != null) { // needs payloads
-        payloadLength = payloadLengthBuffer[posBufferUpto];
-        payload.bytes = payloadBytes;
-        payload.offset = payloadByteUpto;
-        payload.length = payloadLength;
-        payloadByteUpto += payloadLength;
-      }
-
-      if (offsetStartDeltaBuffer != null) { // needs offsets
-        startOffset = lastStartOffset + offsetStartDeltaBuffer[posBufferUpto];
-        endOffset = startOffset + offsetLengthBuffer[posBufferUpto];
-        lastStartOffset = startOffset;
+      if (needsOffsetsOrPayloads) {
+        accumulateOffsetsAndPayloads();
       }
 
       posBufferUpto++;
@@ -949,96 +1004,6 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     public long cost() {
       return docFreq;
     }
-  }
-
-  private abstract class BlockImpactsEnum extends ImpactsEnum {
-
-    protected final ForDeltaUtil forDeltaUtil = new ForDeltaUtil();
-    protected final PForUtil pforUtil = new PForUtil();
-
-    protected final int[] docBuffer = new int[BLOCK_SIZE + 1];
-    protected final int[] freqBuffer = new int[BLOCK_SIZE];
-
-    protected final int docFreq; // number of docs in this posting list
-    // sum of freqBuffer in this posting list (or docFreq when omitted)
-    protected final long totalTermFreq;
-    protected final int singletonDocID; // docid when there is a single pulsed posting, otherwise -1
-
-    protected final IndexInput docIn;
-    protected final PostingDecodingUtil docInUtil;
-
-    protected int docCountUpto; // number of docs in or before the current block
-    protected int doc = -1; // doc we last read
-    protected int prevDocID = -1; // last doc ID of the previous block
-    protected int docBufferSize = BLOCK_SIZE;
-    protected int docBufferUpto = BLOCK_SIZE;
-
-    // true if we shallow-advanced to a new block that we have not decoded yet
-    protected boolean needsRefilling;
-
-    // level 0 skip data
-    protected int level0LastDocID = -1;
-    protected long level0DocEndFP;
-    protected final BytesRef level0SerializedImpacts;
-    protected final MutableImpactList level0Impacts;
-    // level 1 skip data
-    protected int level1LastDocID;
-    protected long level1DocEndFP;
-    protected int level1DocCountUpto = 0;
-    protected final BytesRef level1SerializedImpacts;
-    protected final MutableImpactList level1Impacts;
-
-    private BlockImpactsEnum(IntBlockTermState termState) throws IOException {
-      this.docFreq = termState.docFreq;
-      this.docIn = Lucene101PostingsReader.this.docIn.clone();
-      this.docInUtil = VECTORIZATION_PROVIDER.newPostingDecodingUtil(docIn);
-      if (docFreq > 1) {
-        prefetchPostings(docIn, termState);
-      }
-      this.singletonDocID = termState.singletonDocID;
-      this.totalTermFreq = termState.totalTermFreq;
-      level0SerializedImpacts = new BytesRef(maxImpactNumBytesAtLevel0);
-      level1SerializedImpacts = new BytesRef(maxImpactNumBytesAtLevel1);
-      level0Impacts = new MutableImpactList(maxNumImpactsAtLevel0);
-      level1Impacts = new MutableImpactList(maxNumImpactsAtLevel1);
-      if (docFreq < LEVEL1_NUM_DOCS) {
-        level1LastDocID = NO_MORE_DOCS;
-        if (docFreq > 1) {
-          docIn.seek(termState.docStartFP);
-        }
-      } else {
-        level1LastDocID = -1;
-        level1DocEndFP = termState.docStartFP;
-      }
-      // We set the last element of docBuffer to NO_MORE_DOCS, it helps save conditionals in
-      // advance()
-      docBuffer[BLOCK_SIZE] = NO_MORE_DOCS;
-    }
-
-    @Override
-    public int docID() {
-      return doc;
-    }
-
-    @Override
-    public int startOffset() {
-      return -1;
-    }
-
-    @Override
-    public int endOffset() {
-      return -1;
-    }
-
-    @Override
-    public BytesRef getPayload() {
-      return null;
-    }
-
-    @Override
-    public long cost() {
-      return docFreq;
-    }
 
     private final Impacts impacts =
         new Impacts() {
@@ -1047,11 +1012,14 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
 
           @Override
           public int numLevels() {
-            return level1LastDocID == NO_MORE_DOCS ? 1 : 2;
+            return indexHasFreq == false || level1LastDocID == NO_MORE_DOCS ? 1 : 2;
           }
 
           @Override
           public int getDocIdUpTo(int level) {
+            if (indexHasFreq == false) {
+              return NO_MORE_DOCS;
+            }
             if (level == 0) {
               return level0LastDocID;
             }
@@ -1060,11 +1028,13 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
 
           @Override
           public List<Impact> getImpacts(int level) {
-            if (level == 0 && level0LastDocID != NO_MORE_DOCS) {
-              return readImpacts(level0SerializedImpacts, level0Impacts);
-            }
-            if (level == 1) {
-              return readImpacts(level1SerializedImpacts, level1Impacts);
+            if (indexHasFreq) {
+              if (level == 0 && level0LastDocID != NO_MORE_DOCS) {
+                return readImpacts(level0SerializedImpacts, level0Impacts);
+              }
+              if (level == 1) {
+                return readImpacts(level1SerializedImpacts, level1Impacts);
+              }
             }
             return DUMMY_IMPACTS;
           }
@@ -1079,500 +1049,8 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
 
     @Override
     public Impacts getImpacts() {
+      assert needsImpacts;
       return impacts;
-    }
-  }
-
-  final class BlockImpactsDocsEnum extends BlockImpactsEnum {
-    final boolean indexHasPos;
-
-    private long freqFP;
-
-    public BlockImpactsDocsEnum(boolean indexHasPos, IntBlockTermState termState)
-        throws IOException {
-      super(termState);
-      this.indexHasPos = indexHasPos;
-      freqFP = -1;
-    }
-
-    @Override
-    public int freq() throws IOException {
-      if (freqFP != -1) {
-        docIn.seek(freqFP);
-        pforUtil.decode(docInUtil, freqBuffer);
-        freqFP = -1;
-      }
-      return freqBuffer[docBufferUpto - 1];
-    }
-
-    @Override
-    public int nextPosition() {
-      return -1;
-    }
-
-    private void refillDocs() throws IOException {
-      final int left = docFreq - docCountUpto;
-      assert left >= 0;
-
-      if (left >= BLOCK_SIZE) {
-        forDeltaUtil.decodeAndPrefixSum(docInUtil, prevDocID, docBuffer);
-        freqFP = docIn.getFilePointer();
-        PForUtil.skip(docIn);
-        docCountUpto += BLOCK_SIZE;
-      } else if (docFreq == 1) {
-        docBuffer[0] = singletonDocID;
-        freqBuffer[0] = (int) totalTermFreq;
-        freqFP = -1;
-        docBuffer[1] = NO_MORE_DOCS;
-        docCountUpto++;
-        docBufferSize = 1;
-      } else {
-        // Read vInts:
-        PostingsUtil.readVIntBlock(docIn, docBuffer, freqBuffer, left, true, true);
-        prefixSum(docBuffer, left, prevDocID);
-        docBuffer[left] = NO_MORE_DOCS;
-        freqFP = -1;
-        docCountUpto += left;
-        docBufferSize = left;
-      }
-      prevDocID = docBuffer[BLOCK_SIZE - 1];
-      docBufferUpto = 0;
-      assert docBuffer[docBufferSize] == NO_MORE_DOCS;
-    }
-
-    private void skipLevel1To(int target) throws IOException {
-      while (true) {
-        prevDocID = level1LastDocID;
-        level0LastDocID = level1LastDocID;
-        docIn.seek(level1DocEndFP);
-        docCountUpto = level1DocCountUpto;
-        level1DocCountUpto += LEVEL1_NUM_DOCS;
-
-        if (docFreq - docCountUpto < LEVEL1_NUM_DOCS) {
-          level1LastDocID = NO_MORE_DOCS;
-          break;
-        }
-
-        level1LastDocID += docIn.readVInt();
-        level1DocEndFP = docIn.readVLong() + docIn.getFilePointer();
-
-        if (level1LastDocID >= target) {
-          long skip1EndFP = docIn.readShort() + docIn.getFilePointer();
-          int numImpactBytes = docIn.readShort();
-          docIn.readBytes(level1SerializedImpacts.bytes, 0, numImpactBytes);
-          level1SerializedImpacts.length = numImpactBytes;
-          assert indexHasPos || docIn.getFilePointer() == skip1EndFP;
-          docIn.seek(skip1EndFP);
-          break;
-        }
-      }
-    }
-
-    private void skipLevel0To(int target) throws IOException {
-      while (true) {
-        prevDocID = level0LastDocID;
-        if (docFreq - docCountUpto >= BLOCK_SIZE) {
-          long skip0NumBytes = docIn.readVLong();
-          // end offset of skip data (before the actual data starts)
-          long skip0End = docIn.getFilePointer() + skip0NumBytes;
-          int docDelta = readVInt15(docIn);
-          long blockLength = readVLong15(docIn);
-
-          level0LastDocID += docDelta;
-
-          if (target <= level0LastDocID) {
-            level0DocEndFP = docIn.getFilePointer() + blockLength;
-            int numImpactBytes = docIn.readVInt();
-            docIn.readBytes(level0SerializedImpacts.bytes, 0, numImpactBytes);
-            level0SerializedImpacts.length = numImpactBytes;
-            docIn.seek(skip0End);
-            break;
-          }
-
-          // skip block
-          docIn.skipBytes(blockLength);
-          docCountUpto += BLOCK_SIZE;
-        } else {
-          level0LastDocID = NO_MORE_DOCS;
-          break;
-        }
-      }
-    }
-
-    @Override
-    public void advanceShallow(int target) throws IOException {
-      if (target > level0LastDocID) { // advance skip data on level 0
-        if (target > level1LastDocID) { // advance skip data on level 1
-          skipLevel1To(target);
-        } else if (needsRefilling) {
-          docIn.seek(level0DocEndFP);
-          docCountUpto += BLOCK_SIZE;
-        }
-
-        skipLevel0To(target);
-
-        needsRefilling = true;
-      }
-    }
-
-    private void moveToNextLevel0Block() throws IOException {
-      if (doc == level1LastDocID) {
-        skipLevel1To(doc + 1);
-      } else if (needsRefilling) {
-        docIn.seek(level0DocEndFP);
-        docCountUpto += BLOCK_SIZE;
-      }
-
-      prevDocID = level0LastDocID;
-      if (docFreq - docCountUpto >= BLOCK_SIZE) {
-        final long skip0Len = docIn.readVLong(); // skip len
-        final long skip0End = docIn.getFilePointer() + skip0Len;
-        final int docDelta = readVInt15(docIn);
-        final long blockLength = readVLong15(docIn);
-        level0LastDocID += docDelta;
-        level0DocEndFP = docIn.getFilePointer() + blockLength;
-        final int numImpactBytes = docIn.readVInt();
-        docIn.readBytes(level0SerializedImpacts.bytes, 0, numImpactBytes);
-        level0SerializedImpacts.length = numImpactBytes;
-        docIn.seek(skip0End);
-      } else {
-        level0LastDocID = NO_MORE_DOCS;
-      }
-
-      refillDocs();
-      needsRefilling = false;
-    }
-
-    @Override
-    public int nextDoc() throws IOException {
-      if (docBufferUpto == BLOCK_SIZE) {
-        if (needsRefilling) {
-          refillDocs();
-          needsRefilling = false;
-        } else {
-          moveToNextLevel0Block();
-        }
-      }
-
-      return this.doc = docBuffer[docBufferUpto++];
-    }
-
-    @Override
-    public int advance(int target) throws IOException {
-      if (target > level0LastDocID || needsRefilling) {
-        advanceShallow(target);
-        refillDocs();
-        needsRefilling = false;
-      }
-
-      int next = VectorUtil.findNextGEQ(docBuffer, target, docBufferUpto, docBufferSize);
-      this.doc = docBuffer[next];
-      docBufferUpto = next + 1;
-      return doc;
-    }
-  }
-
-  final class BlockImpactsPostingsEnum extends BlockImpactsEnum {
-    private final int[] posDeltaBuffer = new int[BLOCK_SIZE];
-
-    private int posBufferUpto;
-    final IndexInput posIn;
-    final PostingDecodingUtil posInUtil;
-
-    final boolean indexHasFreq;
-    final boolean indexHasOffsets;
-    final boolean indexHasPayloads;
-    final boolean indexHasOffsetsOrPayloads;
-
-    private int freq; // freq we last read
-    private int position; // current position
-
-    // how many positions "behind" we are; nextPosition must
-    // skip these to "catch up":
-    private int posPendingCount;
-
-    // File pointer where the last (vInt encoded) pos delta
-    // block is.  We need this to know whether to bulk
-    // decode vs vInt decode the block:
-    private final long lastPosBlockFP;
-
-    // level 0 skip data
-    private long level0PosEndFP;
-    private int level0BlockPosUpto;
-    // level 1 skip data
-    private long level1PosEndFP;
-    private int level1BlockPosUpto;
-
-    public BlockImpactsPostingsEnum(FieldInfo fieldInfo, IntBlockTermState termState)
-        throws IOException {
-      super(termState);
-      final IndexOptions options = fieldInfo.getIndexOptions();
-      indexHasFreq = options.compareTo(IndexOptions.DOCS_AND_FREQS) >= 0;
-      indexHasOffsets =
-          options.compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) >= 0;
-      indexHasPayloads = fieldInfo.hasPayloads();
-      indexHasOffsetsOrPayloads = indexHasOffsets || indexHasPayloads;
-
-      this.posIn = Lucene101PostingsReader.this.posIn.clone();
-      posInUtil = VECTORIZATION_PROVIDER.newPostingDecodingUtil(posIn);
-
-      // Where this term's postings start in the .pos file:
-      final long posTermStartFP = termState.posStartFP;
-      posIn.seek(posTermStartFP);
-      level1PosEndFP = posTermStartFP;
-      level0PosEndFP = posTermStartFP;
-      posPendingCount = 0;
-      if (termState.totalTermFreq < BLOCK_SIZE) {
-        lastPosBlockFP = posTermStartFP;
-      } else if (termState.totalTermFreq == BLOCK_SIZE) {
-        lastPosBlockFP = -1;
-      } else {
-        lastPosBlockFP = posTermStartFP + termState.lastPosBlockOffset;
-      }
-      level1BlockPosUpto = 0;
-      posBufferUpto = BLOCK_SIZE;
-    }
-
-    @Override
-    public int freq() {
-      return freq;
-    }
-
-    private void refillDocs() throws IOException {
-      final int left = docFreq - docCountUpto;
-      assert left >= 0;
-
-      if (left >= BLOCK_SIZE) {
-        forDeltaUtil.decodeAndPrefixSum(docInUtil, prevDocID, docBuffer);
-        pforUtil.decode(docInUtil, freqBuffer);
-        docCountUpto += BLOCK_SIZE;
-      } else if (docFreq == 1) {
-        docBuffer[0] = singletonDocID;
-        freqBuffer[0] = (int) totalTermFreq;
-        docBuffer[1] = NO_MORE_DOCS;
-        docCountUpto++;
-        docBufferSize = 1;
-      } else {
-        // Read vInts:
-        PostingsUtil.readVIntBlock(docIn, docBuffer, freqBuffer, left, indexHasFreq, true);
-        prefixSum(docBuffer, left, prevDocID);
-        docBuffer[left] = NO_MORE_DOCS;
-        docCountUpto += left;
-        docBufferSize = left;
-      }
-      prevDocID = docBuffer[BLOCK_SIZE - 1];
-      docBufferUpto = 0;
-      assert docBuffer[docBufferSize] == NO_MORE_DOCS;
-    }
-
-    private void skipLevel1To(int target) throws IOException {
-      while (true) {
-        prevDocID = level1LastDocID;
-        level0LastDocID = level1LastDocID;
-        docIn.seek(level1DocEndFP);
-        level0PosEndFP = level1PosEndFP;
-        level0BlockPosUpto = level1BlockPosUpto;
-        docCountUpto = level1DocCountUpto;
-        level1DocCountUpto += LEVEL1_NUM_DOCS;
-
-        if (docFreq - docCountUpto < LEVEL1_NUM_DOCS) {
-          level1LastDocID = NO_MORE_DOCS;
-          break;
-        }
-
-        level1LastDocID += docIn.readVInt();
-        level1DocEndFP = docIn.readVLong() + docIn.getFilePointer();
-
-        long skip1EndFP = docIn.readShort() + docIn.getFilePointer();
-        int numImpactBytes = docIn.readShort();
-        if (level1LastDocID >= target) {
-          docIn.readBytes(level1SerializedImpacts.bytes, 0, numImpactBytes);
-          level1SerializedImpacts.length = numImpactBytes;
-        } else {
-          docIn.skipBytes(numImpactBytes);
-        }
-        level1PosEndFP += docIn.readVLong();
-        level1BlockPosUpto = docIn.readByte();
-        assert indexHasOffsetsOrPayloads || docIn.getFilePointer() == skip1EndFP;
-
-        if (level1LastDocID >= target) {
-          docIn.seek(skip1EndFP);
-          break;
-        }
-      }
-    }
-
-    private void skipLevel0To(int target) throws IOException {
-      while (true) {
-        prevDocID = level0LastDocID;
-
-        // If nextBlockPosFP is less than the current FP, it means that the block of positions for
-        // the first docs of the next block are already decoded. In this case we just accumulate
-        // frequencies into posPendingCount instead of seeking backwards and decoding the same pos
-        // block again.
-        if (level0PosEndFP >= posIn.getFilePointer()) {
-          posIn.seek(level0PosEndFP);
-          posPendingCount = level0BlockPosUpto;
-          posBufferUpto = BLOCK_SIZE;
-        } else {
-          posPendingCount += sumOverRange(freqBuffer, docBufferUpto, BLOCK_SIZE);
-        }
-
-        if (docFreq - docCountUpto >= BLOCK_SIZE) {
-          docIn.readVLong(); // skip0 num bytes
-          int docDelta = readVInt15(docIn);
-          long blockLength = readVLong15(docIn);
-          level0DocEndFP = docIn.getFilePointer() + blockLength;
-
-          level0LastDocID += docDelta;
-
-          if (target <= level0LastDocID) {
-            int numImpactBytes = docIn.readVInt();
-            docIn.readBytes(level0SerializedImpacts.bytes, 0, numImpactBytes);
-            level0SerializedImpacts.length = numImpactBytes;
-            level0PosEndFP += docIn.readVLong();
-            level0BlockPosUpto = docIn.readByte();
-            if (indexHasOffsetsOrPayloads) {
-              docIn.readVLong(); // pay fp delta
-              docIn.readVInt(); // pay upto
-            }
-            break;
-          }
-          // skip block
-          docIn.skipBytes(docIn.readVLong()); // impacts
-          level0PosEndFP += docIn.readVLong();
-          level0BlockPosUpto = docIn.readVInt();
-          docIn.seek(level0DocEndFP);
-          docCountUpto += BLOCK_SIZE;
-        } else {
-          level0LastDocID = NO_MORE_DOCS;
-          break;
-        }
-      }
-    }
-
-    @Override
-    public void advanceShallow(int target) throws IOException {
-      if (target > level0LastDocID) { // advance level 0 skip data
-
-        if (target > level1LastDocID) { // advance skip data on level 1
-          skipLevel1To(target);
-        } else if (needsRefilling) {
-          docIn.seek(level0DocEndFP);
-          docCountUpto += BLOCK_SIZE;
-        }
-
-        skipLevel0To(target);
-
-        needsRefilling = true;
-      }
-    }
-
-    @Override
-    public int nextDoc() throws IOException {
-      if (docBufferUpto == BLOCK_SIZE) {
-        advanceShallow(doc + 1);
-        assert needsRefilling;
-        refillDocs();
-        needsRefilling = false;
-      }
-
-      doc = docBuffer[docBufferUpto];
-      freq = freqBuffer[docBufferUpto];
-      posPendingCount += freq;
-      docBufferUpto++;
-      position = 0;
-      return this.doc;
-    }
-
-    @Override
-    public int advance(int target) throws IOException {
-      advanceShallow(target);
-      if (needsRefilling) {
-        refillDocs();
-        needsRefilling = false;
-      }
-
-      int next = VectorUtil.findNextGEQ(docBuffer, target, docBufferUpto, docBufferSize);
-      posPendingCount += sumOverRange(freqBuffer, docBufferUpto, next + 1);
-      freq = freqBuffer[next];
-      docBufferUpto = next + 1;
-      position = 0;
-      return this.doc = docBuffer[next];
-    }
-
-    private void skipPositions() throws IOException {
-      // Skip positions now:
-      int toSkip = posPendingCount - freq;
-      // if (DEBUG) {
-      //   System.out.println("      FPR.skipPositions: toSkip=" + toSkip);
-      // }
-
-      final int leftInBlock = BLOCK_SIZE - posBufferUpto;
-      if (toSkip < leftInBlock) {
-        posBufferUpto += toSkip;
-      } else {
-        toSkip -= leftInBlock;
-        while (toSkip >= BLOCK_SIZE) {
-          assert posIn.getFilePointer() != lastPosBlockFP;
-          PForUtil.skip(posIn);
-          toSkip -= BLOCK_SIZE;
-        }
-        refillPositions();
-        posBufferUpto = toSkip;
-      }
-
-      position = 0;
-    }
-
-    private void refillPositions() throws IOException {
-      if (posIn.getFilePointer() == lastPosBlockFP) {
-        final int count = (int) (totalTermFreq % BLOCK_SIZE);
-        int payloadLength = 0;
-        for (int i = 0; i < count; i++) {
-          int code = posIn.readVInt();
-          if (indexHasPayloads) {
-            if ((code & 1) != 0) {
-              payloadLength = posIn.readVInt();
-            }
-            posDeltaBuffer[i] = code >>> 1;
-            if (payloadLength != 0) {
-              posIn.skipBytes(payloadLength);
-            }
-          } else {
-            posDeltaBuffer[i] = code;
-          }
-
-          if (indexHasOffsets) {
-            int deltaCode = posIn.readVInt();
-            if ((deltaCode & 1) != 0) {
-              posIn.readVInt(); // offset length
-            }
-          }
-        }
-      } else {
-        pforUtil.decode(posInUtil, posDeltaBuffer);
-      }
-    }
-
-    @Override
-    public int nextPosition() throws IOException {
-      assert posPendingCount > 0;
-
-      if (posPendingCount > freq) {
-        skipPositions();
-        posPendingCount = freq;
-      }
-
-      if (posBufferUpto == BLOCK_SIZE) {
-        refillPositions();
-        posBufferUpto = 0;
-      }
-      position += posDeltaBuffer[posBufferUpto];
-
-      posBufferUpto++;
-      posPendingCount--;
-      return position;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
@@ -738,11 +738,11 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
         if (docFreq - docCountUpto >= BLOCK_SIZE) {
           long level0NumBytes = docIn.readVLong();
           docIn.skipBytes(level0NumBytes);
-          refillDocs();
+          refillFullBlock();
           level0LastDocID = docBuffer[BLOCK_SIZE - 1];
         } else {
           level0LastDocID = NO_MORE_DOCS;
-          refillDocs();
+          refillRemainder();
         }
       } else {
         moveToNextLevel0BlockWithFreqs();

--- a/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
@@ -399,7 +399,7 @@ public class PhraseQuery extends Query {
   /**
    * A guess of the average number of simple operations for the initial seek and buffer refill per
    * document for the positions of a term. See also {@link
-   * Lucene101PostingsReader.BlockImpactsPostingsEnum#nextPosition()}.
+   * Lucene101PostingsReader.BlockPostingsEnum#nextPosition()}.
    *
    * <p>Aside: Instead of being constant this could depend among others on {@link
    * Lucene101PostingsFormat#BLOCK_SIZE}, {@link TermsEnum#docFreq()}, {@link
@@ -410,9 +410,8 @@ public class PhraseQuery extends Query {
   private static final int TERM_POSNS_SEEK_OPS_PER_DOC = 128;
 
   /**
-   * Number of simple operations in {@link
-   * Lucene101PostingsReader.BlockImpactsPostingsEnum#nextPosition()} when no seek or buffer refill
-   * is done.
+   * Number of simple operations in {@link Lucene101PostingsReader.BlockPostingsEnum#nextPosition()}
+   * when no seek or buffer refill is done.
    */
   private static final int TERM_OPS_PER_POS = 7;
 

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/TermIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/TermIntervalsSource.java
@@ -261,7 +261,7 @@ class TermIntervalsSource extends IntervalsSource {
   /**
    * A guess of the average number of simple operations for the initial seek and buffer refill per
    * document for the positions of a term. See also {@link
-   * Lucene101PostingsReader.EverythingEnum#nextPosition()}.
+   * Lucene101PostingsReader.BlockPostingsEnum#nextPosition()}.
    *
    * <p>Aside: Instead of being constant this could depend among others on {@link
    * Lucene101PostingsFormat#BLOCK_SIZE}, {@link TermsEnum#docFreq()}, {@link
@@ -272,7 +272,7 @@ class TermIntervalsSource extends IntervalsSource {
   private static final int TERM_POSNS_SEEK_OPS_PER_DOC = 128;
 
   /**
-   * Number of simple operations in {@link Lucene101PostingsReader.EverythingEnum#nextPosition()}
+   * Number of simple operations in {@link Lucene101PostingsReader.BlockPostingsEnum#nextPosition()}
    * when no seek or buffer refill is done.
    */
   private static final int TERM_OPS_PER_POS = 7;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
@@ -1416,7 +1416,7 @@ public class RandomPostingsTester {
       final boolean alwaysTestMax)
       throws Exception {
 
-    if (options.contains(Option.THREADS)) {
+    if (options.contains(Option.THREADS) && false) {
       int numThreads = LuceneTestCase.TEST_NIGHTLY ? TestUtil.nextInt(random, 2, 5) : 2;
       Thread[] threads = new Thread[numThreads];
       for (int threadUpto = 0; threadUpto < numThreads; threadUpto++) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
@@ -1292,7 +1292,7 @@ public class RandomPostingsTester {
           target = impactsEnum.docID() + delta;
         }
 
-        if (advance && target > max && random.nextBoolean()) {
+        if (target > max && random.nextBoolean()) {
           int delta = Math.min(random.nextInt(512), DocIdSetIterator.NO_MORE_DOCS - target);
           max = target + delta;
 
@@ -1416,7 +1416,7 @@ public class RandomPostingsTester {
       final boolean alwaysTestMax)
       throws Exception {
 
-    if (options.contains(Option.THREADS) && false) {
+    if (options.contains(Option.THREADS)) {
       int numThreads = LuceneTestCase.TEST_NIGHTLY ? TestUtil.nextInt(random, 2, 5) : 2;
       Thread[] threads = new Thread[numThreads];
       for (int threadUpto = 0; threadUpto < numThreads; threadUpto++) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
@@ -1292,7 +1292,7 @@ public class RandomPostingsTester {
           target = impactsEnum.docID() + delta;
         }
 
-        if (target > max && random.nextBoolean()) {
+        if (advance && target > max && random.nextBoolean()) {
           int delta = Math.min(random.nextInt(512), DocIdSetIterator.NO_MORE_DOCS - target);
           max = target + delta;
 


### PR DESCRIPTION
Recent speedups by making call sites bimorphic made me want to play with combining all postings enums and impacts enums of the default codec into a single class, in order to reduce polymorphism. Unfortunately, it does not yield a speedup since the major polymorphic call sites we have that hurt performance (`DefaultBulkScorer`, `ConjunctionDISI`) are still 3-polymorphic or more.

Yet, reduced polymorphism at little performance impact is a good trade-off as it would help make call sites bimorphic for users who don't have as much query diversity as nightly benchmarks, or in the future when we remove other causes of polymorphism.