### PR TITLE
Implement IntersectVisitor#visit(IntsRef) whenever it makes sense

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -61,6 +61,10 @@ Improvements
 
 * GITHUB#14113: Remove unnecessary ByteArrayDataInput allocations from `Lucene90DocValuesProducer$TermsDict.decompressBlock`. (Ankit Jain)
 
+* GITHUB#14138: Implement IntersectVisitor#visit(IntsRef) in  many of the current implementations and add
+  BulkAdder#add(IntRef) method. They should provide better perfromance due to less virtual method calls and
+  more efficient bulk processing. (Ignacio Vera)
+
 Optimizations
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -62,7 +62,7 @@ Improvements
 * GITHUB#14113: Remove unnecessary ByteArrayDataInput allocations from `Lucene90DocValuesProducer$TermsDict.decompressBlock`. (Ankit Jain)
 
 * GITHUB#14138: Implement IntersectVisitor#visit(IntsRef) in  many of the current implementations and add
-  BulkAdder#add(IntRef) method. They should provide better perfromance due to less virtual method calls and
+  BulkAdder#add(IntRef) method. They should provide better performance due to less virtual method calls and
   more efficient bulk processing. (Ignacio Vera)
 
 Optimizations

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -62,7 +62,7 @@ Improvements
 * GITHUB#14113: Remove unnecessary ByteArrayDataInput allocations from `Lucene90DocValuesProducer$TermsDict.decompressBlock`. (Ankit Jain)
 
 * GITHUB#14138: Implement IntersectVisitor#visit(IntsRef) in  many of the current implementations and add
-  BulkAdder#add(IntRef) method. They should provide better performance due to less virtual method calls and
+  BulkAdder#add(IntsRef) method. They should provide better performance due to less virtual method calls and
   more efficient bulk processing. (Ignacio Vera)
 
 Optimizations

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -44,6 +44,7 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.NumericUtils;
 
 /** Distance query for {@link LatLonPoint}. */
@@ -234,6 +235,13 @@ final class LatLonPointDistanceQuery extends Query {
           }
 
           @Override
+          public void visit(IntsRef ref) {
+            for (int i = 0; i < ref.length; i++) {
+              visit(ref.ints[ref.offset + i]);
+            }
+          }
+
+          @Override
           public void visit(DocIdSetIterator iterator) throws IOException {
             adder.add(iterator);
           }
