### PR TITLE
Randomize KnnVector codec params in RandomCodec; addresses gh-14047

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -24,7 +24,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+* GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
+  when all values are identical. (Mike Sokolov)
 
 Other
 ---------------------

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBasicBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBasicBackwardsCompatibility.java
@@ -541,6 +541,7 @@ public class TestBasicBackwardsCompatibility extends BackwardsCompatibilityTestB
         new IndexWriter(
             dir,
             newIndexWriterConfig(new MockAnalyzer(random))
+                .setCodec(TestUtil.getDefaultCodec())
                 .setOpenMode(IndexWriterConfig.OpenMode.APPEND)
                 .setMergePolicy(newLogMergePolicy()));
     // add 10 docs
@@ -579,6 +580,7 @@ public class TestBasicBackwardsCompatibility extends BackwardsCompatibilityTestB
         new IndexWriter(
             dir,
             newIndexWriterConfig(new MockAnalyzer(random))
+                .setCodec(TestUtil.getDefaultCodec())
                 .setOpenMode(IndexWriterConfig.OpenMode.APPEND)
                 .setMergePolicy(newLogMergePolicy()));
     writer.forceMerge(1);
@@ -630,6 +632,7 @@ public class TestBasicBackwardsCompatibility extends BackwardsCompatibilityTestB
         new IndexWriter(
             dir,
             newIndexWriterConfig(new MockAnalyzer(random))
+                .setCodec(TestUtil.getDefaultCodec())
                 .setOpenMode(IndexWriterConfig.OpenMode.APPEND));
     writer.forceMerge(1);
     writer.close();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
@@ -93,6 +93,7 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       VectorSimilarityFunction sim,
       float constMultiplier,
       QuantizedByteVectorValues values) {
+    checkDimensions(targetBytes.length, values.dimension());
     return switch (sim) {
       case EUCLIDEAN -> new Euclidean(values, constMultiplier, targetBytes);
       case COSINE, DOT_PRODUCT ->
@@ -110,6 +111,13 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
               values,
               VectorUtil::scaleMaxInnerProductScore);
     };
