### PR TITLE
Re-enabling test muted in #11787

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -608,7 +608,6 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   }
 
   /** Tests filtering when all vectors have the same score. */
-  @AwaitsFix(bugUrl = "https://github.com/apache/lucene/issues/11787")
   public void testFilterWithSameScore() throws IOException {
     int numDocs = 100;
     int dimension = atLeast(5);


### PR DESCRIPTION
this test has been muted for a long time. Seems like it has been fixed in the time being. I tried with the same seed & many thousands of runs and it hasn't been a repeat offender.