### PR TITLE
Remove unused DocIdSet#all method

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -59,13 +59,11 @@ API Changes
 * GITHUB#14236: CombinedFieldQuery moved from lucene-sandbox to lucene-core.
   (Adrien Grand)
 
-<<<<<<< HEAD
-* GITHUB#14289: The unused public static DocIdSet#all method has been deprecated.
-  (Luca Cavanna)
-=======
 * GITHUB#14282: Remove redundant field argument from the DocIdSetBuilder constructor that takes a
   PointValues instance. (Luca Cavanna)
->>>>>>> main
+
+* GITHUB#14289: The unused public static DocIdSet#all method has been deprecated.
+  (Luca Cavanna)
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -14,6 +14,8 @@ API Changes
 * GITHUB#14160: Adjusts the default HNSW search behavior so that filter optimized search is enabled
   when 60% or less of vectors pass the pre-filter. (Ben Chaplin, Ben Trent)
 
+* GITHUB#14288: The unused public static DocIdSet#all method has been removed. (Luca Cavanna)
+
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -57,6 +57,9 @@ API Changes
 * GITHUB#14236: CombinedFieldQuery moved from lucene-sandbox to lucene-core.
   (Adrien Grand)
 
+* GITHUB#14289: The unused public static DocIdSet#all method has been deprecated.
+  (Luca Cavanna)
+
 New Features
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
@@ -48,26 +48,6 @@ public abstract class DocIdSet implements Accountable {
         }
       };
 
-  /** A {@code DocIdSet} that matches all doc ids up to a specified doc (exclusive). */
-  public static DocIdSet all(int maxDoc) {
-    return new DocIdSet() {
-      @Override
-      public DocIdSetIterator iterator() throws IOException {
-        return DocIdSetIterator.all(maxDoc);
-      }
-
-      @Override
-      public Bits bits() throws IOException {
-        return new Bits.MatchAllBits(maxDoc);
-      }
-
-      @Override
-      public long ramBytesUsed() {
-        return Integer.BYTES;
-      }
-    };
-  }
-
   /**
    * Provides a {@link DocIdSetIterator} to access the set. This implementation can return <code>
    * null</code> if there are no docs that match.


### PR DESCRIPTION
DocIdSet#all is no longer relevant since Query and Filter were merged. We can remove it.