### PR TITLE
Relation check within 1D BKD Leaves

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -443,12 +443,7 @@ public abstract class PointRangeQuery extends Query {
             new IntersectVisitor() {
               @Override
               public void visit(int docID) {
-                // this branch should be unreachable
-                throw new UnsupportedOperationException(
-                    "This IntersectVisitor does not perform any actions on a "
-                        + "docID="
-                        + docID
-                        + " node being visited");
+                matchingNodeCount[0]++;
               }
 
               @Override

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -888,6 +888,7 @@ public class BKDReader extends PointValues {
         int count,
         PointValues.IntersectVisitor visitor)
         throws IOException {
+      int acc = 0;
       int i;
       for (i = 0; i < count; ) {
         int length = in.readVInt();
@@ -898,7 +899,7 @@ public class BKDReader extends PointValues {
               dim * config.bytesPerDim() + prefix,
               config.bytesPerDim() - prefix);
         }
-        if (config.numDims() == 1) {
+        if (config.numDims() == 1 && ++acc == 4) {
           Relation r = visitor.compare(scratchPackedValue, maxPackedValue);
           if (r != Relation.CELL_CROSSES_QUERY) {
             if (r == Relation.CELL_INSIDE_QUERY) {
@@ -906,6 +907,7 @@ public class BKDReader extends PointValues {
             }
             return;
           }
+          acc = 0;
         }
         scratchIterator.reset(i, length);
         visitor.visit(scratchIterator, scratchPackedValue);

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -888,7 +888,10 @@ public class BKDReader extends PointValues {
         int count,
         PointValues.IntersectVisitor visitor)
         throws IOException {
-      int acc = 0;
+      // Check relation per 4 values.
+      // Initialized as 2 to check the 2nd value in the leaf since it is a common shortcut point for
+      // the exact queries on the value stored across leaves.
+      int acc = 2;
       int i;
       for (i = 0; i < count; ) {
         int length = in.readVInt();

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -889,9 +889,9 @@ public class BKDReader extends PointValues {
         PointValues.IntersectVisitor visitor)
         throws IOException {
       // Check relation per 4 values.
-      // Initialized as 2 to check the 2nd value in the leaf since it is a common shortcut point for
-      // the exact queries on the value stored across leaves.
-      int acc = 2;
+      // Minus 2 to check from the second value in the leaf since it is a common shortcut point for
+      // the queries on the value stored across leaves.
+      int acc = 4 - 2;
       int i;
       for (i = 0; i < count; ) {
         int length = in.readVInt();


### PR DESCRIPTION
This patch tries to introduce additional relation check to shortcut visiting within BKD leaves. This helps queries that hit few docs like PointInSetQuery or narrow RangeQueries on high-cardinality fields, without too much overhead to many-hits queries since their bottleneck is not visiting edge leaves.

The goal that visits less points can be achieved by reducing `maxPointsInLeafNode` as well. This patch mainly aims to optimize default config and help cases that need many-hits queries and few-hits queries on the same format.

wikimediumall:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                          IntNRQ       66.70      (3.8%)       65.73      (3.5%)   -1.5% (  -8% -    6%) 0.215
               TermDayOfYearSort       83.39      (6.3%)       82.40      (7.6%)   -1.2% ( -14% -   13%) 0.591
                  FilteredIntNRQ       64.46      (3.7%)       63.90      (4.9%)   -0.9% (  -9% -    8%) 0.522
             CountFilteredIntNRQ       38.03      (2.7%)       37.94      (3.9%)   -0.2% (  -6% -    6%) 0.821
                      TermDTSort       84.62      (3.4%)       85.39      (3.8%)    0.9% (  -6% -    8%) 0.431
                          IntSet      248.07      (3.9%)      277.50      (4.9%)   11.9% (   2% -   21%) 0.000
```
