### PR TITLE
Enable error-prone checks for NonFinalStaticField

### DIFF
--- a/gradle/validation/error-prone.gradle
+++ b/gradle/validation/error-prone.gradle
@@ -486,7 +486,7 @@ allprojects { prj ->
             // '-Xep:NonApiType:OFF', // noisy
             // '-Xep:NonAtomicVolatileUpdate:OFF', // TODO: there are problems
             // '-Xep:NonCanonicalType:OFF', // noisy
-            // '-Xep:NonFinalStaticField:OFF', // noisy
+            '-Xep:NonFinalStaticField:WARN',
             '-Xep:NonOverridingEquals:WARN',
             '-Xep:NotJavadoc:WARN',
             '-Xep:NullOptional:WARN',

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/MappingCharFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/MappingCharFilterFactory.java
@@ -97,7 +97,7 @@ public class MappingCharFilterFactory extends CharFilterFactory implements Resou
   }
 
   // "source" => "target"
-  static Pattern p = Pattern.compile("\"(.*)\"\\s*=>\\s*\"(.*)\"\\s*$");
+  private static final Pattern p = Pattern.compile("\"(.*)\"\\s*=>\\s*\"(.*)\"\\s*$");
 
   protected void parseRules(List<String> rules, NormalizeCharMap.Builder builder) {
     for (String rule : rules) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData1.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData1.java
@@ -44,7 +44,7 @@ class KStemData1 {
   private KStemData1() {}
 
   // KStemData1 ... KStemData8 are created from "head_word_list.txt"
-  static String[] data = {
+  static final String[] data = {
     "aback", "abacus", "abandon", "abandoned", "abase",
     "abash", "abate", "abattoir", "abbess", "abbey",
     "abbot", "abbreviate", "abbreviation", "abc", "abdicate",

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData2.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData2.java
@@ -42,7 +42,7 @@ package org.apache.lucene.analysis.en;
 class KStemData2 {
   private KStemData2() {}
 
-  static String[] data = {
+  static final String[] data = {
     "cash", "cashew", "cashier", "cashmere", "casing",
     "casino", "cask", "casket", "casque", "cassava",
     "casserole", "cassette", "cassock", "cassowary", "cast",

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData3.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData3.java
@@ -42,7 +42,7 @@ package org.apache.lucene.analysis.en;
 class KStemData3 {
   private KStemData3() {}
 
-  static String[] data = {
+  static final String[] data = {
     "distasteful", "distemper", "distempered", "distend", "distension",
     "distil", "distill", "distillation", "distiller", "distillery",
     "distinct", "distinction", "distinctive", "distinguish", "distinguishable",

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData4.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData4.java
@@ -42,7 +42,7 @@ package org.apache.lucene.analysis.en;
 class KStemData4 {
   private KStemData4() {}
 
-  static String[] data = {
+  static final String[] data = {
     "granular", "granulate", "granule", "grape", "grapefruit",
     "grapeshot", "grapevine", "graph", "graphic", "graphical",
     "graphically", "graphite", "graphology", "grapnel", "grapple",

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData5.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData5.java
@@ -42,7 +42,7 @@ package org.apache.lucene.analysis.en;
 class KStemData5 {
   private KStemData5() {}
 
-  static String[] data = {
+  static final String[] data = {
     "lock", "locker", "locket", "lockjaw", "locknut",
     "lockout", "locks", "locksmith", "lockstitch", "lockup",
     "loco", "locomotion", "locomotive", "locum", "locus",

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData6.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData6.java
@@ -42,7 +42,7 @@ package org.apache.lucene.analysis.en;
 class KStemData6 {
   private KStemData6() {}
 
-  static String[] data = {
+  static final String[] data = {
     "pedant", "pedantic", "pedantry", "peddle", "peddler",
     "pederast", "pederasty", "pedestal", "pedestrian", "pediatrician",
     "pediatrics", "pedicab", "pedicel", "pedicure", "pedigree",

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData7.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData7.java
@@ -42,7 +42,7 @@ package org.apache.lucene.analysis.en;
 class KStemData7 {
   private KStemData7() {}
 
-  static String[] data = {
+  static final String[] data = {
     "rupee", "rupture", "rural", "ruritanian", "ruse",
     "rush", "rushes", "rushlight", "rusk", "russet",
     "rust", "rustic", "rusticate", "rustication", "rustle",

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData8.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemData8.java
@@ -42,7 +42,7 @@ package org.apache.lucene.analysis.en;
 class KStemData8 {
   private KStemData8() {}
 
-  static String[] data = {
+  static final String[] data = {
     "tenor", "tenpin", "tense", "tensile", "tension",
     "tent", "tentacle", "tentative", "tenterhooks", "tenuity",
     "tenuous", "tenure", "tepee", "tepid", "tequila",

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemmer.java
@@ -642,33 +642,32 @@ class KStemmer {
     DictEntry entry;
 
     CharArrayMap<DictEntry> d = new CharArrayMap<>(1000, false);
-    for (int i = 0; i < exceptionWords.length; i++) {
-      if (!d.containsKey(exceptionWords[i])) {
-        entry = new DictEntry(exceptionWords[i], true);
-        d.put(exceptionWords[i], entry);
+    for (String exceptionWord : exceptionWords) {
+      if (!d.containsKey(exceptionWord)) {
+        entry = new DictEntry(exceptionWord, true);
+        d.put(exceptionWord, entry);
       } else {
         throw new RuntimeException(
-            "Warning: Entry [" + exceptionWords[i] + "] already in dictionary 1");
+            "Warning: Entry [" + exceptionWord + "] already in dictionary 1");
       }
     }
 
-    for (int i = 0; i < directConflations.length; i++) {
-      if (!d.containsKey(directConflations[i][0])) {
-        entry = new DictEntry(directConflations[i][1], false);
-        d.put(directConflations[i][0], entry);
+    for (String[] directConflation : directConflations) {
+      if (!d.containsKey(directConflation[0])) {
+        entry = new DictEntry(directConflation[1], false);
+        d.put(directConflation[0], entry);
       } else {
         throw new RuntimeException(
-            "Warning: Entry [" + directConflations[i][0] + "] already in dictionary 2");
+            "Warning: Entry [" + directConflation[0] + "] already in dictionary 2");
       }
     }
 
-    for (int i = 0; i < countryNationality.length; i++) {
-      if (!d.containsKey(countryNationality[i][0])) {
-        entry = new DictEntry(countryNationality[i][1], false);
-        d.put(countryNationality[i][0], entry);
+    for (String[] strings : countryNationality) {
+      if (!d.containsKey(strings[0])) {
+        entry = new DictEntry(strings[1], false);
+        d.put(strings[0], entry);
       } else {
-        throw new RuntimeException(
-            "Warning: Entry [" + countryNationality[i][0] + "] already in dictionary 3");
+        throw new RuntimeException("Warning: Entry [" + strings[0] + "] already in dictionary 3");
       }
     }
 
@@ -677,92 +676,90 @@ class KStemmer {
     String[] array;
     array = KStemData1.data;
 
-    for (int i = 0; i < array.length; i++) {
-      if (!d.containsKey(array[i])) {
-        d.put(array[i], defaultEntry);
+    for (String s : array) {
+      if (!d.containsKey(s)) {
+        d.put(s, defaultEntry);
       } else {
-        throw new RuntimeException("Warning: Entry [" + array[i] + "] already in dictionary 4");
+        throw new RuntimeException("Warning: Entry [" + s + "] already in dictionary 4");
       }
     }
 
     array = KStemData2.data;
-    for (int i = 0; i < array.length; i++) {
-      if (!d.containsKey(array[i])) {
-        d.put(array[i], defaultEntry);
+    for (String s : array) {
+      if (!d.containsKey(s)) {
+        d.put(s, defaultEntry);
       } else {
-        throw new RuntimeException("Warning: Entry [" + array[i] + "] already in dictionary 4");
+        throw new RuntimeException("Warning: Entry [" + s + "] already in dictionary 4");
       }
     }
 
     array = KStemData3.data;
-    for (int i = 0; i < array.length; i++) {
-      if (!d.containsKey(array[i])) {
-        d.put(array[i], defaultEntry);
+    for (String s : array) {
+      if (!d.containsKey(s)) {
+        d.put(s, defaultEntry);
       } else {
-        throw new RuntimeException("Warning: Entry [" + array[i] + "] already in dictionary 4");
+        throw new RuntimeException("Warning: Entry [" + s + "] already in dictionary 4");
       }
     }
 
     array = KStemData4.data;
-    for (int i = 0; i < array.length; i++) {
-      if (!d.containsKey(array[i])) {
-        d.put(array[i], defaultEntry);
+    for (String s : array) {
+      if (!d.containsKey(s)) {
+        d.put(s, defaultEntry);
       } else {
-        throw new RuntimeException("Warning: Entry [" + array[i] + "] already in dictionary 4");
+        throw new RuntimeException("Warning: Entry [" + s + "] already in dictionary 4");
       }
     }
 
     array = KStemData5.data;
-    for (int i = 0; i < array.length; i++) {
-      if (!d.containsKey(array[i])) {
-        d.put(array[i], defaultEntry);
+    for (String s : array) {
+      if (!d.containsKey(s)) {
+        d.put(s, defaultEntry);
       } else {
-        throw new RuntimeException("Warning: Entry [" + array[i] + "] already in dictionary 4");
+        throw new RuntimeException("Warning: Entry [" + s + "] already in dictionary 4");
       }
     }
 
     array = KStemData6.data;
-    for (int i = 0; i < array.length; i++) {
-      if (!d.containsKey(array[i])) {
-        d.put(array[i], defaultEntry);
+    for (String s : array) {
+      if (!d.containsKey(s)) {
+        d.put(s, defaultEntry);
       } else {
-        throw new RuntimeException("Warning: Entry [" + array[i] + "] already in dictionary 4");
+        throw new RuntimeException("Warning: Entry [" + s + "] already in dictionary 4");
       }
     }
 
     array = KStemData7.data;
-    for (int i = 0; i < array.length; i++) {
-      if (!d.containsKey(array[i])) {
-        d.put(array[i], defaultEntry);
+    for (String s : array) {
+      if (!d.containsKey(s)) {
+        d.put(s, defaultEntry);
       } else {
-        throw new RuntimeException("Warning: Entry [" + array[i] + "] already in dictionary 4");
+        throw new RuntimeException("Warning: Entry [" + s + "] already in dictionary 4");
       }
     }
 
-    for (int i = 0; i < KStemData8.data.length; i++) {
-      if (!d.containsKey(KStemData8.data[i])) {
-        d.put(KStemData8.data[i], defaultEntry);
+    array = KStemData8.data;
+    for (String s : array) {
+      if (!d.containsKey(s)) {
+        d.put(s, defaultEntry);
       } else {
-        throw new RuntimeException(
-            "Warning: Entry [" + KStemData8.data[i] + "] already in dictionary 4");
+        throw new RuntimeException("Warning: Entry [" + s + "] already in dictionary 4");
       }
     }
 
-    for (int i = 0; i < supplementDict.length; i++) {
-      if (!d.containsKey(supplementDict[i])) {
-        d.put(supplementDict[i], defaultEntry);
+    for (String s : supplementDict) {
+      if (!d.containsKey(s)) {
+        d.put(s, defaultEntry);
       } else {
-        throw new RuntimeException(
-            "Warning: Entry [" + supplementDict[i] + "] already in dictionary 5");
+        throw new RuntimeException("Warning: Entry [" + s + "] already in dictionary 5");
       }
     }
 
-    for (int i = 0; i < properNouns.length; i++) {
-      if (!d.containsKey(properNouns[i])) {
-        d.put(properNouns[i], defaultEntry);
+    for (String properNoun : properNouns) {
+      if (!d.containsKey(properNoun)) {
+        d.put(properNoun, defaultEntry);
       } else {
-        throw new RuntimeException(
-            "Warning: Entry [" + properNouns[i] + "] already in dictionary 6");
+        throw new RuntimeException("Warning: Entry [" + properNoun + "] already in dictionary 6");
       }
     }
 
@@ -1346,10 +1343,10 @@ class KStemmer {
     return;
   }
 
-  private static char[] ization = "ization".toCharArray();
-  private static char[] ition = "ition".toCharArray();
-  private static char[] ation = "ation".toCharArray();
-  private static char[] ication = "ication".toCharArray();
+  private static final char[] ization = "ization".toCharArray();
+  private static final char[] ition = "ition".toCharArray();
+  private static final char[] ation = "ation".toCharArray();
+  private static final char[] ication = "ication".toCharArray();
 
   /* handle some derivational endings */
   /*

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterFilterFactory.java
@@ -154,13 +154,13 @@ public class WordDelimiterFilterFactory extends TokenFilterFactory implements Re
   }
 
   // source => type
-  private static Pattern typePattern = Pattern.compile("(.*)\\s*=>\\s*(.*)\\s*$");
+  private static final Pattern TYPE_PATTERN = Pattern.compile("(.*)\\s*=>\\s*(.*)\\s*$");
 
   // parses a list of MappingCharFilter style rules into a custom byte[] type table
   private byte[] parseTypes(List<String> rules) {
     SortedMap<Character, Byte> typeMap = new TreeMap<>();
     for (String rule : rules) {
-      Matcher m = typePattern.matcher(rule);
+      Matcher m = TYPE_PATTERN.matcher(rule);
       if (!m.find()) throw new IllegalArgumentException("Invalid Mapping Rule : [" + rule + "]");
       String lhs = parseString(m.group(1).trim());
       Byte rhs = parseType(m.group(2).trim());

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilterFactory.java
@@ -144,13 +144,13 @@ public class WordDelimiterGraphFilterFactory extends TokenFilterFactory
   }
 
   // source => type
-  private static Pattern typePattern = Pattern.compile("(.*)\\s*=>\\s*(.*)\\s*$");
+  private static final Pattern TYPE_PATTERN = Pattern.compile("(.*)\\s*=>\\s*(.*)\\s*$");
 
   // parses a list of MappingCharFilter style rules into a custom byte[] type table
   private byte[] parseTypes(List<String> rules) {
     SortedMap<Character, Byte> typeMap = new TreeMap<>();
     for (String rule : rules) {
-      Matcher m = typePattern.matcher(rule);
+      Matcher m = TYPE_PATTERN.matcher(rule);
       if (!m.find()) throw new IllegalArgumentException("Invalid Mapping Rule : [" + rule + "]");
       String lhs = parseString(m.group(1).trim());
       Byte rhs = parseType(m.group(2).trim());

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProviderFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/word2vec/Word2VecSynonymProviderFactory.java
@@ -34,7 +34,7 @@ public class Word2VecSynonymProviderFactory {
     DL4J
   }
 
-  private static Map<String, Word2VecSynonymProvider> word2vecSynonymProviders =
+  private static final Map<String, Word2VecSynonymProvider> word2vecSynonymProviders =
       new ConcurrentHashMap<>();
 
   public static Word2VecSynonymProvider getSynonymProvider(

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/StemmerTestBase.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/StemmerTestBase.java
@@ -30,6 +30,7 @@ import org.junit.AfterClass;
 
 /** base class for hunspell stemmer tests */
 public abstract class StemmerTestBase extends LuceneTestCase {
+  @SuppressWarnings("NonFinalStaticField")
   private static Stemmer stemmer;
 
   @AfterClass

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/shingle/TestShingleFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/shingle/TestShingleFilter.java
@@ -48,7 +48,13 @@ public class TestShingleFilter extends BaseTokenStreamTestCase {
   public static final String[] UNIGRAM_ONLY_TYPES =
       new String[] {"word", "word", "word", "word", "word", "word"};
 
-  public static Token[] testTokenWithHoles;
+  public static final Token[] testTokenWithHoles =
+      new Token[] {
+        createToken("please", 0, 6),
+        createToken("divide", 7, 13),
+        createToken("sentence", 19, 27, 2),
+        createToken("shingles", 33, 39, 2),
+      };
 
   public static final Token[] BI_GRAM_TOKENS =
       new Token[] {
@@ -708,18 +714,6 @@ public class TestShingleFilter extends BaseTokenStreamTestCase {
         "shingle", "shingle", "shingle", "shingle", "shingle", "shingle", "shingle", "shingle",
         "shingle", "shingle", "shingle", "shingle",
       };
-
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    testTokenWithHoles =
-        new Token[] {
-          createToken("please", 0, 6),
-          createToken("divide", 7, 13),
-          createToken("sentence", 19, 27, 2),
-          createToken("shingles", 33, 39, 2),
-        };
-  }
 
   /*
    * Class under test for void ShingleFilter(TokenStream, int)

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseIterationMarkCharFilter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseIterationMarkCharFilter.java
@@ -59,11 +59,11 @@ public class JapaneseIterationMarkCharFilter extends CharFilter {
 
   private static final char FULL_STOP_PUNCTUATION = '\u3002'; // 。
 
-  // Hiragana to dakuten map (lookup using code point - 0x30ab（か）*/
-  private static char[] h2d = new char[50];
+  // Hiragana to dakuten map (lookup using code point - 0x30ab（か)
+  private static final char[] h2d = new char[50];
 
-  // Katakana to dakuten map (lookup using code point - 0x30ab（カ
-  private static char[] k2d = new char[50];
+  // Katakana to dakuten map (lookup using code point - 0x30ab（カ)
+  private static final char[] k2d = new char[50];
 
   private final RollingCharBuffer buffer = new RollingCharBuffer();
 

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseNumberFilter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseNumberFilter.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.ja;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Arrays;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -93,11 +94,11 @@ public class JapaneseNumberFilter extends TokenFilter {
       addAttribute(PositionIncrementAttribute.class);
   private final PositionLengthAttribute posLengthAttr = addAttribute(PositionLengthAttribute.class);
 
-  private static char NO_NUMERAL = Character.MAX_VALUE;
+  private static final char NO_NUMERAL = Character.MAX_VALUE;
 
-  private static char[] numerals;
+  private static final char[] numerals;
 
-  private static char[] exponents;
+  private static final char[] exponents;
 
   private State state;
 
@@ -109,9 +110,7 @@ public class JapaneseNumberFilter extends TokenFilter {
 
   static {
     numerals = new char[0x10000];
-    for (int i = 0; i < numerals.length; i++) {
-      numerals[i] = NO_NUMERAL;
-    }
+    Arrays.fill(numerals, NO_NUMERAL);
     numerals['〇'] = 0; // 〇 U+3007 0
     numerals['一'] = 1; // 一 U+4E00 1
     numerals['二'] = 2; // 二 U+4E8C 2
@@ -124,9 +123,6 @@ public class JapaneseNumberFilter extends TokenFilter {
     numerals['九'] = 9; // 九 U+4E5D 9
 
     exponents = new char[0x10000];
-    for (int i = 0; i < exponents.length; i++) {
-      exponents[i] = 0;
-    }
     exponents['十'] = 1; // 十 U+5341 10
     exponents['百'] = 2; // 百 U+767E 100
     exponents['千'] = 3; // 千 U+5343 1,000
@@ -602,7 +598,7 @@ public class JapaneseNumberFilter extends TokenFilter {
 
     private int position;
 
-    private String string;
+    private final String string;
 
     public NumberBuffer(String string) {
       this.string = string;

--- a/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
+++ b/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/uk/UkrainianMorfologikAnalyzer.java
@@ -64,6 +64,7 @@ public final class UkrainianMorfologikAnalyzer extends StopwordAnalyzerBase {
   }
 
   /** Returns a lazy singleton with the default Ukrainian resources. */
+  @SuppressWarnings("NonFinalStaticField")
   private static volatile DefaultResources defaultResources;
 
   private static DefaultResources getDefaultResources() {

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanNumberFilter.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanNumberFilter.java
@@ -83,11 +83,11 @@ public class KoreanNumberFilter extends TokenFilter {
       addAttribute(PositionIncrementAttribute.class);
   private final PositionLengthAttribute posLengthAttr = addAttribute(PositionLengthAttribute.class);
 
-  private static char NO_NUMERAL = Character.MAX_VALUE;
+  private static final char NO_NUMERAL = Character.MAX_VALUE;
 
-  private static char[] numerals;
+  private static final char[] numerals;
 
-  private static char[] exponents;
+  private static final char[] exponents;
 
   private State state;
 
@@ -112,7 +112,6 @@ public class KoreanNumberFilter extends TokenFilter {
     numerals['구'] = 9; // 구 U+AD6C 9
 
     exponents = new char[0x10000];
-    Arrays.fill(exponents, (char) 0);
     exponents['십'] = 1; // 십 U+C2ED 10
     exponents['백'] = 2; // 백 U+BC31 100
     exponents['천'] = 3; // 천 U+CC9C 1,000
@@ -588,7 +587,7 @@ public class KoreanNumberFilter extends TokenFilter {
 
     private int position;
 
-    private String string;
+    private final String string;
 
     public NumberBuffer(String string) {
       this.string = string;

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/OpenNLPOpsFactory.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/tools/OpenNLPOpsFactory.java
@@ -35,14 +35,17 @@ import org.apache.lucene.util.ResourceLoader;
  * thread-safe.
  */
 public class OpenNLPOpsFactory {
-  private static Map<String, SentenceModel> sentenceModels = new ConcurrentHashMap<>();
-  private static ConcurrentHashMap<String, TokenizerModel> tokenizerModels =
+  private static final Map<String, SentenceModel> sentenceModels = new ConcurrentHashMap<>();
+  private static final ConcurrentHashMap<String, TokenizerModel> tokenizerModels =
       new ConcurrentHashMap<>();
-  private static ConcurrentHashMap<String, POSModel> posTaggerModels = new ConcurrentHashMap<>();
-  private static ConcurrentHashMap<String, ChunkerModel> chunkerModels = new ConcurrentHashMap<>();
-  private static Map<String, TokenNameFinderModel> nerModels = new ConcurrentHashMap<>();
-  private static Map<String, LemmatizerModel> lemmatizerModels = new ConcurrentHashMap<>();
-  private static Map<String, DictionaryLemmatizer> lemmaDictionaries = new ConcurrentHashMap<>();
+  private static final ConcurrentHashMap<String, POSModel> posTaggerModels =
+      new ConcurrentHashMap<>();
+  private static final ConcurrentHashMap<String, ChunkerModel> chunkerModels =
+      new ConcurrentHashMap<>();
+  private static final Map<String, TokenNameFinderModel> nerModels = new ConcurrentHashMap<>();
+  private static final Map<String, LemmatizerModel> lemmatizerModels = new ConcurrentHashMap<>();
+  private static final Map<String, DictionaryLemmatizer> lemmaDictionaries =
+      new ConcurrentHashMap<>();
 
   public static NLPSentenceDetectorOp getSentenceDetector(String modelName) throws IOException {
     if (modelName != null) {

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPTokenizerFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPTokenizerFactory.java
@@ -33,8 +33,9 @@ import org.junit.Test;
  */
 public class TestOpenNLPTokenizerFactory extends BaseTokenStreamTestCase {
 
-  private static String SENTENCES = "Sentence number 1 has 6 words. Sentence number 2, 5 words.";
-  private static String[] SENTENCES_punc = {
+  private static final String SENTENCES =
+      "Sentence number 1 has 6 words. Sentence number 2, 5 words.";
+  private static final String[] SENTENCES_punc = {
     "Sentence",
     "number",
     "1",
@@ -50,15 +51,17 @@ public class TestOpenNLPTokenizerFactory extends BaseTokenStreamTestCase {
     "words",
     "."
   };
-  private static int[] SENTENCES_startOffsets = {
+  private static final int[] SENTENCES_startOffsets = {
     0, 9, 16, 18, 22, 24, 29, 31, 40, 47, 48, 50, 52, 57
   };
-  private static int[] SENTENCES_endOffsets = {
+  private static final int[] SENTENCES_endOffsets = {
     8, 15, 17, 21, 23, 29, 30, 39, 46, 48, 49, 51, 57, 58
   };
 
-  private static String SENTENCE1 = "Sentence number 1 has 6 words.";
-  private static String[] SENTENCE1_punc = {"Sentence", "number", "1", "has", "6", "words", "."};
+  private static final String SENTENCE1 = "Sentence number 1 has 6 words.";
+  private static final String[] SENTENCE1_punc = {
+    "Sentence", "number", "1", "has", "6", "words", "."
+  };
 
   @Test
   public void testTokenizer() throws IOException {

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BiSegGraph.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BiSegGraph.java
@@ -32,11 +32,12 @@ import org.apache.lucene.internal.hppc.ObjectCursor;
  */
 class BiSegGraph {
 
-  private IntObjectHashMap<ArrayList<SegTokenPair>> tokenPairListTable = new IntObjectHashMap<>();
+  private final IntObjectHashMap<ArrayList<SegTokenPair>> tokenPairListTable =
+      new IntObjectHashMap<>();
 
   private List<SegToken> segTokenList;
 
-  private static BigramDictionary bigramDict = BigramDictionary.getInstance();
+  private static final BigramDictionary bigramDict = BigramDictionary.getInstance();
 
   public BiSegGraph(SegGraph segGraph) {
     segTokenList = segGraph.makeIndex();

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BigramDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BigramDictionary.java
@@ -40,6 +40,7 @@ class BigramDictionary extends AbstractDictionary {
 
   public static final char WORD_SEGMENT_CHAR = '@';
 
+  @SuppressWarnings("NonFinalStaticField")
   private static BigramDictionary singleInstance;
 
   public static final int PRIME_BIGRAM_LENGTH = 402137;

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/HHMMSegmenter.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/HHMMSegmenter.java
@@ -28,7 +28,7 @@ import org.apache.lucene.analysis.cn.smart.WordType;
  */
 public class HHMMSegmenter {
 
-  private static WordDictionary wordDict = WordDictionary.getInstance();
+  private static final WordDictionary wordDict = WordDictionary.getInstance();
 
   /**
    * Create the {@link SegGraph} for a sentence.

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
@@ -39,6 +39,7 @@ class WordDictionary extends AbstractDictionary {
 
   private WordDictionary() {}
 
+  @SuppressWarnings("NonFinalStaticField")
   private static WordDictionary singleInstance;
 
   /** Large prime number for hash function */
@@ -359,7 +360,7 @@ class WordDictionary extends AbstractDictionary {
    * then initialize the value of that position in the address table.
    */
   private boolean setTableIndex(char c, int j) {
-    int index = getAvaliableTableIndex(c);
+    int index = getAvailableTableIndex(c);
     if (index != -1) {
       charIndexTable[index] = c;
       wordIndexTable[index] = (short) j;
@@ -367,7 +368,7 @@ class WordDictionary extends AbstractDictionary {
     } else return false;
   }
 
-  private short getAvaliableTableIndex(char c) {
+  private short getAvailableTableIndex(char c) {
     int hash1 = (int) (hash1(c) % PRIME_INDEX_LENGTH);
     int hash2 = hash2(c) % PRIME_INDEX_LENGTH;
     if (hash1 < 0) hash1 = PRIME_INDEX_LENGTH + hash1;

--- a/lucene/analysis/stempel/src/java/org/egothor/stemmer/Compile.java
+++ b/lucene/analysis/stempel/src/java/org/egothor/stemmer/Compile.java
@@ -67,10 +67,6 @@ import org.apache.lucene.util.SuppressForbidden;
 /** The Compile class is used to compile a stemmer table. */
 public class Compile {
 
-  static boolean backward;
-  static boolean multi;
-  static Trie trie;
-
   /** no instantiation */
   private Compile() {}
 
@@ -89,9 +85,7 @@ public class Compile {
       return;
     }
 
-    args[0].toUpperCase(Locale.ROOT);
-
-    backward = args[0].charAt(0) == '-';
+    boolean backward = args[0].charAt(0) == '-';
     int qq = (backward) ? 1 : 0;
     boolean storeorig = false;
 
@@ -100,7 +94,7 @@ public class Compile {
       qq++;
     }
 
-    multi = args[0].charAt(qq) == 'M';
+    boolean multi = args[0].charAt(qq) == 'M';
     if (multi) {
       qq++;
     }
@@ -116,7 +110,7 @@ public class Compile {
       // System.out.println("[" + args[i] + "]");
       Diff diff = new Diff();
 
-      allocTrie();
+      Trie trie = allocTrie(multi, backward);
 
       System.out.println(args[i]);
       try (LineNumberReader in =
@@ -150,9 +144,9 @@ public class Compile {
       Lift e = new Lift(false);
       Gener g = new Gener();
 
-      for (int j = 0; j < optimizer.length; j++) {
+      for (char c : optimizer) {
         String prefix;
-        switch (optimizer[j]) {
+        switch (c) {
           case 'G':
             trie = trie.reduce(g);
             prefix = "G: ";
@@ -188,11 +182,11 @@ public class Compile {
     }
   }
 
-  static void allocTrie() {
+  static Trie allocTrie(boolean multi, boolean backward) {
     if (multi) {
-      trie = new MultiTrie2(!backward);
+      return new MultiTrie2(!backward);
     } else {
-      trie = new Trie(!backward);
+      return new Trie(!backward);
     }
   }
 }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswGraphBuilder.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswGraphBuilder.java
@@ -42,6 +42,7 @@ public final class Lucene90HnswGraphBuilder {
   public static final String HNSW_COMPONENT = "HNSW";
 
   /** Random seed for level generation; public to expose for testing * */
+  @SuppressWarnings("NonFinalStaticField")
   public static long randSeed = DEFAULT_RAND_SEED;
 
   private final int maxConn;

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswGraphBuilder.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswGraphBuilder.java
@@ -48,6 +48,7 @@ public final class Lucene91HnswGraphBuilder {
   public static final String HNSW_COMPONENT = "HNSW";
 
   /** Random seed for level generation; public to expose for testing * */
+  @SuppressWarnings("NonFinalStaticField")
   public static long randSeed = DEFAULT_RAND_SEED;
 
   private final int maxConn;

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/EnwikiQueryMaker.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/EnwikiQueryMaker.java
@@ -40,7 +40,7 @@ import org.apache.lucene.util.automaton.Operations;
 public class EnwikiQueryMaker extends AbstractQueryMaker {
 
   // common and a few uncommon queries from wikipedia search logs
-  private static String[] STANDARD_QUERIES = {
+  private static final String[] STANDARD_QUERIES = {
     "Images catbox gif",
     "Imunisasi haram",
     "Favicon ico",

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/ReutersQueryMaker.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/ReutersQueryMaker.java
@@ -36,7 +36,7 @@ import org.apache.lucene.search.WildcardQuery;
  */
 public class ReutersQueryMaker extends AbstractQueryMaker {
 
-  private static String[] STANDARD_QUERIES = {
+  private static final String[] STANDARD_QUERIES = {
     // Start with some short queries
     "Salomon",
     "Comex",

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/SortableSingleDocSource.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/SortableSingleDocSource.java
@@ -31,7 +31,7 @@ import org.apache.lucene.benchmark.byTask.utils.Config;
  */
 public class SortableSingleDocSource extends SingleDocSource {
 
-  private static String[] COUNTRIES =
+  private static final String[] COUNTRIES =
       new String[] {
         "European Union",
         "United States",

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/SpatialDocMaker.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/SpatialDocMaker.java
@@ -50,7 +50,8 @@ public class SpatialDocMaker extends DocMaker {
   public static final String SPATIAL_FIELD = "spatial";
 
   // cache spatialStrategy by round number
-  private static IntObjectHashMap<SpatialStrategy> spatialStrategyCache = new IntObjectHashMap<>();
+  private static final IntObjectHashMap<SpatialStrategy> spatialStrategyCache =
+      new IntObjectHashMap<>();
 
   private SpatialStrategy strategy;
   private ShapeConverter shapeConverter;

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Format.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Format.java
@@ -22,7 +22,7 @@ import java.util.Locale;
 /** Formatting utilities (for reports). */
 public class Format {
 
-  private static NumberFormat[] numFormat = {
+  private static final NumberFormat[] numFormat = {
     NumberFormat.getInstance(Locale.ROOT),
     NumberFormat.getInstance(Locale.ROOT),
     NumberFormat.getInstance(Locale.ROOT),

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/quality/QualityStats.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/quality/QualityStats.java
@@ -29,7 +29,7 @@ public class QualityStats {
 
   private double maxGoodPoints;
   private double recall;
-  private double[] pAt;
+  private final double[] pAt;
   private double pReleventSum = 0;
   private double numPoints = 0;
   private double numGoodPoints = 0;
@@ -39,8 +39,8 @@ public class QualityStats {
 
   /** A certain rank in which a relevant doc was found. */
   public static class RecallPoint {
-    private int rank;
-    private double recall;
+    private final int rank;
+    private final double recall;
 
     private RecallPoint(int rank, double recall) {
       this.rank = rank;
@@ -58,7 +58,7 @@ public class QualityStats {
     }
   }
 
-  private ArrayList<RecallPoint> recallPoints;
+  private final ArrayList<RecallPoint> recallPoints;
 
   /**
    * Construct a QualityStats object with anticipated maximal number of relevant hits.
@@ -170,7 +170,7 @@ public class QualityStats {
     }
   }
 
-  private static String padd = "                                    ";
+  private static final String padd = "                                    ";
 
   private String format(String s, int minLen) {
     s = (s == null ? "" : s);
@@ -200,19 +200,19 @@ public class QualityStats {
     }
     int m = 0; // queries with positive judgements
     // aggregate
-    for (int i = 0; i < stats.length; i++) {
-      avg.searchTime += stats[i].searchTime;
-      avg.docNamesExtractTime += stats[i].docNamesExtractTime;
-      if (stats[i].maxGoodPoints > 0) {
+    for (QualityStats stat : stats) {
+      avg.searchTime += stat.searchTime;
+      avg.docNamesExtractTime += stat.docNamesExtractTime;
+      if (stat.maxGoodPoints > 0) {
         m++;
-        avg.numGoodPoints += stats[i].numGoodPoints;
-        avg.numPoints += stats[i].numPoints;
-        avg.pReleventSum += stats[i].getAvp();
-        avg.recall += stats[i].recall;
-        avg.mrr += stats[i].getMRR();
-        avg.maxGoodPoints += stats[i].maxGoodPoints;
+        avg.numGoodPoints += stat.numGoodPoints;
+        avg.numPoints += stat.numPoints;
+        avg.pReleventSum += stat.getAvp();
+        avg.recall += stat.recall;
+        avg.mrr += stat.getMRR();
+        avg.maxGoodPoints += stat.maxGoodPoints;
         for (int j = 1; j < avg.pAt.length; j++) {
-          avg.pAt[j] += stats[i].getPrecisionAt(j);
+          avg.pAt[j] += stat.getPrecisionAt(j);
         }
       }
     }

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/quality/utils/SubmissionReport.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/quality/utils/SubmissionReport.java
@@ -32,9 +32,9 @@ import org.apache.lucene.search.TopDocs;
  */
 public class SubmissionReport {
 
-  private NumberFormat nf;
-  private PrintWriter logger;
-  private String name;
+  private final NumberFormat nf;
+  private final PrintWriter logger;
+  private final String name;
 
   /**
    * Constructor for SubmissionReport.
@@ -91,7 +91,7 @@ public class SubmissionReport {
     }
   }
 
-  private static String padd = "                                    ";
+  private static final String padd = "                                    ";
 
   private String format(String s, int minLen) {
     s = (s == null ? "" : s);

--- a/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/tasks/CountingSearchTestTask.java
+++ b/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/tasks/CountingSearchTestTask.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.lucene.benchmark.byTask.PerfRunData;
 
 /** Test Search task which counts number of searches. */
+@SuppressWarnings("NonFinalStaticField")
 public class CountingSearchTestTask extends SearchTask {
 
   public static int numSearches = 0;

--- a/lucene/classification/src/test/org/apache/lucene/classification/Test20NewsgroupsClassification.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/Test20NewsgroupsClassification.java
@@ -77,8 +77,8 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
   private static final String SUBJECT_FIELD = "subject";
   // private static final String INDEX_DIR = "/path/to/lucene-solr/lucene/classification/20n";
 
-  private static boolean index = true;
-  private static boolean split = true;
+  private boolean index = true;
+  private boolean split = true;
 
   @SuppressForbidden(reason = "Thread sleep")
   @Test
@@ -87,7 +87,7 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
     String indexProperty = System.getProperty("index");
     if (indexProperty != null) {
       try {
-        index = Boolean.valueOf(indexProperty);
+        index = Boolean.parseBoolean(indexProperty);
       } catch (
           @SuppressWarnings("unused")
           Exception e) {
@@ -98,7 +98,7 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
     String splitProperty = System.getProperty("split");
     if (splitProperty != null) {
       try {
-        split = Boolean.valueOf(splitProperty);
+        split = Boolean.parseBoolean(splitProperty);
       } catch (
           @SuppressWarnings("unused")
           Exception e) {
@@ -441,7 +441,7 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
     }
   }
 
-  private class NewsPost {
+  private static class NewsPost {
     private final String body;
     private final String subject;
     private final String group;

--- a/lucene/core/src/java/org/apache/lucene/codecs/Codec.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/Codec.java
@@ -55,6 +55,7 @@ public abstract class Codec implements NamedSPILoader.NamedSPI {
       return LOADER;
     }
 
+    @SuppressWarnings("NonFinalStaticField")
     static Codec defaultCodec = LOADER.lookup("Lucene101");
   }
 

--- a/lucene/core/src/java/org/apache/lucene/geo/Rectangle2D.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Rectangle2D.java
@@ -291,8 +291,8 @@ final class Rectangle2D implements Component2D {
     return new Rectangle2D(rectangle.minX, rectangle.maxX, rectangle.minY, rectangle.maxY);
   }
 
-  private static double MIN_LON_INCL_QUANTIZE = decodeLongitude(MIN_LON_ENCODED);
-  private static double MAX_LON_INCL_QUANTIZE = decodeLongitude(MAX_LON_ENCODED);
+  private static final double MIN_LON_INCL_QUANTIZE = decodeLongitude(MIN_LON_ENCODED);
+  private static final double MAX_LON_INCL_QUANTIZE = decodeLongitude(MAX_LON_ENCODED);
 
   /** create a component2D from the provided LatLon rectangle */
   static Component2D create(Rectangle rectangle) {

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -4335,6 +4335,7 @@ public final class CheckIndex implements Closeable {
     result.newSegments.commit(result.dir);
   }
 
+  @SuppressWarnings("NonFinalStaticField")
   private static boolean assertsOn;
 
   private static boolean testAsserts() {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexFileDeleter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexFileDeleter.java
@@ -86,9 +86,6 @@ final class IndexFileDeleter implements Closeable {
   final boolean startingCommitDeleted;
   private SegmentInfos lastSegmentInfos;
 
-  /** Change to true to see details of reference counts when infoStream is enabled */
-  public static boolean VERBOSE_REF_COUNTS = false;
-
   private final FileDeleter fileDeleter;
 
   private final IndexWriter writer;
@@ -602,7 +599,7 @@ final class IndexFileDeleter implements Closeable {
   }
 
   private void logInfo(FileDeleter.MsgType msgType, String msg) {
-    if (msgType == FileDeleter.MsgType.REF && VERBOSE_REF_COUNTS == false) {
+    if (msgType == FileDeleter.MsgType.REF) {
       // do not log anything
     } else {
       if (infoStream.isEnabled("IFD")) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -209,6 +209,7 @@ public class IndexWriter
 
   // Use package-private instance var to enforce the limit so testing
   // can use less electricity:
+  @SuppressWarnings("NonFinalStaticField")
   private static int actualMaxDocs = MAX_DOCS;
 
   /** Used only for testing. */

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -146,6 +146,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
    *
    * @see #setInfoStream
    */
+  @SuppressWarnings("NonFinalStaticField")
   private static PrintStream infoStream;
 
   /** Id for this commit; only written starting with Lucene 5.0 */

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -52,10 +52,19 @@ public final class TestSecrets {
     ensureInitialized.accept(FilterIndexInput.class);
   }
 
+  @SuppressWarnings("NonFinalStaticField")
   private static IndexPackageAccess indexPackageAccess;
+
+  @SuppressWarnings("NonFinalStaticField")
   private static ConcurrentMergeSchedulerAccess cmsAccess;
+
+  @SuppressWarnings("NonFinalStaticField")
   private static SegmentReaderAccess segmentReaderAccess;
+
+  @SuppressWarnings("NonFinalStaticField")
   private static IndexWriterAccess indexWriterAccess;
+
+  @SuppressWarnings("NonFinalStaticField")
   private static FilterIndexInputAccess filterIndexInputAccess;
 
   private TestSecrets() {}

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -76,9 +76,15 @@ import org.apache.lucene.util.automaton.ByteRunAutomaton;
  */
 public class IndexSearcher {
 
+  @SuppressWarnings("NonFinalStaticField")
   static int maxClauseCount = 1024;
+
+  @SuppressWarnings("NonFinalStaticField")
   private static QueryCache DEFAULT_QUERY_CACHE;
+
+  @SuppressWarnings("NonFinalStaticField")
   private static QueryCachingPolicy DEFAULT_CACHING_POLICY = new UsageTrackingQueryCachingPolicy();
+
   private QueryTimeout queryTimeout = null;
   // partialResult may be set on one of the threads of the executor. It may be correct to not make
   // this variable volatile since joining these threads should ensure a happens-before relationship

--- a/lucene/core/src/java/org/apache/lucene/util/InfoStream.java
+++ b/lucene/core/src/java/org/apache/lucene/util/InfoStream.java
@@ -53,6 +53,7 @@ public abstract class InfoStream implements Closeable {
   /** returns true if messages are enabled and should be posted to {@link #message}. */
   public abstract boolean isEnabled(String component);
 
+  @SuppressWarnings("NonFinalStaticField")
   private static InfoStream defaultInfoStream = NO_OUTPUT;
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
@@ -360,7 +360,9 @@ public abstract class StringHelper {
   }
 
   // Holds 128 bit unsigned value:
+  @SuppressWarnings("NonFinalStaticField")
   private static BigInteger nextId;
+
   private static final BigInteger mask128;
   private static final Object idLock = new Object();
 

--- a/lucene/core/src/java/org/apache/lucene/util/Version.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Version.java
@@ -89,6 +89,7 @@ public final class Version {
   /**
    * @see #getPackageImplementationVersion()
    */
+  @SuppressWarnings("NonFinalStaticField")
   private static String implementationVersion;
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/UTF32ToUTF8.java
@@ -34,7 +34,7 @@ public final class UTF32ToUTF8 {
   private static final int[] startCodes = new int[] {0, 128, 2048, 65536};
   private static final int[] endCodes = new int[] {127, 2047, 65535, 1114111};
 
-  static byte[] MASKS = new byte[8];
+  private static final byte[] MASKS = new byte[8];
 
   static {
     for (int i = 0; i < 7; i++) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraph.java
@@ -175,7 +175,7 @@ public abstract class HnswGraph {
 
   /** NodesIterator that accepts nodes as an integer array. */
   public static class ArrayNodesIterator extends NodesIterator {
-    static NodesIterator EMPTY = new ArrayNodesIterator(0);
+    private static final NodesIterator EMPTY = new ArrayNodesIterator(0);
 
     private final int[] nodes;
     private int cur = 0;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -55,6 +55,7 @@ public class HnswGraphBuilder implements HnswBuilder {
   public static final String HNSW_COMPONENT = "HNSW";
 
   /** Random seed for level generation; public to expose for testing * */
+  @SuppressWarnings("NonFinalStaticField")
   public static long randSeed = DEFAULT_RAND_SEED;
 
   private final int M; // max number of connections on upper layers

--- a/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
+++ b/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
@@ -41,7 +41,7 @@ import org.apache.lucene.tests.store.MockDirectoryWrapper;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.PrintStreamInfoStream;
-import org.junit.AfterClass;
+import org.junit.After;
 
 /**
  * Holds tests cases to verify external APIs are accessible while not being in
@@ -52,7 +52,7 @@ public class TestMergeSchedulerExternal extends LuceneTestCase {
   volatile boolean mergeCalled;
   volatile boolean mergeThreadCreated;
   volatile boolean excCalled;
-  static volatile InfoStream infoStream;
+  volatile InfoStream infoStream;
 
   private class MyMergeScheduler extends ConcurrentMergeScheduler {
 
@@ -87,7 +87,7 @@ public class TestMergeSchedulerExternal extends LuceneTestCase {
     }
   }
 
-  private static class FailOnlyOnMerge extends MockDirectoryWrapper.Failure {
+  private class FailOnlyOnMerge extends MockDirectoryWrapper.Failure {
     @Override
     public void eval(MockDirectoryWrapper dir) throws IOException {
       if (callStackContainsAnyOf("doMerge")) {
@@ -103,8 +103,8 @@ public class TestMergeSchedulerExternal extends LuceneTestCase {
     }
   }
 
-  @AfterClass
-  public static void afterClass() {
+  @After
+  public void after() {
     infoStream = null;
   }
 

--- a/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestFlatVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestFlatVectorScorer.java
@@ -49,9 +49,9 @@ import org.hamcrest.MatcherAssert;
 
 public class TestFlatVectorScorer extends LuceneTestCase {
 
-  static volatile AtomicInteger count = new AtomicInteger();
-  final FlatVectorsScorer flatVectorsScorer;
-  final ThrowingSupplier<Directory> newDirectory;
+  private static final AtomicInteger count = new AtomicInteger();
+  private final FlatVectorsScorer flatVectorsScorer;
+  private final ThrowingSupplier<Directory> newDirectory;
 
   public TestFlatVectorScorer(
       FlatVectorsScorer flatVectorsScorer, ThrowingSupplier<Directory> newDirectory) {

--- a/lucene/core/src/test/org/apache/lucene/document/BaseLatLonSpatialTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/document/BaseLatLonSpatialTestCase.java
@@ -217,11 +217,7 @@ public abstract class BaseLatLonSpatialTestCase extends BaseSpatialTestCase {
       }
     };
 
-    static ShapeType[] subList;
-
-    static {
-      subList = new ShapeType[] {POINT, LINE, POLYGON};
-    }
+    private static final ShapeType[] subList = new ShapeType[] {POINT, LINE, POLYGON};
 
     public abstract Object nextShape();
   }

--- a/lucene/core/src/test/org/apache/lucene/document/BaseXYShapeTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/document/BaseXYShapeTestCase.java
@@ -243,11 +243,7 @@ public abstract class BaseXYShapeTestCase extends BaseSpatialTestCase {
       }
     };
 
-    static ShapeType[] subList;
-
-    static {
-      subList = new ShapeType[] {POINT, LINE, POLYGON};
-    }
+    private static final ShapeType[] subList = new ShapeType[] {POINT, LINE, POLYGON};
 
     public abstract Object nextShape();
   }

--- a/lucene/core/src/test/org/apache/lucene/document/TestLatLonShape.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLatLonShape.java
@@ -52,33 +52,33 @@ import org.junit.Ignore;
 
 /** Test case for indexing polygons and querying by bounding box */
 public class TestLatLonShape extends LuceneTestCase {
-  protected static String FIELDNAME = "field";
+  private static final String FIELDNAME = "field";
 
   /** quantizes a latitude value to be consistent with index encoding */
-  protected static double quantizeLat(double rawLat) {
+  private static double quantizeLat(double rawLat) {
     return decodeLatitude(encodeLatitude(rawLat));
   }
 
   /** quantizes a longitude value to be consistent with index encoding */
-  protected static double quantizeLon(double rawLon) {
+  private static double quantizeLon(double rawLon) {
     return decodeLongitude(encodeLongitude(rawLon));
   }
 
-  protected void addPolygonsToDoc(String field, Document doc, Polygon polygon) {
+  private void addPolygonsToDoc(String field, Document doc, Polygon polygon) {
     Field[] fields = LatLonShape.createIndexableFields(field, polygon, random().nextBoolean());
     for (Field f : fields) {
       doc.add(f);
     }
   }
 
-  protected void addLineToDoc(String field, Document doc, Line line) {
+  private void addLineToDoc(String field, Document doc, Line line) {
     Field[] fields = LatLonShape.createIndexableFields(field, line);
     for (Field f : fields) {
       doc.add(f);
     }
   }
 
-  protected Query newRectQuery(
+  private Query newRectQuery(
       String field, double minLat, double maxLat, double minLon, double maxLon) {
     return LatLonShape.newBoxQuery(field, QueryRelation.INTERSECTS, minLat, maxLat, minLon, maxLon);
   }

--- a/lucene/core/src/test/org/apache/lucene/document/TestShapeDocValues.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestShapeDocValues.java
@@ -39,7 +39,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 
 /** Simple tests for {@link org.apache.lucene.document.ShapeDocValuesField} */
 public class TestShapeDocValues extends LuceneTestCase {
-  private static double TOLERANCE = 1E-7;
+  private static final double TOLERANCE = 1E-7;
 
   private static final String FIELD_NAME = "field";
 

--- a/lucene/core/src/test/org/apache/lucene/document/TestXYShape.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestXYShape.java
@@ -40,23 +40,23 @@ import org.apache.lucene.util.IOUtils;
 /** Test case for indexing cartesian shapes and search by bounding box, lines, and polygons */
 public class TestXYShape extends LuceneTestCase {
 
-  protected static String FIELDNAME = "field";
+  private static final String FIELDNAME = "field";
 
-  protected static void addPolygonsToDoc(String field, Document doc, XYPolygon polygon) {
+  private static void addPolygonsToDoc(String field, Document doc, XYPolygon polygon) {
     Field[] fields = XYShape.createIndexableFields(field, polygon);
     for (Field f : fields) {
       doc.add(f);
     }
   }
 
-  protected static void addLineToDoc(String field, Document doc, XYLine line) {
+  private static void addLineToDoc(String field, Document doc, XYLine line) {
     Field[] fields = XYShape.createIndexableFields(field, line);
     for (Field f : fields) {
       doc.add(f);
     }
   }
 
-  protected Query newRectQuery(String field, float minX, float maxX, float minY, float maxY) {
+  private Query newRectQuery(String field, float minX, float maxX, float minY, float maxY) {
     return XYShape.newBoxQuery(field, QueryRelation.INTERSECTS, minX, maxX, minY, maxY);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
@@ -61,7 +61,7 @@ import org.junit.BeforeClass;
 //   - skipTo(doc)
 
 public class TestCodecs extends LuceneTestCase {
-  private static String[] fieldNames = new String[] {"one", "two", "three", "four"};
+  private static final String[] fieldNames = new String[] {"one", "two", "three", "four"};
 
   private static int NUM_TEST_ITER;
   private static final int NUM_TEST_THREADS = 3;

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
@@ -352,7 +352,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
     }
   }
 
-  private static String CRASH_FAIL_MESSAGE = "I'm experiencing problems";
+  private static final String CRASH_FAIL_MESSAGE = "I'm experiencing problems";
 
   private static class CrashingFilter extends TokenFilter {
     String fieldName;

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -64,6 +64,7 @@ public class TestKnnGraph extends LuceneTestCase {
 
   private static final String KNN_GRAPH_FIELD = "vector";
 
+  @SuppressWarnings("NonFinalStaticField")
   private static int M = HnswGraphBuilder.DEFAULT_MAX_CONN;
 
   private Codec codec;

--- a/lucene/core/src/test/org/apache/lucene/index/TestStressIndexing.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestStressIndexing.java
@@ -29,8 +29,8 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 public class TestStressIndexing extends LuceneTestCase {
   private abstract static class TimedThread extends Thread {
     volatile boolean failed;
-    private static int RUN_ITERATIONS = TEST_NIGHTLY ? atLeast(100) : atLeast(20);
-    private TimedThread[] allThreads;
+    private static final int RUN_ITERATIONS = TEST_NIGHTLY ? atLeast(100) : atLeast(20);
+    private final TimedThread[] allThreads;
 
     public abstract void doWork() throws Throwable;
 
@@ -54,13 +54,14 @@ public class TestStressIndexing extends LuceneTestCase {
     }
 
     private boolean anyErrors() {
-      for (int i = 0; i < allThreads.length; i++)
-        if (allThreads[i] != null && allThreads[i].failed) return true;
+      for (TimedThread thread : allThreads) {
+        if (thread != null && thread.failed) return true;
+      }
       return false;
     }
   }
 
-  private class IndexerThread extends TimedThread {
+  private static class IndexerThread extends TimedThread {
     IndexWriter writer;
     int nextID;
 
@@ -90,7 +91,7 @@ public class TestStressIndexing extends LuceneTestCase {
   }
 
   private static class SearcherThread extends TimedThread {
-    private Directory directory;
+    private final Directory directory;
 
     public SearcherThread(Directory directory, TimedThread[] threads) {
       super(threads);
@@ -148,7 +149,7 @@ public class TestStressIndexing extends LuceneTestCase {
 
     modifier.close();
 
-    for (int i = 0; i < numThread; i++) assertTrue(!threads[i].failed);
+    for (int i = 0; i < numThread; i++) assertFalse(threads[i].failed);
 
     // System.out.println("    Writer: " + indexerThread.count + " iterations");
     // System.out.println("Searcher 1: " + searcherThread1.count + " searchers created");

--- a/lucene/core/src/test/org/apache/lucene/index/TestStressIndexing2.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestStressIndexing2.java
@@ -41,23 +41,15 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Before;
 
 public class TestStressIndexing2 extends LuceneTestCase {
-  static int maxFields = 4;
-  static int bigFieldSize = 10;
-  static boolean sameFieldOrder = false;
-  static int mergeFactor = 3;
-  static int maxBufferedDocs = 3;
-  static int seed = 0;
-  private static Map<String, FieldType> fieldTypes;
-
-  @Before
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    fieldTypes = new ConcurrentHashMap<>();
-  }
+  int maxFields = 4;
+  int bigFieldSize = 10;
+  boolean sameFieldOrder = false;
+  int mergeFactor = 3;
+  int maxBufferedDocs = 3;
+  int seed = 0;
+  private final Map<String, FieldType> fieldTypes = new ConcurrentHashMap<>();
 
   public void testRandomIWReader() throws Throwable {
     Directory dir = newMaybeVirusCheckingDirectory();
@@ -140,13 +132,8 @@ public class TestStressIndexing2 extends LuceneTestCase {
   }
 
   IndexingThread[] threads;
-  static Comparator<IndexableField> fieldNameComparator =
-      new Comparator<IndexableField>() {
-        @Override
-        public int compare(IndexableField o1, IndexableField o2) {
-          return o1.name().compareTo(o2.name());
-        }
-      };
+  private static final Comparator<IndexableField> fieldNameComparator =
+      Comparator.comparing(IndexableField::name);
 
   // This test avoids using any extra synchronization in the multiple
   // indexing threads to test that IndexWriter does correctly synchronize
@@ -736,7 +723,7 @@ public class TestStressIndexing2 extends LuceneTestCase {
     assertFalse(fieldsEnum2.hasNext());
   }
 
-  private static class IndexingThread extends Thread {
+  private class IndexingThread extends Thread {
     IndexWriter w;
     int base;
     int range;

--- a/lucene/core/src/test/org/apache/lucene/index/TestTermVectorsReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTermVectorsReader.java
@@ -49,7 +49,7 @@ public class TestTermVectorsReader extends LuceneTestCase {
   private Directory dir;
   private SegmentCommitInfo seg;
   private FieldInfos fieldInfos = FieldInfos.EMPTY;
-  private static int TERM_FREQ = 3;
+  private static final int TERM_FREQ = 3;
 
   private static class TestToken implements Comparable<TestToken> {
     String text;

--- a/lucene/core/src/test/org/apache/lucene/index/TestTransactions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTransactions.java
@@ -31,12 +31,12 @@ import org.apache.lucene.util.IOUtils;
 
 public class TestTransactions extends LuceneTestCase {
 
-  private static volatile boolean doFail;
+  private volatile boolean doFail;
 
   private class RandomFailure extends MockDirectoryWrapper.Failure {
     @Override
     public void eval(MockDirectoryWrapper dir) throws IOException {
-      if (TestTransactions.doFail && random().nextInt(10) <= 3) {
+      if (TestTransactions.this.doFail && random().nextInt(10) <= 3) {
         if (VERBOSE) {
           System.out.println(Thread.currentThread().getName() + " TEST: now fail on purpose");
           new Throwable().printStackTrace(System.out);
@@ -48,8 +48,8 @@ public class TestTransactions extends LuceneTestCase {
 
   private abstract static class TimedThread extends Thread {
     volatile boolean failed;
-    private static int MAX_ITERATIONS = atLeast(100);
-    private TimedThread[] allThreads;
+    private static final int MAX_ITERATIONS = atLeast(100);
+    private final TimedThread[] allThreads;
 
     public abstract void doWork() throws Throwable;
 
@@ -74,8 +74,9 @@ public class TestTransactions extends LuceneTestCase {
     }
 
     private boolean anyErrors() {
-      for (int i = 0; i < allThreads.length; i++)
-        if (allThreads[i] != null && allThreads[i].failed) return true;
+      for (TimedThread thread : allThreads) {
+        if (thread != null && thread.failed) return true;
+      }
       return false;
     }
   }
@@ -119,7 +120,7 @@ public class TestTransactions extends LuceneTestCase {
       update(writer1);
       update(writer2);
 
-      TestTransactions.doFail = true;
+      doFail = true;
       try {
         synchronized (lock) {
           try {
@@ -167,7 +168,7 @@ public class TestTransactions extends LuceneTestCase {
           writer2.commit();
         }
       } finally {
-        TestTransactions.doFail = false;
+        doFail = false;
       }
 
       writer1.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestTwoPhaseCommitTool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTwoPhaseCommitTool.java
@@ -23,7 +23,9 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 public class TestTwoPhaseCommitTool extends LuceneTestCase {
 
   private static class TwoPhaseCommitImpl implements TwoPhaseCommit {
+    @SuppressWarnings("NonFinalStaticField")
     static boolean commitCalled = false;
+
     final boolean failOnPrepare;
     final boolean failOnCommit;
     final boolean failOnRollback;

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorScorer.java
@@ -59,8 +59,8 @@ public class TestVectorScorer extends LuceneTestCase {
 
   private static final double DELTA = 1e-5;
 
-  static final FlatVectorsScorer DEFAULT_SCORER = DefaultFlatVectorScorer.INSTANCE;
-  static final FlatVectorsScorer MEMSEG_SCORER =
+  private static final FlatVectorsScorer DEFAULT_SCORER = DefaultFlatVectorScorer.INSTANCE;
+  private static final FlatVectorsScorer MEMSEG_SCORER =
       VectorizationProvider.lookup(true).getLucene99FlatVectorsScorer();
 
   @BeforeClass
@@ -448,7 +448,7 @@ public class TestVectorScorer extends LuceneTestCase {
     return RandomNumbers.randomLongBetween(random(), minInclusive, maxInclusive);
   }
 
-  static Function<Integer, byte[]> BYTE_ARRAY_RANDOM_FUNC =
+  private static final Function<Integer, byte[]> BYTE_ARRAY_RANDOM_FUNC =
       size -> {
         byte[] ba = new byte[size];
         for (int i = 0; i < size; i++) {
@@ -457,19 +457,19 @@ public class TestVectorScorer extends LuceneTestCase {
         return ba;
       };
 
-  static Function<Integer, byte[]> BYTE_ARRAY_MAX_FUNC =
+  private static final Function<Integer, byte[]> BYTE_ARRAY_MAX_FUNC =
       size -> {
         byte[] ba = new byte[size];
         Arrays.fill(ba, Byte.MAX_VALUE);
         return ba;
       };
 
-  static Function<Integer, byte[]> BYTE_ARRAY_MIN_FUNC =
+  private static final Function<Integer, byte[]> BYTE_ARRAY_MIN_FUNC =
       size -> {
         byte[] ba = new byte[size];
         Arrays.fill(ba, Byte.MIN_VALUE);
         return ba;
       };
 
-  static final int TIMES = 100; // a loop iteration times
+  private static final int TIMES = 100; // a loop iteration times
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBaseRangeFilter.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBaseRangeFilter.java
@@ -69,7 +69,7 @@ public class TestBaseRangeFilter extends LuceneTestCase {
   static TestIndex signedIndexDir;
   static TestIndex unsignedIndexDir;
 
-  static int minId = 0;
+  static final int minId = 0;
   static int maxId;
 
   static final int intLength = Integer.toString(Integer.MAX_VALUE).length();

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanOr.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanOr.java
@@ -37,13 +37,13 @@ import org.apache.lucene.util.FixedBitSet;
 
 public class TestBooleanOr extends LuceneTestCase {
 
-  private static String FIELD_T = "T";
-  private static String FIELD_C = "C";
+  private static final String FIELD_T = "T";
+  private static final String FIELD_C = "C";
 
-  private TermQuery t1 = new TermQuery(new Term(FIELD_T, "files"));
-  private TermQuery t2 = new TermQuery(new Term(FIELD_T, "deleting"));
-  private TermQuery c1 = new TermQuery(new Term(FIELD_C, "production"));
-  private TermQuery c2 = new TermQuery(new Term(FIELD_C, "optimize"));
+  private final TermQuery t1 = new TermQuery(new Term(FIELD_T, "files"));
+  private final TermQuery t2 = new TermQuery(new Term(FIELD_T, "deleting"));
+  private final TermQuery c1 = new TermQuery(new Term(FIELD_C, "production"));
+  private final TermQuery c2 = new TermQuery(new Term(FIELD_C, "optimize"));
 
   private IndexSearcher searcher = null;
   private Directory dir;

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisiPriorityQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisiPriorityQueue.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.Random;
+import java.util.function.IntSupplier;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
@@ -146,12 +147,20 @@ public class TestDisiPriorityQueue extends LuceneTestCase {
   }
 
   private static class DummyQuery extends Query {
-    private static int COUNTER = 0;
+    private static final IntSupplier COUNTER =
+        new IntSupplier() {
+          int counter = 0;
+
+          @Override
+          public int getAsInt() {
+            return counter++;
+          }
+        };
     private final int id;
     private final DocIdSetIterator disi;
 
     DummyQuery(DocIdSetIterator disi) {
-      id = COUNTER++;
+      id = COUNTER.getAsInt();
       this.disi = disi;
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntConsumer;
+import java.util.function.IntSupplier;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.LongPoint;
@@ -450,11 +451,19 @@ public class TestLRUQueryCache extends LuceneTestCase {
   /** A query that doesn't match anything */
   private static class DummyQuery extends Query {
 
-    private static int COUNTER = 0;
+    private static final IntSupplier COUNTER =
+        new IntSupplier() {
+          int counter = 0;
+
+          @Override
+          public int getAsInt() {
+            return counter++;
+          }
+        };
     private final int id;
 
     DummyQuery() {
-      id = COUNTER++;
+      id = COUNTER.getAsInt();
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -742,7 +742,7 @@ public class TestPhraseQuery extends LuceneTestCase {
         });
   }
 
-  static String[] DOCS =
+  private static final String[] DOCS =
       new String[] {
         "a b c d e f g h",
         "b c b",

--- a/lucene/core/src/test/org/apache/lucene/search/TestQueryRescorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestQueryRescorer.java
@@ -54,7 +54,7 @@ public class TestQueryRescorer extends LuceneTestCase {
     return LuceneTestCase.newIndexWriterConfig().setSimilarity(new ClassicSimilarity());
   }
 
-  static List<String> dictionary =
+  private static final List<String> dictionary =
       Arrays.asList("river", "quick", "brown", "fox", "jumped", "lazy", "fence");
 
   String randomSentence() {

--- a/lucene/core/src/test/org/apache/lucene/search/similarities/TestSimilarityBase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/similarities/TestSimilarityBase.java
@@ -67,22 +67,22 @@ import org.apache.lucene.util.Version;
  * parameter values for LM), only the best performing setups in the original papers are verified.
  */
 public class TestSimilarityBase extends LuceneTestCase {
-  private static String FIELD_BODY = "body";
-  private static String FIELD_ID = "id";
+  private static final String FIELD_BODY = "body";
+  private static final String FIELD_ID = "id";
 
   /** The tolerance range for float equality. */
-  private static float FLOAT_EPSILON = 1e-5f;
+  private static final float FLOAT_EPSILON = 1e-5f;
 
   /** The DFR basic models to test. */
-  static BasicModel[] BASIC_MODELS = {
+  static final BasicModel[] BASIC_MODELS = {
     new BasicModelG(), new BasicModelIF(), new BasicModelIn(), new BasicModelIne()
   };
 
   /** The DFR aftereffects to test. */
-  static AfterEffect[] AFTER_EFFECTS = {new AfterEffectB(), new AfterEffectL()};
+  static final AfterEffect[] AFTER_EFFECTS = {new AfterEffectB(), new AfterEffectL()};
 
   /** The DFR normalizations to test. */
-  static Normalization[] NORMALIZATIONS = {
+  static final Normalization[] NORMALIZATIONS = {
     new NormalizationH1(),
     new NormalizationH2(),
     new NormalizationH3(),
@@ -91,13 +91,13 @@ public class TestSimilarityBase extends LuceneTestCase {
   };
 
   /** The distributions for IB. */
-  static Distribution[] DISTRIBUTIONS = {new DistributionLL(), new DistributionSPL()};
+  static final Distribution[] DISTRIBUTIONS = {new DistributionLL(), new DistributionSPL()};
 
   /** Lambdas for IB. */
-  static Lambda[] LAMBDAS = {new LambdaDF(), new LambdaTTF()};
+  static final Lambda[] LAMBDAS = {new LambdaDF(), new LambdaTTF()};
 
   /** Independence measures for DFI */
-  static Independence[] INDEPENDENCE_MEASURES = {
+  static final Independence[] INDEPENDENCE_MEASURES = {
     new IndependenceStandardized(), new IndependenceSaturated(), new IndependenceChiSquared()
   };
 
@@ -154,27 +154,27 @@ public class TestSimilarityBase extends LuceneTestCase {
   // ------------------------------- Unit tests --------------------------------
 
   /** The default number of documents in the unit tests. */
-  private static int NUMBER_OF_DOCUMENTS = 100;
+  private static final int NUMBER_OF_DOCUMENTS = 100;
 
   /** The default total number of tokens in the field in the unit tests. */
-  private static long NUMBER_OF_FIELD_TOKENS = 5000;
+  private static final long NUMBER_OF_FIELD_TOKENS = 5000;
 
   /** The default average field length in the unit tests. */
-  private static float AVG_FIELD_LENGTH = 50;
+  private static final float AVG_FIELD_LENGTH = 50;
 
   /** The default document frequency in the unit tests. */
-  private static int DOC_FREQ = 10;
+  private static final int DOC_FREQ = 10;
 
   /**
    * The default total number of occurrences of this term across all documents in the unit tests.
    */
-  private static long TOTAL_TERM_FREQ = 70;
+  private static final long TOTAL_TERM_FREQ = 70;
 
   /** The default tf in the unit tests. */
-  private static float FREQ = 7;
+  private static final float FREQ = 7;
 
   /** The default document length in the unit tests. */
-  private static int DOC_LEN = 40;
+  private static final int DOC_LEN = 40;
 
   /** Creates the default statistics object that the specific tests modify. */
   private BasicStats createStats() {

--- a/lucene/core/src/test/org/apache/lucene/store/BaseDataOutputTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/store/BaseDataOutputTestCase.java
@@ -68,7 +68,8 @@ public abstract class BaseDataOutputTestCase<T extends DataOutput> extends Lucen
     }
   }
 
-  private static List<ThrowingBiFunction<DataOutput, Random, IOConsumer<DataInput>>> GENERATORS;
+  private static final List<ThrowingBiFunction<DataOutput, Random, IOConsumer<DataInput>>>
+      GENERATORS;
 
   static {
     GENERATORS = new ArrayList<>();

--- a/lucene/core/src/test/org/apache/lucene/util/TestMathUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestMathUtil.java
@@ -23,7 +23,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestMathUtil extends LuceneTestCase {
 
-  static long[] PRIMES = new long[] {2, 3, 5, 7, 11, 13, 17, 19, 23, 29};
+  private static final long[] PRIMES = new long[] {2, 3, 5, 7, 11, 13, 17, 19, 23, 29};
 
   static long randomLong() {
     if (random().nextBoolean()) {

--- a/lucene/core/src/test/org/apache/lucene/util/TestSloppyMath.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSloppyMath.java
@@ -27,13 +27,13 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestSloppyMath extends LuceneTestCase {
   // accuracy for cos()
-  static double COS_DELTA = 1E-15;
+  private static final double COS_DELTA = 1E-15;
   // accuracy for asin()
-  static double ASIN_DELTA = 1E-7;
+  private static final double ASIN_DELTA = 1E-7;
   // accuracy for haversinMeters()
-  static double HAVERSIN_DELTA = 38E-2;
+  private static final double HAVERSIN_DELTA = 38E-2;
   // accuracy for haversinMeters() for "reasonable" distances (< 1000km)
-  static double REASONABLE_HAVERSIN_DELTA = 1E-5;
+  private static final double REASONABLE_HAVERSIN_DELTA = 1E-5;
 
   public void testCos() {
     assertTrue(Double.isNaN(cos(Double.NaN)));

--- a/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFST.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFST.java
@@ -39,7 +39,7 @@ import org.junit.Ignore;
 @TimeoutSuite(millis = 100 * TimeUnits.HOUR)
 public class Test2BFST extends LuceneTestCase {
 
-  private static long LIMIT = 3L * 1024 * 1024 * 1024;
+  private static final long LIMIT = 3L * 1024 * 1024 * 1024;
 
   public void test() throws Exception {
     int[] ints = new int[7];

--- a/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFSTOffHeap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/Test2BFSTOffHeap.java
@@ -41,7 +41,7 @@ import org.junit.Ignore;
 @TimeoutSuite(millis = 100 * TimeUnits.HOUR)
 public class Test2BFSTOffHeap extends LuceneTestCase {
 
-  private static long LIMIT = 3L * 1024 * 1024 * 1024;
+  private static final long LIMIT = 3L * 1024 * 1024 * 1024;
 
   public void test() throws Exception {
     int[] ints = new int[7];

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestCustomFunctions.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestCustomFunctions.java
@@ -30,7 +30,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 
 /** Tests customing the function map */
 public class TestCustomFunctions extends CompilerTestCase {
-  private static double DELTA = 0.0000001;
+  private static final double DELTA = 0.0000001;
   private static final Lookup LOOKUP = MethodHandles.lookup();
 
   /** empty list of methods */
@@ -238,7 +238,7 @@ public class TestCustomFunctions extends CompilerTestCase {
     assertEquals(16, expr.evaluate(null), DELTA);
   }
 
-  static String MESSAGE = "This should not happen but it happens";
+  private static final String MESSAGE = "This should not happen but it happens";
 
   public static double staticThrowingException() {
     throw new ArithmeticException(MESSAGE);

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestJavascriptFunction.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestJavascriptFunction.java
@@ -19,7 +19,7 @@ package org.apache.lucene.expressions.js;
 import org.apache.lucene.expressions.Expression;
 
 public class TestJavascriptFunction extends CompilerTestCase {
-  private static double DELTA = 0.0000001;
+  private static final double DELTA = 0.0000001;
 
   private void assertEvaluatesTo(String expression, double expected) throws Exception {
     Expression evaluator = compile(expression);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestConcurrentFacetedIndexing.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestConcurrentFacetedIndexing.java
@@ -38,7 +38,7 @@ public class TestConcurrentFacetedIndexing extends FacetTestCase {
 
   // A No-Op TaxonomyWriterCache which always discards all given categories, and
   // always returns true in put(), to indicate some cache entries were cleared.
-  private static TaxonomyWriterCache NO_OP_CACHE =
+  private static final TaxonomyWriterCache NO_OP_CACHE =
       new TaxonomyWriterCache() {
 
         @Override

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyReader.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyReader.java
@@ -49,7 +49,7 @@ import org.junit.Test;
 
 public class TestDirectoryTaxonomyReader extends FacetTestCase {
 
-  private static FacetLabel ILLEGAL_PATH =
+  private static final FacetLabel ILLEGAL_PATH =
       new FacetLabel("PATH_THAT_CAUSED_IllegalArgumentException");
 
   @Test

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyWriter.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyWriter.java
@@ -52,7 +52,7 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
 
   // A No-Op TaxonomyWriterCache which always discards all given categories, and
   // always returns true in put(), to indicate some cache entries were cleared.
-  private static TaxonomyWriterCache NO_OP_CACHE =
+  private static final TaxonomyWriterCache NO_OP_CACHE =
       new TaxonomyWriterCache() {
 
         @Override

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/GradientFormatter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/GradientFormatter.java
@@ -18,7 +18,7 @@ package org.apache.lucene.search.highlight;
 
 /** Formats text with different color intensity depending on the score of the term. */
 public class GradientFormatter implements Formatter {
-  private float maxScore;
+  private final float maxScore;
 
   int fgRMin, fgGMin, fgBMin;
   int fgRMax, fgGMax, fgBMax;
@@ -151,12 +151,12 @@ public class GradientFormatter implements Formatter {
     return Math.min(colorMin, colorMax) + (int) colScore;
   }
 
-  private static char[] hexDigits = {
+  private static final char[] HEX_DIGITS = {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
   };
 
   private static String intToHex(int i) {
-    return "" + hexDigits[(i & 0xF0) >> 4] + hexDigits[i & 0x0F];
+    return "" + HEX_DIGITS[(i & 0xF0) >> 4] + HEX_DIGITS[i & 0x0F];
   }
 
   /**

--- a/lucene/join/src/java/org/apache/lucene/search/join/PointInSetIncludingScoreQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/PointInSetIncludingScoreQuery.java
@@ -55,7 +55,7 @@ abstract class PointInSetIncludingScoreQuery extends Query implements Accountabl
   protected static final long BASE_RAM_BYTES =
       RamUsageEstimator.shallowSizeOfInstance(PointInSetIncludingScoreQuery.class);
 
-  static BiFunction<byte[], Class<? extends Number>, String> toString =
+  static final BiFunction<byte[], Class<? extends Number>, String> toString =
       (value, numericType) -> {
         if (Integer.class.equals(numericType)) {
           return Integer.toString(IntPoint.decodeDimension(value, 0));

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/LukeMain.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/LukeMain.java
@@ -44,6 +44,7 @@ public class LukeMain {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  @SuppressWarnings("NonFinalStaticField")
   private static JFrame frame;
 
   public static JFrame getOwnerFrame() {

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/PreferencesFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/PreferencesFactory.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 /** Factory of {@link Preferences} */
 public class PreferencesFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static Preferences prefs;
 
   public static synchronized Preferences getInstance() throws IOException {

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/ConfirmDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/ConfirmDialogFactory.java
@@ -41,6 +41,7 @@ import org.apache.lucene.luke.app.desktop.util.lang.Callable;
 /** Factory of confirm dialog */
 public final class ConfirmDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static ConfirmDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/HelpDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/HelpDialogFactory.java
@@ -38,6 +38,7 @@ import org.apache.lucene.luke.app.desktop.util.MessageUtils;
 /** Factory of help dialog */
 public final class HelpDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static HelpDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/AnalysisChainDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/AnalysisChainDialogFactory.java
@@ -47,6 +47,7 @@ import org.apache.lucene.luke.app.desktop.util.MessageUtils;
 /** Factory of analysis chain dialog */
 public class AnalysisChainDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static AnalysisChainDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/EditFiltersDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/EditFiltersDialogFactory.java
@@ -53,6 +53,7 @@ import org.apache.lucene.luke.app.desktop.util.lang.Callable;
 /** Factory of edit filters dialog */
 public final class EditFiltersDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static EditFiltersDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/EditParamsDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/EditParamsDialogFactory.java
@@ -50,6 +50,7 @@ import org.apache.lucene.luke.app.desktop.util.lang.Callable;
 /** Factory of edit parameters dialog */
 public final class EditParamsDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static EditParamsDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/TokenAttributeDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/TokenAttributeDialogFactory.java
@@ -44,6 +44,7 @@ import org.apache.lucene.luke.models.analysis.Analysis;
 /** Factory of token attribute dialog */
 public final class TokenAttributeDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static TokenAttributeDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/AddDocumentDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/AddDocumentDialogFactory.java
@@ -102,6 +102,7 @@ public final class AddDocumentDialogFactory
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  @SuppressWarnings("NonFinalStaticField")
   private static AddDocumentDialogFactory instance;
 
   private static final int ROW_COUNT = 50;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/DocValuesDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/DocValuesDialogFactory.java
@@ -56,6 +56,7 @@ import org.apache.lucene.util.NumericUtils;
 /** Factory of doc values dialog */
 public final class DocValuesDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static DocValuesDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/IndexOptionsDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/IndexOptionsDialogFactory.java
@@ -49,6 +49,7 @@ import org.apache.lucene.luke.app.desktop.util.MessageUtils;
 /** Factory of index options dialog */
 public final class IndexOptionsDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static IndexOptionsDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/StoredValueDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/StoredValueDialogFactory.java
@@ -45,6 +45,7 @@ import org.apache.lucene.luke.app.desktop.util.MessageUtils;
 /** Factory of stored values dialog */
 public final class StoredValueDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static StoredValueDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/TermVectorDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/TermVectorDialogFactory.java
@@ -47,6 +47,7 @@ import org.apache.lucene.luke.models.documents.TermVectorEntry;
 /** Factory of term vector dialog */
 public final class TermVectorDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static TermVectorDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/AboutDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/AboutDialogFactory.java
@@ -54,6 +54,7 @@ import org.apache.lucene.util.Version;
 /** Factory of about dialog */
 public final class AboutDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static AboutDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CheckIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CheckIndexDialogFactory.java
@@ -65,6 +65,7 @@ public final class CheckIndexDialogFactory implements DialogOpener.DialogFactory
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  @SuppressWarnings("NonFinalStaticField")
   private static CheckIndexDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CreateIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CreateIndexDialogFactory.java
@@ -71,6 +71,7 @@ public class CreateIndexDialogFactory implements DialogOpener.DialogFactory {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  @SuppressWarnings("NonFinalStaticField")
   private static CreateIndexDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/ExportTermsDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/ExportTermsDialogFactory.java
@@ -66,6 +66,7 @@ public final class ExportTermsDialogFactory implements DialogOpener.DialogFactor
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  @SuppressWarnings("NonFinalStaticField")
   private static ExportTermsDialogFactory instance;
 
   private final IndexToolsFactory indexToolsFactory = new IndexToolsFactory();

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OpenIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OpenIndexDialogFactory.java
@@ -66,6 +66,7 @@ public final class OpenIndexDialogFactory implements DialogOpener.DialogFactory 
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  @SuppressWarnings("NonFinalStaticField")
   private static OpenIndexDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OptimizeIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OptimizeIndexDialogFactory.java
@@ -59,6 +59,7 @@ import org.apache.lucene.util.NamedThreadFactory;
 /** Factory of optimize index dialog */
 public final class OptimizeIndexDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static OptimizeIndexDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/search/ExplainDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/search/ExplainDialogFactory.java
@@ -49,6 +49,7 @@ import org.apache.lucene.search.Explanation;
 /** Factory of explain dialog */
 public final class ExplainDialogFactory implements DialogOpener.DialogFactory {
 
+  @SuppressWarnings("NonFinalStaticField")
   private static ExplainDialogFactory instance;
 
   private final Preferences prefs;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/MessageUtils.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/MessageUtils.java
@@ -36,7 +36,7 @@ public class MessageUtils {
     return new MessageFormat(pattern, Locale.ENGLISH).format(args);
   }
 
-  private static ResourceBundle bundle =
+  private static final ResourceBundle bundle =
       ResourceBundle.getBundle(MESSAGE_BUNDLE_BASENAME, Locale.ENGLISH);
 
   private MessageUtils() {}

--- a/lucene/luke/src/java/org/apache/lucene/luke/util/LoggerFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/util/LoggerFactory.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 
 /** Logger factory. This configures log interceptors for the GUI. */
 public class LoggerFactory {
+  @SuppressWarnings("NonFinalStaticField")
   public static CircularLogBufferHandler circularBuffer;
 
   public static void initGuiLogging() {

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestBooleanClauseWeightings.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestBooleanClauseWeightings.java
@@ -30,7 +30,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestBooleanClauseWeightings extends LuceneTestCase {
 
-  private static QueryAnalyzer treeBuilder = new QueryAnalyzer();
+  private static final QueryAnalyzer treeBuilder = new QueryAnalyzer();
 
   public void testExactClausesPreferred() {
     Query bq =

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/FunctionTestSetup.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/FunctionTestSetup.java
@@ -49,7 +49,7 @@ public abstract class FunctionTestSetup extends LuceneTestCase {
    * Actual score computation order is slightly different than assumptios this allows for a small
    * amount of variation
    */
-  protected static float TEST_SCORE_TOLERANCE_DELTA = 0.001f;
+  protected static final float TEST_SCORE_TOLERANCE_DELTA = 0.001f;
 
   protected static final int N_DOCS = 17; // select a primary number > 2
 
@@ -111,7 +111,10 @@ public abstract class FunctionTestSetup extends LuceneTestCase {
     "text for the test, but oh much much safer. ",
   };
 
+  @SuppressWarnings("NonFinalStaticField")
   protected static Directory dir;
+
+  @SuppressWarnings("NonFinalStaticField")
   protected static Analyzer anlzr;
 
   @AfterClass

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestLongNormValueSource.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestLongNormValueSource.java
@@ -46,7 +46,7 @@ public class TestLongNormValueSource extends LuceneTestCase {
   static IndexSearcher searcher;
   static Analyzer analyzer;
 
-  private static Similarity sim = new ClassicSimilarity();
+  private static final Similarity sim = new ClassicSimilarity();
 
   @BeforeClass
   public static void beforeClass() throws Exception {

--- a/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadExplanations.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadExplanations.java
@@ -26,7 +26,7 @@ import org.apache.lucene.tests.search.BaseExplanationTestCase;
 /** TestExplanations subclass focusing on payload queries */
 public class TestPayloadExplanations extends BaseExplanationTestCase {
 
-  private static PayloadFunction[] functions =
+  private static final PayloadFunction[] functions =
       new PayloadFunction[] {
         new AveragePayloadFunction(), new MinPayloadFunction(), new MaxPayloadFunction(),
       };

--- a/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadScoreQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadScoreQuery.java
@@ -270,9 +270,9 @@ public class TestPayloadScoreQuery extends LuceneTestCase {
   private static IndexSearcher searcher;
   private static IndexReader reader;
   private static Directory directory;
-  private static JustScorePayloadSimilarity similarity = new JustScorePayloadSimilarity();
-  private static byte[] payload2 = new byte[] {2};
-  private static byte[] payload4 = new byte[] {4};
+  private static final JustScorePayloadSimilarity similarity = new JustScorePayloadSimilarity();
+  private static final byte[] payload2 = new byte[] {2};
+  private static final byte[] payload4 = new byte[] {4};
 
   private static class PayloadAnalyzer extends Analyzer {
     @Override

--- a/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadTermQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadTermQuery.java
@@ -51,12 +51,18 @@ import org.junit.BeforeClass;
 
 /** */
 public class TestPayloadTermQuery extends LuceneTestCase {
+  @SuppressWarnings("NonFinalStaticField")
   private static IndexSearcher searcher;
+
+  @SuppressWarnings("NonFinalStaticField")
   private static IndexReader reader;
-  private static Similarity similarity = new BoostingSimilarity();
+
+  private static final Similarity similarity = new BoostingSimilarity();
   private static final byte[] payloadField = new byte[] {1};
   private static final byte[] payloadMultiField1 = new byte[] {2};
   private static final byte[] payloadMultiField2 = new byte[] {4};
+
+  @SuppressWarnings("NonFinalStaticField")
   protected static Directory directory;
 
   private static class PayloadAnalyzer extends Analyzer {

--- a/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanSimilarity.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanSimilarity.java
@@ -71,17 +71,17 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestSpanSimilarity extends LuceneTestCase {
 
-  List<Similarity> sims;
+  private List<Similarity> sims;
 
   /** The DFR basic models to test. */
-  static BasicModel[] BASIC_MODELS = {
+  private static final BasicModel[] BASIC_MODELS = {
     new BasicModelG(), new BasicModelIF(), new BasicModelIn(), new BasicModelIne()
   };
 
   /** The DFR aftereffects to test. */
-  static AfterEffect[] AFTER_EFFECTS = {new AfterEffectB(), new AfterEffectL()};
+  private static final AfterEffect[] AFTER_EFFECTS = {new AfterEffectB(), new AfterEffectL()};
 
-  static Normalization[] NORMALIZATIONS = {
+  private static final Normalization[] NORMALIZATIONS = {
     new NormalizationH1(),
     new NormalizationH2(),
     new NormalizationH3(),
@@ -90,13 +90,13 @@ public class TestSpanSimilarity extends LuceneTestCase {
   };
 
   /** The distributions for IB. */
-  static Distribution[] DISTRIBUTIONS = {new DistributionLL(), new DistributionSPL()};
+  private static final Distribution[] DISTRIBUTIONS = {new DistributionLL(), new DistributionSPL()};
 
   /** Lambdas for IB. */
-  static Lambda[] LAMBDAS = {new LambdaDF(), new LambdaTTF()};
+  private static final Lambda[] LAMBDAS = {new LambdaDF(), new LambdaTTF()};
 
   /** Independence measures for DFI */
-  static Independence[] INDEPENDENCE_MEASURES = {
+  private static final Independence[] INDEPENDENCE_MEASURES = {
     new IndependenceStandardized(), new IndependenceSaturated(), new IndependenceChiSquared()
   };
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/messages/QueryParserMessages.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/messages/QueryParserMessages.java
@@ -19,6 +19,7 @@ package org.apache.lucene.queryparser.flexible.core.messages;
 import org.apache.lucene.queryparser.flexible.messages.NLS;
 
 /** Flexible Query Parser message bundle class */
+@SuppressWarnings("NonFinalStaticField")
 public class QueryParserMessages extends NLS {
   private static final String BUNDLE_NAME = QueryParserMessages.class.getName();
 

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiAnalyzer.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiAnalyzer.java
@@ -37,7 +37,7 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
  */
 public class TestMultiAnalyzer extends BaseTokenStreamTestCase {
 
-  private static int multiToken = 0;
+  private int multiToken = 0;
 
   public void testMultiAnalyzer() throws ParseException {
 
@@ -124,7 +124,7 @@ public class TestMultiAnalyzer extends BaseTokenStreamTestCase {
    * Expands "multi" to "multi" and "multi2", both at the same position, and expands "triplemulti"
    * to "triplemulti", "multi3", and "multi2".
    */
-  private static class MultiAnalyzer extends Analyzer {
+  private class MultiAnalyzer extends Analyzer {
 
     @Override
     public TokenStreamComponents createComponents(String fieldName) {
@@ -133,7 +133,7 @@ public class TestMultiAnalyzer extends BaseTokenStreamTestCase {
     }
   }
 
-  private static final class TestFilter extends TokenFilter {
+  private final class TestFilter extends TokenFilter {
 
     private String prevType;
     private int prevStartOffset;
@@ -153,7 +153,7 @@ public class TestMultiAnalyzer extends BaseTokenStreamTestCase {
     }
 
     @Override
-    public final boolean incrementToken() throws java.io.IOException {
+    public boolean incrementToken() throws java.io.IOException {
       if (multiToken > 0) {
         termAtt.setEmpty().append("multi" + (multiToken + 1));
         offsetAtt.setOffset(prevStartOffset, prevEndOffset);
@@ -216,7 +216,7 @@ public class TestMultiAnalyzer extends BaseTokenStreamTestCase {
     }
 
     @Override
-    public final boolean incrementToken() throws java.io.IOException {
+    public boolean incrementToken() throws java.io.IOException {
       while (input.incrementToken()) {
         if (termAtt.toString().equals("the")) {
           // stopword, do nothing

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/ext/TestExtendableQueryParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/ext/TestExtendableQueryParser.java
@@ -31,7 +31,7 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 
 /** Testcase for the class {@link ExtendableQueryParser} */
 public class TestExtendableQueryParser extends TestQueryParser {
-  private static char[] DELIMITERS =
+  private static final char[] DELIMITERS =
       new char[] {Extensions.DEFAULT_EXTENSION_FIELD_DELIMITER, '-', '|'};
 
   @Override

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/messages/MessagesTestBundle.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/messages/MessagesTestBundle.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.queryparser.flexible.messages;
 
+@SuppressWarnings("NonFinalStaticField")
 public class MessagesTestBundle extends NLS {
 
   private static final String BUNDLE_NAME = MessagesTestBundle.class.getName();

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestMultiAnalyzerQPHelper.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestMultiAnalyzerQPHelper.java
@@ -39,7 +39,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
  */
 public class TestMultiAnalyzerQPHelper extends LuceneTestCase {
 
-  private static int multiToken = 0;
+  private int multiToken = 0;
 
   public void testMultiAnalyzer() throws QueryNodeException {
 
@@ -135,7 +135,7 @@ public class TestMultiAnalyzerQPHelper extends LuceneTestCase {
    * Expands "multi" to "multi" and "multi2", both at the same position, and expands "triplemulti"
    * to "triplemulti", "multi3", and "multi2".
    */
-  private static class MultiAnalyzer extends Analyzer {
+  private class MultiAnalyzer extends Analyzer {
 
     @Override
     public TokenStreamComponents createComponents(String fieldName) {
@@ -144,7 +144,7 @@ public class TestMultiAnalyzerQPHelper extends LuceneTestCase {
     }
   }
 
-  private static final class TestFilter extends TokenFilter {
+  private final class TestFilter extends TokenFilter {
 
     private String prevType;
     private int prevStartOffset;
@@ -161,7 +161,7 @@ public class TestMultiAnalyzerQPHelper extends LuceneTestCase {
     }
 
     @Override
-    public final boolean incrementToken() throws java.io.IOException {
+    public boolean incrementToken() throws java.io.IOException {
       if (multiToken > 0) {
         termAtt.setEmpty().append("multi" + (multiToken + 1));
         offsetAtt.setOffset(prevStartOffset, prevEndOffset);

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/xml/TestCoreParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/xml/TestCoreParser.java
@@ -47,9 +47,13 @@ public class TestCoreParser extends LuceneTestCase {
 
   private static final String defaultField = "contents";
 
+  @SuppressWarnings("NonFinalStaticField")
   private static Analyzer analyzer;
+
+  @SuppressWarnings("NonFinalStaticField")
   private static CoreParser coreParser;
 
+  @SuppressWarnings("NonFinalStaticField")
   private static CoreParserTestIndexData indexData;
 
   protected Analyzer newAnalyzer() {

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/CopyJob.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/CopyJob.java
@@ -203,7 +203,7 @@ public abstract class CopyJob implements Comparable<CopyJob> {
 
     if (prevJob.current != null) {
       IOUtils.closeWhileHandlingException(prevJob.current);
-      if (Node.VERBOSE_FILES) {
+      if (dest.isVerboseFiles()) {
         dest.message("remove partial file " + prevJob.current.tmpName);
       }
       dest.deleter.forceDeleteFile(prevJob.current.tmpName);
@@ -249,7 +249,7 @@ public abstract class CopyJob implements Comparable<CopyJob> {
 
     if (current != null) {
       IOUtils.closeWhileHandlingException(current);
-      if (Node.VERBOSE_FILES) {
+      if (dest.isVerboseFiles()) {
         dest.message("remove partial file " + current.tmpName);
       }
       dest.deleter.forceDeleteFile(current.tmpName);

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/CopyOneFile.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/CopyOneFile.java
@@ -55,7 +55,7 @@ public class CopyOneFile implements Closeable {
     // checksum:
     bytesToCopy = metaData.length() - Long.BYTES;
 
-    if (Node.VERBOSE_FILES) {
+    if (dest.isVerboseFiles()) {
       dest.message(
           "file "
               + name
@@ -128,7 +128,7 @@ public class CopyOneFile implements Closeable {
         bytesCopied += Long.BYTES;
         close();
 
-        if (Node.VERBOSE_FILES) {
+        if (dest.isVerboseFiles()) {
           dest.message(
               String.format(
                   Locale.ROOT,

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/Node.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/Node.java
@@ -43,8 +43,7 @@ import org.apache.lucene.store.IndexInput;
  */
 public abstract class Node implements Closeable {
 
-  public static boolean VERBOSE_FILES = true;
-  public static boolean VERBOSE_CONNECTIONS = false;
+  private boolean verboseFiles = true;
 
   // Keys we store into IndexWriter's commit user data:
 
@@ -75,6 +74,7 @@ public abstract class Node implements Closeable {
    * Startup time of original test, carefully propagated to all nodes to produce consistent "seconds
    * since start time" in messages
    */
+  @SuppressWarnings("NonFinalStaticField")
   public static long globalStartNS;
 
   /** When this node was started */
@@ -221,16 +221,16 @@ public abstract class Node implements Closeable {
           // corrupting an un-fsync'd file.  On init we try
           // to delete such unreferenced files, but virus checker can block that, leaving this bad
           // file.
-          if (VERBOSE_FILES) {
+          if (verboseFiles) {
             message("file " + fileName + ": will copy [existing file is corrupt]");
           }
           return null;
         }
-        if (VERBOSE_FILES) {
+        if (verboseFiles) {
           message("file " + fileName + " has length=" + bytesToString(length));
         }
       } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException e) {
-        if (VERBOSE_FILES) {
+        if (verboseFiles) {
           message("file " + fileName + ": will copy [file does not exist]");
         }
         return null;
@@ -243,5 +243,13 @@ public abstract class Node implements Closeable {
     }
 
     return result;
+  }
+
+  public boolean isVerboseFiles() {
+    return verboseFiles;
+  }
+
+  public void setVerboseFiles(boolean verboseFiles) {
+    this.verboseFiles = verboseFiles;
   }
 }

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/ReplicaFileDeleter.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/ReplicaFileDeleter.java
@@ -35,7 +35,7 @@ class ReplicaFileDeleter {
         new FileDeleter(
             dir,
             ((msgType, s) -> {
-              if (msgType == FileDeleter.MsgType.FILE && Node.VERBOSE_FILES) {
+              if (msgType == FileDeleter.MsgType.FILE && node.isVerboseFiles()) {
                 node.message(s);
               }
             }));

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/ReplicaNode.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/ReplicaNode.java
@@ -869,7 +869,7 @@ public abstract class ReplicaNode extends Node {
     if (Arrays.equals(destMetaData.header(), srcMetaData.header()) == false
         || Arrays.equals(destMetaData.footer(), srcMetaData.footer()) == false) {
       // Segment name was reused!  This is rare but possible and otherwise devastating:
-      if (Node.VERBOSE_FILES) {
+      if (isVerboseFiles()) {
         message("file " + fileName + ": will copy [header/footer is different]");
       }
       return false;

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/Connection.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/Connection.java
@@ -45,9 +45,6 @@ class Connection implements Closeable {
     this.in = new InputStreamDataInput(sockIn);
     this.bos = new BufferedOutputStream(s.getOutputStream());
     this.out = new OutputStreamDataOutput(bos);
-    if (Node.VERBOSE_CONNECTIONS) {
-      System.out.println("make new client Connection socket=" + this.s + " destPort=" + tcpPort);
-    }
   }
 
   public void flush() throws IOException {

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleCopyJob.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleCopyJob.java
@@ -165,7 +165,7 @@ class SimpleCopyJob extends CopyJob {
       String tmpFileName = ent.getValue();
       String fileName = ent.getKey();
 
-      if (Node.VERBOSE_FILES) {
+      if (dest.isVerboseFiles()) {
         dest.message("rename file " + tmpFileName + " to " + fileName);
       }
 

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestSimpleServer.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestSimpleServer.java
@@ -59,6 +59,7 @@ import org.junit.BeforeClass;
 @SuppressCodecs({"MockRandom", "Direct", "SimpleText"})
 @SuppressSysoutChecks(bugUrl = "Stuff gets printed, important stuff for debugging a failure")
 public class TestSimpleServer extends LuceneTestCase {
+  private static final boolean VERBOSE_CONNECTIONS = true;
 
   static final Set<Thread> clientThreads = Collections.synchronizedSet(new HashSet<>());
   static final AtomicBoolean stop = new AtomicBoolean();
@@ -77,7 +78,7 @@ public class TestSimpleServer extends LuceneTestCase {
       this.node = node;
       this.socket = socket;
       this.bufferSize = TestUtil.nextInt(random(), 128, 65536);
-      if (Node.VERBOSE_CONNECTIONS) {
+      if (VERBOSE_CONNECTIONS) {
         node.message("new connection socket=" + socket);
       }
     }
@@ -100,7 +101,7 @@ public class TestSimpleServer extends LuceneTestCase {
         }
 
         bos.flush();
-        if (Node.VERBOSE_CONNECTIONS) {
+        if (VERBOSE_CONNECTIONS) {
           node.message("bos.flush done");
         }
 
@@ -128,7 +129,7 @@ public class TestSimpleServer extends LuceneTestCase {
           IOUtils.closeWhileHandlingException(socket);
         }
       }
-      if (Node.VERBOSE_CONNECTIONS) {
+      if (VERBOSE_CONNECTIONS) {
         node.message("socket.close done");
       }
     }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/queries/FuzzyLikeThisQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/queries/FuzzyLikeThisQuery.java
@@ -67,13 +67,13 @@ public class FuzzyLikeThisQuery extends Query {
   // a better way might be to convert this into multitermquery rewrite methods.
   // the rewrite method can 'average' the TermStates's term statistics (docfreq,totalTermFreq)
   // provided to TermQuery, so that the general idea is agnostic to any scoring system...
-  static TFIDFSimilarity sim = new ClassicSimilarity();
+  private static final TFIDFSimilarity sim = new ClassicSimilarity();
   ArrayList<FieldVals> fieldVals = new ArrayList<>();
   Analyzer analyzer;
 
   int MAX_VARIANTS_PER_TERM = 50;
   boolean ignoreTF = false;
-  private int maxNumTerms;
+  private final int maxNumTerms;
 
   @Override
   public int hashCode() {

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/bbox/BBoxStrategy.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/bbox/BBoxStrategy.java
@@ -77,7 +77,7 @@ public class BBoxStrategy extends SpatialStrategy {
   //  create more than one Field.
 
   /** pointValues, docValues, and nothing else. */
-  public static FieldType DEFAULT_FIELDTYPE;
+  public static final FieldType DEFAULT_FIELDTYPE;
 
   static {
     // Default: pointValues + docValues

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/vector/PointVectorStrategy.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/vector/PointVectorStrategy.java
@@ -86,7 +86,7 @@ public class PointVectorStrategy extends SpatialStrategy {
   //  create more than one Field.
 
   /** pointValues, docValues, and nothing else. */
-  public static FieldType DEFAULT_FIELDTYPE;
+  public static final FieldType DEFAULT_FIELDTYPE;
 
   static {
     // Default: pointValues + docValues

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/SerializableObject.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/SerializableObject.java
@@ -192,7 +192,7 @@ public interface SerializableObject {
    * @param clazz is the class to write.
    */
   static void writeClass(final OutputStream outputStream, final Class<?> clazz) throws IOException {
-    Integer index = StandardObjects.classRegsitry.get(clazz);
+    Integer index = StandardObjects.CLASS_REGISTRY.get(clazz);
     if (index == null) {
       writeBoolean(outputStream, false);
       writeString(outputStream, clazz.getName());
@@ -213,7 +213,7 @@ public interface SerializableObject {
     boolean standard = readBoolean(inputStream);
     if (standard) {
       int index = inputStream.read();
-      return StandardObjects.codeRegsitry.get(index);
+      return StandardObjects.CODE_REGISTRY.get(index);
     } else {
       String className = readString(inputStream);
       return Class.forName(className);

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/StandardObjects.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/StandardObjects.java
@@ -29,54 +29,54 @@ import org.apache.lucene.internal.hppc.IntObjectHashMap;
 class StandardObjects {
 
   /** Registry of standard classes to corresponding code */
-  static Map<Class<?>, Integer> classRegsitry = new HashMap<>();
+  static final Map<Class<?>, Integer> CLASS_REGISTRY = new HashMap<>();
 
   /** Registry of codes to corresponding classes */
-  static IntObjectHashMap<Class<?>> codeRegsitry = new IntObjectHashMap<>();
+  static final IntObjectHashMap<Class<?>> CODE_REGISTRY = new IntObjectHashMap<>();
 
   static {
-    classRegsitry.put(GeoPoint.class, 0);
-    classRegsitry.put(GeoRectangle.class, 1);
-    classRegsitry.put(GeoStandardCircle.class, 2);
-    classRegsitry.put(GeoStandardPath.class, 3);
-    classRegsitry.put(GeoConvexPolygon.class, 4);
-    classRegsitry.put(GeoConcavePolygon.class, 5);
-    classRegsitry.put(GeoComplexPolygon.class, 6);
-    classRegsitry.put(GeoCompositePolygon.class, 7);
-    classRegsitry.put(GeoCompositeMembershipShape.class, 8);
-    classRegsitry.put(GeoCompositeAreaShape.class, 9);
-    classRegsitry.put(GeoDegeneratePoint.class, 10);
-    classRegsitry.put(GeoDegenerateHorizontalLine.class, 11);
-    classRegsitry.put(GeoDegenerateLatitudeZone.class, 12);
-    classRegsitry.put(GeoDegenerateLongitudeSlice.class, 13);
-    classRegsitry.put(GeoDegenerateVerticalLine.class, 14);
-    classRegsitry.put(GeoLatitudeZone.class, 15);
-    classRegsitry.put(GeoLongitudeSlice.class, 16);
-    classRegsitry.put(GeoNorthLatitudeZone.class, 17);
-    classRegsitry.put(GeoNorthRectangle.class, 18);
-    classRegsitry.put(GeoSouthLatitudeZone.class, 19);
-    classRegsitry.put(GeoSouthRectangle.class, 20);
-    classRegsitry.put(GeoWideDegenerateHorizontalLine.class, 21);
-    classRegsitry.put(GeoWideLongitudeSlice.class, 22);
-    classRegsitry.put(GeoWideNorthRectangle.class, 23);
-    classRegsitry.put(GeoWideRectangle.class, 24);
-    classRegsitry.put(GeoWideSouthRectangle.class, 25);
-    classRegsitry.put(GeoWorld.class, 26);
-    classRegsitry.put(dXdYdZSolid.class, 27);
-    classRegsitry.put(dXdYZSolid.class, 28);
-    classRegsitry.put(dXYdZSolid.class, 29);
-    classRegsitry.put(dXYZSolid.class, 30);
-    classRegsitry.put(XdYdZSolid.class, 31);
-    classRegsitry.put(XdYZSolid.class, 32);
-    classRegsitry.put(XYdZSolid.class, 33);
-    classRegsitry.put(StandardXYZSolid.class, 34);
-    classRegsitry.put(PlanetModel.class, 35);
-    classRegsitry.put(GeoDegeneratePath.class, 36);
-    classRegsitry.put(GeoExactCircle.class, 37);
-    classRegsitry.put(GeoS2Shape.class, 38);
+    CLASS_REGISTRY.put(GeoPoint.class, 0);
+    CLASS_REGISTRY.put(GeoRectangle.class, 1);
+    CLASS_REGISTRY.put(GeoStandardCircle.class, 2);
+    CLASS_REGISTRY.put(GeoStandardPath.class, 3);
+    CLASS_REGISTRY.put(GeoConvexPolygon.class, 4);
+    CLASS_REGISTRY.put(GeoConcavePolygon.class, 5);
+    CLASS_REGISTRY.put(GeoComplexPolygon.class, 6);
+    CLASS_REGISTRY.put(GeoCompositePolygon.class, 7);
+    CLASS_REGISTRY.put(GeoCompositeMembershipShape.class, 8);
+    CLASS_REGISTRY.put(GeoCompositeAreaShape.class, 9);
+    CLASS_REGISTRY.put(GeoDegeneratePoint.class, 10);
+    CLASS_REGISTRY.put(GeoDegenerateHorizontalLine.class, 11);
+    CLASS_REGISTRY.put(GeoDegenerateLatitudeZone.class, 12);
+    CLASS_REGISTRY.put(GeoDegenerateLongitudeSlice.class, 13);
+    CLASS_REGISTRY.put(GeoDegenerateVerticalLine.class, 14);
+    CLASS_REGISTRY.put(GeoLatitudeZone.class, 15);
+    CLASS_REGISTRY.put(GeoLongitudeSlice.class, 16);
+    CLASS_REGISTRY.put(GeoNorthLatitudeZone.class, 17);
+    CLASS_REGISTRY.put(GeoNorthRectangle.class, 18);
+    CLASS_REGISTRY.put(GeoSouthLatitudeZone.class, 19);
+    CLASS_REGISTRY.put(GeoSouthRectangle.class, 20);
+    CLASS_REGISTRY.put(GeoWideDegenerateHorizontalLine.class, 21);
+    CLASS_REGISTRY.put(GeoWideLongitudeSlice.class, 22);
+    CLASS_REGISTRY.put(GeoWideNorthRectangle.class, 23);
+    CLASS_REGISTRY.put(GeoWideRectangle.class, 24);
+    CLASS_REGISTRY.put(GeoWideSouthRectangle.class, 25);
+    CLASS_REGISTRY.put(GeoWorld.class, 26);
+    CLASS_REGISTRY.put(dXdYdZSolid.class, 27);
+    CLASS_REGISTRY.put(dXdYZSolid.class, 28);
+    CLASS_REGISTRY.put(dXYdZSolid.class, 29);
+    CLASS_REGISTRY.put(dXYZSolid.class, 30);
+    CLASS_REGISTRY.put(XdYdZSolid.class, 31);
+    CLASS_REGISTRY.put(XdYZSolid.class, 32);
+    CLASS_REGISTRY.put(XYdZSolid.class, 33);
+    CLASS_REGISTRY.put(StandardXYZSolid.class, 34);
+    CLASS_REGISTRY.put(PlanetModel.class, 35);
+    CLASS_REGISTRY.put(GeoDegeneratePath.class, 36);
+    CLASS_REGISTRY.put(GeoExactCircle.class, 37);
+    CLASS_REGISTRY.put(GeoS2Shape.class, 38);
 
-    for (Map.Entry<Class<?>, Integer> entry : classRegsitry.entrySet()) {
-      codeRegsitry.put(entry.getValue(), entry.getKey());
+    for (Map.Entry<Class<?>, Integer> entry : CLASS_REGISTRY.entrySet()) {
+      CODE_REGISTRY.put(entry.getValue(), entry.getKey());
     }
   }
 }

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/TestGeo3DPoint.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/TestGeo3DPoint.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.IntSupplier;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.PointsFormat;
@@ -154,7 +155,15 @@ public class TestGeo3DPoint extends LuceneTestCase {
   }
 
   private static class Cell {
-    static int nextCellID;
+    static final IntSupplier nextCellID =
+        new IntSupplier() {
+          int counter = 0;
+
+          @Override
+          public int getAsInt() {
+            return counter++;
+          }
+        };
 
     final Cell parent;
     final int cellID;
@@ -181,7 +190,7 @@ public class TestGeo3DPoint extends LuceneTestCase {
       this.yMaxEnc = yMaxEnc;
       this.zMinEnc = zMinEnc;
       this.zMaxEnc = zMaxEnc;
-      this.cellID = nextCellID++;
+      this.cellID = nextCellID.getAsInt();
       this.splitCount = splitCount;
       this.planetModel = planetModel;
     }
@@ -1183,8 +1192,8 @@ public class TestGeo3DPoint extends LuceneTestCase {
     }
   }
 
-  protected static double MINIMUM_EDGE_ANGLE = toRadians(5.0);
-  protected static double MINIMUM_ARC_ANGLE = toRadians(1.0);
+  private static final double MINIMUM_EDGE_ANGLE = toRadians(5.0);
+  private static final double MINIMUM_ARC_ANGLE = toRadians(1.0);
 
   /**
    * Cook up a random Polygon that makes sense, with possible nested polygon within. This is part of

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/BlendedInfixSuggester.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/BlendedInfixSuggester.java
@@ -378,7 +378,7 @@ public class BlendedInfixSuggester extends AnalyzingInfixSuggester {
     return coefficient;
   }
 
-  private static Comparator<Lookup.LookupResult> LOOKUP_COMP = new LookUpComparator();
+  private static final Comparator<Lookup.LookupResult> LOOKUP_COMP = new LookUpComparator();
 
   private static class LookUpComparator implements Comparator<Lookup.LookupResult> {
 

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletionLookup.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletionLookup.java
@@ -76,7 +76,7 @@ public class FSTCompletionLookup extends Lookup {
    *
    * @see #FSTCompletionLookup(Directory, String, FSTCompletion, boolean)
    */
-  private static int INVALID_BUCKETS_COUNT = -1;
+  private static final int INVALID_BUCKETS_COUNT = -1;
 
   /**
    * Shared tail length for conflating in the created automaton. Setting this to larger values

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestLookupBenchmark.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestLookupBenchmark.java
@@ -259,7 +259,7 @@ public class TestLookupBenchmark extends LuceneTestCase {
 
   /** Guard against opts. */
   @SuppressWarnings("unused")
-  private static volatile int guard;
+  private volatile int guard;
 
   private static class BenchmarkResult {
     /** Average time per round (ms). */

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestFreeTextSuggester.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestFreeTextSuggester.java
@@ -303,18 +303,15 @@ public class TestFreeTextSuggester extends LuceneTestCase {
     a.close();
   }
 
-  private static Comparator<LookupResult> byScoreThenKey =
-      new Comparator<LookupResult>() {
-        @Override
-        public int compare(LookupResult a, LookupResult b) {
-          if (a.value > b.value) {
-            return -1;
-          } else if (a.value < b.value) {
-            return 1;
-          } else {
-            // Tie break by UTF16 sort order:
-            return ((String) a.key).compareTo((String) b.key);
-          }
+  private static final Comparator<LookupResult> byScoreThenKey =
+      (a, b) -> {
+        if (a.value > b.value) {
+          return -1;
+        } else if (a.value < b.value) {
+          return 1;
+        } else {
+          // Tie break by UTF16 sort order:
+          return ((String) a.key).compareTo((String) b.key);
         }
       };
 

--- a/lucene/test-framework/src/generated/checksums/generateEmojiTokenizationTest.json
+++ b/lucene/test-framework/src/generated/checksums/generateEmojiTokenizationTest.json
@@ -1,5 +1,5 @@
 {
-    "lucene/test-framework/src/java/org/apache/lucene/tests/analysis/standard/EmojiTokenizationTestUnicode_12_1.java": "22e03ada47168b0986220c57260cfaf8e6e12e16",
-    "lucene/test-framework/src/java/org/apache/lucene/tests/analysis/standard/generateEmojiTokenizationTest.pl": "a21d8aea5d2c30fb47b2bf9b24e20ddf605de46d",
+    "lucene/test-framework/src/java/org/apache/lucene/tests/analysis/standard/EmojiTokenizationTestUnicode_12_1.java": "9c4bc3ce66359cbe1e20d8e3ee718cc90caf21a4",
+    "lucene/test-framework/src/java/org/apache/lucene/tests/analysis/standard/generateEmojiTokenizationTest.pl": "b178c0ec31dc843d5b7a8ff4ae85601a00b0a89f",
     "property:unicodeVersion": "12.1"
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/MockGraphTokenFilter.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/MockGraphTokenFilter.java
@@ -31,7 +31,7 @@ import org.apache.lucene.tests.util.TestUtil;
 public final class MockGraphTokenFilter
     extends LookaheadTokenFilter<LookaheadTokenFilter.Position> {
 
-  private static boolean DEBUG = false;
+  private static final boolean DEBUG = false;
 
   private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/standard/EmojiTokenizationTestUnicode_12_1.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/standard/EmojiTokenizationTestUnicode_12_1.java
@@ -39,7 +39,7 @@ public final class EmojiTokenizationTestUnicode_12_1 {
     }
   }
 
-  private static String[] TESTS =
+  private static final String[] TESTS =
       new String[] {
         "1F600                                      ; fully-qualified     # 😀 E2.0 grinning face",
         "\uD83D\uDE00",

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/standard/generateEmojiTokenizationTest.pl
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/standard/generateEmojiTokenizationTest.pl
@@ -75,7 +75,7 @@ public final class ${class_name} {
     }
   }
 
-  private static String[] TESTS = new String[] {
+  private static final String[] TESTS = new String[] {
 __HEADER__
 
 my @tests = split /\r?\n/, get_URL_content($url);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/uniformsplit/UniformSplitRot13PostingsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/uniformsplit/UniformSplitRot13PostingsFormat.java
@@ -39,6 +39,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 
 /** {@link UniformSplitPostingsFormat} with block encoding using ROT13 cypher. */
+@SuppressWarnings("NonFinalStaticField")
 public class UniformSplitRot13PostingsFormat extends PostingsFormat {
 
   public static volatile boolean encoderCalled;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/geo/EarthDebugger.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/geo/EarthDebugger.java
@@ -82,7 +82,7 @@ public class EarthDebugger {
     }
   }
 
-  private static double MAX_KM_PER_STEP = 100.0;
+  private static final double MAX_KM_PER_STEP = 100.0;
 
   // Web GL earth connects dots by tunneling under the earth, so we approximate a great circle by
   // sampling it, to minimize how deep in the

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/geo/GeoTestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/geo/GeoTestUtil.java
@@ -792,7 +792,7 @@ public class GeoTestUtil {
 
   private static class Loader {
 
-    static Loader LOADER = new Loader();
+    static final Loader LOADER = new Loader();
 
     String readShape(String name) throws IOException {
       InputStream is = getClass().getResourceAsStream(name);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/DocHelper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/DocHelper.java
@@ -49,7 +49,7 @@ public class DocHelper {
   public static final FieldType customType;
   public static final String FIELD_1_TEXT = "field one text";
   public static final String TEXT_FIELD_1_KEY = "textField1";
-  public static Field textField1;
+  public static final Field textField1;
 
   static {
     customType = new FieldType(TextField.TYPE_STORED);
@@ -152,15 +152,23 @@ public class DocHelper {
   }
 
   public static final String LAZY_FIELD_BINARY_KEY = "lazyFieldBinary";
+
+  @SuppressWarnings("NonFinalStaticField")
   public static byte[] LAZY_FIELD_BINARY_BYTES;
+
+  @SuppressWarnings("NonFinalStaticField")
   public static Field lazyFieldBinary;
 
   public static final String LAZY_FIELD_KEY = "lazyField";
   public static final String LAZY_FIELD_TEXT = "These are some field bytes";
-  public static Field lazyField = new Field(LAZY_FIELD_KEY, LAZY_FIELD_TEXT, customType);
+  public static final Field lazyField = new Field(LAZY_FIELD_KEY, LAZY_FIELD_TEXT, customType);
 
   public static final String LARGE_LAZY_FIELD_KEY = "largeLazyField";
+
+  @SuppressWarnings("NonFinalStaticField")
   public static String LARGE_LAZY_FIELD_TEXT;
+
+  @SuppressWarnings("NonFinalStaticField")
   public static Field largeLazyField;
 
   // From Issue 509

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsPath.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsPath.java
@@ -23,10 +23,10 @@ import java.util.HashSet;
 
 class WindowsPath extends FilterPath {
 
-  static HashSet<Character> RESERVED_CHARACTERS =
+  static final HashSet<Character> RESERVED_CHARACTERS =
       new HashSet<>(Arrays.asList('<', '>', ':', '\"', '\\', '|', '?', '*'));
 
-  static HashSet<String> RESERVED_NAMES =
+  static final HashSet<String> RESERVED_NAMES =
       new HashSet<>(
           Arrays.asList(
               "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -544,6 +544,7 @@ public abstract class LuceneTestCase extends Assert {
   static final TestRuleSetupAndRestoreClassEnv classEnvRule;
 
   /** Suite failure marker (any error in the test or suite scope). */
+  @SuppressWarnings("NonFinalStaticField")
   protected static TestRuleMarkFailure suiteFailureMarker;
 
   /** Temporary files cleanup rule. */
@@ -608,7 +609,7 @@ public abstract class LuceneTestCase extends Assert {
    * This controls how suite-level rules are nested. It is important that _all_ rules declared in
    * {@link LuceneTestCase} are executed in proper order if they depend on each other.
    */
-  @ClassRule public static TestRule classRules;
+  @ClassRule public static final TestRule classRules;
 
   static {
     RuleChain r =
@@ -679,6 +680,7 @@ public abstract class LuceneTestCase extends Assert {
   }
 
   /** Set by TestRuleSetupAndRestoreClassEnv */
+  @SuppressWarnings("NonFinalStaticField")
   static LiveIWCFlushMode liveIWCFlushMode;
 
   static void setLiveIWCFlushMode(LiveIWCFlushMode flushMode) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
@@ -55,7 +55,7 @@ public final class RunListenerPrintReproduceInfo extends RunListener {
    * A list of all test suite classes executed so far in this JVM (ehm, under this class's
    * classloader).
    */
-  private static List<String> testClassesRun = new ArrayList<>();
+  private static final List<String> testClassesRun = new ArrayList<>();
 
   /** The currently executing scope. */
   private LifecycleScope scope;

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestCodecReported.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestCodecReported.java
@@ -28,6 +28,7 @@ public class TestCodecReported extends WithNestedTests {
   }
 
   public static class Nested1 extends WithNestedTests.AbstractNestedTest {
+    @SuppressWarnings("NonFinalStaticField")
     public static String codecName;
 
     public void testDummy() {

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestMaxFailuresRule.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestMaxFailuresRule.java
@@ -107,7 +107,10 @@ public class TestMaxFailuresRule extends WithNestedTests {
   public static class Nested2 extends WithNestedTests.AbstractNestedTest {
     public static final int TOTAL_ITERS = 10;
     public static CountDownLatch die;
+
+    @SuppressWarnings("NonFinalStaticField")
     public static Thread zombie;
+
     public static int testNum;
 
     @BeforeClass

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestReproduceMessage.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestReproduceMessage.java
@@ -31,7 +31,10 @@ import org.junit.runners.model.Statement;
 
 /** Test reproduce message is right. */
 public class TestReproduceMessage extends WithNestedTests {
+  @SuppressWarnings("NonFinalStaticField")
   public static SorePoint where;
+
+  @SuppressWarnings("NonFinalStaticField")
   public static SoreType type;
 
   public static class Nested extends AbstractNestedTest {


### PR DESCRIPTION
### Description

On https://github.com/apache/lucene/pull/14221, I foolishly asserted that the error-prone `NonFinalStaticField` checks would be "a lot less noisy". It seems that PR and its mere 12 files had only scratched the surface.

A couple of hours, 153 Java source files (plus one Perl script that generates a Java file) later, we can enable the `NonFinalStaticField` check.

The good (?) news is that I "only" needed to resort to suppressing the warnings in 52 files, and was able to fix the other 101. 🎉 