### PR TITLE
Preserve max-conn when merging onto existing graph Fixes gh#14118

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
@@ -452,11 +452,12 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
     meta.writeVLong(vectorIndexLength);
     meta.writeVInt(field.getVectorDimension());
     meta.writeInt(count);
-    meta.writeVInt(M);
     // write graph nodes on each level
     if (graph == null) {
+      meta.writeVInt(M);
       meta.writeVInt(0);
     } else {
+      meta.writeVInt(graph.maxConn());
       meta.writeVInt(graph.numLevels());
       long valueCount = 0;
       for (int level = 0; level < graph.numLevels(); level++) {


### PR DESCRIPTION
preserve the HNSW graph max-conn when writing
