### PR TITLE
Adjust assert merge flakiness due to fencepost error

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestLogMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestLogMergePolicy.java
@@ -57,7 +57,16 @@ public class TestLogMergePolicy extends BaseMergePolicyTestCase {
       for (SegmentCommitInfo info : oneMerge.segments) {
         mergeSize += lmp.size(info, mockMergeContext);
       }
-      assertTrue(mergeSize <= lmp.minMergeSize || oneMerge.segments.size() <= lmp.getMergeFactor());
+      assertTrue(
+          "mergeSize: "
+              + mergeSize
+              + " minMergeSize: "
+              + lmp.minMergeSize
+              + " segmentsCount: "
+              + oneMerge.segments.size()
+              + " mergeFactor: "
+              + lmp.getMergeFactor(),
+          mergeSize <= lmp.minMergeSize || oneMerge.segments.size() <= lmp.getMergeFactor());
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestLogMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestLogMergePolicy.java
@@ -57,7 +57,7 @@ public class TestLogMergePolicy extends BaseMergePolicyTestCase {
       for (SegmentCommitInfo info : oneMerge.segments) {
         mergeSize += lmp.size(info, mockMergeContext);
       }
-      assertTrue(mergeSize < lmp.minMergeSize || oneMerge.segments.size() <= lmp.getMergeFactor());
+      assertTrue(mergeSize <= lmp.minMergeSize || oneMerge.segments.size() <= lmp.getMergeFactor());
     }
   }
 


### PR DESCRIPTION
The test seed thats failing indicates that its possible for `mergeSize == lmp.minMergeSize()`

So, this smells like a fence-post error, so I switched from `<` to `<=`.

I ran over many thousands of seeds and every (rare) failure I saw were due to `mergeSize == lmp.minMergeSize()`

closes: https://github.com/apache/lucene/issues/14206