### PR TITLE
Adds github action to verify changelog entry and set milestone to PRs

### DIFF
--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -6,7 +6,7 @@ on:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ISSUE: ${{ github.event.issue.html_url }}
-  ESCAPE_HATCH: ${{ '__NA__' }}
+  SKIP_CHANGELOG_LABEL: ${{ '"skip changelog"' }}
   CHANGE_LOG_FILE: ${{ 'lucene/CHANGES.txt' }}
 
 jobs:
@@ -23,15 +23,16 @@ jobs:
       - name: ChangeLog Entry Verifier and Milestone Setter
         run: |
           echo "################## STEP 1 ##################"
-          echo "Checking for escape hatch in the top comment"
-          pr_comment=$(gh pr view ${{ github.event.number }} --json body -q '.body')
-          if echo "$pr_comment" | grep -q ${{ env.ESCAPE_HATCH }}; then
-            echo "Skipping checks as escape hatch: ${ESCAPE_HATCH} is found in the top comment."
-            exit 0
-          else
-            echo "No escape hatch found in the top comment. Proceeding with next steps."
-          fi
-          
+          echo "Get all labels from the PR"
+          mapfile -t labels < <(gh pr view ${{ github.event.number }} --json labels -q '.labels[].name')
+          IFS=','; echo "${labels[*]}"
+          for label in "${labels[@]}"; do
+            if [[ $label == ${{ env.SKIP_CHANGELOG_LABEL }} ]]; then
+              echo "Skipping github action workflow as label: ${SKIP_CHANGELOG_LABEL} is found in the PR."
+              exit 0
+            fi
+          done
+          echo "${{ env.SKIP_CHANGELOG_LABEL }} not found in the PR. Proceeding with next steps."
           
           echo -e "\n"
           echo "################## STEP 2 ##################"
@@ -97,4 +98,6 @@ jobs:
             echo "Milestone:${lucene_version} does not exist. Please create the milestone and run the workflow again."
             exit 0
           fi
-          gh pr edit ${{ github.event.number }} --milestone "${lucene_version}"
+          # Will uncomment this line after we ensure it runs perfectly in production.
+          # gh pr edit ${{ github.event.number }} --milestone "${lucene_version}"
+          echo "Adding/Updating milestone for the PR to:${lucene_version}"

--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -6,7 +6,7 @@ on:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ISSUE: ${{ github.event.issue.html_url }}
-  SKIP_CHANGELOG_LABEL: ${{ '"skip changelog"' }}
+  SKIP_CHANGELOG_CHECK_LABEL: ${{ '"skip-changelog-check"' }}
   CHANGE_LOG_FILE: ${{ 'lucene/CHANGES.txt' }}
 
 jobs:
@@ -27,12 +27,12 @@ jobs:
           mapfile -t labels < <(gh pr view ${{ github.event.number }} --json labels -q '.labels[].name')
           IFS=','; echo "${labels[*]}"
           for label in "${labels[@]}"; do
-            if [[ $label == ${{ env.SKIP_CHANGELOG_LABEL }} ]]; then
-              echo "Skipping github action workflow as label: ${SKIP_CHANGELOG_LABEL} is found in the PR."
+            if [[ $label == ${{ env.SKIP_CHANGELOG_CHECK_LABEL }} ]]; then
+              echo "Skipping github action workflow as label: ${SKIP_CHANGELOG_CHECK_LABEL} is found in the PR."
               exit 0
             fi
           done
-          echo "${{ env.SKIP_CHANGELOG_LABEL }} not found in the PR. Proceeding with next steps."
+          echo "${{ env.SKIP_CHANGELOG_CHECK_LABEL }} not found in the PR. Proceeding with next steps."
           
           echo -e "\n"
           echo "################## STEP 2 ##################"

