### PR TITLE
Fix TestSysoutLimits by making nested test classes not extend LuceneTestCase

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleLimitSysouts.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleLimitSysouts.java
@@ -207,6 +207,7 @@ public class TestRuleLimitSysouts extends TestRuleAdapter {
       checkCaptureStreams();
     }
     resetCaptureState();
+    var bef = bytesWritten.get();
     applyClassAnnotations();
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleLimitSysouts.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleLimitSysouts.java
@@ -207,7 +207,6 @@ public class TestRuleLimitSysouts extends TestRuleAdapter {
       checkCaptureStreams();
     }
     resetCaptureState();
-    var bef = bytesWritten.get();
     applyClassAnnotations();
   }
 

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestSysoutsLimits.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestSysoutsLimits.java
@@ -18,7 +18,11 @@ package org.apache.lucene.tests.util;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import java.util.stream.Collectors;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.JUnitCore;

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestSysoutsLimits.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestSysoutsLimits.java
@@ -18,10 +18,9 @@ package org.apache.lucene.tests.util;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import java.util.stream.Collectors;
-import org.apache.lucene.internal.vectorization.VectorizationProvider;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 
@@ -31,23 +30,32 @@ import org.junit.runner.Result;
 public class TestSysoutsLimits extends WithNestedTests {
   public TestSysoutsLimits() {
     super(false);
-
-    // vectorization provider may print a warning during initialization,
-    // and we count sysout/syserr bytes exactly so bootstrap any
-    // initializations early.
-    VectorizationProvider.getInstance();
   }
 
-  public static class ParentNestedTest extends LuceneTestCase
+  @TestRuleLimitSysouts.Limit(
+      bytes = TestRuleLimitSysouts.DEFAULT_LIMIT,
+      hardLimit = TestRuleLimitSysouts.DEFAULT_HARD_LIMIT)
+  public static class ParentNestedTest extends RandomizedTest
       implements TestRuleIgnoreTestSuites.NestedTestSuite {
+    @ClassRule public static final TestRule classRules;
+
+    static {
+      var suiteFailureMarker = new TestRuleMarkFailure();
+      classRules =
+          RuleChain.outerRule(new TestRuleIgnoreTestSuites())
+              .around(suiteFailureMarker)
+              .around(new TestRuleLimitSysouts(suiteFailureMarker));
+    }
+
     @BeforeClass
     public static void onlyWhenNested() {
-      assumeTrue("Only runs when nested", TestRuleIgnoreTestSuites.isRunningNested());
+      Assume.assumeTrue("Only runs when nested", TestRuleIgnoreTestSuites.isRunningNested());
     }
   }
 
   @TestRuleLimitSysouts.Limit(bytes = 10)
   public static class OverSoftLimit extends ParentNestedTest {
+    @Test
     public void testWrite() {
       System.out.print(RandomizedTest.randomAsciiLettersOfLength(10));
     }
@@ -68,6 +76,7 @@ public class TestSysoutsLimits extends WithNestedTests {
 
   @TestRuleLimitSysouts.Limit(bytes = 10)
   public static class UnderLimit extends ParentNestedTest {
+    @Test
     public void testWrite() {
       System.out.print(RandomizedTest.randomAsciiLettersOfLength(9));
     }
@@ -88,6 +97,7 @@ public class TestSysoutsLimits extends WithNestedTests {
 
   @TestRuleLimitSysouts.Limit(bytes = 10, hardLimit = 20)
   public static class OverHardLimit extends ParentNestedTest {
+    @Test
     public void testWrite() {
       System.out.print("1234567890");
       System.out.print("-marker1-");


### PR DESCRIPTION
This dodges occasional warnings during randomized setup. Fixes #14307
