### PR TITLE
Initialize the dictionary of sorted numeric DV with a known size

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -454,7 +454,7 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
         for (long v : sortedUniqueValues) {
           meta.writeLong(v); // table[] entry
         }
-        encode = new LongIntHashMap();
+        encode = new LongIntHashMap(sortedUniqueValues.length);
         for (int i = 0; i < sortedUniqueValues.length; ++i) {
           encode.put(sortedUniqueValues[i], i);
         }


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
Since we already know the size of the dictionary beforehand, we can initialize it with the expected capacity to prevent rehashing.