### PR TITLE
Strengthen calls to isDeterministic() in TestRegExpParsing

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExpParsing.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExpParsing.java
@@ -27,7 +27,7 @@ import org.apache.lucene.tests.util.automaton.AutomatonTestUtil;
  * Simple unit tests for RegExp parsing.
  *
  * <p>For each type of node, test the toString() and parse tree, test the resulting automaton's
- * language, and whether it is deterministic
+ * language, and test properties such as minimal, deterministic, no dead states
  */
 public class TestRegExpParsing extends LuceneTestCase {
 
@@ -37,7 +37,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_ANYCHAR\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeAnyChar();
     assertSameLanguage(expected, actual);
@@ -49,7 +49,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_ANYSTRING\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeAnyString();
     assertSameLanguage(expected, actual);
@@ -61,7 +61,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_CHAR char=c\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeChar('c');
     assertSameLanguage(expected, actual);
@@ -73,7 +73,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_CHAR char=c\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Operations.union(List.of(Automata.makeChar('c'), Automata.makeChar('C')));
     assertSameLanguage(expected, actual);
@@ -84,6 +84,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     RegExp re = new RegExp("[c]", RegExp.NONE, RegExp.ASCII_CASE_INSENSITIVE);
     assertEquals(
         "REGEXP_CHAR_CLASS starts=[U+0063 U+0043] ends=[U+0063 U+0043]\n", re.toStringTree());
+    AutomatonTestUtil.assertMinimalDFA(re.toAutomaton());
   }
 
   // ranges aren't treated as case-insensitive, but maybe ok with charclass
