### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -13,7 +13,7 @@ on:
       - 'branch_10x'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
 # We split the workflow into two parallel jobs for efficiency:
 # one is running all validation checks without tests,

--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -13,7 +13,7 @@ on:
       - 'branch_10x'
 
 env:
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ DEVELOCITY_ACCESS_KEY }}
 
 # We split the workflow into two parallel jobs for efficiency:
 # one is running all validation checks without tests,

--- a/.github/workflows/run-checks-gradle-upgrade.yml
+++ b/.github/workflows/run-checks-gradle-upgrade.yml
@@ -20,7 +20,7 @@ on:
       - 'gradle/wrapper/**'
 
 env:
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   gradleSanityCheck:

--- a/.github/workflows/run-checks-gradle-upgrade.yml
+++ b/.github/workflows/run-checks-gradle-upgrade.yml
@@ -20,7 +20,7 @@ on:
       - 'gradle/wrapper/**'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
 jobs:
   gradleSanityCheck:

--- a/.github/workflows/run-checks-mod-analysis-common.yml
+++ b/.github/workflows/run-checks-mod-analysis-common.yml
@@ -20,7 +20,7 @@ on:
       - 'lucene/analysis/common/**'
 
 env:
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   test:

--- a/.github/workflows/run-checks-mod-analysis-common.yml
+++ b/.github/workflows/run-checks-mod-analysis-common.yml
@@ -20,7 +20,7 @@ on:
       - 'lucene/analysis/common/**'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
 jobs:
   test:

--- a/.github/workflows/run-checks-mod-distribution.tests.yml
+++ b/.github/workflows/run-checks-mod-distribution.tests.yml
@@ -14,7 +14,7 @@ on:
       - 'branch_10x'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
 jobs:
   test:

--- a/.github/workflows/run-checks-mod-distribution.tests.yml
+++ b/.github/workflows/run-checks-mod-distribution.tests.yml
@@ -14,7 +14,7 @@ on:
       - 'branch_10x'
 
 env:
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Apache Lucene is a high-performance, full-featured text search engine library
 written in Java.
 
 [![Build Status](https://ci-builds.apache.org/job/Lucene/job/Lucene-Artifacts-main/badge/icon?subject=Lucene)](https://ci-builds.apache.org/job/Lucene/job/Lucene-Artifacts-main/)
-[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.apache.org/scans?search.buildToolType=gradle&search.rootProjectNames=lucene-root)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://develocity.apache.org/scans?search.buildToolType=gradle&search.rootProjectNames=lucene-root)
 
 ## Online Documentation
 

--- a/gradle/ge.gradle
+++ b/gradle/ge.gradle
@@ -18,7 +18,7 @@
 def isCIBuild = System.getenv().keySet().find { it ==~ /(?i)((JENKINS|HUDSON)(_\w+)?|CI)/ } != null
 
 gradleEnterprise {
-    server = "https://ge.apache.org"
+    server = "https://develocity.apache.org"
     buildScan {
         capture { taskInputFiles = true }
         uploadInBackground = !isCIBuild

--- a/gradle/ge.gradle
+++ b/gradle/ge.gradle
@@ -17,13 +17,13 @@
 
 def isCIBuild = System.getenv().keySet().find { it ==~ /(?i)((JENKINS|HUDSON)(_\w+)?|CI)/ } != null
 
-gradleEnterprise {
+develocity {
     server = "https://develocity.apache.org"
+    projectId = "lucene"
+
     buildScan {
-        capture { taskInputFiles = true }
         uploadInBackground = !isCIBuild
-        publishAlways()
-        publishIfAuthenticated()
+        publishing.onlyIf { it.isAuthenticated() }
         obfuscation {
             ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
         }
@@ -35,7 +35,7 @@ buildCache {
         enabled = !isCIBuild
     }
 
-    remote(gradleEnterprise.buildCache) {
+    remote(develocity.buildCache) {
         enabled = false
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,8 +26,8 @@ pluginManagement {
 
 plugins {
     id "org.gradle.toolchains.foojay-resolver-convention" version "0.8.0"
-    id 'com.gradle.enterprise' version '3.15.1'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.11.3'
+    id 'com.gradle.develocity' version '3.18.2'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
This PR migrates the Lucene project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR migrates from the legacy Gradle Enterprise plugin to the renamed Develocity plugin and sets a projectId for use by Develocity.