### PR TITLE
Deprecated DocIdSet#all

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -19,6 +19,9 @@ API Changes
 * GITHUB#14236: CombinedFieldQuery moved from lucene-sandbox to lucene-core.
   (Adrien Grand)
 
+* GITHUB#xxxxx: The unused public static DocIdSet#all method has been deprecated.
+  (Luca Cavanna)
+
 New Features
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -19,7 +19,7 @@ API Changes
 * GITHUB#14236: CombinedFieldQuery moved from lucene-sandbox to lucene-core.
   (Adrien Grand)
 
-* GITHUB#xxxxx: The unused public static DocIdSet#all method has been deprecated.
+* GITHUB#14289: The unused public static DocIdSet#all method has been deprecated.
   (Luca Cavanna)
 
 New Features

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
@@ -48,7 +48,11 @@ public abstract class DocIdSet implements Accountable {
         }
       };
 
-  /** A {@code DocIdSet} that matches all doc ids up to a specified doc (exclusive). */
+  /**
+   * A {@code DocIdSet} that matches all doc ids up to a specified doc (exclusive).
+   * @deprecated no longer needed since Query and Filter were merged
+   */
+  @Deprecated
   public static DocIdSet all(int maxDoc) {
     return new DocIdSet() {
       @Override

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
@@ -50,6 +50,7 @@ public abstract class DocIdSet implements Accountable {
 
   /**
    * A {@code DocIdSet} that matches all doc ids up to a specified doc (exclusive).
+   *
    * @deprecated no longer needed since Query and Filter were merged
    */
   @Deprecated


### PR DESCRIPTION
DocIdSet#all is no longer needed since the merge of Query and Filter. It is unused. This commits deprecates it. It will be removed in the next major version.
