### PR TITLE
Optimize commit retention policy to maintain only the last 5 commits

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/KeepOnlyLastCommitDeletionPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/KeepOnlyLastCommitDeletionPolicy.java
@@ -40,9 +40,11 @@ public final class KeepOnlyLastCommitDeletionPolicy extends IndexDeletionPolicy 
   public void onCommit(List<? extends IndexCommit> commits) {
     // Note that commits.size() should normally be 2 (if not
     // called by onInit above):
+    int retainCount = 5; // Number of commits to keep
     int size = commits.size();
-    for (int i = 0; i < size - 1; i++) {
-      commits.get(i).delete();
+
+    for (int i = 0; i < size - retainCount; i++) {
+        commits.get(i).delete(); // Delete only if older than retainCount
     }
   }
 }


### PR DESCRIPTION
This update enhances repository management by limiting the commit retention policy to store only the last 5 commits. By doing so, it prevents unnecessary commit history buildup, improves efficiency, and keeps the repository clean. This change ensures that recent commits remain accessible while reducing clutter in the commit log.

Fixes #14219  partially
