### PR TITLE
Cover all DataType

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -77,6 +77,8 @@ Other
 
 * GITHUB#14116 Use CDL to block threads to avoid flaky tests. (Ao Li)
 
+* GITHUB#14091: Cover all DataType. (Lu Xugang)
+
 ======================= Lucene 10.1.0 =======================
 
 API Changes

--- a/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
@@ -986,7 +986,7 @@ public class TestPackedInts extends LuceneTestCase {
         new long[RandomNumbers.randomIntBetween(random(), 1, TEST_NIGHTLY ? 1000000 : 10000)];
     float[] ratioOptions = new float[] {PackedInts.DEFAULT, PackedInts.COMPACT, PackedInts.FAST};
     for (int bpv : new int[] {0, 1, 63, 64, RandomNumbers.randomIntBetween(random(), 2, 62)}) {
-      for (DataType dataType : Arrays.asList(DataType.DELTA_PACKED)) {
+      for (DataType dataType : DataType.values()) {
         final int pageSize = 1 << TestUtil.nextInt(random(), 6, 20);
         float acceptableOverheadRatio =
             ratioOptions[TestUtil.nextInt(random(), 0, ratioOptions.length - 1)];


### PR DESCRIPTION
A change made ten years ago—did you forget to change `DataType.PACKED` back to `DataType.values()`? 😊  @jpountz  