### PR TITLE
Improve use of generics in DisjunctionMaxQuery construction

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
@@ -53,14 +53,14 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
   /**
    * Creates a new DisjunctionMaxQuery
    *
-   * @param disjuncts a {@code Collection<Query>} of all the disjuncts to add
+   * @param disjuncts a collection of all the disjunct queries to add
    * @param tieBreakerMultiplier the score of each non-maximum disjunct for a document is multiplied
    *     by this weight and added into the final score. If non-zero, the value should be small, on
    *     the order of 0.1, which says that 10 occurrences of word in a lower-scored field that is
    *     also in a higher scored field is just as good as a unique word in the lower scored field
    *     (i.e., one that is not in any higher scored field.
    */
-  public DisjunctionMaxQuery(Collection<Query> disjuncts, float tieBreakerMultiplier) {
+  public DisjunctionMaxQuery(Collection<? extends Query> disjuncts, float tieBreakerMultiplier) {
     Objects.requireNonNull(disjuncts, "Collection of Querys must not be null");
     if (tieBreakerMultiplier < 0 || tieBreakerMultiplier > 1) {
       throw new IllegalArgumentException("tieBreakerMultiplier must be in [0, 1]");

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -638,6 +638,7 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
   }
 
   // Non-functional. Compile only - to ensure generics and type inference play nicely together
+  @SuppressWarnings("unused")
   public void testGenerics() {
     var dmq1 =
         new DisjunctionMaxQuery(

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -47,6 +47,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.CheckHits;
 import org.apache.lucene.tests.search.QueryUtils;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.Ignore;
 
 /** Test of the DisjunctionMaxQuery. */
 @LuceneTestCase.SuppressCodecs("SimpleText")
@@ -637,18 +638,19 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
     dir.close();
   }
 
-  // Non-functional. Compile only - to ensure generics and type inference play nicely together
-  @SuppressWarnings("unused")
+  // Ensure generics and type inference play nicely together
   public void testGenerics() {
-    var dmq1 =
+    var query =
         new DisjunctionMaxQuery(
             Arrays.stream(new String[] {"term"}).map((term) -> tq("test", term)).toList(), 1.0f);
+    assertEquals(1, query.getDisjuncts().size());
 
     var disjuncts =
         List.of(
             new RegexpQuery(new Term("field", "foobar")),
             new WildcardQuery(new Term("field", "foobar")));
-    var dmq2 = new DisjunctionMaxQuery(disjuncts, 1.0f);
+    query = new DisjunctionMaxQuery(disjuncts, 1.0f);
+    assertEquals(2, query.getDisjuncts().size());
   }
 
   /** macro */

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -47,7 +47,6 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.CheckHits;
 import org.apache.lucene.tests.search.QueryUtils;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Ignore;
 
 /** Test of the DisjunctionMaxQuery. */
 @LuceneTestCase.SuppressCodecs("SimpleText")

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -637,13 +637,26 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
     dir.close();
   }
 
+  // Non-functional. Compile only - to ensure generics and type inference play nicely together
+  public void testGenerics() {
+    var dmq1 =
+        new DisjunctionMaxQuery(
+            Arrays.stream(new String[] {"term"}).map((term) -> tq("test", term)).toList(), 1.0f);
+
+    var disjuncts =
+        List.of(
+            new RegexpQuery(new Term("field", "foobar")),
+            new WildcardQuery(new Term("field", "foobar")));
+    var dmq2 = new DisjunctionMaxQuery(disjuncts, 1.0f);
+  }
+
   /** macro */
-  protected Query tq(String f, String t) {
+  protected TermQuery tq(String f, String t) {
     return new TermQuery(new Term(f, t));
   }
 
   /** macro */
-  protected Query tq(String f, String t, float b) {
+  protected BoostQuery tq(String f, String t, float b) {
     Query q = tq(f, t);
     return new BoostQuery(q, b);
   }


### PR DESCRIPTION
This is a small usability improvement which allows construction of a DisjunctionMaxQuery to play nicer with type inference. Follows PECS.