### PR TITLE
Remove IOException from ScorerSupplier#setTopLevelScoringClause signature

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -20,6 +20,8 @@ API Changes
 
 * GITHUB#14290: Remove redundant bits method from DocIdSet. (Luca Cavanna)
 
+* GITHUB#14291: Remove IOException from ScorerSupplier#setTopLevelScoringClause signature (Luca Cavanna)
+
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)

--- a/lucene/core/src/java/org/apache/lucene/document/FeatureQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FeatureQuery.java
@@ -143,7 +143,7 @@ final class FeatureQuery extends Query {
           }
 
           @Override
-          public void setTopLevelScoringClause() throws IOException {
+          public void setTopLevelScoringClause() {
             topLevelScoringClause = true;
           }
         };

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
@@ -88,7 +88,7 @@ final class BooleanScorerSupplier extends ScorerSupplier {
   }
 
   @Override
-  public void setTopLevelScoringClause() throws IOException {
+  public void setTopLevelScoringClause() {
     topLevelScoringClause = true;
     if (subs.get(Occur.SHOULD).size() + subs.get(Occur.MUST).size() == 1) {
       // If there is a single scoring clause, propagate the call.

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
@@ -183,7 +183,7 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
           }
 
           @Override
-          public void setTopLevelScoringClause() throws IOException {
+          public void setTopLevelScoringClause() {
             if (tieBreakerMultiplier == 0) {
               for (ScorerSupplier ss : scorerSuppliers) {
                 // sub scorers need to be able to skip too as calls to setMinCompetitiveScore get

--- a/lucene/core/src/java/org/apache/lucene/search/ScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScorerSupplier.java
@@ -61,5 +61,5 @@ public abstract class ScorerSupplier {
    * and this boolean to know whether to prepare for reacting to {@link
    * Scorer#setMinCompetitiveScore(float)} calls.
    */
-  public void setTopLevelScoringClause() throws IOException {}
+  public void setTopLevelScoringClause() {}
 }

--- a/lucene/core/src/java/org/apache/lucene/search/TermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermQuery.java
@@ -176,7 +176,7 @@ public class TermQuery extends Query {
         }
 
         @Override
-        public void setTopLevelScoringClause() throws IOException {
+        public void setTopLevelScoringClause() {
           topLevelScoringClause = true;
         }
       };

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2ScorerSupplier.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2ScorerSupplier.java
@@ -121,7 +121,7 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     }
 
     @Override
-    public void setTopLevelScoringClause() throws IOException {
+    public void setTopLevelScoringClause() {
       topLevelScoringClause = true;
     }
   }
@@ -436,7 +436,7 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
         .get(20); // triggers assertions as a side-effect
   }
 
-  public void testDisjunctionTopLevelScoringClause() throws Exception {
+  public void testDisjunctionTopLevelScoringClause() {
     Map<Occur, Collection<ScorerSupplier>> subs = new EnumMap<>(Occur.class);
     for (Occur occur : Occur.values()) {
       subs.put(occur, new ArrayList<>());
@@ -453,7 +453,7 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     assertFalse(clause2.topLevelScoringClause);
   }
 
-  public void testConjunctionTopLevelScoringClause() throws Exception {
+  public void testConjunctionTopLevelScoringClause() {
     Map<Occur, Collection<ScorerSupplier>> subs = new EnumMap<>(Occur.class);
     for (Occur occur : Occur.values()) {
       subs.put(occur, new ArrayList<>());
@@ -470,7 +470,7 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     assertFalse(clause2.topLevelScoringClause);
   }
 
-  public void testFilterTopLevelScoringClause() throws Exception {
+  public void testFilterTopLevelScoringClause() {
     Map<Occur, Collection<ScorerSupplier>> subs = new EnumMap<>(Occur.class);
     for (Occur occur : Occur.values()) {
       subs.put(occur, new ArrayList<>());
@@ -487,7 +487,7 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     assertFalse(clause2.topLevelScoringClause);
   }
 
-  public void testSingleMustScoringClause() throws Exception {
+  public void testSingleMustScoringClause() {
     Map<Occur, Collection<ScorerSupplier>> subs = new EnumMap<>(Occur.class);
     for (Occur occur : Occur.values()) {
       subs.put(occur, new ArrayList<>());
@@ -504,7 +504,7 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     assertFalse(clause2.topLevelScoringClause);
   }
 
-  public void testSingleShouldScoringClause() throws Exception {
+  public void testSingleShouldScoringClause() {
     Map<Occur, Collection<ScorerSupplier>> subs = new EnumMap<>(Occur.class);
     for (Occur occur : Occur.values()) {
       subs.put(occur, new ArrayList<>());

--- a/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinQuery.java
@@ -180,7 +180,7 @@ public class ToParentBlockJoinQuery extends Query {
         }
 
         @Override
-        public void setTopLevelScoringClause() throws IOException {
+        public void setTopLevelScoringClause() {
           if (scoreMode == ScoreMode.Max) {
             childScorerSupplier.setTopLevelScoringClause();
           }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerWeight.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerWeight.java
@@ -97,7 +97,7 @@ class QueryProfilerWeight extends FilterWeight {
       }
 
       @Override
-      public void setTopLevelScoringClause() throws IOException {
+      public void setTopLevelScoringClause() {
         subQueryScorerSupplier.setTopLevelScoringClause();
       }
     };

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingWeight.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingWeight.java
@@ -106,7 +106,7 @@ class AssertingWeight extends FilterWeight {
       }
 
       @Override
-      public void setTopLevelScoringClause() throws IOException {
+      public void setTopLevelScoringClause() {
         assert getCalled == false;
         topLevelScoringClause = true;
         inScorerSupplier.setTopLevelScoringClause();


### PR DESCRIPTION
There should be no reason to throw IOException in any implementation of setTopLevelScoringClause . This commit removes IOException from its signature.
