### PR TITLE
DirectIOIndexInput - add overloads for bulk retrieval

### DIFF
--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -464,6 +464,63 @@ public class DirectIODirectory extends FilterDirectory {
     }
 
     @Override
+    public void readInts(int[] dst, int offset, int len) throws IOException {
+      int remainingDst = len;
+      while (remainingDst > 0) {
+        int cnt = Math.min(buffer.remaining() / Integer.BYTES, remainingDst);
+        buffer.asIntBuffer().get(dst, offset + len - remainingDst, cnt);
+        buffer.position(buffer.position() + Integer.BYTES * cnt);
+        remainingDst -= cnt;
+        if (remainingDst > 0) {
+          if (buffer.hasRemaining()) {
+            dst[offset + len - remainingDst] = readInt();
+            --remainingDst;
+          } else {
+            refill(remainingDst * Integer.BYTES);
+          }
+        }
+      }
+    }
+
+    @Override
+    public void readFloats(float[] dst, int offset, int len) throws IOException {
+      int remainingDst = len;
+      while (remainingDst > 0) {
+        int cnt = Math.min(buffer.remaining() / Float.BYTES, remainingDst);
+        buffer.asFloatBuffer().get(dst, offset + len - remainingDst, cnt);
+        buffer.position(buffer.position() + Float.BYTES * cnt);
+        remainingDst -= cnt;
+        if (remainingDst > 0) {
+          if (buffer.hasRemaining()) {
+            dst[offset + len - remainingDst] = Float.intBitsToFloat(readInt());
+            --remainingDst;
+          } else {
+            refill(remainingDst * Float.BYTES);
+          }
+        }
+      }
+    }
+
+    @Override
+    public void readLongs(long[] dst, int offset, int len) throws IOException {
+      int remainingDst = len;
+      while (remainingDst > 0) {
+        int cnt = Math.min(buffer.remaining() / Long.BYTES, remainingDst);
+        buffer.asLongBuffer().get(dst, offset + len - remainingDst, cnt);
+        buffer.position(buffer.position() + Long.BYTES * cnt);
+        remainingDst -= cnt;
+        if (remainingDst > 0) {
+          if (buffer.hasRemaining()) {
+            dst[offset + len - remainingDst] = readLong();
+            --remainingDst;
+          } else {
+            refill(remainingDst * Long.BYTES);
+          }
+        }
+      }
+    }
+
+    @Override
     public DirectIOIndexInput clone() {
       try {
         return new DirectIOIndexInput(this);


### PR DESCRIPTION
This commit adds overloads for bulk retrieval to DirectIOIndexInput. The implementation of these methods is identical to that of BufferedIndexInput, and it already covered by existing tests.

relates: #14106