### PR TITLE
Rename `mergeThreadCount` in ConcurrentMergeScheduler to avoid clashing with method of the same name

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -87,7 +87,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
   private int maxMergeCount = AUTO_DETECT_MERGES_AND_THREADS;
 
   /** How many {@link MergeThread}s have kicked off (this is use to name them). */
-  protected int mergeThreadCount;
+  protected int mergeThreadCounter;
 
   /** Floor for IO write rate limit (we will never go any lower than this) */
   private static final double MIN_MERGE_MB_PER_SEC = 5.0;
@@ -673,7 +673,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
       throws IOException {
     final MergeThread thread = new MergeThread(mergeSource, merge);
     thread.setDaemon(true);
-    thread.setName("Lucene Merge Thread #" + mergeThreadCount++);
+    thread.setName("Lucene Merge Thread #" + mergeThreadCounter++);
     return thread;
   }
 


### PR DESCRIPTION
### Description

Opening up this small PR to rename `mergeThreadCount` (the field) to `mergeThreadCounter` to avoid clashing with a method in the same class also named `mergeThreadCount`

This variable is used to [assign merge thread numbers](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java#L671-L678) by incrementing from 0 so I thought `mergeThreadCounter` may be a more appropriate name. 

Resolves: https://github.com/apache/lucene/issues/13114

Below is a snippet of the current state of the class where the field and method have the same name.

```
/** How many {@link MergeThread}s have kicked off (this is use to name them). */
protected int mergeThreadCount;

/**
 * Returns the number of merge threads that are alive, ignoring the calling thread if it is a
 * merge thread. Note that this number is &le; {@link #mergeThreads} size.
 *
 * @lucene.internal
 */
public synchronized int mergeThreadCount() {
  Thread currentThread = Thread.currentThread();
  int count = 0;
  for (MergeThread mergeThread : mergeThreads) {
    if (currentThread != mergeThread
        && mergeThread.isAlive()
        && mergeThread.merge.isAborted() == false) {
      count++;
    }
  }
  return count;
}
```