+  }
+
+  static void checkDimensions(int queryLen, int fieldLen) {
+    if (queryLen != fieldLen) {
+      throw new IllegalArgumentException(
+          "vector query dimension: " + queryLen + " differs from field dimension: " + fieldLen);
+    }
   }
 
   private static RandomVectorScorer.AbstractRandomVectorScorer dotProductFactory(

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/ScalarQuantizer.java
@@ -97,12 +97,18 @@ public class ScalarQuantizer {
     }
     assert maxQuantile >= minQuantile;
     assert bits > 0 && bits <= 8;
-    this.minQuantile = minQuantile;
-    this.maxQuantile = maxQuantile;
     this.bits = bits;
     final float divisor = (float) ((1 << bits) - 1);
-    this.scale = divisor / (maxQuantile - minQuantile);
-    this.alpha = (maxQuantile - minQuantile) / divisor;
+    if (minQuantile == maxQuantile) {
+      // avoid divide-by-zero with an arbitrary but plausible choice (leads to alpha = scale = 1)
+      this.minQuantile = minQuantile - divisor;
+      this.maxQuantile = maxQuantile + divisor;
+    } else {
+      this.minQuantile = minQuantile;
+      this.maxQuantile = maxQuantile;
+    }
+    this.scale = divisor / (this.maxQuantile - this.minQuantile);
+    this.alpha = (this.maxQuantile - this.minQuantile) / divisor;
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
@@ -44,6 +44,7 @@ import org.apache.lucene.util.TestVectorUtil;
 import org.apache.lucene.util.VectorUtil;
 
 public class TestKnnFloatVectorQuery extends BaseKnnVectorQueryTestCase {
+
   @Override
   KnnFloatVectorQuery getKnnVectorQuery(String field, float[] query, int k, Query queryFilter) {
     return new KnnFloatVectorQuery(field, query, k, queryFilter);
@@ -130,16 +131,16 @@ public class TestKnnFloatVectorQuery extends BaseKnnVectorQueryTestCase {
         DocIdSetIterator it = scorer.iterator();
         assertEquals(2, it.cost());
         assertEquals(0, it.nextDoc());
-        assertEquals(0, scorer.score(), 0);
+        assertEquals(0, scorer.score(), EPSILON);
         assertEquals(1, it.advance(1));
-        assertEquals(1, scorer.score(), 0);
+        assertEquals(1, scorer.score(), EPSILON);
       }
     }
   }
 
   public void testScoreDotProduct() throws IOException {
     try (Directory d = newDirectory()) {
-      try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
+      try (IndexWriter w = new IndexWriter(d, configStandardCodec())) {
         for (int j = 1; j <= 5; j++) {
           Document doc = new Document();
           doc.add(
@@ -174,7 +175,7 @@ public class TestKnnFloatVectorQuery extends BaseKnnVectorQueryTestCase {
             (float) ((1 + (2 * 2 + 3 * 4) / Math.sqrt((2 * 2 + 3 * 3) * (2 * 2 + 4 * 4))) / 2);
 
         // doc 1 happens to have the max score
-        assertEquals(score1, scorer.getMaxScore(2), 0.0001);
+        assertEquals(score1, scorer.getMaxScore(2), 0.001);
         assertEquals(score1, scorer.getMaxScore(Integer.MAX_VALUE), 0.0001);
 
         DocIdSetIterator it = scorer.iterator();

--- a/lucene/core/src/test/org/apache/lucene/search/TestVectorSimilarityValuesSource.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestVectorSimilarityValuesSource.java
@@ -18,6 +18,7 @@
 package org.apache.lucene.search;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnByteVectorField;
@@ -29,8 +30,10 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.junit.AfterClass;
@@ -47,6 +50,13 @@ public class TestVectorSimilarityValuesSource extends LuceneTestCase {
     dir = newDirectory();
     analyzer = new MockAnalyzer(random());
     IndexWriterConfig iwConfig = newIndexWriterConfig(analyzer);
+    iwConfig.setCodec(
+        new AssertingCodec() {
+          @Override
+          public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+            return TestUtil.getDefaultKnnVectorsFormat();
+          }
+        });
     iwConfig.setMergePolicy(newLogMergePolicy());
     RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwConfig);
 

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoin.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoin.java
@@ -27,6 +27,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
@@ -56,6 +57,7 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.search.similarities.SimilarityBase;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.CheckHits;
 import org.apache.lucene.tests.search.QueryUtils;
@@ -252,7 +254,17 @@ public class TestBlockJoin extends LuceneTestCase {
     final Directory dir = newDirectory();
     final RandomIndexWriter w =
         new RandomIndexWriter(
-            random(), dir, newIndexWriterConfig().setMergePolicy(newMergePolicy(random(), false)));
+            random(),
+            dir,
+            newIndexWriterConfig()
+                .setCodec(
+                    new AssertingCodec() {
+                      @Override
+                      public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                        return TestUtil.getDefaultKnnVectorsFormat();
+                      }
+                    })
+                .setMergePolicy(newMergePolicy(random(), false)));
 
     final List<Document> docs = new ArrayList<>();
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
@@ -25,7 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
 import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.PointsFormat;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.PointsWriter;
@@ -34,6 +36,8 @@ import org.apache.lucene.codecs.blocktreeords.BlockTreeOrdsPostingsFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90PointsReader;
 import org.apache.lucene.codecs.lucene90.Lucene90PointsWriter;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.apache.lucene.codecs.memory.DirectPostingsFormat;
 import org.apache.lucene.codecs.memory.FSTPostingsFormat;
 import org.apache.lucene.index.FieldInfo;
@@ -44,6 +48,7 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
 import org.apache.lucene.tests.codecs.asserting.AssertingDocValuesFormat;
+import org.apache.lucene.tests.codecs.asserting.AssertingKnnVectorsFormat;
 import org.apache.lucene.tests.codecs.asserting.AssertingPointsFormat;
 import org.apache.lucene.tests.codecs.asserting.AssertingPostingsFormat;
 import org.apache.lucene.tests.codecs.blockterms.LuceneFixedGap;
@@ -71,11 +76,17 @@ public class RandomCodec extends AssertingCodec {
   /** Shuffled list of docvalues formats to use for new mappings */
   private List<DocValuesFormat> dvFormats = new ArrayList<>();
 
+  /** Shuffled list of knn formats to use for new mappings */
+  private List<KnnVectorsFormat> knnFormats = new ArrayList<>();
+
   /** unique set of format names this codec knows about */
   public Set<String> formatNames = new HashSet<>();
 
   /** unique set of docvalues format names this codec knows about */
   public Set<String> dvFormatNames = new HashSet<>();
+
+  /** unique set of knn format names this codec knows about */
+  public Set<String> knnFormatNames = new HashSet<>();
 
   public final Set<String> avoidCodecs;
 
@@ -88,6 +99,10 @@ public class RandomCodec extends AssertingCodec {
 
   private Map<String, DocValuesFormat> previousDVMappings =
       Collections.synchronizedMap(new HashMap<String, DocValuesFormat>());
+
+  private Map<String, KnnVectorsFormat> previousKnnMappings =
+      Collections.synchronizedMap(new HashMap<String, KnnVectorsFormat>());
+
   private final int perFieldSeed;
 
   // a little messy: randomize the default codec's parameters here.
@@ -191,6 +206,18 @@ public class RandomCodec extends AssertingCodec {
     return codec;
   }
 
+  @Override
+  public KnnVectorsFormat getKnnVectorsFormatForField(String name) {
+    KnnVectorsFormat format = previousKnnMappings.get(name);
+    if (format == null) {
+      format = knnFormats.get(Math.abs(perFieldSeed ^ name.hashCode()) % knnFormats.size());
+      previousKnnMappings.put(name, format);
+      // Safety:
+      assert previousKnnMappings.size() < 10000 : "test went insane";
+    }
+    return format;
+  }
+
   public RandomCodec(Random random, Set<String> avoidCodecs) {
     this.perFieldSeed = random.nextInt();
     this.avoidCodecs = avoidCodecs;
@@ -236,8 +263,46 @@ public class RandomCodec extends AssertingCodec {
         new Lucene90DocValuesFormat(),
         new AssertingDocValuesFormat());
 
+    boolean concurrentKnnMerging = random.nextBoolean();
+    addKnn(
+        avoidCodecs,
+        TestUtil.getDefaultKnnVectorsFormat(),
+        new Lucene99HnswVectorsFormat(
+            TestUtil.nextInt(random, 5, 50),
+            TestUtil.nextInt(random, 10, 50),
+            concurrentKnnMerging ? TestUtil.nextInt(random, 2, 8) : 1,
+            concurrentKnnMerging ? ForkJoinPool.commonPool() : null),
+        new Lucene99HnswScalarQuantizedVectorsFormat(
+            TestUtil.nextInt(random, 5, 50),
+            TestUtil.nextInt(random, 10, 50),
+            concurrentKnnMerging ? TestUtil.nextInt(random, 2, 8) : 1,
+            7,
+            false,
+            randomConfidenceInterval(random),
+            concurrentKnnMerging ? ForkJoinPool.commonPool() : null),
+        // TODO: also test 4-bit quantization, but this must somehow be restricted to even-length
+        // fields
+        /*
+        new Lucene99HnswScalarQuantizedVectorsFormat(TestUtil.nextInt(random, 5, 50),
+                                                     TestUtil.nextInt(random, 10, 50),
+                                                     1,
+                                                     4,
+                                                     random.nextBoolean(),
+                                                     randomConfidenceInterval(random),
+                                                     null),
+        new Lucene99HnswScalarQuantizedVectorsFormat(TestUtil.nextInt(random, 5, 50),
+                                                     TestUtil.nextInt(random, 10, 50),
+                                                     TestUtil.nextInt(random, 2, 8),
+                                                     4,
+                                                     random.nextBoolean(),
+                                                     randomConfidenceInterval(random),
+                                                     ForkJoinPool.commonPool()),
+        */
+        new AssertingKnnVectorsFormat());
+
     Collections.shuffle(formats, random);
     Collections.shuffle(dvFormats, random);
+    Collections.shuffle(knnFormats, random);
 
     // Avoid too many open files:
     if (formats.size() > 4) {
@@ -245,6 +310,21 @@ public class RandomCodec extends AssertingCodec {
     }
     if (dvFormats.size() > 4) {
       dvFormats = dvFormats.subList(0, 4);
+    }
+    if (knnFormats.size() > 4) {
+      knnFormats = knnFormats.subList(0, 4);
+    }
+  }
+
+  private final Float randomConfidenceInterval(Random random) {
+    switch (random.nextInt(3)) {
+      default:
+      case 0:
+        return null;
+      case 1:
+        return 0f;
+      case 2:
+        return random.nextFloat(0.9f, 1f);
     }
   }
 
@@ -266,6 +346,15 @@ public class RandomCodec extends AssertingCodec {
       if (!avoidCodecs.contains(d.getName())) {
         dvFormats.add(d);
         dvFormatNames.add(d.getName());
+      }
+    }
+  }
+
+  private final void addKnn(Set<String> avoidCodecs, KnnVectorsFormat... knnFormat) {
+    for (KnnVectorsFormat kf : knnFormat) {
+      if (!avoidCodecs.contains(kf.getName())) {
+        knnFormats.add(kf);
+        knnFormatNames.add(kf.getName());
       }
     }
   }


### PR DESCRIPTION
This adds the randomization to RandomCodec and addresses some test issues.

* In a few places I had to disable the randomization; basically wherever we are carefully testing scores. In these cases we won't have the same testing for quantized scores, but I think those would require more targeted testing since it's unclear what kinds of guarantees we can make about score values under quantization.
* In a few other palces I added some slop to the score comparisons; basically if we had a score comparison in a test that was primarily focused on other things (like testing Explain)
* I fixed a divide-by-zero edge case in the ScalarQuantizer (when there is only a single vector in a segment)
* I standardized bounds checking so we have consistent exception messages for dimension mismatches 
