### PR TITLE
Remove some randomness in testRandomWithFilter

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -637,16 +637,17 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
             int tag = (int) fieldDoc.fields[0];
             assertTrue(lower <= tag && tag <= numDocs);
           }
-
-          // Test a filter that exhausts visitedLimit in upper levels, and switches to exact search
-          Query filter4 = IntPoint.newRangeQuery("tag", lower, lower + 6);
-          expectThrows(
-              UnsupportedOperationException.class,
-              () ->
-                  searcher.search(
-                      getThrowingKnnVectorQuery("field", randomVector(dimension), 1, filter4),
-                      numDocs));
         }
+        // Test a filter that exhausts visitedLimit in upper levels, and switches to exact search
+        // due to extreme edge cases, removing the randomness
+        float[] vector = new float[dimension];
+        for (int i = 0; i < dimension; i++) {
+          vector[i] = i % 2 == 0 ? 42 : 7;
+        }
+        Query filter4 = IntPoint.newRangeQuery("tag", 250, 256);
+        expectThrows(
+            UnsupportedOperationException.class,
+            () -> searcher.search(getThrowingKnnVectorQuery("field", vector, 1, filter4), numDocs));
       }
     }
   }


### PR DESCRIPTION
I have noticed some rare failures of this test, but every time it failed, it was due to a valid set of kNN docs being found before the exploration limit was actually hit. This is due to extremely lucky entry point selection, which is possible.

So, I removed some of the randomness. I still like to have at least SOME randomness (e.g. the index being random, dims, etc.). This gives us some nice behavior coverage. If this keeps failing periodically (due to lucky entry points), maybe all randomness will need to be removed for this particular case.

closes: https://github.com/apache/lucene/issues/14266