### PR TITLE
aws jmh benchmark cleanups

### DIFF
--- a/dev-tools/aws-jmh/README.md
+++ b/dev-tools/aws-jmh/README.md
@@ -2,15 +2,19 @@ Runs lucene microbenchmarks across a variety of CPUs in EC2.
 
 Example:
 
+```console
 export AWS_ACCESS_KEY_ID=xxxxx
 export AWS_SECRET_ACCESS_KEY=yyyy
 make PATCH_BRANCH=rmuir:some-speedup
+```
 
 Results file will be in build/report.txt
 
 You can also pass additional JMH args if you want:
 
+```console
 make PATCH_BRANCH=rmuir:some-speedup JMH_ARGS='float -p size=756'
+```
 
 Prerequisites:
 

--- a/dev-tools/aws-jmh/README.md
+++ b/dev-tools/aws-jmh/README.md
@@ -1,3 +1,20 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ -->
+
 Runs lucene microbenchmarks across a variety of CPUs in EC2.
 
 Example:

--- a/dev-tools/aws-jmh/README.txt
+++ b/dev-tools/aws-jmh/README.txt
@@ -11,3 +11,8 @@ Results file will be in build/report.txt
 You can also pass additional JMH args if you want:
 
 make PATCH_BRANCH=rmuir:some-speedup JMH_ARGS='float -p size=756'
+
+Prerequisites:
+
+1. It is expected that you have an ed25519 ssh key, use `ssh-keygen -t ed25519` to make one.
+2. AWS key's IAM user needs `AmazonEC2FullAccess` and `AWSCloudFormationFullAccess` permissions at a minimum.

--- a/dev-tools/aws-jmh/group_vars/all.yml
+++ b/dev-tools/aws-jmh/group_vars/all.yml
@@ -53,7 +53,9 @@ main_branch: "apache:main"
 patch_branch: "{{ lookup('env', 'PATCH_BRANCH') }}"
 
 assemble_command: ./gradlew -p lucene/benchmark-jmh assemble
-jmh_command: java -jar lucene/benchmark-jmh/build/benchmarks/lucene-benchmark-jmh-10.0.0-SNAPSHOT.jar -rf text
+# must match benchmark jar to run
+jmh_jar_path: "lucene/benchmark-jmh/build/benchmarks/"
+jmh_jar_glob: "lucene-benchmark-jmh-*.jar"
 jmh_args: "{{ lookup('env', 'JMH_ARGS', default='-p size=1024') }}"
 
 # services that cause noise and don't help us

--- a/dev-tools/aws-jmh/group_vars/all.yml
+++ b/dev-tools/aws-jmh/group_vars/all.yml
@@ -43,6 +43,9 @@ instances:
   - name: graviton3
     type: c7g.large
     ami: "{{ arm_ami }}"
+  - name: graviton4
+    type: c8g.large
+    ami: "{{ arm_ami }}"
 
 jdk_version: 21.0.1
 x86_jdk_url: "https://download.java.net/java/GA/jdk{{ jdk_version }}/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-{{ jdk_version }}_linux-x64_bin.tar.gz"

--- a/dev-tools/aws-jmh/playbook.yml
+++ b/dev-tools/aws-jmh/playbook.yml
@@ -90,18 +90,16 @@
 
     - name: Checkout main
       git:
-        repo: "git@github.com:{{ (main_branch | split(':'))[0] }}/lucene.git"
+        repo: "https://github.com/{{ (main_branch | split(':'))[0] }}/lucene.git"
         version: "{{ (main_branch | split(':'))[1] }}"
         dest: main
-        accept_newhostkey: true
         depth: 1
 
     - name: Checkout patch
       git:
-        repo: "git@github.com:{{ (patch_branch | split(':'))[0] }}/lucene.git"
+        repo: "https://github.com/{{ (patch_branch | split(':'))[0] }}/lucene.git"
         version: "{{ (patch_branch | split(':'))[1] }}"
         dest: patch
-        accept_newhostkey: true
         depth: 1
 
     - name: Assemble Sources

--- a/dev-tools/aws-jmh/playbook.yml
+++ b/dev-tools/aws-jmh/playbook.yml
@@ -112,13 +112,24 @@
         - main
         - patch
 
-    - name: Run benchmark
-      command:
-        cmd: "{{ jmh_command }} -rff ~/{{ item }}.txt {{ jmh_args }}"
-        chdir: "{{ item }}"
+    - name: Locate benchmark jar
+      find:
+        paths: "{{ item }}/{{ jmh_jar_path }}"
+        pattern: "{{ jmh_jar_glob }}"
+      register: found_jmh_jars
       loop:
         - main
         - patch
+
+    - name: Run benchmark
+      command:
+        cmd: "java -jar {{ jmh_jar }} -rf text -rff ~/{{ item }}.txt {{ jmh_args }}"
+      loop:
+        - main
+        - patch
+      vars:
+        jmh_jars: "{{ found_jmh_jars.results | selectattr('item', 'eq', item) | map(attribute='files') }}"
+        jmh_jar: "{{ jmh_jars | first | map(attribute='path') | first }}"
 
     - name: Read main results
       command:


### PR DESCRIPTION
This script lets you benchmark a patch across 10 different cpu types in parallel, just copy the branch name from PR and pass to `make`, along with any jmh args if you dont want to run all benchmarks, for example:
 
```
make PATCH_BRANCH=ChrisHegarty:unroll_by_2 JMH_ARGS='floatDotProductVector -p size=1024'
```
It creates a combined `build/report.txt` by CPU, suitable for copy/pasting into a PR.

Apply some cleanups:
* Remove hardcoded lucene 10 jar, which was breaking the benchie: use a glob pattern instead.
* Add graviton4 instance type (c8g) to the benchmark.
