### PR TITLE
Update stopwords.txt

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -27,6 +27,8 @@ Bug Fixes
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 
+* GITHUB#14075: Remove duplicate and add missing entry on brazilian portuguese stopwords list. (Arthur Caccavo)
+
 Other
 ---------------------
 (No changes)

--- a/lucene/analysis/common/src/resources/org/apache/lucene/analysis/br/stopwords.txt
+++ b/lucene/analysis/common/src/resources/org/apache/lucene/analysis/br/stopwords.txt
@@ -68,7 +68,7 @@ mesmas
 mesmo
 mesmos
 na
-nas
+no
 nao
 nas
 nem


### PR DESCRIPTION
### Description

In brazillian portuguese the conjuntion "em(preposition)+<a|o|as|os>(article)" take the form "na, nas, no, nos" being commom stop words.

For some reason the "nas" conjunction appear twice and the "no" is nowhere to be found, I think it was probably a mistake.

This pull request add the word to the list and remove the duplication.

For reference the same word can be found on the Portuguese [stopwords.txt](https://github.com/apache/lucene/blob/0203815/lucene/analysis/common/src/resources/org/apache/lucene/analysis/snowball/portuguese_stop.txt) on line 34

Fix #14065