--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -1,0 +1,100 @@
+name: "Change Log Entry Verifier and Milestone Setter"
+run-name: Change log entry verifier and milestone setter
+on:
+  - pull_request_target
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  ISSUE: ${{ github.event.issue.html_url }}
+  ESCAPE_HATCH: ${{ '__NA__' }}
+  CHANGE_LOG_FILE: ${{ 'lucene/CHANGES.txt' }}
+
+jobs:
+  changelog-verifier-and-milestone-setter:
+    name: Verify Change Log Entry and Set Milestone
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: ChangeLog Entry Verifier and Milestone Setter
+        run: |
+          echo "################## STEP 1 ##################"
+          echo "Checking for escape hatch in the top comment"
+          pr_comment=$(gh pr view ${{ github.event.number }} --json body -q '.body')
+          if echo "$pr_comment" | grep -q ${{ env.ESCAPE_HATCH }}; then
+            echo "Skipping checks as escape hatch: ${ESCAPE_HATCH} is found in the top comment."
+            exit 0
+          else
+            echo "No escape hatch found in the top comment. Proceeding with next steps."
+          fi
+          
+          
+          echo -e "\n"
+          echo "################## STEP 2 ##################"
+          echo "Checking for change log entry in ${{ env.CHANGE_LOG_FILE }}"
+          git log  --pretty=oneline | tail -n 2 | cat
+          echo "merge base sha: ${{ github.event.pull_request.base.sha }}, merge head sha: ${{ github.event.pull_request.head.sha }}"
+          if ! git diff ${{ github.event.pull_request.base.sha }} --name-only | grep -q "${{ env.CHANGE_LOG_FILE }}"; then
+            echo "Change log file:${{ env.CHANGE_LOG_FILE }} does not contains an entry corresponding to changes introduced in PR. Please add a changelog entry."
+            exit 0
+          else
+            echo "${{ env.CHANGE_LOG_FILE }} contains change log entry. Proceeding with next steps."
+          fi
+
+
+          echo -e "\n"
+          echo "################## STEP 3 ##################"
+          echo "Extracting Lucene version from change log entry"
+          # git diff header pattern -> "@@ -15,0 +16,4 @@" 
+          # try to extract the line number at which new entry is added, here it's line number 16
+          diff=$(git diff ${{ github.event.pull_request.base.sha }} --unified=0 -- ${{ env.CHANGE_LOG_FILE }})
+          lucene_version=""
+          diff_header_pattern="@@ -[0-9]+,?[0-9]* \+([0-9]*),?[0-9]* @@"
+          if [[ $diff =~ $diff_header_pattern ]]; then
+            echo "Match found: ${BASH_REMATCH[0]}"
+            new_entry_line_number=$((BASH_REMATCH[1]))
+            echo "Found introduced change log entry at line number:${new_entry_line_number}"
+            lucene_version_regex="=+ ?Lucene ?([0-9.]*) ?=+"
+            current_line_number=0
+            while IFS="" read -r line; do
+              current_line_number=$((current_line_number+1))
+                if [[ $line =~ $lucene_version_regex ]]; then
+                  lucene_version="${BASH_REMATCH[1]}"
+                fi
+                if [[ $current_line_number -ge $new_entry_line_number ]]; then
+                  echo "Reached the line number at which new entry is added in ${{ env.CHANGE_LOG_FILE }}"
+                  break
+                fi
+            done < ${{ env.CHANGE_LOG_FILE }}
+            if [[ -z $lucene_version ]]; then
+              echo "Could not find Lucene version in the change log entry. Please add the Lucene version in the change log entry."
+              exit 0
+            fi
+            echo "Found corresponding Lucene version: ${lucene_version} based on change log entry. Proceeding with next steps."
+          else
+            echo "Could not find the line number at which new entry is added in ${{ env.CHANGE_LOG_FILE }}"
+            exit 0
+          fi
+
+
+          echo -e "\n"
+          echo "################## STEP 4 ##################"
+          echo "Adding/Updating milestone for the PR"
+          mapfile -t milestones < <(gh repo view --json milestones -q '.milestones[].title')
+          IFS=','; echo "${milestones[*]}"
+          milestone_exists=false
+          for milestone in "${milestones[@]}"; do
+            if [[ $milestone == "$lucene_version" ]]; then
+              milestone_exists=true
+              break
+            fi
+          done
+          if [[ $milestone_exists == false ]]; then
+            echo "Milestone:${lucene_version} does not exist. Please create the milestone and run the workflow again."
+            exit 0
+          fi
+          gh pr edit ${{ github.event.number }} --milestone "${lucene_version}"

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -160,6 +160,8 @@ Other
 
 * GITHUB#14223 : Fixed a flaky test TestKnnFloatVectorQuery.testFindFewer (Navneet Verma)
 
+* GITHUB#14279 : Add github action to verify changelog entry and set milestone to PRs. (Amir Raza)
+
 ======================= Lucene 10.1.0 =======================
 
 API Changes


### PR DESCRIPTION
### Description
Adds github action workflow to verify change log entry and set milestone based on the location of change log entry.

This workflow does the following step by step:
1. Check if the PR has `skip changelog` label to skip the further steps. `Committers should add this label if they want skip adding change log entry`. This is helpful when change log entry is not required.
2. Verifies if there is an entry in change log file (lucene/CHANGES.txt). 
3. Extracts the milestone version based on the location of the change log entry.
4. Checks if the milestone exist in github then applies (adds/updates) the milestone version to the PR.
5. Flags if milestone version do not exist. Currently, we are only logging it. We can either add a comment to create the milestone or create one automatically if a new banner is created (=== Lucene XXX ===) under change log file.

Currently, I have only added logs in the action workflow testing all the flow. It's not blocking the merging process. 
We can make it blocking based on the discussion in this PR.

Tested changes here: https://github.com/pseudo-nymous/lucene/pull/13

Closes: https://github.com/apache/lucene/issues/13898 https://github.com/apache/lucene/issues/14190
