### PR TITLE
Fix urls describing why NIOFS is not recommended for Windows

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -31,7 +31,7 @@ Bug Fixes
 
 Other
 ---------------------
-(No changes)
+* GITHUB#14081: Fix urls describing why NIOFS is not recommended for Windows (Marcel Yeonghyeon Ko)
 
 ======================= Lucene 10.2.0 =======================
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -31,7 +31,7 @@ Bug Fixes
 
 Other
 ---------------------
-* GITHUB#14081: Fix urls describing why NIOFS is not recommended for Windows (Marcel Yeonghyeon Ko)
+(No changes)
 
 ======================= Lucene 10.2.0 =======================
 
@@ -61,7 +61,7 @@ Bug Fixes
 
 Other
 ---------------------
-(No changes)
+* GITHUB#14081: Fix urls describing why NIOFS is not recommended for Windows (Marcel Yeonghyeon Ko)
 
 ======================= Lucene 10.1.0 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/store/FSDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/FSDirectory.java
@@ -60,7 +60,7 @@ import org.apache.lucene.util.IOUtils;
  *       post</a>.
  *   <li>{@link NIOFSDirectory} uses java.nio's FileChannel's positional io when reading to avoid
  *       synchronization when reading from the same file. Unfortunately, due to a Windows-only <a
- *       href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6265734">Sun JRE bug</a> this is a
+ *       href="https://bugs.java.com/bugdatabase/view_bug?bug_id=6265734">Sun JRE bug</a> this is a
  *       poor choice for Windows, but on all other platforms this is the preferred choice.
  *       Applications using {@link Thread#interrupt()} or {@link Future#cancel(boolean)} should use
  *       {@code RAFDirectory} instead, which is provided in the {@code misc} module. See {@link

--- a/lucene/core/src/java/org/apache/lucene/store/NIOFSDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NIOFSDirectory.java
@@ -36,7 +36,7 @@ import org.apache.lucene.util.IOUtils;
  * <p><b>NOTE</b>: NIOFSDirectory is not recommended on Windows because of a bug in how
  * FileChannel.read is implemented in Sun's JRE. Inside of the implementation the position is
  * apparently synchronized. See <a
- * href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6265734">here</a> for details.
+ * href="https://bugs.java.com/bugdatabase/view_bug?bug_id=6265734">here</a> for details.
  *
  * <p><b>NOTE:</b> Accessing this class either directly or indirectly from a thread while it's
  * interrupted can close the underlying file descriptor immediately if at the same time the thread


### PR DESCRIPTION
### Description
- Lucene opens segment files whether JRE_IS_64BIT is true or false as below:
```java
  public static FSDirectory open(Path path, LockFactory lockFactory) throws IOException {
    if (Constants.JRE_IS_64BIT) {
      return new MMapDirectory(path, lockFactory);
    } else {
      return new NIOFSDirectory(path, lockFactory);
    }
  }
```
- In FSDirectory.java and NIOFSDirectory.java, there are [url](https://bugs.java.com/bugdatabase/view_bug?bug_id=6265734) links describing why NIOFSDirectory is not appropriate way to open file only for Windows. Unfortunately these have no longer been valid url, so I fixed them in this PR.