### PR TITLE
fix for gh#14110: stablize BpVectorReordered heuristic

### DIFF
--- a/lucene/misc/src/java/org/apache/lucene/misc/index/BpVectorReorderer.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/index/BpVectorReorderer.java
@@ -311,10 +311,8 @@ public class BpVectorReorderer extends AbstractBPReorderer {
               depth,
               vectorScore)
           .compute();
-
-      float scale =
-          VectorUtil.dotProduct(leftCentroid, leftCentroid)
-              + VectorUtil.dotProduct(rightCentroid, rightCentroid);
+      vectorSubtract(leftCentroid, rightCentroid, scratch);
+      float scale = (float) Math.sqrt(VectorUtil.dotProduct(scratch, scratch));
       float maxLeftBias = Float.NEGATIVE_INFINITY;
       for (int i = ids.offset; i < midPoint; ++i) {
         maxLeftBias = Math.max(maxLeftBias, biases[i]);

--- a/lucene/misc/src/test/org/apache/lucene/misc/index/TestBpVectorReorderer.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/index/TestBpVectorReorderer.java
@@ -62,7 +62,7 @@ public class TestBpVectorReorderer extends LuceneTestCase {
   }
 
   private void createQuantizedIndex(Directory dir, List<float[]> vectors) throws IOException {
-    IndexWriterConfig cfg = newIndexWriterConfig();
+    IndexWriterConfig cfg = new IndexWriterConfig();
     cfg.setCodec(
         new Lucene101Codec() {
           @Override


### PR DESCRIPTION
It turned out that the initial shuffled order resulted in a left / right split with centroids that were very close together, the heuristic would terminate without doing any swaps, causing the test to fail. The test assumes that at least one swap will happen in the first iteration level. I changed the heuristic to be based on the size of the difference between the two centroids rather than the sum of their sizes.
