### PR TITLE
Replace special-casing of `DocBaseBitSetIterator` with `#intoBitSet`.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/DocBaseBitSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocBaseBitSetIterator.java
@@ -94,6 +94,12 @@ public class DocBaseBitSetIterator extends DocIdSetIterator {
   @Override
   public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
     upTo = Math.min(upTo, length);
+    // This doc id set is a bit hacky as it is sometimes OR'ed into a smaller bit set, which only
+    // works because trailing bits are unset.
+    if (upTo - offset > bitSet.length()) {
+      upTo = offset + bitSet.length();
+      assert bits.nextSetBit(upTo - docBase) == NO_MORE_DOCS;
+    }
     if (upTo > doc) {
       FixedBitSet.orRange(bits, doc - docBase, bitSet, doc - offset, upTo - doc);
       advance(upTo); // set the current doc

--- a/lucene/core/src/java/org/apache/lucene/util/DocBaseBitSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocBaseBitSetIterator.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.util;
 
+import java.io.IOException;
 import org.apache.lucene.search.DocIdSetIterator;
 
 /**
@@ -88,5 +89,14 @@ public class DocBaseBitSetIterator extends DocIdSetIterator {
   @Override
   public long cost() {
     return cost;
+  }
+
+  @Override
+  public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+    upTo = Math.min(upTo, length);
+    if (upTo > doc) {
+      FixedBitSet.orRange(bits, doc - docBase, bitSet, doc - offset, upTo - doc);
+      advance(upTo); // set the current doc
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/DocBaseBitSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocBaseBitSetIterator.java
@@ -99,7 +99,7 @@ public class DocBaseBitSetIterator extends DocIdSetIterator {
     // throw an exception.
     actualUpto = (int) Math.min(actualUpto, offset + (long) bitSet.length());
     if (actualUpto > doc) {
-      FixedBitSet.orRange(bits, doc - docBase, bitSet, doc - offset, upTo - doc);
+      FixedBitSet.orRange(bits, doc - docBase, bitSet, doc - offset, actualUpto - doc);
       advance(actualUpto); // set the current doc
     }
     super.intoBitSet(upTo, bitSet, offset);

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -339,30 +339,9 @@ public final class FixedBitSet extends BitSet {
 
   @Override
   public void or(DocIdSetIterator iter) throws IOException {
-    if (iter instanceof DocBaseBitSetIterator) {
-      // TODO: implement DocBaseBitSetIterator#intoBitSet instead
-      checkUnpositioned(iter);
-      DocBaseBitSetIterator baseIter = (DocBaseBitSetIterator) iter;
-      or(baseIter.getDocBase() >> 6, baseIter.getBitSet());
-    } else {
-      checkUnpositioned(iter);
-      iter.nextDoc();
-      iter.intoBitSet(DocIdSetIterator.NO_MORE_DOCS, this, 0);
-    }
-  }
-
-  private void or(final int otherOffsetWords, FixedBitSet other) {
-    or(otherOffsetWords, other.bits, other.numWords);
-  }
-
-  private void or(final int otherOffsetWords, final long[] otherArr, final int otherNumWords) {
-    assert otherNumWords + otherOffsetWords <= numWords
-        : "numWords=" + numWords + ", otherNumWords=" + otherNumWords;
-    int pos = Math.min(numWords - otherOffsetWords, otherNumWords);
-    final long[] thisArr = this.bits;
-    while (--pos >= 0) {
-      thisArr[pos + otherOffsetWords] |= otherArr[pos];
-    }
+    checkUnpositioned(iter);
+    iter.nextDoc();
+    iter.intoBitSet(DocIdSetIterator.NO_MORE_DOCS, this, 0);
   }
 
   /** Read {@code numBits} (between 1 and 63) bits from {@code bitSet} at {@code from}. */


### PR DESCRIPTION
This takes advantage of the new `#intoBitSet` API to remove special casing of `DocBaseBitSetIterator` in `FixedBitSet#or(DocIdSetIterator)`.