### PR TITLE
Filtered disjunctions may miss some top hits.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
@@ -170,8 +170,9 @@ final class MaxScoreBulkScorer extends BulkScorer {
 
     DisiWrapper top = essentialQueue.top();
     assert top.doc < max;
-    if (top.doc < filter.doc) {
+    while (top.doc < filter.doc) {
       top.doc = top.approximation.advance(filter.doc);
+      top = essentialQueue.updateTop();
     }
 
     // Only score an inner window, after that we'll check if the min competitive score has increased


### PR DESCRIPTION
This is a rare bug (for instance none of the queries in nightly benchmarks return different top hits with the fix, and I haven't been able to create a proper test) but still a bug.
