### PR TITLE
Add support for querying multiple fields to QueryBuilder.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/TextField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/TextField.java
@@ -28,7 +28,6 @@ import org.apache.lucene.util.QueryBuilder;
  * <p>To create queries on {@link TextField}, see {@link QueryBuilder} and more specifically {@link
  * QueryBuilder#createBooleanQuery(String, String, org.apache.lucene.search.BooleanClause.Occur)} to
  * query against a single field or {@link QueryBuilder#createBooleanQuery(java.util.Map, String,
- * org.apache.lucene.util.QueryBuilder.MultiFieldScoreMode,
  * org.apache.lucene.search.BooleanClause.Occur)} to query against several fields.
  */
 public final class TextField extends Field {

--- a/lucene/core/src/java/org/apache/lucene/document/TextField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/TextField.java
@@ -19,10 +19,17 @@ package org.apache.lucene.document;
 import java.io.Reader;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.util.QueryBuilder;
 
 /**
  * A field that is indexed and tokenized, without term vectors. For example this would be used on a
  * 'body' field, that contains the bulk of a document's text.
+ *
+ * <p>To create queries on {@link TextField}, see {@link QueryBuilder} and more specifically {@link
+ * QueryBuilder#createBooleanQuery(String, String, org.apache.lucene.search.BooleanClause.Occur)} to
+ * query against a single field or {@link QueryBuilder#createBooleanQuery(java.util.Map, String,
+ * org.apache.lucene.util.QueryBuilder.MultiFieldScoreMode,
+ * org.apache.lucene.search.BooleanClause.Occur)} to query against several fields.
  */
 public final class TextField extends Field {
 

--- a/lucene/core/src/java/org/apache/lucene/search/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/search/package-info.java
@@ -291,15 +291,12 @@
  * boost of 10, and "body" with a boost of 1:
  *
  * <pre class="prettyprint">
- * BooleanQuery.Builder builder = new BooleanQuery.Builder();
- * for (String term : new String[] { "apache", "lucene" }) {
- *   Query query = new CombinedFieldQuery(term)
- *         .addField("title", 10f)
- *         .addField("body", 1f)
- *         .build();
- *   builder.add(query, Occur.SHOULD);
- * }
- * Query query = builder.build();
+ * QueryBuilder builder = new QueryBuilder(analyzer);
+ * Query query = builder.createBooleanQuery(
+ *     Map.of("title", 10f, "body", 1f),
+ *     "apache lucene",
+ *     MultiFieldScoreMode.PER_TERM_COMBINED,
+ *     BooleanClause.Occur.SHOULD);
  * </pre>
  *
  * <h3>Integrating field values into the score</h3>

--- a/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java
@@ -664,6 +664,7 @@ public class QueryBuilder {
     }
     BooleanQuery.Builder builder = new BooleanQuery.Builder();
     int[] articulationPoints = graph.articulationPoints();
+    boolean termQuery = articulationPoints.length == 0;
     int lastState = 0;
     for (int i = 0; i <= articulationPoints.length; i++) {
       int start = lastState;
@@ -674,6 +675,7 @@ public class QueryBuilder {
       lastState = end;
       final Query positionalQuery;
       if (graph.hasSidePath(start)) {
+        termQuery = false;
         final Iterator<TokenStream> sidePathsIterator = graph.getFiniteStrings(start, end);
         Iterator<Query> queries =
             new Iterator<>() {
@@ -729,9 +731,10 @@ public class QueryBuilder {
       }
     }
     BooleanQuery bq = builder.build();
-    if (bq.clauses().isEmpty()) {
+    if (bq.clauses().size() == 0) {
       return null;
-    } else if (bq.clauses().size() == 1) {
+    } else if (termQuery) {
+      assert bq.clauses().size() == 1;
       return bq.clauses().get(0).query();
     } else {
       return bq;

--- a/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
+++ b/lucene/core/src/java/org/apache/lucene/util/graph/GraphTokenStreamFiniteStrings.java
@@ -85,6 +85,11 @@ public final class GraphTokenStreamFiniteStrings {
         Operations.removeDeadStates(Operations.determinize(aut, DEFAULT_DETERMINIZE_WORK_LIMIT));
   }
 
+  /** Return the number of states of this automaton. */
+  public int getNumStates() {
+    return det.getNumStates();
+  }
+
   /**
    * Returns whether the provided state is the start of multiple side paths of different length (eg:
    * new york, ny)

--- a/lucene/core/src/java/overview.html
+++ b/lucene/core/src/java/overview.html
@@ -46,8 +46,8 @@ to check if the results are what we expect):</p>
       try (DirectoryReader ireader = DirectoryReader.open(directory)) {
         IndexSearcher isearcher = new IndexSearcher(ireader);
         // Parse a simple query that searches for "text":
-        QueryParser parser = new QueryParser("fieldname", analyzer);
-        Query query = parser.parse("text");
+        QueryBuilder parser = new QueryBuilder(analyzer);
+        Query query = parser.createBooleanQuery("fieldname", "text");
         ScoreDoc[] hits = isearcher.search(query, 10).scoreDocs;
         assertEquals(1, hits.length);
         // Iterate through the results:

--- a/lucene/core/src/test/org/apache/lucene/util/TestQueryBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestQueryBuilder.java
@@ -407,8 +407,11 @@ public class TestQueryBuilder extends LuceneTestCase {
               .add(syn2, BooleanClause.Occur.SHOULD)
               .build();
 
+      BooleanQuery expectedGraphQuery = new BooleanQuery.Builder().add(synQuery, occur).build();
+
       QueryBuilder queryBuilder = new QueryBuilder(new MockSynonymAnalyzer());
-      assertEquals(synQuery, queryBuilder.createBooleanQuery("field", "guinea pig", occur));
+      assertEquals(
+          expectedGraphQuery, queryBuilder.createBooleanQuery("field", "guinea pig", occur));
 
       BooleanQuery expectedBooleanQuery =
           new BooleanQuery.Builder()
@@ -480,8 +483,10 @@ public class TestQueryBuilder extends LuceneTestCase {
               .add(cavy, BooleanClause.Occur.SHOULD)
               .build();
 
+      Query expectedGraphQuery = new BooleanQuery.Builder().add(synQuery, occur).build();
+
       assertEquals(
-          synQuery,
+          expectedGraphQuery,
           queryBuilder.createBooleanQuery(
               fields, "guinea pig", MultiFieldScoreMode.PER_TERM_COMBINED, occur));
 
@@ -504,13 +509,21 @@ public class TestQueryBuilder extends LuceneTestCase {
               Arrays.asList(
                   new BoostQuery(
                       new BooleanQuery.Builder()
-                          .add(titleSyn1, BooleanClause.Occur.SHOULD)
-                          .add(titleSyn2, BooleanClause.Occur.SHOULD)
+                          .add(
+                              new BooleanQuery.Builder()
+                                  .add(titleSyn1, BooleanClause.Occur.SHOULD)
+                                  .add(titleSyn2, BooleanClause.Occur.SHOULD)
+                                  .build(),
+                              occur)
                           .build(),
                       10f),
                   new BooleanQuery.Builder()
-                      .add(bodySyn1, BooleanClause.Occur.SHOULD)
-                      .add(bodySyn2, BooleanClause.Occur.SHOULD)
+                      .add(
+                          new BooleanQuery.Builder()
+                              .add(bodySyn1, BooleanClause.Occur.SHOULD)
+                              .add(bodySyn2, BooleanClause.Occur.SHOULD)
+                              .build(),
+                          occur)
                       .build()),
               0f);
 
@@ -537,9 +550,11 @@ public class TestQueryBuilder extends LuceneTestCase {
               .add(syn1, BooleanClause.Occur.SHOULD)
               .add(syn2, BooleanClause.Occur.SHOULD)
               .build();
+      BooleanQuery expectedGraphQuery = new BooleanQuery.Builder().add(synQuery, occur).build();
       QueryBuilder queryBuilder = new QueryBuilder(new MockSynonymAnalyzer());
       queryBuilder.setAutoGenerateMultiTermSynonymsPhraseQuery(true);
-      assertEquals(synQuery, queryBuilder.createBooleanQuery("field", "guinea pig", occur));
+      assertEquals(
+          expectedGraphQuery, queryBuilder.createBooleanQuery("field", "guinea pig", occur));
 
       BooleanQuery expectedBooleanQuery =
           new BooleanQuery.Builder()


### PR DESCRIPTION
`QueryBuilder#createBooleanQuery` now supports querying multiple fields. Scoring-wise, it supports two options: either BM25F, the best choice but requires fields to be indexed/searched with the same analyzer, index options and similarity, or taking the max score across fields, a poor option but that doesn't make any assumption about how fields are indexed/searched.

To make it work properly, I added support for multiple terms back to `CombinedFieldQuery` (like in sandbox) to support synonyms.
