### PR TITLE
Fix DirectIOIndexInput seek to not read when position is within buffer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -171,6 +171,8 @@ Bug Fixes
 
 * GITHUB#14215: Fix degenerate case in HNSW where all vectors have the same score. (Ben Trent)
 
+* GITHUB#14320: Fix DirectIOIndexInput seek to not read when position is within buffer (Chris Hegarty)
+
 Other
 ---------------------
 

--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -373,7 +373,13 @@ public class DirectIODirectory extends FilterDirectory {
     @Override
     public void seek(long pos) throws IOException {
       if (pos != getFilePointer()) {
-        seekInternal(pos);
+        final long absolutePos = pos + offset;
+        if (absolutePos >= filePos && absolutePos <= filePos + buffer.limit()) {
+          // the new position is within the existing buffer
+          buffer.position(Math.toIntExact(absolutePos - filePos));
+        } else {
+          seekInternal(pos); // do an actual seek/read
+        }
       }
       assert pos == getFilePointer();
     }

--- a/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
@@ -209,4 +209,31 @@ public class TestDirectIODirectory extends BaseDirectoryTestCase {
               OptionalLong.of(largeSize)));
     }
   }
+
+  // Ping-pong seeks should be really fast, since the position should be within buffer.
+  // The test should complete within sub-second times, not minutes.
+  public void testSeekSmall() throws IOException {
+    Path tmpDir = createTempDir("testSeekSmall");
+    int blockSize = Math.toIntExact(Files.getFileStore(tmpDir).getBlockSize());
+    try (Directory dir = getDirectory(tmpDir)) {
+      int len = atLeast(100);
+      try (IndexOutput o = dir.createOutput("out", newIOContext(random()))) {
+        byte[] b = new byte[len];
+        for (int i = 0; i < len; i++) {
+          b[i] = (byte) i;
+        }
+        o.writeBytes(b, 0, len);
+      }
+      try (IndexInput in = dir.openInput("out", newIOContext(random()))) {
+        for (int i = 0; i < 100_000; i++) {
+          in.seek(2);
+          assertEquals(2, in.readByte());
+          in.seek(1);
+          assertEquals(1, in.readByte());
+          in.seek(0);
+          assertEquals(0, in.readByte());
+        }
+      }
+    }
+  }
 }

--- a/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
@@ -214,7 +214,6 @@ public class TestDirectIODirectory extends BaseDirectoryTestCase {
   // The test should complete within sub-second times, not minutes.
   public void testSeekSmall() throws IOException {
     Path tmpDir = createTempDir("testSeekSmall");
-    int blockSize = Math.toIntExact(Files.getFileStore(tmpDir).getBlockSize());
     try (Directory dir = getDirectory(tmpDir)) {
       int len = atLeast(100);
       try (IndexOutput o = dir.createOutput("out", newIOContext(random()))) {


### PR DESCRIPTION
This commit changes DirectIOIndexInput::seek so that it repositions the indexInput's position without a read, when the new position is within the bounds of the current buffer.

Prior to this fix (on Linux):
```
times out after more than 10 mins
```

With this fix:
```
The slowest tests (exceeding 500 ms) during this run:
   3.48s TestDirectIODirectory.testRandomByte (:lucene:misc)
```

relates #14315