### PR TITLE
Correct bug with seeded vector queries with incorrect entrypoint ids

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/SeededKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SeededKnnVectorQuery.java
@@ -229,10 +229,11 @@ public class SeededKnnVectorQuery extends AbstractKnnVectorQuery {
     private final int[] sortedDocIds;
     private int idx = -1;
 
-    private TopDocsDISI(TopDocs topDocs) {
+    private TopDocsDISI(TopDocs topDocs, LeafReaderContext ctx) {
       sortedDocIds = new int[topDocs.scoreDocs.length];
       for (int i = 0; i < topDocs.scoreDocs.length; i++) {
-        sortedDocIds[i] = topDocs.scoreDocs[i].doc;
+        // Remove the doc base as added by the collector
+        sortedDocIds[i] = topDocs.scoreDocs[i].doc - ctx.docBase;
       }
       Arrays.sort(sortedDocIds);
     }
@@ -311,7 +312,8 @@ public class SeededKnnVectorQuery extends AbstractKnnVectorQuery {
       }
       // Most underlying iterators are indexed, so we can map the seed docs to the vector docs
       if (vectorIterator instanceof KnnVectorValues.DocIndexIterator indexIterator) {
-        DocIdSetIterator seedDocs = new MappedDISI(indexIterator, new TopDocsDISI(seedTopDocs));
+        DocIdSetIterator seedDocs =
+            new MappedDISI(indexIterator, new TopDocsDISI(seedTopDocs, ctx));
         return knnCollectorManager.newCollector(
             visitLimit, new KnnSearchStrategy.Seeded(seedDocs, seedTopDocs.scoreDocs.length), ctx);
       }


### PR DESCRIPTION
The tests caught a bug! Good thing!

The code wasn't taking account of the underlying leaf context doc base when creating the top doc iterator for a segment.

No changes entry as its a bugfix for an unreleased query.

closes: https://github.com/apache/lucene/issues/14195
closes: https://github.com/apache/lucene/issues/14196