### PR TITLE
Remove IOException from DocIdSet#iterator signature

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -14,6 +14,8 @@ API Changes
 * GITHUB#14160: Adjusts the default HNSW search behavior so that filter optimized search is enabled
   when 60% or less of vectors pass the pre-filter. (Ben Chaplin, Ben Trent)
 
+* GITHUB#14284: Remove IOException from DocIdSet#iterator signature (Luca Cavanna)
+
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
@@ -52,7 +52,7 @@ public abstract class DocIdSet implements Accountable {
   public static DocIdSet all(int maxDoc) {
     return new DocIdSet() {
       @Override
-      public DocIdSetIterator iterator() throws IOException {
+      public DocIdSetIterator iterator() {
         return DocIdSetIterator.all(maxDoc);
       }
 
@@ -72,7 +72,7 @@ public abstract class DocIdSet implements Accountable {
    * Provides a {@link DocIdSetIterator} to access the set. This implementation can return <code>
    * null</code> if there are no docs that match.
    */
-  public abstract DocIdSetIterator iterator() throws IOException;
+  public abstract DocIdSetIterator iterator();
 
   // TODO: somehow this class should express the cost of
   // iteration vs the cost of random access Bits; for

--- a/lucene/core/src/java/org/apache/lucene/util/IntArrayDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntArrayDocIdSet.java
@@ -55,7 +55,7 @@ final class IntArrayDocIdSet extends DocIdSet {
   }
 
   @Override
-  public DocIdSetIterator iterator() throws IOException {
+  public DocIdSetIterator iterator() {
     return new IntArrayDocIdSetIterator(docs, length);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/NotDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/NotDocIdSet.java
@@ -66,7 +66,7 @@ public final class NotDocIdSet extends DocIdSet {
   }
 
   @Override
-  public DocIdSetIterator iterator() throws IOException {
+  public DocIdSetIterator iterator() {
     final DocIdSetIterator inIterator = in.iterator();
     return new DocIdSetIterator() {
 

--- a/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
@@ -167,7 +167,7 @@ public class RoaringDocIdSet extends DocIdSet {
     }
 
     @Override
-    public DocIdSetIterator iterator() throws IOException {
+    public DocIdSetIterator iterator() {
       return new DocIdSetIterator() {
 
         int i = -1; // this is the index of the current document in the array
@@ -178,7 +178,7 @@ public class RoaringDocIdSet extends DocIdSet {
         }
 
         @Override
-        public int nextDoc() throws IOException {
+        public int nextDoc() {
           if (++i >= docIDs.length) {
             return doc = NO_MORE_DOCS;
           }
@@ -196,7 +196,7 @@ public class RoaringDocIdSet extends DocIdSet {
         }
 
         @Override
-        public int advance(int target) throws IOException {
+        public int advance(int target) {
           // binary search
           int lo = i + 1;
           int hi = docIDs.length - 1;
@@ -219,7 +219,7 @@ public class RoaringDocIdSet extends DocIdSet {
         }
 
         @Override
-        public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+        public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) {
           if (doc >= upTo) {
             return;
           }
@@ -257,7 +257,7 @@ public class RoaringDocIdSet extends DocIdSet {
   }
 
   @Override
-  public DocIdSetIterator iterator() throws IOException {
+  public DocIdSetIterator iterator() {
     if (cardinality == 0) {
       return null;
     }
@@ -270,7 +270,7 @@ public class RoaringDocIdSet extends DocIdSet {
     DocIdSetIterator sub;
     int doc;
 
-    Iterator() throws IOException {
+    Iterator() {
       doc = -1;
       block = -1;
       sub = DocIdSetIterator.empty();

--- a/lucene/core/src/test/org/apache/lucene/search/IntArrayDocIdSet.java
+++ b/lucene/core/src/test/org/apache/lucene/search/IntArrayDocIdSet.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.search;
 
-import java.io.IOException;
 import java.util.Arrays;
 import org.apache.lucene.util.ArrayUtil;
 

--- a/lucene/core/src/test/org/apache/lucene/search/IntArrayDocIdSet.java
+++ b/lucene/core/src/test/org/apache/lucene/search/IntArrayDocIdSet.java
@@ -45,7 +45,7 @@ class IntArrayDocIdSet extends DocIdSet {
   }
 
   @Override
-  public DocIdSetIterator iterator() throws IOException {
+  public DocIdSetIterator iterator() {
     return new DocIdSetIterator() {
       int i = 0;
       int doc = -1;

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/ContainsPrefixTreeQuery.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/ContainsPrefixTreeQuery.java
@@ -299,7 +299,7 @@ public class ContainsPrefixTreeQuery extends AbstractPrefixTreeQuery {
     }
 
     @Override
-    public DocIdSetIterator iterator() throws IOException {
+    public DocIdSetIterator iterator() {
       if (size() == 0) return null;
       // copy the unsorted values to a new array then sort them
       int d = 0;
@@ -329,7 +329,7 @@ public class ContainsPrefixTreeQuery extends AbstractPrefixTreeQuery {
         }
 
         @Override
-        public int nextDoc() throws IOException {
+        public int nextDoc() {
           if (++idx < size) return docs[idx];
           return NO_MORE_DOCS;
         }


### PR DESCRIPTION
There is no implementation of DocIdSet#iterator that throws IOException. This commit proposes removing throwing IOException from its signature.