### PR TITLE
Accept nodes where score == Math.nextUp(results.minCompetitiveSimilarity()) after #14215

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -287,7 +287,7 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
         }
         float friendSimilarity = scorer.score(friendOrd);
         results.incVisitedCount(1);
-        if (friendSimilarity > minAcceptedSimilarity) {
+        if (friendSimilarity >= minAcceptedSimilarity) {
           candidates.add(friendOrd, friendSimilarity);
           if (acceptOrds == null || acceptOrds.get(friendOrd)) {
             if (results.collect(friendOrd, friendSimilarity)) {

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -61,6 +61,7 @@ import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.AbstractKnnCollector;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnCollector;
@@ -72,6 +73,7 @@ import org.apache.lucene.search.TaskExecutor;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
@@ -704,6 +706,58 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     assertTrue(nn.earlyTerminated());
     // The visited count shouldn't exceed the limit
     assertTrue(nn.visitedCount() <= visitedLimit);
+  }
+
+  public void testFindAll() throws IOException {
+    int numVectors = 10;
+    KnnVectorValues vectorValues = circularVectorValues(numVectors);
+    T target = getTargetVector();
+    float minScore = Float.POSITIVE_INFINITY;
+    for (int i = 0; i < numVectors; i++) {
+      float score =
+          switch (getVectorEncoding()) {
+            case BYTE ->
+                similarityFunction.compare(
+                    ((ByteVectorValues) vectorValues).vectorValue(i), (byte[]) target);
+            case FLOAT32 ->
+                similarityFunction.compare(
+                    ((FloatVectorValues) vectorValues).vectorValue(i), (float[]) target);
+          };
+      minScore = Math.min(minScore, score);
+    }
+    RandomVectorScorerSupplier scorerSupplier = buildScorerSupplier(vectorValues);
+    HnswGraphBuilder builder = HnswGraphBuilder.create(scorerSupplier, 16, 100, random().nextInt());
+    OnHeapHnswGraph hnsw = builder.build(numVectors);
+    float finalMinScore = Math.nextDown(minScore);
+
+    AbstractKnnCollector collector =
+        new AbstractKnnCollector(numVectors, Long.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT) {
+          int collected;
+
+          @Override
+          public boolean collect(int docId, float similarity) {
+            collected++;
+            return true;
+          }
+
+          @Override
+          public int numCollected() {
+            return collected;
+          }
+
+          @Override
+          public float minCompetitiveSimilarity() {
+            return finalMinScore;
+          }
+
+          @Override
+          public TopDocs topDocs() {
+            return null;
+          }
+        };
+    HnswGraphSearcher.search(
+        buildScorer(vectorValues, target), collector, hnsw, new BitSet.MatchAllBits(numVectors));
+    assertEquals(numVectors, collector.numCollected());
   }
 
   public void testHnswGraphBuilderInvalid() throws IOException {


### PR DESCRIPTION
In https://github.com/apache/lucene/pull/12770 we refine how we were searching the graph by only considering nodes that were making the values of the score better, basically the condition in line 290 become `friendSimilarity > minAcceptedSimilarity`.

In #14215, to improve the termination check and avoid edge cases when having many duplicated vectors, we change how we compute the minAcceptedSimilarity to `Math.nextUp(results.minCompetitiveSimilarity())`. 

Because we didn't change the first condition, now we are not considering nodes where `friendSimilarity 
 == minAcceptedSimilarity` although those nodes will have better score.