### PR TITLE
Improve user-facing docs.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/document/package-info.java
@@ -46,10 +46,61 @@
  * make the process of taking a file and converting it into a Lucene {@link
  * org.apache.lucene.document.Document}.
  *
- * <p>The {@link org.apache.lucene.document.DateTools} is a utility class to make dates and times
- * searchable. {@link org.apache.lucene.document.IntPoint}, {@link
- * org.apache.lucene.document.LongPoint}, {@link org.apache.lucene.document.FloatPoint} and {@link
- * org.apache.lucene.document.DoublePoint} enable indexing of numeric values (and also dates) for
- * fast range queries using {@link org.apache.lucene.search.PointRangeQuery}
+ * <h2>How to index ...</h2>
+ *
+ * <h3>Strings</h3>
+ *
+ * <p>{@link org.apache.lucene.document.TextField} allows indexing tokens from a String so that one
+ * can perform full-text search on it. The way that the input is tokenized depends on the {@link
+ * org.apache.lucene.analysis.Analyzer} that is configured on the {@link
+ * org.apache.lucene.index.IndexWriterConfig}. TextField can also be optionally stored.
+ *
+ * <p>{@link org.apache.lucene.document.KeywordField} indexes whole values as a single term so that
+ * one can perform exact search on it. It also records doc values to enable sorting or faceting on
+ * this field. Finally, it also supports optionally storing the value.
+ *
+ * <p>If faceting or sorting are not required, {@link org.apache.lucene.document.StringField} is a
+ * variant of {@link org.apache.lucene.document.KeywordField} that does not index doc values.
+ *
+ * <h3>Numbers</h3>
+ *
+ * <p>If a numeric field represents an identifier rather than a quantity and is more commonly
+ * searched on single values than on ranges of values, it is generally recommended to index its
+ * string representation via {@link org.apache.lucene.document.KeywordField} (or {@link
+ * org.apache.lucene.document.StringField} if doc values are not necessary).
+ *
+ * <p>{@link org.apache.lucene.document.LongField}, {@link org.apache.lucene.document.IntField},
+ * {@link org.apache.lucene.document.DoubleField} and {@link org.apache.lucene.document.FloatField}
+ * index values in a points index for efficient range queries, and also create doc-values for these
+ * fields for efficient sorting and faceting.
+ *
+ * <p>If the field is aimed at being used to tune the score, {@link
+ * org.apache.lucene.document.FeatureField} helps internally store numeric data as term frequencies
+ * in a way that makes it efficient to influence scoring at search time.
+ *
+ * <h3>Other types of structured data</h3>
+ *
+ * <p>It is recommended to index dates as a {@link org.apache.lucene.document.LongField} that stores
+ * the number of milliseconds since Epoch.
+ *
+ * <p>IP fields can be indexed via {@link org.apache.lucene.document.InetAddressPoint} in addition
+ * to a {@link org.apache.lucene.document.SortedDocValuesField} (if the field is single-valued) or
+ * {@link org.apache.lucene.document.SortedSetDocValuesField} that stores the result of {@link
+ * org.apache.lucene.document.InetAddressPoint#encode}.
+ *
+ * <h3>Dense numeric vectors</h3>
+ *
+ * <p>Dense numeric vectors can be indexed with {@link
+ * org.apache.lucene.document.KnnFloatVectorField} if its dimensions are floating-point numbers or
+ * {@link org.apache.lucene.document.KnnByteVectorField} if its dimensions are bytes. This allows
+ * searching for nearest neighbors at search time.
+ *
+ * <h3>Sparse numeric vectors</h3>
+ *
+ * <p>To perform nearest-neighbor search on sparse vectors rather than dense vectors, each dimension
+ * of the sparse vector should be indexed as a {@link org.apache.lucene.document.FeatureField}.
+ * Queries can then be constructed as a {@link org.apache.lucene.search.BooleanQuery} with {@link
+ * org.apache.lucene.document.FeatureField#newLinearQuery(String, String, float) linear queries} as
+ * {@link org.apache.lucene.search.BooleanClause.Occur#SHOULD} clauses.
  */
 package org.apache.lucene.document;

--- a/lucene/core/src/java/org/apache/lucene/search/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/search/package-info.java
@@ -41,6 +41,12 @@
  * important Query classes. For details on implementing your own Query class, see <a
  * href="#customQueriesExpert">Custom Queries -- Expert Level</a> below.
  *
+ * <p>Make sure to look at {@link org.apache.lucene.search.Query} factory methods on {@link
+ * org.apache.lucene.index.IndexableField}s that you feed into the index writer, they are convenient
+ * to use and sometimes more efficient than a naively constructed {@link
+ * org.apache.lucene.search.Query}. See {@link
+ * org.apache.lucene.document.LongField#newRangeQuery(String, long, long)} for instance.
+ *
  * <p>To perform a search, applications usually call {@link
  * org.apache.lucene.search.IndexSearcher#search(Query,int)}.
  *
@@ -204,7 +210,8 @@
  * documents that need to be scored based on boolean logic in the Query specification, and then
  * ranks this subset of matching documents via the retrieval model. For some valuable references on
  * VSM and IR in general refer to <a
- * href="http://wiki.apache.org/lucene-java/InformationRetrieval">Lucene Wiki IR references</a>.
+ * href="https://cwiki.apache.org/confluence/display/LUCENEJAVA/InformationRetrieval">Lucene Wiki IR
+ * references</a>.
  *
  * <p>The rest of this document will cover <a href="#scoringBasics">Scoring basics</a> and explain
  * how to change your {@link org.apache.lucene.search.similarities.Similarity Similarity}. Next, it
@@ -253,8 +260,12 @@
  * org.apache.lucene.index.IndexWriterConfig#setSimilarity(org.apache.lucene.search.similarities.Similarity)
  * IndexWriterConfig.setSimilarity(Similarity)} and at query-time with {@link
  * org.apache.lucene.search.IndexSearcher#setSimilarity(org.apache.lucene.search.similarities.Similarity)
- * IndexSearcher.setSimilarity(Similarity)}. Be sure to use the same Similarity at query-time as at
- * index-time (so that norms are encoded/decoded correctly); Lucene makes no effort to verify this.
+ * IndexSearcher.setSimilarity(Similarity)}. Be sure to use search-time similarities that encode the
+ * length normalization factor the same way as the similarity that you used at index time. All
+ * Lucene built-in similarities use the default encoding so they are compatible, but if you use a
+ * custom similarity that changes the encoding of the length normalization factor, you are on your
+ * own: Lucene makes no effort to ensure that the index-time and the search-time similarities are
+ * compatible.
  *
  * <p>You can influence scoring by configuring a different built-in Similarity implementation, or by
  * tweaking its parameters, subclassing it to override behavior. Some implementations also offer a

--- a/lucene/core/src/java/org/apache/lucene/search/similarities/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/search/similarities/package-info.java
@@ -76,10 +76,14 @@
  * org.apache.lucene.search.similarities.BM25Similarity#BM25Similarity(float,float) b} parameter to
  * {@code 0}.
  *
- * <p>To change {@link org.apache.lucene.search.similarities.Similarity}, one must do so for both
- * indexing and searching, and the changes must happen before either of these actions take place.
- * Although in theory there is nothing stopping you from changing mid-stream, it just isn't
- * well-defined what is going to happen.
+ * <p>To switch to a {@link org.apache.lucene.search.similarities.Similarity} that encodes the
+ * length normalization differently, one must do so for both indexing and searching, and the changes
+ * must happen before either of these actions take place. Note that all of Lucene's built-in
+ * similarities - and more generally all {@link org.apache.lucene.search.similarities.Similarity}
+ * sub-classes that don't override {@link
+ * org.apache.lucene.search.similarities.Similarity#computeNorm(org.apache.lucene.index.FieldInvertState)}
+ * - encode the length normalization factor the same way, so it is fine to change the similarity at
+ * search-time without recreating the index.
  *
  * <p>To make this change, implement your own {@link
  * org.apache.lucene.search.similarities.Similarity} (likely you'll want to simply subclass {@link

--- a/lucene/core/src/java/overview.html
+++ b/lucene/core/src/java/overview.html
@@ -20,7 +20,9 @@
 </head>
 <body>
 
-<p>Apache Lucene is a high-performance, full-featured text search engine library.
+<p>Apache Lucene is a high-performance, full-featured search engine library.
+It supports  structured search, full-text search, faceting, nearest-neighbor
+search across high-dimensionality vectors, spell correction or query suggestions.
 Here's a simple example how to use Lucene for indexing and searching (using JUnit
 to check if the results are what we expect):</p>
 
@@ -31,32 +33,33 @@ to check if the results are what we expect):</p>
     Analyzer analyzer = new StandardAnalyzer();
 
     Path indexPath = Files.createTempDirectory("tempIndex");
-    Directory directory = FSDirectory.open(indexPath);
-    IndexWriterConfig config = new IndexWriterConfig(analyzer);
-    IndexWriter iwriter = new IndexWriter(directory, config);
-    Document doc = new Document();
-    String text = "This is the text to be indexed.";
-    doc.add(new Field("fieldname", text, TextField.TYPE_STORED));
-    iwriter.addDocument(doc);
-    iwriter.close();
-    
-    // Now search the index:
-    DirectoryReader ireader = DirectoryReader.open(directory);
-    IndexSearcher isearcher = new IndexSearcher(ireader);
-    // Parse a simple query that searches for "text":
-    QueryParser parser = new QueryParser("fieldname", analyzer);
-    Query query = parser.parse("text");
-    ScoreDoc[] hits = isearcher.search(query, 10).scoreDocs;
-    assertEquals(1, hits.length);
-    // Iterate through the results:
-    StoredFields storedFields = isearcher.storedFields();
-    for (int i = 0; i &lt; hits.length; i++) {
-      Document hitDoc = storedFields.document(hits[i].doc);
-      assertEquals("This is the text to be indexed.", hitDoc.get("fieldname"));
-    }
-    ireader.close();
-    directory.close();
-    IOUtils.rm(indexPath);</pre>
+    try (Directory directory = FSDirectory.open(indexPath)) {
+      IndexWriterConfig config = new IndexWriterConfig(analyzer);
+      try (IndexWriter iwriter = new IndexWriter(directory, config)) {
+        Document doc = new Document();
+        String text = "This is the text to be indexed.";
+        doc.add(new Field("fieldname", text, TextField.TYPE_STORED));
+        iwriter.addDocument(doc);
+      }
+
+      // Now search the index:
+      try (DirectoryReader ireader = DirectoryReader.open(directory)) {
+        IndexSearcher isearcher = new IndexSearcher(ireader);
+        // Parse a simple query that searches for "text":
+        QueryParser parser = new QueryParser("fieldname", analyzer);
+        Query query = parser.parse("text");
+        ScoreDoc[] hits = isearcher.search(query, 10).scoreDocs;
+        assertEquals(1, hits.length);
+        // Iterate through the results:
+        StoredFields storedFields = isearcher.storedFields();
+        for (int i = 0; i &lt; hits.length; i++) {
+          Document hitDoc = storedFields.document(hits[i].doc);
+          assertEquals("This is the text to be indexed.", hitDoc.get("fieldname"));
+        }
+      }
+    } finally {
+      IOUtils.rm(indexPath);
+    }</pre>
 <!-- ======================================================== -->
 
 
@@ -67,7 +70,7 @@ to check if the results are what we expect):</p>
 <li>
 <b>{@link org.apache.lucene.analysis}</b>
 defines an abstract {@link org.apache.lucene.analysis.Analyzer Analyzer}
-API for converting text from a {@link java.io.Reader}
+API for converting text from a {@link java.lang.String} or {@link java.io.Reader}
 into a {@link org.apache.lucene.analysis.TokenStream TokenStream},
 an enumeration of token {@link org.apache.lucene.util.Attribute Attribute}s.&nbsp;
 A TokenStream can be composed by applying {@link org.apache.lucene.analysis.TokenFilter TokenFilter}s
@@ -86,7 +89,7 @@ as well as different implementations that can be chosen depending upon applicati
 <b>{@link org.apache.lucene.document}</b>
 provides a simple {@link org.apache.lucene.document.Document Document}
 class.&nbsp; A Document is simply a set of named {@link org.apache.lucene.document.Field Field}s,
-whose values may be strings or instances of {@link java.io.Reader}.</li>
+whose values may be numbers, strings or instances of {@link java.io.Reader}.</li>
 
 <li>
 <b>{@link org.apache.lucene.index}</b>
@@ -121,8 +124,7 @@ To use Lucene, an application should:
 <ol>
 <li>
 Create {@link org.apache.lucene.document.Document Document}s by
-adding
-{@link org.apache.lucene.document.Field Field}s;</li>
+adding {@link org.apache.lucene.document.Field Field}s;</li>
 
 <li>
 Create an {@link org.apache.lucene.index.IndexWriter IndexWriter}


### PR DESCRIPTION
This improves user-facing docs in Lucene's package javadocs:
 - Make some docs up-to-date, e.g. some of them were still referring to oal.index.Fields.
 - More emphasis of structured search and knn search.
 - More guidance on how to index data in `oal.document`.
 - Add API docs for impacts.
 - Discourage less strongly to change the similarity at search time.
 - Recommend using Query factory methods on Field classes instead of creating queries manually.
