### PR TITLE
Mark DocIdBitSet#bits deprecated also in subclasses

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSet.java
@@ -38,6 +38,7 @@ public abstract class DocIdSet implements Accountable {
         // we explicitly provide no random access, as this filter is 100% sparse and iterator exits
         // faster
         @Override
+        @Deprecated
         public Bits bits() {
           return null;
         }
@@ -62,6 +63,7 @@ public abstract class DocIdSet implements Accountable {
       }
 
       @Override
+      @Deprecated
       public Bits bits() throws IOException {
         return new Bits.MatchAllBits(maxDoc);
       }

--- a/lucene/core/src/java/org/apache/lucene/util/BitDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitDocIdSet.java
@@ -58,6 +58,7 @@ public class BitDocIdSet extends DocIdSet {
   }
 
   @Override
+  @Deprecated
   public BitSet bits() {
     return set;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/NotDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/NotDocIdSet.java
@@ -41,6 +41,7 @@ public final class NotDocIdSet extends DocIdSet {
   }
 
   @Override
+  @Deprecated
   public Bits bits() throws IOException {
     final Bits inBits = in.bits();
     if (inBits == null) {

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/ContainsPrefixTreeQuery.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/ContainsPrefixTreeQuery.java
@@ -292,6 +292,7 @@ public class ContainsPrefixTreeQuery extends AbstractPrefixTreeQuery {
     }
 
     @Override
+    @Deprecated
     public Bits bits() throws IOException {
       // if the # of docids is super small, return null since iteration is going
       // to be faster


### PR DESCRIPTION
This is the second part of #14292, which marks the method deprecated not only in the base class but also in all of its subclasses.