### PR TITLE
[Unit] Increase Dynamic Range Faceting coverage by adding previously nonexistent unit tests

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -20,6 +20,7 @@ New Features
 
 Improvements
 ---------------------
+* GITHUB#14238: Improve test coverage of Dynamic Range Faceting. (John Houser)
 
 (No changes)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -20,7 +20,6 @@ New Features
 
 Improvements
 ---------------------
-* GITHUB#14238: Improve test coverage of Dynamic Range Faceting. (John Houser)
 
 (No changes)
 
@@ -86,6 +85,7 @@ Improvements
   the wrapped analyzer's strategy to decide if components can be reused or need
   to be updated. (Mayya Sharipova)
 
+* GITHUB#14238: Improve test coverage of Dynamic Range Faceting. (John Houser)
 
 Optimizations
 ---------------------

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestDynamicRangeUtil.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestDynamicRangeUtil.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.facet.range;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
@@ -76,11 +77,246 @@ public class TestDynamicRangeUtil extends LuceneTestCase {
     long[] values = new long[] {45, 32, 52, 14, 455, 342, 53};
     long[] weights = new long[] {143, 23, 1, 52343, 53, 12, 2534};
 
-    // value 14 has its own bin since the weight is large, and the rest of values fall the other bin
-    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(1, 52343, 14L, 14L, 14D));
+    // value 14 has its own bin since the weight is large, and the rest of the values fall in the
+    // other bin
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(1, 52343L, 14L, 14L, 14D));
     expectedRangeInfoList.add(
-        new DynamicRangeUtil.DynamicRangeInfo(6, 2766, 32L, 455L, 163.16666666666666D));
+        new DynamicRangeUtil.DynamicRangeInfo(6, 2766L, 32L, 455L, 163.16666666666666D));
     assertDynamicNumericRangeResults(values, weights, 4, 55109, expectedRangeInfoList);
