### PR TITLE
Use github wf to add module labels for PR based on file changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,133 @@
+# This file defines module label mappings for the Lucene project.
+# Each module is associated with a set of file globs that, when matched,
+# will trigger the corresponding label to be applied to pull requests.
+#
+# This configuration is used by the workflow defined in .github/workflows/label-pull-request.yml.
+# If we are adding new labels or refactoring modules, we will need to modify this file globs here to ensure that the correct labels are applied.
+
+# For more information on how to define globs, visit: https://github.com/actions/labeler
+
+module:analysis:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/analysis/**'
+
+module:benchmark:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/benchmark/**'
+
+module:classification:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/classification/**'
+
+module:core/codecs:
+  - changed-files:
+      - any-glob-to-any-file: ['lucene/core/src/java/org/apache/lucene/codecs/**', 'lucene/core/src/test/org/apache/lucene/codecs/**']
+
+module:core/FSTs:
+  - changed-files:
+      - any-glob-to-any-file: ['lucene/core/src/java/org/apache/lucene/util/fst/**', 'lucene/core/src/test/org/apache/lucene/util/fst/**']
+
+module:core/hnsw:
+  - changed-files:
+      - any-glob-to-any-file: ['lucene/core/src/java/org/apache/lucene/util/hnsw/**', 'lucene/core/src/test/org/apache/lucene/util/hnsw/**']
+
+module:core/index:
+  - changed-files:
+      - any-glob-to-any-file: ['lucene/core/src/java/org/apache/lucene/index/**', 'lucene/core/src/test/org/apache/lucene/index/**']
+
+module:core/search:
+  - changed-files:
+      - any-glob-to-any-file: ['lucene/core/src/java/org/apache/lucene/search/**', 'lucene/core/src/test/org/apache/lucene/search/**']
+
+module:core/store:
+  - changed-files:
+      - any-glob-to-any-file: ['lucene/core/src/java/org/apache/lucene/store/**', 'lucene/core/src/test/org/apache/lucene/store/**']
+
+module:core/other:
+  - changed-files:
+      - any-glob-to-any-file: ['lucene/core/**']
+      - all-globs-to-all-files:
+            - '!lucene/core/src/java/org/apache/lucene/codecs/**'
+            - '!lucene/core/src/test/org/apache/lucene/codecs/**'
+            - '!lucene/core/src/java/org/apache/lucene/util/fst/**'
+            - '!lucene/core/src/test/org/apache/lucene/util/fst/**'
+            - '!lucene/core/src/java/org/apache/lucene/util/hnsw/**'
+            - '!lucene/core/src/test/org/apache/lucene/util/hnsw/**'
+            - '!lucene/core/src/java/org/apache/lucene/index/**'
+            - '!lucene/core/src/test/org/apache/lucene/index/**'
+            - '!lucene/core/src/java/org/apache/lucene/search/**'
+            - '!lucene/core/src/test/org/apache/lucene/search/**'
+            - '!lucene/core/src/java/org/apache/lucene/store/**'
+            - '!lucene/core/src/test/org/apache/lucene/store/**'
+
+module:demo:
+    - changed-files:
+        - any-glob-to-any-file: 'lucene/demo/**'
+
+module:expressions:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/expressions/**'
+
+module:facet:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/facet/**'
+
+module:grouping:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/grouping/**'
+
+module:highlighter:
+    - changed-files:
+        - any-glob-to-any-file: 'lucene/highlighter/**'
+
+module:join:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/join/**'
+
+module:luke:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/luke/**'
+
+module:misc:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/misc/**'
+
+module:monitor:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/monitor/**'
+
+module:queries:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/queries/**'
+
+module:queryparser:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/queryparser/**'
+
+module:replicator:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/replicator/**'
+
+module:sandbox:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/sandbox/**'
+
+module:spatial:
+    - changed-files:
+        - any-glob-to-any-file: ['lucene/spatial-test-fixtures/**']
+
+module:spatial3d:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/spatial3d/**'
+
+module:spatial-extras:
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/spatial-extras/**'
+
+module:suggest:
+    - changed-files:
+        - any-glob-to-any-file: 'lucene/suggest/**'
+
+module:test-framework:
+    - changed-files:
+        - any-glob-to-any-file: 'lucene/test-framework/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -44,25 +44,26 @@ module:core/store:
       - any-glob-to-any-file: ['lucene/core/src/java/org/apache/lucene/store/**', 'lucene/core/src/test/org/apache/lucene/store/**']
 
 module:core/other:
-  - changed-files:
-      - any-glob-to-any-file: ['lucene/core/**']
-      - all-globs-to-all-files:
-            - '!lucene/core/src/java/org/apache/lucene/codecs/**'
-            - '!lucene/core/src/test/org/apache/lucene/codecs/**'
-            - '!lucene/core/src/java/org/apache/lucene/util/fst/**'
-            - '!lucene/core/src/test/org/apache/lucene/util/fst/**'
-            - '!lucene/core/src/java/org/apache/lucene/util/hnsw/**'
-            - '!lucene/core/src/test/org/apache/lucene/util/hnsw/**'
-            - '!lucene/core/src/java/org/apache/lucene/index/**'
-            - '!lucene/core/src/test/org/apache/lucene/index/**'
-            - '!lucene/core/src/java/org/apache/lucene/search/**'
-            - '!lucene/core/src/test/org/apache/lucene/search/**'
-            - '!lucene/core/src/java/org/apache/lucene/store/**'
-            - '!lucene/core/src/test/org/apache/lucene/store/**'
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: ['lucene/core/**']
+          - all-globs-to-all-files:
+              - '!lucene/core/src/java/org/apache/lucene/codecs/**'
+              - '!lucene/core/src/test/org/apache/lucene/codecs/**'
+              - '!lucene/core/src/java/org/apache/lucene/util/fst/**'
+              - '!lucene/core/src/test/org/apache/lucene/util/fst/**'
+              - '!lucene/core/src/java/org/apache/lucene/util/hnsw/**'
+              - '!lucene/core/src/test/org/apache/lucene/util/hnsw/**'
+              - '!lucene/core/src/java/org/apache/lucene/index/**'
+              - '!lucene/core/src/test/org/apache/lucene/index/**'
+              - '!lucene/core/src/java/org/apache/lucene/search/**'
+              - '!lucene/core/src/test/org/apache/lucene/search/**'
+              - '!lucene/core/src/java/org/apache/lucene/store/**'
+              - '!lucene/core/src/test/org/apache/lucene/store/**'
 
 module:demo:
-    - changed-files:
-        - any-glob-to-any-file: 'lucene/demo/**'
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/demo/**'
 
 module:expressions:
   - changed-files:
@@ -77,8 +78,8 @@ module:grouping:
       - any-glob-to-any-file: 'lucene/grouping/**'
 
 module:highlighter:
-    - changed-files:
-        - any-glob-to-any-file: 'lucene/highlighter/**'
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/highlighter/**'
 
 module:join:
   - changed-files:
@@ -113,21 +114,17 @@ module:sandbox:
       - any-glob-to-any-file: 'lucene/sandbox/**'
 
 module:spatial:
-    - changed-files:
-        - any-glob-to-any-file: ['lucene/spatial-test-fixtures/**']
+  - changed-files:
+      - any-glob-to-any-file: ['lucene/spatial-extras/**', 'lucene/spatial-test-fixtures/**']
 
 module:spatial3d:
   - changed-files:
       - any-glob-to-any-file: 'lucene/spatial3d/**'
 
-module:spatial-extras:
-  - changed-files:
-      - any-glob-to-any-file: 'lucene/spatial-extras/**'
-
 module:suggest:
-    - changed-files:
-        - any-glob-to-any-file: 'lucene/suggest/**'
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/suggest/**'
 
 module:test-framework:
-    - changed-files:
-        - any-glob-to-any-file: 'lucene/test-framework/**'
+  - changed-files:
+      - any-glob-to-any-file: 'lucene/test-framework/**'

--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -1,0 +1,23 @@
+# This file defines the workflow for labeling pull requests with module tags based on the changed files in the PR.
+# It uses the `actions/labeler` GitHub Action to achieve the same.
+#
+# The workflow is triggered on the `pull_request_target` event which ensures workflow is only run from the master branch.
+# The job `labeler` runs on `ubuntu-latest` and has permissions to read contents and write pull requests.
+#
+# For more information on the `actions/labeler` GitHub Action, refer to https://github.com/actions/labeler
+
+name: "Pull Request Labeler"
+run-name: Labelling pull request with module tags based on changed files in the PR
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true


### PR DESCRIPTION
### Description
Adds a new bot to automate labelling of pull requests with module tags based on file changes.
This bot uses `.github/labeler.yml` file to maintain mapping for module labels to corresponding regex paths to track. 

This workflow is triggered using `pull_request_target` event which provides necessary write permission for adding labels to PRs. More details around this event: [StackOverflow](https://stackoverflow.com/questions/74957218/what-is-the-difference-between-pull-request-and-pull-request-target-event-in-git)

### Testing
Tested changes by creating pr on my own fork. https://github.com/pseudo-nymous/lucene/pull/2

Further testing with sync flag: https://github.com/pseudo-nymous/lucene/pull/3

Closes #13897