### PR TITLE
Implement #intoBitset for DocIdSetIterator#all and DocIdSetIterator#range

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -105,6 +105,8 @@ Optimizations
 
 * GITHUB#14176: Reduce when visiting bpv24-encoded doc ids in BKD leaves. (Guo Feng)
 
+* GITHUB#14269: Implement #intoBitset for DocIdSetIterator#all and DocIdSetIterator#range. (Guo Feng)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSetIterator.java
@@ -28,7 +28,7 @@ import org.apache.lucene.util.FixedBitSet;
 public abstract class DocIdSetIterator {
 
   /** An empty {@code DocIdSetIterator} instance */
-  public static final DocIdSetIterator empty() {
+  public static DocIdSetIterator empty() {
     return new DocIdSetIterator() {
       boolean exhausted = false;
 
@@ -60,7 +60,7 @@ public abstract class DocIdSetIterator {
   }
 
   /** A {@link DocIdSetIterator} that matches all documents up to {@code maxDoc - 1}. */
-  public static final DocIdSetIterator all(int maxDoc) {
+  public static DocIdSetIterator all(int maxDoc) {
     return new DocIdSetIterator() {
       int doc = -1;
 
@@ -70,12 +70,12 @@ public abstract class DocIdSetIterator {
       }
 
       @Override
-      public int nextDoc() throws IOException {
+      public int nextDoc() {
         return advance(doc + 1);
       }
 
       @Override
-      public int advance(int target) throws IOException {
+      public int advance(int target) {
         doc = target;
         if (doc >= maxDoc) {
           doc = NO_MORE_DOCS;
@@ -91,12 +91,10 @@ public abstract class DocIdSetIterator {
       @Override
       public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) {
         assert offset <= doc;
-        if (upTo >= maxDoc) {
-          bitSet.set(doc - offset, maxDoc - offset);
-          doc = NO_MORE_DOCS;
-        } else if (upTo > doc) {
+        upTo = Math.min(upTo, maxDoc);
+        if (upTo > doc) {
           bitSet.set(doc - offset, upTo - offset);
-          doc = upTo;
+          advance(upTo);
         }
       }
     };
@@ -106,7 +104,7 @@ public abstract class DocIdSetIterator {
    * A {@link DocIdSetIterator} that matches a range documents from minDocID (inclusive) to maxDocID
    * (exclusive).
    */
-  public static final DocIdSetIterator range(int minDoc, int maxDoc) {
+  public static DocIdSetIterator range(int minDoc, int maxDoc) {
     if (minDoc >= maxDoc) {
       throw new IllegalArgumentException(
           "minDoc must be < maxDoc but got minDoc=" + minDoc + " maxDoc=" + maxDoc);
@@ -123,12 +121,12 @@ public abstract class DocIdSetIterator {
       }
 
       @Override
-      public int nextDoc() throws IOException {
+      public int nextDoc() {
         return advance(doc + 1);
       }
 
       @Override
-      public int advance(int target) throws IOException {
+      public int advance(int target) {
         if (target < minDoc) {
           doc = minDoc;
         } else if (target >= maxDoc) {
@@ -147,12 +145,10 @@ public abstract class DocIdSetIterator {
       @Override
       public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) {
         assert offset <= doc;
-        if (upTo >= maxDoc) {
-          bitSet.set(doc - offset, maxDoc - offset);
-          doc = NO_MORE_DOCS;
-        } else if (upTo > doc) {
+        upTo = Math.min(upTo, maxDoc);
+        if (upTo > doc) {
           bitSet.set(doc - offset, upTo - offset);
-          doc = upTo;
+          advance(upTo);
         }
       }
     };
@@ -248,7 +244,7 @@ public abstract class DocIdSetIterator {
    * </pre>
    *
    * <p><b>Note</b>: {@code offset} must be less than or equal to the {@link #docID() current doc
-   * ID}. Behaviour is undefined if this iterator is unpositioned or exhausted.
+   * ID}. Behaviour is undefined if this iterator is unpositioned.
    *
    * <p><b>Note</b>: It is important not to clear bits from {@code bitSet} that may be already set.
    *

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSetIterator.java
@@ -87,6 +87,18 @@ public abstract class DocIdSetIterator {
       public long cost() {
         return maxDoc;
       }
+
+      @Override
+      public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) {
+        assert offset <= doc;
+        if (upTo >= maxDoc) {
+          bitSet.set(doc - offset, maxDoc - offset);
+          doc = NO_MORE_DOCS;
+        } else if (upTo > doc) {
+          bitSet.set(doc - offset, upTo - offset);
+          doc = upTo;
+        }
+      }
     };
   }
 
@@ -130,6 +142,18 @@ public abstract class DocIdSetIterator {
       @Override
       public long cost() {
         return maxDoc - minDoc;
+      }
+
+      @Override
+      public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) {
+        assert offset <= doc;
+        if (upTo >= maxDoc) {
+          bitSet.set(doc - offset, maxDoc - offset);
+          doc = NO_MORE_DOCS;
+        } else if (upTo > doc) {
+          bitSet.set(doc - offset, upTo - offset);
+          doc = upTo;
+        }
       }
     };
   }
@@ -224,7 +248,7 @@ public abstract class DocIdSetIterator {
    * </pre>
    *
    * <p><b>Note</b>: {@code offset} must be less than or equal to the {@link #docID() current doc
-   * ID}.
+   * ID}. Behaviour is undefined if this iterator is unpositioned or exhausted.
    *
    * <p><b>Note</b>: It is important not to clear bits from {@code bitSet} that may be already set.
    *

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocIdSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocIdSetIterator.java
@@ -19,7 +19,6 @@ package org.apache.lucene.search;
 
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
-import java.io.IOException;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.FixedBitSet;
 
@@ -105,7 +104,8 @@ public class TestDocIdSetIterator extends LuceneTestCase {
                     ? expectedDisi.docID() - 1
                     : expectedDisi.docID() + random().nextInt(5);
             int offset = expectedDisi.docID() - random().nextInt(max);
-            defaultIntoBitset(expectedDisi, upTo, expected, offset);
+            // use the default impl of intoBitSet
+            new FilterDocIdSetIterator(expectedDisi).intoBitSet(upTo, expected, offset);
             actualDisi.intoBitSet(upTo, actual, offset);
             assertArrayEquals(expected.getBits(), actual.getBits());
           }
@@ -113,14 +113,6 @@ public class TestDocIdSetIterator extends LuceneTestCase {
         assertEquals(expectedDisi.docID(), actualDisi.docID());
         doc = expectedDisi.docID();
       }
-    }
-  }
-
-  private static void defaultIntoBitset(
-      DocIdSetIterator disi, int upTo, FixedBitSet bitSet, int offset) throws IOException {
-    assert offset <= disi.docID();
-    for (int doc = disi.docID(); doc < upTo; doc = disi.nextDoc()) {
-      bitSet.set(doc - offset);
     }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocIdSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocIdSetIterator.java
@@ -19,7 +19,9 @@ package org.apache.lucene.search;
 
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
+import java.io.IOException;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.FixedBitSet;
 
 public class TestDocIdSetIterator extends LuceneTestCase {
   public void testRangeBasic() throws Exception {
@@ -63,5 +65,62 @@ public class TestDocIdSetIterator extends LuceneTestCase {
     assertEquals(18, disi.nextDoc());
     assertEquals(19, disi.nextDoc());
     assertEquals(NO_MORE_DOCS, disi.nextDoc());
+  }
+
+  public void testIntoBitset() throws Exception {
+    for (int i = 0; i < 10; i++) {
+      int max = 1 + random().nextInt(500);
+      DocIdSetIterator expectedDisi;
+      DocIdSetIterator actualDisi;
+      if ((i & 1) == 0) {
+        int min = random().nextInt(max);
+        expectedDisi = DocIdSetIterator.range(min, max);
+        actualDisi = DocIdSetIterator.range(min, max);
+      } else {
+        expectedDisi = DocIdSetIterator.all(max);
+        actualDisi = DocIdSetIterator.all(max);
+      }
+      FixedBitSet expected = new FixedBitSet(max * 2);
+      FixedBitSet actual = new FixedBitSet(max * 2);
+      int doc = -1;
+      expectedDisi.nextDoc();
+      actualDisi.nextDoc();
+      while (doc != NO_MORE_DOCS) {
+        int r = random().nextInt(3);
+        switch (r) {
+          case 0 -> {
+            expectedDisi.nextDoc();
+            actualDisi.nextDoc();
+          }
+          case 1 -> {
+            int jump = expectedDisi.docID() + random().nextInt(5);
+            expectedDisi.advance(jump);
+            actualDisi.advance(jump);
+          }
+          case 2 -> {
+            expected.clear();
+            actual.clear();
+            int upTo =
+                random().nextBoolean()
+                    ? expectedDisi.docID() - 1
+                    : expectedDisi.docID() + random().nextInt(5);
+            int offset = expectedDisi.docID() - random().nextInt(max);
+            defaultIntoBitset(expectedDisi, upTo, expected, offset);
+            actualDisi.intoBitSet(upTo, actual, offset);
+            assertArrayEquals(expected.getBits(), actual.getBits());
+          }
+        }
+        assertEquals(expectedDisi.docID(), actualDisi.docID());
+        doc = expectedDisi.docID();
+      }
+    }
+  }
+
+  private static void defaultIntoBitset(
+      DocIdSetIterator disi, int upTo, FixedBitSet bitSet, int offset) throws IOException {
+    assert offset <= disi.docID();
+    for (int doc = disi.docID(); doc < upTo; doc = disi.nextDoc()) {
+      bitSet.set(doc - offset);
+    }
   }
 }


### PR DESCRIPTION
Implement `#intoBitset` for `DocIdSetIterator#all` and `DocIdSetIterator#range`.

For reference, `DocIdSetIterator#all` used in queries hit all docs. `DocIdSetIterator#range` used in docvalue queries on index sorting field.