### PR TITLE
BlockJoinBulkScorer could check for parent deletions (not children)

### DIFF
--- a/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinQuery.java
@@ -533,7 +533,8 @@ public class ToParentBlockJoinQuery extends Query {
       }
 
       BatchAwareLeafCollector wrappedCollector = wrapCollector(collector, acceptDocs);
-      // We don't propagate the acceptDocs since only parents are checked for deletion in the wrapped collector
+      // We don't propagate the acceptDocs since only parents are checked for deletion in the
+      // wrapped collector
       childBulkScorer.score(wrappedCollector, null, prevParent + 1, lastParent + 1);
       wrappedCollector.endBatch();
 

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinBulkScorer.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinBulkScorer.java
@@ -435,7 +435,12 @@ public class TestBlockJoinBulkScorer extends LuceneTestCase {
 
           ScorerSupplier ss = weight.scorerSupplier(searcher.getIndexReader().leaves().get(0));
           ss.setTopLevelScoringClause();
-          assertScores(reader.maxDoc(), ss.bulkScorer(), scoreMode, 6.0f, List.of(expectedScores1, expectedScores2));
+          assertScores(
+              reader.maxDoc(),
+              ss.bulkScorer(),
+              scoreMode,
+              6.0f,
+              List.of(expectedScores1, expectedScores2));
         }
 
         {
@@ -504,7 +509,8 @@ public class TestBlockJoinBulkScorer extends LuceneTestCase {
 
           ScorerSupplier ss = weight.scorerSupplier(searcher.getIndexReader().leaves().get(0));
           ss.setTopLevelScoringClause();
-          assertScores(reader.maxDoc(), ss.bulkScorer(), scoreMode, Math.nextUp(0f), expectedScores);
+          assertScores(
+              reader.maxDoc(), ss.bulkScorer(), scoreMode, Math.nextUp(0f), expectedScores);
         }
       }
     }


### PR DESCRIPTION
This change ensures that BlockJoinBulkScorer verifies deletions at the parent level.