### PR TITLE
Remove bits method from DocIdSet

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -67,6 +67,8 @@ API Changes
 * GITHUB#14289: The unused public static DocIdSet#all method has been deprecated.
   (Luca Cavanna)
 
+* GITHUB#14292: The redundant DocIdSet#bits method has been deprecated. (Luca Cavanna)
+
 New Features
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -14,6 +14,8 @@ API Changes
 * GITHUB#14160: Adjusts the default HNSW search behavior so that filter optimized search is enabled
   when 60% or less of vectors pass the pre-filter. (Ben Chaplin, Ben Trent)
 
+* GITHUB#14290: Remove redundant bits method from DocIdSet. (Luca Cavanna)
+
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
@@ -18,7 +18,6 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.Bits;
 
 /**
  * A DocIdSet contains a set of doc ids. Implementing classes must only implement {@link #iterator}
@@ -33,13 +32,6 @@ public abstract class DocIdSet implements Accountable {
         @Override
         public DocIdSetIterator iterator() {
           return DocIdSetIterator.empty();
-        }
-
-        // we explicitly provide no random access, as this filter is 100% sparse and iterator exits
-        // faster
-        @Override
-        public Bits bits() {
-          return null;
         }
 
         @Override
@@ -57,11 +49,6 @@ public abstract class DocIdSet implements Accountable {
       }
 
       @Override
-      public Bits bits() throws IOException {
-        return new Bits.MatchAllBits(maxDoc);
-      }
-
-      @Override
       public long ramBytesUsed() {
         return Integer.BYTES;
       }
@@ -73,27 +60,4 @@ public abstract class DocIdSet implements Accountable {
    * null</code> if there are no docs that match.
    */
   public abstract DocIdSetIterator iterator() throws IOException;
