### PR TITLE
Fix negative cost in some IntersectVisitor implementations after  #14138

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -280,7 +280,7 @@ final class LatLonPointDistanceQuery extends Query {
             for (int i = 0; i < ref.length; i++) {
               result.clear(ref.ints[ref.offset + i]);
             }
-            cost[0] = -ref.length;
+            cost[0] = Math.max(0, cost[0] - ref.length);
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
@@ -677,7 +677,7 @@ abstract class SpatialQuery extends Query {
         for (int i = 0; i < ref.length; i++) {
           result.clear(ref.ints[ref.offset + i]);
         }
-        cost[0] -= ref.length;
+        cost[0] = Math.max(0, cost[0] - ref.length);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -233,7 +233,7 @@ public abstract class PointRangeQuery extends Query {
             for (int i = ref.offset; i < ref.offset + ref.length; i++) {
               result.clear(ref.ints[i]);
             }
-            cost[0] -= ref.length;
+            cost[0] = Math.max(0, cost[0] - ref.length);
           }
 
           @Override


### PR DESCRIPTION
Introduced in https://github.com/apache/lucene/pull/14138, we need to prevent negative scores when substracting the added hits in LatLonPointDistanceQuery, SpatialQuery and PointRangeQuery.