### PR TITLE
Add github on-commit tests on MacOS and Windows

### DIFF
--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: ./.github/actions/prepare-for-build
 
       - name: Run gradle check (without tests)
-        run: ./gradlew check -x test -Ptask.times=true --max-workers 2
+        run: ./gradlew check -x test "-Ptask.times=true" --max-workers 2
 
 
   # This runs all tests without any other validation checks.

--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         java: [ '21' ]
 
     runs-on: ${{ matrix.os }}
@@ -51,7 +51,7 @@ jobs:
         # Operating systems to run on.
         # windows-latest: fairly slow to build and results in odd errors (see LUCENE-10167)
         # macos-latest: a tad slower than ubuntu and pretty much the same (?) so leaving out.
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         java: [ '21' ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest ]
         java: [ '21' ]
 
     runs-on: ${{ matrix.os }}
@@ -52,15 +52,14 @@ jobs:
     strategy:
       matrix:
         # Operating systems to run on.
-        # windows-latest: fairly slow to build and results in odd errors (see LUCENE-10167)
-        # macos-latest: a tad slower than ubuntu and pretty much the same (?) so leaving out.
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
         java: [ '21' ]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Correct git autocrlf
+      - name: Correct git autocrlf on Windows
+        if: startsWith(matrix.os, 'windows')
         run: git config --global core.autocrlf false
 
       - uses: actions/checkout@v4

--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -34,6 +34,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Correct git autocrlf
+        run: git config --global core.autocrlf false
+
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare-for-build
 
@@ -57,6 +60,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Correct git autocrlf
+        run: git config --global core.autocrlf false
+
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare-for-build
 


### PR DESCRIPTION
There are some low-level APIs used now that may be surprising and behave differently on different platforms. I suggest we enable MacOS and Windows builds to have a broader coverage and earlier feedback. 

Windows builds are significantly slower compared to unix-ish platforms. I don't think there is a way around it (unless somebody works at github and could arrange a higher-cpu runner ;). But since those builds are shifted to the background and don't interfere with normal dev workflow, I don't think it's such a big issue.

This said, it'd be nice to have the tests run great again...