### PR TITLE
Remove field argument from DocIdSetBuilder constructor

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -135,7 +135,7 @@ final class LatLonPointDistanceQuery extends Query {
         LatLonPoint.checkCompatible(fieldInfo);
 
         // matching docids
-        DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+        DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values);
         final IntersectVisitor visitor = getIntersectVisitor(result);
 
         return new ScorerSupplier() {

--- a/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
@@ -481,7 +481,7 @@ public abstract class RangeFieldQuery extends Query {
         } else {
           return new ScorerSupplier() {
 
-            final DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+            final DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values);
             final IntersectVisitor visitor = getIntersectVisitor(result);
             long cost = -1;
 

--- a/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SpatialQuery.java
@@ -196,7 +196,7 @@ abstract class SpatialQuery extends Query {
         return null;
       }
       // walk the tree to get matching documents
-      return new RelationScorerSupplier(values, spatialVisitor, queryRelation, field) {
+      return new RelationScorerSupplier(values, spatialVisitor, queryRelation) {
         @Override
         public Scorer get(long leadCost) throws IOException {
           return getScorer(reader, score, scoreMode);
@@ -275,18 +275,15 @@ abstract class SpatialQuery extends Query {
     private final PointValues values;
     private final SpatialVisitor spatialVisitor;
     private final QueryRelation queryRelation;
-    private final String field;
     private long cost = -1;
 
     RelationScorerSupplier(
         final PointValues values,
         SpatialVisitor spatialVisitor,
-        final QueryRelation queryRelation,
-        final String field) {
+        final QueryRelation queryRelation) {
       this.values = values;
       this.spatialVisitor = spatialVisitor;
       this.queryRelation = queryRelation;
-      this.field = field;
     }
 
     protected Scorer getScorer(
@@ -332,7 +329,7 @@ abstract class SpatialQuery extends Query {
             cost[0] == 0 ? DocIdSetIterator.empty() : new BitSetIterator(result, cost[0]);
         return new ConstantScoreScorer(boost, scoreMode, iterator);
       } else {
-        final DocIdSetBuilder docIdSetBuilder = new DocIdSetBuilder(reader.maxDoc(), values, field);
+        final DocIdSetBuilder docIdSetBuilder = new DocIdSetBuilder(reader.maxDoc(), values);
         values.intersect(getSparseVisitor(spatialVisitor, queryRelation, docIdSetBuilder));
         final DocIdSetIterator iterator = docIdSetBuilder.build().iterator();
         return new ConstantScoreScorer(boost, scoreMode, iterator);

--- a/lucene/core/src/java/org/apache/lucene/document/XYPointInGeometryQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/XYPointInGeometryQuery.java
@@ -151,7 +151,7 @@ final class XYPointInGeometryQuery extends Query {
         return new ScorerSupplier() {
 
           long cost = -1;
-          DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+          final DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values);
           final IntersectVisitor visitor = getIntersectVisitor(result, tree);
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
@@ -180,7 +180,7 @@ public abstract class PointInSetQuery extends Query implements Accountable {
 
             @Override
             public Scorer get(long leadCost) throws IOException {
-              DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+              DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values);
               values.intersect(new MergePointVisitor(sortedPackedPoints.iterator(), result));
               DocIdSetIterator iterator = result.build().iterator();
               return new ConstantScoreScorer(score(), scoreMode, iterator);
@@ -191,7 +191,7 @@ public abstract class PointInSetQuery extends Query implements Accountable {
               try {
                 if (cost == -1) {
                   // Computing the cost may be expensive, so only do it if necessary
-                  DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+                  DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values);
                   cost =
                       values.estimateDocCount(
                           new MergePointVisitor(sortedPackedPoints.iterator(), result));
@@ -215,7 +215,7 @@ public abstract class PointInSetQuery extends Query implements Accountable {
 
             @Override
             public Scorer get(long leadCost) throws IOException {
-              DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+              DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values);
               SinglePointVisitor visitor = new SinglePointVisitor(result);
               TermIterator iterator = sortedPackedPoints.iterator();
               for (BytesRef point = iterator.next(); point != null; point = iterator.next()) {
@@ -229,7 +229,7 @@ public abstract class PointInSetQuery extends Query implements Accountable {
             public long cost() {
               try {
                 if (cost == -1) {
-                  DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+                  DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values);
                   SinglePointVisitor visitor = new SinglePointVisitor(result);
                   TermIterator iterator = sortedPackedPoints.iterator();
                   cost = 0;

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -356,7 +356,7 @@ public abstract class PointRangeQuery extends Query {
         } else {
           return new ScorerSupplier() {
 
-            final DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+            final DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values);
             final IntersectVisitor visitor = getIntersectVisitor(result);
             long cost = -1;
 

--- a/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
@@ -137,7 +137,7 @@ public final class DocIdSetBuilder {
    * Create a {@link DocIdSetBuilder} instance that is optimized for accumulating docs that match
    * the given {@link PointValues}.
    */
-  public DocIdSetBuilder(int maxDoc, PointValues values, String field) throws IOException {
+  public DocIdSetBuilder(int maxDoc, PointValues values) throws IOException {
     this(maxDoc, values.getDocCount(), values.size());
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
@@ -174,14 +174,14 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
 
   public void testEmptyPoints() throws IOException {
     PointValues values = new DummyPointValues(0, 0);
-    DocIdSetBuilder builder = new DocIdSetBuilder(1, values, "foo");
+    DocIdSetBuilder builder = new DocIdSetBuilder(1, values);
     assertEquals(1d, builder.numValuesPerDoc, 0d);
   }
 
   public void testLeverageStats() throws IOException {
     // single-valued points
     PointValues values = new DummyPointValues(42, 42);
-    DocIdSetBuilder builder = new DocIdSetBuilder(100, values, "foo");
+    DocIdSetBuilder builder = new DocIdSetBuilder(100, values);
     assertEquals(1d, builder.numValuesPerDoc, 0d);
     assertFalse(builder.multivalued);
     DocIdSetBuilder.BulkAdder adder = builder.grow(2);
@@ -193,7 +193,7 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
 
     // multi-valued points
     values = new DummyPointValues(42, 63);
-    builder = new DocIdSetBuilder(100, values, "foo");
+    builder = new DocIdSetBuilder(100, values);
     assertEquals(1.5, builder.numValuesPerDoc, 0d);
     assertTrue(builder.multivalued);
     adder = builder.grow(2);
@@ -205,12 +205,12 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
 
     // incomplete stats
     values = new DummyPointValues(42, -1);
-    builder = new DocIdSetBuilder(100, values, "foo");
+    builder = new DocIdSetBuilder(100, values);
     assertEquals(1d, builder.numValuesPerDoc, 0d);
     assertTrue(builder.multivalued);
 
     values = new DummyPointValues(-1, 84);
-    builder = new DocIdSetBuilder(100, values, "foo");
+    builder = new DocIdSetBuilder(100, values);
     assertEquals(1d, builder.numValuesPerDoc, 0d);
     assertTrue(builder.multivalued);
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiRangeQuery.java
@@ -350,7 +350,7 @@ public abstract class MultiRangeQuery extends Query implements Cloneable {
         } else {
           return new ScorerSupplier() {
 
-            final DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+            final DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values);
             final PointValues.IntersectVisitor visitor = getIntersectVisitor(result, range);
             long cost = -1;
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/PointInGeo3DShapeQuery.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/PointInGeo3DShapeQuery.java
@@ -102,7 +102,7 @@ final class PointInGeo3DShapeQuery extends Query implements Accountable {
         assert xyzSolid.getRelationship(shape) == GeoArea.WITHIN || xyzSolid.getRelationship(shape) == GeoArea.OVERLAPS: "expected WITHIN (1) or OVERLAPS (2) but got " + xyzSolid.getRelationship(shape) + "; shape="+shape+"; XYZSolid="+xyzSolid;
         */
 
-        DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+        DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values);
 
         values.intersect(new PointInShapeIntersectVisitor(result, shape, shapeBounds));
 


### PR DESCRIPTION
The argument is unused, its callers can stop providing it.