### PR TITLE
IndexInput.isLoaded seems to return false for mmap index inputs on Windows

### DIFF
--- a/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitUtil;
+import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.GroupVIntUtil;
 import org.apache.lucene.util.IOConsumer;
 
@@ -422,12 +423,20 @@ abstract class MemorySegmentIndexInput extends IndexInput
 
   @Override
   public Optional<Boolean> isLoaded() {
+    boolean isLoaded = true;
     for (MemorySegment seg : segments) {
       if (seg.isLoaded() == false) {
-        return Optional.of(Boolean.FALSE);
+        isLoaded = false;
+        break;
       }
     }
-    return Optional.of(Boolean.TRUE);
+
+    if (Constants.WINDOWS && isLoaded == false) {
+      // see https://github.com/apache/lucene/issues/14050
+      return Optional.empty();
+    }
+
+    return Optional.of(isLoaded);
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
@@ -63,6 +63,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitUtil;
+import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.GroupVIntUtil;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.packed.PackedInts;
@@ -1667,7 +1668,10 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
           in = orig.slice("slice", startOffset, totalLength - startOffset);
         }
         var loaded = in.isLoaded();
-        if (FilterDirectory.unwrap(dir) instanceof MMapDirectory
+
+        if (Constants.WINDOWS) {
+          // On Windows, we temporarily don't care until this is fixed: #14050
+        } else if (FilterDirectory.unwrap(dir) instanceof MMapDirectory
             // direct IO wraps MMap but does not support isLoaded
             && !(dir.getClass().getName().contains("DirectIO"))) {
           assertTrue(loaded.isPresent());


### PR DESCRIPTION
Fixes #14050 