### PR TITLE
gh-14127: remove duplicate neighbors when writing HNSW graphs

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
@@ -408,6 +408,7 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
     // write vectors' neighbours on each level into the vectorIndex file
     int countOnLevel0 = graph.size();
     int[][] offsets = new int[graph.numLevels()][];
+    int[] scratch = new int[graph.maxConn() * 2];
     for (int level = 0; level < graph.numLevels(); level++) {
       int[] sortedNodes = NodesIterator.getSortedNodes(graph.getNodesOnLevel(level));
       offsets[level] = new int[sortedNodes.length];
@@ -417,18 +418,26 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
         int size = neighbors.size();
         // Write size in VInt as the neighbors list is typically small
         long offsetStart = vectorIndex.getFilePointer();
-        vectorIndex.writeVInt(size);
-        // Destructively modify; it's ok we are discarding it after this
         int[] nnodes = neighbors.nodes();
         Arrays.sort(nnodes, 0, size);
         // Now that we have sorted, do delta encoding to minimize the required bits to store the
         // information
-        for (int i = size - 1; i > 0; --i) {
-          assert nnodes[i] < countOnLevel0 : "node too large: " + nnodes[i] + ">=" + countOnLevel0;
-          nnodes[i] -= nnodes[i - 1];
+        int actualSize = 0;
+        if (size > 0) {
+          scratch[0] = nnodes[0];
+          actualSize = 1;
         }
-        for (int i = 0; i < size; i++) {
-          vectorIndex.writeVInt(nnodes[i]);
+        for (int i = 1; i < size; i++) {
+          assert nnodes[i] < countOnLevel0 : "node too large: " + nnodes[i] + ">=" + countOnLevel0;
+          if (nnodes[i - 1] == nnodes[i]) {
+            continue;
+          }
+          scratch[actualSize++] = nnodes[i] - nnodes[i - 1];
+        }
+        // Write the size after duplicates are removed
+        vectorIndex.writeVInt(actualSize);
+        for (int i = 0; i < actualSize; i++) {
+          vectorIndex.writeVInt(scratch[i]);
         }
         offsets[level][nodeOffsetId++] =
             Math.toIntExact(vectorIndex.getFilePointer() - offsetStart);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
@@ -129,6 +129,7 @@ public class HnswUtil {
         }
         Component component =
             markRooted(hnsw, level, connectedNodes, notFullyConnected, maxConn, nextClear);
+        assert component.start() == nextClear;
         assert component.size() > 0;
         components.add(component);
         total += component.size();


### PR DESCRIPTION
should fix #gh-14127 test failures.

I believe there are no back-compat concerns here since this would be a no-op for graphs with no duplicates (I think that is what we were always producing before), and even if we did produce dups before, this will produce a functionally-equivalent graph, just a bit more compact.

I also don't think we need to take any special action w.r.t. to the CheckIndex check that was added since if we never produced dups without reordering then it won't randomly start failing on indexes that checked out OK before.  Although there is some chance I'm wrong - it's difficult to *prove* we could not have produced duplicates before, I think we would have seen problems by now with the CheckIndex check having been out in the wild on main and 10x branch? 