### PR TITLE
Add nullability annotations to IndexSearcher APIs

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -581,7 +581,8 @@ public class IndexSearcher {
    * @throws TooManyClauses If a query would exceed {@link IndexSearcher#getMaxClauseCount()}
    *     clauses.
    */
-  public TopDocs searchAfter(@Nullable ScoreDoc after, Query query, int numHits) throws IOException {
+  public TopDocs searchAfter(@Nullable ScoreDoc after, Query query, int numHits)
+      throws IOException {
     final int limit = Math.max(1, reader.maxDoc());
     if (after != null && after.doc >= limit) {
       throw new IllegalArgumentException(
@@ -714,7 +715,8 @@ public class IndexSearcher {
   }
 
   private TopFieldDocs searchAfter(
-      @Nullable FieldDoc after, Query query, int numHits, Sort sort, boolean doDocScores) throws IOException {
+      @Nullable FieldDoc after, Query query, int numHits, Sort sort, boolean doDocScores)
+      throws IOException {
     final int limit = Math.max(1, reader.maxDoc());
     if (after != null && after.doc >= limit) {
       throw new IllegalArgumentException(

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -42,6 +42,7 @@ import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.Nullable;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 
 /**
@@ -198,7 +199,7 @@ public class IndexSearcher {
    *
    * @lucene.experimental
    */
-  public IndexSearcher(IndexReader r, Executor executor) {
+  public IndexSearcher(IndexReader r, @Nullable Executor executor) {
     this(r.getContext(), executor);
   }
 
@@ -215,7 +216,7 @@ public class IndexSearcher {
    * @see IndexReader#getContext()
    * @lucene.experimental
    */
-  public IndexSearcher(IndexReaderContext context, Executor executor) {
+  public IndexSearcher(IndexReaderContext context, @Nullable Executor executor) {
     assert context.isTopLevel
         : "IndexSearcher's ReaderContext must be topLevel for reader " + context.reader();
     reader = context.reader();
@@ -580,7 +581,7 @@ public class IndexSearcher {
    * @throws TooManyClauses If a query would exceed {@link IndexSearcher#getMaxClauseCount()}
    *     clauses.
    */
-  public TopDocs searchAfter(ScoreDoc after, Query query, int numHits) throws IOException {
+  public TopDocs searchAfter(@Nullable ScoreDoc after, Query query, int numHits) throws IOException {
     final int limit = Math.max(1, reader.maxDoc());
     if (after != null && after.doc >= limit) {
       throw new IllegalArgumentException(
@@ -713,7 +714,7 @@ public class IndexSearcher {
   }
 
   private TopFieldDocs searchAfter(
-      FieldDoc after, Query query, int numHits, Sort sort, boolean doDocScores) throws IOException {
+      @Nullable FieldDoc after, Query query, int numHits, Sort sort, boolean doDocScores) throws IOException {
     final int limit = Math.max(1, reader.maxDoc());
     if (after != null && after.doc >= limit) {
       throw new IllegalArgumentException(
@@ -1131,6 +1132,7 @@ public class IndexSearcher {
    *
    * @lucene.experimental
    */
+  @Nullable
   public CollectionStatistics collectionStatistics(String field) throws IOException {
     assert field != null;
     long docCount = 0;

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollectorManager.java
@@ -77,7 +77,8 @@ public class TopFieldCollectorManager implements CollectorManager<TopFieldCollec
    *     count of the result will be accurate. {@link Integer#MAX_VALUE} may be used to make the hit
    *     count accurate, but this will also make query processing slower.
    */
-  public TopFieldCollectorManager(Sort sort, int numHits, @Nullable FieldDoc after, int totalHitsThreshold) {
+  public TopFieldCollectorManager(
+      Sort sort, int numHits, @Nullable FieldDoc after, int totalHitsThreshold) {
     if (totalHitsThreshold < 0) {
       throw new IllegalArgumentException(
           "totalHitsThreshold must be >= 0, got " + totalHitsThreshold);

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollectorManager.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.apache.lucene.util.Nullable;
 
 /**
  * Create a TopFieldCollectorManager which uses a shared hit counter to maintain number of hits and
@@ -76,7 +77,7 @@ public class TopFieldCollectorManager implements CollectorManager<TopFieldCollec
    *     count of the result will be accurate. {@link Integer#MAX_VALUE} may be used to make the hit
    *     count accurate, but this will also make query processing slower.
    */
-  public TopFieldCollectorManager(Sort sort, int numHits, FieldDoc after, int totalHitsThreshold) {
+  public TopFieldCollectorManager(Sort sort, int numHits, @Nullable FieldDoc after, int totalHitsThreshold) {
     if (totalHitsThreshold < 0) {
       throw new IllegalArgumentException(
           "totalHitsThreshold must be >= 0, got " + totalHitsThreshold);

--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollectorManager.java
@@ -83,7 +83,8 @@ public class TopScoreDocCollectorManager
    *     count of the result will be accurate. {@link Integer#MAX_VALUE} may be used to make the hit
    *     count accurate, but this will also make query processing slower.
    */
-  public TopScoreDocCollectorManager(int numHits, @Nullable ScoreDoc after, int totalHitsThreshold) {
+  public TopScoreDocCollectorManager(
+      int numHits, @Nullable ScoreDoc after, int totalHitsThreshold) {
     if (totalHitsThreshold < 0) {
       throw new IllegalArgumentException(
           "totalHitsThreshold must be >= 0, got " + totalHitsThreshold);

--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollectorManager.java
@@ -18,6 +18,7 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Collection;
+import org.apache.lucene.util.Nullable;
 
 /**
  * Create a TopScoreDocCollectorManager which uses a shared hit counter to maintain number of hits
@@ -57,7 +58,7 @@ public class TopScoreDocCollectorManager
    */
   @Deprecated
   public TopScoreDocCollectorManager(
-      int numHits, ScoreDoc after, int totalHitsThreshold, boolean supportsConcurrency) {
+      int numHits, @Nullable ScoreDoc after, int totalHitsThreshold, boolean supportsConcurrency) {
     this(numHits, after, totalHitsThreshold);
   }
 
@@ -82,7 +83,7 @@ public class TopScoreDocCollectorManager
    *     count of the result will be accurate. {@link Integer#MAX_VALUE} may be used to make the hit
    *     count accurate, but this will also make query processing slower.
    */
-  public TopScoreDocCollectorManager(int numHits, ScoreDoc after, int totalHitsThreshold) {
+  public TopScoreDocCollectorManager(int numHits, @Nullable ScoreDoc after, int totalHitsThreshold) {
     if (totalHitsThreshold < 0) {
       throw new IllegalArgumentException(
           "totalHitsThreshold must be >= 0, got " + totalHitsThreshold);

--- a/lucene/core/src/java/org/apache/lucene/util/Nullable.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Nullable.java
@@ -1,4 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.util;
 
-public @interface Nullable {
-}
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a type to indicate that it is allowed to take {@code null} as a valid value.
+ *
+ * @lucene.internal
+ */
+@Documented
+@Target(ElementType.TYPE_USE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Nullable {}

--- a/lucene/core/src/java/org/apache/lucene/util/Nullable.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Nullable.java
@@ -1,0 +1,4 @@
+package org.apache.lucene.util;
+
+public @interface Nullable {
+}


### PR DESCRIPTION
Annotate public APIs with an internal definition of `@Nullable` where appropriate.

This proposal is a follow up from the discussion [here](https://lists.apache.org/thread/oh09k7nlvntzf49gx7d399d1chdk1z0n). This change adds an internal copy of JSpecify's `@Nullable` to lucene-util and uses Intellij's "infer nullability" feature to automatically apply the annotation to `IndexSearcher` and its dependencies. If this looks good, there will be a follow up PR to automatically annotate other APIs.

The motivation for this change is to increase the null safety of downstream projects using Lucene by allowing users to configure a javac plugin to lint their build. This change was tested with NullAway, which recognizes any annotation with the simple class name `@Nullable`
