### PR TITLE
PointInSetQuery early exit on non-matching segments

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -67,6 +67,8 @@ Optimizations
 ---------------------
 * GITHUB#14418: Quick exit on filter query matching no docs when rewriting knn query. (Pan Guixin)
 
+* GITHUB#14268: PointInSetQuery early exit on non-matching segments. (hanbj)
+
 Bug Fixes
 ---------------------
 (No changes)


### PR DESCRIPTION
### Description
When creating a PointInSetQuery object, the data in the packedPoints parameter is returned in order, so the maximum and minimum values ​​can be determined when iterating over packedPoints.

With the maximum and minimum values, the query can be returned early in special cases during the serial search of the segment.