### PR TITLE
Use DenseConjunctionBulkScorer for single queries sometimes.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -113,6 +113,10 @@ Optimizations
 * GITHUB#14080: Use the `DocIdSetIterator#loadIntoBitSet` API to speed up dense
   conjunctions. (Adrien Grand)
 
+* GITHUB#14293: Use the `DocIdSetIterator#loadIntoBitSet` API to speed up
+  intersection of dense queries with live docs and/or collectors' competitive
+  iterators. (Adrien Grand)
+
 * GITHUB#14133: Dense blocks of postings are now encoded as bit sets.
   (Adrien Grand)
 

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -31,6 +31,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.DocValuesRangeIterator;
 import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllScorerSupplier;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
@@ -125,8 +126,8 @@ final class SortedNumericDocValuesRangeQuery extends Query {
           if (skipper.docCount() == maxDoc
               && skipper.minValue() >= lowerValue
               && skipper.maxValue() <= upperValue) {
-            return ConstantScoreScorerSupplier.fromIterator(
-                DocIdSetIterator.all(maxDoc), score(), scoreMode, maxDoc);
+
+            return new MatchAllScorerSupplier(score(), scoreMode, maxDoc);
           }
         }
 

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -25,7 +25,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreScorerSupplier;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.DocValuesRangeIterator;
@@ -116,18 +116,17 @@ final class SortedNumericDocValuesRangeQuery extends Query {
           return null;
         }
 
+        int maxDoc = context.reader().maxDoc();
         DocValuesSkipper skipper = context.reader().getDocValuesSkipper(field);
         if (skipper != null) {
           if (skipper.minValue() > upperValue || skipper.maxValue() < lowerValue) {
             return null;
           }
-          if (skipper.docCount() == context.reader().maxDoc()
+          if (skipper.docCount() == maxDoc
               && skipper.minValue() >= lowerValue
               && skipper.maxValue() <= upperValue) {
-            final var scorer =
-                new ConstantScoreScorer(
-                    score(), scoreMode, DocIdSetIterator.all(skipper.docCount()));
-            return new DefaultScorerSupplier(scorer);
+            return ConstantScoreScorerSupplier.fromIterator(
+                DocIdSetIterator.all(maxDoc), score(), scoreMode, maxDoc);
           }
         }
 
@@ -139,8 +138,8 @@ final class SortedNumericDocValuesRangeQuery extends Query {
             final DocIdSetIterator psIterator =
                 getDocIdSetIteratorOrNullForPrimarySort(context.reader(), singleton, skipper);
             if (psIterator != null) {
-              return new DefaultScorerSupplier(
-                  new ConstantScoreScorer(score(), scoreMode, psIterator));
+              return ConstantScoreScorerSupplier.fromIterator(
+                  psIterator, score(), scoreMode, maxDoc);
             }
           }
           iterator =
@@ -182,8 +181,8 @@ final class SortedNumericDocValuesRangeQuery extends Query {
         if (skipper != null) {
           iterator = new DocValuesRangeIterator(iterator, skipper, lowerValue, upperValue, false);
         }
-        final var scorer = new ConstantScoreScorer(score(), scoreMode, iterator);
-        return new DefaultScorerSupplier(scorer);
+        return ConstantScoreScorerSupplier.fromIterator(
+            TwoPhaseIterator.asDocIdSetIterator(iterator), score(), scoreMode, maxDoc);
       }
     };
   }

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
@@ -335,7 +335,8 @@ final class BooleanScorerSupplier extends ScorerSupplier {
       if (filters.stream().map(Scorer::twoPhaseIterator).allMatch(Objects::isNull)
           && maxDoc >= DenseConjunctionBulkScorer.WINDOW_SIZE
           && cost >= maxDoc / DenseConjunctionBulkScorer.DENSITY_THRESHOLD_INVERSE) {
-        return new DenseConjunctionBulkScorer(filters.stream().map(Scorer::iterator).toList());
+        return new DenseConjunctionBulkScorer(
+            filters.stream().map(Scorer::iterator).toList(), maxDoc, 0f);
       }
 
       return new DefaultBulkScorer(new ConjunctionScorer(filters, Collections.emptyList()));
@@ -397,7 +398,7 @@ final class BooleanScorerSupplier extends ScorerSupplier {
           && maxDoc >= DenseConjunctionBulkScorer.WINDOW_SIZE
           && leadCost >= maxDoc / DenseConjunctionBulkScorer.DENSITY_THRESHOLD_INVERSE) {
         return new DenseConjunctionBulkScorer(
-            requiredNoScoring.stream().map(Scorer::iterator).toList());
+            requiredNoScoring.stream().map(Scorer::iterator).toList(), maxDoc, 0f);
       } else {
         return new ConjunctionBulkScorer(requiredScoring, requiredNoScoring);
       }

--- a/lucene/core/src/java/org/apache/lucene/search/ConstantScoreScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ConstantScoreScorerSupplier.java
@@ -20,9 +20,14 @@ import java.io.IOException;
 import java.util.Collections;
 import org.apache.lucene.search.Weight.DefaultBulkScorer;
 
