### PR TITLE
Remove BitDocIdSet#bits method

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -22,6 +22,8 @@ API Changes
 
 * GITHUB#14291: Remove IOException from ScorerSupplier#setTopLevelScoringClause signature (Luca Cavanna)
 
+* GITHUB#14297: Replace last usage of BitDocIdSet#bits and remove the method. (Luca Cavanna)
+
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -22,8 +22,6 @@ API Changes
 
 * GITHUB#14291: Remove IOException from ScorerSupplier#setTopLevelScoringClause signature (Luca Cavanna)
 
-* GITHUB#14297: Replace last usage of BitDocIdSet#bits and remove the method. (Luca Cavanna)
-
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)

--- a/lucene/core/src/java/org/apache/lucene/util/BitDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitDocIdSet.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.util;
 
-import java.io.IOException;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -56,22 +55,6 @@ public class BitDocIdSet extends DocIdSet {
   @Override
   public DocIdSetIterator iterator() {
     return new BitSetIterator(set, cost);
-  }
-
-  /**
-   * Provides a {@link Bits} interface for random access to matching documents.
-   *
-   * @return {@code null}, if this {@code DocIdSet} does not support random access. In contrast to
-   *     {@link #iterator()}, a return value of {@code null} <b>does not</b> imply that no documents
-   *     match the filter! The default implementation does not provide random access, so you only
-   *     need to implement this method if your DocIdSet can guarantee random access to every docid
-   *     in O(1) time without external disk access (as {@link Bits} interface cannot throw {@link
-   *     IOException}). This is generally true for bit sets like {@link
-   *     org.apache.lucene.util.FixedBitSet}, which return itself if they are used as {@code
-   *     DocIdSet}.
-   */
-  public BitSet bits() {
-    return set;
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/util/TestFixedBitDocIdSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFixedBitDocIdSet.java
@@ -16,9 +16,7 @@
  */
 package org.apache.lucene.util;
 
-import java.io.IOException;
 import java.util.BitSet;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.tests.util.BaseDocIdSetTestCase;
 
 public class TestFixedBitDocIdSet extends BaseDocIdSetTestCase<BitDocIdSet> {
@@ -30,26 +28,5 @@ public class TestFixedBitDocIdSet extends BaseDocIdSetTestCase<BitDocIdSet> {
       set.set(doc);
     }
     return new BitDocIdSet(set);
-  }
-
-  @Override
-  public void assertEquals(int numBits, BitSet ds1, BitDocIdSet ds2) throws IOException {
-    super.assertEquals(numBits, ds1, ds2);
-    // bits()
-    final Bits bits = ds2.bits();
-    if (bits != null) {
-      // test consistency between bits and iterator
-      DocIdSetIterator it2 = ds2.iterator();
-      for (int previousDoc = -1, doc = it2.nextDoc(); ; previousDoc = doc, doc = it2.nextDoc()) {
-        final int max = doc == DocIdSetIterator.NO_MORE_DOCS ? bits.length() : doc;
-        for (int i = previousDoc + 1; i < max; ++i) {
-          assertFalse(bits.get(i));
-        }
-        if (doc == DocIdSetIterator.NO_MORE_DOCS) {
-          break;
-        }
-        assertTrue(bits.get(doc));
-      }
-    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestSparseFixedBitDocIdSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSparseFixedBitDocIdSet.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.util;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
@@ -46,14 +45,5 @@ public class TestSparseFixedBitDocIdSet extends BaseDocIdSetTestCase<BitDocIdSet
       set.set(i);
     }
     return new BitDocIdSet(set, set.approximateCardinality());
-  }
-
-  @Override
-  public void assertEquals(int numBits, BitSet ds1, BitDocIdSet ds2) throws IOException {
-    for (int i = 0; i < numBits; ++i) {
-      assertEquals(ds1.get(i), ds2.bits().get(i));
-    }
-    assertEquals(ds1.cardinality(), ds2.bits().cardinality());
-    super.assertEquals(numBits, ds1, ds2);
   }
 }


### PR DESCRIPTION
We removed DocIdSet#bits in #14290. This commit removes the last usage of the former bits method from QueryBitSetProducer. A BitSet can be used directly instead of a DocIdSet, introducing a sentinel that's specific to QueryBitSetProducer.