### PR TITLE
Fixed a flaky test TestKnnFloatVectorQuery.testFindFewer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -130,6 +130,8 @@ Other
 * GITHUB#14130: Upgrade OpenNLP from 2.3.2 to 2.5.3, which transitively upgrades Slf4j 
   from 1.7.36 to 2.0.16. (Michael Froh)
 
+* GITHUB#14223 : Fixed a flaky test TestKnnFloatVectorQuery.testFindFewer (Navneet Verma)
+
 ======================= Lucene 10.1.0 =======================
 
 API Changes

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -187,8 +187,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
       assertMatches(searcher, kvq, 2);
       ScoreDoc[] scoreDocs = searcher.search(kvq, 3).scoreDocs;
       assertEquals(scoreDocs.length, 2);
-      assertIdMatches(reader, "id2", scoreDocs[0]);
-      assertIdMatches(reader, "id0", scoreDocs[1]);
+      assertTopIdsMatches(reader, Set.of("id2", "id0"), scoreDocs);
     }
   }
 
@@ -1024,6 +1023,16 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
       throws IOException {
     String actualId = reader.storedFields().document(scoreDoc.doc).get("id");
     assertEquals(expectedId, actualId);
+  }
+
+  void assertTopIdsMatches(IndexReader reader, Set<String> expectedIds, ScoreDoc[] scoreDocs)
+      throws IOException {
+    Set<String> actualIds = new HashSet<>();
+    for (ScoreDoc scoreDoc : scoreDocs) {
+      actualIds.add(reader.storedFields().document(scoreDoc.doc).get("id"));
+    }
+    assertEquals(expectedIds.size(), actualIds.size());
+    assertEquals(expectedIds, actualIds);
   }
 
   void assertDocScoreQueryToString(Query query) {


### PR DESCRIPTION
### Description
Fixed a flaky test TestKnnFloatVectorQuery.testFindFewer

This PR solves the issue: https://github.com/apache/lucene/issues/14175


Details on why the test was failing is added here: https://github.com/apache/lucene/issues/14175#issuecomment-2650199394

Tested by running below command which has the failing seed:

```
./gradlew :lucene:core:test --tests "org.apache.lucene.search.TestKnnFloatVectorQuery.testFindFewer" -Ptests.jvms=6 "-Ptests.jvmargs=-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1" -Ptests.seed=F014AA7B38C50E06 -Ptests.locale=fr-Latn-FR -Ptests.timezone=America/Sitka -Ptests.gui=false -Ptests.file.encoding=UTF-8 -Ptests.vectorsize=256 -Ptests.forceintegervectors=true
```


<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
