### PR TITLE
Remove some randomness from flaky BaseVectorSimilarityQueryTestCase#testFallbackToExact

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
@@ -431,8 +431,8 @@ abstract class BaseVectorSimilarityQueryTestCase<
 
   public void testFallbackToExact() throws IOException {
     // Restrictive filter, along with similarity to visit a large number of nodes
-    int numFiltered = random().nextInt(numDocs / 10, numDocs / 5);
-    int targetVisited = random().nextInt(numFiltered * 2, numDocs);
+    int numFiltered = numDocs / 5;
+    int targetVisited = numDocs;
 
     V[] vectors = getRandomVectors(numDocs, dim);
     V queryVector = getRandomVector(dim);


### PR DESCRIPTION
Periodically, the similarity requested according to the desired matched docs actually doesn't explore enough docs to fall back to exact.

Since the purpose of this test is to verify that falling back to exact occurs, I removed some randomness.

I ran 10k+ times and it never failed. Previously it would fail multiple times in a 100 runs.


closes: https://github.com/apache/lucene/issues/14230