### PR TITLE
Expose the ImpactsEnum impl in Lucene101PostingsFormat.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsFormat.java
@@ -26,6 +26,7 @@ import org.apache.lucene.codecs.PostingsReaderBase;
 import org.apache.lucene.codecs.PostingsWriterBase;
 import org.apache.lucene.codecs.lucene90.blocktree.Lucene90BlockTreeTermsReader;
 import org.apache.lucene.codecs.lucene90.blocktree.Lucene90BlockTreeTermsWriter;
+import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
@@ -350,6 +351,14 @@ public final class Lucene101PostingsFormat extends PostingsFormat {
   public static final int LEVEL1_NUM_DOCS = LEVEL1_FACTOR * BLOCK_SIZE;
 
   public static final int LEVEL1_MASK = LEVEL1_NUM_DOCS - 1;
+
+  /**
+   * Return the class that implements {@link ImpactsEnum} in this {@link PostingsFormat}. This is
+   * internally used to help the JVM make good inlining decisions.
+   */
+  public static Class<? extends ImpactsEnum> getImpactsEnumImpl() {
+    return Lucene101PostingsReader.BlockPostingsEnum.class;
+  }
 
   static final String TERMS_CODEC = "Lucene90PostingsWriterTerms";
   static final String META_CODEC = "Lucene101PostingsWriterMeta";

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
@@ -293,8 +293,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     return res;
   }
 
-  // public for access from ScorerUtil
-  public final class BlockPostingsEnum extends ImpactsEnum {
+  final class BlockPostingsEnum extends ImpactsEnum {
 
     private enum DeltaEncoding {
       /**
@@ -425,7 +424,8 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     // true if we shallow-advanced to a new block that we have not decoded yet
     private boolean needsRefilling;
 
-    BlockPostingsEnum(FieldInfo fieldInfo, int flags, boolean needsImpacts) throws IOException {
+    public BlockPostingsEnum(FieldInfo fieldInfo, int flags, boolean needsImpacts)
+        throws IOException {
       options = fieldInfo.getIndexOptions();
       indexHasFreq = options.compareTo(IndexOptions.DOCS_AND_FREQS) >= 0;
       indexHasPos = options.compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
@@ -293,7 +293,8 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     return res;
   }
 
-  final class BlockPostingsEnum extends ImpactsEnum {
+  // public for access from ScorerUtil
+  public final class BlockPostingsEnum extends ImpactsEnum {
 
     private enum DeltaEncoding {
       /**
@@ -424,8 +425,7 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     // true if we shallow-advanced to a new block that we have not decoded yet
     private boolean needsRefilling;
 
-    public BlockPostingsEnum(FieldInfo fieldInfo, int flags, boolean needsImpacts)
-        throws IOException {
+    BlockPostingsEnum(FieldInfo fieldInfo, int flags, boolean needsImpacts) throws IOException {
       options = fieldInfo.getIndexOptions();
       indexHasFreq = options.compareTo(IndexOptions.DOCS_AND_FREQS) >= 0;
       indexHasPos = options.compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;

--- a/lucene/core/src/java/org/apache/lucene/search/ScorerUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScorerUtil.java
@@ -18,7 +18,7 @@ package org.apache.lucene.search;
 
 import java.util.stream.LongStream;
 import java.util.stream.StreamSupport;
-import org.apache.lucene.codecs.lucene101.Lucene101PostingsReader;
+import org.apache.lucene.codecs.lucene101.Lucene101PostingsFormat;
 import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
@@ -28,7 +28,7 @@ import org.apache.lucene.util.PriorityQueue;
 class ScorerUtil {
 
   private static final Class<?> DEFAULT_IMPACTS_ENUM_CLASS =
-      Lucene101PostingsReader.BlockPostingsEnum.class;
+      Lucene101PostingsFormat.getImpactsEnumImpl();
   private static final Class<?> DEFAULT_ACCEPT_DOCS_CLASS =
       new FixedBitSet(1).asReadOnlyBits().getClass();
 

--- a/lucene/core/src/java/org/apache/lucene/search/ScorerUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScorerUtil.java
@@ -16,52 +16,21 @@
  */
 package org.apache.lucene.search;
 
-import java.io.IOException;
 import java.util.stream.LongStream;
 import java.util.stream.StreamSupport;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.document.FeatureField;
-import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.codecs.lucene101.Lucene101PostingsReader;
 import org.apache.lucene.index.ImpactsEnum;
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.PostingsEnum;
-import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.store.ByteBuffersDirectory;
-import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.PriorityQueue;
 
 /** Util class for Scorer related methods */
 class ScorerUtil {
 
-  private static final Class<?> DEFAULT_IMPACTS_ENUM_CLASS;
-  private static final Class<?> DEFAULT_ACCEPT_DOCS_CLASS;
-
-  static {
-    try (Directory dir = new ByteBuffersDirectory();
-        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig())) {
-      Document doc = new Document();
-      doc.add(new FeatureField("field", "value", 1f));
-      w.addDocument(doc);
-      try (DirectoryReader reader = DirectoryReader.open(w)) {
-        LeafReader leafReader = reader.leaves().get(0).reader();
-        TermsEnum te = leafReader.terms("field").iterator();
-        if (te.seekExact(new BytesRef("value")) == false) {
-          throw new Error();
-        }
-        ImpactsEnum ie = te.impacts(PostingsEnum.FREQS);
-        DEFAULT_IMPACTS_ENUM_CLASS = ie.getClass();
-      }
-    } catch (IOException e) {
-      throw new Error(e);
-    }
-
-    DEFAULT_ACCEPT_DOCS_CLASS = new FixedBitSet(1).asReadOnlyBits().getClass();
-  }
+  private static final Class<?> DEFAULT_IMPACTS_ENUM_CLASS =
+      Lucene101PostingsReader.BlockPostingsEnum.class;
+  private static final Class<?> DEFAULT_ACCEPT_DOCS_CLASS =
+      new FixedBitSet(1).asReadOnlyBits().getClass();
 
   static long costWithMinShouldMatch(LongStream costs, int numScorers, int minShouldMatch) {
     // the idea here is the following: a boolean query c1,c2,...cn with minShouldMatch=m


### PR DESCRIPTION
This allows access from `ScorerUtil` so that it no longer needs a static block that creates an index to be able to introspect what implementation is used for impacts.

Closes #14303