### PR TITLE
Address completion fields testing gap and truly allow loading FST off heap

### DIFF
--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion101PostingsFormat.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion101PostingsFormat.java
@@ -25,17 +25,10 @@ import org.apache.lucene.codecs.PostingsFormat;
  * @lucene.experimental
  */
 public class Completion101PostingsFormat extends CompletionPostingsFormat {
-  /** Creates a {@link Completion101PostingsFormat} that will load the completion FST on-heap. */
-  public Completion101PostingsFormat() {
-    this(FSTLoadMode.ON_HEAP);
-  }
 
-  /**
-   * Creates a {@link Completion101PostingsFormat} that will use the provided <code>fstLoadMode
-   * </code> to determine if the completion FST should be loaded on or off heap.
-   */
-  public Completion101PostingsFormat(FSTLoadMode fstLoadMode) {
-    super("Completion101", fstLoadMode);
+  /** Creates a {@link Completion101PostingsFormat} */
+  public Completion101PostingsFormat() {
+    super("Completion101");
   }
 
   @Override

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion50PostingsFormat.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion50PostingsFormat.java
@@ -27,17 +27,9 @@ import org.apache.lucene.codecs.PostingsFormat;
  * @lucene.experimental
  */
 public class Completion50PostingsFormat extends CompletionPostingsFormat {
-  /** Creates a {@link Completion50PostingsFormat} that will load the completion FST on-heap. */
+  /** Creates a {@link Completion50PostingsFormat} */
   public Completion50PostingsFormat() {
-    this(FSTLoadMode.ON_HEAP);
-  }
-
-  /**
-   * Creates a {@link Completion50PostingsFormat} that will use the provided <code>fstLoadMode
-   * </code> to determine if the completion FST should be loaded on or off heap.
-   */
-  public Completion50PostingsFormat(FSTLoadMode fstLoadMode) {
-    super("completion", fstLoadMode);
+    super("completion");
   }
 
   @Override

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion84PostingsFormat.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion84PostingsFormat.java
@@ -27,17 +27,9 @@ import org.apache.lucene.codecs.PostingsFormat;
  * @lucene.experimental
  */
 public class Completion84PostingsFormat extends CompletionPostingsFormat {
-  /** Creates a {@link Completion84PostingsFormat} that will load the completion FST on-heap. */
+  /** Creates a {@link Completion84PostingsFormat} */
   public Completion84PostingsFormat() {
-    this(FSTLoadMode.ON_HEAP);
-  }
-
-  /**
-   * Creates a {@link Completion84PostingsFormat} that will use the provided <code>fstLoadMode
-   * </code> to determine if the completion FST should be loaded on or off heap.
-   */
-  public Completion84PostingsFormat(FSTLoadMode fstLoadMode) {
-    super("Completion84", fstLoadMode);
+    super("Completion84");
   }
 
   @Override

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion90PostingsFormat.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion90PostingsFormat.java
@@ -27,17 +27,9 @@ import org.apache.lucene.codecs.PostingsFormat;
  * @lucene.experimental
  */
 public class Completion90PostingsFormat extends CompletionPostingsFormat {
-  /** Creates a {@link Completion90PostingsFormat} that will load the completion FST on-heap. */
+  /** Creates a {@link Completion90PostingsFormat} */
   public Completion90PostingsFormat() {
-    this(FSTLoadMode.ON_HEAP);
-  }
-
-  /**
-   * Creates a {@link Completion90PostingsFormat} that will use the provided <code>fstLoadMode
-   * </code> to determine if the completion FST should be loaded on or off heap.
-   */
-  public Completion90PostingsFormat(FSTLoadMode fstLoadMode) {
-    super("Completion90", fstLoadMode);
+    super("Completion90");
   }
 
   @Override

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion912PostingsFormat.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion912PostingsFormat.java
@@ -27,17 +27,9 @@ import org.apache.lucene.codecs.PostingsFormat;
  * @lucene.experimental
  */
 public class Completion912PostingsFormat extends CompletionPostingsFormat {
-  /** Creates a {@link Completion912PostingsFormat} that will load the completion FST on-heap. */
+  /** Creates a {@link Completion912PostingsFormat} */
   public Completion912PostingsFormat() {
-    this(FSTLoadMode.ON_HEAP);
-  }
-
-  /**
-   * Creates a {@link Completion912PostingsFormat} that will use the provided <code>fstLoadMode
-   * </code> to determine if the completion FST should be loaded on or off heap.
-   */
-  public Completion912PostingsFormat(FSTLoadMode fstLoadMode) {
-    super("Completion912", fstLoadMode);
+    super("Completion912");
   }
 
   @Override

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion99PostingsFormat.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/Completion99PostingsFormat.java
@@ -27,17 +27,9 @@ import org.apache.lucene.codecs.PostingsFormat;
  * @lucene.experimental
  */
 public class Completion99PostingsFormat extends CompletionPostingsFormat {
-  /** Creates a {@link Completion99PostingsFormat} that will load the completion FST on-heap. */
+  /** Creates a {@link Completion99PostingsFormat} */
   public Completion99PostingsFormat() {
-    this(FSTLoadMode.ON_HEAP);
-  }
-
-  /**
-   * Creates a {@link Completion99PostingsFormat} that will use the provided <code>fstLoadMode
-   * </code> to determine if the completion FST should be loaded on or off heap.
-   */
-  public Completion99PostingsFormat(FSTLoadMode fstLoadMode) {
-    super("Completion99", fstLoadMode);
+    super("Completion99");
   }
 
   @Override

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionPostingsFormat.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionPostingsFormat.java
@@ -104,13 +104,12 @@ public abstract class CompletionPostingsFormat extends PostingsFormat {
   static final String INDEX_EXTENSION = "cmp";
   static final String DICT_EXTENSION = "lkp";
 
-  /**
-   * Default way of loading FSTs when reading a completion field
-   */
+  /** Default way of loading FSTs when reading a completion field */
   public static final FSTLoadMode DEFAULT_FST_LOAD_MODE = FSTLoadMode.ON_HEAP;
+
   /**
-   * The {@link FSTLoadMode} that drives how {@link CompletionPostingsFormat} subclasses load their FSTs,
-   * used whenever a completion field is read.
+   * The {@link FSTLoadMode} that drives how {@link CompletionPostingsFormat} subclasses load their
+   * FSTs, used whenever a completion field is read.
    */
   public static FSTLoadMode FST_LOAD_MODE = DEFAULT_FST_LOAD_MODE;
 

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionPostingsFormat.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionPostingsFormat.java
@@ -104,6 +104,9 @@ public abstract class CompletionPostingsFormat extends PostingsFormat {
   static final String INDEX_EXTENSION = "cmp";
   static final String DICT_EXTENSION = "lkp";
 
+  public static final FSTLoadMode DEFAULT_FST_LOAD_MODE = FSTLoadMode.ON_HEAP;
+  public static FSTLoadMode FST_LOAD_MODE = DEFAULT_FST_LOAD_MODE;
+
   /** An enum that allows to control if suggester FSTs are loaded into memory or read off-heap */
   public enum FSTLoadMode {
     /**
@@ -122,18 +125,13 @@ public abstract class CompletionPostingsFormat extends PostingsFormat {
 
   private final FSTLoadMode fstLoadMode;
 
-  /** Used only by core Lucene at read-time via Service Provider instantiation */
-  public CompletionPostingsFormat(String name) {
-    this(name, FSTLoadMode.ON_HEAP);
-  }
-
   /**
    * Creates a {@link CompletionPostingsFormat} that will use the provided <code>fstLoadMode</code>
    * to determine if the completion FST should be loaded on or off heap.
    */
-  public CompletionPostingsFormat(String name, FSTLoadMode fstLoadMode) {
+  protected CompletionPostingsFormat(String name) {
     super(name);
-    this.fstLoadMode = fstLoadMode;
+    this.fstLoadMode = FST_LOAD_MODE;
   }
 
   /** Concrete implementation should specify the delegating postings format */

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionPostingsFormat.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionPostingsFormat.java
@@ -104,7 +104,14 @@ public abstract class CompletionPostingsFormat extends PostingsFormat {
   static final String INDEX_EXTENSION = "cmp";
   static final String DICT_EXTENSION = "lkp";
 
+  /**
+   * Default way of loading FSTs when reading a completion field
+   */
   public static final FSTLoadMode DEFAULT_FST_LOAD_MODE = FSTLoadMode.ON_HEAP;
+  /**
+   * The {@link FSTLoadMode} that drives how {@link CompletionPostingsFormat} subclasses load their FSTs,
+   * used whenever a completion field is read.
+   */
   public static FSTLoadMode FST_LOAD_MODE = DEFAULT_FST_LOAD_MODE;
 
   /** An enum that allows to control if suggester FSTs are loaded into memory or read off-heap */

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionsTermsReader.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionsTermsReader.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import org.apache.lucene.search.suggest.document.CompletionPostingsFormat.FSTLoadMode;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.Accountable;
 
 /**

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionsTermsReader.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionsTermsReader.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import org.apache.lucene.search.suggest.document.CompletionPostingsFormat.FSTLoadMode;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.Accountable;
 
 /**

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestSuggestField.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestSuggestField.java
@@ -80,7 +80,7 @@ public class TestSuggestField extends LuceneTestCase {
   public void before() throws Exception {
     dir = newDirectory();
     CompletionPostingsFormat.FST_LOAD_MODE =
-            RandomPicks.randomFrom(random(), CompletionPostingsFormat.FSTLoadMode.values());
+        RandomPicks.randomFrom(random(), CompletionPostingsFormat.FSTLoadMode.values());
   }
 
   @After
@@ -953,6 +953,7 @@ public class TestSuggestField extends LuceneTestCase {
     Codec filterCodec =
         new FilterCodec(TestUtil.getDefaultCodec().getName(), TestUtil.getDefaultCodec()) {
           final PostingsFormat postingsFormat = new Completion101PostingsFormat();
+
           @Override
           public PostingsFormat postingsFormat() {
             return new PerFieldPostingsFormat() {

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestSuggestField.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestSuggestField.java
@@ -79,11 +79,14 @@ public class TestSuggestField extends LuceneTestCase {
   @Before
   public void before() throws Exception {
     dir = newDirectory();
+    CompletionPostingsFormat.FST_LOAD_MODE =
+            RandomPicks.randomFrom(random(), CompletionPostingsFormat.FSTLoadMode.values());
   }
 
   @After
   public void after() throws Exception {
     dir.close();
+    CompletionPostingsFormat.FST_LOAD_MODE = CompletionPostingsFormat.DEFAULT_FST_LOAD_MODE;
   }
 
   @Test
@@ -949,10 +952,7 @@ public class TestSuggestField extends LuceneTestCase {
     iwc.setMergePolicy(newLogMergePolicy());
     Codec filterCodec =
         new FilterCodec(TestUtil.getDefaultCodec().getName(), TestUtil.getDefaultCodec()) {
-          final CompletionPostingsFormat.FSTLoadMode fstLoadMode =
-              RandomPicks.randomFrom(random(), CompletionPostingsFormat.FSTLoadMode.values());
-          final PostingsFormat postingsFormat = new Completion101PostingsFormat(fstLoadMode);
-
+          final PostingsFormat postingsFormat = new Completion101PostingsFormat();
           @Override
           public PostingsFormat postingsFormat() {
             return new PerFieldPostingsFormat() {


### PR DESCRIPTION
We currently have a gap in testing the completion postings format. While it allows to load FSTs off heap, and the format has a constructor that takes the fst load mode, at read time SPI goes through the default constructor that has fst load mode hardcoded to on heap at all times. This means that despite we randomize fst load mode in `TestSuggestField`, we never effectively load the completion FST off heap, we only set the load mode to something different than on heap when writing, where the load mode takes no effect.

This commit introduces a static method that allows to switch the loading of the FST for all the completion postings format.

This unveiled a bug when loading FST off heap and the index input is a `MemorySegmentIndexInput` which is fixed by #14271

Besides the testing concerns, an important question is: what are users supposed to do to enable off heap loading of completion fields? Is the intention that they need to register custom postings format, although it's only the loading part that needs overriding? Or do we want to make that easier somehow reusing the existing postings format? I think it is rather odd to require users to customize the postings format, and have to support their own format for the time being, if the write side is identical to the standard one.