+  }
+
+  public void testComputeDynamicNumericRangesWithLargeTopN() {
+    List<DynamicRangeUtil.DynamicRangeInfo> expectedRangeInfoList = new ArrayList<>();
+    long[] values = new long[] {487, 439, 794, 277};
+    long[] weights = new long[] {59, 508, 736, 560};
+
+    // More requested ranges (TopN) than values should return ranges with weights larger than the
+    // average weight - excluding the last range
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(1, 560L, 277L, 277L, 277D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(1, 508L, 439L, 439L, 439D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(2, 795L, 487L, 794L, 640.5D));
+    assertDynamicNumericRangeResults(values, weights, 42, 1863L, expectedRangeInfoList);
+  }
+
+  public void testComputeDynamicNumericRangesWithSingleTopN() {
+    List<DynamicRangeUtil.DynamicRangeInfo> expectedRangeInfoList = new ArrayList<>();
+    long[] values = new long[] {487, 439, 794, 277};
+    long[] weights = new long[] {59, 508, 736, 560};
+
+    // A single requested range (TopN) should return a single range regardless of the weights
+    // provided
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(4, 1863L, 277L, 794L, 499.25D));
+    assertDynamicNumericRangeResults(values, weights, 1, 1863L, expectedRangeInfoList);
+  }
+
+  public void testComputeDynamicNumericRangesWithTwoTopN() {
+    List<DynamicRangeUtil.DynamicRangeInfo> expectedRangeInfoList = new ArrayList<>();
+    long[] values = new long[] {487, 439, 794, 277};
+    long[] weights = new long[] {59, 508, 736, 560};
+
+    // Two requested ranges (TopN) should return two ranges where the first range's weight is equal
+    // or larger than half of the total weight
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(2, 1068L, 277L, 439L, 358.0D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(2, 795L, 487L, 794L, 640.5D));
+    assertDynamicNumericRangeResults(values, weights, 2, 1863L, expectedRangeInfoList);
+  }
+
+  public void testComputeDynamicNumericRangesWithSameWeights() {
+    List<DynamicRangeUtil.DynamicRangeInfo> expectedRangeInfoList = new ArrayList<>();
+    long[] values = new long[100];
+    long[] weights = new long[100];
+    for (int i = 0; i < 100; i++) {
+      values[i] = i;
+      weights[i] = 50;
+    }
+
+    // Supplying only equal weights should return ranges with equal counts - excluding the last
+    // range
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 0L, 24L, 12.0D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 25L, 49L, 37.0D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 50L, 74L, 62.0D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 75L, 99L, 87.0D));
+    assertDynamicNumericRangeResults(values, weights, 4, 5000L, expectedRangeInfoList);
+  }
+
+  public void testComputeDynamicNumericRangesWithSameWeightsShuffled() {
+    List<DynamicRangeUtil.DynamicRangeInfo> expectedRangeInfoList = new ArrayList<>();
+    long[] values = new long[100];
+    long[] weights = new long[100];
+    for (int i = 0; i < 100; i++) {
+      values[i] = i;
+      weights[i] = 50;
+    }
+
+    // Shuffling the values and weights should not change the answer when the weights are the same
+    shuffleValuesWeights(values, weights);
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 0L, 24L, 12.0D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 25L, 49L, 37.0D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 50L, 74L, 62.0D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 75L, 99L, 87.0D));
+    assertDynamicNumericRangeResults(values, weights, 4, 5000L, expectedRangeInfoList);
+  }
+
+  public void testComputeDynamicNumericRangesWithSameValuesShuffled() {
+    List<DynamicRangeUtil.DynamicRangeInfo> expectedRangeInfoList = new ArrayList<>();
+    long totalWeight = 0;
+    long[] values = new long[100];
+    long[] weights = new long[100];
+    for (int i = 0; i < 100; i++) {
+      values[i] = 50;
+      weights[i] = i;
+      totalWeight += i;
+    }
+
+    // Shuffling the values and weights should not change the answer when the values are the same
+    shuffleValuesWeights(values, weights);
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(51, 1275L, 50L, 50L, 50D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(21, 1281L, 50L, 50L, 50D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(16, 1272L, 50L, 50L, 50D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(12, 1122L, 50L, 50L, 50D));
+
+    assertDynamicNumericRangeResults(values, weights, 4, totalWeight, expectedRangeInfoList);
+  }
+
+  public void testComputeDynamicNumericRangesWithMisplacedValue() {
+    List<DynamicRangeUtil.DynamicRangeInfo> expectedRangeInfoList = new ArrayList<>();
+    long[] values =
+        new long[] {
+          1, 2, 11, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 12, 111, 112, 113, 114, 115
+        };
+    long[] weights =
+        new long[] {
+          2, 3, 12, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 13, 112, 113, 114, 115, 116
+        };
+
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(8, 444L, 1L, 104L, 54.5D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(4, 430L, 105L, 108L, 106.5D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(4, 446L, 109L, 112L, 110.5D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(3, 345L, 113L, 115L, 114.0D));
+    assertDynamicNumericRangeResults(values, weights, 4, 1665, expectedRangeInfoList);
+  }
+
+  public void testComputeDynamicNumericRangesWithRandomValues() {
+    int arraySize = random().nextInt(100);
+    long[] values = new long[arraySize];
+    long[] weights = new long[arraySize];
+
+    for (int i = 0; i < arraySize; i++) {
+      values[i] = random().nextLong(1000);
+      weights[i] = random().nextLong(1000);
+    }
+
+    int topN = random().nextInt(100);
+
+    long totalWeight = 0;
+    for (long weight : weights) {
+      totalWeight += weight;
+    }
+
+    assertDynamicNumericRangeValidProperties(values, weights, topN, totalWeight);
+  }
+
+  /** Implementation of Durstenfeld's algorithm for shuffling values and weights */
+  private void shuffleValuesWeights(long[] values, long[] weights) {
+    for (int i = values.length - 1; i > 0; i--) {
+      int rdmIdx = random().nextInt(i + 1);
+      long tmpValue = values[i];
+      long tmpWeight = weights[i];
+      values[i] = values[rdmIdx];
+      weights[i] = weights[rdmIdx];
+      values[rdmIdx] = tmpValue;
+      weights[rdmIdx] = tmpWeight;
+    }
+  }
+
+  private static void assertDynamicNumericRangeValidProperties(
+      long[] values, long[] weights, int topN, long totalWeight) {
+    List<List<Long>> sortedPairs = new ArrayList<>();
+    for (int i = 0; i < values.length; i++) {
+      long value = values[i];
+      long weight = weights[i];
+      List<Long> pair = new ArrayList<>();
+      pair.add(value);
+      pair.add(weight);
+      sortedPairs.add(pair);
+    }
+
+    sortedPairs.sort(
+        Comparator.comparingLong((List<Long> innerList) -> innerList.get(0))
+            .thenComparingLong((List<Long> innerList) -> innerList.get(1)));
+
+    int len = values.length;
+
+    double rangeWeightTarget = (double) totalWeight / Math.min(topN, len);
+
+    List<DynamicRangeUtil.DynamicRangeInfo> mockDynamicRangeResult =
+        DynamicRangeUtil.computeDynamicNumericRanges(
+            values, weights, values.length, totalWeight, topN);
+
+    // Adjacent ranges do not overlap - only adjacent max-min can overlap
+    for (int i = 0; i < mockDynamicRangeResult.size() - 1; i++) {
+      DynamicRangeUtil.DynamicRangeInfo rangeInfo = mockDynamicRangeResult.get(i);
+      DynamicRangeUtil.DynamicRangeInfo nextRangeInfo = mockDynamicRangeResult.get(i + 1);
+      assertTrue(rangeInfo.max() <= nextRangeInfo.min());
+    }
+
+    // The count of every range sums to the number of values
+    int accuCount = 0;
+    for (int i = 0; i < mockDynamicRangeResult.size(); i++) {
+      DynamicRangeUtil.DynamicRangeInfo rangeInfo = mockDynamicRangeResult.get(i);
+      int count = rangeInfo.count();
+      accuCount += count;
+    }
+    assertTrue(accuCount == len);
+
+    // All values appear in atleast one range
+    for (int pairOffset = 0, rangeIdx = 0; rangeIdx < mockDynamicRangeResult.size(); rangeIdx++) {
+      DynamicRangeUtil.DynamicRangeInfo rangeInfo = mockDynamicRangeResult.get(rangeIdx);
+      int count = rangeInfo.count();
+      for (int i = pairOffset; i < pairOffset + count; i++) {
+        List<Long> pair = sortedPairs.get(i);
+        long value = pair.get(0);
+        assertTrue(rangeInfo.min() <= value && value <= rangeInfo.max());
+      }
+      pairOffset += count;
+    }
+
+    // Weights of each range is over the rangeWeightTarget - exclude last range
+    for (int i = 0; i < mockDynamicRangeResult.size() - 1; i++) {
+      DynamicRangeUtil.DynamicRangeInfo rangeInfo = mockDynamicRangeResult.get(i);
+      assertTrue(rangeInfo.weight() >= rangeWeightTarget);
+    }
+
+    // Removing the last weight from a range brings it under the rangeWeightTarget - exclude last
+    // range
+    for (int pairOffset = 0, rangeIdx = 0;
+        rangeIdx < mockDynamicRangeResult.size() - 1;
+        rangeIdx++) {
+      DynamicRangeUtil.DynamicRangeInfo rangeInfo = mockDynamicRangeResult.get(rangeIdx);
+      int count = rangeInfo.count();
+      long lastWeight = Long.MAX_VALUE;
+      for (int i = pairOffset; i < pairOffset + count; i++) {
+        List<Long> pair = sortedPairs.get(i);
+        long weight = pair.get(1);
+        lastWeight = weight;
+      }
+      pairOffset += count;
+      assertTrue(rangeInfo.weight() - lastWeight < rangeWeightTarget);
+    }
+
+    // Centroids for each range are correct
+    for (int pairOffset = 0, rangeIdx = 0; rangeIdx < mockDynamicRangeResult.size(); rangeIdx++) {
+      DynamicRangeUtil.DynamicRangeInfo rangeInfo = mockDynamicRangeResult.get(rangeIdx);
+      int count = rangeInfo.count();
+      long accuValue = 0;
+      for (int i = pairOffset; i < pairOffset + count; i++) {
+        List<Long> pair = sortedPairs.get(i);
+        long value = pair.get(0);
+        accuValue += value;
+      }
+      pairOffset += count;
+      assertTrue(rangeInfo.centroid() == ((double) accuValue / count));
+    }
   }
 
   private static void assertDynamicNumericRangeResults(
@@ -92,12 +328,6 @@ public class TestDynamicRangeUtil extends LuceneTestCase {
     List<DynamicRangeUtil.DynamicRangeInfo> mockDynamicRangeResult =
         DynamicRangeUtil.computeDynamicNumericRanges(
             values, weights, values.length, totalWeight, topN);
-    assertTrue(compareDynamicRangeResult(mockDynamicRangeResult, expectedDynamicRangeResult));
-  }
-
-  private static boolean compareDynamicRangeResult(
-      List<DynamicRangeUtil.DynamicRangeInfo> mockResult,
-      List<DynamicRangeUtil.DynamicRangeInfo> expectedResult) {
-    return mockResult.size() == expectedResult.size() && mockResult.containsAll(expectedResult);
+    assertEquals(mockDynamicRangeResult, expectedDynamicRangeResult);
   }
 }

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestDynamicRangeUtil.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestDynamicRangeUtil.java
@@ -289,14 +289,10 @@ public class TestDynamicRangeUtil extends LuceneTestCase {
     for (int pairOffset = 0, rangeIdx = 0; rangeIdx < mockDynamicRangeResult.size(); rangeIdx++) {
       DynamicRangeUtil.DynamicRangeInfo rangeInfo = mockDynamicRangeResult.get(rangeIdx);
       int count = rangeInfo.count();
-      long min = Long.MAX_VALUE;
-      long max = Long.MIN_VALUE;
-      for (int i = pairOffset; i < pairOffset + count; i++) {
-        List<Long> pair = sortedPairs.get(i);
-        long value = pair.get(0);
-        min = Math.min(min, value);
-        max = Math.max(max, value);
-      }
+      List<Long> minPair = sortedPairs.get(pairOffset);
+      List<Long> maxPair = sortedPairs.get(pairOffset + count - 1);
+      long min = minPair.get(0);
+      long max = maxPair.get(0);
       assertTrue(rangeInfo.min() == min);
       assertTrue(rangeInfo.max() == max);
       pairOffset += count;

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestDynamicRangeUtil.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestDynamicRangeUtil.java
@@ -244,8 +244,7 @@ public class TestDynamicRangeUtil extends LuceneTestCase {
     }
 
     sortedPairs.sort(
-        Comparator.comparingLong((WeightedPair weightedPair) -> weightedPair.value())
-            .thenComparingLong((WeightedPair weightedPair) -> weightedPair.weight()));
+        Comparator.comparingLong(WeightedPair::value).thenComparingLong(WeightedPair::weight));
 
     int len = values.length;
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestDynamicRangeUtil.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestDynamicRangeUtil.java
@@ -63,6 +63,24 @@ public class TestDynamicRangeUtil extends LuceneTestCase {
     assertDynamicNumericRangeResults(values, weights, 4, totalWeight, expectedRangeInfoList);
   }
 
+  public void testComputeDynamicNumericRangesWithSameWeights() {
+    List<DynamicRangeUtil.DynamicRangeInfo> expectedRangeInfoList = new ArrayList<>();
+    long[] values = new long[100];
+    long[] weights = new long[100];
+    for (int i = 0; i < 100; i++) {
+      values[i] = i;
+      weights[i] = 50;
+    }
+
+    // Supplying only equal weights should return ranges with equal counts - excluding the last
+    // range
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 0L, 24L, 12.0D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 25L, 49L, 37.0D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 50L, 74L, 62.0D));
+    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 75L, 99L, 87.0D));
+    assertDynamicNumericRangeResults(values, weights, 4, 5000L, expectedRangeInfoList);
+  }
+
   public void testComputeDynamicNumericRangesWithOneValue() {
     long[] values = new long[] {50};
     long[] weights = new long[] {1};
@@ -121,24 +139,6 @@ public class TestDynamicRangeUtil extends LuceneTestCase {
     assertDynamicNumericRangeResults(values, weights, 2, 1863L, expectedRangeInfoList);
   }
 
-  public void testComputeDynamicNumericRangesWithSameWeights() {
-    List<DynamicRangeUtil.DynamicRangeInfo> expectedRangeInfoList = new ArrayList<>();
-    long[] values = new long[100];
-    long[] weights = new long[100];
-    for (int i = 0; i < 100; i++) {
-      values[i] = i;
-      weights[i] = 50;
-    }
-
-    // Supplying only equal weights should return ranges with equal counts - excluding the last
-    // range
-    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 0L, 24L, 12.0D));
-    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 25L, 49L, 37.0D));
-    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 50L, 74L, 62.0D));
-    expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 75L, 99L, 87.0D));
-    assertDynamicNumericRangeResults(values, weights, 4, 5000L, expectedRangeInfoList);
-  }
-
   public void testComputeDynamicNumericRangesWithSameWeightsShuffled() {
     List<DynamicRangeUtil.DynamicRangeInfo> expectedRangeInfoList = new ArrayList<>();
     long[] values = new long[100];
@@ -148,7 +148,9 @@ public class TestDynamicRangeUtil extends LuceneTestCase {
       weights[i] = 50;
     }
 
-    // Shuffling the values and weights should not change the answer when the weights are the same
+    // Shuffling the values and weights should not change the answer between runs
+    // We expect that returned ranges should come in a strict, deterministic order
+    // with the same values and weights
     shuffleValuesWeights(values, weights);
     expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 0L, 24L, 12.0D));
     expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(25, 1250L, 25L, 49L, 37.0D));