-
-  // TODO: somehow this class should express the cost of
-  // iteration vs the cost of random access Bits; for
-  // expensive Filters (e.g. distance < 1 km) we should use
-  // bits() after all other Query/Filters have matched, but
-  // this is the opposite of what bits() is for now
-  // (down-low filtering using e.g. FixedBitSet)
-
-  /**
-   * Optionally provides a {@link Bits} interface for random access to matching documents.
-   *
-   * @return {@code null}, if this {@code DocIdSet} does not support random access. In contrast to
-   *     {@link #iterator()}, a return value of {@code null} <b>does not</b> imply that no documents
-   *     match the filter! The default implementation does not provide random access, so you only
-   *     need to implement this method if your DocIdSet can guarantee random access to every docid
-   *     in O(1) time without external disk access (as {@link Bits} interface cannot throw {@link
-   *     IOException}). This is generally true for bit sets like {@link
-   *     org.apache.lucene.util.FixedBitSet}, which return itself if they are used as {@code
-   *     DocIdSet}.
-   */
-  public Bits bits() throws IOException {
-    return null;
-  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.search;
 
-import java.io.IOException;
 import org.apache.lucene.util.Accountable;
 
 /**

--- a/lucene/core/src/java/org/apache/lucene/util/BitDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitDocIdSet.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.util;
 
+import java.io.IOException;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -57,7 +58,18 @@ public class BitDocIdSet extends DocIdSet {
     return new BitSetIterator(set, cost);
   }
 
-  @Override
+  /**
+   * Provides a {@link Bits} interface for random access to matching documents.
+   *
+   * @return {@code null}, if this {@code DocIdSet} does not support random access. In contrast to
+   *     {@link #iterator()}, a return value of {@code null} <b>does not</b> imply that no documents
+   *     match the filter! The default implementation does not provide random access, so you only
+   *     need to implement this method if your DocIdSet can guarantee random access to every docid
+   *     in O(1) time without external disk access (as {@link Bits} interface cannot throw {@link
+   *     IOException}). This is generally true for bit sets like {@link
+   *     org.apache.lucene.util.FixedBitSet}, which return itself if they are used as {@code
+   *     DocIdSet}.
+   */
   public BitSet bits() {
     return set;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/NotDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/NotDocIdSet.java
@@ -41,26 +41,6 @@ public final class NotDocIdSet extends DocIdSet {
   }
 
   @Override
-  public Bits bits() throws IOException {
-    final Bits inBits = in.bits();
-    if (inBits == null) {
-      return null;
-    }
-    return new Bits() {
-
-      @Override
-      public boolean get(int index) {
-        return !inBits.get(index);
-      }
-
-      @Override
-      public int length() {
-        return inBits.length();
-      }
-    };
-  }
-
-  @Override
   public long ramBytesUsed() {
     return BASE_RAM_BYTES_USED + in.ramBytesUsed();
   }

--- a/lucene/core/src/test/org/apache/lucene/util/TestFixedBitDocIdSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFixedBitDocIdSet.java
@@ -18,16 +18,38 @@ package org.apache.lucene.util;
 
 import java.io.IOException;
 import java.util.BitSet;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.tests.util.BaseDocIdSetTestCase;
 
 public class TestFixedBitDocIdSet extends BaseDocIdSetTestCase<BitDocIdSet> {
 
   @Override
-  public BitDocIdSet copyOf(BitSet bs, int length) throws IOException {
+  public BitDocIdSet copyOf(BitSet bs, int length) {
     final FixedBitSet set = new FixedBitSet(length);
     for (int doc = bs.nextSetBit(0); doc != -1; doc = bs.nextSetBit(doc + 1)) {
       set.set(doc);
     }
     return new BitDocIdSet(set);
+  }
+
+  @Override
+  public void assertEquals(int numBits, BitSet ds1, BitDocIdSet ds2) throws IOException {
+    super.assertEquals(numBits, ds1, ds2);
+    // bits()
+    final Bits bits = ds2.bits();
+    if (bits != null) {
+      // test consistency between bits and iterator
+      DocIdSetIterator it2 = ds2.iterator();
+      for (int previousDoc = -1, doc = it2.nextDoc(); ; previousDoc = doc, doc = it2.nextDoc()) {
+        final int max = doc == DocIdSetIterator.NO_MORE_DOCS ? bits.length() : doc;
+        for (int i = previousDoc + 1; i < max; ++i) {
+          assertFalse(bits.get(i));
+        }
+        if (doc == DocIdSetIterator.NO_MORE_DOCS) {
+          break;
+        }
+        assertTrue(bits.get(doc));
+      }
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestNotDocIdSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestNotDocIdSet.java
@@ -18,7 +18,6 @@ package org.apache.lucene.util;
 
 import java.io.IOException;
 import java.util.BitSet;
-import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.tests.util.BaseDocIdSetTestCase;
 
 public class TestNotDocIdSet extends BaseDocIdSetTestCase<NotDocIdSet> {
@@ -30,21 +29,5 @@ public class TestNotDocIdSet extends BaseDocIdSetTestCase<NotDocIdSet> {
       set.set(doc);
     }
     return new NotDocIdSet(length, new BitDocIdSet(set));
-  }
-
-  @Override
-  public void assertEquals(int numBits, BitSet ds1, NotDocIdSet ds2) throws IOException {
-    super.assertEquals(numBits, ds1, ds2);
-    final Bits bits2 = ds2.bits();
-    assertNotNull(bits2); // since we wrapped a FixedBitSet
-    assertEquals(numBits, bits2.length());
-    for (int i = 0; i < numBits; ++i) {
-      assertEquals(ds1.get(i), bits2.get(i));
-    }
-  }
-
-  public void testBits() throws IOException {
-    assertNull(new NotDocIdSet(3, DocIdSet.EMPTY).bits());
-    assertNotNull(new NotDocIdSet(3, new BitDocIdSet(new FixedBitSet(3))).bits());
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestSparseFixedBitDocIdSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSparseFixedBitDocIdSet.java
@@ -26,7 +26,7 @@ import org.apache.lucene.tests.util.BaseDocIdSetTestCase;
 public class TestSparseFixedBitDocIdSet extends BaseDocIdSetTestCase<BitDocIdSet> {
 
   @Override
-  public BitDocIdSet copyOf(BitSet bs, int length) throws IOException {
+  public BitDocIdSet copyOf(BitSet bs, int length) {
     final SparseFixedBitSet set = new SparseFixedBitSet(length);
     // SparseFixedBitSet can be sensitive to the order of insertion so
     // randomize insertion a bit

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/ContainsPrefixTreeQuery.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/ContainsPrefixTreeQuery.java
@@ -292,13 +292,6 @@ public class ContainsPrefixTreeQuery extends AbstractPrefixTreeQuery {
     }
 
     @Override
-    public Bits bits() throws IOException {
-      // if the # of docids is super small, return null since iteration is going
-      // to be faster
-      return size() > 4 ? this : null;
-    }
-
-    @Override
     public DocIdSetIterator iterator() {
       if (size() == 0) return null;
       // copy the unsorted values to a new array then sort them

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/BaseDocIdSetTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/BaseDocIdSetTestCase.java
@@ -23,7 +23,6 @@ import java.util.BitSet;
 import java.util.Random;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 
 /** Base test class for {@link DocIdSet}s. */
@@ -160,23 +159,6 @@ public abstract class BaseDocIdSetTestCase<T extends DocIdSet> extends LuceneTes
           assertEquals(doc, it2.advance(target));
           assertEquals(doc, it2.docID());
         }
-      }
-    }
-
-    // bits()
-    final Bits bits = ds2.bits();
-    if (bits != null) {
-      // test consistency between bits and iterator
-      it2 = ds2.iterator();
-      for (int previousDoc = -1, doc = it2.nextDoc(); ; previousDoc = doc, doc = it2.nextDoc()) {
-        final int max = doc == DocIdSetIterator.NO_MORE_DOCS ? bits.length() : doc;
-        for (int i = previousDoc + 1; i < max; ++i) {
-          assertEquals(false, bits.get(i));
-        }
-        if (doc == DocIdSetIterator.NO_MORE_DOCS) {
-          break;
-        }
-        assertEquals(true, bits.get(doc));
       }
     }
   }


### PR DESCRIPTION
The bits method is now redundant in the DocIdSet base class. This commit removes it, while leaving a single leftover usage in BitDocIdSet as a new method that is specific to that implementation.