### PR TITLE
Support JDK 24 in Panama Vectorization Provider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,11 @@ ext {
   minJavaVersion = JavaVersion.toVersion(deps.versions.minJava.get())
 
   // also change this in extractor tool: ExtractForeignAPI
-  vectorIncubatorJavaVersions = [ JavaVersion.VERSION_21, JavaVersion.VERSION_22, JavaVersion.VERSION_23 ] as Set
+  vectorIncubatorJavaVersions = [
+    JavaVersion.VERSION_21,
+    JavaVersion.VERSION_22,
+    JavaVersion.VERSION_23,
+    JavaVersion.VERSION_24 ] as Set
 
   // snapshot build marker used in scripts.
   snapshotBuild = version.contains("SNAPSHOT")

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -88,6 +88,8 @@ New Features
   `longestMatch = true`. The value can be set to false to reduce the number of extracted subwords. For example,
   if the word "schwein" is extracted, the sub-word "wein" is not extracted anymore. (Renato Haeberli)
 
+* GITHUB#XXXXX: Add support JDK 24 to the Panama Vectorization Provider. (Chris Hegarty)
+
 Improvements
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -88,7 +88,7 @@ New Features
   `longestMatch = true`. The value can be set to false to reduce the number of extracted subwords. For example,
   if the word "schwein" is extracted, the sub-word "wein" is not extracted anymore. (Renato Haeberli)
 
-* GITHUB#XXXXX: Add support JDK 24 to the Panama Vectorization Provider. (Chris Hegarty)
+* GITHUB#14300: Add support JDK 24 to the Panama Vectorization Provider. (Chris Hegarty)
 
 Improvements
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -77,7 +77,7 @@ public abstract class VectorizationProvider {
 
   private static final String UPPER_JAVA_FEATURE_VERSION_SYSPROP =
       "org.apache.lucene.vectorization.upperJavaFeatureVersion";
-  private static final int DEFAULT_UPPER_JAVA_FEATURE_VERSION = 23;
+  private static final int DEFAULT_UPPER_JAVA_FEATURE_VERSION = 24;
 
   private static int getUpperJavaFeatureVersion() {
     int runtimeVersion = DEFAULT_UPPER_JAVA_FEATURE_VERSION;


### PR DESCRIPTION
This commit updates the Vectorization Provider to support JDK 24. The API has not changed so the changes minimally bump the major JDK check, and enable the incubating API during testing.

JDK 24 is past rampdown phase 2.

I tested this locally with:
`CI=true ./gradlew check -Ptests.vectorsize="default" -Ptests.forceintegervectors=false `