### PR TITLE
improve checkJavadocLinks.py to detect "invalid reference"

### DIFF
--- a/gradle/documentation/check-broken-links/checkJavadocLinks.py
+++ b/gradle/documentation/check-broken-links/checkJavadocLinks.py
@@ -39,6 +39,12 @@ class FindHyperlinks(HTMLParser):
     self.printed = False
 
   def handle_starttag(self, tag, attrs):
+    # look for explicit broken link
+    if tag == 'details':
+      for attName, attValue in attrs:
+        if attName == 'class' and attValue == 'invalid-tag':
+          raise RuntimeError('javadoc generated an invalid-tag')
+
     # NOTE: I don't think 'a' should be in here. But try debugging 
     # NumericRangeQuery.html. (Could be javadocs bug, it's a generic type...)
     if tag not in ('link', 'meta', 'frame', 'br', 'wbr', 'hr', 'p', 'li', 'img', 'col', 'a', 'dt', 'dd', 'input'):
@@ -108,7 +114,7 @@ def parse(baseURL, html):
   try:
     parser.feed(html)
     parser.close()
-  except:
+  except Exception:
     # TODO: Python's html.parser is now always lenient, which is no good for us: we want correct HTML in our javadocs
     parser.printFile()
     print('  WARNING: failed to parse %s:' % baseURL)
@@ -140,7 +146,7 @@ def checkAll(dirName):
   else:
     iter = os.walk(dirName)
 
-  for root, dirs, files in iter:
+  for root, _, files in iter:
     for f in files:
       main, ext = os.path.splitext(f)
       ext = ext.lower()
@@ -162,7 +168,7 @@ def checkAll(dirName):
   # ... then verify:
   print()
   print('Verify...')
-  for fullPath, (links, anchors) in allFiles.items():
+  for fullPath, (links, _) in allFiles.items():
     #print fullPath
     printed = False
     for link in links:


### PR DESCRIPTION
See background by @mkhludnev on the dev list: https://lists.apache.org/thread/pm1szr9og6qhmjzp371xwk0mvwxxkd1l

In some cases: "invalid reference" is generated, passes through Xdoclint and broken-link checkers, yet links are broken.

Instead of a 404, javadocs seems to emit this in the resulting HTML:

```xml
<details class="invalid-tag">
<summary>invalid reference</summary>
<pre>flexible query parser</pre>
</details
```

Fix `checkJavadocLinks.py` to fail the build on these.

Closes #14285

Note: I rewound to before the fix was committed to this issue and validated it fails build. Not great error but par for the course for this checker, and it does the job.
![Screen_Shot_2025-02-24_at_18 44 04](https://github.com/user-attachments/assets/47539cbc-8dd0-4f0b-9a24-6db1e0ca4ecd)
