### PR TITLE
Repeatable hunspell tests

### DIFF
--- a/.github/workflows/run-checks-mod-analysis-common-hunspell.yml
+++ b/.github/workflows/run-checks-mod-analysis-common-hunspell.yml
@@ -1,4 +1,4 @@
-name: "Run checks: module lucene/analysis/common"
+name: "Run checks: module lucene/analysis/common (hunspell)"
 
 on:
   workflow_dispatch:
@@ -24,7 +24,7 @@ env:
 
 jobs:
   test:
-    name: Extra regression tests
+    name: Extra Hunspell regression tests
     timeout-minutes: 15
 
     runs-on: ubuntu-latest
@@ -33,5 +33,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare-for-build
 
-      - name: Run 'gradlew lucene/analysis/common check testRegressions'
-        run: ./gradlew -p lucene/analysis/common check testRegressions
+      - name: Run Hunspell regression tests
+        run: ./gradlew -p lucene/analysis/common -Ptests.hunspell.regressions=true -Ptests.verbose=true test --tests "TestAllDictionaries"

--- a/.github/workflows/run-scheduled-hunspell.yml
+++ b/.github/workflows/run-scheduled-hunspell.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
 
   schedule:
-    - cron: '13 4 * * 1' // 4:13 on Mondays
+    # 4:13 on Mondays
+    - cron: '13 4 * * 1'
 
 env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/.github/workflows/run-scheduled-hunspell.yml
+++ b/.github/workflows/run-scheduled-hunspell.yml
@@ -1,0 +1,31 @@
+name: "Run scheduled checks: Hunspell tests against latest dictionaries"
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: '13 4 * * 1' // 4:13 on Mondays
+
+env:
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
+jobs:
+  test:
+    name: Hunspell regression tests against latest dictionaries
+    timeout-minutes: 15
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare-for-build
+
+      - name: Run Hunspell regression tests against latest commits in dictionary repositories
+        run: >
+          ./gradlew -p lucene/analysis/common 
+          -Ptests.hunspell.regressions=true
+          -Ptests.verbose=true
+          -Ptests.hunspell.libreoffice.ref=master
+          -Ptests.hunspell.woorm.ref=main
+          test 
+          --tests "TestAllDictionaries"

--- a/lucene/analysis/common/build.gradle
+++ b/lucene/analysis/common/build.gradle
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import java.nio.file.Files;
+
 apply plugin: 'java-library'
 
 description = 'Analyzers for indexing content in different languages and domains'
@@ -24,34 +26,54 @@ dependencies {
   moduleTestImplementation project(':lucene:test-framework')
 }
 
