### PR TITLE
ExceptionInInitializerError in ScorerUtil

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/ScorerUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScorerUtil.java
@@ -38,9 +38,13 @@ import org.apache.lucene.util.PriorityQueue;
 /** Util class for Scorer related methods */
 class ScorerUtil {
 
-  private static final Class<?> DEFAULT_IMPACTS_ENUM_CLASS;
+  private static Class<?> DEFAULT_IMPACTS_ENUM_CLASS = null;
 
-  static {
+  private static Class<?> getDefaultImpactsEnumClass() {
+    if (DEFAULT_IMPACTS_ENUM_CLASS != null) {
+      return DEFAULT_IMPACTS_ENUM_CLASS;
+    }
+
     try (Directory dir = new ByteBuffersDirectory();
         IndexWriter w = new IndexWriter(dir, new IndexWriterConfig())) {
       Document doc = new Document();
@@ -54,6 +58,7 @@ class ScorerUtil {
         }
         ImpactsEnum ie = te.impacts(PostingsEnum.FREQS);
         DEFAULT_IMPACTS_ENUM_CLASS = ie.getClass();
+        return DEFAULT_IMPACTS_ENUM_CLASS;
       }
     } catch (IOException e) {
       throw new Error(e);
@@ -92,7 +97,7 @@ class ScorerUtil {
    * bimorphic at most and candidate for inlining.
    */
   static DocIdSetIterator likelyImpactsEnum(DocIdSetIterator it) {
-    if (it.getClass() != DEFAULT_IMPACTS_ENUM_CLASS
+    if (it.getClass() != getDefaultImpactsEnumClass()
         && it.getClass() != FilterDocIdSetIterator.class) {
       it = new FilterDocIdSetIterator(it);
     }


### PR DESCRIPTION
lazy initialize the ScorerUtil DEFAULT_IMPACTS_ENUM_CLASS to prevent initialization issues with this class if the thread gets interrupted.

### Description

The ScorerUtils fails to initialize if a thread gets interrupted right when it executes its static initialization routine.
One has to restart the JVM then to make it work again.

`Caused by: java.lang.ExceptionInInitializerError: Exception org.apache.lucene.util.ThreadInterruptedException: java.lang.InterruptedException [in thread "/ng_api/infoHub/suggestions"]
	at org.apache.lucene.index.IndexWriter$EventQueue.close(IndexWriter.java:354)
	at org.apache.lucene.index.IndexWriter.rollbackInternalNoCommit(IndexWriter.java:2506)
	at org.apache.lucene.index.IndexWriter.rollbackInternal(IndexWriter.java:2456)
	at org.apache.lucene.index.IndexWriter.shutdown(IndexWriter.java:1341)
	at org.apache.lucene.index.IndexWriter.close(IndexWriter.java:1369)
	at org.apache.lucene.search.ScorerUtil.<clinit>(ScorerUtil.java:56)`

I made the patch so that it will ignore double-initialization of that constant in case of multithreading. I thought it is not worth to tackle with that in that scenario.