### PR TITLE
python scripts: fix enough so that undefined variable analysis works

### DIFF
--- a/dev-tools/scripts/.editorconfig
+++ b/dev-tools/scripts/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.py]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/dev-tools/scripts/addVersion.py
+++ b/dev-tools/scripts/addVersion.py
@@ -18,12 +18,10 @@
 import os
 import sys
 sys.path.append(os.path.dirname(__file__))
-from scriptutil import *
-
+from scriptutil import find_branch_type, find_current_version, run, update_file, Version
 import argparse
 import re
 from configparser import ConfigParser, ExtendedInterpolation
-from textwrap import dedent
 
 def update_changes(filename, new_version, init_changes, headers):
   print('  adding new section to %s...' % filename, end='', flush=True)
@@ -55,7 +53,7 @@ def add_constant(new_version, deprecate):
     if last.strip() != '@Deprecated':
       spaces = ' ' * (len(last) - len(last.lstrip()) - 1)
       del buffer[-1] # Remove comment closer line
-      if (len(buffer) >= 4 and re.search('for Lucene.\s*$', buffer[-1]) != None):
+      if (len(buffer) >= 4 and re.search('for Lucene.\s*$', buffer[-1]) is not None):
         del buffer[-3:] # drop the trailing lines '<p> / Use this to get the latest ... / ... for Lucene.'
       buffer.append(( '{0} * @deprecated ({1}) Use latest\n'
                     + '{0} */\n'

--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -24,7 +24,9 @@ import sys
 import subprocess
 from subprocess import TimeoutExpired
 import textwrap
-import urllib.request, urllib.error, urllib.parse
+import urllib.request
+import urllib.error
+import urllib.parse
 import xml.etree.ElementTree as ET
 
 import scriptutil

--- a/dev-tools/scripts/githubPRs.py
+++ b/dev-tools/scripts/githubPRs.py
@@ -28,13 +28,7 @@ import json
 import re
 from github import Github
 from jira import JIRA
-from datetime import datetime
-from time import strftime
-try:
-  from jinja2 import Environment, BaseLoader
-  can_do_html = True
-except:
-  can_do_html = False
+from jinja2 import Environment, BaseLoader
 
 def read_config():
   parser = argparse.ArgumentParser(description='Find open Pull Requests that need attention')
@@ -51,9 +45,6 @@ def out(text):
     print(text)
 
 def make_html(dict):
-  if not can_do_html:
-    print ("ERROR: Cannot generate HTML. Please install jinja2")
-    sys.exit(1)
   global conf
   template = Environment(loader=BaseLoader).from_string("""
   <h1>Lucene Github PR report</h1>

--- a/dev-tools/scripts/pyproject.toml
+++ b/dev-tools/scripts/pyproject.toml
@@ -3,6 +3,7 @@ venvPath = "."
 venv = ".venv"
 # TODO: improve!
 # typeCheckingMode = "strict"
+reportUnnecessaryTypeIgnoreComment = "error"
 typeCheckingMode = "basic"
 # TODO: we should fix these
 reportArgumentType = "none"
@@ -13,7 +14,6 @@ reportOperatorIssue = "none"
 reportOptionalIterable = "none"
 reportOptionalMemberAccess = "none"
 reportOptionalSubscript = "none"
-reportUndefinedVariable = "none"
 
 [tool.ruff]
 line-length = 200
@@ -25,22 +25,6 @@ indent-width = 2
 
 # disabling/enabling of rules
 ignore = [
-  # we should fix these
-  "E401",  # multiple imports on one line
-  "E701",  # multiple statements on one line
-  "E711",  # comparison should be "is not None"
-  "E703",  # unnecessary semicolon
-  "E713",  # test for membership should be "not in"
-  "E714",  # test for object identity should be "is not"
-  "E722",  # do not use bare except
-  "E741",  # ambiguous variable name
-  "F401",  # unused import
-  "F403",  # unable to detect undefined names due to star imports
-  "F405",  # undefined name or defined from star imports
-  "F811",  # redefinition of unused
-  "F821",  # undefined name
-  "F841",  # local variable assigned but never used
-
   # These rules are always disabled: conflict with the formatter
   # don't enable! https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
   "W191", "E111", "E114", "E117", "D206", "D300", "Q000", "Q001",

--- a/dev-tools/scripts/releasedJirasRegex.py
+++ b/dev-tools/scripts/releasedJirasRegex.py
@@ -18,7 +18,7 @@
 import sys
 import os
 sys.path.append(os.path.dirname(__file__))
-from scriptutil import *
+from scriptutil import Version
 import argparse
 import re
 

--- a/dev-tools/scripts/reproduceJenkinsFailures.py
+++ b/dev-tools/scripts/reproduceJenkinsFailures.py
@@ -85,8 +85,8 @@ def runOutput(cmd):
   print('[repro] %s' % cmd)
   try:
     return subprocess.check_output(cmd.split(' '), universal_newlines=True).strip()
-  except CalledProcessError as e:
-    raise RuntimeError("ERROR: Cmd '%s' failed with exit code %d and the following output:\n%s" 
+  except subprocess.CalledProcessError as e:
+    raise RuntimeError("ERROR: Cmd '%s' failed with exit code %d and the following output:\n%s"
                        % (cmd, e.returncode, e.output))
 
 # Remembers non-zero exit code in lastFailureCode unless rememberFailure==False
@@ -142,10 +142,10 @@ def fetchAndParseJenkinsLog(url, numRetries):
       print('[repro] Encountered IncompleteRead exception, aborting after too many retries.')
       raise RuntimeError('ERROR: fetching %s : %s' % (url, e))
 
-  if revisionFromLog == None:
+  if revisionFromLog is None:
     if reJenkinsURLWithoutConsoleText.match(url):
       print('[repro] Not a Jenkins log. Appending "/consoleText" and retrying ...\n')
-      return fetchAndParseJenkinsLog(url + '/consoleText', numRetries)                                                        
+      return fetchAndParseJenkinsLog(url + '/consoleText', numRetries)
     else:
       raise RuntimeError('ERROR: %s does not appear to be a Jenkins log.' % url)
   if 0 == len(tests):
@@ -173,7 +173,7 @@ def prepareWorkspace(useGit, gitRef):
         raise RuntimeError('ERROR: "%s" failed.  See above.' % checkoutBranchCmd)
     gitCheckoutSucceeded = True
     run('git merge --ff-only', rememberFailure=False) # Ignore failure on non-branch ref
-  
+
   code = run('ant clean')
   if 0 != code:
     raise RuntimeError('ERROR: "ant clean" failed.  See above.')
@@ -204,7 +204,7 @@ def runTests(testIters, modules, tests):
   for module in modules:
     moduleTests = list(modules[module])
     testList = '|'.join(map(lambda t: '*.%s' % t, moduleTests))
-    numTests = len(moduleTests)   
+    numTests = len(moduleTests)
     params = tests[moduleTests[0]] # Assumption: all tests in this module have the same cmdline params
     os.chdir(module)
     code = run('ant compile-test')
@@ -214,7 +214,7 @@ def runTests(testIters, modules, tests):
       run(testCmdline % (testIters, testIters * numTests, testList, antOptions, params))
     finally:
       os.chdir(cwd)
-      
+
 def printAndMoveReports(testIters, newSubDir, location):
   failures = {}
   for start in ('lucene/build', 'solr/build'):
@@ -237,7 +237,7 @@ def printAndMoveReports(testIters, newSubDir, location):
           os.makedirs(newDirPath, exist_ok=True)
           os.rename(filePath, os.path.join(newDirPath, file))
   print("[repro] Failures%s:" % location)
-  for testcase in sorted(failures, key=lambda t: (failures[t],t)): # sort by failure count, then by testcase 
+  for testcase in sorted(failures, key=lambda t: (failures[t],t)): # sort by failure count, then by testcase
     print("[repro]   %d/%d failed: %s" % (failures[testcase], testIters, testcase))
   return failures
 
@@ -258,15 +258,15 @@ def main():
     # have to play nice with ant clean, so printAndMoveReports will move all the junit XML files here...
     print('[repro] JUnit rest result XML files will be moved to: ./repro-reports')
     if os.path.isdir('repro-reports'):
-      print('[repro]   Deleting old ./repro-reports');
+      print('[repro]   Deleting old ./repro-reports')
       shutil.rmtree('repro-reports')
     prepareWorkspace(config.useGit, revisionFromLog)
     modules = groupTestsByModule(tests)
     runTests(config.testIters, modules, tests)
     failures = printAndMoveReports(config.testIters, 'orig',
                                    ' w/original seeds' + (' at %s' % revisionFromLog if config.useGit else ''))
-                                  
-    
+
+
     if config.useGit:
       # Retest 100% failures at the tip of the branch
       oldTests = tests
@@ -282,7 +282,7 @@ def main():
         runTests(config.testIters, modules, tests)
         failures = printAndMoveReports(config.testIters, 'branch-tip',
                                        ' original seeds at the tip of %s' % branchFromLog)
-      
+
         # Retest 100% tip-of-branch failures without a seed
         oldTests = tests
         tests = {}
@@ -297,7 +297,7 @@ def main():
           runTests(config.testIters, modules, tests)
           printAndMoveReports(config.testIters, 'branch-tip-no-seed',
                               ' at the tip of %s without a seed' % branchFromLog)
-  except Exception as e:
+  except Exception:
     print('[repro] %s' % traceback.format_exc())
     sys.exit(1)
   finally:

--- a/dev-tools/scripts/scriptutil.py
+++ b/dev-tools/scripts/scriptutil.py
@@ -20,7 +20,8 @@ import sys
 import os
 from enum import Enum
 import time
-import urllib.request, urllib.error, urllib.parse
+import urllib.request
+import urllib.error
 import urllib.parse
 
 class Version(object):

--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -32,7 +32,6 @@ import textwrap
 import traceback
 import urllib.error
 import urllib.parse
-import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 import zipfile
@@ -195,7 +194,7 @@ def normSlashes(path):
 
 def checkAllJARs(topDir, gitRevision, version):
   print('    verify JAR metadata/identity/no javax.* or java.* classes...')
-  for root, dirs, files in os.walk(topDir):
+  for root, _, files in os.walk(topDir):
 
     normRoot = normSlashes(root)
 
@@ -327,7 +326,7 @@ def testChanges(version, changesURLString):
 
 def testChangesText(dir, version):
   "Checks all CHANGES.txt under this dir."
-  for root, dirs, files in os.walk(dir):
+  for root, _, files in os.walk(dir):
 
     # NOTE: O(N) but N should be smallish:
     if 'CHANGES.txt' in files:
@@ -415,9 +414,12 @@ reUnixPath = re.compile(r'\b[a-zA-Z_]+=(?:"(?:\\"|[^"])*"' + '|(?:\\\\.|[^"\'\\s
 
 
 def unix2win(matchobj):
-  if matchobj.group(1) is not None: return cygwinWindowsRoot + matchobj.group()
-  if matchobj.group(2) is not None: return '"%s%s' % (cygwinWindowsRoot, matchobj.group().lstrip('"'))
-  if matchobj.group(3) is not None: return "'%s%s" % (cygwinWindowsRoot, matchobj.group().lstrip("'"))
+  if matchobj.group(1) is not None:
+    return cygwinWindowsRoot + matchobj.group()
+  if matchobj.group(2) is not None:
+    return '"%s%s' % (cygwinWindowsRoot, matchobj.group().lstrip('"'))
+  if matchobj.group(3) is not None:
+    return "'%s%s" % (cygwinWindowsRoot, matchobj.group().lstrip("'"))
   return matchobj.group()
 
 
@@ -427,7 +429,8 @@ def cygwinifyPaths(command):
   # values are automatically converted, so only paths outside of
   # environment variable values should be converted to Windows paths.
   # Assumption: all paths will be absolute.
-  if '; gradlew ' in command: command = reUnixPath.sub(unix2win, command)
+  if '; gradlew ' in command:
+    command = reUnixPath.sub(unix2win, command)
   return command
 
 
@@ -450,7 +453,8 @@ def printFileContents(fileName):
 
 
 def run(command, logFile):
-  if cygwin: command = cygwinifyPaths(command)
+  if cygwin:
+    command = cygwinifyPaths(command)
   if os.system('%s > %s 2>&1' % (command, logFile)):
     logPath = os.path.abspath(logFile)
     print('\ncommand "%s" failed:' % command)
@@ -488,18 +492,18 @@ def getDirEntries(urlString):
       path = path[:-1]
     if cygwin: # Convert Windows path to Cygwin path
       path = re.sub(r'^/([A-Za-z]):/', r'/cygdrive/\1/', path)
-    l = []
+    files = []
     for ent in os.listdir(path):
       entPath = '%s/%s' % (path, ent)
       if os.path.isdir(entPath):
         entPath += '/'
         ent += '/'
-      l.append((ent, 'file://%s' % entPath))
-    l.sort()
-    return l
+      files.append((ent, 'file://%s' % entPath))
+    files.sort()
+    return files
   else:
     links = getHREFs(urlString)
-    for i, (text, subURL) in enumerate(links):
+    for i, (text, _) in enumerate(links):
       if text == 'Parent Directory' or text == '..':
         return links[(i+1):]
 
@@ -518,10 +522,10 @@ def unpackAndVerify(java, tmpDir, artifact, gitRevision, version, testArgs):
     run('unzip %s/%s' % (tmpDir, artifact), unpackLogFile)
 
   # make sure it unpacks to proper subdir
-  l = os.listdir(destDir)
+  files = os.listdir(destDir)
   expected = 'lucene-%s' % version
-  if l != [expected]:
-    raise RuntimeError('unpack produced entries %s; expected only %s' % (l, expected))
+  if files != [expected]:
+    raise RuntimeError('unpack produced entries %s; expected only %s' % (files, expected))
 
   unpackPath = '%s/%s' % (destDir, expected)
   verifyUnpacked(java, artifact, unpackPath, gitRevision, version, testArgs)
@@ -733,7 +737,7 @@ def getBinaryDistFiles(tmpDir, version, baseURL):
   unpackLogFile = '%s/unpack-%s-getBinaryDistFiles.log' % (tmpDir, distribution)
   run('tar xzf %s/%s' % (tmpDir, distribution), unpackLogFile)
   distributionFiles = []
-  for root, dirs, files in os.walk(destDir):
+  for root, _, files in os.walk(destDir):
     distributionFiles.extend([os.path.join(root, file) for file in files])
   return distributionFiles
 
@@ -1037,9 +1041,9 @@ def getAllLuceneReleases():
         raise RuntimeError('failed to parse version: %s' % tup[-1])
       releases.add(tuple(int(x) for x in tup))
 
-  l = list(releases)
-  l.sort()
-  return l
+  releaseList = list(releases)
+  releaseList.sort()
+  return releaseList
 
 
 def confirmAllReleasesAreTestedForBackCompat(smokeVersion, unpackPath):
@@ -1077,10 +1081,10 @@ def confirmAllReleasesAreTestedForBackCompat(smokeVersion, unpackPath):
 
     testedIndices.add(tup)
 
-  l = list(testedIndices)
-  l.sort()
   if False:
-    for release in l:
+    indexList = list(testedIndices)
+    indexList.sort()
+    for release in indexList:
       print('  %s' % '.'.join(str(x) for x in release))
 
   allReleases = set(allReleases)
@@ -1108,7 +1112,6 @@ def confirmAllReleasesAreTestedForBackCompat(smokeVersion, unpackPath):
   if len(notTested) > 0:
     notTested.sort()
     print('Releases that don\'t seem to be tested:')
-    failed = True
     for x in notTested:
       print('  %s' % '.'.join(str(y) for y in x))
     raise RuntimeError('some releases are not tested by TestBackwardsCompatibility?')


### PR DESCRIPTION
Fix basic errors from linter and get undefined variable analysis working through the type-checker.

This will detect common problems such as typos, instead of at runtime. The changes are straightforward: cleaning up imports, basic bad things.

