### PR TITLE
Stop asserting on the max number of merged segments in TestTieredMergePolicy#testPartialMerge.

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestTieredMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTieredMergePolicy.java
@@ -215,18 +215,13 @@ public class TestTieredMergePolicy extends BaseMergePolicyTestCase {
       conf.setMergePolicy(tmp);
       conf.setMaxBufferedDocs(2);
       tmp.setSegmentsPerTier(6);
-      tmp.setFloorSegmentMB(Double.MIN_VALUE);
 
       IndexWriter w = new IndexWriter(dir, conf);
-      int maxCount = 0;
       final int numDocs = TestUtil.nextInt(random(), 20, 100);
       for (int i = 0; i < numDocs; i++) {
         Document doc = new Document();
         doc.add(newTextField("content", "aaa " + (i % 4), Field.Store.NO));
         w.addDocument(doc);
-        int count = w.getSegmentCount();
-        maxCount = Math.max(count, maxCount);
-        assertTrue("count=" + count + " maxCount=" + maxCount, count >= maxCount - 6);
       }
 
       w.flush(true, true);


### PR DESCRIPTION
This assertion isn't right as `TieredMergePolicy` has become more sophisticated with the introduction of `targetSearchConcurrency` and different merging rules for merges below the floor size.

Closes #14255