### PR TITLE
Add knn result consistency test

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -489,6 +489,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
     assertRandomConsistency(false);
   }
 
+  @AwaitsFix(bugUrl = "https://github.com/apache/lucene/issues/14180")
   public void testRandomConsistencyMultiThreaded() throws IOException {
     assertRandomConsistency(true);
   }

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -23,6 +23,7 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Random;
 import java.util.Set;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.document.Document;
@@ -40,7 +41,9 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.QueryTimeout;
+import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorEncoding;
@@ -482,23 +485,41 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   }
 
   /** Tests with random vectors, number of documents, etc. Uses RandomIndexWriter. */
-  public void testRandomConsistency() throws IOException {
-    int numDocs = atLeast(500);
-    int dimension = atLeast(5);
-    int numIters = atLeast(10);
+  public void testRandomConsistencySingleThreaded() throws IOException {
+    assertRandomConsistency(false);
+  }
+
+  public void testRandomConsistencyMultiThreaded() throws IOException {
+    assertRandomConsistency(true);
+  }
+
+  private void assertRandomConsistency(boolean multiThreaded) throws IOException {
+    int numDocs = 100;
+    int dimension = 4;
+    int numIters = 10;
     boolean everyDocHasAVector = random().nextBoolean();
+    Random r = random();
     try (Directory d = newDirectoryForTest()) {
-      RandomIndexWriter w = new RandomIndexWriter(random(), d);
-      for (int i = 0; i < numDocs; i++) {
-        Document doc = new Document();
-        if (everyDocHasAVector || random().nextInt(10) != 2) {
-          doc.add(getKnnVectorField("field", randomVector(dimension)));
+      // To ensure consistency between seeded runs, remove some randomness
+      IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
+      iwc.setMergeScheduler(new SerialMergeScheduler());
+      iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+      iwc.setMaxBufferedDocs(numDocs);
+      iwc.setRAMBufferSizeMB(IndexWriterConfig.DISABLE_AUTO_FLUSH);
+      try (IndexWriter w = new IndexWriter(d, iwc)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          if (everyDocHasAVector || random().nextInt(10) != 2) {
+            doc.add(getKnnVectorField("field", randomVector(dimension)));
+          }
+          w.addDocument(doc);
+          if (r.nextBoolean() && i % 50 == 0) {
+            w.flush();
+          }
         }
-        w.addDocument(doc);
       }
-      w.close();
       try (IndexReader reader = DirectoryReader.open(d)) {
-        IndexSearcher searcher = newSearcher(reader);
+        IndexSearcher searcher = newSearcher(reader, true, true, multiThreaded);
         // first get the initial set of docs, and we expect all future queries to be exactly the
         // same
         int k = random().nextInt(80) + 1;


### PR DESCRIPTION
Inspired by some weird behavior I have seen, adding a consistency test. 

I found that indeed, this fails over some seeds.

Frustratingly, the seeded failures do not seem to be repeatable. But, running 

```
./gradlew :lucene:core:test --tests "org.apache.lucene.search.TestSeededKnnFloatVectorQuery.testRandomConsistency" -Dtests.iters=1000
```

Results in failures, though, not consistently. This seems to indicate some funky race condition.

Obviously, this shouldn't be merged until we figure out the consistency issue.