### PR TITLE
Fix test failure in TestSoftDeletesDirectoryReaderWrapper on expected number of deletes

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesDirectoryReaderWrapper.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesDirectoryReaderWrapper.java
@@ -296,8 +296,12 @@ public class TestSoftDeletesDirectoryReaderWrapper extends LuceneTestCase {
       try (DirectoryReader reader = DirectoryReader.open(writer)) {
         SoftDeletesDirectoryReaderWrapper wrapped =
             new SoftDeletesDirectoryReaderWrapper(reader, softDeletesField);
+        int expectedNumDeletes = 0;
+        for (int i = 0; i < wrapped.leaves().size(); i++) {
+          expectedNumDeletes += wrapped.leaves().get(i).reader().numDeletedDocs();
+        }
         assertEquals(numDocs, wrapped.numDocs());
-        assertEquals(numDeletes, wrapped.numDeletedDocs());
+        assertEquals(expectedNumDeletes, wrapped.numDeletedDocs());
       }
       writer
           .getConfig()


### PR DESCRIPTION
### Description

This PR fixes TestSoftDeletesDirectoryReaderWrapper.testAvoidWrappingReadersWithoutSoftDeletes which consistently fails with a reproducible seed:

```
./gradlew test --tests TestSoftDeletesDirectoryReaderWrapper.testAvoidWrappingReadersWithoutSoftDeletes -i \
-Dtests.seed=CB973876C2F6A82A \
-Dtests.locale=fr-SN \
-Dtests.timezone=Etc/GMT+7 \
-Dtests.asserts=true \
-Dtests.file.encoding=UTF-8
```

Thank you to @easyice for the suggested solution and pointers for this fix. For more details about the test failure see: https://github.com/apache/lucene/issues/14020#issuecomment-2523524793

Resolves: https://github.com/apache/lucene/issues/14020