### PR TITLE
Adjust test for new random quantization formats

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
@@ -131,7 +131,7 @@ public class TestKnnFloatVectorQuery extends BaseKnnVectorQueryTestCase {
         DocIdSetIterator it = scorer.iterator();
         assertEquals(2, it.cost());
         assertEquals(0, it.nextDoc());
-        assertEquals(0, scorer.score(), EPSILON);
+        assertTrue(0 <= scorer.score());
         assertEquals(1, it.advance(1));
         assertEquals(1, scorer.score(), EPSILON);
       }


### PR DESCRIPTION
lucene now randomly adjusts quantization params, etc. and consequently this test sometimes doesn't return exactly a score of `0`. Adjusting to ensure we are never negative.

Related: https://github.com/apache/lucene/pull/14049
closes: https://github.com/apache/lucene/issues/14051