### PR TITLE
Remove mmap isLoaded check before madvise

### DIFF
--- a/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -350,11 +350,8 @@ abstract class MemorySegmentIndexInput extends IndexInput
         offset,
         length,
         segment -> {
-          if (segment.isLoaded() == false) {
-            // We have a cache miss on at least one page, let's reset the counter.
-            consecutivePrefetchHitCount = 0;
-            nativeAccess.madviseWillNeed(segment);
-          }
+          consecutivePrefetchHitCount = 0;
+          nativeAccess.madviseWillNeed(segment);
         });
   }
 


### PR DESCRIPTION
The counter guarding the `madvise` callback is not all that effective in preventing `madvise` calls on slices since it's not shared with the original input and this keeps showing up hot in profiling ES benchmarks.
An outright `madvise` call should be about as expensive as the `isLoaded` check when things are already in the page cache and cheaper than that same call + a call to `isLoaded` that returns `false`, simply by avoiding another roundtrip to userspace.

-> remove the isLoaded guard to speed up call cases

Excerpt from ES profile motivating this:

![image](https://github.com/user-attachments/assets/1d634b0c-e6b1-4bdd-9f3d-dbbf49a173fa)

Checking the page table for loaded is comparable in cost to many thousands of cycles in practice.
Plus, the racy nature of such a check reduces its value in memory constrained scenarios.