### PR TITLE
Optimize single value ranges for multivalue sortedset docvalues ranges.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -79,7 +79,8 @@ New Features
   These queries allow for the vector search entry points to be initialized via a `seed` query. This follows
   the research provided via https://arxiv.org/abs/2307.16779. (Sean MacAvaney, Ben Trent).
 
-* GITHUB#13974: Introducing DocValuesMultiRangeQuery.SortedSetStabbingBuilder into sandbox. (Mikhail Khludnev)
+* GITHUB#13974,GITHUB#14276: Introducing DocValuesMultiRangeQuery.SortedSetStabbingBuilder into sandbox.
+  (Mikhail Khludnev)
 
 * GITHUB#14204: Added HistogramCollectorManager to efficiently compute a
   histogram of the distribution of the values of a field, for documents

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/DocValuesMultiRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/DocValuesMultiRangeQuery.java
@@ -43,6 +43,10 @@ public final class DocValuesMultiRangeQuery {
       this.upper = BytesRef.deepCopyOf(upperValue);
     }
 
+    public ByteRange(BytesRef singleValue) {
+      this.upper = this.lower = BytesRef.deepCopyOf(singleValue);
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -85,6 +89,12 @@ public final class DocValuesMultiRangeQuery {
     // TODO support nulls as min,max boundaries ???
     public SortedSetStabbingBuilder add(BytesRef lowerValue, BytesRef upperValue) {
       clauses.add(new ByteRange(lowerValue, upperValue));
+      return this;
+    }
+
+    /** Adds a value when lower and upper values are equal */
+    public SortedSetStabbingBuilder add(BytesRef singleValue) {
+      clauses.add(new ByteRange(singleValue));
       return this;
     }
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/SortedSetDocValuesMultiRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/SortedSetDocValuesMultiRangeQuery.java
@@ -105,7 +105,9 @@ public class SortedSetDocValuesMultiRangeQuery extends Query {
         case FOUND, NOT_FOUND:
           lowerOrd = termsEnum.ord();
       }
-      seekStatus = termsEnum.seekCeil(range.upper);
+      if (range.lower != range.upper) { // just a quick reference check, equality is too rare
+        seekStatus = termsEnum.seekCeil(range.upper);
+      }
       long upperOrd = -1;
       switch (seekStatus) {
         case TermsEnum.SeekStatus.END:


### PR DESCRIPTION
### Description

Optimize `lower==upper` ranges.  It's an addition to #13974.