-// Fetch the data and enable regression tests against woorm/ libreoffice dictionaries.
-task checkoutHunspellRegressionRepos() {
-  ext {
-    checkoutDir = file("${buildDir}/hunspell-regressions")
-  }
+def checkoutDirProv = project.layout.buildDirectory.dir("hunspell-regressions")
 
-  outputs.dir checkoutDir
+// Fetch the data and enable regression tests against woorm/ libreoffice dictionaries.
+def checkoutHunspellRegressionRepos = tasks.register("checkoutHunspellRegressionRepos", {
+  outputs.dir(checkoutDirProv)
+  outputs.upToDateWhen { false }
+
   doFirst {
-    // Clone the repositories we need if they don't exist.
+    // Clone the repositories and refs we need.
     [
-        "libreoffice": "https://github.com/LibreOffice/dictionaries",
-        "woorm": "https://github.com/wooorm/dictionaries"
-    ].each { name, repo ->
-      if (!file("${checkoutDir}/${name}").exists()) {
-        checkoutDir.mkdirs()
-        // This will work only if git is available, but I assume it is.
+        "libreoffice": [
+          "url": "https://github.com/LibreOffice/dictionaries",
+          "ref": "master"
+        ],
+        "woorm": [
+          "url": "https://github.com/wooorm/dictionaries",
+          "ref": "main"
+        ]
+    ].each { name, repoSpec ->
+      def url = repoSpec.url
+      def ref = repoSpec.ref
+      def cloneDir = checkoutDirProv.map { dir -> dir.dir(name) }.get().asFile.toPath()
+
+      def logger = this.logger
+      def gitExec = (List<String> cmdArgs) -> {
+        logger.lifecycle("Executing git " + cmdArgs.join(" "))
         project.exec {
           executable "git"
           ignoreExitValue false
-          workingDir checkoutDir
-          args = [ "clone", "--depth=1", repo, name ]
+          workingDir cloneDir
+          args = cmdArgs
         }
       }
+
+      if (!Files.exists(cloneDir)) {
+        Files.createDirectories(cloneDir);
+        gitExec(["init", "--initial-branch", "irrelevant"])
+        gitExec(["config", "advice.detachedHead", "false"])
+        gitExec(["remote", "add", "origin", url])
+      }
+
+      gitExec(["fetch", "--depth", "1", "origin", ref])
+      gitExec(["checkout", "FETCH_HEAD"])
     }
   }
-}
+})
 
-task testRegressions(type: Test) {
+tasks.register("testRegressions", Test, {
   group "Verification"
   description "Run Hunspell regression tests against Woorm/ LibreOffice git repositories."
 
@@ -60,15 +82,15 @@ task testRegressions(type: Test) {
   failFast = true
   include "**/TestAllDictionaries*"
 
-  systemProperty "hunspell.dictionaries", checkoutHunspellRegressionRepos.checkoutDir
+  systemProperty "hunspell.dictionaries", checkoutDirProv.map { dir -> dir.asFile.absolutePath }.get()
 
   doFirst {
     logger.lifecycle("Running Hunspell regression tests...")
   }
-}
+})
 
-// Pass all hunspell-tests-specific project properties to tests as system properties.
-tasks.withType(Test) {
+// Pass all hunspell-tests-specific project properties to tests as system properties, if they're specified.
+tasks.withType(Test).configureEach {
   [
       "hunspell.dictionaries",
       "hunspell.corpora",

--- a/lucene/analysis/common/build.gradle
+++ b/lucene/analysis/common/build.gradle
@@ -26,68 +26,101 @@ dependencies {
   moduleTestImplementation project(':lucene:test-framework')
 }
 
-def checkoutDirProv = project.layout.buildDirectory.dir("hunspell-regressions")
+// Enable Hunspell tests against LibreOffice/ Woorm dictionaries. We pull
+// these dictionaries dynamically from git of each respective project. To keep
+// things consistent across pull requests/ re-runs, we use a fixed git commit
+// for each project ({@linkplain https://github.com/apache/lucene/issues/14235 #14235}),
+// with a periodic workflow running against the latest commit on each
+// project's respective development branch.
 
-// Fetch the data and enable regression tests against woorm/ libreoffice dictionaries.
-def checkoutHunspellRegressionRepos = tasks.register("checkoutHunspellRegressionRepos", {
-  outputs.dir(checkoutDirProv)
-  outputs.upToDateWhen { false }
+// A gradle property with the parent directory for all git clones for each project.
+def cloneDirProperty = project.layout.buildDirectory.dir("hunspell-regressions")
 
-  doFirst {
-    // Clone the repositories and refs we need.
+// The list of dictionary projects to pull/ check against. Also includes
+// a full commit reference for each project. These should be updated
+// from time to time based on what's available at the head reference.
+def dictionaryProjects = [
     [
-        "libreoffice": [
-          "url": "https://github.com/LibreOffice/dictionaries",
-          "ref": "master"
-        ],
-        "woorm": [
-          "url": "https://github.com/wooorm/dictionaries",
-          "ref": "main"
-        ]
-    ].each { name, repoSpec ->
-      def url = repoSpec.url
-      def ref = repoSpec.ref
-      def cloneDir = checkoutDirProv.map { dir -> dir.dir(name) }.get().asFile.toPath()
+        "name": "libreoffice",
+        "url": "https://github.com/LibreOffice/dictionaries",
+        "ref": "762abe74008b94b2ff06db6f4024b59a8254c467" // head: master
+    ],
+    [
+        "name": "woorm",
+        "url": "https://github.com/wooorm/dictionaries",
+        "ref": "8cfea406b505e4d7df52d5a19bce525df98c54ab" // head: main
+    ]
+]
 
-      def logger = this.logger
+// We need this for the new gradle configuration cache. I personally think it's
+// awful.
+interface ExecOperationsProvider {
+  @javax.inject.Inject
+  ExecOperations getExecOperations()
+}
+
+// Generate a set of tasks cloning the git repository of each project
+// and setting it to the given reference (hash or named).
+def cloningTasks = dictionaryProjects.collect { repoSpec ->
+  def cloningTask = tasks.register(repoSpec.name + "CloneAndSetRef", {task ->
+    def targetDir = cloneDirProperty.map { dir -> dir.dir(repoSpec.name) }
+
+    // The repository reference should be taken from a gradle property or default to the stable
+    // reference above.
+    def ref = providers.gradleProperty("tests.hunspell." + repoSpec.name + ".ref").orElse(repoSpec.ref)
+
+    // register task outputs.
+    outputs.dir(targetDir)
+
+    // register task inputs; we care about the url and ref.
+    inputs.property("ref", ref)
+    inputs.properties(repoSpec)
+
+    doFirst {
+      def execOps = objects.newInstance(ExecOperationsProvider).execOperations
+
+      def logger = task.logger
+      def dotGitPath = targetDir.get().asFile.toPath().toAbsolutePath().resolve(".git")
       def gitExec = (List<String> cmdArgs) -> {
         logger.lifecycle("Executing git " + cmdArgs.join(" "))
-        project.exec {
+        execOps.exec {
           executable "git"
           ignoreExitValue false
-          workingDir cloneDir
+          workingDir dotGitPath.getParent().toString()
           args = cmdArgs
+
+          // An explicit GIT_DIR to prevent .git upward scanning if something goes wrong.
+          environment("GIT_DIR", dotGitPath.toString())
         }
       }
 
-      if (!Files.exists(cloneDir)) {
-        Files.createDirectories(cloneDir);
+      // if the target doesn't exist, create an empty repository, set
+      // the remote url (origin) but don't fetch anything.
+      if (!Files.exists(dotGitPath)) {
+        Files.createDirectories(dotGitPath.getParent())
         gitExec(["init", "--initial-branch", "irrelevant"])
         gitExec(["config", "advice.detachedHead", "false"])
-        gitExec(["remote", "add", "origin", url])
+        gitExec(["remote", "add", "origin", repoSpec.url])
       }
 
-      gitExec(["fetch", "--depth", "1", "origin", ref])
+      // Fetch just the revision we're interested in.
+      // This avoids downloading the entire repo.
+      gitExec(["fetch", "--depth", "1", "origin", ref.get()])
       gitExec(["checkout", "FETCH_HEAD"])
     }
+  })
+  return cloningTask
+}
+
+// check if we should run tests with hunspell dictionaries.
+def withDictionaries = Boolean.parseBoolean(propertyOrDefault("tests.hunspell.regressions", "false"))
+if (withDictionaries) {
+  tasks.withType(Test).configureEach {
+    dependsOn cloningTasks
+    inputs.dir cloneDirProperty
+    systemProperty "hunspell.dictionaries", cloneDirProperty.map { dir -> dir.asFile.absolutePath }.get()
   }
-})
-
-tasks.register("testRegressions", Test, {
-  group "Verification"
-  description "Run Hunspell regression tests against Woorm/ LibreOffice git repositories."
-
-  dependsOn checkoutHunspellRegressionRepos
-
-  failFast = true
-  include "**/TestAllDictionaries*"
-
-  systemProperty "hunspell.dictionaries", checkoutDirProv.map { dir -> dir.asFile.absolutePath }.get()
-
-  doFirst {
-    logger.lifecycle("Running Hunspell regression tests...")
-  }
-})
+}
 
 // Pass all hunspell-tests-specific project properties to tests as system properties, if they're specified.
 tasks.withType(Test).configureEach {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestAllDictionaries.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestAllDictionaries.java
@@ -55,6 +55,10 @@ import org.junit.Ignore;
  * property and prints their memory usage. All *.aff files are traversed recursively inside the
  * given directory. Each *.aff file must have a same-named sibling *.dic file. For examples of such
  * directories, refer to the {@link org.apache.lucene.analysis.hunspell package documentation}.
+ *
+ * <p>The build contains tasks that automatically download certain public dictionary files and test
+ * against them. Take a look at github workflows under {@code .github/workflows} to see how these
+ * tests are launched if you'd like to repeat locally.
  */
 @SuppressSysoutChecks(bugUrl = "prints important memory utilization stats per dictionary")
 public class TestAllDictionaries extends LuceneTestCase {

--- a/lucene/core/src/java/module-info.java
+++ b/lucene/core/src/java/module-info.java
@@ -63,6 +63,14 @@ module org.apache.lucene.core {
   // Open certain packages for the test framework (ram usage tester).
   opens org.apache.lucene.document to
       org.apache.lucene.test_framework;
+  opens org.apache.lucene.util.fst to
+      org.apache.lucene.test_framework;
+  opens org.apache.lucene.store to
+      org.apache.lucene.test_framework;
+  opens org.apache.lucene.util.automaton to
+      org.apache.lucene.test_framework;
+  opens org.apache.lucene.util to
+      org.apache.lucene.test_framework;
 
   exports org.apache.lucene.util.quantization;
   exports org.apache.lucene.codecs.hnsw;


### PR DESCRIPTION
Fixes #14235 

Sorry this took surprisingly long. I've tried to clean up a few things along the way:
* the repositories are now pulled at constant refs embedded inside the gradle file, unless an explicit reference is passed using gradle properties for each repository. So `-Ptests.hunspell.libreoffice.ref=master` will test against the master branch (or any other sha provided there). For woorm, it's `-Ptests.hunspell.woorm.ref=main`. 
* I've added a scheduled workflow run every Monday against latest dev branches of both projects.

I also cleaned up gradle scripts a bit.
* removed the separate test task and replaced it with a property that controls whether we pull/ test against remote repositories: `-Ptests.hunspell.regressions=true`. The separate task wasn't configured properly (it wasn't running in module mode) and in general I think it's better to just keep the 'test' task for running tests.
* gh workflows run just the `TestAllDictionaries` class, not everything.

I also had to open up some core packages to the test framework - this is a side effect of TestAllDictionaries measuring memory of Dictionary objects it creates. I think it'd be nice to make Dictionary implement Accountable and remove opens statements but it's probably a follow up issue.