### PR TITLE
Correct hashCode of SynonymQuery

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
@@ -149,7 +149,7 @@ public final class SynonymQuery extends Query {
 
   @Override
   public int hashCode() {
-    return 31 * classHash() + Arrays.hashCode(terms);
+    return 31 * classHash() + Arrays.hashCode(terms) + field.hashCode();
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
@@ -87,6 +87,15 @@ public class TestSynonymQuery extends LuceneTestCase {
         new SynonymQuery.Builder("field2").addTerm(new Term("field2", "b"), 0.4f).build());
   }
 
+  public void testHashCode() {
+    Query q0 = new SynonymQuery.Builder("field1").addTerm(new Term("field1", "a"), 0.4f).build();
+    Query q1 = new SynonymQuery.Builder("field1").addTerm(new Term("field1", "a"), 0.4f).build();
+    Query q2 = new SynonymQuery.Builder("field2").addTerm(new Term("field2", "a"), 0.4f).build();
+
+    assertEquals(q0.hashCode(), q1.hashCode());
+    assertNotEquals(q0.hashCode(), q2.hashCode());
+  }
+
   public void testGetField() {
     SynonymQuery query =
         new SynonymQuery.Builder("field1").addTerm(new Term("field1", "a")).build();


### PR DESCRIPTION
PR #12260 modified equals method of SynonymQuery, 
but hashCode method was not adjusted accordingly.