### PR TITLE
fix lambdas for java 23

### DIFF
--- a/gradle/validation/ecj-lint/ecj.javadocs.prefs
+++ b/gradle/validation/ecj-lint/ecj.javadocs.prefs
@@ -1,13 +1,18 @@
 eclipse.preferences.version=1
+org.eclipse.jdt.core.builder.annotationPath.allLocations=enabled
 org.eclipse.jdt.core.compiler.annotation.inheritNullAnnotations=disabled
 org.eclipse.jdt.core.compiler.annotation.missingNonNullByDefaultAnnotation=ignore
 org.eclipse.jdt.core.compiler.annotation.nonnull=org.eclipse.jdt.annotation.NonNull
 org.eclipse.jdt.core.compiler.annotation.nonnull.secondary=
 org.eclipse.jdt.core.compiler.annotation.nonnullbydefault=org.eclipse.jdt.annotation.NonNullByDefault
 org.eclipse.jdt.core.compiler.annotation.nonnullbydefault.secondary=
+org.eclipse.jdt.core.compiler.annotation.notowning=org.eclipse.jdt.annotation.NotOwning
 org.eclipse.jdt.core.compiler.annotation.nullable=org.eclipse.jdt.annotation.Nullable
 org.eclipse.jdt.core.compiler.annotation.nullable.secondary=
 org.eclipse.jdt.core.compiler.annotation.nullanalysis=disabled
+org.eclipse.jdt.core.compiler.annotation.owning=org.eclipse.jdt.annotation.Owning
+# TODO: look into it and see if it can provide value, lots of errors
+org.eclipse.jdt.core.compiler.annotation.resourceanalysis=disabled
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=23
@@ -46,8 +51,10 @@ org.eclipse.jdt.core.compiler.problem.forbiddenReference=error
 org.eclipse.jdt.core.compiler.problem.hiddenCatchBlock=error
 org.eclipse.jdt.core.compiler.problem.includeNullInfoFromAsserts=disabled
 org.eclipse.jdt.core.compiler.problem.incompatibleNonInheritedInterfaceMethod=error
+org.eclipse.jdt.core.compiler.problem.incompatibleOwningContract=error
 org.eclipse.jdt.core.compiler.problem.incompleteEnumSwitch=error
 org.eclipse.jdt.core.compiler.problem.indirectStaticAccess=ignore
+org.eclipse.jdt.core.compiler.problem.insufficientResourceAnalysis=error
 org.eclipse.jdt.core.compiler.problem.invalidJavadoc=error
 org.eclipse.jdt.core.compiler.problem.invalidJavadocTags=enabled
 org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsDeprecatedRef=disabled
@@ -130,6 +137,7 @@ org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionWhenOverridin
 org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter=error
 org.eclipse.jdt.core.compiler.problem.unusedImport=error
 org.eclipse.jdt.core.compiler.problem.unusedLabel=error
+org.eclipse.jdt.core.compiler.problem.unusedLambdaParameter=error
 org.eclipse.jdt.core.compiler.problem.unusedLocal=error
 org.eclipse.jdt.core.compiler.problem.unusedObjectAllocation=ignore
 org.eclipse.jdt.core.compiler.problem.unusedParameter=ignore

--- a/lucene/analysis.tests/src/test/org/apache/lucene/analysis/tests/TestRandomChains.java
+++ b/lucene/analysis.tests/src/test/org/apache/lucene/analysis/tests/TestRandomChains.java
@@ -202,9 +202,9 @@ public class TestRandomChains extends BaseTokenStreamTestCase {
                     return bytes;
                   });
               put(Random.class, random -> new Random(random.nextLong()));
-              put(Version.class, random -> Version.LATEST);
+              put(Version.class, _ -> Version.LATEST);
               put(AttributeFactory.class, BaseTokenStreamTestCase::newAttributeFactory);
