### PR TITLE
Add PR number to output of changelog action

### DIFF
--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -23,7 +23,7 @@ jobs:
       - name: ChangeLog Entry Verifier and Milestone Setter
         run: |
           echo "################## STEP 1 ##################"
-          echo "Get all labels from the PR"
+          echo "Get all labels from PR #${{ github.event.number }}"
           mapfile -t labels < <(gh pr view ${{ github.event.number }} --json labels -q '.labels[].name')
           IFS=','; echo "${labels[*]}"
           for label in "${labels[@]}"; do


### PR DESCRIPTION
Make it easier to understand the output by having the PR number referenced in the logs.