### PR TITLE
Fix failure found by TestOperations.testGetRandomAcceptedString

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -1242,8 +1242,16 @@ public class RegExp {
 
     do {
       // look for escape
-      if (match('\\') && peek("\\ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")) {
-        expandPreDefined(starts, ends);
+      if (match('\\')) {
+        if (peek("\\ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")) {
+          // special "escape" or invalid escape
+          expandPreDefined(starts, ends);
+        } else {
+          // escaped character, don't parse it
+          int c = next();
+          starts.add(c);
+          ends.add(c);
+        }
       } else {
         // parse a character
         int c = parseCharExp();

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -1242,7 +1242,7 @@ public class RegExp {
 
     do {
       // look for escape
-      if (match('\\')) {
+      if (match('\\') && peek("\\ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")) {
         expandPreDefined(starts, ends);
       } else {
         // parse a character

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestOperations.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestOperations.java
@@ -132,10 +132,11 @@ public class TestOperations extends LuceneTestCase {
     final int ITER2 = atLeast(100);
     for (int i = 0; i < ITER1; i++) {
 
-      final RegExp re = new RegExp(AutomatonTestUtil.randomRegexp(random()), RegExp.NONE);
+      final String text = AutomatonTestUtil.randomRegexp(random());
+      final RegExp re = new RegExp(text, RegExp.NONE);
       // System.out.println("TEST i=" + i + " re=" + re);
       final Automaton a = Operations.determinize(re.toAutomaton(), DEFAULT_DETERMINIZE_WORK_LIMIT);
-      assertFalse(Operations.isEmpty(a));
+      assertFalse("empty: " + text, Operations.isEmpty(a));
 
       final AutomatonTestUtil.RandomAcceptedStrings rx =
           new AutomatonTestUtil.RandomAcceptedStrings(a);

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExpParsing.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExpParsing.java
@@ -379,6 +379,15 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertSameLanguage(expected, actual);
   }
 
+  public void testEscapedDashCharClass() {
+    RegExp re = new RegExp("[\\-]");
+    assertEquals("REGEXP_CHAR char=-\n", re.toStringTree());
+    Automaton actual = re.toAutomaton();
+    assertTrue(actual.isDeterministic());
+    Automaton expected = Automata.makeChar('-');
+    assertSameLanguage(expected, actual);
+  }
+
   public void testEmpty() {
     RegExp re = new RegExp("#", RegExp.EMPTY);
     assertEquals("#", re.toString());

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExpParsing.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExpParsing.java
@@ -391,6 +391,26 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertSameLanguage(expected, actual);
   }
 
+  public void testEmptyClass() {
+    Exception expected =
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              new RegExp("[]");
+            });
+    assertEquals("expected ']' at position 2", expected.getMessage());
+  }
+
+  public void testEscapedInvalidClass() {
+    Exception expected =
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              new RegExp("[\\]");
+            });
+    assertEquals("expected ']' at position 3", expected.getMessage());
+  }
+
   public void testInterval() {
     RegExp re = new RegExp("<5-40>");
     assertEquals("<5-40>", re.toString());


### PR DESCRIPTION
string: `?+½]+]+Ř*+[\]ᖴﴁ.`

expected: before #14193
```
java.lang.IllegalArgumentException: expected ']' at position 17
```

actual: after #14193
```
REGEXP_CONCATENATION
  REGEXP_CONCATENATION
    REGEXP_CONCATENATION
      REGEXP_CONCATENATION
        REGEXP_CONCATENATION
          REGEXP_CONCATENATION
            REGEXP_CONCATENATION
              REGEXP_CONCATENATION
                REGEXP_REPEAT_MIN min=1
                  REGEXP_CHAR char=?
                REGEXP_CHAR char=½
              REGEXP_REPEAT_MIN min=1
                REGEXP_CHAR char=]
            REGEXP_CHAR char=
          REGEXP_REPEAT_MIN min=1
            REGEXP_CHAR char=]
        REGEXP_REPEAT_MIN min=1
          REGEXP_REPEAT
            REGEXP_CHAR char=Ř
      REGEXP_CHAR_CLASS starts=[] ends=[]
    REGEXP_STRING string=ᖴﴁ
  REGEXP_ANYCHAR
```

Problem is caused by RegExp accepting too much rather than throwing exceptions like it should have. The lenience in the parser comes from `expandPreDefined()` which invades on escape character parsing for character classes (e.g. `\s`). This one adds a lot of complexity to parsing.

Don't invoke expandPreDefined(), except for the set of characters that it explicitly handles. This is also consistent with the way expandPreDefined()'s complexity is managed elsewhere in the parser, such as in `parseSimpleExp()`.

Add parsing tests for `testEmptyClass()`, which is unchanged by this PR, but should be there, and `testEscapedInvalidClass()`, which fails without the change.

Closes #14224 