-              put(AttributeSource.class, random -> null); // force IAE/NPE
+              put(AttributeSource.class, _ -> null); // force IAE/NPE
               put(
                   Set.class,
                   random -> {
@@ -242,19 +242,17 @@ public class TestRandomChains extends BaseTokenStreamTestCase {
                   });
               // TODO: don't want to make the exponentially slow ones Dawid documents
               // in TestPatternReplaceFilter, so dont use truly random patterns (for now)
-              put(Pattern.class, random -> Pattern.compile("a"));
+              put(Pattern.class, _ -> Pattern.compile("a"));
               put(
                   Pattern[].class,
-                  random ->
-                      new Pattern[] {Pattern.compile("([a-z]+)"), Pattern.compile("([0-9]+)")});
+                  _ -> new Pattern[] {Pattern.compile("([a-z]+)"), Pattern.compile("([0-9]+)")});
               put(
                   PayloadEncoder.class,
-                  random ->
-                      new IdentityEncoder()); // the other encoders will throw exceptions if tokens
+                  _ -> new IdentityEncoder()); // the other encoders will throw exceptions if tokens
               // arent numbers?
               put(
                   Dictionary.class,
-                  random -> {
+                  _ -> {
                     // TODO: make nastier
                     InputStream affixStream =
                         TestRandomChains.class.getResourceAsStream("simple.aff");
@@ -270,7 +268,7 @@ public class TestRandomChains extends BaseTokenStreamTestCase {
                   });
               put(
                   HyphenationTree.class,
-                  random -> {
+                  _ -> {
                     // TODO: make nastier
                     try {
                       InputSource is =
@@ -509,14 +507,14 @@ public class TestRandomChains extends BaseTokenStreamTestCase {
               put(
                   JapaneseTokenizer.Mode.class,
                   random -> jaTokModes[random.nextInt(jaTokModes.length)]);
-              put(org.apache.lucene.analysis.ja.dict.UserDictionary.class, random -> null);
+              put(org.apache.lucene.analysis.ja.dict.UserDictionary.class, _ -> null);
 
               // Nori:
               final var koComplFilterModes = KoreanTokenizer.DecompoundMode.values();
               put(
                   KoreanTokenizer.DecompoundMode.class,
                   random -> koComplFilterModes[random.nextInt(koComplFilterModes.length)]);
-              put(org.apache.lucene.analysis.ko.dict.UserDictionary.class, random -> null);
+              put(org.apache.lucene.analysis.ko.dict.UserDictionary.class, _ -> null);
 
               // Phonetic:
               final var bmNameTypes = org.apache.commons.codec.language.bm.NameType.values();
@@ -553,9 +551,7 @@ public class TestRandomChains extends BaseTokenStreamTestCase {
                   });
 
               // Stempel
-              put(
-                  StempelStemmer.class,
-                  random -> new StempelStemmer(PolishAnalyzer.getDefaultTable()));
+              put(StempelStemmer.class, _ -> new StempelStemmer(PolishAnalyzer.getDefaultTable()));
             }
           });
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
@@ -812,7 +812,7 @@ public class Dictionary {
         affixArg = new StringBuilder(affixArg).reverse().toString();
       }
 
-      affixes.computeIfAbsent(affixArg, __ -> new IntArrayList()).add(currentAffix);
+      affixes.computeIfAbsent(affixArg, _ -> new IntArrayList()).add(currentAffix);
       currentAffix++;
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/FragmentChecker.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/FragmentChecker.java
@@ -24,7 +24,7 @@ package org.apache.lucene.analysis.hunspell;
  * @see NGramFragmentChecker
  */
 public interface FragmentChecker {
-  FragmentChecker EVERYTHING_POSSIBLE = (word, start, end) -> false;
+  FragmentChecker EVERYTHING_POSSIBLE = (_, _, _) -> false;
 
   /**
    * Check if the given word range intersects any fragment which is impossible in the current

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Hunspell.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Hunspell.java
@@ -171,7 +171,7 @@ public class Hunspell {
         offset,
         length,
         context,
-        (stem, formID, morphDataId, outerPrefix, innerPrefix, outerSuffix, innerSuffix) -> {
+        (stem, formID, _, _, _, _, _) -> {
           if (!acceptCase(toCheck, formID, stem)) {
             return dictionary.hasFlag(formID, Dictionary.HIDDEN_FLAG);
           }
@@ -478,7 +478,7 @@ public class Hunspell {
     words.add(ref);
 
     Stemmer.RootProcessor stopOnMatching =
-        (stem, formID, morphDataId, outerPrefix, innerPrefix, outerSuffix, innerSuffix) -> {
+        (_, formID, _, _, _, _, _) -> {
           ref.ints[0] = formID;
           for (CompoundRule r : dictionary.compoundRules) {
             if (r.fullyMatches(words)) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
@@ -68,7 +68,7 @@ final class Stemmer {
     analyze(
         word,
         length,
-        (stem, formID, morphDataId, outerPrefix, innerPrefix, outerSuffix, innerSuffix) -> {
+        (stem, _, morphDataId, _, _, _, _) -> {
           list.add(newStem(stem, morphDataId));
           return true;
         });
@@ -98,7 +98,7 @@ final class Stemmer {
     WordCase wordCase = caseOf(word, length);
     if (wordCase == WordCase.UPPER || wordCase == WordCase.TITLE) {
       CaseVariationProcessor variationProcessor =
-          (variant, varLength, originalCase) ->
+          (variant, varLength, _) ->
               doStem(variant, 0, varLength, WordContext.SIMPLE_WORD, processor);
       varyCase(word, length, wordCase, variationProcessor);
     }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Suggester.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Suggester.java
@@ -172,7 +172,7 @@ public class Suggester {
               return compoundCache
                   .computeIfAbsent(
                       new String(chars, offset, length),
-                      __ ->
+                      _ ->
                           Optional.ofNullable(super.findStem(chars, offset, length, null, context)))
                   .orElse(null);
             }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/WordFormGenerator.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/WordFormGenerator.java
@@ -402,7 +402,7 @@ public class WordFormGenerator {
 
       for (String word : words) {
         checkCanceled.run();
-        stemToPossibleFlags.computeIfAbsent(word, __ -> new LinkedHashSet<>());
+        stemToPossibleFlags.computeIfAbsent(word, _ -> new LinkedHashSet<>());
         var processor =
             new Stemmer.StemCandidateProcessor(WordContext.SIMPLE_WORD) {
               @Override
@@ -427,14 +427,14 @@ public class WordFormGenerator {
                     || allGenerated(swf).stream().noneMatch(forbidden::contains)) {
                   registerStem(candidate);
                   stemToPossibleFlags
-                      .computeIfAbsent(candidate, __ -> new LinkedHashSet<>())
+                      .computeIfAbsent(candidate, _ -> new LinkedHashSet<>())
                       .add(flagSet);
                 }
                 return true;
               }
 
               void registerStem(String stem) {
-                stemsToForms.computeIfAbsent(stem, __ -> new LinkedHashSet<>()).add(word);
+                stemsToForms.computeIfAbsent(stem, _ -> new LinkedHashSet<>()).add(word);
               }
             };
         processor.registerStem(word);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ProtectedTermFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ProtectedTermFilterFactory.java
@@ -138,7 +138,7 @@ public class ProtectedTermFilterFactory extends ConditionalTokenFilterFactory {
         String filterName = splitKey.get(0).toLowerCase(Locale.ROOT);
         if (wrappedFilterArgs.containsKey(filterName)) { // Skip if not in "wrappedFilter" arg
           Map<String, String> filterArgs =
-              wrappedFilterArgs.computeIfAbsent(filterName, k -> new HashMap<>());
+              wrappedFilterArgs.computeIfAbsent(filterName, _ -> new HashMap<>());
           String argKey = splitKey.get(1);
           filterArgs.put(
               argKey, argValue); // argKey is guaranteed unique, don't need to check for duplicates

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestAllDictionaries.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestAllDictionaries.java
@@ -121,8 +121,8 @@ public class TestAllDictionaries extends LuceneTestCase {
               switch (firstWord) {
                 case "SET":
                 case "FLAG":
-                  local.computeIfAbsent(firstWord, (k) -> new ArrayList<>()).add(is.position());
-                  global.computeIfAbsent(firstWord, (k) -> new ArrayList<>()).add(is.position());
+                  local.computeIfAbsent(firstWord, (_) -> new ArrayList<>()).add(is.position());
+                  global.computeIfAbsent(firstWord, (_) -> new ArrayList<>()).add(is.position());
                   break;
               }
             }

--- a/lucene/classification/src/java/org/apache/lucene/classification/utils/NearestFuzzyQuery.java
+++ b/lucene/classification/src/java/org/apache/lucene/classification/utils/NearestFuzzyQuery.java
@@ -231,7 +231,7 @@ public class NearestFuzzyQuery extends Query {
       ScoreTerm st = q.pop();
       if (st != null) {
         ArrayList<ScoreTerm> l =
-            variantQueries.computeIfAbsent(st.fuzziedSourceTerm, k -> new ArrayList<>());
+            variantQueries.computeIfAbsent(st.fuzziedSourceTerm, _ -> new ArrayList<>());
         l.add(st);
       }
     }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/uniformsplit/sharedterms/STUniformSplitTermsWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/uniformsplit/sharedterms/STUniformSplitTermsWriter.java
@@ -386,7 +386,7 @@ public class STUniformSplitTermsWriter extends UniformSplitTermsWriter {
           segmentTerms.fieldTermStatesMap.entrySet()) {
         List<SegmentPostings> segmentPostingsList =
             fieldPostingsMap.computeIfAbsent(
-                fieldTermState.getKey(), k -> new ArrayList<>(groupedSegmentTerms.size()));
+                fieldTermState.getKey(), _ -> new ArrayList<>(groupedSegmentTerms.size()));
         segmentPostingsList.add(
             new SegmentPostings(
                 segmentTerms.segmentIndex,

--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
@@ -134,7 +134,7 @@ class BufferedUpdates implements Accountable {
   void addNumericUpdate(NumericDocValuesUpdate update, int docIDUpto) {
     FieldUpdatesBuffer buffer =
         fieldUpdates.computeIfAbsent(
-            update.field, k -> new FieldUpdatesBuffer(fieldUpdatesBytesUsed, update, docIDUpto));
+            update.field, _ -> new FieldUpdatesBuffer(fieldUpdatesBytesUsed, update, docIDUpto));
     if (update.hasValue) {
       buffer.addUpdate(update.term, update.getValue(), docIDUpto);
     } else {
@@ -146,7 +146,7 @@ class BufferedUpdates implements Accountable {
   void addBinaryUpdate(BinaryDocValuesUpdate update, int docIDUpto) {
     FieldUpdatesBuffer buffer =
         fieldUpdates.computeIfAbsent(
-            update.field, k -> new FieldUpdatesBuffer(fieldUpdatesBytesUsed, update, docIDUpto));
+            update.field, _ -> new FieldUpdatesBuffer(fieldUpdatesBytesUsed, update, docIDUpto));
     if (update.hasValue) {
       buffer.addUpdate(update.term, update.getValue(), docIDUpto);
     } else {
@@ -211,7 +211,7 @@ class BufferedUpdates implements Accountable {
       BytesRefIntMap hash =
           deleteTerms.computeIfAbsent(
               term.field,
-              k -> {
+              _ -> {
                 bytesUsed.addAndGet(RamUsageEstimator.sizeOf(term.field));
                 return new BytesRefIntMap(pool, bytesUsed);
               });

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
@@ -215,7 +215,7 @@ final class DocumentsWriter implements Closeable, Accountable {
       if (infoStream.isEnabled("DW")) {
         infoStream.message("DW", "abort");
       }
-      for (final DocumentsWriterPerThread perThread : perThreadPool.filterAndLock(x -> true)) {
+      for (final DocumentsWriterPerThread perThread : perThreadPool.filterAndLock(_ -> true)) {
         try {
           abortDocumentsWriterPerThread(perThread);
         } finally {
@@ -291,7 +291,7 @@ final class DocumentsWriter implements Closeable, Accountable {
     try {
       deleteQueue.clear();
       perThreadPool.lockNewWriters();
-      writers.addAll(perThreadPool.filterAndLock(x -> true));
+      writers.addAll(perThreadPool.filterAndLock(_ -> true));
       for (final DocumentsWriterPerThread perThread : writers) {
         assert perThread.isHeldByCurrentThread();
         abortDocumentsWriterPerThread(perThread);

--- a/lucene/core/src/java/org/apache/lucene/index/FilterDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterDirectoryReader.java
@@ -177,7 +177,7 @@ public abstract class FilterDirectoryReader extends DirectoryReader {
       // here we wrap the listener and call it with our cache key
       // this is important since this key will be used to cache the reader and otherwise we won't
       // free caches etc.
-      delegate.addClosedListener(unused -> listener.onClose(cacheKey));
+      delegate.addClosedListener(_ -> listener.onClose(cacheKey));
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -86,7 +86,7 @@ final class FrozenBufferedUpdates {
         : "segment private packet should only have del queries";
 
     PrefixCodedTerms.Builder builder = new PrefixCodedTerms.Builder();
-    updates.deleteTerms.forEachOrdered((term, doc) -> builder.add(term));
+    updates.deleteTerms.forEachOrdered((term, _) -> builder.add(term));
     deleteTerms = builder.finish();
 
     deleteQueries = new Query[updates.deleteQueries.size()];

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3333,7 +3333,7 @@ public class IndexWriter
                 infoStream.message("IW", "now abort pending addIndexes merge");
               }
               merge.setAborted();
-              merge.close(false, false, mr -> {});
+              merge.close(false, false, _ -> {});
               onMergeFinished(merge);
             });
         pendingAddIndexesMerges.clear();
@@ -3350,7 +3350,7 @@ public class IndexWriter
         handleMergeException(t, merge);
       } finally {
         synchronized (IndexWriter.this) {
-          merge.close(success, false, mr -> {});
+          merge.close(success, false, _ -> {});
           onMergeFinished(merge);
         }
       }
@@ -3731,7 +3731,7 @@ public class IndexWriter
                 // necessary files to disk and checkpointed them.
                 pointInTimeMerges =
                     preparePointInTimeMerge(
-                        toCommit, stopAddingMergedSegments::get, MergeTrigger.COMMIT, sci -> {});
+                        toCommit, stopAddingMergedSegments::get, MergeTrigger.COMMIT, _ -> {});
               }
             }
             success = true;

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -147,7 +147,7 @@ final class ReadersAndUpdates {
       throw new IllegalArgumentException("call finish first");
     }
     List<DocValuesFieldUpdates> fieldUpdates =
-        pendingDVUpdates.computeIfAbsent(update.field, key -> new ArrayList<>());
+        pendingDVUpdates.computeIfAbsent(update.field, _ -> new ArrayList<>());
     assert assertNoDupGen(fieldUpdates, update);
 
     ramBytesUsed.addAndGet(update.ramBytesUsed());

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -810,7 +810,7 @@ public final class SortingCodecReader extends FilterCodecReader {
   private boolean assertCreatedOnlyOnce(String field, boolean norms) {
     assert Thread.holdsLock(this);
     // this is mainly there to make sure we change anything in the way we merge we realize it early
-    int timesCached = cacheStats.compute(field + "N:" + norms, (s, i) -> i == null ? 1 : i + 1);
+    int timesCached = cacheStats.compute(field + "N:" + norms, (_, i) -> i == null ? 1 : i + 1);
     if (timesCached > 1) {
       assert norms == false : "[" + field + "] norms must not be cached twice";
       boolean isSortField = false;

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java
@@ -64,7 +64,7 @@ abstract class AbstractVectorSimilarityQuery extends Query {
   }
 
   protected KnnCollectorManager getKnnCollectorManager() {
-    return (visitLimit, searchStrategy, context) ->
+    return (visitLimit, _, _) ->
         new VectorSimilarityCollector(traversalSimilarity, resultSimilarity, visitLimit);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdStream.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdStream.java
@@ -39,7 +39,7 @@ public abstract class DocIdStream {
   /** Count the number of entries in this stream. This is a terminal operation. */
   public int count() throws IOException {
     int[] count = new int[1];
-    forEach(doc -> count[0]++);
+    forEach(_ -> count[0]++);
     return count[0];
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
@@ -44,7 +44,7 @@ import org.apache.lucene.util.automaton.RegExp;
 public class RegexpQuery extends AutomatonQuery {
 
   /** A provider that provides no named automata */
-  public static final AutomatonProvider DEFAULT_PROVIDER = name -> null;
+  public static final AutomatonProvider DEFAULT_PROVIDER = _ -> null;
 
   /**
    * Constructs a query for terms matching <code>term</code>.

--- a/lucene/core/src/java/org/apache/lucene/search/SloppyPhraseMatcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SloppyPhraseMatcher.java
@@ -589,7 +589,7 @@ public final class SloppyPhraseMatcher extends PhraseMatcher {
     HashMap<Term, Integer> tcnt = new HashMap<>();
     for (PhrasePositions pp : phrasePositions) {
       for (Term t : pp.terms) {
-        Integer cnt = tcnt.compute(t, (key, old) -> old == null ? 1 : 1 + old);
+        Integer cnt = tcnt.compute(t, (_, old) -> old == null ? 1 : 1 + old);
         if (cnt == 2) {
           tord.put(t, tord.size());
         }

--- a/lucene/core/src/java/org/apache/lucene/search/TopDocs.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopDocs.java
@@ -405,7 +405,7 @@ public class TopDocs {
         double rrfScoreContribution = 1d / Math.addExact(k, rank);
         rrfScore.compute(
             new ShardIndexAndDoc(scoreDoc.shardIndex, scoreDoc.doc),
-            (key, score) -> (score == null ? 0 : score) + rrfScoreContribution);
+            (_, score) -> (score == null ? 0 : score) + rrfScoreContribution);
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
@@ -44,7 +44,7 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
 
   /** A singleton instance of "no-reuse" buffer strategy. */
   public static final Consumer<ByteBuffer> NO_REUSE =
-      (bb) -> {
+      (_) -> {
         throw new RuntimeException("reset() is not allowed on this buffer.");
       };
 

--- a/lucene/core/src/java/org/apache/lucene/store/LockVerifyServer.java
+++ b/lucene/core/src/java/org/apache/lucene/store/LockVerifyServer.java
@@ -150,6 +150,6 @@ public class LockVerifyServer {
       System.exit(1);
     }
 
-    run(args[0], Integer.parseInt(args[1]), addr -> {});
+    run(args[0], Integer.parseInt(args[1]), _ -> {});
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -86,13 +86,13 @@ public class MMapDirectory extends FSDirectory {
    * Argument for {@link #setPreload(BiPredicate)} that configures all files to be preloaded upon
    * opening them.
    */
-  public static final BiPredicate<String, IOContext> ALL_FILES = (filename, context) -> true;
+  public static final BiPredicate<String, IOContext> ALL_FILES = (_, _) -> true;
 
   /**
    * Argument for {@link #setPreload(BiPredicate)} that configures no files to be preloaded upon
    * opening them.
    */
-  public static final BiPredicate<String, IOContext> NO_FILES = (filename, context) -> false;
+  public static final BiPredicate<String, IOContext> NO_FILES = (_, _) -> false;
 
   /**
    * This sysprop allows to control the total maximum number of mmapped files that can be associated
@@ -107,7 +107,7 @@ public class MMapDirectory extends FSDirectory {
       "org.apache.lucene.store.MMapDirectory.sharedArenaMaxPermits";
 
   /** Argument for {@link #setGroupingFunction(Function)} that configures no grouping. */
-  public static final Function<String, Optional<String>> NO_GROUPING = filename -> Optional.empty();
+  public static final Function<String, Optional<String>> NO_GROUPING = _ -> Optional.empty();
 
   /** Argument for {@link #setGroupingFunction(Function)} that configures grouping by segment. */
   public static final Function<String, Optional<String>> GROUP_BY_SEGMENT =
@@ -134,7 +134,7 @@ public class MMapDirectory extends FSDirectory {
    * opening them if they use the {@link ReadAdvice#RANDOM_PRELOAD} advice.
    */
   public static final BiPredicate<String, IOContext> BASED_ON_LOAD_IO_CONTEXT =
-      (filename, context) -> context.readAdvice() == ReadAdvice.RANDOM_PRELOAD;
+      (_, context) -> context.readAdvice() == ReadAdvice.RANDOM_PRELOAD;
 
   private BiPredicate<String, IOContext> preload = NO_FILES;
 

--- a/lucene/core/src/java/org/apache/lucene/util/HotspotVMOptions.java
+++ b/lucene/core/src/java/org/apache/lucene/util/HotspotVMOptions.java
@@ -43,7 +43,7 @@ final class HotspotVMOptions {
 
   static {
     boolean isHotspot = false;
-    Function<String, Optional<String>> accessor = name -> Optional.empty();
+    Function<String, Optional<String>> accessor = _ -> Optional.empty();
     try {
       final Class<?> beanClazz = Class.forName(HOTSPOT_BEAN_CLASS);
       // we use reflection for this, because the management factory is not part

--- a/lucene/core/src/java/org/apache/lucene/util/MapOfSets.java
+++ b/lucene/core/src/java/org/apache/lucene/util/MapOfSets.java
@@ -52,7 +52,7 @@ public class MapOfSets<K, V> {
    * @return the size of the Set associated with key once val is added to it.
    */
   public int put(K key, V val) {
-    final Set<V> theSet = theMap.computeIfAbsent(key, k -> new HashSet<>(23));
+    final Set<V> theSet = theMap.computeIfAbsent(key, _ -> new HashSet<>(23));
     theSet.add(val);
     return theSet.size();
   }
@@ -64,7 +64,7 @@ public class MapOfSets<K, V> {
    * @return the size of the Set associated with key once val is added to it.
    */
   public int putAll(K key, Collection<? extends V> vals) {
-    final Set<V> theSet = theMap.computeIfAbsent(key, k -> new HashSet<>(23));
+    final Set<V> theSet = theMap.computeIfAbsent(key, _ -> new HashSet<>(23));
     theSet.addAll(vals);
     return theSet.size();
   }

--- a/lucene/core/src/test/org/apache/lucene/analysis/TestAnalyzerWrapper.java
+++ b/lucene/core/src/test/org/apache/lucene/analysis/TestAnalyzerWrapper.java
@@ -37,7 +37,7 @@ public class TestAnalyzerWrapper extends LuceneTestCase {
           @Override
           protected TokenStreamComponents createComponents(String fieldName) {
             return new TokenStreamComponents(
-                r -> {
+                _ -> {
                   sourceCalled.set(true);
                 },
                 new CannedTokenStream());
@@ -93,7 +93,7 @@ public class TestAnalyzerWrapper extends LuceneTestCase {
         new Analyzer(wrappedAnalyzerStrategy) {
           @Override
           protected TokenStreamComponents createComponents(String fieldName) {
-            return new TokenStreamComponents(r -> {}, new CannedTokenStream());
+            return new TokenStreamComponents(_ -> {}, new CannedTokenStream());
           }
         };
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -776,7 +776,7 @@ public class TestAddIndexes extends LuceneTestCase {
           break;
         }
         if (mergesTriggered >= mergesToDo) {
-          merge.close(false, false, mr -> {});
+          merge.close(false, false, _ -> {});
           mergeSource.onMergeFinished(merge);
         } else {
           mergeSource.merge(merge);

--- a/lucene/core/src/test/org/apache/lucene/index/TestApproximatePriorityQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestApproximatePriorityQueue.java
@@ -26,26 +26,26 @@ public class TestApproximatePriorityQueue extends LuceneTestCase {
     pq.add(32L, 32L);
     pq.add(0L, 0L);
     assertFalse(pq.isEmpty());
-    assertEquals(Long.valueOf(32L), pq.poll(x -> true));
+    assertEquals(Long.valueOf(32L), pq.poll(_ -> true));
     assertFalse(pq.isEmpty());
-    assertEquals(Long.valueOf(8L), pq.poll(x -> true));
+    assertEquals(Long.valueOf(8L), pq.poll(_ -> true));
     assertFalse(pq.isEmpty());
-    assertEquals(Long.valueOf(0L), pq.poll(x -> true));
+    assertEquals(Long.valueOf(0L), pq.poll(_ -> true));
     assertTrue(pq.isEmpty());
-    assertNull(pq.poll(x -> true));
+    assertNull(pq.poll(_ -> true));
   }
 
   public void testPollThenAdd() {
     ApproximatePriorityQueue<Long> pq = new ApproximatePriorityQueue<>();
     pq.add(8L, 8L);
-    assertEquals(Long.valueOf(8L), pq.poll(x -> true));
-    assertNull(pq.poll(x -> true));
+    assertEquals(Long.valueOf(8L), pq.poll(_ -> true));
+    assertNull(pq.poll(_ -> true));
     pq.add(0L, 0L);
-    assertEquals(Long.valueOf(0L), pq.poll(x -> true));
-    assertNull(pq.poll(x -> true));
+    assertEquals(Long.valueOf(0L), pq.poll(_ -> true));
+    assertNull(pq.poll(_ -> true));
     pq.add(0L, 0L);
-    assertEquals(Long.valueOf(0L), pq.poll(x -> true));
-    assertNull(pq.poll(x -> true));
+    assertEquals(Long.valueOf(0L), pq.poll(_ -> true));
+    assertNull(pq.poll(_ -> true));
   }
 
   public void testCollision() {
@@ -55,15 +55,15 @@ public class TestApproximatePriorityQueue extends LuceneTestCase {
     pq.add(0L, 0L);
     pq.add(3L, 3L); // Same nlz as 2
     assertFalse(pq.isEmpty());
-    assertEquals(Long.valueOf(2L), pq.poll(x -> true));
+    assertEquals(Long.valueOf(2L), pq.poll(_ -> true));
     assertFalse(pq.isEmpty());
-    assertEquals(Long.valueOf(1L), pq.poll(x -> true));
+    assertEquals(Long.valueOf(1L), pq.poll(_ -> true));
     assertFalse(pq.isEmpty());
-    assertEquals(Long.valueOf(3L), pq.poll(x -> true));
+    assertEquals(Long.valueOf(3L), pq.poll(_ -> true));
     assertFalse(pq.isEmpty());
-    assertEquals(Long.valueOf(0L), pq.poll(x -> true));
+    assertEquals(Long.valueOf(0L), pq.poll(_ -> true));
     assertTrue(pq.isEmpty());
-    assertNull(pq.poll(x -> true));
+    assertNull(pq.poll(_ -> true));
   }
 
   public void testPollWithPredicate() {

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentApproximatePriorityQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentApproximatePriorityQueue.java
@@ -33,10 +33,10 @@ public class TestConcurrentApproximatePriorityQueue extends LuceneTestCase {
     pq.add(3, 3);
     pq.add(10, 10);
     pq.add(7, 7);
-    assertEquals(Integer.valueOf(10), pq.poll(x -> true));
-    assertEquals(Integer.valueOf(7), pq.poll(x -> true));
-    assertEquals(Integer.valueOf(3), pq.poll(x -> true));
-    assertNull(pq.poll(x -> true));
+    assertEquals(Integer.valueOf(10), pq.poll(_ -> true));
+    assertEquals(Integer.valueOf(7), pq.poll(_ -> true));
+    assertEquals(Integer.valueOf(3), pq.poll(_ -> true));
+    assertNull(pq.poll(_ -> true));
   }
 
   public void testPollFromDifferentThread() throws Exception {
@@ -53,10 +53,10 @@ public class TestConcurrentApproximatePriorityQueue extends LuceneTestCase {
         new Thread() {
           @Override
           public void run() {
-            assertEquals(Integer.valueOf(10), pq.poll(x -> true));
-            assertEquals(Integer.valueOf(7), pq.poll(x -> true));
-            assertEquals(Integer.valueOf(3), pq.poll(x -> true));
-            assertNull(pq.poll(x -> true));
+            assertEquals(Integer.valueOf(10), pq.poll(_ -> true));
+            assertEquals(Integer.valueOf(7), pq.poll(_ -> true));
+            assertEquals(Integer.valueOf(3), pq.poll(_ -> true));
+            assertNull(pq.poll(_ -> true));
           }
         };
     t.start();
@@ -95,9 +95,9 @@ public class TestConcurrentApproximatePriorityQueue extends LuceneTestCase {
     t.start();
     takeLock.await();
     pq.add(1, 1); // The lock is taken so this needs to go to a different queue
-    assertEquals(Integer.valueOf(1), pq.poll(x -> true));
+    assertEquals(Integer.valueOf(1), pq.poll(_ -> true));
     releaseLock.countDown();
-    assertEquals(Integer.valueOf(3), pq.poll(x -> true));
-    assertNull(pq.poll(x -> true));
+    assertEquals(Integer.valueOf(3), pq.poll(_ -> true));
+    assertNull(pq.poll(_ -> true));
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestCustomNorms.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCustomNorms.java
@@ -56,7 +56,7 @@ public class TestCustomNorms extends LuceneTestCase {
       int boost = TestUtil.nextInt(random(), 1, 10);
       String value =
           IntStream.range(0, boost)
-              .mapToObj(k -> Integer.toString(boost))
+              .mapToObj(_ -> Integer.toString(boost))
               .collect(Collectors.joining(" "));
       Field f = new TextField(FLOAT_TEST_FIELD, value, Field.Store.YES);
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDirectoryReader.java
@@ -984,7 +984,7 @@ public class TestDirectoryReader extends LuceneTestCase {
     writer.commit();
     final DirectoryReader reader = DirectoryReader.open(writer);
     final int[] closeCount = new int[1];
-    final IndexReader.ClosedListener listener = key -> closeCount[0]++;
+    final IndexReader.ClosedListener listener = _ -> closeCount[0]++;
 
     reader.getReaderCacheHelper().addClosedListener(listener);
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterPerThreadPool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterPerThreadPool.java
@@ -59,7 +59,7 @@ public class TestDocumentsWriterPerThreadPool extends LuceneTestCase {
       assertEquals(1, pool.size());
       pool.marksAsFreeAndUnlock(second);
       assertEquals(1, pool.size());
-      for (DocumentsWriterPerThread lastPerThead : pool.filterAndLock(x -> true)) {
+      for (DocumentsWriterPerThread lastPerThead : pool.filterAndLock(_ -> true)) {
         pool.checkout(lastPerThead);
         lastPerThead.unlock();
       }
@@ -107,7 +107,7 @@ public class TestDocumentsWriterPerThreadPool extends LuceneTestCase {
       first.unlock();
       pool.close();
       pool.unlockNewWriters();
-      for (DocumentsWriterPerThread perThread : pool.filterAndLock(x -> true)) {
+      for (DocumentsWriterPerThread perThread : pool.filterAndLock(_ -> true)) {
         assertTrue(pool.checkout(perThread));
         perThread.unlock();
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldUpdatesBuffer.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldUpdatesBuffer.java
@@ -290,7 +290,7 @@ public class TestFieldUpdatesBuffer extends LuceneTestCase {
       SortedMap<BytesRef, DocValuesUpdate.NumericDocValuesUpdate> byTerms = new TreeMap<>();
       for (DocValuesUpdate.NumericDocValuesUpdate update : updates) {
         byTerms.compute(
-            update.term.bytes, (k, v) -> v != null && v.docIDUpTo >= update.docIDUpTo ? v : update);
+            update.term.bytes, (_, v) -> v != null && v.docIDUpTo >= update.docIDUpTo ? v : update);
       }
       updates = new ArrayList<>(byTerms.values());
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexReaderClose.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexReaderClose.java
@@ -179,20 +179,20 @@ public class TestIndexReaderClose extends LuceneTestCase {
     w.close();
 
     // The reader is open, everything should work
-    r.getReaderCacheHelper().addClosedListener(key -> {});
-    r.leaves().get(0).reader().getReaderCacheHelper().addClosedListener(key -> {});
-    r.leaves().get(0).reader().getCoreCacheHelper().addClosedListener(key -> {});
+    r.getReaderCacheHelper().addClosedListener(_ -> {});
+    r.leaves().get(0).reader().getReaderCacheHelper().addClosedListener(_ -> {});
+    r.leaves().get(0).reader().getCoreCacheHelper().addClosedListener(_ -> {});
 
     // But now we close
     r.close();
     expectThrows(
-        AlreadyClosedException.class, () -> r.getReaderCacheHelper().addClosedListener(key -> {}));
+        AlreadyClosedException.class, () -> r.getReaderCacheHelper().addClosedListener(_ -> {}));
     expectThrows(
         AlreadyClosedException.class,
-        () -> r.leaves().get(0).reader().getReaderCacheHelper().addClosedListener(key -> {}));
+        () -> r.leaves().get(0).reader().getReaderCacheHelper().addClosedListener(_ -> {}));
     expectThrows(
         AlreadyClosedException.class,
-        () -> r.leaves().get(0).reader().getCoreCacheHelper().addClosedListener(key -> {}));
+        () -> r.leaves().get(0).reader().getCoreCacheHelper().addClosedListener(_ -> {}));
 
     dir.close();
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
@@ -2335,7 +2335,7 @@ public class TestIndexSorting extends LuceneTestCase {
       doc.add(new NumericDocValuesField("numeric", id));
       String value =
           IntStream.range(0, id)
-              .mapToObj(k -> Integer.toString(id))
+              .mapToObj(_ -> Integer.toString(id))
               .collect(Collectors.joining(" "));
       TextField norms = new TextField("norms", value, Store.NO);
       doc.add(norms);

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -4264,7 +4264,7 @@ public class TestIndexWriter extends LuceneTestCase {
       t.join();
       assertEquals(4, executed.get());
       expectThrows(AlreadyClosedException.class, () -> queue.processEvents());
-      expectThrows(AlreadyClosedException.class, () -> queue.add(w -> {}));
+      expectThrows(AlreadyClosedException.class, () -> queue.add(_ -> {}));
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
@@ -647,7 +647,7 @@ public class TestIndexWriterReader extends LuceneTestCase {
             newIndexWriterConfig(new MockAnalyzer(random()))
                 .setMaxBufferedDocs(2)
                 .setMaxFullFlushMergeWaitMillis(0)
-                .setMergedSegmentWarmer((leafReader) -> warmCount.incrementAndGet())
+                .setMergedSegmentWarmer((_) -> warmCount.incrementAndGet())
                 .setMergeScheduler(new ConcurrentMergeScheduler())
                 .setMergePolicy(newLogMergePolicy()));
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMergePolicy.java
@@ -46,7 +46,7 @@ public class TestMergePolicy extends LuceneTestCase {
               () -> {
                 try {
                   for (MergePolicy.OneMerge m : ms.merges) {
-                    m.close(true, false, mr -> {});
+                    m.close(true, false, _ -> {});
                   }
                 } catch (IOException e) {
                   throw new AssertionError(e);
@@ -71,7 +71,7 @@ public class TestMergePolicy extends LuceneTestCase {
           new Thread(
               () -> {
                 try {
-                  ms.merges.get(0).close(true, false, mr -> {});
+                  ms.merges.get(0).close(true, false, _ -> {});
                 } catch (IOException e) {
                   throw new AssertionError(e);
                 }
@@ -97,7 +97,7 @@ public class TestMergePolicy extends LuceneTestCase {
               () -> {
                 while (stop.get() == false) {
                   try {
-                    ms.merges.get(i.getAndIncrement()).close(true, false, mr -> {});
+                    ms.merges.get(i.getAndIncrement()).close(true, false, _ -> {});
                     Thread.sleep(1);
                   } catch (IOException | InterruptedException e) {
                     throw new AssertionError(e);
@@ -122,8 +122,8 @@ public class TestMergePolicy extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       MergePolicy.MergeSpecification spec = createRandomMergeSpecification(dir, 1);
       MergePolicy.OneMerge oneMerge = spec.merges.get(0);
-      oneMerge.close(true, false, mr -> {});
-      expectThrows(IllegalStateException.class, () -> oneMerge.close(false, false, mr -> {}));
+      oneMerge.close(true, false, _ -> {});
+      expectThrows(IllegalStateException.class, () -> oneMerge.close(false, false, _ -> {}));
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestNorms.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestNorms.java
@@ -76,7 +76,7 @@ public class TestNorms extends LuceneTestCase {
       int boost = TestUtil.nextInt(random, 1, 255);
       String value =
           IntStream.range(0, boost)
-              .mapToObj(k -> Integer.toString(boost))
+              .mapToObj(_ -> Integer.toString(boost))
               .collect(Collectors.joining(" "));
       Field f = new TextField(BYTE_TEST_FIELD, value, Field.Store.YES);
       doc.add(f);

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
@@ -393,7 +393,7 @@ public class TestSegmentToThreadMapping extends LuceneTestCase {
     IndexReader r = w.getReader();
     w.close();
 
-    IndexSearcher s = new IndexSearcher(r, command -> {});
+    IndexSearcher s = new IndexSearcher(r, _ -> {});
     IndexSearcher.LeafSlice[] slices = s.getSlices();
     assertNotNull(slices);
 
@@ -422,7 +422,7 @@ public class TestSegmentToThreadMapping extends LuceneTestCase {
     w.close();
 
     IndexSearcher s =
-        new IndexSearcher(r, command -> {}) {
+        new IndexSearcher(r, _ -> {}) {
           @Override
           protected LeafSlice[] slices(List<LeafReaderContext> leaves) {
             // force partitioning of segment with max docs per slice set to 1: 1 doc per partition.

--- a/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesRetentionMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesRetentionMergePolicy.java
@@ -502,7 +502,7 @@ public class TestSoftDeletesRetentionMergePolicy extends LuceneTestCase {
     writer
         .getConfig()
         .setMergedSegmentWarmer(
-            sr -> {
+            _ -> {
               if (update.compareAndSet(true, false)) {
                 try {
                   writer.softUpdateDocument(
@@ -575,7 +575,7 @@ public class TestSoftDeletesRetentionMergePolicy extends LuceneTestCase {
     writer
         .getConfig()
         .setMergedSegmentWarmer(
-            sr -> {
+            _ -> {
               if (delete.compareAndSet(true, false)) {
                 try {
                   long seqNo = writer.tryDeleteDocument(reader, 0);

--- a/lucene/core/src/test/org/apache/lucene/index/TestStressIndexing2.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestStressIndexing2.java
@@ -812,7 +812,7 @@ public class TestStressIndexing2 extends LuceneTestCase {
         FieldType fieldType =
             fieldTypes.computeIfAbsent(
                 fieldName,
-                fn -> {
+                _ -> {
                   FieldType ft = new FieldType();
                   switch (nextInt(4)) {
                     case 0:

--- a/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
@@ -575,7 +575,7 @@ abstract class BaseVectorSimilarityQueryTestCase<
 
   @SuppressWarnings("unchecked")
   V[] getRandomVectors(int numDocs, int dim) {
-    return (V[]) IntStream.range(0, numDocs).mapToObj(i -> getRandomVector(dim)).toArray();
+    return (V[]) IntStream.range(0, numDocs).mapToObj(_ -> getRandomVector(dim)).toArray();
   }
 
   @SafeVarargs

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRewriteMethod.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRewriteMethod.java
@@ -119,7 +119,7 @@ public class TestDocValuesRewriteMethod extends LuceneTestCase {
             new Term(fieldName, regexp),
             RegExp.NONE,
             0,
-            name -> null,
+            _ -> null,
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
             new DocValuesRewriteMethod());
     RegexpQuery docValuesWithSkip =
@@ -127,7 +127,7 @@ public class TestDocValuesRewriteMethod extends LuceneTestCase {
             new Term(fieldName + "_with-skip", regexp),
             RegExp.NONE,
             0,
-            name -> null,
+            _ -> null,
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
             new DocValuesRewriteMethod());
     RegexpQuery inverted = new RegexpQuery(new Term(fieldName, regexp), RegExp.NONE);
@@ -155,7 +155,7 @@ public class TestDocValuesRewriteMethod extends LuceneTestCase {
               new Term(fieldName, "[aA]"),
               RegExp.NONE,
               0,
-              name -> null,
+              _ -> null,
               Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
               new DocValuesRewriteMethod());
       RegexpQuery a2 =
@@ -163,7 +163,7 @@ public class TestDocValuesRewriteMethod extends LuceneTestCase {
               new Term(fieldName, "[aA]"),
               RegExp.NONE,
               0,
-              name -> null,
+              _ -> null,
               Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
               new DocValuesRewriteMethod());
       RegexpQuery b =
@@ -171,7 +171,7 @@ public class TestDocValuesRewriteMethod extends LuceneTestCase {
               new Term(fieldName, "[bB]"),
               RegExp.NONE,
               0,
-              name -> null,
+              _ -> null,
               Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
               new DocValuesRewriteMethod());
       assertEquals(a1, a2);

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldCacheRewriteMethod.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldCacheRewriteMethod.java
@@ -34,7 +34,7 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
             new Term(fieldName, regexp),
             RegExp.NONE,
             0,
-            name -> null,
+            _ -> null,
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
             new DocValuesRewriteMethod());
 
@@ -43,7 +43,7 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
             new Term(fieldName, regexp),
             RegExp.NONE,
             0,
-            name -> null,
+            _ -> null,
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
             MultiTermQuery.CONSTANT_SCORE_REWRITE);
 
@@ -52,7 +52,7 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
             new Term(fieldName, regexp),
             RegExp.NONE,
             0,
-            name -> null,
+            _ -> null,
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
             MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE);
 
@@ -80,7 +80,7 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
               new Term(fieldName, "[aA]"),
               RegExp.NONE,
               0,
-              name -> null,
+              _ -> null,
               Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
               new DocValuesRewriteMethod());
       RegexpQuery a2 =
@@ -88,7 +88,7 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
               new Term(fieldName, "[aA]"),
               RegExp.NONE,
               0,
-              name -> null,
+              _ -> null,
               Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
               new DocValuesRewriteMethod());
       RegexpQuery b =
@@ -96,7 +96,7 @@ public class TestFieldCacheRewriteMethod extends TestRegexpRandom2 {
               new Term(fieldName, "[bB]"),
               RegExp.NONE,
               0,
-              name -> null,
+              _ -> null,
               Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
               new DocValuesRewriteMethod());
       assertEquals(a1, a2);

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -107,7 +107,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
         new LRUQueryCache(
             1 + random().nextInt(20),
             1 + random().nextInt(10000),
-            context -> random().nextBoolean(),
+            _ -> random().nextBoolean(),
             Float.POSITIVE_INFINITY);
     Directory dir = newDirectory();
     final RandomIndexWriter w = new RandomIndexWriter(random(), dir);
@@ -251,7 +251,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     final DirectoryReader reader = w.getReader();
     final IndexSearcher searcher = newSearcher(reader);
     final LRUQueryCache queryCache =
-        new LRUQueryCache(2, 100000, context -> true, Float.POSITIVE_INFINITY);
+        new LRUQueryCache(2, 100000, _ -> true, Float.POSITIVE_INFINITY);
 
     final Query blue = new TermQuery(new Term("color", "blue"));
     final Query red = new TermQuery(new Term("color", "red"));
@@ -341,7 +341,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     final Query query2 = new TermQuery(new Term("color", "blue"));
 
     final LRUQueryCache queryCache =
-        new LRUQueryCache(Integer.MAX_VALUE, Long.MAX_VALUE, context -> true, 1);
+        new LRUQueryCache(Integer.MAX_VALUE, Long.MAX_VALUE, _ -> true, 1);
     searcher.setQueryCache(queryCache);
     searcher.setQueryCachingPolicy(ALWAYS_CACHE);
 
@@ -366,7 +366,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
         new LRUQueryCache(
             1 + random().nextInt(5),
             1 + random().nextInt(10000),
-            context -> random().nextBoolean(),
+            _ -> random().nextBoolean(),
             Float.POSITIVE_INFINITY);
     // an accumulator that only sums up memory usage of referenced filters and doc id sets
     final RamUsageTester.Accumulator acc =
@@ -508,7 +508,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
   @AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/LUCENE-7595")
   public void testRamBytesUsedConstantEntryOverhead() throws IOException {
     final LRUQueryCache queryCache =
-        new LRUQueryCache(1000000, 10000000, context -> true, Float.POSITIVE_INFINITY);
+        new LRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY);
 
     final RamUsageTester.Accumulator acc =
         new RamUsageTester.Accumulator() {
@@ -575,7 +575,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
 
   public void testCachingAccountableQuery() throws IOException {
     final LRUQueryCache queryCache =
-        new LRUQueryCache(1000000, 10000000, context -> true, Float.POSITIVE_INFINITY);
+        new LRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY);
 
     Directory dir = newDirectory();
     final RandomIndexWriter w = new RandomIndexWriter(random(), dir);
@@ -604,7 +604,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
   }
 
   public void testConsistencyWithAccountableQueries() throws IOException {
-    var queryCache = new LRUQueryCache(1, 10000000, context -> true, Float.POSITIVE_INFINITY);
+    var queryCache = new LRUQueryCache(1, 10000000, _ -> true, Float.POSITIVE_INFINITY);
 
     var dir = newDirectory();
     var writer = new RandomIndexWriter(random(), dir);
@@ -645,7 +645,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
         new LRUQueryCache(
             1 + random().nextInt(5),
             1 + random().nextInt(1000),
-            context -> random().nextBoolean(),
+            _ -> random().nextBoolean(),
             Float.POSITIVE_INFINITY);
 
     Directory dir = newDirectory();
@@ -715,7 +715,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
   }
 
   public void testStats() throws IOException {
-    final LRUQueryCache queryCache = new LRUQueryCache(1, 10000000, context -> true, 1);
+    final LRUQueryCache queryCache = new LRUQueryCache(1, 10000000, _ -> true, 1);
 
     Directory dir = newDirectory();
     final RandomIndexWriter w = new RandomIndexWriter(random(), dir);
@@ -847,7 +847,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     final AtomicLong cacheSize = new AtomicLong();
 
     final LRUQueryCache queryCache =
-        new LRUQueryCache(2, 10000000, context -> true, 1) {
+        new LRUQueryCache(2, 10000000, _ -> true, 1) {
           @Override
           protected void onHit(Object readerCoreKey, Query query) {
             super.onHit(readerCoreKey, query);
@@ -981,8 +981,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     query.add(new BoostQuery(expectedCacheKey, 42f), Occur.MUST);
 
     final LRUQueryCache queryCache =
-        new LRUQueryCache(
-            1000000, 10000000, context -> random().nextBoolean(), Float.POSITIVE_INFINITY);
+        new LRUQueryCache(1000000, 10000000, _ -> random().nextBoolean(), Float.POSITIVE_INFINITY);
     Directory dir = newDirectory();
     final RandomIndexWriter w = new RandomIndexWriter(random(), dir);
     Document doc = new Document();
@@ -1029,7 +1028,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     w.close();
 
     final LRUQueryCache queryCache =
-        new LRUQueryCache(1000000, 10000000, context -> true, Float.POSITIVE_INFINITY);
+        new LRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY);
     searcher.setQueryCache(queryCache);
     searcher.setQueryCachingPolicy(ALWAYS_CACHE);
 
@@ -1135,7 +1134,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
 
     final LRUQueryCache queryCache =
         new LRUQueryCache(
-            maxSize, maxRamBytesUsed, context -> random().nextBoolean(), Float.POSITIVE_INFINITY);
+            maxSize, maxRamBytesUsed, _ -> random().nextBoolean(), Float.POSITIVE_INFINITY);
     IndexSearcher uncachedSearcher = null;
     IndexSearcher cachedSearcher = null;
 
@@ -1226,7 +1225,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
 
     // size of 1 so that 2nd query evicts from the cache
     final LRUQueryCache queryCache =
-        new LRUQueryCache(1, 10000, context -> true, Float.POSITIVE_INFINITY);
+        new LRUQueryCache(1, 10000, _ -> true, Float.POSITIVE_INFINITY);
     final IndexSearcher searcher = newSearcher(reader);
     searcher.setQueryCache(queryCache);
     searcher.setQueryCachingPolicy(ALWAYS_CACHE);
@@ -1263,7 +1262,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
 
     // size of 1 byte
     final LRUQueryCache queryCache =
-        new LRUQueryCache(1, 1, context -> random().nextBoolean(), Float.POSITIVE_INFINITY);
+        new LRUQueryCache(1, 1, _ -> random().nextBoolean(), Float.POSITIVE_INFINITY);
     final IndexSearcher searcher = newSearcher(reader);
     searcher.setQueryCache(queryCache);
     searcher.setQueryCachingPolicy(ALWAYS_CACHE);
@@ -1305,8 +1304,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
         final FrequencyCountingPolicy policy = new FrequencyCountingPolicy();
         final IndexSearcher indexSearcher = new IndexSearcher(indexReader);
         indexSearcher.setQueryCache(
-            new LRUQueryCache(
-                100, 10240, context -> random().nextBoolean(), Float.POSITIVE_INFINITY));
+            new LRUQueryCache(100, 10240, _ -> random().nextBoolean(), Float.POSITIVE_INFINITY));
         indexSearcher.setQueryCachingPolicy(policy);
         final Query foo = new TermQuery(new Term("f", "foo"));
         final Query bar = new TermQuery(new Term("f", "bar"));
@@ -1341,7 +1339,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     public void onUse(final Query query) {
       AtomicInteger count;
       synchronized (counts) {
-        count = counts.computeIfAbsent(query, k -> new AtomicInteger());
+        count = counts.computeIfAbsent(query, _ -> new AtomicInteger());
       }
       count.incrementAndGet();
     }
@@ -1401,8 +1399,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     LeafReaderContext leaf = searcher.getIndexReader().leaves().get(0);
     AtomicBoolean scorerCalled = new AtomicBoolean();
     AtomicBoolean bulkScorerCalled = new AtomicBoolean();
-    LRUQueryCache cache =
-        new LRUQueryCache(1, Long.MAX_VALUE, context -> true, Float.POSITIVE_INFINITY);
+    LRUQueryCache cache = new LRUQueryCache(1, Long.MAX_VALUE, _ -> true, Float.POSITIVE_INFINITY);
 
     // test that the bulk scorer is propagated when a scorer should not be cached
     Weight weight = searcher.createWeight(new MatchAllDocsQuery(), ScoreMode.COMPLETE_NO_SCORES, 1);
@@ -1424,7 +1421,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     final DirectoryReader reader = w.getReader();
     final IndexSearcher searcher = newSearcher(reader);
     final LRUQueryCache queryCache =
-        new LRUQueryCache(2, 100000, context -> true, Float.POSITIVE_INFINITY) {
+        new LRUQueryCache(2, 100000, _ -> true, Float.POSITIVE_INFINITY) {
           @Override
           protected void onDocIdSetEviction(
               Object readerCoreKey, int numEntries, long sumRamBytesUsed) {
@@ -1538,7 +1535,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
 
     // don't cache if the reader does not expose a cache helper
     assertNull(reader.leaves().get(0).reader().getCoreCacheHelper());
-    LRUQueryCache cache = new LRUQueryCache(2, 10000, context -> true, Float.POSITIVE_INFINITY);
+    LRUQueryCache cache = new LRUQueryCache(2, 10000, _ -> true, Float.POSITIVE_INFINITY);
     searcher.setQueryCache(cache);
     assertEquals(0, searcher.count(new DummyQuery()));
     assertEquals(0, cache.getCacheCount());
@@ -1599,7 +1596,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
     searcher.setQueryCachingPolicy(ALWAYS_CACHE);
 
-    LRUQueryCache cache = new LRUQueryCache(2, 10000, context -> true, Float.POSITIVE_INFINITY);
+    LRUQueryCache cache = new LRUQueryCache(2, 10000, _ -> true, Float.POSITIVE_INFINITY);
     searcher.setQueryCache(cache);
 
     assertEquals(0, searcher.count(new NoCacheQuery()));
@@ -1771,7 +1768,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     IndexSearcher searcher = new AssertingIndexSearcher(random(), reader);
     searcher.setQueryCachingPolicy(ALWAYS_CACHE);
 
-    LRUQueryCache cache = new LRUQueryCache(1, 10000, context -> true, Float.POSITIVE_INFINITY);
+    LRUQueryCache cache = new LRUQueryCache(1, 10000, _ -> true, Float.POSITIVE_INFINITY);
     searcher.setQueryCache(cache);
 
     DVCacheQuery query = new DVCacheQuery("field");
@@ -1829,7 +1826,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     IndexWriterConfig iwc = newIndexWriterConfig().setSoftDeletesField("soft_delete");
     IndexWriter w = new IndexWriter(dir, iwc);
     LRUQueryCache queryCache =
-        new LRUQueryCache(10, 1000 * 1000, ctx -> true, Float.POSITIVE_INFINITY);
+        new LRUQueryCache(10, 1000 * 1000, _ -> true, Float.POSITIVE_INFINITY);
     IndexSearcher.setDefaultQueryCache(queryCache);
     IndexSearcher.setDefaultQueryCachingPolicy(ALWAYS_CACHE);
 
@@ -1910,7 +1907,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     DirectoryReader reader = DirectoryReader.open(w);
     DirectoryReader noCacheReader = new DummyDirectoryReader(reader);
 
-    LRUQueryCache cache = new LRUQueryCache(1, 100000, context -> true, Float.POSITIVE_INFINITY);
+    LRUQueryCache cache = new LRUQueryCache(1, 100000, _ -> true, Float.POSITIVE_INFINITY);
     IndexSearcher searcher = new AssertingIndexSearcher(random(), reader);
     searcher.setQueryCache(cache);
     searcher.setQueryCachingPolicy(ALWAYS_CACHE);
@@ -1973,7 +1970,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
     Set<Query> cacheSet = new HashSet<>();
 
     // only term query is cached
-    final LRUQueryCache partCache = new LRUQueryCache(1000000, 10000000, context -> true, 1);
+    final LRUQueryCache partCache = new LRUQueryCache(1000000, 10000000, _ -> true, 1);
     searcher.setQueryCache(partCache);
     searcher.search(query, 1);
     cacheSet.add(subQuery1);
@@ -1981,7 +1978,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
 
     // both queries are cached
     final LRUQueryCache allCache =
-        new LRUQueryCache(1000000, 10000000, context -> true, Float.POSITIVE_INFINITY);
+        new LRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY);
     searcher.setQueryCache(allCache);
     searcher.search(query, 1);
     cacheSet.add(subQuery2);
@@ -2062,14 +2059,14 @@ public class TestLRUQueryCache extends LuceneTestCase {
     Set<Query> cacheSet = new HashSet<>();
 
     // both queries are not cached
-    final LRUQueryCache partCache = new LRUQueryCache(1000000, 10000000, context -> true, 1);
+    final LRUQueryCache partCache = new LRUQueryCache(1000000, 10000000, _ -> true, 1);
     searcher.setQueryCache(partCache);
     searcher.search(query, 1);
     assertEquals(cacheSet, new HashSet<>(partCache.cachedQueries()));
 
     // only subQuery1 is cached
     final LRUQueryCache allCache =
-        new LRUQueryCache(1000000, 10000000, context -> true, Float.POSITIVE_INFINITY);
+        new LRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY);
     searcher.setQueryCache(allCache);
     searcher.search(query, 1);
     cacheSet.add(subQuery1);
@@ -2100,7 +2097,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
       IndexSearcher searcher = newSearcher(reader);
       searcher.setQueryCachingPolicy(ALWAYS_CACHE);
       LRUQueryCache allCache =
-          new LRUQueryCache(1000000, 10000000, context -> true, Float.POSITIVE_INFINITY);
+          new LRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY);
       searcher.setQueryCache(allCache);
       Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 1);
       LeafReaderContext context = getOnlyLeafReader(reader).getContext();
@@ -2118,7 +2115,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
       IndexSearcher searcher = newSearcher(reader);
       searcher.setQueryCachingPolicy(ALWAYS_CACHE);
       LRUQueryCache allCache =
-          new LRUQueryCache(1000000, 10000000, context -> true, Float.POSITIVE_INFINITY);
+          new LRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY);
       searcher.setQueryCache(allCache);
       Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 1);
       LeafReaderContext context = getOnlyLeafReader(reader).getContext();

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiCollectorManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiCollectorManager.java
@@ -210,7 +210,7 @@ public class TestMultiCollectorManager extends LuceneTestCase {
     private final Predicate<Integer> predicate;
 
     SimpleCollectorManager() {
-      this.predicate = val -> true;
+      this.predicate = _ -> true;
     }
 
     SimpleCollectorManager(Predicate<Integer> predicate) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -1017,7 +1017,7 @@ public class TestPhraseQuery extends LuceneTestCase {
       int numTerms = random().nextInt(1 << random().nextInt(5));
       String text =
           IntStream.range(0, numTerms)
-              .mapToObj(index -> random().nextBoolean() ? "a" : random().nextBoolean() ? "b" : "c")
+              .mapToObj(_ -> random().nextBoolean() ? "a" : random().nextBoolean() ? "b" : "c")
               .collect(Collectors.joining(" "));
       doc.add(new TextField("foo", text, Store.NO));
       w.addDocument(doc);

--- a/lucene/core/src/test/org/apache/lucene/search/TestQueryVisitor.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestQueryVisitor.java
@@ -169,7 +169,7 @@ public class TestQueryVisitor extends LuceneTestCase {
           private void countQuery(Query q) {
             queryCounts.compute(
                 q.getClass(),
-                (query, i) -> {
+                (_, i) -> {
                   if (i == null) {
                     return 1;
                   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSegmentCacheables.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSegmentCacheables.java
@@ -42,8 +42,8 @@ public class TestSegmentCacheables extends LuceneTestCase {
 
   public void testMultipleDocValuesDelegates() throws IOException {
 
-    SegmentCacheable seg = (ctx) -> true;
-    SegmentCacheable non = (ctx) -> false;
+    SegmentCacheable seg = (_) -> true;
+    SegmentCacheable non = (_) -> false;
     SegmentCacheable dv1 = (ctx) -> DocValues.isCacheable(ctx, "field1");
     SegmentCacheable dv2 = (ctx) -> DocValues.isCacheable(ctx, "field2");
     SegmentCacheable dv3 = (ctx) -> DocValues.isCacheable(ctx, "field3");

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortRandom.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortRandom.java
@@ -259,7 +259,7 @@ public class TestSortRandom extends LuceneTestCase {
           FixedBitSet bits =
               bitsets.computeIfAbsent(
                   context,
-                  ctx -> {
+                  _ -> {
                     Random random = new Random(context.docBase ^ seed);
                     final int maxDoc = context.reader().maxDoc();
                     try {

--- a/lucene/core/src/test/org/apache/lucene/search/TestUsageTrackingFilterCachingPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestUsageTrackingFilterCachingPolicy.java
@@ -74,8 +74,7 @@ public class TestUsageTrackingFilterCachingPolicy extends LuceneTestCase {
 
     IndexSearcher searcher = new IndexSearcher(reader);
     UsageTrackingQueryCachingPolicy policy = new UsageTrackingQueryCachingPolicy();
-    LRUQueryCache cache =
-        new LRUQueryCache(10, Long.MAX_VALUE, ctx -> true, Float.POSITIVE_INFINITY);
+    LRUQueryCache cache = new LRUQueryCache(10, Long.MAX_VALUE, _ -> true, Float.POSITIVE_INFINITY);
     searcher.setQueryCache(cache);
     searcher.setQueryCachingPolicy(policy);
 

--- a/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
@@ -44,7 +44,7 @@ public class TestMMapDirectory extends BaseDirectoryTestCase {
   @Override
   protected Directory getDirectory(Path path) throws IOException {
     MMapDirectory m = new MMapDirectory(path);
-    m.setPreload((file, context) -> random().nextBoolean());
+    m.setPreload((_, _) -> random().nextBoolean());
     return m;
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/SelectorBenchmark.java
+++ b/lucene/core/src/test/org/apache/lucene/util/SelectorBenchmark.java
@@ -36,7 +36,7 @@ public class SelectorBenchmark {
   private enum SelectorFactory {
     INTRO_SELECTOR(
         "IntroSelector",
-        (arr, s) -> {
+        (arr, _) -> {
           return new IntroSelector() {
 
             Entry pivot;

--- a/lucene/core/src/test/org/apache/lucene/util/SorterBenchmark.java
+++ b/lucene/core/src/test/org/apache/lucene/util/SorterBenchmark.java
@@ -36,17 +36,17 @@ public class SorterBenchmark {
   private enum SorterFactory {
     INTRO_SORTER(
         "IntroSorter",
-        (arr, s) -> {
+        (arr, _) -> {
           return new ArrayIntroSorter<>(arr, Entry::compareTo);
         }),
     TIM_SORTER(
         "TimSorter",
-        (arr, s) -> {
+        (arr, _) -> {
           return new ArrayTimSorter<>(arr, Entry::compareTo, arr.length / 64);
         }),
     MERGE_SORTER(
         "MergeSorter",
-        (arr, s) -> {
+        (arr, _) -> {
           return new ArrayInPlaceMergeSorter<>(arr, Entry::compareTo);
         }),
     ;

--- a/lucene/core/src/test/org/apache/lucene/util/compress/TestLowercaseAsciiCompression.java
+++ b/lucene/core/src/test/org/apache/lucene/util/compress/TestLowercaseAsciiCompression.java
@@ -75,7 +75,7 @@ public class TestLowercaseAsciiCompression extends LuceneTestCase {
 
   public void testFarAwayExceptions() throws Exception {
     String s =
-        "01W" + IntStream.range(0, 300).mapToObj(i -> "a").collect(Collectors.joining()) + "W.";
+        "01W" + IntStream.range(0, 300).mapToObj(_ -> "a").collect(Collectors.joining()) + "W.";
     assertTrue(doTestCompress(s.getBytes(StandardCharsets.UTF_8)));
   }
 

--- a/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
+++ b/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
@@ -305,7 +305,7 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
           throw new AssertionError("Impossible.");
         }
         String service = matcher.group("serviceName");
-        services.computeIfAbsent(service, k -> new TreeSet<>()).addAll(implementations);
+        services.computeIfAbsent(service, _ -> new TreeSet<>()).addAll(implementations);
       }
     }
 
@@ -319,7 +319,7 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
             Collectors.toMap(
                 ModuleDescriptor.Provides::service,
                 provides -> new TreeSet<>(provides.providers()),
-                (k, v) -> {
+                (_, _) -> {
                   throw new RuntimeException();
                 },
                 TreeMap::new));
@@ -334,7 +334,7 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
   @Test
   public void testAllExportedPackagesInSync() throws IOException {
     for (var module : allLuceneModules) {
-      Set<String> jarPackages = getJarPackages(module, entry -> true);
+      Set<String> jarPackages = getJarPackages(module, _ -> true);
       Set<ModuleDescriptor.Exports> moduleExports = new HashSet<>(module.descriptor().exports());
 
       if (module.descriptor().name().equals("org.apache.lucene.luke")) {

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/SimpleBindings.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/SimpleBindings.java
@@ -53,7 +53,7 @@ public final class SimpleBindings extends Bindings {
 
   /** Bind a {@link DoubleValuesSource} directly to the given name. */
   public void add(String name, DoubleValuesSource source) {
-    map.put(name, bindings -> source);
+    map.put(name, _ -> source);
   }
 
   /**

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/js/JavascriptCompiler.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/js/JavascriptCompiler.java
@@ -419,7 +419,7 @@ public final class JavascriptCompiler {
             // place dynamic constant with MethodHandle on top of stack
             gen.visitLdcInsn(
                 new ConstantDynamic(
-                    "func" + constantsMap.computeIfAbsent(text, k -> constantsMap.size()),
+                    "func" + constantsMap.computeIfAbsent(text, _ -> constantsMap.size()),
                     METHOD_HANDLE_TYPE.getDescriptor(),
                     DYNAMIC_CONSTANT_BOOTSTRAP_HANDLE,
                     text));
@@ -444,7 +444,7 @@ public final class JavascriptCompiler {
             int index;
 
             text = normalizeQuotes(ctx.getText());
-            index = externalsMap.computeIfAbsent(text, k -> externalsMap.size());
+            index = externalsMap.computeIfAbsent(text, _ -> externalsMap.size());
 
             gen.loadArg(0);
             gen.push(index);

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollectorManager.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollectorManager.java
@@ -102,7 +102,7 @@ public class FacetsCollectorManager implements CollectorManager<FacetsCollector,
       for (FacetsCollector.MatchingDocs matchingDocs : facetsCollector.getMatchingDocs()) {
         matchingDocsMap.compute(
             matchingDocs.context(),
-            (leafReaderContext, existing) -> {
+            (_, existing) -> {
               if (existing == null) {
                 return matchingDocs;
               }

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetsConfig.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetsConfig.java
@@ -79,21 +79,21 @@ public class FacetsConfig {
     NONE,
 
     /**
-     * Index only full-path drill down terms. No dimension nor sub-path indexing. e.g. for
-     * FacetField("a", "foo/bar/baz"), we would only index value "a/foo/bar/baz".
+     * Index only full-path drill down terms. No dimension nor sub-path indexing. e.g. for {@code
+     * FacetField("a", "foo/bar/baz")}, we would only index value "a/foo/bar/baz".
      */
     FULL_PATH_ONLY,
 
     /**
-     * Index sub-path and full-path drill down terms. No dimension indexing. e.g. for
-     * FacetField("a", "foo/bar/baz"), we would only index values "a/foo", "a/foo/bar", and
+     * Index sub-path and full-path drill down terms. No dimension indexing. e.g. for {@code
+     * FacetField("a", "foo/bar/baz")}, we would only index values "a/foo", "a/foo/bar", and
      * "a/foo/bar/baz".
      */
     ALL_PATHS_NO_DIM,
 
     /**
-     * Index dimension and full-path drill down terms. No sub-path indexing. e.g. for
-     * FacetField("a", "foo/bar/baz"), we would only index values "a" and "a/foo/bar/baz".
+     * Index dimension and full-path drill down terms. No sub-path indexing. e.g. for {@code
+     * FacetField("a", "foo/bar/baz")}, we would only index values "a" and "a/foo/bar/baz".
      */
     DIMENSION_AND_FULL_PATH,
 
@@ -276,7 +276,7 @@ public class FacetsConfig {
           checkSeen(seenDims, facetField.dim);
         }
         String indexFieldName = dimConfig.indexFieldName;
-        List<FacetField> fields = byField.computeIfAbsent(indexFieldName, k -> new ArrayList<>());
+        List<FacetField> fields = byField.computeIfAbsent(indexFieldName, _ -> new ArrayList<>());
         fields.add(facetField);
       }
 
@@ -288,7 +288,7 @@ public class FacetsConfig {
         }
         String indexFieldName = dimConfig.indexFieldName;
         List<SortedSetDocValuesFacetField> fields =
-            dvByField.computeIfAbsent(indexFieldName, k -> new ArrayList<>());
+            dvByField.computeIfAbsent(indexFieldName, _ -> new ArrayList<>());
         fields.add(facetField);
       }
 
@@ -309,7 +309,7 @@ public class FacetsConfig {
 
         String indexFieldName = dimConfig.indexFieldName;
         List<AssociationFacetField> fields =
-            assocByField.computeIfAbsent(indexFieldName, k -> new ArrayList<>());
+            assocByField.computeIfAbsent(indexFieldName, _ -> new ArrayList<>());
         fields.add(facetField);
 
         // Best effort: detect mis-matched types in same

--- a/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/sortedset/TestSortedSetDocValuesFacets.java
@@ -1379,7 +1379,7 @@ public class TestSortedSetDocValuesFacets extends FacetTestCase {
               // Slow, yet hopefully bug-free, faceting:
               @SuppressWarnings({"rawtypes", "unchecked"})
               Map<String, Integer>[] expectedCounts = new HashMap[numDims];
-              Arrays.setAll(expectedCounts, i -> new HashMap<>());
+              Arrays.setAll(expectedCounts, _ -> new HashMap<>());
 
               for (TestDoc doc : testDocs) {
                 if (doc.content.equals(searchToken)) {

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetAssociations.java
@@ -126,7 +126,7 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
           String path = paths[random().nextInt(3)];
           if (random().nextBoolean()) { // maybe index an int association with the dim
             int nextInt = atLeast(1);
-            randomIntValues.computeIfAbsent(path, k -> new ArrayList<>()).add(nextInt);
+            randomIntValues.computeIfAbsent(path, _ -> new ArrayList<>()).add(nextInt);
             doc.add(new IntAssociationFacetField(nextInt, "int_random", path));
           }
           if (random().nextBoolean()) { // maybe index a float association with the dim
@@ -139,7 +139,7 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
         String path = paths[random().nextInt(3)];
         if (random().nextBoolean()) {
           int nextInt = atLeast(1);
-          randomIntSingleValued.computeIfAbsent(path, k -> new ArrayList<>()).add(nextInt);
+          randomIntSingleValued.computeIfAbsent(path, _ -> new ArrayList<>()).add(nextInt);
           doc.add(new IntAssociationFacetField(nextInt, "int_single_valued", path));
         }
         if (random().nextBoolean()) {
@@ -187,9 +187,9 @@ public class TestTaxonomyFacetAssociations extends FacetTestCase {
           String dim = label.components[0];
           String child = label.components[1];
           if ("float_random".equals(dim)) {
-            randomFloatValues.computeIfAbsent(child, k -> new ArrayList<>()).add(value);
+            randomFloatValues.computeIfAbsent(child, _ -> new ArrayList<>()).add(value);
           } else if ("float_single_valued".equals(dim)) {
-            randomFloatSingleValued.computeIfAbsent(child, k -> new ArrayList<>()).add(value);
+            randomFloatSingleValued.computeIfAbsent(child, _ -> new ArrayList<>()).add(value);
           }
         }
       }

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyReader.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyReader.java
@@ -662,7 +662,7 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     // adding a smaller bound on ints ensures that we will have some duplicate ordinals in random
     // test cases
     Arrays.setAll(
-        randomArray, i -> Integer.toString(random().nextInt(maxNumberOfUniqueLabelsToIndex)));
+        randomArray, _ -> Integer.toString(random().nextInt(maxNumberOfUniqueLabelsToIndex)));
 
     FacetLabel[] allPaths = new FacetLabel[randomArray.length];
 

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/QueryTermExtractor.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/QueryTermExtractor.java
@@ -97,7 +97,7 @@ public final class QueryTermExtractor {
    */
   public static WeightedTerm[] getTerms(Query query, boolean prohibited, String fieldName) {
     HashSet<WeightedTerm> terms = new HashSet<>();
-    Predicate<String> fieldSelector = fieldName == null ? f -> true : fieldName::equals;
+    Predicate<String> fieldSelector = fieldName == null ? _ -> true : fieldName::equals;
     query.visit(new BoostedTermExtractor(1, terms, prohibited, fieldSelector));
     return terms.toArray(new WeightedTerm[0]);
   }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/FieldValueHighlighters.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/FieldValueHighlighters.java
@@ -57,7 +57,7 @@ public final class FieldValueHighlighters {
       int maxLeadingCharacters, String ellipsis, Set<String> fields) {
     PassageSelector passageSelector = defaultPassageSelector();
     PassageFormatter passageFormatter = new PassageFormatter(ellipsis, "", "");
-    return new AbstractFieldValueHighlighter((field, hasMatches) -> fields.contains(field)) {
+    return new AbstractFieldValueHighlighter((field, _) -> fields.contains(field)) {
       @Override
       public List<String> format(
           String field,
@@ -119,7 +119,7 @@ public final class FieldValueHighlighters {
       String field, String... moreFields) {
     HashSet<String> matchFields = new HashSet<>(Arrays.asList(moreFields));
     matchFields.add(field);
-    return new AbstractFieldValueHighlighter((fld, hasMatches) -> matchFields.contains(fld)) {
+    return new AbstractFieldValueHighlighter((fld, _) -> matchFields.contains(fld)) {
       @Override
       public Collection<String> alwaysFetchedFields() {
         return matchFields;
@@ -142,7 +142,7 @@ public final class FieldValueHighlighters {
    * emitted).
    */
   public static MatchHighlighter.FieldValueHighlighter skipRemaining() {
-    return new AbstractFieldValueHighlighter((field, hasMatches) -> true) {
+    return new AbstractFieldValueHighlighter((_, _) -> true) {
       @Override
       public List<String> format(
           String field,

--- a/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchHighlighter.java
@@ -178,7 +178,7 @@ public class MatchHighlighter {
       hits.forEach(
           (field, offsets) -> {
             List<QueryOffsetRange> target =
-                matchRanges.computeIfAbsent(field, (fld) -> new ArrayList<>());
+                matchRanges.computeIfAbsent(field, (_) -> new ArrayList<>());
             offsets.forEach(o -> target.add(new QueryOffsetRange(query, o.from, o.to)));
           });
     }
@@ -233,8 +233,8 @@ public class MatchHighlighter {
       highlighter.highlightDocuments(
           topDocs,
           (int docId,
-              LeafReader leafReader,
-              int leafDocId,
+              LeafReader _,
+              int _,
               MatchRegionRetriever.FieldValueProvider fieldValueProvider,
               Map<String, List<OffsetRange>> hits) -> {
             DocHit docHit = docHits.get(docId);

--- a/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchRegionRetriever.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/MatchRegionRetriever.java
@@ -217,7 +217,7 @@ public class MatchRegionRetriever {
     highlightDocuments(
         Arrays.stream(topDocs.scoreDocs).mapToInt(scoreDoc -> scoreDoc.doc).sorted().iterator(),
         consumer,
-        field -> Integer.MAX_VALUE);
+        _ -> Integer.MAX_VALUE);
   }
 
   /**
@@ -475,7 +475,7 @@ public class MatchRegionRetriever {
     return (field) -> {
       FieldInfo fieldInfo = fieldInfos.fieldInfo(field);
       if (fieldInfo == null) {
-        return (mi, doc) -> {
+        return (_, _) -> {
           throw new IOException("FieldInfo is null for field: " + field);
         };
       }
@@ -500,7 +500,7 @@ public class MatchRegionRetriever {
 
         case NONE:
         default:
-          return (matchesIterator, doc) -> {
+          return (_, _) -> {
             throw new IOException(
                 "Field is indexed without positions and/or offsets: "
                     + field
@@ -557,7 +557,7 @@ public class MatchRegionRetriever {
     }
 
     private void addField(FieldInfo field, String value) {
-      fieldValues.computeIfAbsent(field.name, v -> new ArrayList<>()).add(value);
+      fieldValues.computeIfAbsent(field.name, _ -> new ArrayList<>()).add(value);
     }
 
     @Override

--- a/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/PassageFormatter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/matchhighlight/PassageFormatter.java
@@ -40,7 +40,7 @@ public class PassageFormatter {
   private final ArrayList<OffsetRange> markerStack = new ArrayList<>();
 
   public PassageFormatter(String ellipsis, String markerStart, String markerEnd) {
-    this(ellipsis, (m) -> markerStart, (m) -> markerEnd);
+    this(ellipsis, (_) -> markerStart, (_) -> markerEnd);
   }
 
   public PassageFormatter(

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/NoOpOffsetStrategy.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/NoOpOffsetStrategy.java
@@ -35,7 +35,7 @@ public class NoOpOffsetStrategy extends FieldOffsetStrategy {
     super(
         new UHComponents(
             "_ignored_",
-            (s) -> false,
+            (_) -> false,
             new MatchNoDocsQuery(),
             new BytesRef[0],
             PhraseHelper.NONE,

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/PhraseHelper.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/PhraseHelper.java
@@ -65,12 +65,7 @@ public class PhraseHelper {
 
   public static final PhraseHelper NONE =
       new PhraseHelper(
-          new MatchAllDocsQuery(),
-          "_ignored_",
-          (s) -> false,
-          spanQuery -> null,
-          query -> null,
-          true);
+          new MatchAllDocsQuery(), "_ignored_", (_) -> false, _ -> null, _ -> null, true);
 
   private final String fieldName;
   private final Set<BytesRef> positionInsensitiveTerms; // (TermQuery terms)

--- a/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestMatchHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestMatchHighlighter.java
@@ -501,7 +501,7 @@ public class TestMatchHighlighter extends LuceneTestCase {
                     new MatchHighlighter(searcher, analyzer)
                         .appendFieldHighlighter(
                             FieldValueHighlighters.highlighted(
-                                80 * 3, 1, new PassageFormatter("...", ">", "<"), fld -> true))
+                                80 * 3, 1, new PassageFormatter("...", ">", "<"), _ -> true))
                         .appendFieldHighlighter(FieldValueHighlighters.skipRemaining());
 
                 StandardQueryParser qp = new StandardQueryParser(analyzer);
@@ -746,7 +746,7 @@ public class TestMatchHighlighter extends LuceneTestCase {
                       new PassageFormatter(
                           "...",
                           (range) -> "<span class='" + queryToClass.apply(range) + "'>",
-                          (range) -> "</span>");
+                          (_) -> "</span>");
 
                   return passageFormatter.format(contiguousValue, bestPassages, valueRanges);
                 }

--- a/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestMatchRegionRetriever.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestMatchRegionRetriever.java
@@ -748,7 +748,7 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
     AsciiMatchRangeHighlighter formatter = new AsciiMatchRangeHighlighter(analyzer);
 
     MatchRegionRetriever.MatchOffsetsConsumer highlightCollector =
-        (docId, leafReader, leafDocId, fieldValueProvider, fieldHighlights) -> {
+        (_, leafReader, leafDocId, _, fieldHighlights) -> {
           StringBuilder sb = new StringBuilder();
 
           Document document = leafReader.storedFields().document(leafDocId);
@@ -767,8 +767,8 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
           }
         };
 
-    Predicate<String> fieldsToLoadUnconditionally = fieldName -> false;
-    Predicate<String> fieldsToLoadIfWithHits = fieldName -> true;
+    Predicate<String> fieldsToLoadUnconditionally = _ -> false;
+    Predicate<String> fieldsToLoadIfWithHits = _ -> true;
     MatchRegionRetriever highlighter =
         new MatchRegionRetriever(
             searcher,
@@ -781,7 +781,7 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
     highlighter.highlightDocuments(
         Arrays.stream(topDocs.scoreDocs).mapToInt(scoreDoc -> scoreDoc.doc).sorted().iterator(),
         highlightCollector,
-        field -> Integer.MAX_VALUE,
+        _ -> Integer.MAX_VALUE,
         maxBlockSize,
         maxBlocksProcessedInParallel);
 

--- a/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestPassageSelector.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestPassageSelector.java
@@ -342,7 +342,7 @@ public class TestPassageSelector extends LuceneTestCase {
           p -> {
             assertNotEquals(p.from, p.to);
             p.markers.forEach(
-                r -> {
+                _ -> {
                   assertNotEquals(p.from, p.to);
                 });
           });

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighter.java
@@ -122,7 +122,7 @@ public class TestUnifiedHighlighter extends UnifiedHighlighterTestBase {
     uhBuilder.withCacheFieldValCharsThreshold(random().nextInt(100));
     if (requireFieldMatch == Boolean.FALSE
         || (requireFieldMatch == null && random().nextBoolean())) {
-      uhBuilder.withFieldMatcher(f -> true); // requireFieldMatch==false
+      uhBuilder.withFieldMatcher(_ -> true); // requireFieldMatch==false
     }
     return overriddenBuilderForTests(uhBuilder, mandatoryFlags).build();
   }
@@ -1176,7 +1176,7 @@ public class TestUnifiedHighlighter extends UnifiedHighlighterTestBase {
     IndexReader ir = indexSomeFields();
     IndexSearcher searcher = newSearcher(ir);
     UnifiedHighlighter highlighterNoFieldMatch =
-        UnifiedHighlighter.builder(searcher, indexAnalyzer).withFieldMatcher(qf -> true).build();
+        UnifiedHighlighter.builder(searcher, indexAnalyzer).withFieldMatcher(_ -> true).build();
     UnifiedHighlighter.Builder uhBuilder = new UnifiedHighlighter.Builder(searcher, indexAnalyzer);
     UnifiedHighlighter highlighterFieldMatch =
         overrideFieldMatcherForTests(randomUnifiedHighlighter(uhBuilder), null, "text");
@@ -1263,7 +1263,7 @@ public class TestUnifiedHighlighter extends UnifiedHighlighterTestBase {
     IndexReader ir = indexSomeFields();
     IndexSearcher searcher = newSearcher(ir);
     UnifiedHighlighter highlighterNoFieldMatch =
-        UnifiedHighlighter.builder(searcher, indexAnalyzer).withFieldMatcher(qf -> true).build();
+        UnifiedHighlighter.builder(searcher, indexAnalyzer).withFieldMatcher(_ -> true).build();
     UnifiedHighlighter.Builder uhBuilder = new UnifiedHighlighter.Builder(searcher, indexAnalyzer);
     UnifiedHighlighter highlighterFieldMatch =
         overrideFieldMatcherForTests(
@@ -1487,7 +1487,7 @@ public class TestUnifiedHighlighter extends UnifiedHighlighterTestBase {
     UnifiedHighlighter highlighterNoFieldMatch =
         UnifiedHighlighter.builder(searcher, indexAnalyzer)
             // requireFieldMatch=false
-            .withFieldMatcher(qf -> true)
+            .withFieldMatcher(_ -> true)
             .build();
     UnifiedHighlighter.Builder uhBuilder = new UnifiedHighlighter.Builder(searcher, indexAnalyzer);
     UnifiedHighlighter highlighterFieldMatch =

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/visibility/TestUnifiedHighlighterExtensibility.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/visibility/TestUnifiedHighlighterExtensibility.java
@@ -64,7 +64,7 @@ public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
         new FieldOffsetStrategy(
             new UHComponents(
                 "field",
-                (s) -> false,
+                (_) -> false,
                 new MatchAllDocsQuery(),
                 new BytesRef[0],
                 PhraseHelper.NONE,

--- a/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/JoinUtil.java
@@ -185,7 +185,7 @@ public final class JoinUtil {
           };
     } else {
       scoreAggregator =
-          (key, score) -> {
+          (_, _) -> {
             throw new UnsupportedOperationException();
           };
     }

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/LukeMain.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/LukeMain.java
@@ -58,7 +58,7 @@ public class LukeMain {
     // uncaught error handler
     MessageBroker messageBroker = MessageBroker.getInstance();
     try {
-      Thread.setDefaultUncaughtExceptionHandler((thread, cause) -> handle(cause, messageBroker));
+      Thread.setDefaultUncaughtExceptionHandler((_, cause) -> handle(cause, messageBroker));
 
       frame = new LukeWindowProvider().get();
       frame.setLocation(200, 100);
@@ -107,7 +107,7 @@ public class LukeMain {
                     MessageUtils.getLocalizedMessage("openindex.dialog.title"),
                     600,
                     420,
-                    (factory) -> {});
+                    (_) -> {});
 
             long _end = System.nanoTime() / 1_000_000;
             log.info(

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/AnalysisPanelProvider.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/AnalysisPanelProvider.java
@@ -189,7 +189,7 @@ public final class AnalysisPanelProvider implements AnalysisTabOperator {
     clearBtn.setFont(StyleConstants.FONT_BUTTON_LARGE);
     clearBtn.setMargin(new Insets(5, 5, 5, 5));
     clearBtn.addActionListener(
-        e -> {
+        _ -> {
           inputArea.setText("");
           operatorRegistry
               .get(SimpleAnalyzeResultPanelOperator.class)

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/DocumentsPanelProvider.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/DocumentsPanelProvider.java
@@ -661,7 +661,7 @@ public final class DocumentsPanelProvider implements DocumentsTabOperator {
   }
 
   private void showAddDocumentDialog() {
-    new DialogOpener<>(addDocDialogFactory).open("Add document", 600, 500, (factory) -> {});
+    new DialogOpener<>(addDocDialogFactory).open("Add document", 600, 500, (_) -> {});
   }
 
   private void showTermVectorDialog() {

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/LogsPanelProvider.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/LogsPanelProvider.java
@@ -80,7 +80,7 @@ public final class LogsPanelProvider {
             FontUtils.elegantIconHtml("&#xe0e6;", MessageUtils.getLocalizedMessage("button.copy")));
     copyBtn.setMargin(new Insets(3, 3, 3, 3));
     copyBtn.addActionListener(
-        e -> {
+        _ -> {
           Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
           StringSelection selection = new StringSelection(logTextArea.getText());
           clipboard.setContents(selection, null);
@@ -123,7 +123,7 @@ public final class LogsPanelProvider {
 
     // Update state on filter change.
     logFilter.addActionListener(
-        e -> {
+        _ -> {
           updater.accept(logBuffer.getLogRecords());
         });
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/MenuBarProvider.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/MenuBarProvider.java
@@ -196,20 +196,12 @@ public final class MenuBarProvider {
 
     void showOpenIndexDialog(ActionEvent e) {
       new DialogOpener<>(openIndexDialogFactory)
-          .open(
-              MessageUtils.getLocalizedMessage("openindex.dialog.title"),
-              600,
-              420,
-              (factory) -> {});
+          .open(MessageUtils.getLocalizedMessage("openindex.dialog.title"), 600, 420, (_) -> {});
     }
 
     void showCreateIndexDialog(ActionEvent e) {
       new DialogOpener<>(createIndexDialogFactory)
-          .open(
-              MessageUtils.getLocalizedMessage("createindex.dialog.title"),
-              600,
-              360,
-              (factory) -> {});
+          .open(MessageUtils.getLocalizedMessage("createindex.dialog.title"), 600, 360, (_) -> {});
     }
 
     void reopenIndex(ActionEvent e) {
@@ -258,21 +250,20 @@ public final class MenuBarProvider {
     }
 
     void showOptimizeIndexDialog(ActionEvent e) {
-      new DialogOpener<>(optimizeIndexDialogFactory)
-          .open("Optimize index", 600, 600, factory -> {});
+      new DialogOpener<>(optimizeIndexDialogFactory).open("Optimize index", 600, 600, _ -> {});
     }
 
     void showCheckIndexDialog(ActionEvent e) {
-      new DialogOpener<>(checkIndexDialogFactory).open("Check index", 600, 600, factory -> {});
+      new DialogOpener<>(checkIndexDialogFactory).open("Check index", 600, 600, _ -> {});
     }
 
     void showAboutDialog(ActionEvent e) {
       final String title = "About Luke v" + Version.LATEST.toString();
-      new DialogOpener<>(aboutDialogFactory).open(title, 800, 480, factory -> {});
+      new DialogOpener<>(aboutDialogFactory).open(title, 800, 480, _ -> {});
     }
 
     void showExportTermsDialog(ActionEvent e) {
-      new DialogOpener<>(exportTermsDialogFactory).open("Export terms", 600, 450, factory -> {});
+      new DialogOpener<>(exportTermsDialogFactory).open("Export terms", 600, 450, _ -> {});
     }
   }
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/SearchPanelProvider.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/SearchPanelProvider.java
@@ -678,7 +678,7 @@ public final class SearchPanelProvider implements SearchTabOperator {
     JMenuItem item1 =
         new JMenuItem(MessageUtils.getLocalizedMessage("search.results.menu.explain"));
     item1.addActionListener(
-        e -> {
+        _ -> {
           int docid =
               (int)
                   resultsTable
@@ -703,7 +703,7 @@ public final class SearchPanelProvider implements SearchTabOperator {
     JMenuItem item2 =
         new JMenuItem(MessageUtils.getLocalizedMessage("search.results.menu.showdoc"));
     item2.addActionListener(
-        e -> {
+        _ -> {
           int docid =
               (int)
                   resultsTable

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/ConfirmDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/ConfirmDialogFactory.java
@@ -104,13 +104,13 @@ public final class ConfirmDialogFactory implements DialogOpener.DialogFactory {
     footer.setOpaque(false);
     JButton okBtn = new JButton(MessageUtils.getLocalizedMessage("button.ok"));
     okBtn.addActionListener(
-        e -> {
+        _ -> {
           callback.call();
           dialog.dispose();
         });
     footer.add(okBtn);
     JButton closeBtn = new JButton(MessageUtils.getLocalizedMessage("button.close"));
-    closeBtn.addActionListener(e -> dialog.dispose());
+    closeBtn.addActionListener(_ -> dialog.dispose());
     footer.add(closeBtn);
     panel.add(footer, BorderLayout.PAGE_END);
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/HelpDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/HelpDialogFactory.java
@@ -97,7 +97,7 @@ public final class HelpDialogFactory implements DialogOpener.DialogFactory {
     JPanel footer = new JPanel(new FlowLayout(FlowLayout.TRAILING));
     footer.setOpaque(false);
     JButton closeBtn = new JButton(MessageUtils.getLocalizedMessage("button.close"));
-    closeBtn.addActionListener(e -> dialog.dispose());
+    closeBtn.addActionListener(_ -> dialog.dispose());
     footer.add(closeBtn);
     panel.add(footer, BorderLayout.PAGE_END);
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/AnalysisChainDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/AnalysisChainDialogFactory.java
@@ -91,7 +91,7 @@ public class AnalysisChainDialogFactory implements DialogOpener.DialogFactory {
     JPanel footer = new JPanel(new FlowLayout(FlowLayout.TRAILING, 10, 5));
     footer.setOpaque(false);
     JButton closeBtn = new JButton(MessageUtils.getLocalizedMessage("button.close"));
-    closeBtn.addActionListener(e -> dialog.dispose());
+    closeBtn.addActionListener(_ -> dialog.dispose());
     footer.add(closeBtn);
     panel.add(footer, BorderLayout.PAGE_END);
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/EditFiltersDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/EditFiltersDialogFactory.java
@@ -142,7 +142,7 @@ public final class EditFiltersDialogFactory implements DialogOpener.DialogFactor
     footer.setOpaque(false);
     JButton okBtn = new JButton(MessageUtils.getLocalizedMessage("button.ok"));
     okBtn.addActionListener(
-        e -> {
+        _ -> {
           List<Integer> deletedIndexes = new ArrayList<>();
           for (int i = 0; i < filtersTable.getRowCount(); i++) {
             boolean deleted =
@@ -169,7 +169,7 @@ public final class EditFiltersDialogFactory implements DialogOpener.DialogFactor
         });
     footer.add(okBtn);
     JButton cancelBtn = new JButton(MessageUtils.getLocalizedMessage("button.cancel"));
-    cancelBtn.addActionListener(e -> dialog.dispose());
+    cancelBtn.addActionListener(_ -> dialog.dispose());
     footer.add(cancelBtn);
     panel.add(footer, BorderLayout.PAGE_END);
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/EditParamsDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/EditParamsDialogFactory.java
@@ -140,7 +140,7 @@ public final class EditParamsDialogFactory implements DialogOpener.DialogFactory
     footer.setOpaque(false);
     JButton okBtn = new JButton(MessageUtils.getLocalizedMessage("button.ok"));
     okBtn.addActionListener(
-        e -> {
+        _ -> {
           Map<String, String> params = new HashMap<>();
           for (int i = 0; i < paramsTable.getRowCount(); i++) {
             boolean deleted =
@@ -166,7 +166,7 @@ public final class EditParamsDialogFactory implements DialogOpener.DialogFactory
     footer.add(okBtn);
     JButton cancelBtn = new JButton(MessageUtils.getLocalizedMessage("button.cancel"));
     cancelBtn.addActionListener(
-        e -> {
+        _ -> {
           this.params.clear();
           dialog.dispose();
         });

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/TokenAttributeDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/TokenAttributeDialogFactory.java
@@ -114,7 +114,7 @@ public final class TokenAttributeDialogFactory implements DialogOpener.DialogFac
     JPanel footer = new JPanel(new FlowLayout(FlowLayout.TRAILING));
     footer.setOpaque(false);
     JButton okBtn = new JButton(MessageUtils.getLocalizedMessage("button.ok"));
-    okBtn.addActionListener(e -> dialog.dispose());
+    okBtn.addActionListener(_ -> dialog.dispose());
     footer.add(okBtn);
     panel.add(footer, BorderLayout.PAGE_END);
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/AddDocumentDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/AddDocumentDialogFactory.java
@@ -152,7 +152,7 @@ public final class AddDocumentDialogFactory
     this.indexOptionsDialogFactory = IndexOptionsDialogFactory.getInstance();
     this.helpDialogFactory = HelpDialogFactory.getInstance();
     this.newFieldList =
-        IntStream.range(0, ROW_COUNT).mapToObj(i -> NewField.newInstance()).toList();
+        IntStream.range(0, ROW_COUNT).mapToObj(_ -> NewField.newInstance()).toList();
 
     operatorRegistry.register(AddDocumentDialogOperator.class, this);
     indexHandler.addObserver(new Observer());
@@ -168,7 +168,7 @@ public final class AddDocumentDialogFactory
 
     closeBtn.setText(MessageUtils.getLocalizedMessage("button.cancel"));
     closeBtn.setMargin(new Insets(3, 3, 3, 3));
-    closeBtn.addActionListener(e -> dialog.dispose());
+    closeBtn.addActionListener(_ -> dialog.dispose());
 
     infoTA.setRows(3);
     infoTA.setLineWrap(true);
@@ -260,8 +260,7 @@ public final class AddDocumentDialogFactory
         80);
     fieldsTable.setShowGrid(true);
     JComboBox<Class<? extends IndexableField>> typesCombo = new JComboBox<>(presetFieldClasses);
-    typesCombo.setRenderer(
-        (list, value, index, isSelected, cellHasFocus) -> new JLabel(value.getSimpleName()));
+    typesCombo.setRenderer((_, value, _, _, _) -> new JLabel(value.getSimpleName()));
     fieldsTable
         .getColumnModel()
         .getColumn(FieldsTableModel.Column.TYPE.getIndex())
@@ -321,7 +320,7 @@ public final class AddDocumentDialogFactory
     JComboBox<String> typeCombo = new JComboBox<>(typeList);
     typeCombo.setSelectedItem(typeList[0]);
     typeCombo.addActionListener(
-        e -> {
+        _ -> {
           String selected = (String) typeCombo.getSelectedItem();
           descTA.setText(MessageUtils.getLocalizedMessage("help.fieldtype." + selected));
         });

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/DocValuesDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/DocValuesDialogFactory.java
@@ -191,7 +191,7 @@ public final class DocValuesDialogFactory implements DialogOpener.DialogFactory 
 
     JButton closeBtn = new JButton(MessageUtils.getLocalizedMessage("button.close"));
     closeBtn.setMargin(new Insets(3, 0, 3, 0));
-    closeBtn.addActionListener(e -> dialog.dispose());
+    closeBtn.addActionListener(_ -> dialog.dispose());
     footer.add(closeBtn);
 
     return footer;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/IndexOptionsDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/IndexOptionsDialogFactory.java
@@ -221,11 +221,11 @@ public final class IndexOptionsDialogFactory implements DialogOpener.DialogFacto
     panel.setOpaque(false);
     JButton okBtn = new JButton(MessageUtils.getLocalizedMessage("button.ok"));
     okBtn.setMargin(new Insets(3, 3, 3, 3));
-    okBtn.addActionListener(e -> saveOptions());
+    okBtn.addActionListener(_ -> saveOptions());
     panel.add(okBtn);
     JButton cancelBtn = new JButton(MessageUtils.getLocalizedMessage("button.cancel"));
     cancelBtn.setMargin(new Insets(3, 3, 3, 3));
-    cancelBtn.addActionListener(e -> dialog.dispose());
+    cancelBtn.addActionListener(_ -> dialog.dispose());
     panel.add(cancelBtn);
 
     return panel;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/StoredValueDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/StoredValueDialogFactory.java
@@ -115,7 +115,7 @@ public final class StoredValueDialogFactory implements DialogOpener.DialogFactor
             FontUtils.elegantIconHtml("&#xe0e6;", MessageUtils.getLocalizedMessage("button.copy")));
     copyBtn.setMargin(new Insets(3, 3, 3, 3));
     copyBtn.addActionListener(
-        e -> {
+        _ -> {
           Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
           StringSelection selection = new StringSelection(value);
           clipboard.setContents(selection, null);
@@ -124,7 +124,7 @@ public final class StoredValueDialogFactory implements DialogOpener.DialogFactor
 
     JButton closeBtn = new JButton(MessageUtils.getLocalizedMessage("button.close"));
     closeBtn.setMargin(new Insets(3, 3, 3, 3));
-    closeBtn.addActionListener(e -> dialog.dispose());
+    closeBtn.addActionListener(_ -> dialog.dispose());
     footer.add(closeBtn);
     panel.add(footer, BorderLayout.PAGE_END);
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/TermVectorDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/documents/TermVectorDialogFactory.java
@@ -119,7 +119,7 @@ public final class TermVectorDialogFactory implements DialogOpener.DialogFactory
     footer.setOpaque(false);
     JButton closeBtn = new JButton(MessageUtils.getLocalizedMessage("button.close"));
     closeBtn.setMargin(new Insets(3, 3, 3, 3));
-    closeBtn.addActionListener(e -> dialog.dispose());
+    closeBtn.addActionListener(_ -> dialog.dispose());
     footer.add(closeBtn);
     panel.add(footer, BorderLayout.PAGE_END);
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/AboutDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/AboutDialogFactory.java
@@ -166,7 +166,7 @@ public final class AboutDialogFactory implements DialogOpener.DialogFactory {
     JButton closeBtn = new JButton(MessageUtils.getLocalizedMessage("button.close"));
     closeBtn.setMargin(new Insets(5, 5, 5, 5));
     if (closeBtn.getActionListeners().length == 0) {
-      closeBtn.addActionListener(e -> dialog.dispose());
+      closeBtn.addActionListener(_ -> dialog.dispose());
     }
     panel.add(closeBtn);
     return panel;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CheckIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CheckIndexDialogFactory.java
@@ -185,7 +185,7 @@ public final class CheckIndexDialogFactory implements DialogOpener.DialogFactory
     JButton closeBtn = new JButton(MessageUtils.getLocalizedMessage("button.close"));
     closeBtn.setFont(StyleConstants.FONT_BUTTON_LARGE);
     closeBtn.setMargin(new Insets(3, 0, 3, 0));
-    closeBtn.addActionListener(e -> dialog.dispose());
+    closeBtn.addActionListener(_ -> dialog.dispose());
     execButtons.add(closeBtn);
     panel.add(execButtons);
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CreateIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CreateIndexDialogFactory.java
@@ -146,7 +146,7 @@ public class CreateIndexDialogFactory implements DialogOpener.DialogFactory {
     createBtn.addActionListener(listeners::createIndex);
 
     cancelBtn.setText(MessageUtils.getLocalizedMessage("button.cancel"));
-    cancelBtn.addActionListener(e -> dialog.dispose());
+    cancelBtn.addActionListener(_ -> dialog.dispose());
   }
 
   @Override

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/ExportTermsDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/ExportTermsDialogFactory.java
@@ -200,7 +200,7 @@ public final class ExportTermsDialogFactory implements DialogOpener.DialogFactor
     execButtons.add(exportBtn);
     JButton closeBtn = new JButton(MessageUtils.getLocalizedMessage("button.close"));
     closeBtn.setMargin(new Insets(3, 0, 3, 0));
-    closeBtn.addActionListener(e -> dialog.dispose());
+    closeBtn.addActionListener(_ -> dialog.dispose());
     execButtons.add(closeBtn);
     return execButtons;
   }

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OpenIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OpenIndexDialogFactory.java
@@ -265,7 +265,7 @@ public final class OpenIndexDialogFactory implements DialogOpener.DialogFactory 
     panel.add(okBtn);
 
     JButton cancelBtn = new JButton(MessageUtils.getLocalizedMessage("button.cancel"));
-    cancelBtn.addActionListener(e -> dialog.dispose());
+    cancelBtn.addActionListener(_ -> dialog.dispose());
     panel.add(cancelBtn);
 
     return panel;

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OptimizeIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OptimizeIndexDialogFactory.java
@@ -171,7 +171,7 @@ public final class OptimizeIndexDialogFactory implements DialogOpener.DialogFact
     JButton closeBtn = new JButton(MessageUtils.getLocalizedMessage("button.close"));
     closeBtn.setFont(StyleConstants.FONT_BUTTON_LARGE);
     closeBtn.setMargin(new Insets(3, 0, 3, 0));
-    closeBtn.addActionListener(e -> dialog.dispose());
+    closeBtn.addActionListener(_ -> dialog.dispose());
     execButtons.add(closeBtn);
     panel.add(execButtons);
 

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/search/ExplainDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/search/ExplainDialogFactory.java
@@ -117,7 +117,7 @@ public final class ExplainDialogFactory implements DialogOpener.DialogFactory {
             FontUtils.elegantIconHtml("&#xe0e6;", MessageUtils.getLocalizedMessage("button.copy")));
     copyBtn.setMargin(new Insets(3, 3, 3, 3));
     copyBtn.addActionListener(
-        e -> {
+        _ -> {
           Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
           StringSelection selection = new StringSelection(explanationToString());
           clipboard.setContents(selection, null);
@@ -126,7 +126,7 @@ public final class ExplainDialogFactory implements DialogOpener.DialogFactory {
 
     JButton closeBtn = new JButton(MessageUtils.getLocalizedMessage("button.close"));
     closeBtn.setMargin(new Insets(3, 3, 3, 3));
-    closeBtn.addActionListener(e -> dialog.dispose());
+    closeBtn.addActionListener(_ -> dialog.dispose());
     footer.add(closeBtn);
     panel.add(footer, BorderLayout.PAGE_END);
 
@@ -172,7 +172,7 @@ public final class ExplainDialogFactory implements DialogOpener.DialogFactory {
 
   private void traverseToCopy(StringBuilder sb, int depth, Explanation[] explanations) {
     for (Explanation explanation : explanations) {
-      IntStream.range(0, depth).forEach(i -> sb.append("  "));
+      IntStream.range(0, depth).forEach(_ -> sb.append("  "));
       sb.append(format(explanation));
       sb.append("\n");
       traverseToCopy(sb, depth + 1, explanation.getDetails());

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/fragments/search/QueryParserPaneProvider.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/fragments/search/QueryParserPaneProvider.java
@@ -353,7 +353,7 @@ public final class QueryParserPaneProvider implements QueryParserTabOperator {
             .map(PointTypesTableModel.NumType::name)
             .toArray(String[]::new);
     JComboBox<String> numTypesCombo = new JComboBox<>(numTypes);
-    numTypesCombo.setRenderer((list, value, index, isSelected, cellHasFocus) -> new JLabel(value));
+    numTypesCombo.setRenderer((_, value, _, _, _) -> new JLabel(value));
     pointRangeQueryTable
         .getColumnModel()
         .getColumn(PointTypesTableModel.Column.TYPE.getIndex())
@@ -361,8 +361,7 @@ public final class QueryParserPaneProvider implements QueryParserTabOperator {
     pointRangeQueryTable
         .getColumnModel()
         .getColumn(PointTypesTableModel.Column.TYPE.getIndex())
-        .setCellRenderer(
-            (table, value, isSelected, hasFocus, row, column) -> new JLabel((String) value));
+        .setCellRenderer((_, value, _, _, _, _) -> new JLabel((String) value));
     pointRangeQueryTable
         .getColumnModel()
         .getColumn(PointTypesTableModel.Column.FIELD.getIndex())

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/TableUtils.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/TableUtils.java
@@ -83,7 +83,7 @@ public class TableUtils {
   public static <T extends TableColumnInfo> TreeMap<Integer, T> columnMap(T[] columns) {
     return Arrays.stream(columns)
         .collect(
-            Collectors.toMap(T::getIndex, UnaryOperator.identity(), (e1, e2) -> e1, TreeMap::new));
+            Collectors.toMap(T::getIndex, UnaryOperator.identity(), (e1, _) -> e1, TreeMap::new));
   }
 
   private TableUtils() {}

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
@@ -129,7 +129,7 @@ public final class AnalysisImpl implements Analysis {
       AttributeImpl att = itr.next();
       Map<String, String> attValues = new LinkedHashMap<>();
       att.reflectWith(
-          (attClass, key, value) -> {
+          (_, key, value) -> {
             if (value != null) attValues.put(key, value.toString());
           });
       attributes.add(new TokenAttribute(att.getClass().getSimpleName(), attValues));

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/overview/TermCounts.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/overview/TermCounts.java
@@ -74,6 +74,6 @@ final class TermCounts {
         .sorted(comparator)
         .collect(
             Collectors.toMap(
-                Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v1, LinkedHashMap::new));
+                Map.Entry::getKey, Map.Entry::getValue, (v1, _) -> v1, LinkedHashMap::new));
   }
 }

--- a/lucene/misc/src/test/org/apache/lucene/misc/TestSweetSpotSimilarity.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/TestSweetSpotSimilarity.java
@@ -39,7 +39,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 public class TestSweetSpotSimilarity extends LuceneTestCase {
 
   private static float computeNorm(Similarity sim, String field, int length) throws IOException {
-    String value = IntStream.range(0, length).mapToObj(i -> "a").collect(Collectors.joining(" "));
+    String value = IntStream.range(0, length).mapToObj(_ -> "a").collect(Collectors.joining(" "));
     Directory dir = new ByteBuffersDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig().setSimilarity(sim));
     w.addDocument(Collections.singleton(newTextField(field, value, Store.NO)));

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/CandidateMatcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/CandidateMatcher.java
@@ -76,7 +76,7 @@ public abstract class CandidateMatcher<T extends QueryMatch> {
     MatchHolder<T> docMatches = matches.get(doc);
     docMatches.matches.compute(
         match.getQueryId(),
-        (key, oldValue) -> {
+        (_, oldValue) -> {
           if (oldValue != null) {
             return resolve(match, oldValue);
           }

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/HighlightsMatch.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/HighlightsMatch.java
@@ -143,7 +143,7 @@ public class HighlightsMatch extends QueryMatch {
     HighlightsMatch newMatch = new HighlightsMatch(queryId);
     for (HighlightsMatch match : matches) {
       for (String field : match.getFields()) {
-        Set<Hit> hitSet = newMatch.hits.computeIfAbsent(field, f -> new TreeSet<>());
+        Set<Hit> hitSet = newMatch.hits.computeIfAbsent(field, _ -> new TreeSet<>());
         hitSet.addAll(match.getHits(field));
       }
     }
@@ -176,7 +176,7 @@ public class HighlightsMatch extends QueryMatch {
   }
 
   void addHit(String field, int startPos, int endPos, int startOffset, int endOffset) {
-    Set<Hit> hitSet = hits.computeIfAbsent(field, f -> new TreeSet<>());
+    Set<Hit> hitSet = hits.computeIfAbsent(field, _ -> new TreeSet<>());
     hitSet.add(new Hit(startPos, startOffset, endPos, endOffset));
   }
 

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/Monitor.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/Monitor.java
@@ -275,7 +275,7 @@ public class Monitor implements Closeable {
    */
   public Set<String> getQueryIds() throws IOException {
     final Set<String> ids = new HashSet<>();
-    queryIndex.scan((id, query, dataValues) -> ids.add(id));
+    queryIndex.scan((id, _, _) -> ids.add(id));
     return ids;
   }
 
@@ -370,7 +370,7 @@ public class Monitor implements Closeable {
         MatchesIterator mi = matches.getMatches(field);
         while (mi.next()) {
           matchingTerms
-              .computeIfAbsent(id, i -> new StringBuilder())
+              .computeIfAbsent(id, _ -> new StringBuilder())
               .append(" ")
               .append(mi.getQuery());
         }

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/MultipassTermFilteredPresearcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/MultipassTermFilteredPresearcher.java
@@ -111,7 +111,7 @@ public class MultipassTermFilteredPresearcher extends TermFilteredPresearcher {
 
     @Override
     public void addTerm(String field, BytesRef term) {
-      BytesRefHash t = terms.computeIfAbsent(field, f -> new BytesRefHash());
+      BytesRefHash t = terms.computeIfAbsent(field, _ -> new BytesRefHash());
       t.add(term);
     }
 

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryAnalyzer.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryAnalyzer.java
@@ -40,7 +40,7 @@ class QueryAnalyzer {
   }
 
   QueryAnalyzer() {
-    this.unknownQueryMapper = (q, w) -> null;
+    this.unknownQueryMapper = (_, _) -> null;
   }
 
   private static BiFunction<Query, TermWeightor, QueryTree> buildMapper(
@@ -85,7 +85,7 @@ class QueryAnalyzer {
           long positiveCount =
               bq.clauses().stream().filter(c -> c.occur() != BooleanClause.Occur.MUST_NOT).count();
           if (positiveCount == 0) {
-            children.add(w -> QueryTree.anyTerm("PURE NEGATIVE QUERY[" + parent + "]"));
+            children.add(_ -> QueryTree.anyTerm("PURE NEGATIVE QUERY[" + parent + "]"));
           }
         }
         return QueryVisitor.EMPTY_VISITOR;

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryIndex.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryIndex.java
@@ -67,7 +67,7 @@ abstract class QueryIndex implements Closeable {
     BytesRef[] bytesHolder = new BytesRef[1];
     search(
         new TermQuery(new Term(FIELDS.query_id, queryId)),
-        (id, query, dataValues) -> bytesHolder[0] = dataValues.mq.binaryValue());
+        (_, _, dataValues) -> bytesHolder[0] = dataValues.mq.binaryValue());
     return bytesHolder[0] != null ? serializer.deserialize(bytesHolder[0]) : null;
   }
 
@@ -76,7 +76,7 @@ abstract class QueryIndex implements Closeable {
   }
 
   long search(final Query query, QueryCollector matcher) throws IOException {
-    QueryBuilder builder = termFilter -> query;
+    QueryBuilder builder = _ -> query;
     return search(builder, matcher);
   }
 
@@ -142,7 +142,7 @@ abstract class QueryIndex implements Closeable {
     QueryTermFilter(IndexReader reader) throws IOException {
       for (LeafReaderContext ctx : reader.leaves()) {
         for (FieldInfo fi : ctx.reader().getFieldInfos()) {
-          BytesRefHash terms = termsHash.computeIfAbsent(fi.name, f -> new BytesRefHash());
+          BytesRefHash terms = termsHash.computeIfAbsent(fi.name, _ -> new BytesRefHash());
           Terms t = ctx.reader().terms(fi.name);
           if (t != null) {
             TermsEnum te = t.iterator();

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
@@ -216,7 +216,7 @@ public class TermFilteredPresearcher extends Presearcher {
 
       @Override
       public void addTerm(String field, BytesRef term) {
-        List<BytesRef> t = terms.computeIfAbsent(field, f -> new ArrayList<>());
+        List<BytesRef> t = terms.computeIfAbsent(field, _ -> new ArrayList<>());
         t.add(term);
       }
 
@@ -271,7 +271,7 @@ public class TermFilteredPresearcher extends Presearcher {
     Map<String, BytesRefHash> fieldTerms = new HashMap<>();
     querytree.collectTerms(
         (field, term) -> {
-          BytesRefHash tt = fieldTerms.computeIfAbsent(field, f -> new BytesRefHash());
+          BytesRefHash tt = fieldTerms.computeIfAbsent(field, _ -> new BytesRefHash());
           tt.add(term);
         });
     return fieldTerms;

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/WritableQueryIndex.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/WritableQueryIndex.java
@@ -152,7 +152,7 @@ class WritableQueryIndex extends QueryIndex {
     purgeCache(
         newCache ->
             scan(
-                (id, cacheEntry, dataValues) -> {
+                (id, _, dataValues) -> {
                   if (ids.contains(id)) {
                     // this is a branch of a query that has already been reconstructed, but
                     // then split by decomposition - we don't need to parse it again
@@ -234,7 +234,7 @@ class WritableQueryIndex extends QueryIndex {
     purgeCache(
         newCache ->
             scan(
-                (id, query, dataValues) -> {
+                (_, query, _) -> {
                   if (query != null) newCache.put(query.cacheId, query);
                 }));
     lastPurged = System.nanoTime();

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestTermPresearcher.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestTermPresearcher.java
@@ -53,7 +53,7 @@ public class TestTermPresearcher extends PresearcherTestBase {
       Map<String, Long> timings = new HashMap<>();
       QueryTimeListener timeListener =
           (queryId, timeInNanos) ->
-              timings.compute(queryId, (q, t) -> t == null ? timeInNanos : t + timeInNanos);
+              timings.compute(queryId, (_, t) -> t == null ? timeInNanos : t + timeInNanos);
       MatchingQueries<QueryMatch> matches =
           monitor.match(
               buildDoc(TEXTFIELD, "this is a test document"),

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/UnorderedIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/UnorderedIntervalsSource.java
@@ -43,7 +43,7 @@ class UnorderedIntervalsSource extends MinimizingConjunctionIntervalsSource {
   private static List<IntervalsSource> deduplicate(List<IntervalsSource> sources) {
     Map<IntervalsSource, Integer> counts = new LinkedHashMap<>(); // preserve order for testing
     for (IntervalsSource source : sources) {
-      counts.compute(source, (k, v) -> v == null ? 1 : v + 1);
+      counts.compute(source, (_, v) -> v == null ? 1 : v + 1);
     }
     List<IntervalsSource> deduplicated = new ArrayList<>();
     for (IntervalsSource source : counts.keySet()) {

--- a/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
@@ -767,7 +767,7 @@ public final class MoreLikeThis {
       Map<String, Map<String, Int>> field2termFreqMap, Terms vector, String fieldName)
       throws IOException {
     Map<String, Int> termFreqMap =
-        field2termFreqMap.computeIfAbsent(fieldName, k -> new HashMap<>());
+        field2termFreqMap.computeIfAbsent(fieldName, _ -> new HashMap<>());
     final TermsEnum termsEnum = vector.iterator();
     final CharsRefBuilder spare = new CharsRefBuilder();
     BytesRef text;
@@ -806,7 +806,7 @@ public final class MoreLikeThis {
           "To use MoreLikeThis without " + "term vectors, you must provide an Analyzer");
     }
     Map<String, Int> termFreqMap =
-        perFieldTermFrequencies.computeIfAbsent(fieldName, k -> new HashMap<>());
+        perFieldTermFrequencies.computeIfAbsent(fieldName, _ -> new HashMap<>());
     try (TokenStream ts = analyzer.tokenStream(fieldName, r)) {
       int tokenCount = 0;
       // for every token

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestFunctionMatchQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestFunctionMatchQuery.java
@@ -62,7 +62,7 @@ public class TestFunctionMatchQuery extends FunctionTestSetup {
   }
 
   public void testTwoPhaseIteratorMatchCost() throws IOException {
-    DoublePredicate predicate = d -> true;
+    DoublePredicate predicate = _ -> true;
 
     // should use default match cost
     FunctionMatchQuery fmq = new FunctionMatchQuery(in, predicate);

--- a/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestPayloadFilteredInterval.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestPayloadFilteredInterval.java
@@ -91,8 +91,8 @@ public class TestPayloadFilteredInterval extends LuceneTestCase {
   }
 
   public void testPayloadFilteredTermIntervalsSourceEquals() {
-    IntervalsSource interval = Intervals.term("test", (payload) -> true);
-    IntervalsSource sameInterval = Intervals.term("test", (payload) -> true);
+    IntervalsSource interval = Intervals.term("test", (_) -> true);
+    IntervalsSource sameInterval = Intervals.term("test", (_) -> true);
     IntervalsSource differentInterval = Intervals.term("test");
 
     assertTrue(interval.equals(sameInterval));

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/RegexpQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/RegexpQueryNodeBuilder.java
@@ -48,7 +48,7 @@ public class RegexpQueryNodeBuilder implements StandardQueryBuilder {
         new Term(regexpNode.getFieldAsString(), regexpNode.textToBytesRef()),
         RegExp.ALL,
         0,
-        name -> null,
+        _ -> null,
         Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
         method);
   }

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestQPHelper.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestQPHelper.java
@@ -1200,7 +1200,7 @@ public class TestQPHelper extends LuceneTestCase {
             new Term("field", "[a-z][123]"),
             RegExp.ALL,
             0,
-            name -> null,
+            _ -> null,
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
             MultiTermQuery.SCORING_BOOLEAN_REWRITE);
     assertEquals(new BoostQuery(q, 0.5f), qp.parse("/[A-Z][123]/^0.5", df));

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
@@ -1101,7 +1101,7 @@ public abstract class QueryParserTestBase extends LuceneTestCase {
             new Term("field", "[a-z][123]"),
             RegExp.ALL,
             0,
-            name -> null,
+            _ -> null,
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
             MultiTermQuery.SCORING_BOOLEAN_REWRITE);
     assertTrue(getQuery("/[A-Z][123]/^0.5", qp) instanceof BoostQuery);

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestAnalyzingSuggester.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestAnalyzingSuggester.java
@@ -1066,7 +1066,7 @@ public class TestAnalyzingSuggester extends LuceneTestCase {
           @Override
           protected TokenStreamComponents createComponents(String fieldName) {
             return new TokenStreamComponents(
-                r -> {},
+                _ -> {},
                 new CannedTokenStream(
                     token("hairy", 1, 1), token("smelly", 0, 1), token("dog", 1, 1)));
           }
@@ -1265,7 +1265,7 @@ public class TestAnalyzingSuggester extends LuceneTestCase {
           @Override
           protected TokenStreamComponents createComponents(String fieldName) {
             return new TokenStreamComponents(
-                r -> {}, new CannedTokenStream(new Token("a", 0, 1), new Token("b", 0, 0, 1)));
+                _ -> {}, new CannedTokenStream(new Token("a", 0, 1), new Token("b", 0, 0, 1)));
           }
         };
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
@@ -869,7 +869,7 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
     public IndexInput openInput(String name, IOContext context) throws IOException {
       IndexInput in = super.openInput(name, context);
       final FixedBitSet set =
-          readBytes.computeIfAbsent(name, n -> new FixedBitSet(Math.toIntExact(in.length())));
+          readBytes.computeIfAbsent(name, _ -> new FixedBitSet(Math.toIntExact(in.length())));
       if (set.length() != in.length()) {
         throw new IllegalStateException();
       }
@@ -880,7 +880,7 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
     public ChecksumIndexInput openChecksumInput(String name) throws IOException {
       ChecksumIndexInput in = super.openChecksumInput(name);
       final FixedBitSet set =
-          readBytes.computeIfAbsent(name, n -> new FixedBitSet(Math.toIntExact(in.length())));
+          readBytes.computeIfAbsent(name, _ -> new FixedBitSet(Math.toIntExact(in.length())));
       if (set.length() != in.length()) {
         throw new IllegalStateException();
       }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseMergePolicyTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseMergePolicyTestCase.java
@@ -143,7 +143,7 @@ public abstract class BaseMergePolicyTestCase extends LuceneTestCase {
     }
     SegmentInfos infos = new SegmentInfos(Version.LATEST.major);
     try (Directory directory = newDirectory()) {
-      MergePolicy.MergeContext context = new MockMergeContext(s -> 0);
+      MergePolicy.MergeContext context = new MockMergeContext(_ -> 0);
       int numSegs = random().nextInt(10);
       for (int i = 0; i < numSegs; i++) {
         SegmentInfo info =

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
@@ -254,8 +254,8 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
       positionToTerms = CollectionUtil.newHashMap(len);
       startOffsetToTerms = CollectionUtil.newHashMap(len);
       for (int i = 0; i < len; ++i) {
-        positionToTerms.computeIfAbsent(positions[i], k -> new HashSet<>(1)).add(i);
-        startOffsetToTerms.computeIfAbsent(startOffsets[i], k -> new HashSet<>(1)).add(i);
+        positionToTerms.computeIfAbsent(positions[i], _ -> new HashSet<>(1)).add(i);
+        startOffsetToTerms.computeIfAbsent(startOffsets[i], _ -> new HashSet<>(1)).add(i);
       }
 
       freqs = new HashMap<>();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
@@ -1218,7 +1218,7 @@ public class RandomPostingsTester {
       if (fieldInfo.hasNorms()) {
         docToNorm = DOC_TO_NORM;
       } else {
-        docToNorm = doc -> 1L;
+        docToNorm = _ -> 1L;
       }
 
       // First check impacts and block uptos

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsFS.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsFS.java
@@ -67,8 +67,8 @@ public class WindowsFS extends HandleTrackingFS {
       final Object key = getKey(path);
       // we have to read the key under the lock otherwise me might leak the openFile handle
       // if we concurrently delete or move this file.
-      Map<Path, Integer> pathMap = openFiles.computeIfAbsent(key, k -> new HashMap<>());
-      pathMap.put(path, pathMap.computeIfAbsent(path, p -> 0).intValue() + 1);
+      Map<Path, Integer> pathMap = openFiles.computeIfAbsent(key, _ -> new HashMap<>());
+      pathMap.put(path, pathMap.computeIfAbsent(path, _ -> 0).intValue() + 1);
     }
   }
 
@@ -147,7 +147,7 @@ public class WindowsFS extends HandleTrackingFS {
             Integer v = map.remove(target);
             if (v != null) {
               Map<Path, Integer> pathIntegerMap =
-                  openFiles.computeIfAbsent(newKey, k -> new HashMap<>());
+                  openFiles.computeIfAbsent(newKey, _ -> new HashMap<>());
               Integer existingValue = pathIntegerMap.getOrDefault(target, 0);
               pathIntegerMap.put(target, existingValue + v);
             }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1849,7 +1849,7 @@ public abstract class LuceneTestCase extends Assert {
     // we need to reset the query cache in an @BeforeClass so that tests that
     // instantiate an IndexSearcher in an @BeforeClass method use a fresh new cache
     IndexSearcher.setDefaultQueryCache(
-        new LRUQueryCache(10000, 1 << 25, context -> true, Float.POSITIVE_INFINITY));
+        new LRUQueryCache(10000, 1 << 25, _ -> true, Float.POSITIVE_INFINITY));
     IndexSearcher.setDefaultQueryCachingPolicy(MAYBE_CACHE_POLICY);
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/RamUsageTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/RamUsageTester.java
@@ -292,7 +292,7 @@ public final class RamUsageTester {
               a(Path.class, v -> charArraySize(v.toString().length()));
 
               // Ignorable JDK classes.
-              a(ByteOrder.class, v -> 0);
+              a(ByteOrder.class, _ -> 0);
             }
 
             @SuppressWarnings("unchecked")

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestReproduceMessage.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestReproduceMessage.java
@@ -47,7 +47,7 @@ public class TestReproduceMessage extends WithNestedTests {
 
     @Rule
     public TestRule rule =
-        (base, description) ->
+        (base, _) ->
             new Statement() {
               @Override
               public void evaluate() throws Throwable {


### PR DESCRIPTION
After the upgrade to java 23, my editor is flooded with warnings of unused variables from lambdas. Fix them.

I also downloaded eclipse, installed it, checked all possible compiler options, compared the resulting file and ensured out eclipse compiler file is synced up, so that everything is explicit.