### PR TITLE
Reduce knn recall test flakiness

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
@@ -62,6 +62,11 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
     return KnnVectorsFormat.DEFAULT_MAX_DIMENSIONS;
   }
 
+  @Override
+  public String toString() {
+    return "AssertingKnnVectorsFormat{" + "delegate=" + delegate + '}';
+  }
+
   static class AssertingKnnVectorsWriter extends KnnVectorsWriter {
     final KnnVectorsWriter delegate;
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomCodec.java
@@ -364,6 +364,8 @@ public class RandomCodec extends AssertingCodec {
     return super.toString()
         + ": "
         + previousMappings.toString()
+        + ", knn_vectors:"
+        + previousKnnMappings.toString()
         + ", docValues:"
         + previousDVMappings.toString()
         + ", maxPointsInLeafNode="


### PR DESCRIPTION
I have noticed some additional flakiness for knn recall. 

For example:

```
./gradlew test --tests TestPerFieldKnnVectorsFormat.testRecall -Dtests.seed=FAEFE5196FDED25B -Dtests.locale=twq-Latn-NE -Dtests.timezone=America/New_York -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```

So, I am making two minor adjustments to the test:

 - Increasing hnsw efsearch to 25 (still only gathering 10 nearest docs in the end)
 - Better filling vectors for tiny lines


I also added some nicer `toString` methods and output for the test, so if we notice it failing again, we can quickly see for what codec and options.