### PR TITLE
Stop closing index input when loading NRTSuggester

### DIFF
--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionsTermsReader.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionsTermsReader.java
@@ -72,10 +72,8 @@ public final class CompletionsTermsReader implements Accountable {
    */
   public synchronized NRTSuggester suggester() throws IOException {
     if (suggester == null) {
-      try (IndexInput dictClone = dictIn.clone()) { // let multiple fields load concurrently
-        dictClone.seek(offset);
-        suggester = NRTSuggester.load(dictClone, fstLoadMode);
-      }
+      IndexInput indexInput = dictIn.slice("NRTSuggester", offset, dictIn.length() - offset);
+      suggester = NRTSuggester.load(indexInput, fstLoadMode);
     }
     return suggester;
   }


### PR DESCRIPTION
Closing the index input is not necessary when loading the NRTSuggester. Also, it causes a bug as the clone gets closed right before the suggester instance gets returned, which makes it unusable in the later lookup method which slices the index input while it's already closed. This is addressed by creating a slice, that is not further closed, so that the index input is still usable once the suggester is returned.

This was not discovered so far due to a testing gap that is fixed by #14270.
The bug was introduced by #13524 , stacktrace follows:

```
Already closed: MemorySegmentIndexInput(path="/home/javanna/apache/lucene/lucene/suggest/build/tmp/tests-tmp/test539812848641464359/_2_Completion101_0.lkp")
org.apache.lucene.store.AlreadyClosedException: Already closed: MemorySegmentIndexInput(path="/home/javanna/apache/lucene/lucene/suggest/build/tmp/tests-tmp/test539812848641464359/_2_Completion101_0.lkp")
    at __randomizedtesting.SeedInfo.seed([88A0E29FD265DAD4:C82996819FD55267]:0)
    at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.store.MemorySegmentIndexInput.alreadyClosed(MemorySegmentIndexInput.java:128)
    at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.store.MemorySegmentIndexInput.ensureOpen(MemorySegmentIndexInput.java:103)
    at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.store.MemorySegmentIndexInput.buildSlice(MemorySegmentIndexInput.java:644)
    at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.store.MemorySegmentIndexInput.slice(MemorySegmentIndexInput.java:614)
    at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.store.MemorySegmentIndexInput$SingleSegmentImpl.slice(MemorySegmentIndexInput.java:718)
    at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.store.IndexInput.randomAccessSlice(IndexInput.java:163)
    at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.util.fst.OffHeapFSTStore.getReverseBytesReader(OffHeapFSTStore.java:57)
    at org.apache.lucene.core@11.0.0-SNAPSHOT/org.apache.lucene.util.fst.FST.getBytesReader(FST.java:1149)
    at org.apache.lucene.search.suggest.analyzing.FSTUtil.intersectPrefixPaths(FSTUtil.java:65)
    at org.apache.lucene.search.suggest.document.NRTSuggester.lookup(NRTSuggester.java:133)
    at org.apache.lucene.search.suggest.document.CompletionScorer.score(CompletionScorer.java:73)
    at org.apache.lucene.search.suggest.document.SuggestIndexSearcher.suggest(SuggestIndexSearcher.java:75)
    at org.apache.lucene.search.suggest.document.SuggestIndexSearcher.suggest(SuggestIndexSearcher.java:53)
```