@@ -267,6 +275,13 @@ final class LatLonPointDistanceQuery extends Query {
           public void visit(int docID) {
             result.clear(docID);
             cost[0]--;
+          }
+
+          @Override
+          public void visit(IntsRef ref) {
+            for (int i = 0; i < ref.length; i++) {
+              visit(ref.ints[ref.offset + i]);
+            }
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -236,9 +236,7 @@ final class LatLonPointDistanceQuery extends Query {
 
           @Override
           public void visit(IntsRef ref) {
-            for (int i = 0; i < ref.length; i++) {
-              visit(ref.ints[ref.offset + i]);
-            }
+            adder.add(ref);
           }
 
           @Override
@@ -280,8 +278,9 @@ final class LatLonPointDistanceQuery extends Query {
           @Override
           public void visit(IntsRef ref) {
             for (int i = 0; i < ref.length; i++) {
-              visit(ref.ints[ref.offset + i]);
+              result.clear(ref.ints[ref.offset + i]);
             }
+            cost[0] = -ref.length;
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
@@ -35,6 +35,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.NumericUtils;
 
 final class LongDistanceFeatureQuery extends Query {
@@ -403,6 +404,21 @@ final class LongDistanceFeatureQuery extends Query {
 
               // Doc is in-bounds
               adder.add(docID);
+            }
+
+            @Override
+            public void visit(DocIdSetIterator iterator) throws IOException {
+              int docID;
+              while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                visit(docID);
+              }
+            }
+
+            @Override
+            public void visit(IntsRef ref) {
+              for (int i = 0; i < ref.length; ++i) {
+                visit(ref.ints[ref.offset + i]);
+              }
             }
 
             @Override

--- a/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
@@ -403,9 +403,7 @@ public abstract class RangeFieldQuery extends Query {
 
           @Override
           public void visit(IntsRef ref) {
-            for (int i = 0; i < ref.length; ++i) {
-              visit(ref.ints[ref.offset + i]);
-            }
+            adder.add(ref);
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
@@ -38,6 +38,7 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.ArrayUtil.ByteArrayComparator;
 import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.IntsRef;
 
 /**
  * Query class for searching {@code RangeField} types by a defined {@link Relation}.
@@ -401,7 +402,14 @@ public abstract class RangeFieldQuery extends Query {
           }
 
           @Override
-          public void visit(int docID) throws IOException {
+          public void visit(IntsRef ref) {
+            for (int i = 0; i < ref.length; ++i) {
+              visit(ref.ints[ref.offset + i]);
+            }
+          }
+
+          @Override
+          public void visit(int docID) {
             adder.add(docID);
           }
 
@@ -411,7 +419,7 @@ public abstract class RangeFieldQuery extends Query {
           }
 
           @Override
-          public void visit(int docID, byte[] leaf) throws IOException {
+          public void visit(int docID, byte[] leaf) {
             if (queryType.matches(ranges, leaf, numDims, bytesPerDim, comparator)) {
               visit(docID);
             }

--- a/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
@@ -448,9 +448,7 @@ abstract class SpatialQuery extends Query {
 
       @Override
       public void visit(IntsRef ref) {
-        for (int i = 0; i < ref.length; i++) {
-          visit(ref.ints[ref.offset + i]);
-        }
+        adder.add(ref);
       }
 
       @Override
@@ -500,8 +498,9 @@ abstract class SpatialQuery extends Query {
       @Override
       public void visit(IntsRef ref) {
         for (int i = 0; i < ref.length; i++) {
-          visit(ref.ints[ref.offset + i]);
+          result.set(ref.ints[ref.offset + i]);
         }
+        cost[0] += ref.length;
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
@@ -49,6 +49,7 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IntsRef;
 
 /**
  * Base query class for all spatial geometries: {@link LatLonShape}, {@link LatLonPoint} and {@link
@@ -446,6 +447,13 @@ abstract class SpatialQuery extends Query {
       }
 
       @Override
+      public void visit(IntsRef ref) {
+        for (int i = 0; i < ref.length; i++) {
+          visit(ref.ints[ref.offset + i]);
+        }
+      }
+
+      @Override
       public void visit(int docID, byte[] t) {
         if (leafPredicate.test(t)) {
           visit(docID);
@@ -490,6 +498,13 @@ abstract class SpatialQuery extends Query {
       }
 
       @Override
+      public void visit(IntsRef ref) {
+        for (int i = 0; i < ref.length; i++) {
+          visit(ref.ints[ref.offset + i]);
+        }
+      }
+
+      @Override
       public void visit(int docID, byte[] t) {
         if (result.get(docID) == false) {
           if (leafPredicate.test(t)) {
@@ -530,6 +545,14 @@ abstract class SpatialQuery extends Query {
       public void visit(int docID) {
         result.set(docID);
         cost[0]++;
+      }
+
+      @Override
+      public void visit(IntsRef ref) {
+        for (int i = 0; i < ref.length; i++) {
+          result.set(ref.ints[ref.offset + i]);
+        }
+        cost[0] += ref.length;
       }
 
       @Override
@@ -590,6 +613,13 @@ abstract class SpatialQuery extends Query {
       }
 
       @Override
+      public void visit(IntsRef ref) {
+        for (int i = 0; i < ref.length; i++) {
+          visit(ref.ints[ref.offset + i]);
+        }
+      }
+
+      @Override
       public void visit(int docID, byte[] t) {
         if (excluded.get(docID) == false) {
           Component2D.WithinRelation within = leafFunction.apply(t);
@@ -644,6 +674,14 @@ abstract class SpatialQuery extends Query {
       }
 
       @Override
+      public void visit(IntsRef ref) {
+        for (int i = 0; i < ref.length; i++) {
+          result.clear(ref.ints[ref.offset + i]);
+        }
+        cost[0] -= ref.length;
+      }
+
+      @Override
       public void visit(DocIdSetIterator iterator) throws IOException {
         result.andNot(iterator);
         cost[0] = Math.max(0, cost[0] - iterator.cost());
@@ -691,6 +729,13 @@ abstract class SpatialQuery extends Query {
       @Override
       public void visit(DocIdSetIterator iterator) throws IOException {
         result.andNot(iterator);
+      }
+
+      @Override
+      public void visit(IntsRef ref) {
+        for (int i = 0; i < ref.length; i++) {
+          visit(ref.ints[ref.offset + i]);
+        }
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/document/XYPointInGeometryQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/XYPointInGeometryQuery.java
@@ -38,6 +38,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.IntsRef;
 
 /**
  * Finds all previously indexed points that fall within the specified XY geometries.
@@ -88,6 +89,13 @@ final class XYPointInGeometryQuery extends Query {
       @Override
       public void visit(DocIdSetIterator iterator) throws IOException {
         adder.add(iterator);
+      }
+
+      @Override
+      public void visit(IntsRef ref) {
+        for (int i = 0; i < ref.length; i++) {
+          visit(ref.ints[ref.offset + i]);
+        }
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/document/XYPointInGeometryQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/XYPointInGeometryQuery.java
@@ -93,9 +93,7 @@ final class XYPointInGeometryQuery extends Query {
 
       @Override
       public void visit(IntsRef ref) {
-        for (int i = 0; i < ref.length; i++) {
-          visit(ref.ints[ref.offset + i]);
-        }
+        adder.add(ref);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -188,9 +188,7 @@ public abstract class PointRangeQuery extends Query {
 
           @Override
           public void visit(IntsRef ref) {
-            for (int i = ref.offset; i < ref.offset + ref.length; i++) {
-              adder.add(ref.ints[i]);
-            }
+            adder.add(ref);
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
@@ -41,7 +41,7 @@ public final class DocIdSetBuilder {
    *
    * @see DocIdSetBuilder#grow
    */
-  public abstract static class BulkAdder {
+  public abstract static sealed class BulkAdder permits FixedBitSetAdder, BufferAdder {
     public abstract void add(int doc);
 
     public abstract void add(IntsRef docs);
@@ -54,7 +54,7 @@ public final class DocIdSetBuilder {
     }
   }
 
-  private static class FixedBitSetAdder extends BulkAdder {
+  private static final class FixedBitSetAdder extends BulkAdder {
     final FixedBitSet bitSet;
 
     FixedBitSetAdder(FixedBitSet bitSet) {
@@ -93,7 +93,7 @@ public final class DocIdSetBuilder {
     }
   }
 
-  private static class BufferAdder extends BulkAdder {
+  private static final class BufferAdder extends BulkAdder {
     final Buffer buffer;
 
     BufferAdder(Buffer buffer) {

--- a/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
@@ -44,6 +44,12 @@ public final class DocIdSetBuilder {
   public abstract static class BulkAdder {
     public abstract void add(int doc);
 
+    public void add(IntsRef docs) {
+      for (int i = 0; i < docs.length; i++) {
+        add(docs.ints[docs.offset + i]);
+      }
+    }
+
     public void add(DocIdSetIterator iterator) throws IOException {
       int docID;
       while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
@@ -95,6 +101,11 @@ public final class DocIdSetBuilder {
     @Override
     public void add(int doc) {
       buffer.array[buffer.length++] = doc;
+    }
+
+    @Override
+    public void add(IntsRef docs) {
+      System.arraycopy(docs.ints, docs.offset, buffer.array, buffer.length, docs.length);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
@@ -106,6 +106,7 @@ public final class DocIdSetBuilder {
     @Override
     public void add(IntsRef docs) {
       System.arraycopy(docs.ints, docs.offset, buffer.array, buffer.length, docs.length);
+      buffer.length += docs.length;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
@@ -41,25 +41,15 @@ public final class DocIdSetBuilder {
    *
    * @see DocIdSetBuilder#grow
    */
-  public abstract static sealed class BulkAdder permits FixedBitSetAdder, BufferAdder {
-    public abstract void add(int doc);
+  public sealed interface BulkAdder permits FixedBitSetAdder, BufferAdder {
+    void add(int doc);
 
-    public abstract void add(IntsRef docs);
+    void add(IntsRef docs);
 
-    public void add(DocIdSetIterator iterator) throws IOException {
-      int docID;
-      while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-        add(docID);
-      }
-    }
+    void add(DocIdSetIterator iterator) throws IOException;
   }
 
-  private static final class FixedBitSetAdder extends BulkAdder {
-    final FixedBitSet bitSet;
-
-    FixedBitSetAdder(FixedBitSet bitSet) {
-      this.bitSet = bitSet;
-    }
+  private record FixedBitSetAdder(FixedBitSet bitSet) implements BulkAdder {
 
     @Override
     public void add(int doc) {
@@ -93,12 +83,7 @@ public final class DocIdSetBuilder {
     }
   }
 
-  private static final class BufferAdder extends BulkAdder {
-    final Buffer buffer;
-
-    BufferAdder(Buffer buffer) {
-      this.buffer = buffer;
-    }
+  private record BufferAdder(Buffer buffer) implements BulkAdder {
 
     @Override
     public void add(int doc) {
@@ -109,6 +94,14 @@ public final class DocIdSetBuilder {
     public void add(IntsRef docs) {
       System.arraycopy(docs.ints, docs.offset, buffer.array, buffer.length, docs.length);
       buffer.length += docs.length;
+    }
+
+    @Override
+    public void add(DocIdSetIterator iterator) throws IOException {
+      int docID;
+      while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+        add(docID);
+      }
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
@@ -56,6 +56,7 @@ public final class DocIdSetBuilder {
       bitSet.set(doc);
     }
 
+    @Override
     public void add(IntsRef docs) {
       for (int i = 0; i < docs.length; i++) {
         bitSet.set(docs.ints[docs.offset + i]);

--- a/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
@@ -44,11 +44,7 @@ public final class DocIdSetBuilder {
   public abstract static class BulkAdder {
     public abstract void add(int doc);
 
-    public void add(IntsRef docs) {
-      for (int i = 0; i < docs.length; i++) {
-        add(docs.ints[docs.offset + i]);
-      }
-    }
+    public abstract void add(IntsRef docs);
 
     public void add(DocIdSetIterator iterator) throws IOException {
       int docID;
@@ -68,6 +64,12 @@ public final class DocIdSetBuilder {
     @Override
     public void add(int doc) {
       bitSet.set(doc);
+    }
+
+    public void add(IntsRef docs) {
+      for (int i = 0; i < docs.length; i++) {
+        bitSet.set(docs.ints[docs.offset + i]);
+      }
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.MathUtil;
 
 /**
@@ -144,6 +145,19 @@ public class BKDReader extends PointValues {
           @Override
           public void visit(int docID) {
             count[0]++;
+          }
+
+          @Override
+          public void visit(DocIdSetIterator iterator) throws IOException {
+            int docID;
+            while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+              visit(docID);
+            }
+          }
+
+          @Override
+          public void visit(IntsRef ref) {
+            count[0] += ref.length;
           }
 
           @Override

--- a/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
@@ -125,24 +125,32 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
         array[k] = tmp;
       }
 
-      // add docs out of order
-      DocIdSetBuilder builder = new DocIdSetBuilder(maxDoc);
-      for (j = 0; j < array.length; ) {
-        final int l = TestUtil.nextInt(random(), 1, array.length - j);
-        DocIdSetBuilder.BulkAdder adder = null;
-        for (int k = 0, budget = 0; k < l; ++k) {
-          if (budget == 0 || rarely()) {
-            budget = TestUtil.nextInt(random(), 1, l - k + 5);
-            adder = builder.grow(budget);
+      {
+        // add docs out of order
+        DocIdSetBuilder builder = new DocIdSetBuilder(maxDoc);
+        for (j = 0; j < array.length; ) {
+          final int l = TestUtil.nextInt(random(), 1, array.length - j);
+          DocIdSetBuilder.BulkAdder adder = null;
+          if (random().nextBoolean()) {
+            for (int k = 0, budget = 0; k < l; ++k) {
+              if (budget == 0 || rarely()) {
+                budget = TestUtil.nextInt(random(), 1, l - k + 5);
+                adder = builder.grow(budget);
+              }
+              adder.add(array[j++]);
+              budget--;
+            }
+          } else {
+            IntsRef intsRef = new IntsRef(array, j, l);
+            adder = builder.grow(l);
+            adder.add(intsRef);
           }
-          adder.add(array[j++]);
-          budget--;
         }
-      }
 
-      final DocIdSet expected = new BitDocIdSet(docs);
-      final DocIdSet actual = builder.build();
-      assertEquals(expected, actual);
+        final DocIdSet expected = new BitDocIdSet(docs);
+        final DocIdSet actual = builder.build();
+        assertEquals(expected, actual);
+      }
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
@@ -144,6 +144,7 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
             IntsRef intsRef = new IntsRef(array, j, l);
             adder = builder.grow(l);
             adder.add(intsRef);
+            j += l;
           }
         }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
@@ -125,33 +125,31 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
         array[k] = tmp;
       }
 
-      {
-        // add docs out of order
-        DocIdSetBuilder builder = new DocIdSetBuilder(maxDoc);
-        for (j = 0; j < array.length; ) {
-          final int l = TestUtil.nextInt(random(), 1, array.length - j);
-          DocIdSetBuilder.BulkAdder adder = null;
-          if (usually()) {
-            for (int k = 0, budget = 0; k < l; ++k) {
-              if (budget == 0 || rarely()) {
-                budget = TestUtil.nextInt(random(), 1, l - k + 5);
-                adder = builder.grow(budget);
-              }
-              adder.add(array[j++]);
-              budget--;
+      // add docs out of order
+      DocIdSetBuilder builder = new DocIdSetBuilder(maxDoc);
+      for (j = 0; j < array.length; ) {
+        final int l = TestUtil.nextInt(random(), 1, array.length - j);
+        DocIdSetBuilder.BulkAdder adder = null;
+        if (usually()) {
+          for (int k = 0, budget = 0; k < l; ++k) {
+            if (budget == 0 || rarely()) {
+              budget = TestUtil.nextInt(random(), 1, l - k + 5);
+              adder = builder.grow(budget);
             }
-          } else {
-            IntsRef intsRef = new IntsRef(array, j, l);
-            adder = builder.grow(l);
-            adder.add(intsRef);
-            j += l;
+            adder.add(array[j++]);
+            budget--;
           }
+        } else {
+          IntsRef intsRef = new IntsRef(array, j, l);
+          adder = builder.grow(l);
+          adder.add(intsRef);
+          j += l;
         }
-
-        final DocIdSet expected = new BitDocIdSet(docs);
-        final DocIdSet actual = builder.build();
-        assertEquals(expected, actual);
       }
+
+      final DocIdSet expected = new BitDocIdSet(docs);
+      final DocIdSet actual = builder.build();
+      assertEquals(expected, actual);
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
@@ -131,7 +131,7 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
         for (j = 0; j < array.length; ) {
           final int l = TestUtil.nextInt(random(), 1, array.length - j);
           DocIdSetBuilder.BulkAdder adder = null;
-          if (random().nextBoolean()) {
+          if (usually()) {
             for (int k = 0, budget = 0; k < l; ++k) {
               if (budget == 0 || rarely()) {
                 budget = TestUtil.nextInt(random(), 1, l - k + 5);

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/PointInShapeIntersectVisitor.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/PointInShapeIntersectVisitor.java
@@ -27,6 +27,7 @@ import org.apache.lucene.spatial3d.geom.GeoShape;
 import org.apache.lucene.spatial3d.geom.PlanetModel.DocValueEncoder;
 import org.apache.lucene.spatial3d.geom.XYZBounds;
 import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.NumericUtils;
 
 class PointInShapeIntersectVisitor implements IntersectVisitor {
@@ -65,6 +66,11 @@ class PointInShapeIntersectVisitor implements IntersectVisitor {
   @Override
   public void visit(DocIdSetIterator iterator) throws IOException {
     adder.add(iterator);
+  }
+
+  @Override
+  public void visit(IntsRef ref) throws IOException {
+    adder.add(ref);
   }
 
   @Override


### PR DESCRIPTION
In https://github.com/apache/lucene/pull/13149, the method Implement IntersectVisitor#visit(IntsRef) was introduced which is a nice. trick to avoid multiple virtual calls to IntersectVisitor#visit(int).

This was only implemented for PointRangeQuery but it is useful for all implementation that expects hitting that code path. Therefore in this PR we proposed to implement this method wherever it make sense.