### PR TITLE
Automatically remove dead states from concatenated automata.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
@@ -149,7 +149,7 @@ public final class Operations {
 
     result.finishState();
 
-    return result;
+    return removeDeadStates(result);
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
@@ -667,8 +667,12 @@ public class TestAutomaton extends LuceneTestCase {
   }
 
   public void testRemoveDeadStates() throws Exception {
-    Automaton a =
-        Operations.concatenate(Arrays.asList(Automata.makeString("x"), Automata.makeString("y")));
+    Automaton a = new Automaton();
+    a.createState();
+    a.copy(Automata.makeString("xy"));
+    a.addEpsilon(0, 1); // State 1 is dead, nothing leads to it.
+    a.finishState();
+
     assertEquals(4, a.getNumStates());
     a = Operations.removeDeadStates(a);
     assertEquals(3, a.getNumStates());


### PR DESCRIPTION
Concatenating automata frequently creates dead states. This PR suggests that `Operations#concatenate` automatically removes these dead states. This is not unseen: `Operations#repeat`, `Operations#union` and other automaton manipulation utilities also automatically remove dead states.

Here is an example of what concatenating automata that accept "f" and "g" returns, without this patch:
![automaton](https://github.com/user-attachments/assets/3076e674-d38a-4230-a801-3fdfb5fbc15a)

With this patch, state 3 gets removed.

Relates #14193.