-/** Specialization of {@link ScorerSupplier} for queries that produce constant scores. */
+/**
+ * Specialization of {@link ScorerSupplier} for queries that produce constant scores.
+ *
+ * @lucene.internal
+ */
 public abstract class ConstantScoreScorerSupplier extends ScorerSupplier {
 
+  /** Create a {@link ConstantScoreScorerSupplier} for the given iterator. */
   public static ConstantScoreScorerSupplier fromIterator(
       DocIdSetIterator iterator, float score, ScoreMode scoreMode, int maxDoc) {
     return new ConstantScoreScorerSupplier(score, scoreMode, maxDoc) {

--- a/lucene/core/src/java/org/apache/lucene/search/ConstantScoreScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ConstantScoreScorerSupplier.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.Collections;
+import org.apache.lucene.search.Weight.DefaultBulkScorer;
+
+/** Specialization of {@link ScorerSupplier} for queries that produce constant scores. */
+public abstract class ConstantScoreScorerSupplier extends ScorerSupplier {
+
+  public static ConstantScoreScorerSupplier fromIterator(
+      DocIdSetIterator iterator, float score, ScoreMode scoreMode, int maxDoc) {
+    return new ConstantScoreScorerSupplier(score, scoreMode, maxDoc) {
+
+      @Override
+      public long cost() {
+        return iterator.cost();
+      }
+
+      @Override
+      public DocIdSetIterator iterator(long leadCost) throws IOException {
+        return iterator;
+      }
+    };
+  }
+
+  private final ScoreMode scoreMode;
+  private final float score;
+  private final int maxDoc;
+
+  /** Constructor, invoked by sub-classes. */
+  protected ConstantScoreScorerSupplier(float score, ScoreMode scoreMode, int maxDoc) {
+    this.scoreMode = scoreMode;
+    this.score = score;
+    this.maxDoc = maxDoc;
+  }
+
+  /** Return an iterator given the cost of the leading clause. */
+  public abstract DocIdSetIterator iterator(long leadCost) throws IOException;
+
+  @Override
+  public final Scorer get(long leadCost) throws IOException {
+    DocIdSetIterator iterator = iterator(leadCost);
+    TwoPhaseIterator twoPhase = TwoPhaseIterator.unwrap(iterator);
+    if (twoPhase == null) {
+      return new ConstantScoreScorer(score, scoreMode, iterator);
+    } else {
+      return new ConstantScoreScorer(score, scoreMode, twoPhase);
+    }
+  }
+
+  @Override
+  public final BulkScorer bulkScorer() throws IOException {
+    DocIdSetIterator iterator = iterator(Long.MAX_VALUE);
+    if (maxDoc >= DenseConjunctionBulkScorer.WINDOW_SIZE / 2
+        && iterator.cost() >= maxDoc / DenseConjunctionBulkScorer.DENSITY_THRESHOLD_INVERSE
+        && TwoPhaseIterator.unwrap(iterator) == null) {
+      return new DenseConjunctionBulkScorer(Collections.singletonList(iterator), maxDoc, score);
+    } else {
+      return new DefaultBulkScorer(new ConstantScoreScorer(score, scoreMode, iterator));
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/DenseConjunctionBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DenseConjunctionBulkScorer.java
@@ -27,6 +27,8 @@ import org.apache.lucene.util.FixedBitSet;
  * BulkScorer implementation of {@link ConjunctionScorer} that is specialized for dense clauses.
  * Whenever sensible, it intersects clauses by loading their matches into a bit set and computing
  * the intersection of clauses by and-ing these bit sets.
+ *
+ * <p>An empty set of iterators is interpreted as meaning that all docs in [0, maxDoc) match.
  */
 final class DenseConjunctionBulkScorer extends BulkScorer {
 
@@ -38,56 +40,73 @@ final class DenseConjunctionBulkScorer extends BulkScorer {
   // we're erring on the conservative side.
   static final int DENSITY_THRESHOLD_INVERSE = Long.SIZE / 2;
 
-  private final DocIdSetIterator lead;
-  private final List<DocIdSetIterator> others;
+  private final int maxDoc;
+  private final List<DocIdSetIterator> iterators;
+  private final SimpleScorable scorable;
 
   private final FixedBitSet windowMatches = new FixedBitSet(WINDOW_SIZE);
   private final FixedBitSet clauseWindowMatches = new FixedBitSet(WINDOW_SIZE);
   private final DocIdStreamView docIdStreamView = new DocIdStreamView();
+  private final RangeDocIdStream rangeDocIdStream = new RangeDocIdStream();
+  private final SingleIteratorDocIdStream singleIteratorDocIdStream =
+      new SingleIteratorDocIdStream();
 
-  DenseConjunctionBulkScorer(List<DocIdSetIterator> iterators) {
-    if (iterators.size() <= 1) {
-      throw new IllegalArgumentException("Expected 2 or more clauses, got " + iterators.size());
-    }
+  DenseConjunctionBulkScorer(List<DocIdSetIterator> iterators, int maxDoc, float constantScore) {
+    this.maxDoc = maxDoc;
     iterators = new ArrayList<>(iterators);
     iterators.sort(Comparator.comparingLong(DocIdSetIterator::cost));
-    lead = iterators.get(0);
-    others = List.copyOf(iterators.subList(1, iterators.size()));
+    this.iterators = iterators;
+    this.scorable = new SimpleScorable();
+    scorable.score = constantScore;
   }
 
   @Override
   public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
-    for (DocIdSetIterator it : others) {
+    collector.setScorer(scorable);
+    List<DocIdSetIterator> iterators = this.iterators;
+    if (collector.competitiveIterator() != null) {
+      iterators = new ArrayList<>(iterators);
+      iterators.add(collector.competitiveIterator());
+    }
+
+    for (DocIdSetIterator it : iterators) {
       min = Math.max(min, it.docID());
     }
 
-    if (lead.docID() < min) {
-      lead.advance(min);
+    max = Math.min(max, maxDoc);
+
+    DocIdSetIterator lead = null;
+    if (iterators.isEmpty() == false) {
+      lead = iterators.get(0);
+      if (lead.docID() < min) {
+        min = lead.advance(min);
+      }
     }
 
-    if (lead.docID() >= max) {
-      return lead.docID();
+    if (min >= max) {
+      return min >= maxDoc ? DocIdSetIterator.NO_MORE_DOCS : min;
     }
 
-    // This scorer is only used for conjunctions of FILTER clauses, so we set a simple scorer that
-    // always returns a score of zero.
-    collector.setScorer(new SimpleScorable());
-    List<DocIdSetIterator> otherIterators = this.others;
-    DocIdSetIterator collectorIterator = collector.competitiveIterator();
-    if (collectorIterator != null) {
-      otherIterators = new ArrayList<>(otherIterators);
-      otherIterators.add(collectorIterator);
-    }
-
-    final DocIdSetIterator[] others = otherIterators.toArray(DocIdSetIterator[]::new);
-
-    int windowMax;
+    int windowMax = min;
     do {
-      windowMax = (int) Math.min(max, (long) lead.docID() + WINDOW_SIZE);
-      scoreWindowUsingBitSet(collector, acceptDocs, others, windowMax);
+      if (scorable.minCompetitiveScore > scorable.score) {
+        return DocIdSetIterator.NO_MORE_DOCS;
+      }
+
+      int windowBase = lead == null ? windowMax : lead.docID();
+      windowMax = (int) Math.min(max, (long) windowBase + WINDOW_SIZE);
+      if (windowMax > windowBase) {
+        scoreWindowUsingBitSet(collector, acceptDocs, iterators, windowBase, windowMax);
+      }
     } while (windowMax < max);
 
-    return lead.docID();
+    if (lead != null) {
+      return lead.docID();
+    } else if (windowMax >= maxDoc) {
+      return DocIdSetIterator.NO_MORE_DOCS;
+    } else {
+      return windowMax;
+    }
   }
 
   private static int advance(FixedBitSet set, int i) {
@@ -99,33 +118,58 @@ final class DenseConjunctionBulkScorer extends BulkScorer {
   }
 
   private void scoreWindowUsingBitSet(
-      LeafCollector collector, Bits acceptDocs, DocIdSetIterator[] others, int max)
+      LeafCollector collector,
+      Bits acceptDocs,
+      List<DocIdSetIterator> iterators,
+      int windowBase,
+      int windowMax)
       throws IOException {
+    assert windowMax > windowBase;
     assert windowMatches.scanIsEmpty();
     assert clauseWindowMatches.scanIsEmpty();
 
-    int offset = lead.docID();
-    lead.intoBitSet(max, windowMatches, offset);
-    if (acceptDocs != null) {
-      // Apply live docs.
-      acceptDocs.applyMask(windowMatches, offset);
+    if (acceptDocs == null) {
+      if (iterators.isEmpty()) {
+        // All docs in the range match.
+        rangeDocIdStream.from = windowBase;
+        rangeDocIdStream.to = windowMax;
+        collector.collect(rangeDocIdStream);
+        return;
+      } else if (iterators.size() == 1) {
+        singleIteratorDocIdStream.iterator = iterators.get(0);
+        singleIteratorDocIdStream.from = windowBase;
+        singleIteratorDocIdStream.to = windowMax;
+        collector.collect(singleIteratorDocIdStream);
+        return;
+      }
     }
 
-    int upTo = 0;
-    for (;
-        upTo < others.length
-            && windowMatches.cardinality() >= WINDOW_SIZE / DENSITY_THRESHOLD_INVERSE;
-        upTo++) {
-      DocIdSetIterator other = others[upTo];
-      if (other.docID() < offset) {
-        other.advance(offset);
+    if (iterators.isEmpty()) {
+      windowMatches.set(0, windowMax - windowBase);
+    } else {
+      DocIdSetIterator lead = iterators.get(0);
+      lead.intoBitSet(windowMax, windowMatches, windowBase);
+    }
+
+    if (acceptDocs != null) {
+      // Apply live docs.
+      acceptDocs.applyMask(windowMatches, windowBase);
+    }
+
+    int windowSize = windowMax - windowBase;
+    int threshold = windowSize / DENSITY_THRESHOLD_INVERSE;
+    int upTo = 1; // the leading clause at index 0 is already applied
+    for (; upTo < iterators.size() && windowMatches.cardinality() >= threshold; upTo++) {
+      DocIdSetIterator other = iterators.get(upTo);
+      if (other.docID() < windowBase) {
+        other.advance(windowBase);
       }
-      other.intoBitSet(max, clauseWindowMatches, offset);
+      other.intoBitSet(windowMax, clauseWindowMatches, windowBase);
       windowMatches.and(clauseWindowMatches);
       clauseWindowMatches.clear();
     }
 
-    if (upTo < others.length) {
+    if (upTo < iterators.size()) {
       // If the leading clause is sparse on this doc ID range or if the intersection became sparse
       // after applying a few clauses, we finish evaluating the intersection using the traditional
       // leap-frog approach. This proved important with a query such as "+secretary +of +state" on
@@ -134,15 +178,15 @@ final class DenseConjunctionBulkScorer extends BulkScorer {
       advanceHead:
       for (int windowMatch = windowMatches.nextSetBit(0);
           windowMatch != DocIdSetIterator.NO_MORE_DOCS; ) {
-        int doc = offset + windowMatch;
-        for (int i = upTo; i < others.length; ++i) {
-          DocIdSetIterator other = others[i];
+        int doc = windowBase + windowMatch;
+        for (int i = upTo; i < iterators.size(); ++i) {
+          DocIdSetIterator other = iterators.get(i);
           int otherDoc = other.docID();
           if (otherDoc < doc) {
             otherDoc = other.advance(doc);
           }
           if (doc != otherDoc) {
-            int clearUpTo = Math.min(WINDOW_SIZE, otherDoc - offset);
+            int clearUpTo = Math.min(WINDOW_SIZE, otherDoc - windowBase);
             windowMatches.clear(windowMatch, clearUpTo);
             windowMatch = advance(windowMatches, clearUpTo);
             continue advanceHead;
@@ -152,39 +196,46 @@ final class DenseConjunctionBulkScorer extends BulkScorer {
       }
     }
 
-    docIdStreamView.offset = offset;
+    docIdStreamView.windowBase = windowBase;
     collector.collect(docIdStreamView);
     windowMatches.clear();
 
-    // If another clause is more advanced than lead1 then advance lead1, it's important to take
-    // advantage of large gaps in the postings lists of other clauses.
-    int maxOtherDocID = -1;
-    for (DocIdSetIterator other : others) {
-      maxOtherDocID = Math.max(maxOtherDocID, other.docID());
-    }
-    if (lead.docID() < maxOtherDocID) {
-      lead.advance(maxOtherDocID);
+    // If another clause is more advanced than the leading clause then advance the leading clause,
+    // it's important to take advantage of large gaps in the postings lists of other clauses.
+    if (iterators.size() >= 2) {
+      DocIdSetIterator lead = iterators.get(0);
+      int maxOtherDocID = -1;
+      for (int i = 1; i < iterators.size(); ++i) {
+        maxOtherDocID = Math.max(maxOtherDocID, iterators.get(i).docID());
+      }
+      if (lead.docID() < maxOtherDocID) {
+        lead.advance(maxOtherDocID);
+      }
     }
   }
 
   @Override
   public long cost() {
-    return lead.cost();
+    if (iterators.isEmpty()) {
+      return maxDoc;
+    } else {
+      return iterators.get(0).cost();
+    }
   }
 
   final class DocIdStreamView extends DocIdStream {
 
-    int offset;
+    int windowBase;
 
     @Override
     public void forEach(CheckedIntConsumer<IOException> consumer) throws IOException {
-      int offset = this.offset;
+      int windowBase = this.windowBase;
       long[] bitArray = windowMatches.getBits();
       for (int idx = 0; idx < bitArray.length; idx++) {
         long bits = bitArray[idx];
         while (bits != 0L) {
           int ntz = Long.numberOfTrailingZeros(bits);
-          consumer.accept(offset + ((idx << 6) | ntz));
+          consumer.accept(windowBase + ((idx << 6) | ntz));
           bits ^= 1L << ntz;
         }
       }
@@ -193,6 +244,53 @@ final class DenseConjunctionBulkScorer extends BulkScorer {
     @Override
     public int count() throws IOException {
       return windowMatches.cardinality();
+    }
+  }
+
+  final class RangeDocIdStream extends DocIdStream {
+
+    int from, to;
+
+    @Override
+    public void forEach(CheckedIntConsumer<IOException> consumer) throws IOException {
+      for (int i = from; i < to; ++i) {
+        consumer.accept(i);
+      }
+    }
+
+    @Override
+    public int count() throws IOException {
+      return to - from;
+    }
+  }
+
+  /** {@link DocIdStream} for a {@link DocIdSetIterator} with no live docs to apply. */
+  final class SingleIteratorDocIdStream extends DocIdStream {
+
+    int from, to;
+    DocIdSetIterator iterator;
+
+    @Override
+    public void forEach(CheckedIntConsumer<IOException> consumer) throws IOException {
+      // If there are no live docs to apply, loading matching docs into a bit set and then iterating
+      // bits is unlikely to beat iterating the iterator directly.
+      if (iterator.docID() < from) {
+        iterator.advance(from);
+      }
+      for (int doc = iterator.docID(); doc < to; doc = iterator.nextDoc()) {
+        consumer.accept(doc);
+      }
+    }
+
+    @Override
+    public int count() throws IOException {
+      // If the collector is just interested in the count, loading in a bit set and counting bits is
+      // often faster than incrementing a counter on every call to nextDoc().
+      assert windowMatches.scanIsEmpty();
+      iterator.intoBitSet(to, clauseWindowMatches, from);
+      int count = clauseWindowMatches.cardinality();
+      clauseWindowMatches.clear();
+      return count;
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/MatchAllDocsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MatchAllDocsQuery.java
@@ -18,7 +18,6 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.util.Bits;
 
 /** A query that matches all documents. */
 public final class MatchAllDocsQuery extends Query {
@@ -33,49 +32,11 @@ public final class MatchAllDocsQuery extends Query {
 
       @Override
       public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
-        return new ScorerSupplier() {
-
-          @Override
-          public Scorer get(long leadCost) throws IOException {
-            return new ConstantScoreScorer(
-                score(), scoreMode, DocIdSetIterator.all(context.reader().maxDoc()));
-          }
-
-          @Override
-          public BulkScorer bulkScorer() throws IOException {
-            if (scoreMode.isExhaustive() == false) {
-              return super.bulkScorer();
-            }
-            final float score = score();
-            final int maxDoc = context.reader().maxDoc();
-            return new BulkScorer() {
-              @Override
-              public int score(LeafCollector collector, Bits acceptDocs, int min, int max)
-                  throws IOException {
-                max = Math.min(max, maxDoc);
-                Score scorer = new Score();
-                scorer.score = score;
-                collector.setScorer(scorer);
-                for (int doc = min; doc < max; ++doc) {
-                  if (acceptDocs == null || acceptDocs.get(doc)) {
-                    collector.collect(doc);
-                  }
-                }
-                return max == maxDoc ? DocIdSetIterator.NO_MORE_DOCS : max;
-              }
-
-              @Override
-              public long cost() {
-                return maxDoc;
-              }
-            };
-          }
-
-          @Override
-          public long cost() {
-            return context.reader().maxDoc();
-          }
-        };
+        return ConstantScoreScorerSupplier.fromIterator(
+            DocIdSetIterator.all(context.reader().maxDoc()),
+            score(),
+            scoreMode,
+            context.reader().maxDoc());
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/search/MatchAllDocsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MatchAllDocsQuery.java
@@ -32,11 +32,7 @@ public final class MatchAllDocsQuery extends Query {
 
       @Override
       public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
-        return ConstantScoreScorerSupplier.fromIterator(
-            DocIdSetIterator.all(context.reader().maxDoc()),
-            score(),
-            scoreMode,
-            context.reader().maxDoc());
+        return new MatchAllScorerSupplier(score(), scoreMode, context.reader().maxDoc());
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/search/MatchAllScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MatchAllScorerSupplier.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * {@link ScorerSupplier} that matches all docs.
+ *
+ * @lucene.internal
+ */
+public final class MatchAllScorerSupplier extends ScorerSupplier {
+
+  private final float score;
+  private final ScoreMode scoreMode;
+  private final int maxDoc;
+
+  /** Sole constructor */
+  public MatchAllScorerSupplier(float score, ScoreMode scoreMode, int maxDoc) {
+    this.score = score;
+    this.scoreMode = scoreMode;
+    this.maxDoc = maxDoc;
+  }
+
+  @Override
+  public Scorer get(long leadCost) throws IOException {
+    return new ConstantScoreScorer(score, scoreMode, DocIdSetIterator.all(maxDoc));
+  }
+
+  @Override
+  public BulkScorer bulkScorer() throws IOException {
+    if (maxDoc >= DenseConjunctionBulkScorer.WINDOW_SIZE / 2) {
+      return new DenseConjunctionBulkScorer(Collections.emptyList(), maxDoc, score);
+    } else {
+      return super.bulkScorer();
+    }
+  }
+
+  @Override
+  public long cost() {
+    return maxDoc;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -341,17 +341,7 @@ public abstract class PointRangeQuery extends Query {
 
         if (allDocsMatch) {
           // all docs have a value and all points are within bounds, so everything matches
-          return new ConstantScoreScorerSupplier(score(), scoreMode, reader.maxDoc()) {
-            @Override
-            public DocIdSetIterator iterator(long leadCost) {
-              return DocIdSetIterator.all(reader.maxDoc());
-            }
-
-            @Override
-            public long cost() {
-              return reader.maxDoc();
-            }
-          };
+          return new MatchAllScorerSupplier(score(), scoreMode, reader.maxDoc());
         } else {
           return new ConstantScoreScorerSupplier(score(), scoreMode, reader.maxDoc()) {
 

--- a/lucene/core/src/java/org/apache/lucene/search/TermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermQuery.java
@@ -166,6 +166,17 @@ public class TermQuery extends Query {
         }
 
         @Override
+        public BulkScorer bulkScorer() throws IOException {
+          if (scoreMode.needsScores() == false) {
+            DocIdSetIterator iterator = get(Long.MAX_VALUE).iterator();
+            int maxDoc = context.reader().maxDoc();
+            return ConstantScoreScorerSupplier.fromIterator(iterator, 0f, scoreMode, maxDoc)
+                .bulkScorer();
+          }
+          return super.bulkScorer();
+        }
+
+        @Override
         public long cost() {
           try {
             TermsEnum te = getTermsEnum();

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.FixedBitSet;
 
 /**
  * Abstract numeric comparator for comparing numeric values. This comparator provides a skipping
@@ -411,6 +412,17 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
         @Override
         public int advance(int target) throws IOException {
           return docID = competitiveIterator.advance(target);
+        }
+
+        @Override
+        public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+          // The competitive iterator is usually a BitSetIterator, which has an optimized
+          // implementation of #intoBitSet.
+          if (competitiveIterator.docID() < docID) {
+            competitiveIterator.advance(docID);
+          }
+          competitiveIterator.intoBitSet(upTo, bitSet, offset);
+          docID = competitiveIterator.docID();
         }
       };
     }

--- a/lucene/core/src/test/org/apache/lucene/search/ReadAheadMatchAllDocsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/ReadAheadMatchAllDocsQuery.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.tests.search;
+
+import java.io.IOException;
+import java.util.Collections;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
+
+/**
+ * Query that matches all docs by returning a DenseConjunctionBulkScorer over a single clause. This
+ * helps make sure that the competitive iterators produced by TopFieldCollector are compatible with
+ * the read-ahead of this bulk scorer.
+ */
+public final class ReadAheadMatchAllDocsQuery extends Query {
+
+  /** Sole constructor */
+  public ReadAheadMatchAllDocsQuery() {}
+
+  @Override
+  public String toString(String field) {
+    return "ReadAheadMatchAllDocsQuery";
+  }
+
+  @Override
+  public void visit(QueryVisitor visitor) {
+    // no-op
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return sameClassAs(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    return classHash();
+  }
+
+  @Override
+  public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
+      throws IOException {
+    return new ConstantScoreWeight(this, boost) {
+
+      @Override
+      public boolean isCacheable(LeafReaderContext ctx) {
+        return true;
+      }
+
+      @Override
+      public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+        // Don't use ConstantScoreScoreSupplier, which only uses DenseConjunctionBulkScorer on
+        // larg-ish segments.
+        return new ScorerSupplier() {
+
+          @Override
+          public Scorer get(long leadCost) throws IOException {
+            return new ConstantScoreScorer(
+                score(), scoreMode, DocIdSetIterator.all(context.reader().maxDoc()));
+          }
+
+          @Override
+          public BulkScorer bulkScorer() throws IOException {
+            return new DenseConjunctionBulkScorer(
+                Collections.singletonList(DocIdSetIterator.all(context.reader().maxDoc())),
+                context.reader().maxDoc(),
+                score());
+          }
+
+          @Override
+          public long cost() {
+            return context.reader().maxDoc();
+          }
+        };
+      }
+    };
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/ReadAheadMatchAllDocsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/ReadAheadMatchAllDocsQuery.java
@@ -14,22 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.lucene.tests.search;
+package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Collections;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.BulkScorer;
-import org.apache.lucene.search.ConstantScoreScorer;
-import org.apache.lucene.search.ConstantScoreWeight;
-import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryVisitor;
-import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.ScorerSupplier;
-import org.apache.lucene.search.Weight;
 
 /**
  * Query that matches all docs by returning a DenseConjunctionBulkScorer over a single clause. This

--- a/lucene/core/src/test/org/apache/lucene/search/ReadAheadMatchAllDocsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/ReadAheadMatchAllDocsQuery.java
@@ -18,6 +18,8 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 import org.apache.lucene.index.LeafReaderContext;
 
 /**
@@ -27,8 +29,12 @@ import org.apache.lucene.index.LeafReaderContext;
  */
 public final class ReadAheadMatchAllDocsQuery extends Query {
 
+  private final Random random;
+
   /** Sole constructor */
-  public ReadAheadMatchAllDocsQuery() {}
+  public ReadAheadMatchAllDocsQuery(Random random) {
+    this.random = new Random(random.nextLong());
+  }
 
   @Override
   public String toString(String field) {
@@ -74,10 +80,14 @@ public final class ReadAheadMatchAllDocsQuery extends Query {
 
           @Override
           public BulkScorer bulkScorer() throws IOException {
-            return new DenseConjunctionBulkScorer(
-                Collections.singletonList(DocIdSetIterator.all(context.reader().maxDoc())),
-                context.reader().maxDoc(),
-                score());
+            List<DocIdSetIterator> clauses;
+            if (random.nextBoolean()) {
+              clauses = Collections.emptyList();
+            } else {
+              clauses = Collections.singletonList(DocIdSetIterator.all(context.reader().maxDoc()));
+            }
+
+            return new DenseConjunctionBulkScorer(clauses, context.reader().maxDoc(), score());
           }
 
           @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreQuery.java
@@ -17,8 +17,6 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.DirectoryReader;
@@ -30,7 +28,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.QueryUtils;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.apache.lucene.util.IOUtils;
 
 /**
  * This class only tests some basic functionality in CSQ, the main parts are mostly tested by
@@ -52,116 +49,6 @@ public class TestConstantScoreQuery extends LuceneTestCase {
     QueryUtils.checkUnequal(q2, q3);
     QueryUtils.checkUnequal(q1, q3);
     QueryUtils.checkUnequal(q1, new TermQuery(new Term("a", "b")));
-  }
-
-  private void checkHits(
-      IndexSearcher searcher,
-      Query q,
-      final float expectedScore,
-      final Class<? extends Scorable> innerScorerClass)
-      throws IOException {
-    final AtomicInteger count = new AtomicInteger();
-    searcher.search(
-        q,
-        new CollectorManager<SimpleCollector, Void>() {
-          @Override
-          public SimpleCollector newCollector() {
-            return new SimpleCollector() {
-              private Scorable scorer;
-
-              @Override
-              public void setScorer(Scorable scorer) {
-                this.scorer = scorer;
-                if (innerScorerClass != null) {
-                  Scorable innerScorer = rootScorer(scorer);
-                  assertEquals(
-                      "inner Scorer is implemented by wrong class",
-                      innerScorerClass,
-                      innerScorer.getClass());
-                }
-              }
-
-              @Override
-              public void collect(int doc) throws IOException {
-                assertEquals("Score differs from expected", expectedScore, this.scorer.score(), 0);
-                count.incrementAndGet();
-              }
-
-              @Override
-              public ScoreMode scoreMode() {
-                return ScoreMode.COMPLETE;
-              }
-            };
-          }
-
-          @Override
-          public Void reduce(Collection<SimpleCollector> collectors) {
-            return null;
-          }
-        });
-    assertEquals("invalid number of results", 1, count.get());
-  }
-
-  private Scorable rootScorer(Scorable s) {
-    while (true) {
-      try {
-        Collection<Scorable.ChildScorable> children = s.getChildren();
-        if (children.size() == 0) return s;
-        s = children.stream().findFirst().get().child();
-      } catch (
-          @SuppressWarnings("unused")
-          Exception e) {
-        // If FakeScorer returns UnsupportedOperationException
-        // We catch Exception here to deal with the (impossible) IOException too
-        return s;
-      }
-    }
-  }
-
-  public void testWrapped2Times() throws Exception {
-    Directory directory = null;
-    IndexReader reader = null;
-    IndexSearcher searcher = null;
-    try {
-      directory = newDirectory();
-      RandomIndexWriter writer = new RandomIndexWriter(random(), directory);
-
-      Document doc = new Document();
-      doc.add(newStringField("field", "term1", Field.Store.NO));
-      doc.add(newStringField("field", "term2", Field.Store.NO));
-      writer.addDocument(doc);
-
-      reader = writer.getReader();
-      writer.close();
-      // we don't wrap with AssertingIndexSearcher in order to have the original scorer in
-      // setScorer.
-      searcher = newSearcher(reader, true, false);
-      searcher.setQueryCache(null); // to assert on scorer impl
-
-      final BoostQuery csq1 =
-          new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("field", "term1"))), 2f);
-      final BoostQuery csq2 =
-          new BoostQuery(
-              new ConstantScoreQuery(
-                  new ConstantScoreQuery(new TermQuery(new Term("field", "term2")))),
-              5f);
-
-      final BooleanQuery.Builder bq = new BooleanQuery.Builder();
-      bq.add(csq1, BooleanClause.Occur.SHOULD);
-      bq.add(csq2, BooleanClause.Occur.SHOULD);
-
-      final BoostQuery csqbq = new BoostQuery(new ConstantScoreQuery(bq.build()), 17f);
-
-      checkHits(searcher, csq1, csq1.getBoost(), TermScorer.class);
-      checkHits(searcher, csq2, csq2.getBoost(), TermScorer.class);
-
-      // for the combined BQ, the scorer should always be BooleanScorer's BucketScorer, because our
-      // scorer supports out-of order collection!
-      final Class<Score> bucketScorerClass = Score.class;
-      checkHits(searcher, csqbq, csqbq.getBoost(), bucketScorerClass);
-    } finally {
-      IOUtils.close(reader, directory);
-    }
   }
 
   // a query for which other queries don't have special rewrite rules

--- a/lucene/core/src/test/org/apache/lucene/search/TestDenseConjunctionBulkScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDenseConjunctionBulkScorer.java
@@ -18,6 +18,8 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
+import org.apache.lucene.tests.search.AssertingBulkScorer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.FixedBitSet;
@@ -34,12 +36,16 @@ public class TestDenseConjunctionBulkScorer extends LuceneTestCase {
       clause2.set(i);
       clause3.set(i);
     }
-    DenseConjunctionBulkScorer scorer =
+    BulkScorer scorer =
         new DenseConjunctionBulkScorer(
             Arrays.asList(
                 new BitSetIterator(clause1, clause1.approximateCardinality()),
                 new BitSetIterator(clause2, clause2.approximateCardinality()),
-                new BitSetIterator(clause3, clause3.approximateCardinality())));
+                new BitSetIterator(clause3, clause3.approximateCardinality())),
+            maxDoc,
+            0f);
+    // AssertingBulkScorer randomly splits the scored range into smaller ranges
+    scorer = AssertingBulkScorer.wrap(random(), scorer, maxDoc);
     FixedBitSet result = new FixedBitSet(maxDoc);
     scorer.score(
         new LeafCollector() {
@@ -56,6 +62,19 @@ public class TestDenseConjunctionBulkScorer extends LuceneTestCase {
         DocIdSetIterator.NO_MORE_DOCS);
 
     assertEquals(clause1, result);
+
+    // Now exercise DocIdStream.count()
+    scorer =
+        new DenseConjunctionBulkScorer(
+            Arrays.asList(
+                new BitSetIterator(clause1, clause1.approximateCardinality()),
+                new BitSetIterator(clause2, clause2.approximateCardinality()),
+                new BitSetIterator(clause3, clause3.approximateCardinality())),
+            maxDoc,
+            0f);
+    CountingLeafCollector collector = new CountingLeafCollector();
+    scorer.score(collector, null, 0, DocIdSetIterator.NO_MORE_DOCS);
+    assertEquals(clause1.cardinality(), collector.count);
   }
 
   public void testApplyAcceptDocs() throws IOException {
@@ -68,11 +87,15 @@ public class TestDenseConjunctionBulkScorer extends LuceneTestCase {
     for (int i = 0; i < maxDoc; i += 2) {
       acceptDocs.set(i);
     }
-    DenseConjunctionBulkScorer scorer =
+    BulkScorer scorer =
         new DenseConjunctionBulkScorer(
             Arrays.asList(
                 new BitSetIterator(clause1, clause1.approximateCardinality()),
-                new BitSetIterator(clause2, clause2.approximateCardinality())));
+                new BitSetIterator(clause2, clause2.approximateCardinality())),
+            maxDoc,
+            0f);
+    // AssertingBulkScorer randomly splits the scored range into smaller ranges
+    scorer = AssertingBulkScorer.wrap(random(), scorer, maxDoc);
     FixedBitSet result = new FixedBitSet(maxDoc);
     scorer.score(
         new LeafCollector() {
@@ -89,6 +112,18 @@ public class TestDenseConjunctionBulkScorer extends LuceneTestCase {
         DocIdSetIterator.NO_MORE_DOCS);
 
     assertEquals(acceptDocs, result);
+
+    // Now exercise DocIdStream.count()
+    scorer =
+        new DenseConjunctionBulkScorer(
+            Arrays.asList(
+                new BitSetIterator(clause1, clause1.approximateCardinality()),
+                new BitSetIterator(clause2, clause2.approximateCardinality())),
+            maxDoc,
+            0f);
+    CountingLeafCollector collector = new CountingLeafCollector();
+    scorer.score(collector, acceptDocs, 0, DocIdSetIterator.NO_MORE_DOCS);
+    assertEquals(acceptDocs.cardinality(), collector.count);
   }
 
   public void testEmptyIntersection() throws IOException {
@@ -99,11 +134,15 @@ public class TestDenseConjunctionBulkScorer extends LuceneTestCase {
       clause1.set(i);
       clause2.set(i + 1);
     }
-    DenseConjunctionBulkScorer scorer =
+    BulkScorer scorer =
         new DenseConjunctionBulkScorer(
             Arrays.asList(
                 new BitSetIterator(clause1, clause1.approximateCardinality()),
-                new BitSetIterator(clause2, clause2.approximateCardinality())));
+                new BitSetIterator(clause2, clause2.approximateCardinality())),
+            maxDoc,
+            0f);
+    // AssertingBulkScorer randomly splits the scored range into smaller ranges
+    scorer = AssertingBulkScorer.wrap(random(), scorer, maxDoc);
     FixedBitSet result = new FixedBitSet(maxDoc);
     scorer.score(
         new LeafCollector() {
@@ -120,6 +159,18 @@ public class TestDenseConjunctionBulkScorer extends LuceneTestCase {
         DocIdSetIterator.NO_MORE_DOCS);
 
     assertTrue(result.scanIsEmpty());
+
+    // Now exercise DocIdStream.count()
+    scorer =
+        new DenseConjunctionBulkScorer(
+            Arrays.asList(
+                new BitSetIterator(clause1, clause1.approximateCardinality()),
+                new BitSetIterator(clause2, clause2.approximateCardinality())),
+            maxDoc,
+            0f);
+    CountingLeafCollector collector = new CountingLeafCollector();
+    scorer.score(collector, null, 0, DocIdSetIterator.NO_MORE_DOCS);
+    assertEquals(0, collector.count);
   }
 
   public void testClustered() throws IOException {
@@ -130,12 +181,16 @@ public class TestDenseConjunctionBulkScorer extends LuceneTestCase {
     clause1.set(10_000, 90_000);
     clause2.set(0, 80_000);
     clause3.set(20_000, 100_000);
-    DenseConjunctionBulkScorer scorer =
+    BulkScorer scorer =
         new DenseConjunctionBulkScorer(
             Arrays.asList(
                 new BitSetIterator(clause1, clause1.approximateCardinality()),
                 new BitSetIterator(clause2, clause2.approximateCardinality()),
-                new BitSetIterator(clause3, clause3.approximateCardinality())));
+                new BitSetIterator(clause3, clause3.approximateCardinality())),
+            maxDoc,
+            0f);
+    // AssertingBulkScorer randomly splits the scored range into smaller ranges
+    scorer = AssertingBulkScorer.wrap(random(), scorer, maxDoc);
     FixedBitSet result = new FixedBitSet(maxDoc);
     scorer.score(
         new LeafCollector() {
@@ -155,6 +210,19 @@ public class TestDenseConjunctionBulkScorer extends LuceneTestCase {
     expected.set(20_000, 80_000);
     assertArrayEquals(expected.getBits(), result.getBits());
     assertEquals(expected, result);
+
+    // Now exercise DocIdStream.count()
+    scorer =
+        new DenseConjunctionBulkScorer(
+            Arrays.asList(
+                new BitSetIterator(clause1, clause1.approximateCardinality()),
+                new BitSetIterator(clause2, clause2.approximateCardinality()),
+                new BitSetIterator(clause3, clause3.approximateCardinality())),
+            maxDoc,
+            0f);
+    CountingLeafCollector collector = new CountingLeafCollector();
+    scorer.score(collector, null, 0, DocIdSetIterator.NO_MORE_DOCS);
+    assertEquals(expected.cardinality(), collector.count);
   }
 
   public void testSparseAfter2ndClause() throws IOException {
@@ -174,12 +242,16 @@ public class TestDenseConjunctionBulkScorer extends LuceneTestCase {
     for (int i = 0; i < maxDoc; i += 19) {
       clause3.set(i);
     }
-    DenseConjunctionBulkScorer scorer =
+    BulkScorer scorer =
         new DenseConjunctionBulkScorer(
             Arrays.asList(
                 new BitSetIterator(clause1, clause1.approximateCardinality()),
                 new BitSetIterator(clause2, clause2.approximateCardinality()),
-                new BitSetIterator(clause3, clause3.approximateCardinality())));
+                new BitSetIterator(clause3, clause3.approximateCardinality())),
+            maxDoc,
+            0f);
+    // AssertingBulkScorer randomly splits the scored range into smaller ranges
+    scorer = AssertingBulkScorer.wrap(random(), scorer, maxDoc);
     FixedBitSet result = new FixedBitSet(maxDoc);
     scorer.score(
         new LeafCollector() {
@@ -200,5 +272,240 @@ public class TestDenseConjunctionBulkScorer extends LuceneTestCase {
       expected.set(i);
     }
     assertEquals(expected, result);
+
+    // Now exercise DocIdStream.count()
+    scorer =
+        new DenseConjunctionBulkScorer(
+            Arrays.asList(
+                new BitSetIterator(clause1, clause1.approximateCardinality()),
+                new BitSetIterator(clause2, clause2.approximateCardinality()),
+                new BitSetIterator(clause3, clause3.approximateCardinality())),
+            maxDoc,
+            0f);
+    CountingLeafCollector collector = new CountingLeafCollector();
+    scorer.score(collector, null, 0, DocIdSetIterator.NO_MORE_DOCS);
+    assertEquals(expected.cardinality(), collector.count);
+  }
+
+  public void testZeroClauseNoLiveDocs() throws IOException {
+    int maxDoc = 100_000;
+    BulkScorer scorer = new DenseConjunctionBulkScorer(Collections.emptyList(), maxDoc, 0f);
+    // AssertingBulkScorer randomly splits the scored range into smaller ranges
+    scorer = AssertingBulkScorer.wrap(random(), scorer, maxDoc);
+    FixedBitSet result = new FixedBitSet(maxDoc);
+    scorer.score(
+        new LeafCollector() {
+          @Override
+          public void setScorer(Scorable scorer) throws IOException {}
+
+          @Override
+          public void collect(int doc) throws IOException {
+            result.set(doc);
+          }
+        },
+        null,
+        0,
+        DocIdSetIterator.NO_MORE_DOCS);
+
+    result.flip(0, maxDoc);
+    assertEquals(DocIdSetIterator.NO_MORE_DOCS, result.nextSetBit(0));
+
+    // Now exercise DocIdStream.count()
+    scorer = new DenseConjunctionBulkScorer(Collections.emptyList(), maxDoc, 0f);
+    CountingLeafCollector collector = new CountingLeafCollector();
+    scorer.score(collector, null, 0, DocIdSetIterator.NO_MORE_DOCS);
+    assertEquals(maxDoc, collector.count);
+  }
+
+  public void testZeroClauseWithLiveDocs() throws IOException {
+    int maxDoc = 100_000;
+    BulkScorer scorer = new DenseConjunctionBulkScorer(Collections.emptyList(), maxDoc, 0f);
+    // AssertingBulkScorer randomly splits the scored range into smaller ranges
+    scorer = AssertingBulkScorer.wrap(random(), scorer, maxDoc);
+    FixedBitSet acceptDocs = new FixedBitSet(maxDoc);
+    acceptDocs.set(10_000, 20_000);
+    for (int i = 30_000; i < maxDoc; i += 3) {
+      acceptDocs.set(i);
+    }
+    FixedBitSet result = new FixedBitSet(maxDoc);
+    scorer.score(
+        new LeafCollector() {
+          @Override
+          public void setScorer(Scorable scorer) throws IOException {}
+
+          @Override
+          public void collect(int doc) throws IOException {
+            result.set(doc);
+          }
+        },
+        acceptDocs,
+        0,
+        DocIdSetIterator.NO_MORE_DOCS);
+
+    assertEquals(acceptDocs, result);
+
+    // Now exercise DocIdStream.count()
+    scorer = new DenseConjunctionBulkScorer(Collections.emptyList(), maxDoc, 0f);
+    CountingLeafCollector collector = new CountingLeafCollector();
+    scorer.score(collector, acceptDocs, 0, DocIdSetIterator.NO_MORE_DOCS);
+    assertEquals(acceptDocs.cardinality(), collector.count);
+  }
+
+  public void testOneClauseNoLiveDocs() throws IOException {
+    int maxDoc = 100_000;
+    FixedBitSet clause1 = new FixedBitSet(maxDoc);
+    for (int i = 0; i < maxDoc; i += 2) {
+      clause1.set(i);
+    }
+    BulkScorer scorer =
+        new DenseConjunctionBulkScorer(
+            Collections.singletonList(
+                new BitSetIterator(clause1, clause1.approximateCardinality())),
+            maxDoc,
+            0f);
+    // AssertingBulkScorer randomly splits the scored range into smaller ranges
+    scorer = AssertingBulkScorer.wrap(random(), scorer, maxDoc);
+    FixedBitSet result = new FixedBitSet(maxDoc);
+    scorer.score(
+        new LeafCollector() {
+          @Override
+          public void setScorer(Scorable scorer) throws IOException {}
+
+          @Override
+          public void collect(int doc) throws IOException {
+            result.set(doc);
+          }
+        },
+        null,
+        0,
+        DocIdSetIterator.NO_MORE_DOCS);
+
+    assertEquals(clause1, result);
+
+    // Now exercise DocIdStream.count()
+    scorer =
+        new DenseConjunctionBulkScorer(
+            Collections.singletonList(
+                new BitSetIterator(clause1, clause1.approximateCardinality())),
+            maxDoc,
+            0f);
+    CountingLeafCollector collector = new CountingLeafCollector();
+    scorer.score(collector, null, 0, DocIdSetIterator.NO_MORE_DOCS);
+    assertEquals(clause1.cardinality(), collector.count);
+  }
+
+  public void testOneClauseWithLiveDocs() throws IOException {
+    int maxDoc = 100_000;
+    FixedBitSet clause1 = new FixedBitSet(maxDoc);
+    for (int i = 0; i < maxDoc; i += 2) {
+      clause1.set(i);
+    }
+    BulkScorer scorer =
+        new DenseConjunctionBulkScorer(
+            Collections.singletonList(
+                new BitSetIterator(clause1, clause1.approximateCardinality())),
+            maxDoc,
+            0f);
+    // AssertingBulkScorer randomly splits the scored range into smaller ranges
+    scorer = AssertingBulkScorer.wrap(random(), scorer, maxDoc);
+    FixedBitSet acceptDocs = new FixedBitSet(maxDoc);
+    acceptDocs.set(10_000, 20_000);
+    for (int i = 30_000; i < maxDoc; i += 3) {
+      acceptDocs.set(i);
+    }
+    FixedBitSet result = new FixedBitSet(maxDoc);
+    scorer.score(
+        new LeafCollector() {
+          @Override
+          public void setScorer(Scorable scorer) throws IOException {}
+
+          @Override
+          public void collect(int doc) throws IOException {
+            result.set(doc);
+          }
+        },
+        acceptDocs,
+        0,
+        DocIdSetIterator.NO_MORE_DOCS);
+
+    FixedBitSet expected = new FixedBitSet(maxDoc);
+    expected.or(acceptDocs);
+    expected.and(clause1);
+    assertEquals(expected, result);
+
+    // Now exercise DocIdStream.count()
+    scorer =
+        new DenseConjunctionBulkScorer(
+            Collections.singletonList(
+                new BitSetIterator(clause1, clause1.approximateCardinality())),
+            maxDoc,
+            0f);
+    CountingLeafCollector collector = new CountingLeafCollector();
+    scorer.score(collector, acceptDocs, 0, DocIdSetIterator.NO_MORE_DOCS);
+    assertEquals(expected.cardinality(), collector.count);
+  }
+
+  public void testStopOnMinCompetitiveScore() throws IOException {
+    int maxDoc = 100_000;
+    FixedBitSet clause1 = new FixedBitSet(maxDoc);
+    FixedBitSet clause2 = new FixedBitSet(maxDoc);
+    for (int i = 0; i < maxDoc; i += 2) {
+      clause1.set(i);
+    }
+    for (int i = 0; i < maxDoc; i += 5) {
+      clause2.set(i);
+    }
+    BulkScorer scorer =
+        new DenseConjunctionBulkScorer(
+            Arrays.asList(
+                new BitSetIterator(clause1, clause1.approximateCardinality()),
+                new BitSetIterator(clause2, clause2.approximateCardinality())),
+            maxDoc,
+            0f);
+    // AssertingBulkScorer randomly splits the scored range into smaller ranges
+    scorer = AssertingBulkScorer.wrap(random(), scorer, maxDoc);
+    FixedBitSet result = new FixedBitSet(maxDoc);
+    scorer.score(
+        new LeafCollector() {
+
+          private Scorable scorable;
+
+          @Override
+          public void setScorer(Scorable scorer) throws IOException {
+            this.scorable = scorer;
+          }
+
+          @Override
+          public void collect(int doc) throws IOException {
+            result.set(doc);
+            if (doc == 50_000) {
+              scorable.setMinCompetitiveScore(Float.MIN_VALUE);
+            }
+            // It should never go above the doc when setMinCompetitiveScore was called, plus the
+            // window size
+            assertTrue(doc < 50_000 + DenseConjunctionBulkScorer.WINDOW_SIZE);
+          }
+        },
+        null,
+        0,
+        DocIdSetIterator.NO_MORE_DOCS);
+  }
+
+  private static class CountingLeafCollector implements LeafCollector {
+
+    int count;
+
+    @Override
+    public void setScorer(Scorable scorer) throws IOException {}
+
+    @Override
+    public void collect(int doc) throws IOException {
+      count++;
+    }
+
+    @Override
+    public void collect(DocIdStream stream) throws IOException {
+      count += stream.count();
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -56,6 +56,7 @@ import org.apache.lucene.search.SortField.Type;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.CheckHits;
+import org.apache.lucene.tests.search.ScorerIndexSearcher;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
@@ -81,20 +82,14 @@ public class TestSortOptimization extends LuceneTestCase {
       writer.addDocument(doc);
       if (i == 7000) writer.flush(); // two segments
     }
-    final IndexReader reader = DirectoryReader.open(writer);
+    final DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
-    // single threaded so totalHits is deterministic
-    IndexSearcher searcher = newSearcher(reader, true, true, false);
     final SortField sortField = new SortField("my_field", SortField.Type.LONG);
     final Sort sort = new Sort(sortField);
     final int numHits = 3;
-    final int totalHitsThreshold = 3;
 
     { // simple sort
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(sort, numHits, totalHitsThreshold);
-
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
 
       assertEquals(topDocs.scoreDocs.length, numHits);
       for (int i = 0; i < numHits; i++) {
@@ -108,9 +103,7 @@ public class TestSortOptimization extends LuceneTestCase {
     { // paging sort with after
       long afterValue = 2;
       FieldDoc after = new FieldDoc(2, Float.NaN, new Long[] {afterValue});
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(sort, numHits, after, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, after);
       assertEquals(topDocs.scoreDocs.length, numHits);
       for (int i = 0; i < numHits; i++) {
         FieldDoc fieldDoc = (FieldDoc) topDocs.scoreDocs[i];
@@ -121,10 +114,8 @@ public class TestSortOptimization extends LuceneTestCase {
     }
 
     { // test that if there is the secondary sort on _score, scores are filled correctly
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(
-              new Sort(sortField, FIELD_SCORE), numHits, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      Sort sort2 = new Sort(sortField, FIELD_SCORE);
+      TopDocs topDocs = assertSearchHits(reader, sort2, numHits, null);
       assertEquals(topDocs.scoreDocs.length, numHits);
       for (int i = 0; i < numHits; i++) {
         FieldDoc fieldDoc = (FieldDoc) topDocs.scoreDocs[i];
@@ -137,10 +128,8 @@ public class TestSortOptimization extends LuceneTestCase {
     }
 
     { // test that if numeric field is a secondary sort, no optimization is run
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(
-              new Sort(FIELD_SCORE, sortField), numHits, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      Sort sort2 = new Sort(FIELD_SCORE, sortField);
+      TopDocs topDocs = assertSearchHits(reader, sort2, numHits, null);
       assertEquals(topDocs.scoreDocs.length, numHits);
       assertEquals(
           topDocs.totalHits.value(),
@@ -165,19 +154,13 @@ public class TestSortOptimization extends LuceneTestCase {
       doc.add(new NumericDocValuesField("my_field", i));
       writer.addDocument(doc);
     }
-    final IndexReader reader = DirectoryReader.open(writer);
+    final DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
-    // single threaded so totalHits is deterministic
-    IndexSearcher searcher =
-        newSearcher(reader, random().nextBoolean(), random().nextBoolean(), false);
     final SortField sortField = new SortField("my_field", SortField.Type.LONG);
     final Sort sort = new Sort(sortField);
     final int numHits = 3;
-    final int totalHitsThreshold = 3;
 
-    final TopFieldCollectorManager collectorManager =
-        new TopFieldCollectorManager(sort, numHits, totalHitsThreshold);
-    TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+    TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
     assertEquals(
         topDocs.scoreDocs.length, numHits); // sort still works and returns expected number of docs
     for (int i = 0; i < numHits; i++) {
@@ -210,22 +193,16 @@ public class TestSortOptimization extends LuceneTestCase {
       writer.addDocument(doc);
       if (i == 7000) writer.flush(); // two segments
     }
-    final IndexReader reader = DirectoryReader.open(writer);
+    final DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
-    // single threaded so totalHits is deterministic
-    IndexSearcher searcher =
-        newSearcher(reader, random().nextBoolean(), random().nextBoolean(), false);
     final int numHits = 3;
-    final int totalHitsThreshold = 3;
 
     { // test that optimization is run when missing value setting of SortField is competitive with
       // Puring.GREATER_THAN_OR_EQUAL_TO
       final SortField sortField = new SortField("my_field", SortField.Type.LONG);
       sortField.setMissingValue(0L); // set a competitive missing value
       final Sort sort = new Sort(sortField);
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(sort, numHits, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
       assertEquals(topDocs.scoreDocs.length, numHits);
       assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
     }
@@ -236,9 +213,7 @@ public class TestSortOptimization extends LuceneTestCase {
       sortField1.setMissingValue(0L); // set a competitive missing value
       sortField2.setMissingValue(0L); // set a competitive missing value
       final Sort sort = new Sort(sortField1, sortField2);
-      CollectorManager<TopFieldCollector, TopFieldDocs> manager =
-          new TopFieldCollectorManager(sort, numHits, null, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), manager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
       assertEquals(topDocs.scoreDocs.length, numHits);
       assertEquals(
           topDocs.totalHits.value(),
@@ -248,9 +223,7 @@ public class TestSortOptimization extends LuceneTestCase {
       final SortField sortField = new SortField("my_field", SortField.Type.LONG);
       sortField.setMissingValue(100L); // set a NON competitive missing value
       final Sort sort = new Sort(sortField);
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(sort, numHits, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
       assertEquals(topDocs.scoreDocs.length, numHits);
       assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
     }
@@ -263,9 +236,7 @@ public class TestSortOptimization extends LuceneTestCase {
       final SortField sortField = new SortField("my_field", SortField.Type.LONG);
       sortField.setMissingValue(Long.MAX_VALUE); // set a competitive missing value
       final Sort sort = new Sort(sortField);
-      CollectorManager<TopFieldCollector, TopFieldDocs> manager =
-          new TopFieldCollectorManager(sort, numHits, after, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), manager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, after);
       assertEquals(topDocs.scoreDocs.length, numHits);
       assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
     }
@@ -278,9 +249,7 @@ public class TestSortOptimization extends LuceneTestCase {
       final SortField sortField = new SortField("my_field", SortField.Type.LONG, true);
       sortField.setMissingValue(Long.MAX_VALUE); // set a competitive missing value
       final Sort sort = new Sort(sortField);
-      CollectorManager<TopFieldCollector, TopFieldDocs> manager =
-          new TopFieldCollectorManager(sort, numHits, after, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), manager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, after);
       assertEquals(topDocs.scoreDocs.length, numHits);
       assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
     }
@@ -293,9 +262,7 @@ public class TestSortOptimization extends LuceneTestCase {
       final SortField sortField = new SortField("my_field", SortField.Type.LONG);
       sortField.setMissingValue(2L);
       final Sort sort = new Sort(sortField);
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(sort, numHits, after, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, after);
       assertEquals(topDocs.scoreDocs.length, numHits);
       for (int i = 0; i < numHits; i++) {
         FieldDoc fieldDoc = (FieldDoc) topDocs.scoreDocs[i];
@@ -332,13 +299,9 @@ public class TestSortOptimization extends LuceneTestCase {
       }
       writer.addDocument(doc);
     }
-    final IndexReader reader = DirectoryReader.open(writer);
+    final DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
-    // single threaded so totalHits is deterministic
-    IndexSearcher searcher =
-        newSearcher(reader, random().nextBoolean(), random().nextBoolean(), false);
     final int numHits = 3;
-    final int totalHitsThreshold = 3;
     TopDocs topDocs1;
     TopDocs topDocs2;
 
@@ -346,9 +309,7 @@ public class TestSortOptimization extends LuceneTestCase {
       final SortField sortField = new SortField("my_field", SortField.Type.LONG, true);
       sortField.setMissingValue(0L); // missing value is not competitive
       final Sort sort = new Sort(sortField);
-      CollectorManager<TopFieldCollector, TopFieldDocs> manager =
-          new TopFieldCollectorManager(sort, numHits, null, totalHitsThreshold);
-      topDocs1 = searcher.search(new MatchAllDocsQuery(), manager);
+      topDocs1 = assertSearchHits(reader, sort, numHits, null);
       assertNonCompetitiveHitsAreSkipped(topDocs1.totalHits.value(), numDocs);
     }
     { // Test that sort on sorted numeric field without sort optimization and with sort optimization
@@ -357,9 +318,7 @@ public class TestSortOptimization extends LuceneTestCase {
       sortField.setMissingValue(0L); // missing value is not competitive
       final Sort sort = new Sort(sortField);
       sortField.setOptimizeSortWithPoints(false);
-      CollectorManager<TopFieldCollector, TopFieldDocs> manager =
-          new TopFieldCollectorManager(sort, numHits, null, totalHitsThreshold);
-      topDocs2 = searcher.search(new MatchAllDocsQuery(), manager);
+      topDocs2 = assertSearchHits(reader, sort, numHits, null);
       // assert that the resulting hits are the same
       assertEquals(topDocs1.scoreDocs.length, topDocs2.scoreDocs.length);
       assertEquals(topDocs1.scoreDocs.length, numHits);
@@ -380,9 +339,7 @@ public class TestSortOptimization extends LuceneTestCase {
       sortField1.setMissingValue(0L); // missing value is not competitive
       sortField2.setMissingValue(0L); // missing value is not competitive
       final Sort multiSorts = new Sort(new SortField[] {sortField1, sortField2});
-      CollectorManager<TopFieldCollector, TopFieldDocs> manager =
-          new TopFieldCollectorManager(multiSorts, numHits, null, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), manager);
+      TopDocs topDocs = assertSearchHits(reader, multiSorts, numHits, null);
       // can't optimization with NumericDocValues when there are multiple comparators
       assertEquals(topDocs.totalHits.value(), numDocs);
     }
@@ -412,21 +369,15 @@ public class TestSortOptimization extends LuceneTestCase {
       // if there is only one segment, we could test that totalHits must always equal (numHits + 1)
       if (i == 7000 && random().nextBoolean()) writer.flush(); // two segments
     }
-    final IndexReader reader = DirectoryReader.open(writer);
+    final DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
-    // single threaded so totalHits is deterministic
-    IndexSearcher searcher =
-        newSearcher(reader, random().nextBoolean(), random().nextBoolean(), false);
     final int numHits = 3;
-    final int totalHitsThreshold = 3;
 
     { // test that sorting on a single field with equal values uses the optimization with
       // GREATER_THAN_OR_EQUAL_TO
       final SortField sortField = new SortField("my_field1", SortField.Type.INT);
       final Sort sort = new Sort(sortField);
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(sort, numHits, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
       assertEquals(topDocs.scoreDocs.length, numHits);
       for (int i = 0; i < numHits; i++) {
         FieldDoc fieldDoc = (FieldDoc) topDocs.scoreDocs[i];
@@ -446,9 +397,7 @@ public class TestSortOptimization extends LuceneTestCase {
       final SortField sortField = new SortField("my_field1", SortField.Type.INT);
       final Sort sort = new Sort(sortField);
       final FieldDoc after = new FieldDoc(afterDocID, Float.NaN, new Integer[] {afterValue});
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(sort, numHits, after, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, after);
       assertEquals(topDocs.scoreDocs.length, numHits);
       for (int i = 0; i < numHits; i++) {
         FieldDoc fieldDoc = (FieldDoc) topDocs.scoreDocs[i];
@@ -463,9 +412,7 @@ public class TestSortOptimization extends LuceneTestCase {
       final SortField sortField1 = new SortField("my_field1", SortField.Type.INT);
       final SortField sortField2 = new SortField("my_field2", SortField.Type.INT);
       final Sort sort = new Sort(sortField1, sortField2);
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(sort, numHits, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
       assertEquals(topDocs.scoreDocs.length, numHits);
       for (int i = 0; i < numHits; i++) {
         FieldDoc fieldDoc = (FieldDoc) topDocs.scoreDocs[i];
@@ -493,21 +440,14 @@ public class TestSortOptimization extends LuceneTestCase {
       doc.add(new FloatPoint("my_field", i));
       writer.addDocument(doc);
     }
-    final IndexReader reader = DirectoryReader.open(writer);
+    final DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
-    // single threaded so totalHits is deterministic
-    IndexSearcher searcher =
-        newSearcher(reader, random().nextBoolean(), random().nextBoolean(), false);
     final SortField sortField = new SortField("my_field", SortField.Type.FLOAT);
     final Sort sort = new Sort(sortField);
     final int numHits = 3;
-    final int totalHitsThreshold = 3;
 
     { // simple sort
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(sort, numHits, totalHitsThreshold);
-
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
       assertEquals(topDocs.scoreDocs.length, numHits);
       for (int i = 0; i < numHits; i++) {
         FieldDoc fieldDoc = (FieldDoc) topDocs.scoreDocs[i];
@@ -529,7 +469,7 @@ public class TestSortOptimization extends LuceneTestCase {
     final int numIndices = 3;
     final int numDocsInIndex = atLeast(50);
     Directory[] dirs = new Directory[numIndices];
-    IndexReader[] readers = new IndexReader[numIndices];
+    DirectoryReader[] readers = new DirectoryReader[numIndices];
     for (int i = 0; i < numIndices; i++) {
       dirs[i] = newDirectory();
       IndexWriterConfig config =
@@ -549,7 +489,6 @@ public class TestSortOptimization extends LuceneTestCase {
     }
 
     final int size = 7;
-    final int totalHitsThreshold = 7;
     final Sort sort = new Sort(FIELD_DOC, new SortField("my_field", SortField.Type.LONG));
     TopFieldDocs[] topDocs = new TopFieldDocs[numIndices];
     int curNumHits;
@@ -559,12 +498,7 @@ public class TestSortOptimization extends LuceneTestCase {
     int numHits = 0;
     do {
       for (int i = 0; i < numIndices; i++) {
-        // single threaded so totalHits is deterministic
-        IndexSearcher searcher =
-            newSearcher(readers[i], random().nextBoolean(), random().nextBoolean(), false);
-        final TopFieldCollectorManager collectorManager =
-            new TopFieldCollectorManager(sort, size, after, totalHitsThreshold);
-        topDocs[i] = searcher.search(new MatchAllDocsQuery(), collectorManager);
+        topDocs[i] = assertSearchHits(readers[i], sort, size, after);
         for (int docID = 0; docID < topDocs[i].scoreDocs.length; docID++) {
           topDocs[i].scoreDocs[docID].shardIndex = i;
         }
@@ -601,22 +535,16 @@ public class TestSortOptimization extends LuceneTestCase {
       }
     }
 
-    final IndexReader reader = DirectoryReader.open(writer);
+    final DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
-    // single threaded so totalHits is deterministic
-    IndexSearcher searcher =
-        newSearcher(reader, random().nextBoolean(), random().nextBoolean(), false);
     final int numHits = 10;
-    final int totalHitsThreshold = 10;
     final int[] searchAfters = {3, 10, numDocs - 10};
     for (int searchAfter : searchAfters) {
       // sort by _doc with search after should trigger optimization
       {
         final Sort sort = new Sort(FIELD_DOC);
         FieldDoc after = new FieldDoc(searchAfter, Float.NaN, new Integer[] {searchAfter});
-        final TopFieldCollectorManager collectorManager =
-            new TopFieldCollectorManager(sort, numHits, after, totalHitsThreshold);
-        TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+        TopDocs topDocs = assertSearchHits(reader, sort, numHits, after);
         int expNumHits =
             (searchAfter >= (numDocs - numHits)) ? (numDocs - searchAfter - 1) : numHits;
         assertEquals(expNumHits, topDocs.scoreDocs.length);
@@ -632,9 +560,7 @@ public class TestSortOptimization extends LuceneTestCase {
       {
         final Sort sort = new Sort(FIELD_DOC, FIELD_SCORE);
         FieldDoc after = new FieldDoc(searchAfter, Float.NaN, new Object[] {searchAfter, 1.0f});
-        final TopFieldCollectorManager collectorManager =
-            new TopFieldCollectorManager(sort, numHits, after, totalHitsThreshold);
-        TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+        TopDocs topDocs = assertSearchHits(reader, sort, numHits, after);
         int expNumHits =
             (searchAfter >= (numDocs - numHits)) ? (numDocs - searchAfter - 1) : numHits;
         assertEquals(expNumHits, topDocs.scoreDocs.length);
@@ -650,9 +576,7 @@ public class TestSortOptimization extends LuceneTestCase {
       {
         final Sort sort = new Sort(new SortField(null, SortField.Type.DOC, true));
         FieldDoc after = new FieldDoc(searchAfter, Float.NaN, new Integer[] {searchAfter});
-        final TopFieldCollectorManager collectorManager =
-            new TopFieldCollectorManager(sort, numHits, after, totalHitsThreshold);
-        TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+        TopDocs topDocs = assertSearchHits(reader, sort, numHits, after);
         int expNumHits = (searchAfter < numHits) ? searchAfter : numHits;
         assertEquals(expNumHits, topDocs.scoreDocs.length);
         for (int i = 0; i < topDocs.scoreDocs.length; i++) {
@@ -684,17 +608,15 @@ public class TestSortOptimization extends LuceneTestCase {
     }
     writer.flush();
 
-    IndexReader reader = DirectoryReader.open(writer);
-    IndexSearcher searcher = newSearcher(reader);
+    DirectoryReader reader = DirectoryReader.open(writer);
     int visitedHits = 0;
-    ScoreDoc after = null;
+    FieldDoc after = null;
     while (visitedHits < numDocs) {
       int batch = 1 + random().nextInt(500);
-      Query query = new MatchAllDocsQuery();
-      TopDocs topDocs = searcher.searchAfter(after, query, batch, new Sort(FIELD_DOC));
+      TopFieldDocs topDocs = assertSearchHits(reader, new Sort(FIELD_DOC), batch, after);
       int expectedHits = Math.min(numDocs - visitedHits, batch);
       assertEquals(expectedHits, topDocs.scoreDocs.length);
-      after = topDocs.scoreDocs[expectedHits - 1];
+      after = (FieldDoc) topDocs.scoreDocs[expectedHits - 1];
       for (int i = 0; i < topDocs.scoreDocs.length; i++) {
         assertEquals(visitedHits, topDocs.scoreDocs[i].doc);
         visitedHits++;
@@ -720,21 +642,15 @@ public class TestSortOptimization extends LuceneTestCase {
         seg++;
       }
     }
-    final IndexReader reader = DirectoryReader.open(writer);
+    final DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
-    // single threaded so totalHits is deterministic
-    IndexSearcher searcher =
-        newSearcher(reader, random().nextBoolean(), random().nextBoolean(), false);
 
     final int numHits = 3;
-    final int totalHitsThreshold = 3;
     final Sort sort = new Sort(FIELD_DOC);
 
     // sort by _doc should skip all non-competitive documents
     {
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(sort, numHits, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), collectorManager);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
       assertEquals(numHits, topDocs.scoreDocs.length);
       for (int i = 0; i < numHits; i++) {
         assertEquals(i, topDocs.scoreDocs[i].doc);
@@ -745,16 +661,14 @@ public class TestSortOptimization extends LuceneTestCase {
 
     // sort by _doc with a bool query should skip all non-competitive documents
     {
-      final TopFieldCollectorManager collectorManager =
-          new TopFieldCollectorManager(sort, numHits, totalHitsThreshold);
       int lowerRange = 40;
       BooleanQuery.Builder bq = new BooleanQuery.Builder();
       bq.add(LongPoint.newRangeQuery("lf", lowerRange, Long.MAX_VALUE), BooleanClause.Occur.MUST);
       bq.add(new TermQuery(new Term("tf", "seg1")), BooleanClause.Occur.MUST);
 
-      TopDocs topDocs = searcher.search(bq.build(), collectorManager);
+      TopDocs topDocs = assertSearchHits(reader, bq.build(), sort, numHits, null);
       assertEquals(numHits, topDocs.scoreDocs.length);
-      StoredFields storedFields = searcher.storedFields();
+      StoredFields storedFields = reader.storedFields();
       for (int i = 0; i < numHits; i++) {
         Document d = storedFields.document(topDocs.scoreDocs[i].doc);
         assertEquals(Integer.toString(i + lowerRange), d.get("slf"));
@@ -825,7 +739,7 @@ public class TestSortOptimization extends LuceneTestCase {
     doc.add(new NumericDocValuesField("intRange", 4));
 
     writer.addDocument(doc);
-    IndexReader reader = writer.getReader();
+    DirectoryReader reader = writer.getReader();
     writer.close();
 
     IndexSearcher searcher = newSearcher(reader, random().nextBoolean(), random().nextBoolean());
@@ -880,12 +794,11 @@ public class TestSortOptimization extends LuceneTestCase {
         writer.addDocument(doc);
       }
     }
-    IndexReader reader = DirectoryReader.open(writer);
+    DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
-    IndexSearcher searcher = newSearcher(reader, random().nextBoolean(), random().nextBoolean());
     SortField sortField = new SortField("my_field", SortField.Type.LONG);
     TopFieldDocs topDocs =
-        searcher.search(new MatchAllDocsQuery(), 1 + random().nextInt(100), new Sort(sortField));
+        assertSearchHits(reader, new Sort(sortField), 1 + random().nextInt(100), null);
     FieldDoc fieldDoc = (FieldDoc) topDocs.scoreDocs[0];
     assertEquals(smallestValue, ((Long) fieldDoc.fields[0]).intValue());
     reader.close();
@@ -931,12 +844,11 @@ public class TestSortOptimization extends LuceneTestCase {
     } else {
       seqNos.sort(Collections.reverseOrder());
     }
-    IndexReader reader = DirectoryReader.open(writer);
+    DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
-    IndexSearcher searcher = newSearcher(reader, random().nextBoolean(), random().nextBoolean());
     SortField sortField = new SortField("seq_no", SortField.Type.LONG, reverse);
     int visitedHits = 0;
-    ScoreDoc after = null;
+    FieldDoc after = null;
     // test page search
     while (visitedHits < seqNos.size()) {
       int batch = 1 + random().nextInt(100);
@@ -944,10 +856,10 @@ public class TestSortOptimization extends LuceneTestCase {
           random().nextBoolean()
               ? new MatchAllDocsQuery()
               : LongPoint.newRangeQuery("seq_no", 0, Long.MAX_VALUE);
-      TopDocs topDocs = searcher.searchAfter(after, query, batch, new Sort(sortField));
+      TopDocs topDocs = assertSearchHits(reader, query, new Sort(sortField), batch, after);
       int expectedHits = Math.min(seqNos.size() - visitedHits, batch);
       assertEquals(expectedHits, topDocs.scoreDocs.length);
-      after = topDocs.scoreDocs[expectedHits - 1];
+      after = (FieldDoc) topDocs.scoreDocs[expectedHits - 1];
       for (int i = 0; i < topDocs.scoreDocs.length; i++) {
         FieldDoc fieldDoc = (FieldDoc) topDocs.scoreDocs[i];
         long expectedSeqNo = seqNos.get(visitedHits);
@@ -958,9 +870,7 @@ public class TestSortOptimization extends LuceneTestCase {
 
     // test search
     int numHits = 1 + random().nextInt(100);
-    CollectorManager<TopFieldCollector, TopFieldDocs> manager =
-        new TopFieldCollectorManager(new Sort(sortField), numHits, null, numHits);
-    TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), manager);
+    TopDocs topDocs = assertSearchHits(reader, new Sort(sortField), numHits, after);
     for (int i = 0; i < topDocs.scoreDocs.length; i++) {
       long expectedSeqNo = seqNos.get(i);
       FieldDoc fieldDoc = (FieldDoc) topDocs.scoreDocs[i];
@@ -984,10 +894,8 @@ public class TestSortOptimization extends LuceneTestCase {
       doc.add(new LongField("my_field", value2, Field.Store.NO));
       writer.addDocument(doc);
     }
-    final IndexReader reader = DirectoryReader.open(writer);
+    final DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
-    // single threaded so totalHits is deterministic
-    IndexSearcher searcher = newSearcher(reader, true, true, false);
 
     SortedNumericSelector.Type type =
         RandomPicks.randomFrom(random(), SortedNumericSelector.Type.values());
@@ -997,26 +905,20 @@ public class TestSortOptimization extends LuceneTestCase {
     final Sort sort = new Sort(sortField); // sort without sort optimization
     final SortField sortField2 = LongField.newSortField("my_field", reverse, type);
     final Sort sort2 = new Sort(sortField2); // sort with sort optimization
-    Query query = new MatchAllDocsQuery();
-    final int totalHitsThreshold = 3;
 
     long expectedCollectedHits = 0;
     long collectedHits = 0;
     long collectedHits2 = 0;
     int visitedHits = 0;
-    ScoreDoc after = null;
+    FieldDoc after = null;
     while (visitedHits < numDocs) {
       int batch = 1 + random().nextInt(100);
       int expectedHits = Math.min(numDocs - visitedHits, batch);
 
-      CollectorManager<TopFieldCollector, TopFieldDocs> manager =
-          new TopFieldCollectorManager(sort, batch, (FieldDoc) after, totalHitsThreshold);
-      TopDocs topDocs = searcher.search(query, manager);
+      TopDocs topDocs = assertSearchHits(reader, sort, batch, after);
       ScoreDoc[] scoreDocs = topDocs.scoreDocs;
 
-      CollectorManager<TopFieldCollector, TopFieldDocs> manager2 =
-          new TopFieldCollectorManager(sort2, batch, (FieldDoc) after, totalHitsThreshold);
-      TopDocs topDocs2 = searcher.search(query, manager2);
+      TopDocs topDocs2 = assertSearchHits(reader, sort2, batch, after);
       ScoreDoc[] scoreDocs2 = topDocs2.scoreDocs;
 
       // assert that the resulting hits are the same
@@ -1033,7 +935,7 @@ public class TestSortOptimization extends LuceneTestCase {
       expectedCollectedHits += numDocs;
       collectedHits += topDocs.totalHits.value();
       collectedHits2 += topDocs2.totalHits.value();
-      after = scoreDocs[expectedHits - 1];
+      after = (FieldDoc) scoreDocs[expectedHits - 1];
     }
     assertEquals(visitedHits, numDocs);
     assertEquals(expectedCollectedHits, collectedHits);
@@ -1064,7 +966,7 @@ public class TestSortOptimization extends LuceneTestCase {
       final BytesRef value = new BytesRef(Integer.toString(random().nextInt(1000)));
       doc.add(new KeywordField("my_field", value, Field.Store.NO));
       writer.addDocument(doc);
-      if (i % 2000 == 0) writer.flush(); // multiple segments
+      if (i == 7000) writer.flush(); // multiple segments
     }
     final DirectoryReader reader = DirectoryReader.open(writer);
     writer.close();
@@ -1082,7 +984,7 @@ public class TestSortOptimization extends LuceneTestCase {
     // one segment with all values missing to start with
     writer.addDocument(new Document());
     for (int i = 0; i < numDocs - 2; ++i) {
-      if (i % 2000 == 0) writer.flush(); // multiple segments
+      if (i == 7000) writer.flush(); // multiple segments
       final Document doc = new Document();
       if (random().nextInt(2) == 0) {
         final BytesRef value = new BytesRef(Integer.toString(random().nextInt(1000)));
@@ -1207,13 +1109,8 @@ public class TestSortOptimization extends LuceneTestCase {
     Sort sort = new Sort(sortField);
     final int numDocs = reader.numDocs();
     final int numHits = 5;
-    final int totalHitsThreshold = 5;
 
-    CollectorManager<TopFieldCollector, TopFieldDocs> manager =
-        new TopFieldCollectorManager(sort, numHits, null, totalHitsThreshold);
-    IndexSearcher searcher =
-        newSearcher(reader, random().nextBoolean(), random().nextBoolean(), false);
-    TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), manager);
+    TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
     assertEquals(numDocs, topDocs.totalHits.value());
   }
 
@@ -1234,19 +1131,51 @@ public class TestSortOptimization extends LuceneTestCase {
     return topDocs;
   }
 
-  private TopDocs assertSearchHits(DirectoryReader reader, Sort sort, int n, FieldDoc after)
+  private TopFieldDocs assertSearchHits(DirectoryReader reader, Sort sort, int n, FieldDoc after)
       throws IOException {
-    // single threaded so totalHits is deterministic
-    IndexSearcher searcher = newSearcher(reader, true, true, false);
-    Query query = new MatchAllDocsQuery();
-    CollectorManager<TopFieldCollector, TopFieldDocs> manager =
-        new TopFieldCollectorManager(sort, n, after, n);
-    TopDocs topDocs = searcher.search(query, manager);
-    IndexSearcher unoptimizedSearcher =
-        newSearcher(new NoIndexDirectoryReader(reader), true, true, false);
-    TopDocs unoptimizedTopDocs = unoptimizedSearcher.search(query, manager);
-    CheckHits.checkEqual(query, unoptimizedTopDocs.scoreDocs, topDocs.scoreDocs);
-    return topDocs;
+    return assertSearchHits(reader, new MatchAllDocsQuery(), sort, n, after);
+  }
+
+  private TopFieldDocs assertSearchHits(
+      DirectoryReader reader, Query query, Sort sort, int n, FieldDoc after) throws IOException {
+    // single threaded and no bulk-scoring optimizations so that the total hit count is
+    // deterministic and can be reasoned about
+    IndexSearcher searcher = new ScorerIndexSearcher(reader);
+    searcher.setQueryCache(null);
+
+    TopFieldDocs optimizedTopDocs =
+        searcher.search(query, new TopFieldCollectorManager(sort, n, after, n));
+
+    if (query instanceof MatchAllDocsQuery) {
+      // Searcher that hides index structures to force a linear scan of the sort fields, and make
+      // sure that the same hits are returned
+      // We can only do that on a MatchAllDocsQuery, otherwise the query won't have data structures
+      // to operate on :)
+      IndexSearcher unoptimizedSearcher =
+          newSearcher(new NoIndexDirectoryReader(reader), true, true, false);
+      unoptimizedSearcher.setQueryCache(null);
+      TopFieldDocs unoptimizedTopDocs =
+          unoptimizedSearcher.search(query, new TopFieldCollectorManager(sort, n, after, n));
+      CheckHits.checkEqual(query, unoptimizedTopDocs.scoreDocs, optimizedTopDocs.scoreDocs);
+    }
+
+    // Use the random searcher in combination with DummyMatchAllDocsQuery to make sure we test the
+    // behavior when the bulk scorer reads ahead
+    Query randomQuery;
+    if (query instanceof MatchAllDocsQuery) {
+      randomQuery = new ReadAheadMatchAllDocsQuery();
+    } else {
+      randomQuery = query;
+    }
+    // Random IndexSearcher to make sure that enabling threading and bulk-scoring optimizations
+    // doesn't affect the returned hits
+    IndexSearcher randomSearcher = newSearcher(reader);
+    randomSearcher.setQueryCache(null);
+    TopFieldDocs randomTopDocs =
+        randomSearcher.search(randomQuery, new TopFieldCollectorManager(sort, n, after, n));
+    CheckHits.checkEqual(query, optimizedTopDocs.scoreDocs, randomTopDocs.scoreDocs);
+
+    return optimizedTopDocs;
   }
 
   private static final class NoIndexDirectoryReader extends FilterDirectoryReader {

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -1163,7 +1163,7 @@ public class TestSortOptimization extends LuceneTestCase {
     // behavior when the bulk scorer reads ahead
     Query randomQuery;
     if (query instanceof MatchAllDocsQuery) {
-      randomQuery = new ReadAheadMatchAllDocsQuery();
+      randomQuery = new ReadAheadMatchAllDocsQuery(random());
     } else {
       randomQuery = query;
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingBulkScorer.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingBulkScorer.java
@@ -22,30 +22,27 @@ import java.util.Random;
 import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.LeafCollector;
-import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.util.Bits;
 
 /** Wraps a Scorer with additional checks */
-final class AssertingBulkScorer extends BulkScorer {
+public final class AssertingBulkScorer extends BulkScorer {
 
-  public static BulkScorer wrap(Random random, BulkScorer other, int maxDoc, ScoreMode scoreMode) {
+  public static BulkScorer wrap(Random random, BulkScorer other, int maxDoc) {
     if (other == null || other instanceof AssertingBulkScorer) {
       return other;
     }
-    return new AssertingBulkScorer(random, other, maxDoc, scoreMode);
+    return new AssertingBulkScorer(random, other, maxDoc);
   }
 
   final Random random;
   final BulkScorer in;
   final int maxDoc;
-  final ScoreMode scoreMode;
   int max = 0;
 
-  private AssertingBulkScorer(Random random, BulkScorer in, int maxDoc, ScoreMode scoreMode) {
+  private AssertingBulkScorer(Random random, BulkScorer in, int maxDoc) {
     this.random = random;
     this.in = in;
     this.maxDoc = maxDoc;
-    this.scoreMode = scoreMode;
   }
 
   public BulkScorer getIn() {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.DocIdStream;
 import org.apache.lucene.search.FilterLeafCollector;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
+import org.apache.lucene.util.FixedBitSet;
 
 /** Wraps another Collector and checks that order is respected. */
 class AssertingLeafCollector extends FilterLeafCollector {
@@ -88,6 +89,14 @@ class AssertingLeafCollector extends FilterLeafCollector {
         assert target <= max
             : "advancing beyond the end of the scored window: target=" + target + ", max=" + max;
         return in.advance(target);
+      }
+
+      @Override
+      public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+        assert upTo <= max
+            : "advancing beyond the end of the scored window: upTo=" + upTo + ", max=" + max;
+        in.intoBitSet(upTo, bitSet, offset);
+        assert in.docID() >= upTo;
       }
     };
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingWeight.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingWeight.java
@@ -95,7 +95,7 @@ class AssertingWeight extends FilterWeight {
         }
 
         return AssertingBulkScorer.wrap(
-            new Random(random.nextLong()), inScorer, context.reader().maxDoc(), scoreMode);
+            new Random(random.nextLong()), inScorer, context.reader().maxDoc());
       }
 
       @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/ScorerIndexSearcher.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/ScorerIndexSearcher.java
@@ -22,12 +22,11 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.Collector;
-import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FilterWeight;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.Bits;
 
 /** An {@link IndexSearcher} that always uses the {@link Scorer} API, never {@link BulkScorer}. */
 public class ScorerIndexSearcher extends IndexSearcher {
@@ -55,29 +54,35 @@ public class ScorerIndexSearcher extends IndexSearcher {
   protected void searchLeaf(
       LeafReaderContext ctx, int minDocId, int maxDocId, Weight weight, Collector collector)
       throws IOException {
-    // the default slices method does not create segment partitions, and we don't provide an
-    // executor to this searcher in our codebase, so we should not run into this problem. This class
-    // can though be used externally, hence it is better to provide a clear and hard error.
-    if (minDocId != 0 || maxDocId != DocIdSetIterator.NO_MORE_DOCS) {
-      throw new IllegalStateException(
-          "intra-segment concurrency is not supported by this searcher");
-    }
-    // we force the use of Scorer (not BulkScorer) to make sure
-    // that the scorer passed to LeafCollector.setScorer supports
-    // Scorer.getChildren
-    Scorer scorer = weight.scorer(ctx);
-    if (scorer != null) {
-      final DocIdSetIterator iterator = scorer.iterator();
-      final LeafCollector leafCollector = collector.getLeafCollector(ctx);
-      leafCollector.setScorer(scorer);
-      final Bits liveDocs = ctx.reader().getLiveDocs();
-      for (int doc = iterator.nextDoc();
-          doc != DocIdSetIterator.NO_MORE_DOCS;
-          doc = iterator.nextDoc()) {
-        if (liveDocs == null || liveDocs.get(doc)) {
-          leafCollector.collect(doc);
-        }
-      }
-    }
+    Weight filterWeight =
+        new FilterWeight(weight) {
+          @Override
+          public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+            ScorerSupplier in = super.scorerSupplier(context);
+            if (in == null) {
+              return null;
+            }
+            return new ScorerSupplier() {
+
+              @Override
+              public Scorer get(long leadCost) throws IOException {
+                return in.get(leadCost);
+              }
+
+              @Override
+              public BulkScorer bulkScorer() throws IOException {
+                // Don't delegate to `in` to make sure we get a DefaultBulkScorer
+                return super.bulkScorer();
+              }
+
+              @Override
+              public long cost() {
+                return in.cost();
+              }
+            };
+          }
+        };
+
+    super.searchLeaf(ctx, minDocId, maxDocId, filterWeight, collector);
   }
 }


### PR DESCRIPTION
Even though there is a single clause, it often needs to be intersected, either with live docs or with the collector's competitive iterator.

This uses `DenseConjunctionBulkScorer` for:
 - `MatchAllDocsQuery`,
 - `TermQuery` when scores are not needed and `docFreq >= maxDoc / 32`,
 - some constant-score queries including `PointRangeQuery` when `cost >= maxDoc / 32`.

In addition,
 - `DenseConjunctionBulkScorer` was improved to stop collecting hits when the min competitive score is greater than the configured constant score,
 - Added test coverage to sorting tests to make sure that their competitive iterators are happy with how `DenseConjunctionBulkScorer` reads ahead.

The downside of this change is that it forces the impacted queries to score at least 4096 (the window size) docs at once. So queries that can start skipping very early (and which are thus very fast) may see a slowdown (e.g. `TermMonthSort`). On the other hand, when it takes time before dynamic pruning becomes effective, there could be a speedup thanks to the more efficient intersection logic (e.g.  `TermDTSort`).

This change should also help in the presence of deleted docs, by taking advantage of the more efficient way how deleted docs are applied in this bulk scorer.

Closes #14283