### PR TITLE
Clean up public non-final statics

### DIFF
--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/AnalyzerProfile.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/AnalyzerProfile.java
@@ -34,13 +34,9 @@ import java.util.Properties;
 public class AnalyzerProfile {
 
   /** Global indicating the configured analysis data directory */
-  public static final String ANALYSIS_DATA_DIR;
+  public static final String ANALYSIS_DATA_DIR = resolveDataDir();
 
-  static {
-    ANALYSIS_DATA_DIR = init();
-  }
-
-  private static String init() {
+  private static String resolveDataDir() {
     String dirName = "analysis-data";
     String propName = "analysis.properties";
 

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/AnalyzerProfile.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/AnalyzerProfile.java
@@ -34,45 +34,44 @@ import java.util.Properties;
 public class AnalyzerProfile {
 
   /** Global indicating the configured analysis data directory */
-  public static String ANALYSIS_DATA_DIR = "";
+  public static final String ANALYSIS_DATA_DIR;
 
   static {
-    init();
+    ANALYSIS_DATA_DIR = init();
   }
 
-  private static void init() {
+  private static String init() {
     String dirName = "analysis-data";
     String propName = "analysis.properties";
 
     // Try the system property：-Danalysis.data.dir=/path/to/analysis-data
-    ANALYSIS_DATA_DIR = System.getProperty("analysis.data.dir", "");
-    if (ANALYSIS_DATA_DIR.length() != 0) return;
+    String analysisDataDir = System.getProperty("analysis.data.dir", "");
+    if (analysisDataDir.isEmpty() == false) return analysisDataDir;
 
+    Path lib = Paths.get("lib");
     Path[] candidateFiles =
         new Path[] {
-          Paths.get(dirName),
-          Paths.get("lib").resolve(dirName),
-          Paths.get(propName),
-          Paths.get("lib").resolve(propName)
+          Paths.get(dirName), lib.resolve(dirName), Paths.get(propName), lib.resolve(propName)
         };
     for (Path file : candidateFiles) {
       if (Files.exists(file)) {
         if (Files.isDirectory(file)) {
-          ANALYSIS_DATA_DIR = file.toAbsolutePath().toString();
-        } else if (Files.isRegularFile(file) && getAnalysisDataDir(file).length() != 0) {
-          ANALYSIS_DATA_DIR = getAnalysisDataDir(file).toString();
+          analysisDataDir = file.toAbsolutePath().toString();
+        } else if (Files.isRegularFile(file) && getAnalysisDataDir(file).isEmpty() == false) {
+          analysisDataDir = getAnalysisDataDir(file);
         }
         break;
       }
     }
 
-    if (ANALYSIS_DATA_DIR.length() == 0) {
+    if (analysisDataDir.isEmpty()) {
       // Dictionary directory cannot be found.
       throw new RuntimeException(
           "WARNING: Can not find lexical dictionary directory!"
               + " This will cause unpredictable exceptions in your application!"
               + " Please refer to the manual to download the dictionaries.");
     }
+    return analysisDataDir;
   }
 
   private static String getAnalysisDataDir(Path propFile) {

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/Constants.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/Constants.java
@@ -18,14 +18,5 @@ package org.apache.lucene.benchmark;
 
 /** Various benchmarking constants (mostly defaults) */
 public class Constants {
-
-  public static final int DEFAULT_RUN_COUNT = 5;
-  public static final int DEFAULT_SCALE_UP = 5;
-  public static final int DEFAULT_LOG_STEP = 1000;
-
-  public static Boolean[] BOOLEANS = new Boolean[] {Boolean.FALSE, Boolean.TRUE};
-
-  public static final int DEFAULT_MAXIMUM_DOCUMENTS = Integer.MAX_VALUE;
-
   public static final String PARALLEL_TASK_THREAD_NAME_PREFIX = "ParallelTaskThread";
 }

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/TaskSequence.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/TaskSequence.java
@@ -30,7 +30,7 @@ import org.apache.lucene.util.SuppressForbidden;
 /** Sequence of parallel or sequential tasks. */
 @SuppressForbidden(reason = "Thread sleep")
 public class TaskSequence extends PerfTask {
-  public static int REPEAT_EXHAUST = -2;
+  public static final int REPEAT_EXHAUST = -2;
   private ArrayList<PerfTask> tasks;
   private int repetitions = 1;
   private boolean parallel;

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/utils/ExtractWikipedia.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/utils/ExtractWikipedia.java
@@ -36,7 +36,7 @@ public class ExtractWikipedia {
 
   private Path outputDir;
 
-  public static int count = 0;
+  private int count = 0;
 
   static final int BASE = 10;
   protected DocMaker docMaker;

--- a/lucene/core/src/java/org/apache/lucene/store/SleepingLockWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/store/SleepingLockWrapper.java
@@ -33,7 +33,7 @@ public final class SleepingLockWrapper extends FilterDirectory {
   /**
    * How long {@link #obtainLock} waits, in milliseconds, in between attempts to acquire the lock.
    */
-  public static long DEFAULT_POLL_INTERVAL = 1000;
+  public static final long DEFAULT_POLL_INTERVAL = 1000;
 
   private final long lockWaitTimeout;
   private final long pollInterval;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -100,7 +100,7 @@ public abstract class HnswGraph {
   public abstract NodesIterator getNodesOnLevel(int level) throws IOException;
 
   /** Empty graph value */
-  public static HnswGraph EMPTY =
+  public static final HnswGraph EMPTY =
       new HnswGraph() {
 
         @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanationsWithFillerDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanationsWithFillerDocs.java
@@ -43,7 +43,7 @@ public class TestSimpleExplanationsWithFillerDocs extends TestSimpleExplanations
    * If non-null then the filler docs are not empty, and need to be filtered out from queries using
    * this as both field name &amp; field value
    */
-  public static String EXTRA = null;
+  private static String EXTRA = null;
 
   private static final Document EMPTY_DOC = new Document();
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/StyleConstants.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/StyleConstants.java
@@ -21,21 +21,21 @@ import java.awt.Color;
 import java.awt.Font;
 
 /** Constants for the default styles */
-public class StyleConstants {
+public final class StyleConstants {
 
-  public static Font FONT_BUTTON_LARGE = new Font("SanSerif", Font.PLAIN, 15);
+  public static final Font FONT_BUTTON_LARGE = new Font("SanSerif", Font.PLAIN, 15);
 
-  public static Font FONT_MONOSPACE_LARGE = new Font("monospaced", Font.PLAIN, 12);
+  public static final Font FONT_MONOSPACE_LARGE = new Font("monospaced", Font.PLAIN, 12);
 
-  public static Color LINK_COLOR = Color.decode("#0099ff");
+  public static final Color LINK_COLOR = Color.decode("#0099ff");
 
-  public static Color DISABLED_COLOR = Color.decode("#d9d9d9");
+  public static final Color DISABLED_COLOR = Color.decode("#d9d9d9");
 
-  public static int TABLE_ROW_HEIGHT_DEFAULT = 18;
+  public static final int TABLE_ROW_HEIGHT_DEFAULT = 18;
 
-  public static int TABLE_COLUMN_MARGIN_DEFAULT = 10;
+  public static final int TABLE_COLUMN_MARGIN_DEFAULT = 10;
 
-  public static int TABLE_ROW_MARGIN_DEFAULT = 3;
+  public static final int TABLE_ROW_MARGIN_DEFAULT = 3;
 
   private StyleConstants() {}
 }

--- a/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanCollection.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanCollection.java
@@ -42,7 +42,7 @@ public class TestSpanCollection extends LuceneTestCase {
 
   public static final String FIELD = "field";
 
-  public static FieldType OFFSETS = new FieldType(TextField.TYPE_STORED);
+  public static final FieldType OFFSETS = new FieldType(TextField.TYPE_STORED);
 
   static {
     OFFSETS.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS);

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/Node.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/Node.java
@@ -52,13 +52,13 @@ public abstract class Node implements Closeable {
    * Key to store the primary gen in the commit data, which increments every time we promote a new
    * primary, so replicas can detect when the primary they were talking to is changed
    */
-  public static String PRIMARY_GEN_KEY = "__primaryGen";
+  public static final String PRIMARY_GEN_KEY = "__primaryGen";
 
   /**
    * Key to store the version in the commit data, which increments every time we open a new NRT
    * reader
    */
-  public static String VERSION_KEY = "__version";
+  public static final String VERSION_KEY = "__version";
 
   /** Compact ordinal for this node */
   protected final int id;

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/BlendedInfixSuggester.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/BlendedInfixSuggester.java
@@ -56,12 +56,12 @@ import org.apache.lucene.util.BytesRef;
 public class BlendedInfixSuggester extends AnalyzingInfixSuggester {
 
   /** Coefficient used for linear blending */
-  protected static double LINEAR_COEF = 0.10;
+  protected static final double LINEAR_COEF = 0.10;
 
   private Double exponent = 2.0;
 
   /** Default factor */
-  public static int DEFAULT_NUM_FACTOR = 10;
+  public static final int DEFAULT_NUM_FACTOR = 10;
 
   /** Factor to multiply the number of searched elements */
   private final int numFactor;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/DocHelper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/DocHelper.java
@@ -61,7 +61,7 @@ public class DocHelper {
   // Fields will be lexicographically sorted.  So, the order is: field, text, two
   public static final int[] FIELD_2_FREQS = {3, 1, 1};
   public static final String TEXT_FIELD_2_KEY = "textField2";
-  public static Field textField2;
+  public static final Field textField2;
 
   static {
     TEXT_TYPE_STORED_WITH_TVS = new FieldType(TextField.TYPE_STORED);
@@ -75,7 +75,7 @@ public class DocHelper {
   public static final FieldType customType3;
   public static final String FIELD_3_TEXT = "aaaNoNorms aaaNoNorms bbbNoNorms";
   public static final String TEXT_FIELD_3_KEY = "textField3";
-  public static Field textField3;
+  public static final Field textField3;
 
   static {
     customType3 = new FieldType(TextField.TYPE_STORED);
@@ -85,7 +85,7 @@ public class DocHelper {
 
   public static final String KEYWORD_TEXT = "Keyword";
   public static final String KEYWORD_FIELD_KEY = "keyField";
-  public static Field keyField;
+  public static final Field keyField;
 
   static {
     keyField = new StringField(KEYWORD_FIELD_KEY, KEYWORD_TEXT, Field.Store.YES);
@@ -94,7 +94,7 @@ public class DocHelper {
   public static final FieldType customType5;
   public static final String NO_NORMS_TEXT = "omitNormsText";
   public static final String NO_NORMS_KEY = "omitNorms";
-  public static Field noNormsField;
+  public static final Field noNormsField;
 
   static {
     customType5 = new FieldType(TextField.TYPE_STORED);
@@ -106,7 +106,7 @@ public class DocHelper {
   public static final FieldType customType6;
   public static final String NO_TF_TEXT = "analyzed with no tf and positions";
   public static final String NO_TF_KEY = "omitTermFreqAndPositions";
-  public static Field noTFField;
+  public static final Field noTFField;
 
   static {
     customType6 = new FieldType(TextField.TYPE_STORED);
@@ -117,7 +117,7 @@ public class DocHelper {
   public static final FieldType customType7;
   public static final String UNINDEXED_FIELD_TEXT = "unindexed field text";
   public static final String UNINDEXED_FIELD_KEY = "unIndField";
-  public static Field unIndField;
+  public static final Field unIndField;
 
   static {
     customType7 = new FieldType();
@@ -137,13 +137,13 @@ public class DocHelper {
 
   public static final String UNSTORED_1_FIELD_TEXT = "unstored field text";
   public static final String UNSTORED_FIELD_1_KEY = "unStoredField1";
-  public static Field unStoredField1 =
+  public static final Field unStoredField1 =
       new TextField(UNSTORED_FIELD_1_KEY, UNSTORED_1_FIELD_TEXT, Field.Store.NO);
 
   public static final FieldType customType8;
   public static final String UNSTORED_2_FIELD_TEXT = "unstored field text";
   public static final String UNSTORED_FIELD_2_KEY = "unStoredField2";
-  public static Field unStoredField2;
+  public static final Field unStoredField2;
 
   static {
     customType8 = new FieldType(TextField.TYPE_NOT_STORED);
@@ -166,20 +166,21 @@ public class DocHelper {
   // From Issue 509
   public static final String FIELD_UTF1_TEXT = "field one \u4e00text";
   public static final String TEXT_FIELD_UTF1_KEY = "textField1Utf8";
-  public static Field textUtfField1 = new Field(TEXT_FIELD_UTF1_KEY, FIELD_UTF1_TEXT, customType);
+  public static final Field textUtfField1 =
+      new Field(TEXT_FIELD_UTF1_KEY, FIELD_UTF1_TEXT, customType);
 
   public static final String FIELD_UTF2_TEXT = "field field field \u4e00two text";
   // Fields will be lexicographically sorted.  So, the order is: field, text, two
   public static final int[] FIELD_UTF2_FREQS = {3, 1, 1};
   public static final String TEXT_FIELD_UTF2_KEY = "textField2Utf8";
-  public static Field textUtfField2 =
+  public static final Field textUtfField2 =
       new Field(TEXT_FIELD_UTF2_KEY, FIELD_UTF2_TEXT, TEXT_TYPE_STORED_WITH_TVS);
 
-  public static Map<String, Object> nameValues;
+  public static final Map<String, Object> nameValues;
 
   // ordered list of all the fields...
   // could use LinkedHashMap for this purpose if Java1.4 is OK
-  public static Field[] fields =
+  public static final Field[] fields =
       new Field[] {
         textField1,
         textField2,
@@ -199,32 +200,28 @@ public class DocHelper {
         largeLazyField
       };
 
-  public static Map<String, IndexableField> all = new HashMap<>();
-  public static Map<String, IndexableField> indexed = new HashMap<>();
-  public static Map<String, IndexableField> stored = new HashMap<>();
-  public static Map<String, IndexableField> unstored = new HashMap<>();
-  public static Map<String, IndexableField> unindexed = new HashMap<>();
-  public static Map<String, IndexableField> termvector = new HashMap<>();
-  public static Map<String, IndexableField> notermvector = new HashMap<>();
-  public static Map<String, IndexableField> lazy = new HashMap<>();
-  public static Map<String, IndexableField> noNorms = new HashMap<>();
-  public static Map<String, IndexableField> noTf = new HashMap<>();
+  public static final Map<String, IndexableField> all = new HashMap<>();
+  public static final Map<String, IndexableField> indexed = new HashMap<>();
+  public static final Map<String, IndexableField> stored = new HashMap<>();
+  public static final Map<String, IndexableField> unstored = new HashMap<>();
+  public static final Map<String, IndexableField> unindexed = new HashMap<>();
+  public static final Map<String, IndexableField> termvector = new HashMap<>();
+  public static final Map<String, IndexableField> notermvector = new HashMap<>();
+  public static final Map<String, IndexableField> lazy = new HashMap<>();
+  public static final Map<String, IndexableField> noNorms = new HashMap<>();
+  public static final Map<String, IndexableField> noTf = new HashMap<>();
 
   static {
     // Initialize the large Lazy Field
-    StringBuilder buffer = new StringBuilder();
-    for (int i = 0; i < 10000; i++) {
-      buffer.append("Lazily loading lengths of language in lieu of laughing ");
-    }
+    String buffer = "Lazily loading lengths of language in lieu of laughing ".repeat(10000);
 
     LAZY_FIELD_BINARY_BYTES = "These are some binary field bytes".getBytes(StandardCharsets.UTF_8);
     lazyFieldBinary = new StoredField(LAZY_FIELD_BINARY_KEY, LAZY_FIELD_BINARY_BYTES);
     fields[fields.length - 2] = lazyFieldBinary;
-    LARGE_LAZY_FIELD_TEXT = buffer.toString();
+    LARGE_LAZY_FIELD_TEXT = buffer;
     largeLazyField = new Field(LARGE_LAZY_FIELD_KEY, LARGE_LAZY_FIELD_TEXT, customType);
     fields[fields.length - 1] = largeLazyField;
-    for (int i = 0; i < fields.length; i++) {
-      IndexableField f = fields[i];
+    for (IndexableField f : fields) {
       add(all, f);
       if (f.fieldType().indexOptions() != IndexOptions.NONE) add(indexed, f);
       else add(unindexed, f);
@@ -268,8 +265,8 @@ public class DocHelper {
    * @param doc The document to write
    */
   public static void setupDoc(Document doc) {
-    for (int i = 0; i < fields.length; i++) {
-      doc.add(fields[i]);
+    for (Field field : fields) {
+      doc.add(field);
     }
   }
 
@@ -279,8 +276,7 @@ public class DocHelper {
    */
   public static SegmentCommitInfo writeDoc(Random random, Directory dir, Document doc)
       throws IOException {
-    return writeDoc(
-        random, dir, new MockAnalyzer(random, MockTokenizer.WHITESPACE, false), null, doc);
+    return writeDoc(dir, new MockAnalyzer(random, MockTokenizer.WHITESPACE, false), null, doc);
   }
 
   /**
@@ -288,8 +284,7 @@ public class DocHelper {
    * SegmentInfo describing the new segment
    */
   public static SegmentCommitInfo writeDoc(
-      Random random, Directory dir, Analyzer analyzer, Similarity similarity, Document doc)
-      throws IOException {
+      Directory dir, Analyzer analyzer, Similarity similarity, Document doc) throws IOException {
     IndexWriter writer =
         new IndexWriter(
             dir,


### PR DESCRIPTION
### Description

Following up on https://github.com/apache/lucene/issues/14151 and https://github.com/apache/lucene/issues/14152, I decided to grep for other `public static` non-`final` variables in the Lucene codebase.

This change makes `static`s `final` where it is both possible and seems appropriate. (That is, the variables really do seem to be constants.) I made a couple `private` instead, since they are modified, but privately.

I also updated some old-school code where IntelliJ flagged opportunities to use newer Java idioms.