### PR TITLE
Reuse entry point scores and provide mechanisms to provide scores for directly entry points

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswGraphBuilder.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswGraphBuilder.java
@@ -166,7 +166,8 @@ public final class Lucene91HnswGraphBuilder {
     // for levels <= nodeLevel search with topk = beamWidth, and add connections
     for (int level = Math.min(nodeLevel, curMaxLevel); level >= 0; level--) {
       candidates = graphSearcher.searchLevel(scorer, beamWidth, level, eps, hnsw);
-      eps = candidates.popUntilNearestKNodes();
+      candidates.popUntilNearestKNodes();
+      eps = candidates.nodes();
       hnsw.addNode(level, node);
       addDiverseNeighbors(level, node, candidates);
     }

--- a/lucene/core/src/java/org/apache/lucene/search/knn/MappedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/search/knn/MappedDISI.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search.knn;
+
+import java.io.IOException;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.search.DocIdSetIterator;
+
+/**
+ * A {@link DocIdSetIterator} that maps the doc ids from a {@link TopDocsDISI} to the corresponding
+ * vector ordinal
+ *
+ * @lucene.internal
+ */
+public sealed class MappedDISI extends DocIdSetIterator {
+  KnnVectorValues.DocIndexIterator indexedDISI;
+  DocIdSetIterator sourceDISI;
+
+  /**
+   * Create a new instance of a {@link MappedDISI}
+   *
+   * @param indexedDISI the mapping from doc to vector ordinal iterator
+   * @param sourceDISI the source iterator
+   * @return a new {@link MappedDISI}
+   */
+  public static MappedDISI from(
+      KnnVectorValues.DocIndexIterator indexedDISI, TopDocsDISI sourceDISI) {
+    if (sourceDISI instanceof TopDocsDISI.Scored scoredIterator) {
+      return new Scored(indexedDISI, scoredIterator);
+    }
+    return new MappedDISI(indexedDISI, sourceDISI);
+  }
+
+  MappedDISI(KnnVectorValues.DocIndexIterator indexedDISI, TopDocsDISI sourceDISI) {
+    this.indexedDISI = indexedDISI;
+    this.sourceDISI = sourceDISI;
+  }
+
+  /**
+   * Advances the source iterator to the first document number that is greater than or equal to the
+   * provided target and returns the corresponding index.
+   */
+  @Override
+  public int advance(int target) throws IOException {
+    int newTarget = sourceDISI.advance(target);
+    if (newTarget != NO_MORE_DOCS) {
+      indexedDISI.advance(newTarget);
+    }
+    return docID();
+  }
+
+  @Override
+  public long cost() {
+    return sourceDISI.cost();
+  }
+
+  @Override
+  public int docID() {
+    if (indexedDISI.docID() == NO_MORE_DOCS || sourceDISI.docID() == NO_MORE_DOCS) {
+      return NO_MORE_DOCS;
+    }
+    return indexedDISI.index();
+  }
+
+  /** Advances to the next document in the source iterator and returns the corresponding index. */
+  @Override
+  public int nextDoc() throws IOException {
+    int newTarget = sourceDISI.nextDoc();
+    if (newTarget != NO_MORE_DOCS) {
+      indexedDISI.advance(newTarget);
+    }
+    return docID();
+  }
+
+  /** A {@link MappedDISI}, but where the source iterator can also provide scores */
+  public static final class Scored extends MappedDISI {
+    private final TopDocsDISI.Scored scoredIterator;
+
+    Scored(KnnVectorValues.DocIndexIterator indexedDISI, TopDocsDISI.Scored scoredIterator) {
+      super(indexedDISI, scoredIterator);
+      this.scoredIterator = scoredIterator;
+    }
+
+    public float score() {
+      return scoredIterator.score();
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/knn/TopDocsDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/search/knn/TopDocsDISI.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search.knn;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.TopDocs;
+
+/**
+ * A {@link DocIdSetIterator} that wraps a {@link TopDocs} object.
+ *
+ * @lucene.internal
+ */
+public sealed class TopDocsDISI extends DocIdSetIterator {
+
+  private final int[] sortedDocIds;
+  protected int idx = -1;
+
+  /**
+   * Creates a {@link TopDocsDISI} from a {@link TopDocs} object. The resulting docs account for the
+   * provided leaf context base
+   *
+   * @param topDocs the TopDocs to wrap
+   * @param ctx the leaf for the top docs
+   * @return new iterator over the top docs
+   */
+  public static TopDocsDISI fromTopDocs(TopDocs topDocs, LeafReaderContext ctx) {
+    int[] sortedDocIds = new int[topDocs.scoreDocs.length];
+    for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+      assert topDocs.scoreDocs[i].doc >= ctx.docBase;
+      // Remove the doc base as added by the collector
+      sortedDocIds[i] = topDocs.scoreDocs[i].doc - ctx.docBase;
+    }
+    Arrays.sort(sortedDocIds);
+    return new TopDocsDISI(sortedDocIds);
+  }
+
+  /**
+   * Creates a {@link TopDocsDISI.Scored} from a {@link TopDocs} object. This allows callers to
+   * potentially request the underlying original score
+   *
+   * @param topDocs the TopDocs to wrap
+   * @param ctx the leaf for the top docs
+   * @return new iterator over the top docs
+   */
+  public static TopDocsDISI.Scored fromTopDocsWithScores(TopDocs topDocs, LeafReaderContext ctx) {
+    // now sort both `scores` and `docs` within `TopDocs` according to doc id
+    int[] sortedDocIds = new int[topDocs.scoreDocs.length];
+    float[] sortedScores = new float[topDocs.scoreDocs.length];
+    Integer[] sortedIndices = new Integer[topDocs.scoreDocs.length];
+    for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+      sortedIndices[i] = i;
+    }
+    Arrays.sort(sortedIndices, Comparator.comparingInt(a -> topDocs.scoreDocs[a].doc));
+    for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+      assert topDocs.scoreDocs[sortedIndices[i]].doc >= ctx.docBase;
+      sortedScores[i] = topDocs.scoreDocs[sortedIndices[i]].score;
+      sortedDocIds[i] = topDocs.scoreDocs[sortedIndices[i]].doc - ctx.docBase;
+    }
+    return new Scored(sortedDocIds, sortedScores);
+  }
+
+  TopDocsDISI(int[] sortedDocIds) {
+    this.sortedDocIds = sortedDocIds;
+  }
+
+  @Override
+  public int advance(int target) throws IOException {
+    return slowAdvance(target);
+  }
+
+  @Override
+  public long cost() {
+    return sortedDocIds.length;
+  }
+
+  @Override
+  public int docID() {
+    if (idx == -1) {
+      return -1;
+    } else if (idx >= sortedDocIds.length) {
+      return DocIdSetIterator.NO_MORE_DOCS;
+    } else {
+      return sortedDocIds[idx];
+    }
+  }
+
+  @Override
+  public int nextDoc() {
+    idx += 1;
+    return docID();
+  }
+
+  /** A {@link TopDocsDISI} but can also provide scores */
+  public static final class Scored extends TopDocsDISI {
+    private final float[] scores;
+
+    Scored(int[] sortedDocIds, float[] scores) {
+      super(sortedDocIds);
+      this.scores = scores;
+    }
+
+    public float score() {
+      return scores[idx];
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/FilteredHnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/FilteredHnswGraphSearcher.java
@@ -105,6 +105,8 @@ public class FilteredHnswGraphSearcher extends HnswGraphSearcher {
       RandomVectorScorer scorer,
       int level,
       final int[] eps,
+      final float[] epsScores,
+      int epCount,
       HnswGraph graph,
       Bits acceptOrds)
       throws IOException {
@@ -114,13 +116,14 @@ public class FilteredHnswGraphSearcher extends HnswGraphSearcher {
 
     prepareScratchState();
 
-    for (int ep : eps) {
+    for (int i = 0; i < eps.length; i++) {
+      int ep = eps[i];
       if (visited.getAndSet(ep) == false) {
         if (results.earlyTerminated()) {
           return;
         }
-        float score = scorer.score(ep);
         results.incVisitedCount(1);
+        final float score = epsScores != null ? epsScores[i] : scorer.score(ep);
         candidates.add(ep, score);
         if (acceptOrds.get(ep)) {
           results.collect(ep, score);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -129,6 +129,21 @@ public class NeighborQueue {
     return decodeNodeId(heap.pop());
   }
 
+  /**
+   * Collect the decoded nodes and scores into the provided arrays
+   *
+   * @param nodes where to place the decoded nodes
+   * @param scores where to place the decoded scores
+   */
+  public void collectNodesAndScores(int[] nodes, float[] scores) {
+    int size = size();
+    assert nodes.length >= size && scores.length >= size;
+    for (int i = 0; i < size; i++) {
+      nodes[i] = decodeNodeId(heap.get(i + 1));
+      scores[i] = decodeScore(heap.get(i + 1));
+    }
+  }
+
   public int[] nodes() {
     int size = size();
     int[] nodes = new int[size];


### PR DESCRIPTION
Spinning out of: https://github.com/apache/lucene/pull/14226

That particular evolution of kNN querying is attempting to re-entry individual segment graphs with new exit and search criteria. To prevent having to rescore the new entry points, this PR provides the ability to (optionally) keep track of the scores for entry points. 

Additionally, this will take advantage of entry point score retention during graph building and searching. The performance improvements are marginal.