### PR TITLE
Remove `acceptDocs` argument from `DocIdSetIterator#intoBitSet` and introduce `Bits#applyMask`.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -41,6 +41,9 @@ API Changes
 * GITHUB#14069: Added DocIdSetIterator#intoBitSet API to let implementations
   optimize loading doc IDs into a bit set. (Adrien Grand)
 
+* GITHUB#14134: Added Bits#applyMask API to help apply live docs as a mask on a
+  bit set of matches. (Adrien Grand)
+
 New Features
 ---------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
@@ -53,7 +53,6 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.ReadAdvice;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitUtil;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
@@ -878,16 +877,13 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     }
 
     @Override
-    public void intoBitSet(Bits acceptDocs, int upTo, FixedBitSet bitSet, int offset)
-        throws IOException {
+    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
       if (doc >= upTo) {
         return;
       }
 
       // Handle the current doc separately, it may be on the previous docBuffer.
-      if (acceptDocs == null || acceptDocs.get(doc)) {
-        bitSet.set(doc - offset);
-      }
+      bitSet.set(doc - offset);
 
       for (; ; ) {
         if (docBufferUpto == BLOCK_SIZE) {
@@ -898,7 +894,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
         int start = docBufferUpto;
         int end = computeBufferEndBoundary(upTo);
         if (end != 0) {
-          bufferIntoBitSet(start, end, acceptDocs, bitSet, offset);
+          bufferIntoBitSet(start, end, bitSet, offset);
           doc = docBuffer[end - 1];
         }
         docBufferUpto = end;
@@ -922,15 +918,12 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
       }
     }
 
-    private void bufferIntoBitSet(
-        int start, int end, Bits acceptDocs, FixedBitSet bitSet, int offset) throws IOException {
-      // acceptDocs#get (if backed by FixedBitSet), bitSet#set and `doc - offset` get
-      // auto-vectorized
+    private void bufferIntoBitSet(int start, int end, FixedBitSet bitSet, int offset)
+        throws IOException {
+      // bitSet#set and `doc - offset` get auto-vectorized
       for (int i = start; i < end; ++i) {
         int doc = docBuffer[i];
-        if (acceptDocs == null || acceptDocs.get(doc)) {
-          bitSet.set(doc - offset);
-        }
+        bitSet.set(doc - offset);
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/search/DenseConjunctionBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DenseConjunctionBulkScorer.java
@@ -105,7 +105,11 @@ final class DenseConjunctionBulkScorer extends BulkScorer {
     assert clauseWindowMatches.scanIsEmpty();
 
     int offset = lead.docID();
-    lead.intoBitSet(acceptDocs, max, windowMatches, offset);
+    lead.intoBitSet(max, windowMatches, offset);
+    if (acceptDocs != null) {
+      // Apply live docs.
+      acceptDocs.applyMask(windowMatches, offset);
+    }
 
     int upTo = 0;
     for (;
@@ -116,9 +120,7 @@ final class DenseConjunctionBulkScorer extends BulkScorer {
       if (other.docID() < offset) {
         other.advance(offset);
       }
-      // No need to apply acceptDocs on other clauses since we already applied live docs on the
-      // leading clause.
-      other.intoBitSet(null, max, clauseWindowMatches, offset);
+      other.intoBitSet(max, clauseWindowMatches, offset);
       windowMatches.and(clauseWindowMatches);
       clauseWindowMatches.clear();
     }

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionDISIApproximation.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionDISIApproximation.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 
 /**
@@ -150,17 +149,16 @@ public final class DisjunctionDISIApproximation extends DocIdSetIterator {
   }
 
   @Override
-  public void intoBitSet(Bits acceptDocs, int upTo, FixedBitSet bitSet, int offset)
-      throws IOException {
+  public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
     while (leadTop.doc < upTo) {
-      leadTop.approximation.intoBitSet(acceptDocs, upTo, bitSet, offset);
+      leadTop.approximation.intoBitSet(upTo, bitSet, offset);
       leadTop.doc = leadTop.approximation.docID();
       leadTop = leadIterators.updateTop();
     }
 
     minOtherDoc = Integer.MAX_VALUE;
     for (DisiWrapper w : otherIterators) {
-      w.approximation.intoBitSet(acceptDocs, upTo, bitSet, offset);
+      w.approximation.intoBitSet(upTo, bitSet, offset);
       w.doc = w.approximation.docID();
       minOtherDoc = Math.min(minOtherDoc, w.doc);
     }

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSetIterator.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 
 /**
@@ -220,9 +219,7 @@ public abstract class DocIdSetIterator {
    *
    * <pre class="prettyprint">
    * for (int doc = docID(); doc &lt; upTo; doc = nextDoc()) {
-   *   if (acceptDocs == null || acceptDocs.get(doc)) {
-   *     bitSet.set(doc - offset);
-   *   }
+   *   bitSet.set(doc - offset);
    * }
    * </pre>
    *
@@ -233,13 +230,10 @@ public abstract class DocIdSetIterator {
    *
    * @lucene.internal
    */
-  public void intoBitSet(Bits acceptDocs, int upTo, FixedBitSet bitSet, int offset)
-      throws IOException {
+  public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
     assert offset <= docID();
     for (int doc = docID(); doc < upTo; doc = nextDoc()) {
-      if (acceptDocs == null || acceptDocs.get(doc)) {
-        bitSet.set(doc - offset);
-      }
+      bitSet.set(doc - offset);
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/BitSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitSetIterator.java
@@ -99,20 +99,13 @@ public class BitSetIterator extends DocIdSetIterator {
   }
 
   @Override
-  public void intoBitSet(Bits acceptDocs, int upTo, FixedBitSet bitSet, int offset)
-      throws IOException {
-    // TODO: Can we also optimize the case when acceptDocs is not null?
-    if (acceptDocs == null
-        && offset < bits.length()
-        && bits instanceof FixedBitSet fixedBits
-        // no bits are set between `offset` and `doc`
-        && fixedBits.nextSetBit(offset) == doc
-        // the whole `bitSet` is getting filled
-        && (upTo - offset == bitSet.length())) {
-      bitSet.orRange(fixedBits, offset);
+  public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+    upTo = Math.min(upTo, bits.length());
+    if (upTo > doc && bits instanceof FixedBitSet fixedBits) {
+      FixedBitSet.orRange(fixedBits, doc, bitSet, doc - offset, upTo - doc);
       advance(upTo); // set the current doc
     } else {
-      super.intoBitSet(acceptDocs, upTo, bitSet, offset);
+      super.intoBitSet(upTo, bitSet, offset);
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/Bits.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Bits.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.util;
 
+import org.apache.lucene.search.DocIdSetIterator;
+
 /**
  * Interface for Bitset-like structures.
  *
@@ -33,6 +35,32 @@ public interface Bits {
 
   /** Returns the number of bits in this set */
   int length();
+
+  /**
+   * Apply this {@code Bits} instance to the given {@link FixedBitSet}, which starts at the given
+   * {@code offset}.
+   *
+   * <p>This should behave the same way as the default implementation, which does the following:
+   *
+   * <pre class="prettyprint">
+   * for (int i = bitSet.nextSetBit(0);
+   *     i != DocIdSetIterator.NO_MORE_DOCS;
+   *     i = i + 1 >= bitSet.length() ? DocIdSetIterator.NO_MORE_DOCS : bitSet.nextSetBit(i + 1)) {
+   *   if (get(offset + i) == false) {
+   *     bitSet.clear(i);
+   *   }
+   * }
+   * </pre>
+   */
+  default void applyMask(FixedBitSet bitSet, int offset) {
+    for (int i = bitSet.nextSetBit(0);
+        i != DocIdSetIterator.NO_MORE_DOCS;
+        i = i + 1 >= bitSet.length() ? DocIdSetIterator.NO_MORE_DOCS : bitSet.nextSetBit(i + 1)) {
+      if (get(offset + i) == false) {
+        bitSet.clear(i);
+      }
+    }
+  }
 
   Bits[] EMPTY_ARRAY = new Bits[0];
 

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -18,6 +18,7 @@ package org.apache.lucene.util;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -346,7 +347,7 @@ public final class FixedBitSet extends BitSet {
     } else {
       checkUnpositioned(iter);
       iter.nextDoc();
-      iter.intoBitSet(null, DocIdSetIterator.NO_MORE_DOCS, this, 0);
+      iter.intoBitSet(DocIdSetIterator.NO_MORE_DOCS, this, 0);
     }
   }
 
@@ -364,40 +365,150 @@ public final class FixedBitSet extends BitSet {
     }
   }
 
+  /** Read {@code numBits} (between 1 and 63) bits from {@code bitSet} at {@code from}. */
+  private static long readNBits(long[] bitSet, int from, int numBits) {
+    assert numBits > 0 && numBits < Long.SIZE;
+    long bits = bitSet[from >> 6] >>> from;
+    int numBitsSoFar = Long.SIZE - (from & 0x3F);
+    if (numBitsSoFar < numBits) {
+      bits |= bitSet[(from >> 6) + 1] << -from;
+    }
+    return bits & ((1L << numBits) - 1);
+  }
+
   /**
-   * Or {@code min(length(), other.length() - from} bits starting at {@code from} from {@code other}
-   * into this bit set starting at 0.
+   * Or {@code length} bits starting at {@code sourceFrom} from {@code source} into {@code dest}
+   * starting at {@code destFrom}.
    */
-  void orRange(FixedBitSet other, int from) {
-    int numBits = Math.min(length(), other.length() - from);
-    if (numBits <= 0) {
+  public static void orRange(
+      FixedBitSet source, int sourceFrom, FixedBitSet dest, int destFrom, int length) {
+    assert length >= 0;
+    Objects.checkFromIndexSize(sourceFrom, length, source.length());
+    Objects.checkFromIndexSize(destFrom, length, dest.length());
+
+    if (length == 0) {
       return;
     }
-    int numFullWords = numBits >> 6;
-    long[] otherBits = other.getBits();
-    int wordOffset = from >> 6;
-    if ((from & 0x3F) == 0) {
-      // from is aligned with a long[]
+
+    long[] sourceBits = source.getBits();
+    long[] destBits = dest.getBits();
+
+    // First, align `destFrom` with a word start, ie. a multiple of Long.SIZE (64)
+    if ((destFrom & 0x3F) != 0) {
+      int numBitsNeeded = Math.min(-destFrom & 0x3F, length);
+      long bits = readNBits(sourceBits, sourceFrom, numBitsNeeded) << destFrom;
+      destBits[destFrom >> 6] |= bits;
+
+      sourceFrom += numBitsNeeded;
+      destFrom += numBitsNeeded;
+      length -= numBitsNeeded;
+    }
+
+    if (length == 0) {
+      return;
+    }
+
+    assert (destFrom & 0x3F) == 0;
+
+    // Now OR at the word level
+    int numFullWords = length >> 6;
+    int sourceWordFrom = sourceFrom >> 6;
+    int destWordFrom = destFrom >> 6;
+
+    // Note: these two for loops auto-vectorize
+    if ((sourceFrom & 0x3F) == 0) {
+      // sourceFrom and destFrom are both aligned with a long[]
       for (int i = 0; i < numFullWords; ++i) {
-        bits[i] |= otherBits[wordOffset + i];
+        destBits[destWordFrom + i] |= sourceBits[sourceWordFrom + i];
       }
     } else {
       for (int i = 0; i < numFullWords; ++i) {
-        bits[i] |= (otherBits[wordOffset + i] >>> from) | (otherBits[wordOffset + i + 1] << -from);
+        destBits[destWordFrom + i] |=
+            (sourceBits[sourceWordFrom + i] >>> sourceFrom)
+                | (sourceBits[sourceWordFrom + i + 1] << -sourceFrom);
       }
     }
 
-    // Handle the remainder
-    for (int i = numFullWords << 6; i < numBits; ++i) {
-      if (other.get(from + i)) {
-        set(i);
+    sourceFrom += numFullWords << 6;
+    destFrom += numFullWords << 6;
+    length -= numFullWords << 6;
+
+    // Finally handle tail bits
+    if (length > 0) {
+      long bits = readNBits(sourceBits, sourceFrom, length);
+      destBits[destFrom >> 6] |= bits;
+    }
+  }
+
+  /**
+   * And {@code length} bits starting at {@code sourceFrom} from {@code source} into {@code dest}
+   * starting at {@code destFrom}.
+   */
+  public static void andRange(
+      FixedBitSet source, int sourceFrom, FixedBitSet dest, int destFrom, int length) {
+    assert length >= 0 : length;
+    Objects.checkFromIndexSize(sourceFrom, length, source.length());
+    Objects.checkFromIndexSize(destFrom, length, dest.length());
+
+    if (length == 0) {
+      return;
+    }
+
+    long[] sourceBits = source.getBits();
+    long[] destBits = dest.getBits();
+
+    // First, align `destFrom` with a word start, ie. a multiple of Long.SIZE (64)
+    if ((destFrom & 0x3F) != 0) {
+      int numBitsNeeded = Math.min(-destFrom & 0x3F, length);
+      long bits = readNBits(sourceBits, sourceFrom, numBitsNeeded) << destFrom;
+      bits |= ~(((1L << numBitsNeeded) - 1) << destFrom);
+      destBits[destFrom >> 6] &= bits;
+
+      sourceFrom += numBitsNeeded;
+      destFrom += numBitsNeeded;
+      length -= numBitsNeeded;
+    }
+
+    if (length == 0) {
+      return;
+    }
+
+    assert (destFrom & 0x3F) == 0;
+
+    // Now AND at the word level
+    int numFullWords = length >> 6;
+    int sourceWordFrom = sourceFrom >> 6;
+    int destWordFrom = destFrom >> 6;
+
+    // Note: these two for loops auto-vectorize
+    if ((sourceFrom & 0x3F) == 0) {
+      // sourceFrom and destFrom are both aligned with a long[]
+      for (int i = 0; i < numFullWords; ++i) {
+        destBits[destWordFrom + i] &= sourceBits[sourceWordFrom + i];
       }
+    } else {
+      for (int i = 0; i < numFullWords; ++i) {
+        destBits[destWordFrom + i] &=
+            (sourceBits[sourceWordFrom + i] >>> sourceFrom)
+                | (sourceBits[sourceWordFrom + i + 1] << -sourceFrom);
+      }
+    }
+
+    sourceFrom += numFullWords << 6;
+    destFrom += numFullWords << 6;
+    length -= numFullWords << 6;
+
+    // Finally handle tail bits
+    if (length > 0) {
+      long bits = readNBits(sourceBits, sourceFrom, length);
+      bits |= (~0L << length);
+      destBits[destFrom >> 6] &= bits;
     }
   }
 
   /** this = this OR other */
   public void or(FixedBitSet other) {
-    orRange(other, 0);
+    orRange(other, 0, this, 0, other.length());
   }
 
   /** this = this XOR other */
@@ -686,5 +797,19 @@ public final class FixedBitSet extends BitSet {
    */
   public Bits asReadOnlyBits() {
     return new FixedBits(bits, numBits);
+  }
+
+  @Override
+  public void applyMask(FixedBitSet bitSet, int offset) {
+    // Note: Some scorers don't track maxDoc and may thus call this method with an offset that is
+    // beyond bitSet.length()
+    int length = Math.min(bitSet.length(), length() - offset);
+    if (length >= 0) {
+      andRange(this, offset, bitSet, 0, length);
+    }
+    if (length < bitSet.length()
+        && bitSet.nextSetBit(Math.max(0, length)) != DocIdSetIterator.NO_MORE_DOCS) {
+      throw new IllegalArgumentException("Some bits are set beyond the end of live docs");
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
@@ -17,9 +17,7 @@
 package org.apache.lucene.util;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Random;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.tests.util.BaseBitSetTestCase;
@@ -646,40 +644,72 @@ public class TestFixedBitSet extends BaseBitSetTestCase<FixedBitSet> {
   }
 
   public void testOrRange() {
-    FixedBitSet set1 = new FixedBitSet(1_000);
-    FixedBitSet set2 = new FixedBitSet(10_000);
-    for (int i = 0; i < set2.length(); i += 3) {
-      set2.set(i);
+    FixedBitSet dest = new FixedBitSet(1_000);
+    FixedBitSet source = new FixedBitSet(10_000);
+    for (int i = 0; i < source.length(); i += 3) {
+      source.set(i);
     }
 
-    // Check different values of `offset`
-    List<Integer> offsets = new ArrayList<>();
-    for (int offset = 64; offset < 128; ++offset) {
-      // Test all possible alignments
-      offsets.add(offset);
-    }
-    for (int offset = set2.length() - 128; offset < set2.length() - 64; ++offset) {
-      // Again, test all possible alignments, but this time we stop or-ing bits when exceeding the
-      // size of set2 rather than set1
-      offsets.add(offset);
-    }
-
-    for (int offset : offsets) {
-      set1.clear();
-      for (int i = 0; i < set1.length(); i += 10) {
-        set1.set(i);
+    // Test all possible alignments, and both a "short" (less than 64) and a long length.
+    for (int sourceFrom = 64; sourceFrom < 128; ++sourceFrom) {
+      for (int destFrom = 256; destFrom < 320; ++destFrom) {
+        for (int length :
+            new int[] {
+              0,
+              TestUtil.nextInt(random(), 1, Long.SIZE - 1),
+              TestUtil.nextInt(random(), Long.SIZE, 512)
+            }) {
+          dest.clear();
+          for (int i = 0; i < dest.length(); i += 10) {
+            dest.set(i);
+          }
+          FixedBitSet.orRange(source, sourceFrom, dest, destFrom, length);
+          for (int i = 0; i < dest.length(); ++i) {
+            boolean destSet = i % 10 == 0;
+            if (i < destFrom || i >= destFrom + length) {
+              // Outside of the range, unmodified
+              assertEquals("" + i, destSet, dest.get(i));
+            } else {
+              boolean sourceSet = source.get(sourceFrom + (i - destFrom));
+              assertEquals(sourceSet || destSet, dest.get(i));
+            }
+          }
+        }
       }
-      set1.orRange(set2, offset);
-      int upTo = Math.min(set1.length(), set2.length() - offset);
-      for (int i = 0; i < set1.length(); ++i) {
-        if (i % 10 == 0 || i >= upTo) {
-          // These bits were set before, they should still be set
-          assertEquals(i % 10 == 0, set1.get(i));
-        } else if ((offset + i) % 3 == 0) {
-          // These bits were set in set1, should be set in set2
-          assertTrue(set1.get(i));
-        } else {
-          assertFalse(set1.get(i));
+    }
+  }
+
+  public void testAndRange() {
+    FixedBitSet dest = new FixedBitSet(1_000);
+    FixedBitSet source = new FixedBitSet(10_000);
+    for (int i = 0; i < source.length(); i += 3) {
+      source.set(i);
+    }
+
+    // Test all possible alignments, and both a "short" (less than 64) and a long length.
+    for (int sourceFrom = 64; sourceFrom < 128; ++sourceFrom) {
+      for (int destFrom = 256; destFrom < 320; ++destFrom) {
+        for (int length :
+            new int[] {
+              0,
+              TestUtil.nextInt(random(), 1, Long.SIZE - 1),
+              TestUtil.nextInt(random(), Long.SIZE, 512)
+            }) {
+          dest.clear();
+          for (int i = 0; i < dest.length(); i += 2) {
+            dest.set(i);
+          }
+          FixedBitSet.andRange(source, sourceFrom, dest, destFrom, length);
+          for (int i = 0; i < dest.length(); ++i) {
+            boolean destSet = i % 2 == 0;
+            if (i < destFrom || i >= destFrom + length) {
+              // Outside of the range, unmodified
+              assertEquals("" + i, destSet, dest.get(i));
+            } else {
+              boolean sourceSet = source.get(sourceFrom + (i - destFrom));
+              assertEquals("" + i, sourceSet && destSet, dest.get(i));
+            }
+          }
         }
       }
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingLiveDocsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingLiveDocsFormat.java
@@ -24,6 +24,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
 
 /** Just like the default live docs format but with additional asserts. */
 public class AssertingLiveDocsFormat extends LiveDocsFormat {
@@ -86,6 +87,12 @@ public class AssertingLiveDocsFormat extends LiveDocsFormat {
     @Override
     public int length() {
       return in.length();
+    }
+
+    @Override
+    public void applyMask(FixedBitSet bitSet, int offset) {
+      assert offset >= 0;
+      in.applyMask(bitSet, offset);
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
@@ -1388,10 +1388,6 @@ public class RandomPostingsTester {
       PostingsEnum pe2 = termsEnum.postings(null, flags);
       FixedBitSet set1 = new FixedBitSet(1024);
       FixedBitSet set2 = new FixedBitSet(1024);
-      FixedBitSet acceptDocs = new FixedBitSet(maxDoc);
-      for (int i = 0; i < maxDoc; i += 2) {
-        acceptDocs.set(i);
-      }
 
       while (true) {
         pe1.nextDoc();
@@ -1400,11 +1396,9 @@ public class RandomPostingsTester {
         int offset =
             TestUtil.nextInt(random, Math.max(0, pe1.docID() - set1.length()), pe1.docID());
         int upTo = offset + random.nextInt(set1.length());
-        pe1.intoBitSet(acceptDocs, upTo, set1, offset);
+        pe1.intoBitSet(upTo, set1, offset);
         for (int d = pe2.docID(); d < upTo; d = pe2.nextDoc()) {
-          if (acceptDocs.get(d)) {
-            set2.set(d - offset);
-          }
+          set2.set(d - offset);
         }
 
         assertEquals(set1, set2);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingScorer.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingScorer.java
@@ -24,7 +24,6 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 
 /** Wraps a Scorer with additional checks */
@@ -196,11 +195,10 @@ public class AssertingScorer extends Scorer {
       }
 
       @Override
-      public void intoBitSet(Bits acceptDocs, int upTo, FixedBitSet bitSet, int offset)
-          throws IOException {
+      public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
         assert docID() != -1;
         assert offset <= docID();
-        in.intoBitSet(acceptDocs, upTo, bitSet, offset);
+        in.intoBitSet(upTo, bitSet, offset);
         assert docID() >= upTo;
       }
     };


### PR DESCRIPTION
Most `DocIdSetIterator` implementations can no longer implement `#intoBitSet` efficiently as soon as there are live docs. So this commit remove this argument and instead introduces a new `Bits#applyMask` API that helps clear bits in a bit set when the corresponding doc ID is not live.

Relates #14133