### PR TITLE
prefetch may select the wrong memory segment for multi-segment slices

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -60,7 +60,9 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+
+* GITHUB#14109: prefetch may select the wrong memory segment for
+  multi-segment slices. (Chris Hegarty)
 
 Other
 ---------------------

--- a/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -337,8 +337,6 @@ abstract class MemorySegmentIndexInput extends IndexInput
 
     ensureOpen();
 
-    Objects.checkFromIndexSize(offset, length, length());
-
     if (BitUtil.isZeroOrPowerOfTwo(consecutivePrefetchHitCount++) == false) {
       // We've had enough consecutive hits on the page cache that this number is neither zero nor a
       // power of two. There is a good chance that a good chunk of this index input is cached in
@@ -380,8 +378,6 @@ abstract class MemorySegmentIndexInput extends IndexInput
     }
 
     ensureOpen();
-
-    Objects.checkFromIndexSize(offset, length, length());
 
     final NativeAccess nativeAccess = NATIVE_ACCESS.get();
 
@@ -818,6 +814,12 @@ abstract class MemorySegmentIndexInput extends IndexInput
         throw handlePositionalIOOBE(e, "segmentSliceOrNull", pos);
       }
     }
+
+    @Override
+    public void prefetch(long offset, long length) throws IOException {
+      Objects.checkFromIndexSize(offset, length, this.length);
+      super.prefetch(offset, length);
+    }
   }
 
   /** This class adds offset support to MemorySegmentIndexInput, which is needed for slices. */
@@ -902,6 +904,12 @@ abstract class MemorySegmentIndexInput extends IndexInput
     @Override
     MemorySegmentIndexInput buildSlice(String sliceDescription, long ofs, long length) {
       return super.buildSlice(sliceDescription, this.offset + ofs, length);
+    }
+
+    @Override
+    public void prefetch(long offset, long length) throws IOException {
+      Objects.checkFromIndexSize(offset, length, this.length);
+      super.prefetch(this.offset + offset, length);
     }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
@@ -329,4 +329,42 @@ public class TestMMapDirectory extends BaseDirectoryTestCase {
     assertFalse(func.apply("segment.si").isPresent());
     assertFalse(func.apply("_51a.si").isPresent());
   }
+
+  public void testPrefetchWithSingleSegment() throws IOException {
+    testPrefetchWithSegments(64 * 1024);
+  }
+
+  public void testPrefetchWithMultiSegment() throws IOException {
+    testPrefetchWithSegments(16 * 1024);
+  }
+
+  static final Class<IndexOutOfBoundsException> IOOBE = IndexOutOfBoundsException.class;
+
+  // does not verify that the actual segment is prefetched, but rather exercises the code and bounds
+  void testPrefetchWithSegments(int maxChunkSize) throws IOException {
+    byte[] bytes = new byte[(maxChunkSize * 2) + 1];
+    try (Directory dir =
+        new MMapDirectory(createTempDir("testPrefetchWithSegments"), maxChunkSize)) {
+      try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+        out.writeBytes(bytes, 0, bytes.length);
+      }
+
+      try (var in = dir.openInput("test", IOContext.READONCE)) {
+        in.prefetch(0, in.length());
+        expectThrows(IOOBE, () -> in.prefetch(1, in.length()));
+        expectThrows(IOOBE, () -> in.prefetch(in.length(), 1));
+
+        var slice1 = in.slice("slice-1", 1, in.length() - 1);
+        slice1.prefetch(0, slice1.length());
+        expectThrows(IOOBE, () -> slice1.prefetch(1, slice1.length()));
+        expectThrows(IOOBE, () -> slice1.prefetch(slice1.length(), 1));
+
+        // we sliced off all but one byte from the first complete memory segment
+        var slice2 = in.slice("slice-2", maxChunkSize - 1, in.length() - maxChunkSize + 1);
+        slice2.prefetch(0, slice2.length());
+        expectThrows(IOOBE, () -> slice2.prefetch(1, slice2.length()));
+        expectThrows(IOOBE, () -> slice2.prefetch(slice2.length(), 1));
+      }
+    }
+  }
 }


### PR DESCRIPTION
This commit fixes a bug where by prefetch may select the wrong memory segment for multi-segment slices.

The issue was discovered when debugging a large test scenario, where the index input was backed by several memory segments. When sliced, a multi-segment index input uses an offset into the initial memory segment. This offset should be added to the prefetch offset to determine the absolute offset. The unfortunate part is that the bounds checks need to either be moved to the subclasses, or somehow coerced to look at segment byteSizes rather than length. I found the former to be more straightforward.