@@ -91,6 +92,7 @@ public class TestRegExpParsing extends LuceneTestCase {
   public void testCaseInsensitiveClassRange() {
     RegExp re = new RegExp("[c-d]", RegExp.NONE, RegExp.ASCII_CASE_INSENSITIVE);
     assertEquals("REGEXP_CHAR_RANGE from=c to=d\n", re.toStringTree());
+    AutomatonTestUtil.assertMinimalDFA(re.toAutomaton());
   }
 
   public void testCaseInsensitiveCharUpper() {
@@ -99,7 +101,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_CHAR char=C\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Operations.union(List.of(Automata.makeChar('c'), Automata.makeChar('C')));
     assertSameLanguage(expected, actual);
@@ -111,7 +113,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_CHAR char=4\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeChar('4');
     assertSameLanguage(expected, actual);
@@ -123,7 +125,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_CHAR char=Ж\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeChar('Ж');
     assertSameLanguage(expected, actual);
@@ -143,7 +145,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected =
         Operations.union(
@@ -164,8 +166,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
-    assertEquals(2, actual.getNumStates());
+    AutomatonTestUtil.assertMinimalDFA(actual);
   }
 
   public void testCharRange() {
@@ -174,7 +175,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_CHAR_RANGE from=b to=d\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeCharRange('b', 'd');
     assertSameLanguage(expected, actual);
@@ -194,7 +195,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected =
         Operations.union(
@@ -217,7 +218,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_CHAR_RANGE from=0 to=9\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeCharRange('0', '9');
     assertSameLanguage(expected, actual);
@@ -229,7 +230,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         "REGEXP_CHAR_CLASS starts=[U+0000 U+003A] ends=[U+002F U+10FFFF]\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected =
         Operations.minus(
@@ -246,7 +247,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected =
         Operations.union(
@@ -265,7 +266,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeAnyChar();
     expected =
@@ -291,7 +292,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected =
         Operations.union(
@@ -310,7 +311,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeAnyChar();
     expected =
@@ -335,8 +336,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         "REGEXP_CHAR_CLASS starts=[U+0030 U+0061 U+0009 U+000D U+0020 U+0062 U+0063] ends=[U+0035 U+0061 U+000A U+000D U+0020 U+0062 U+0064]\n",
         re.toStringTree());
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
-    assertEquals(2, actual.getNumStates());
+    AutomatonTestUtil.assertMinimalDFA(actual);
   }
 
   public void testTruncatedCharClass() {
@@ -361,7 +361,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_CHAR char=?\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeChar('?');
     assertSameLanguage(expected, actual);
@@ -373,7 +373,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_CHAR char=\\\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeChar('\\');
     assertSameLanguage(expected, actual);
@@ -382,8 +382,10 @@ public class TestRegExpParsing extends LuceneTestCase {
   public void testEscapedDashCharClass() {
     RegExp re = new RegExp("[\\-]");
     assertEquals("REGEXP_CHAR char=-\n", re.toStringTree());
+
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
+
     Automaton expected = Automata.makeChar('-');
     assertSameLanguage(expected, actual);
   }
@@ -394,7 +396,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_EMPTY\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeEmpty();
     assertSameLanguage(expected, actual);
@@ -427,6 +429,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
     Automaton actual = re.toAutomaton();
     // TODO: numeric intervals are NFAs
+    AutomatonTestUtil.assertCleanNFA(actual);
 
     Automaton expected = Automata.makeDecimalInterval(5, 40, 0);
     assertSameLanguage(expected, actual);
@@ -439,6 +442,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
     Automaton actual = re.toAutomaton();
     // TODO: numeric intervals are NFAs
+    AutomatonTestUtil.assertCleanNFA(actual);
 
     Automaton expected = Automata.makeDecimalInterval(5, 40, 0);
     assertSameLanguage(expected, actual);
@@ -474,7 +478,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals(String.join("\n", "REGEXP_OPTIONAL", "  REGEXP_CHAR char=a\n"), re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Operations.optional(Automata.makeChar('a'));
     assertSameLanguage(expected, actual);
@@ -486,7 +490,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals(String.join("\n", "REGEXP_REPEAT", "  REGEXP_CHAR char=a\n"), re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Operations.repeat(Automata.makeChar('a'));
     assertSameLanguage(expected, actual);
@@ -499,7 +503,9 @@ public class TestRegExpParsing extends LuceneTestCase {
         String.join("\n", "REGEXP_REPEAT_MIN min=1", "  REGEXP_CHAR char=a\n"), re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    // not minimal, but close: minimal + 1
+    assertEquals(3, actual.getNumStates());
+    AutomatonTestUtil.assertCleanDFA(actual);
 
     Automaton expected = Operations.repeat(Automata.makeChar('a'), 1);
     assertSameLanguage(expected, actual);
@@ -513,7 +519,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Operations.repeat(Automata.makeChar('a'), 5, 5);
     assertSameLanguage(expected, actual);
@@ -526,7 +532,9 @@ public class TestRegExpParsing extends LuceneTestCase {
         String.join("\n", "REGEXP_REPEAT_MIN min=5", "  REGEXP_CHAR char=a\n"), re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    // not minimal, but close: minimal + 1
+    assertEquals(7, actual.getNumStates());
+    AutomatonTestUtil.assertCleanDFA(actual);
 
     Automaton expected = Operations.repeat(Automata.makeChar('a'), 5);
     assertSameLanguage(expected, actual);
@@ -540,7 +548,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Operations.repeat(Automata.makeChar('a'), 5, 8);
     assertSameLanguage(expected, actual);
@@ -568,7 +576,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_STRING string=boo\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeString("boo");
     assertSameLanguage(expected, actual);
@@ -580,7 +588,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_STRING string=boo\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton c1 = Operations.union(List.of(Automata.makeChar('b'), Automata.makeChar('B')));
     Automaton c2 = Operations.union(List.of(Automata.makeChar('o'), Automata.makeChar('O')));
@@ -595,7 +603,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals("REGEXP_STRING string=boo\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeString("boo");
     assertSameLanguage(expected, actual);
@@ -621,7 +629,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected =
         Operations.concatenate(
@@ -641,7 +649,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected =
         Operations.intersection(Automata.makeCharRange('b', 'f'), Automata.makeCharRange('e', 'f'));
@@ -676,7 +684,7 @@ public class TestRegExpParsing extends LuceneTestCase {
         re.toStringTree());
 
     Automaton actual = re.toAutomaton();
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected =
         Operations.union(
@@ -714,7 +722,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals(Set.of("myletter"), re.getIdentifiers());
 
     Automaton actual = re.toAutomaton(myProvider);
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeChar('z');
     assertSameLanguage(expected, actual);
@@ -727,7 +735,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     assertEquals(Set.of("myletter"), re.getIdentifiers());
 
     Automaton actual = re.toAutomaton(Map.of("myletter", Automata.makeChar('z')));
-    assertTrue(actual.isDeterministic());
+    AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected = Automata.makeChar('z');
     assertSameLanguage(expected, actual);


### PR DESCRIPTION
TestRegExpParsing assertions about regexes: that the internal parse tree matches an expected structure, and then that resulting automaton is the correct language. In cases where a DFA is expected, we assert that it is `isDeterministic()`. In cases where an NFA is expected, there is currently just a code comment in the test.

Replace calls to `isDeterministic()` with `assertMinimalDFA()` if the parser should give minimal output.

Use `assertCleanDFA()` and `assertCleanNFA()` otherwise to ensure that automaton has no dead states, and if appropriate, is deterministic.