@@ -168,7 +170,9 @@ public class TestDynamicRangeUtil extends LuceneTestCase {
       totalWeight += i;
     }
 
-    // Shuffling the values and weights should not change the answer when the values are the same
+    // Shuffling the values and weights should not change the answer between runs
+    // We expect that returned ranges should come in a strict, deterministic order
+    // with the same values and weights
     shuffleValuesWeights(values, weights);
     expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(51, 1275L, 50L, 50L, 50D));
     expectedRangeInfoList.add(new DynamicRangeUtil.DynamicRangeInfo(21, 1281L, 50L, 50L, 50D));

--- a/lucene/facet/src/test/org/apache/lucene/facet/range/TestDynamicRangeUtil.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/range/TestDynamicRangeUtil.java
@@ -285,6 +285,23 @@ public class TestDynamicRangeUtil extends LuceneTestCase {
       pairOffset += count;
     }
 
+    // The minimum/maximum of each range is actually the smallest/largest value
+    for (int pairOffset = 0, rangeIdx = 0; rangeIdx < mockDynamicRangeResult.size(); rangeIdx++) {
+      DynamicRangeUtil.DynamicRangeInfo rangeInfo = mockDynamicRangeResult.get(rangeIdx);
+      int count = rangeInfo.count();
+      long min = Long.MAX_VALUE;
+      long max = Long.MIN_VALUE;
+      for (int i = pairOffset; i < pairOffset + count; i++) {
+        List<Long> pair = sortedPairs.get(i);
+        long value = pair.get(0);
+        min = Math.min(min, value);
+        max = Math.max(max, value);
+      }
+      assertTrue(rangeInfo.min() == min);
+      assertTrue(rangeInfo.max() == max);
+      pairOffset += count;
+    }
+
     // Weights of each range is over the rangeWeightTarget - exclude last range
     for (int i = 0; i < mockDynamicRangeResult.size() - 1; i++) {
       DynamicRangeUtil.DynamicRangeInfo rangeInfo = mockDynamicRangeResult.get(i);
@@ -298,12 +315,8 @@ public class TestDynamicRangeUtil extends LuceneTestCase {
         rangeIdx++) {
       DynamicRangeUtil.DynamicRangeInfo rangeInfo = mockDynamicRangeResult.get(rangeIdx);
       int count = rangeInfo.count();
-      long lastWeight = Long.MAX_VALUE;
-      for (int i = pairOffset; i < pairOffset + count; i++) {
-        List<Long> pair = sortedPairs.get(i);
-        long weight = pair.get(1);
-        lastWeight = weight;
-      }
+      List<Long> lastPair = sortedPairs.get(pairOffset + count - 1);
+      long lastWeight = lastPair.get(1);
       pairOffset += count;
       assertTrue(rangeInfo.weight() - lastWeight < rangeWeightTarget);
     }


### PR DESCRIPTION
### Description

Adds additional unit tests to increase coverage of Dynamic Range Faceting.
- Adds tests for varying TopN values
- Adds test for inputs with the same weights
- Adds tests that randomly shuffle the inputs
- Adds test for a single misplaced value
- Adds randomized test that is checked based on the properties of the ranges

Performance improvements included in [GH#13914](https://github.com/apache/lucene/pull/13914) showed that a few more unit tests may be needed to have sufficient coverage. Additionally, a few other unit tests were added for completeness. For instance, while `LargeTopN` was added because it exposed a previously unfound bug, `SingleTopN` and `TwoTopN` were added because we were not testing small TopN values. Here a few of the highlighted unit tests that were previously nonexistent with their error messages:

`testComputeDynamicNumericRangesWithMisplacedValue` (Notice values marked with **)

>```java.lang.AssertionError: expected:<[DynamicRangeInfo[count=8, weight=444, min=**1**, max=104, centroid=54.5], DynamicRangeInfo[count=4, weight=430, min=105, max=108, centroid=106.5], DynamicRangeInfo[count=4, weight=446, min=109, max=112, centroid=110.5], DynamicRangeInfo[count=3, weight=345, min=113, max=115, centroid=114.0]]> but was:<[DynamicRangeInfo[count=8, weight=444, min=**12**, max=104, centroid=54.5], DynamicRangeInfo[count=4, weight=430, min=105, max=108, centroid=106.5], DynamicRangeInfo[count=4, weight=446, min=109, max=112, centroid=110.5], DynamicRangeInfo[count=3, weight=345, min=113, max=115, centroid=114.0]]>``` 

`testComputeDynamicNumericRangesWithLargeTopN`
>```   
>     java.lang.IllegalArgumentException: All kWeights must be < beforeWeight + rangeWeight
   >         at __randomizedtesting.SeedInfo.seed([913AAD1D60B9263B:FFD4EE9EA025DBF]:0)
   >         at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.util.WeightedSelector.checkArgs(WeightedSelector.java:82)
   >         at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.util.WeightedSelector.select(WeightedSelector.java:57)
   >         at org.apache.lucene.facet.range.DynamicRangeUtil.computeDynamicNumericRanges(DynamicRangeUtil.java:266)
   >         at org.apache.lucene.facet.range.TestDynamicRangeUtil.testComputeDynamicNumericRangesWithLargeTopN(TestDynamicRangeUtil.java:169)
   >         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)


`testComputeDynamicNumericRangesWithSameWeights` (Notice values marked with **)

>```   
>     java.lang.AssertionError: expected:<[DynamicRangeInfo[count=**25**, weight=1250, min=0, max=24, centroid=12.0], DynamicRangeInfo[count=25, weight=1250, min=25, max=49, centroid=37.0], DynamicRangeInfo[count=25, weight=1250, min=50, max=74, centroid=62.0], DynamicRangeInfo[count=25, weight=1250, min=75, max=99, centroid=87.0]]> but was:<[DynamicRangeInfo[count=**26**, weight=1300, min=0, max=25, centroid=12.5], DynamicRangeInfo[count=25, weight=1250, min=26, max=50, centroid=38.0], DynamicRangeInfo[count=25, weight=1250, min=51, max=75, centroid=63.0], DynamicRangeInfo[count=24, weight=1200, min=76, max=99, centroid=87.5]]>
   >         at __randomizedtesting.SeedInfo.seed([DA6EB4C0C0CA4022:DBA0A4538AB03899]:0)
   >         at junit@4.13.1/org.junit.Assert.fail(Assert.java:89)
   >         at junit@4.13.1/org.junit.Assert.failNotEquals(Assert.java:835)
   >         at junit@4.13.1/org.junit.Assert.assertEquals(Assert.java:120)
   >         at junit@4.13.1/org.junit.Assert.assertEquals(Assert.java:146)
   >         at org.apache.lucene.facet.range.TestDynamicRangeUtil.compareDynamicRangeResult(TestDynamicRangeUtil.java:361)
   >         at org.apache.lucene.facet.range.TestDynamicRangeUtil.assertDynamicNumericRangeResults(TestDynamicRangeUtil.java:351)
   >         at org.apache.lucene.facet.range.TestDynamicRangeUtil.testComputeDynamicNumericRangesWithSameWeights(TestDynamicRangeUtil.java:156)
### Testing

```
./gradlew tidy
./gradlew clean
./gradlew build
```