### PR TITLE
Allow doc ID set iterators and scorers to optimize bulk iteration / scoring.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/PostingsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PostingsEnum.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import org.apache.lucene.search.DocAndFreqBatch;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 
@@ -97,4 +98,24 @@ public abstract class PostingsEnum extends DocIdSetIterator {
    * anything (neither members of the returned BytesRef nor bytes in the byte[]).
    */
   public abstract BytesRef getPayload() throws IOException;
+
+  private DocAndFreqBatch docAndFreqBatch;
+
+  @Override
+  public DocAndFreqBatch nextDocBatch(int upTo) throws IOException {
+    if (docAndFreqBatch == null) {
+      docAndFreqBatch = new DocAndFreqBatch();
+      docAndFreqBatch.docs = new int[16];
+      docAndFreqBatch.freqs = new int[16];
+      docAndFreqBatch.offset = 0;
+    }
+    int length = 0;
+    for (int doc = docID(); doc < upTo && length < docAndFreqBatch.docs.length; doc = nextDoc()) {
+      docAndFreqBatch.docs[length] = doc;
+      docAndFreqBatch.freqs[length] = freq();
+      ++length;
+    }
+    docAndFreqBatch.length = length;
+    return docAndFreqBatch;
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/DocAndFreqBatch.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocAndFreqBatch.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+public final class DocAndFreqBatch extends DocBatch {
+
+  public int[] freqs;
+}

--- a/lucene/core/src/java/org/apache/lucene/search/DocAndScoreBatch.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocAndScoreBatch.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+public final class DocAndScoreBatch extends DocBatch {
+
+  public float[] scores;
+}

--- a/lucene/core/src/java/org/apache/lucene/search/DocBatch.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocBatch.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+public class DocBatch {
+
+  public int[] docs;
+  public int offset;
+  public int length;
+}

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSetIterator.java
@@ -211,4 +211,26 @@ public abstract class DocIdSetIterator {
    * may be a rough heuristic, hardcoded value, or otherwise completely inaccurate.
    */
   public abstract long cost();
+
+  private DocBatch docBatch;
+
+  /**
+   * Return a next batch of docs and frequencies including the current document. A length of 0
+   * length indicates that there are no documents below {@code upTo} left. It is illegal to call
+   * this method if the iterator is not positioned yet.
+   */
+  public DocBatch nextDocBatch(int upTo) throws IOException {
+    if (docBatch == null) {
+      docBatch = new DocAndFreqBatch();
+      docBatch.docs = new int[16];
+      docBatch.offset = 0;
+    }
+    int length = 0;
+    for (int doc = docID(); doc < upTo && length < docBatch.docs.length; doc = nextDoc()) {
+      docBatch.docs[length] = doc;
+      ++length;
+    }
+    docBatch.length = length;
+    return docBatch;
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/Scorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Scorer.java
@@ -76,4 +76,31 @@ public abstract class Scorer extends Scorable {
    * {@link #advanceShallow(int) shallow-advanced} to included and {@code upTo} included.
    */
   public abstract float getMaxScore(int upTo) throws IOException;
+
+  private DocAndScoreBatch docAndScoreBatch;
+
+  /**
+   * Return a next batch of docs and scores including the current document. A length of 0 length
+   * indicates that there are no documents below {@code upTo} left. It is illegal to call this
+   * method if the iterator is not positioned yet.
+   */
+  public DocAndScoreBatch nextDocAndScoreBatch(int upTo) throws IOException {
+    if (docAndScoreBatch == null) {
+      docAndScoreBatch = new DocAndScoreBatch();
+      docAndScoreBatch.docs = new int[16];
+      docAndScoreBatch.scores = new float[16];
+      docAndScoreBatch.offset = 0;
+    }
+    int length = 0;
+    DocIdSetIterator it = iterator();
+    for (int doc = it.docID();
+        doc < upTo && length < docAndScoreBatch.docs.length;
+        doc = it.nextDoc()) {
+      docAndScoreBatch.docs[length] = doc;
+      docAndScoreBatch.scores[length] = score();
+      ++length;
+    }
+    docAndScoreBatch.length = length;
+    return docAndScoreBatch;
+  }
 }


### PR DESCRIPTION
While trying to understand while Tantivy is still much faster than Lucene at exhaustive evaluation of disjunctions, I noticed that there is significant potential for vectorization that Lucene doesn't take advantage of.

This PR keeps the same overall logic but refactors the code in a way that the compiler can more easily notice when operations are candidates for auto-vectorization (confirmed by the produced assembly).
