### PR TITLE
Fix TestSysoutLimits occasionally failing.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -216,7 +216,8 @@ public abstract class VectorizationProvider {
           "org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil",
           "org.apache.lucene.util.VectorUtil",
           "org.apache.lucene.codecs.lucene101.Lucene101PostingsReader",
-          "org.apache.lucene.codecs.lucene101.PostingIndexInput");
+          "org.apache.lucene.codecs.lucene101.PostingIndexInput",
+          "org.apache.lucene.tests.util.TestSysoutsLimits");
 
   private static void ensureCaller() {
     final boolean validCaller =

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestSysoutsLimits.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestSysoutsLimits.java
@@ -18,6 +18,7 @@ package org.apache.lucene.tests.util;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import java.util.stream.Collectors;
+import org.apache.lucene.internal.vectorization.VectorizationProvider;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -30,6 +31,11 @@ import org.junit.runner.Result;
 public class TestSysoutsLimits extends WithNestedTests {
   public TestSysoutsLimits() {
     super(false);
+
+    // vectorization provider may print a warning during initialization,
+    // and we count sysout/syserr bytes exactly so bootstrap any
+    // initializations early.
+    VectorizationProvider.getInstance();
   }
 
   public static class ParentNestedTest extends LuceneTestCase


### PR DESCRIPTION
VectorizationProvider may print warnings, which clashes with the test's assumptions. I simply forced any static initializations to occur before the test starts.