### PR TITLE
Optimize ContextQuery with big number of contexts

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -76,6 +76,8 @@ Optimizations
 * GITHUB#14133: Dense blocks of postings are now encoded as bit sets.
   (Adrien Grand)
 
+# GITHUB#14169: Optimize ContextQuery with big number of contexts. (Mayya Sharipova)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
@@ -17,8 +17,10 @@
 package org.apache.lucene.search.suggest.document;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.lucene.analysis.miscellaneous.ConcatenateGraphFilter;
 import org.apache.lucene.internal.hppc.IntHashSet;
@@ -230,7 +232,7 @@ public class ContextQuery extends CompletionQuery implements Accountable {
     if (matchAllContexts || contexts.size() == 0) {
       return Operations.concatenate(matchAllAutomaton, sep);
     } else {
-      Automaton contextsAutomaton = null;
+      List<Automaton> automataList = new ArrayList<>();
       for (Map.Entry<IntsRef, ContextMetaData> entry : contexts.entrySet()) {
         final ContextMetaData contextMetaData = entry.getValue();
         final IntsRef ref = entry.getKey();
@@ -239,12 +241,9 @@ public class ContextQuery extends CompletionQuery implements Accountable {
           contextAutomaton = Operations.concatenate(contextAutomaton, matchAllAutomaton);
         }
         contextAutomaton = Operations.concatenate(contextAutomaton, sep);
-        if (contextsAutomaton == null) {
-          contextsAutomaton = contextAutomaton;
-        } else {
-          contextsAutomaton = Operations.union(contextsAutomaton, contextAutomaton);
-        }
+        automataList.add(contextAutomaton);
       }
+      Automaton contextsAutomaton = Operations.union(automataList);
       return contextsAutomaton;
     }
   }


### PR DESCRIPTION
When there are big number of contexts, ContextQuery may take a 
lot of time because of how context automata are constructed. 
Instead of the current approach of repeatedly concatenating and unioning 
context automata, this PR first constructs all individual context automata
and then does one single union at the end.

Thus for the added test with 1000 contexts, the performance improved from 4000 ms to 18 ms.