### PR TITLE
Deprecate the redundant DocIdSet#bits method

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -25,6 +25,8 @@ API Changes
 * GITHUB#14289: The unused public static DocIdSet#all method has been deprecated.
   (Luca Cavanna)
 
+* GITHUB#14292: The redundant DocIdSet#bits method has been deprecated. (Luca Cavanna)
+
 New Features
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
@@ -97,7 +97,9 @@ public abstract class DocIdSet implements Accountable {
    *     IOException}). This is generally true for bit sets like {@link
    *     org.apache.lucene.util.FixedBitSet}, which return itself if they are used as {@code
    *     DocIdSet}.
+   * @deprecated this method is redundant and will be removed.
    */
+  @Deprecated
   public Bits bits() throws IOException {
     return null;
   }


### PR DESCRIPTION
`DocIdSet#bits` is removed by #14290 in main. This commit deprecates it in branch_10x.