### PR TITLE
Reduce Lucene90DocValuesProducer memory footprint

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BinaryDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BinaryDocValuesProducer.java
@@ -1,0 +1,304 @@
+package org.apache.lucene.codecs.lucene90;
+
+import java.io.IOException;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongValues;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+
+/** Reads binary doc values values for {@link Lucene90DocValuesFormat} */
+abstract class BinaryDocValuesProducer {
+
+  public abstract BinaryDocValues getBinary(IndexInput data, int maxDoc, boolean merging)
+      throws IOException;
+
+  private static final BinaryDocValuesProducer EMPTY =
+      new BinaryDocValuesProducer() {
+        @Override
+        public BinaryDocValues getBinary(IndexInput data, int maxDoc, boolean merging) {
+          return DocValues.emptyBinary();
+        }
+      };
+
+  public static BinaryDocValuesProducer create(Lucene90DocValuesProducer.BinaryEntry entry)
+      throws IOException {
+    if (entry.minLength < entry.maxLength) {
+      if (entry.docsWithFieldOffset == -2) {
+        return EMPTY;
+      } else if (entry.docsWithFieldOffset == -1) {
+        return new DenseVariableLengthBinaryDocValuesProducer(entry);
+      } else {
+        return new SparseVariableLengthBinaryDocValuesProducer(entry);
+      }
+    } else {
+      if (entry.docsWithFieldOffset == -2) {
+        return EMPTY;
+      } else if (entry.docsWithFieldOffset == -1) {
+        return new DenseFixedLengthBinaryDocValuesProducer(entry);
+      } else {
+        return new SparseFixedLengthBinaryDocValuesProducer(entry);
+      }
+    }
+  }
+
+  private abstract static class BaseBinaryDocValuesProducer extends BinaryDocValuesProducer {
+    private final long dataOffset;
+    private final long dataLength;
+    protected final int maxLength;
+
+    protected BaseBinaryDocValuesProducer(long dataOffset, long dataLength, int maxLength) {
+      this.dataOffset = dataOffset;
+      this.dataLength = dataLength;
+      this.maxLength = maxLength;
+    }
+
+    public RandomAccessInput getByteSlice(IndexInput data) throws IOException {
+      final RandomAccessInput bytesSlice = data.randomAccessSlice(dataOffset, dataLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (bytesSlice.length() > 0) {
+        bytesSlice.prefetch(0, 1);
+      }
+      return bytesSlice;
+    }
+  }
+
+  private abstract static class VariableLengthBinaryDocValuesProducer
+      extends BaseBinaryDocValuesProducer {
+    private final long docsWithFieldOffset;
+    private final long docsWithFieldLength;
+    private final short jumpTableEntryCount;
+    private final byte denseRankPower;
+    private final int numDocsWithField;
+
+    protected VariableLengthBinaryDocValuesProducer(Lucene90DocValuesProducer.BinaryEntry entry) {
+      super(entry.dataOffset, entry.dataLength, entry.maxLength);
+      this.docsWithFieldOffset = entry.docsWithFieldOffset;
+      this.docsWithFieldLength = entry.docsWithFieldLength;
+      this.jumpTableEntryCount = entry.jumpTableEntryCount;
+      this.denseRankPower = entry.denseRankPower;
+      this.numDocsWithField = entry.numDocsWithField;
+    }
+
+    public IndexedDISI getIndexedDISI(IndexInput data) throws IOException {
+      return new IndexedDISI(
+          data,
+          docsWithFieldOffset,
+          docsWithFieldLength,
+          jumpTableEntryCount,
+          denseRankPower,
+          numDocsWithField);
+    }
+  }
+
+  private static class DenseFixedLengthBinaryDocValuesProducer extends BaseBinaryDocValuesProducer {
+
+    protected DenseFixedLengthBinaryDocValuesProducer(Lucene90DocValuesProducer.BinaryEntry entry) {
+      super(entry.dataOffset, entry.dataLength, entry.maxLength);
+    }
+
+    @Override
+    public BinaryDocValues getBinary(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      RandomAccessInput bytesSlice = getByteSlice(data);
+      final int length = maxLength;
+      return new DenseBinaryDocValues(maxDoc) {
+        final BytesRef bytes = new BytesRef(new byte[length], 0, length);
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+          bytesSlice.readBytes((long) doc * length, bytes.bytes, 0, length);
+          return bytes;
+        }
+      };
+    }
+  }
+
+  private static class DenseVariableLengthBinaryDocValuesProducer
+      extends BaseBinaryDocValuesProducer {
+    final long addressesOffset;
+    final long addressesLength;
+    final DirectMonotonicReader.Meta addressesMeta;
+
+    protected DenseVariableLengthBinaryDocValuesProducer(
+        Lucene90DocValuesProducer.BinaryEntry entry) {
+      super(entry.dataOffset, entry.dataLength, entry.maxLength);
+      this.addressesOffset = entry.addressesOffset;
+      this.addressesLength = entry.addressesLength;
+      this.addressesMeta = entry.addressesMeta;
+    }
+
+    @Override
+    public BinaryDocValues getBinary(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput bytesSlice = getByteSlice(data);
+      // variable length
+      final RandomAccessInput addressesData =
+          data.randomAccessSlice(addressesOffset, addressesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (addressesData.length() > 0) {
+        addressesData.prefetch(0, 1);
+      }
+      final LongValues addresses =
+          DirectMonotonicReader.getInstance(addressesMeta, addressesData, merging);
+      return new DenseBinaryDocValues(maxDoc) {
+        final BytesRef bytes = new BytesRef(new byte[maxLength], 0, maxLength);
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+          long startOffset = addresses.get(doc);
+          bytes.length = (int) (addresses.get(doc + 1L) - startOffset);
+          bytesSlice.readBytes(startOffset, bytes.bytes, 0, bytes.length);
+          return bytes;
+        }
+      };
+    }
+  }
+
+  private static class SparseFixedLengthBinaryDocValuesProducer
+      extends VariableLengthBinaryDocValuesProducer {
+
+    protected SparseFixedLengthBinaryDocValuesProducer(
+        Lucene90DocValuesProducer.BinaryEntry entry) {
+      super(entry);
+    }
+
+    @Override
+    public BinaryDocValues getBinary(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput bytesSlice = getByteSlice(data);
+      final IndexedDISI disi = getIndexedDISI(data);
+      final int length = maxLength;
+      return new SparseBinaryDocValues(disi) {
+        final BytesRef bytes = new BytesRef(new byte[length], 0, length);
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+          bytesSlice.readBytes((long) disi.index() * length, bytes.bytes, 0, length);
+          return bytes;
+        }
+      };
+    }
+  }
+
+  private static class SparseVariableLengthBinaryDocValuesProducer
+      extends VariableLengthBinaryDocValuesProducer {
+
+    private final long addressesOffset;
+    private final long addressesLength;
+    private final DirectMonotonicReader.Meta addressesMeta;
+
+    protected SparseVariableLengthBinaryDocValuesProducer(
+        Lucene90DocValuesProducer.BinaryEntry entry) {
+      super(entry);
+      this.addressesOffset = entry.addressesOffset;
+      this.addressesLength = entry.addressesLength;
+      this.addressesMeta = entry.addressesMeta;
+    }
+
+    @Override
+    public BinaryDocValues getBinary(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput bytesSlice = getByteSlice(data);
+      final IndexedDISI disi = getIndexedDISI(data);
+      final RandomAccessInput addressesData =
+          data.randomAccessSlice(addressesOffset, addressesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (addressesData.length() > 0) {
+        addressesData.prefetch(0, 1);
+      }
+      final LongValues addresses = DirectMonotonicReader.getInstance(addressesMeta, addressesData);
+
+      return new SparseBinaryDocValues(disi) {
+        final BytesRef bytes = new BytesRef(new byte[maxLength], 0, maxLength);
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+          final int index = disi.index();
+          long startOffset = addresses.get(index);
+          bytes.length = (int) (addresses.get(index + 1L) - startOffset);
+          bytesSlice.readBytes(startOffset, bytes.bytes, 0, bytes.length);
+          return bytes;
+        }
+      };
+    }
+  }
+
+  private abstract static class DenseBinaryDocValues extends BinaryDocValues {
+
+    final int maxDoc;
+    int doc = -1;
+
+    DenseBinaryDocValues(int maxDoc) {
+      this.maxDoc = maxDoc;
+    }
+
+    @Override
+    public int nextDoc() {
+      return advance(doc + 1);
+    }
+
+    @Override
+    public int docID() {
+      return doc;
+    }
+
+    @Override
+    public long cost() {
+      return maxDoc;
+    }
+
+    @Override
+    public int advance(int target) {
+      if (target >= maxDoc) {
+        return doc = NO_MORE_DOCS;
+      }
+      return doc = target;
+    }
+
+    @Override
+    public boolean advanceExact(int target) {
+      doc = target;
+      return true;
+    }
+  }
+
+  private abstract static class SparseBinaryDocValues extends BinaryDocValues {
+
+    private final IndexedDISI disi;
+
+    SparseBinaryDocValues(IndexedDISI disi) {
+      this.disi = disi;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      return disi.nextDoc();
+    }
+
+    @Override
+    public int docID() {
+      return disi.docID();
+    }
+
+    @Override
+    public long cost() {
+      return disi.cost();
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+      return disi.advance(target);
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+      return disi.advanceExact(target);
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BinaryDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BinaryDocValuesProducer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.codecs.lucene90;
 
 import java.io.IOException;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LongValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LongValuesProducer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.codecs.lucene90;
 
 import java.io.IOException;
@@ -5,6 +21,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.LongValues;
 
+/** Reads long values used in {@link SortedNumericDocValuesProducer} */
 abstract class LongValuesProducer {
 
   public abstract LongValues getLongValues(IndexInput data, int maxDoc, boolean merging)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LongValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LongValuesProducer.java
@@ -1,0 +1,228 @@
+package org.apache.lucene.codecs.lucene90;
+
+import java.io.IOException;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.LongValues;
+
+abstract class LongValuesProducer {
+
+  public abstract LongValues getLongValues(IndexInput data, int maxDoc, boolean merging)
+      throws IOException;
+
+  public static LongValuesProducer create(Lucene90DocValuesProducer.NumericEntry entry) {
+    if (entry.bitsPerValue == 0) {
+      return new SingleLongValuesProducer(entry.minValue);
+    } else {
+      if (entry.blockShift >= 0) {
+        return new VaryingVPLongValuesProducer(entry);
+      } else {
+        if (entry.table != null) {
+          return new TableLongValuesProducer(entry);
+        } else if (entry.gcd != 1) {
+          return new GcdLongValuesProducer(entry);
+        } else if (entry.minValue != 0) {
+          return new MinValueLongValuesProducer(entry);
+        } else {
+          return new PlainLongValuesProducer(entry);
+        }
+      }
+    }
+  }
+
+  private static class SingleLongValuesProducer extends LongValuesProducer {
+
+    private final long value;
+
+    private SingleLongValuesProducer(long value) {
+      this.value = value;
+    }
+
+    @Override
+    public LongValues getLongValues(IndexInput data, int maxDoc, boolean merging) {
+      return new LongValues() {
+        @Override
+        public long get(long index) {
+          return value;
+        }
+      };
+    }
+  }
+
+  private abstract static class BaseLongValuesProducer extends LongValuesProducer {
+
+    protected final long valuesOffset;
+    private final long valuesLength;
+
+    protected BaseLongValuesProducer(long valuesOffset, long valuesLength) {
+      this.valuesOffset = valuesOffset;
+      this.valuesLength = valuesLength;
+    }
+
+    protected RandomAccessInput slice(IndexInput data) throws IOException {
+      final RandomAccessInput slice = data.randomAccessSlice(valuesOffset, valuesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (slice.length() > 0) {
+        slice.prefetch(0, 1);
+      }
+      return slice;
+    }
+  }
+
+  private static class VaryingVPLongValuesProducer extends BaseLongValuesProducer {
+
+    private final long valueJumpTableOffset;
+    private final int blockShift;
+    private final long gcd;
+    private final long numValues;
+
+    private VaryingVPLongValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry.valuesOffset, entry.valuesLength);
+      this.valueJumpTableOffset = entry.valueJumpTableOffset;
+      this.blockShift = entry.blockShift;
+      this.gcd = entry.gcd;
+      this.numValues = entry.numValues;
+    }
+
+    @Override
+    public LongValues getLongValues(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput slice = slice(data);
+      return new LongValues() {
+        final NumericDocValuesProducer.VaryingBPVReader vBPVReader =
+            new NumericDocValuesProducer.VaryingBPVReader(
+                slice,
+                data,
+                merging,
+                valueJumpTableOffset,
+                blockShift,
+                gcd,
+                valuesOffset,
+                numValues);
+
+        @Override
+        public long get(long index) {
+          try {
+            return vBPVReader.getLongValue(index);
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      };
+    }
+  }
+
+  private static class TableLongValuesProducer extends BaseLongValuesProducer {
+
+    private final long[] table;
+    private final byte bitsPerValue;
+    private final long numValues;
+
+    private TableLongValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry.valuesOffset, entry.valuesLength);
+      this.table = entry.table;
+      this.bitsPerValue = entry.bitsPerValue;
+      this.numValues = entry.numValues;
+    }
+
+    @Override
+    public LongValues getLongValues(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput slice = slice(data);
+      final LongValues values =
+          NumericDocValuesProducer.getDirectReaderInstance(
+              slice, bitsPerValue, 0L, numValues, merging);
+      final long[] table = this.table;
+      return new LongValues() {
+        @Override
+        public long get(long index) {
+          return table[(int) values.get(index)];
+        }
+      };
+    }
+  }
+
+  private static class GcdLongValuesProducer extends BaseLongValuesProducer {
+
+    private final byte bitsPerValue;
+    private final long numValues;
+    private final long gcd;
+    private final long value;
+
+    private GcdLongValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry.valuesOffset, entry.valuesLength);
+      this.bitsPerValue = entry.bitsPerValue;
+      this.numValues = entry.numValues;
+      this.gcd = entry.gcd;
+      this.value = entry.minValue;
+    }
+
+    @Override
+    public LongValues getLongValues(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput slice = slice(data);
+      final LongValues values =
+          NumericDocValuesProducer.getDirectReaderInstance(
+              slice, bitsPerValue, 0L, numValues, merging);
+      final long gcd = this.gcd;
+      final long value = this.value;
+      return new LongValues() {
+        @Override
+        public long get(long index) {
+          return values.get(index) * gcd + value;
+        }
+      };
+    }
+  }
+
+  private static class MinValueLongValuesProducer extends BaseLongValuesProducer {
+
+    private final byte bitsPerValue;
+    private final long numValues;
+    private final long minValue;
+
+    private MinValueLongValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry.valuesOffset, entry.valuesLength);
+      this.bitsPerValue = entry.bitsPerValue;
+      this.numValues = entry.numValues;
+      this.minValue = entry.minValue;
+    }
+
+    @Override
+    public LongValues getLongValues(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput slice = slice(data);
+      final LongValues values =
+          NumericDocValuesProducer.getDirectReaderInstance(
+              slice, bitsPerValue, 0L, numValues, merging);
+      final long minValue = this.minValue;
+      return new LongValues() {
+        @Override
+        public long get(long index) {
+          return values.get(index) + minValue;
+        }
+      };
+    }
+  }
+
+  private static class PlainLongValuesProducer extends BaseLongValuesProducer {
+
+    private final byte bitsPerValue;
+    private final long numValues;
+
+    private PlainLongValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry.valuesOffset, entry.valuesLength);
+      this.bitsPerValue = entry.bitsPerValue;
+      this.numValues = entry.numValues;
+    }
+
+    @Override
+    public LongValues getLongValues(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput slice = slice(data);
+      return NumericDocValuesProducer.getDirectReaderInstance(
+          slice, bitsPerValue, 0L, numValues, merging);
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/NumericDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/NumericDocValuesProducer.java
@@ -1,0 +1,586 @@
+package org.apache.lucene.codecs.lucene90;
+
+import java.io.IOException;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.LongValues;
+import org.apache.lucene.util.packed.DirectReader;
+
+/** Reads numeric doc values values for {@link Lucene90DocValuesFormat} */
+abstract class NumericDocValuesProducer {
+
+  public abstract NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging)
+      throws IOException;
+
+  private static final NumericDocValuesProducer EMPTY =
+      new NumericDocValuesProducer() {
+        @Override
+        public NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging) {
+          return DocValues.emptyNumeric();
+        }
+      };
+
+  public static NumericDocValuesProducer create(Lucene90DocValuesProducer.NumericEntry entry) {
+    if (entry.docsWithFieldOffset == -2) {
+      return EMPTY;
+    } else if (entry.docsWithFieldOffset == -1) {
+      if (entry.bitsPerValue == 0) {
+        return new DenseSingleValueNumericDocValuesProducer(entry.minValue);
+      } else {
+        if (entry.blockShift >= 0) {
+          return new DenseVaryingVPDocValuesProducer(entry);
+        }
+        if (entry.table != null) {
+          return new DenseTableDocValuesProducer(entry);
+        }
+        if (entry.gcd == 1 && entry.minValue == 0) {
+          return new DenseCommonOrdinalsDocValuesProducer(entry);
+        }
+        return new DenseNumericDocValuesProducer(entry);
+      }
+    } else {
+      if (entry.bitsPerValue == 0) {
+        return new SparseSingleValueNumericDocValuesProducer(entry);
+      } else {
+        if (entry.blockShift >= 0) {
+          return new SparseVaryingVPDocValuesProducer(entry);
+        }
+        if (entry.table != null) {
+          return new SparseTableDocValuesProducer(entry);
+        }
+        if (entry.gcd == 1 && entry.minValue == 0) {
+          return new SparseCommonOrdinalsDocValuesProducer(entry);
+        }
+        return new SparseNumericDocValuesProducer(entry);
+      }
+    }
+  }
+
+  private static class DenseSingleValueNumericDocValuesProducer extends NumericDocValuesProducer {
+    private final long value;
+
+    private DenseSingleValueNumericDocValuesProducer(long value) {
+      this.value = value;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging) {
+      return new DenseNumericDocValues(maxDoc) {
+        @Override
+        public long longValue() {
+          return value;
+        }
+      };
+    }
+  }
+
+  private static class SparseSingleValueNumericDocValuesProducer extends NumericDocValuesProducer {
+    private final long value;
+    private final long docsWithFieldOffset;
+    private final long docsWithFieldLength;
+    private final short jumpTableEntryCount;
+    private final byte denseRankPower;
+    private final long numValues;
+
+    private SparseSingleValueNumericDocValuesProducer(
+        Lucene90DocValuesProducer.NumericEntry entry) {
+      this.value = entry.minValue;
+      this.docsWithFieldOffset = entry.docsWithFieldOffset;
+      this.docsWithFieldLength = entry.docsWithFieldLength;
+      this.jumpTableEntryCount = entry.jumpTableEntryCount;
+      this.denseRankPower = entry.denseRankPower;
+      this.numValues = entry.numValues;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final IndexedDISI disi =
+          new IndexedDISI(
+              data,
+              docsWithFieldOffset,
+              docsWithFieldLength,
+              jumpTableEntryCount,
+              denseRankPower,
+              numValues);
+      return new SparseNumericDocValues(disi) {
+        @Override
+        public long longValue() {
+          return value;
+        }
+      };
+    }
+  }
+
+  private abstract static class BaseNumericDocValuesProducer extends NumericDocValuesProducer {
+    protected final long valuesOffset;
+    private final long valuesLength;
+
+    protected BaseNumericDocValuesProducer(long valuesOffset, long valuesLength) {
+      this.valuesOffset = valuesOffset;
+      this.valuesLength = valuesLength;
+    }
+
+    protected final RandomAccessInput getSlice(IndexInput data) throws IOException {
+      final RandomAccessInput slice = data.randomAccessSlice(valuesOffset, valuesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (slice.length() > 0) {
+        slice.prefetch(0, 1);
+      }
+      return slice;
+    }
+  }
+
+  // dense but split into blocks of different bits per value
+  private static class DenseVaryingVPDocValuesProducer extends BaseNumericDocValuesProducer {
+    private final long valueJumpTableOffset;
+    private final int blockShift;
+    private final long gcd;
+    private final long numValues;
+
+    private DenseVaryingVPDocValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry.valuesOffset, entry.valuesLength);
+      this.valueJumpTableOffset = entry.valueJumpTableOffset;
+      this.blockShift = entry.blockShift;
+      this.gcd = entry.gcd;
+      this.numValues = entry.numValues;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      // dense but split into blocks of different bits per value
+      return new DenseNumericDocValues(maxDoc) {
+        final RandomAccessInput slice = getSlice(data);
+        final VaryingBPVReader vBPVReader =
+            new VaryingBPVReader(
+                slice,
+                data,
+                merging,
+                valueJumpTableOffset,
+                blockShift,
+                gcd,
+                valuesOffset,
+                numValues);
+
+        @Override
+        public long longValue() throws IOException {
+          return vBPVReader.getLongValue(doc);
+        }
+      };
+    }
+  }
+
+  private static class DenseTableDocValuesProducer extends BaseNumericDocValuesProducer {
+
+    private final long[] table;
+    private final byte bitsPerValue;
+    private final long numValues;
+
+    private DenseTableDocValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry.valuesOffset, entry.valuesLength);
+      this.table = entry.table;
+      this.bitsPerValue = entry.bitsPerValue;
+      this.numValues = entry.numValues;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput slice = getSlice(data);
+      final LongValues values =
+          getDirectReaderInstance(slice, bitsPerValue, 0L, numValues, merging);
+      final long[] table = this.table;
+      return new DenseNumericDocValues(maxDoc) {
+        @Override
+        public long longValue() {
+          return table[(int) values.get(doc)];
+        }
+      };
+    }
+  }
+
+  // Common case for ordinals, which are encoded as numerics
+  private static class DenseCommonOrdinalsDocValuesProducer extends BaseNumericDocValuesProducer {
+
+    private final byte bitsPerValue;
+    private final long numValues;
+
+    private DenseCommonOrdinalsDocValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry.valuesOffset, entry.valuesLength);
+      this.bitsPerValue = entry.bitsPerValue;
+      this.numValues = entry.numValues;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput slice = getSlice(data);
+      final LongValues values =
+          getDirectReaderInstance(slice, bitsPerValue, 0L, numValues, merging);
+      return new DenseNumericDocValues(maxDoc) {
+        @Override
+        public long longValue() {
+          return values.get(doc);
+        }
+      };
+    }
+  }
+
+  private static class DenseNumericDocValuesProducer extends BaseNumericDocValuesProducer {
+    private final byte bitsPerValue;
+    private final long numValues;
+    private final long minValue;
+    private final long gcd;
+
+    private DenseNumericDocValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry.valuesOffset, entry.valuesLength);
+      this.bitsPerValue = entry.bitsPerValue;
+      this.numValues = entry.numValues;
+      this.minValue = entry.minValue;
+      this.gcd = entry.gcd;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput slice = getSlice(data);
+      final LongValues values =
+          getDirectReaderInstance(slice, bitsPerValue, 0L, numValues, merging);
+
+      final long mul = gcd;
+      final long delta = minValue;
+      return new DenseNumericDocValues(maxDoc) {
+        @Override
+        public long longValue() {
+          return mul * values.get(doc) + delta;
+        }
+      };
+    }
+  }
+
+  private abstract static class BaseSparseNumericDocValuesProducer
+      extends BaseNumericDocValuesProducer {
+    private final long docsWithFieldOffset;
+    private final long docsWithFieldLength;
+    private final short jumpTableEntryCount;
+    private final byte denseRankPower;
+    protected final long numValues;
+
+    protected BaseSparseNumericDocValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry.valuesOffset, entry.valuesLength);
+      this.docsWithFieldOffset = entry.docsWithFieldOffset;
+      this.docsWithFieldLength = entry.docsWithFieldLength;
+      this.jumpTableEntryCount = entry.jumpTableEntryCount;
+      this.denseRankPower = entry.denseRankPower;
+      this.numValues = entry.numValues;
+    }
+
+    protected IndexedDISI getIndexedDISI(IndexInput data) throws IOException {
+      return new IndexedDISI(
+          data,
+          docsWithFieldOffset,
+          docsWithFieldLength,
+          jumpTableEntryCount,
+          denseRankPower,
+          numValues);
+    }
+  }
+
+  // sparse and split into blocks of different bits per value
+  private static class SparseVaryingVPDocValuesProducer extends BaseSparseNumericDocValuesProducer {
+    private final long valueJumpTableOffset;
+    private final int blockShift;
+    private final long gcd;
+
+    private SparseVaryingVPDocValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry);
+      this.valueJumpTableOffset = entry.valueJumpTableOffset;
+      this.blockShift = entry.blockShift;
+      this.gcd = entry.gcd;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final IndexedDISI disi = getIndexedDISI(data);
+      final RandomAccessInput slice = getSlice(data);
+      return new SparseNumericDocValues(disi) {
+        final VaryingBPVReader vBPVReader =
+            new VaryingBPVReader(
+                slice,
+                data,
+                merging,
+                valueJumpTableOffset,
+                blockShift,
+                gcd,
+                valuesOffset,
+                numValues);
+
+        @Override
+        public long longValue() throws IOException {
+          final int index = disi.index();
+          return vBPVReader.getLongValue(index);
+        }
+      };
+    }
+  }
+
+  private static class SparseTableDocValuesProducer extends BaseSparseNumericDocValuesProducer {
+    private final long[] table;
+    private final byte bitsPerValue;
+
+    private SparseTableDocValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry);
+      this.table = entry.table;
+      this.bitsPerValue = entry.bitsPerValue;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final long[] table = this.table;
+      final IndexedDISI disi = getIndexedDISI(data);
+      final RandomAccessInput slice = getSlice(data);
+      final LongValues values =
+          getDirectReaderInstance(slice, bitsPerValue, 0L, numValues, merging);
+      return new SparseNumericDocValues(disi) {
+        @Override
+        public long longValue() {
+          return table[(int) values.get(disi.index())];
+        }
+      };
+    }
+  }
+
+  private static class SparseCommonOrdinalsDocValuesProducer
+      extends BaseSparseNumericDocValuesProducer {
+
+    private final byte bitsPerValue;
+
+    private SparseCommonOrdinalsDocValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry);
+      this.bitsPerValue = entry.bitsPerValue;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final IndexedDISI disi = getIndexedDISI(data);
+      final RandomAccessInput slice = getSlice(data);
+      final LongValues values =
+          getDirectReaderInstance(slice, bitsPerValue, 0L, numValues, merging);
+      return new SparseNumericDocValues(disi) {
+        @Override
+        public long longValue() {
+          return values.get(disi.index());
+        }
+      };
+    }
+  }
+
+  private static class SparseNumericDocValuesProducer extends BaseSparseNumericDocValuesProducer {
+    private final byte bitsPerValue;
+    private final long minValue;
+    private final long gcd;
+
+    private SparseNumericDocValuesProducer(Lucene90DocValuesProducer.NumericEntry entry) {
+      super(entry);
+      this.bitsPerValue = entry.bitsPerValue;
+      this.minValue = entry.minValue;
+      this.gcd = entry.gcd;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+
+      final IndexedDISI disi = getIndexedDISI(data);
+      final RandomAccessInput slice = getSlice(data);
+      final LongValues values =
+          getDirectReaderInstance(slice, bitsPerValue, 0L, numValues, merging);
+      final long mul = gcd;
+      final long delta = minValue;
+      return new SparseNumericDocValues(disi) {
+        @Override
+        public long longValue() throws IOException {
+          return mul * values.get(disi.index()) + delta;
+        }
+      };
+    }
+  }
+
+  private abstract static class DenseNumericDocValues extends NumericDocValues {
+    final int maxDoc;
+    int doc = -1;
+
+    DenseNumericDocValues(int maxDoc) {
+      this.maxDoc = maxDoc;
+    }
+
+    @Override
+    public int docID() {
+      return doc;
+    }
+
+    @Override
+    public int nextDoc() {
+      return advance(doc + 1);
+    }
+
+    @Override
+    public int advance(int target) {
+      if (target >= maxDoc) {
+        return doc = NO_MORE_DOCS;
+      }
+      return doc = target;
+    }
+
+    @Override
+    public boolean advanceExact(int target) {
+      doc = target;
+      return true;
+    }
+
+    @Override
+    public long cost() {
+      return maxDoc;
+    }
+  }
+
+  private abstract static class SparseNumericDocValues extends NumericDocValues {
+
+    final IndexedDISI disi;
+
+    SparseNumericDocValues(IndexedDISI disi) {
+      this.disi = disi;
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+      return disi.advance(target);
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+      return disi.advanceExact(target);
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      return disi.nextDoc();
+    }
+
+    @Override
+    public int docID() {
+      return disi.docID();
+    }
+
+    @Override
+    public long cost() {
+      return disi.cost();
+    }
+  }
+
+  static LongValues getDirectReaderInstance(
+      RandomAccessInput slice, int bitsPerValue, long offset, long numValues, boolean merging) {
+    if (merging) {
+      return DirectReader.getMergeInstance(slice, bitsPerValue, offset, numValues);
+    } else {
+      return DirectReader.getInstance(slice, bitsPerValue, offset);
+    }
+  }
+
+  /**
+   * Reader for longs split into blocks of different bits per values. The longs are requested by
+   * index and must be accessed in monotonically increasing order.
+   */
+  // Note: The order requirement could be removed as the jump-tables allow for backwards iteration
+  // Note 2: The rankSlice is only used if an advance of > 1 block is called. Its construction could
+  // be lazy
+  static class VaryingBPVReader {
+    final RandomAccessInput slice; // 2 slices to avoid cache thrashing when using rank
+    final RandomAccessInput rankSlice;
+    final long valueJumpTableOffset;
+    final long valuesOffset;
+    final long numValues;
+    final int shift;
+    final long mul;
+    final int mask;
+    final boolean merging;
+
+    long block = -1;
+    long delta;
+    long offset;
+    long blockEndOffset;
+    LongValues values;
+
+    VaryingBPVReader(
+        RandomAccessInput slice,
+        IndexInput data,
+        boolean merging,
+        long valueJumpTableOffset,
+        int blockShift,
+        long gcd,
+        long valuesOffset,
+        long numValues)
+        throws IOException {
+
+      this.slice = slice;
+      this.rankSlice =
+          valueJumpTableOffset == -1
+              ? null
+              : data.randomAccessSlice(valueJumpTableOffset, data.length() - valueJumpTableOffset);
+
+      if (rankSlice != null && rankSlice.length() > 0) {
+        // Prefetch the first page of data. Following pages are expected to get prefetched through
+        // read-ahead.
+        rankSlice.prefetch(0, 1);
+      }
+      this.merging = merging;
+      this.valueJumpTableOffset = valueJumpTableOffset;
+      this.valuesOffset = valuesOffset;
+      this.numValues = numValues;
+      shift = blockShift;
+      mul = gcd;
+      mask = (1 << shift) - 1;
+    }
+
+    long getLongValue(long index) throws IOException {
+      final long block = index >>> shift;
+      if (this.block != block) {
+        int bitsPerValue;
+        do {
+          // If the needed block is the one directly following the current block, it is cheaper to
+          // avoid the cache
+          if (rankSlice != null && block != this.block + 1) {
+            blockEndOffset = rankSlice.readLong(block * Long.BYTES) - valuesOffset;
+            this.block = block - 1;
+          }
+          offset = blockEndOffset;
+          bitsPerValue = slice.readByte(offset++);
+          delta = slice.readLong(offset);
+          offset += Long.BYTES;
+          if (bitsPerValue == 0) {
+            blockEndOffset = offset;
+          } else {
+            final int length = slice.readInt(offset);
+            offset += Integer.BYTES;
+            blockEndOffset = offset + length;
+          }
+          this.block++;
+        } while (this.block != block);
+        final int numValues =
+            Math.toIntExact(Math.min(1 << shift, this.numValues - (block << shift)));
+        values =
+            bitsPerValue == 0
+                ? LongValues.ZEROES
+                : getDirectReaderInstance(slice, bitsPerValue, offset, numValues, merging);
+      }
+      return mul * values.get(index & mask) + delta;
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/NumericDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/NumericDocValuesProducer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.codecs.lucene90;
 
 import java.io.IOException;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedDocValuesProducer.java
@@ -1,0 +1,545 @@
+package org.apache.lucene.codecs.lucene90;
+
+import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.TERMS_DICT_BLOCK_LZ4_SHIFT;
+
+import java.io.IOException;
+import org.apache.lucene.index.BaseTermsEnum;
+import org.apache.lucene.index.ImpactsEnum;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.ByteArrayDataInput;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongValues;
+import org.apache.lucene.util.compress.LZ4;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+
+/** Reads sorted doc values values for {@link Lucene90DocValuesFormat} */
+abstract class SortedDocValuesProducer {
+
+  public abstract SortedDocValues getSorted(IndexInput data, int maxDoc, boolean merging)
+      throws IOException;
+
+  public static SortedDocValuesProducer create(Lucene90DocValuesProducer.SortedEntry sortedEntry)
+      throws IOException {
+    Lucene90DocValuesProducer.NumericEntry numericEntry = sortedEntry.ordsEntry;
+    Lucene90DocValuesProducer.TermsDictEntry termsDictEntry = sortedEntry.termsDictEntry;
+    // Specialize the common case for ordinals: single block of packed integers.
+    // final Lucene90DocValuesProducer.NumericEntry ordsEntry = entry.ordsEntry;
+    if (numericEntry.blockShift < 0 // single block
+        && numericEntry.bitsPerValue > 0) { // more than 1 value
+      if (numericEntry.gcd != 1 || numericEntry.minValue != 0 || numericEntry.table != null) {
+        throw new IllegalStateException("Ordinals shouldn't use GCD, offset or table compression");
+      }
+      if (numericEntry.docsWithFieldOffset == -1) { // dense
+        return new DenseSingleBlockSortedDocValuesProducer(numericEntry, termsDictEntry);
+      } else if (numericEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
+        return new SparseSingleBlockSortedDocValuesProducer(numericEntry, termsDictEntry);
+      }
+    }
+    return new OrdsSortedDocValuesProducer(numericEntry, termsDictEntry);
+  }
+
+  private static class DenseSingleBlockSortedDocValuesProducer extends SortedDocValuesProducer {
+
+    private final long valuesOffset;
+    private final long valuesLength;
+    private final byte bitsPerValue;
+    private final long numValues;
+    private final Lucene90DocValuesProducer.TermsDictEntry termsDictEntry;
+
+    private DenseSingleBlockSortedDocValuesProducer(
+        Lucene90DocValuesProducer.NumericEntry numericEntry,
+        Lucene90DocValuesProducer.TermsDictEntry termsDictEntry) {
+      this.valuesOffset = numericEntry.valuesOffset;
+      this.valuesLength = numericEntry.valuesLength;
+      this.bitsPerValue = numericEntry.bitsPerValue;
+      this.numValues = numericEntry.numValues;
+      this.termsDictEntry = termsDictEntry;
+    }
+
+    @Override
+    public SortedDocValues getSorted(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput slice = data.randomAccessSlice(valuesOffset, valuesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (slice.length() > 0) {
+        slice.prefetch(0, 1);
+      }
+      final LongValues values =
+          NumericDocValuesProducer.getDirectReaderInstance(
+              slice, bitsPerValue, 0L, numValues, merging);
+
+      return new BaseSortedDocValues(termsDictEntry, data, merging) {
+
+        private int doc = -1;
+
+        @Override
+        public int ordValue() {
+          return (int) values.get(doc);
+        }
+
+        @Override
+        public boolean advanceExact(int target) {
+          doc = target;
+          return true;
+        }
+
+        @Override
+        public int docID() {
+          return doc;
+        }
+
+        @Override
+        public int nextDoc() {
+          return advance(doc + 1);
+        }
+
+        @Override
+        public int advance(int target) {
+          if (target >= maxDoc) {
+            return doc = NO_MORE_DOCS;
+          }
+          return doc = target;
+        }
+
+        @Override
+        public long cost() {
+          return maxDoc;
+        }
+      };
+    }
+  }
+
+  private static class SparseSingleBlockSortedDocValuesProducer extends SortedDocValuesProducer {
+
+    private final long valuesOffset;
+    private final long valuesLength;
+    private final byte bitsPerValue;
+    private final long numValues;
+    private final long docsWithFieldOffset;
+    private final long docsWithFieldLength;
+    private final int jumpTableEntryCount;
+    private final byte denseRankPower;
+    private final Lucene90DocValuesProducer.TermsDictEntry termsDictEntry;
+
+    private SparseSingleBlockSortedDocValuesProducer(
+        Lucene90DocValuesProducer.NumericEntry numericEntry,
+        Lucene90DocValuesProducer.TermsDictEntry termsDictEntry) {
+      this.valuesOffset = numericEntry.valuesOffset;
+      this.valuesLength = numericEntry.valuesLength;
+      this.bitsPerValue = numericEntry.bitsPerValue;
+      this.numValues = numericEntry.numValues;
+      this.docsWithFieldOffset = numericEntry.docsWithFieldOffset;
+      this.docsWithFieldLength = numericEntry.docsWithFieldLength;
+      this.jumpTableEntryCount = numericEntry.jumpTableEntryCount;
+      this.denseRankPower = numericEntry.denseRankPower;
+      this.termsDictEntry = termsDictEntry;
+    }
+
+    @Override
+    public SortedDocValues getSorted(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput slice = data.randomAccessSlice(valuesOffset, valuesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (slice.length() > 0) {
+        slice.prefetch(0, 1);
+      }
+      final LongValues values =
+          NumericDocValuesProducer.getDirectReaderInstance(
+              slice, bitsPerValue, 0L, numValues, merging);
+
+      final IndexedDISI disi =
+          new IndexedDISI(
+              data,
+              docsWithFieldOffset,
+              docsWithFieldLength,
+              jumpTableEntryCount,
+              denseRankPower,
+              numValues);
+
+      return new BaseSortedDocValues(termsDictEntry, data, merging) {
+        @Override
+        public int ordValue() {
+          return (int) values.get(disi.index());
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          return disi.advanceExact(target);
+        }
+
+        @Override
+        public int docID() {
+          return disi.docID();
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+          return disi.nextDoc();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+          return disi.advance(target);
+        }
+
+        @Override
+        public long cost() {
+          return disi.cost();
+        }
+      };
+    }
+  }
+
+  private static class OrdsSortedDocValuesProducer extends SortedDocValuesProducer {
+
+    private final NumericDocValuesProducer numeric;
+    private final Lucene90DocValuesProducer.TermsDictEntry entry;
+
+    private OrdsSortedDocValuesProducer(
+        Lucene90DocValuesProducer.NumericEntry numericEntry,
+        Lucene90DocValuesProducer.TermsDictEntry termsDictEntry) {
+      this.numeric = NumericDocValuesProducer.create(numericEntry);
+      this.entry = termsDictEntry;
+    }
+
+    @Override
+    public SortedDocValues getSorted(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final NumericDocValues ords = numeric.getNumeric(data, maxDoc, merging);
+      return new BaseSortedDocValues(entry, data, merging) {
+
+        @Override
+        public int ordValue() throws IOException {
+          return (int) ords.longValue();
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          return ords.advanceExact(target);
+        }
+
+        @Override
+        public int docID() {
+          return ords.docID();
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+          return ords.nextDoc();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+          return ords.advance(target);
+        }
+
+        @Override
+        public long cost() {
+          return ords.cost();
+        }
+      };
+    }
+  }
+
+  private abstract static class BaseSortedDocValues extends SortedDocValues {
+
+    final IndexInput data;
+    final Lucene90DocValuesProducer.TermsDictEntry entry;
+    final TermsEnum termsEnum;
+    final boolean merging;
+
+    BaseSortedDocValues(
+        Lucene90DocValuesProducer.TermsDictEntry entry, IndexInput data, boolean merging)
+        throws IOException {
+      this.entry = entry;
+      this.data = data;
+      this.merging = merging;
+      this.termsEnum = termsEnum();
+    }
+
+    @Override
+    public int getValueCount() {
+      return Math.toIntExact(entry.termsDictSize);
+    }
+
+    @Override
+    public BytesRef lookupOrd(int ord) throws IOException {
+      termsEnum.seekExact(ord);
+      return termsEnum.term();
+    }
+
+    @Override
+    public int lookupTerm(BytesRef key) throws IOException {
+      TermsEnum.SeekStatus status = termsEnum.seekCeil(key);
+      switch (status) {
+        case FOUND:
+          return Math.toIntExact(termsEnum.ord());
+        case NOT_FOUND:
+        case END:
+        default:
+          return Math.toIntExact(-1L - termsEnum.ord());
+      }
+    }
+
+    @Override
+    public TermsEnum termsEnum() throws IOException {
+      return new TermsDict(entry, data, merging);
+    }
+  }
+
+  static class TermsDict extends BaseTermsEnum {
+    static final int LZ4_DECOMPRESSOR_PADDING = 7;
+
+    final Lucene90DocValuesProducer.TermsDictEntry entry;
+    final LongValues blockAddresses;
+    final IndexInput bytes;
+    final long blockMask;
+    final LongValues indexAddresses;
+    final RandomAccessInput indexBytes;
+    final BytesRef term;
+    final BytesRef blockBuffer;
+    final ByteArrayDataInput blockInput;
+    long ord = -1;
+    long currentCompressedBlockStart = -1;
+    long currentCompressedBlockEnd = -1;
+
+    TermsDict(Lucene90DocValuesProducer.TermsDictEntry entry, IndexInput data, boolean merging)
+        throws IOException {
+      this.entry = entry;
+      RandomAccessInput addressesSlice =
+          data.randomAccessSlice(entry.termsAddressesOffset, entry.termsAddressesLength);
+      blockAddresses =
+          DirectMonotonicReader.getInstance(entry.termsAddressesMeta, addressesSlice, merging);
+      bytes = data.slice("terms", entry.termsDataOffset, entry.termsDataLength);
+      blockMask = (1L << TERMS_DICT_BLOCK_LZ4_SHIFT) - 1;
+      RandomAccessInput indexAddressesSlice =
+          data.randomAccessSlice(entry.termsIndexAddressesOffset, entry.termsIndexAddressesLength);
+      indexAddresses =
+          DirectMonotonicReader.getInstance(
+              entry.termsIndexAddressesMeta, indexAddressesSlice, merging);
+      indexBytes = data.randomAccessSlice(entry.termsIndexOffset, entry.termsIndexLength);
+      term = new BytesRef(entry.maxTermLength);
+
+      // add the max term length for the dictionary
+      // add 7 padding bytes can help decompression run faster.
+      int bufferSize = entry.maxBlockLength + entry.maxTermLength + LZ4_DECOMPRESSOR_PADDING;
+      blockBuffer = new BytesRef(new byte[bufferSize], 0, bufferSize);
+      blockInput = new ByteArrayDataInput();
+    }
+
+    @Override
+    public BytesRef next() throws IOException {
+      if (++ord >= entry.termsDictSize) {
+        return null;
+      }
+
+      if ((ord & blockMask) == 0L) {
+        decompressBlock();
+      } else {
+        DataInput input = blockInput;
+        final int token = Byte.toUnsignedInt(input.readByte());
+        int prefixLength = token & 0x0F;
+        int suffixLength = 1 + (token >>> 4);
+        if (prefixLength == 15) {
+          prefixLength += input.readVInt();
+        }
+        if (suffixLength == 16) {
+          suffixLength += input.readVInt();
+        }
+        term.length = prefixLength + suffixLength;
+        input.readBytes(term.bytes, prefixLength, suffixLength);
+      }
+      return term;
+    }
+
+    @Override
+    public void seekExact(long ord) throws IOException {
+      if (ord < 0 || ord >= entry.termsDictSize) {
+        throw new IndexOutOfBoundsException();
+      }
+      // Signed shift since ord is -1 when the terms enum is not positioned
+      final long currentBlockIndex = this.ord >> TERMS_DICT_BLOCK_LZ4_SHIFT;
+      final long blockIndex = ord >> TERMS_DICT_BLOCK_LZ4_SHIFT;
+      if (ord < this.ord || blockIndex != currentBlockIndex) {
+        // The looked up ord is before the current ord or belongs to a different block, seek again
+        final long blockAddress = blockAddresses.get(blockIndex);
+        bytes.seek(blockAddress);
+        this.ord = (blockIndex << TERMS_DICT_BLOCK_LZ4_SHIFT) - 1;
+      }
+      // Scan to the looked up ord
+      while (this.ord < ord) {
+        next();
+      }
+    }
+
+    private BytesRef getTermFromIndex(long index) throws IOException {
+      assert index >= 0 && index <= (entry.termsDictSize - 1) >>> entry.termsDictIndexShift;
+      final long start = indexAddresses.get(index);
+      term.length = (int) (indexAddresses.get(index + 1) - start);
+      indexBytes.readBytes(start, term.bytes, 0, term.length);
+      return term;
+    }
+
+    private long seekTermsIndex(BytesRef text) throws IOException {
+      long lo = 0L;
+      long hi = (entry.termsDictSize - 1) >> entry.termsDictIndexShift;
+      while (lo <= hi) {
+        final long mid = (lo + hi) >>> 1;
+        getTermFromIndex(mid);
+        final int cmp = term.compareTo(text);
+        if (cmp <= 0) {
+          lo = mid + 1;
+        } else {
+          hi = mid - 1;
+        }
+      }
+
+      assert hi < 0 || getTermFromIndex(hi).compareTo(text) <= 0;
+      assert hi == ((entry.termsDictSize - 1) >> entry.termsDictIndexShift)
+          || getTermFromIndex(hi + 1).compareTo(text) > 0;
+      assert hi < 0 ^ entry.termsDictSize > 0; // return -1 iff empty term dict
+
+      return hi;
+    }
+
+    private BytesRef getFirstTermFromBlock(long block) throws IOException {
+      assert block >= 0 && block <= (entry.termsDictSize - 1) >>> TERMS_DICT_BLOCK_LZ4_SHIFT;
+      final long blockAddress = blockAddresses.get(block);
+      bytes.seek(blockAddress);
+      term.length = bytes.readVInt();
+      bytes.readBytes(term.bytes, 0, term.length);
+      return term;
+    }
+
+    private long seekBlock(BytesRef text) throws IOException {
+      long index = seekTermsIndex(text);
+      if (index == -1L) {
+        // empty terms dict
+        this.ord = 0;
+        return -2L;
+      }
+
+      long ordLo = index << entry.termsDictIndexShift;
+      long ordHi = Math.min(entry.termsDictSize, ordLo + (1L << entry.termsDictIndexShift)) - 1L;
+
+      long blockLo = ordLo >>> TERMS_DICT_BLOCK_LZ4_SHIFT;
+      long blockHi = ordHi >>> TERMS_DICT_BLOCK_LZ4_SHIFT;
+
+      while (blockLo <= blockHi) {
+        final long blockMid = (blockLo + blockHi) >>> 1;
+        getFirstTermFromBlock(blockMid);
+        final int cmp = term.compareTo(text);
+        if (cmp <= 0) {
+          blockLo = blockMid + 1;
+        } else {
+          blockHi = blockMid - 1;
+        }
+      }
+
+      assert blockHi < 0 || getFirstTermFromBlock(blockHi).compareTo(text) <= 0;
+      assert blockHi == ((entry.termsDictSize - 1) >>> TERMS_DICT_BLOCK_LZ4_SHIFT)
+          || getFirstTermFromBlock(blockHi + 1).compareTo(text) > 0;
+
+      // read the block only if term dict is not empty
+      assert entry.termsDictSize > 0;
+      // reset ord and bytes to the ceiling block even if
+      // text is before the first term (blockHi == -1)
+      final long block = Math.max(blockHi, 0);
+      final long blockAddress = blockAddresses.get(block);
+      this.ord = block << TERMS_DICT_BLOCK_LZ4_SHIFT;
+      bytes.seek(blockAddress);
+      decompressBlock();
+
+      return blockHi;
+    }
+
+    @Override
+    public SeekStatus seekCeil(BytesRef text) throws IOException {
+      final long block = seekBlock(text);
+      if (block == -2) {
+        // empty terms dict
+        assert entry.termsDictSize == 0;
+        return SeekStatus.END;
+      } else if (block == -1) {
+        // before the first term
+        return SeekStatus.NOT_FOUND;
+      }
+
+      while (true) {
+        int cmp = term.compareTo(text);
+        if (cmp == 0) {
+          return SeekStatus.FOUND;
+        } else if (cmp > 0) {
+          return SeekStatus.NOT_FOUND;
+        }
+        if (next() == null) {
+          return SeekStatus.END;
+        }
+      }
+    }
+
+    private void decompressBlock() throws IOException {
+      // The first term is kept uncompressed, so no need to decompress block if only
+      // look up the first term when doing seek block.
+      term.length = bytes.readVInt();
+      bytes.readBytes(term.bytes, 0, term.length);
+      long offset = bytes.getFilePointer();
+      if (offset < entry.termsDataLength - 1) {
+        // Avoid decompress again if we are reading a same block.
+        if (currentCompressedBlockStart != offset) {
+          blockBuffer.offset = term.length;
+          blockBuffer.length = bytes.readVInt();
+          // Decompress the remaining of current block, using the first term as a dictionary
+          System.arraycopy(term.bytes, 0, blockBuffer.bytes, 0, blockBuffer.offset);
+          LZ4.decompress(bytes, blockBuffer.length, blockBuffer.bytes, blockBuffer.offset);
+          currentCompressedBlockStart = offset;
+          currentCompressedBlockEnd = bytes.getFilePointer();
+        } else {
+          // Skip decompression but need to re-seek to block end.
+          bytes.seek(currentCompressedBlockEnd);
+        }
+
+        // Reset the buffer.
+        blockInput.reset(blockBuffer.bytes, blockBuffer.offset, blockBuffer.length);
+      }
+    }
+
+    @Override
+    public BytesRef term() throws IOException {
+      return term;
+    }
+
+    @Override
+    public long ord() throws IOException {
+      return ord;
+    }
+
+    @Override
+    public long totalTermFreq() throws IOException {
+      return -1L;
+    }
+
+    @Override
+    public PostingsEnum postings(PostingsEnum reuse, int flags) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ImpactsEnum impacts(int flags) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int docFreq() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedDocValuesProducer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.codecs.lucene90;
 
 import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.TERMS_DICT_BLOCK_LZ4_SHIFT;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedNumericDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedNumericDocValuesProducer.java
@@ -1,0 +1,239 @@
+package org.apache.lucene.codecs.lucene90;
+
+import java.io.IOException;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.LongValues;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+
+/** Reads sorted numeric doc values values for {@link Lucene90DocValuesFormat} */
+abstract class SortedNumericDocValuesProducer {
+
+  public abstract SortedNumericDocValues getSortedNumeric(
+      IndexInput data, int maxDoc, boolean merging) throws IOException;
+
+  public static SortedNumericDocValuesProducer create(
+      Lucene90DocValuesProducer.SortedNumericEntry entry) {
+    if (entry.numValues == entry.numDocsWithField) {
+      return new SingletonNumericDocValuesProducer(NumericDocValuesProducer.create(entry));
+    }
+    if (entry.docsWithFieldOffset == -1) {
+      // dense
+      return new DenseSortedNumericDocValuesProducer(entry);
+    } else {
+      // sparse
+      return new SparseSortedNumericDocValuesProducer(entry);
+    }
+  }
+
+  private static class SingletonNumericDocValuesProducer extends SortedNumericDocValuesProducer {
+    final NumericDocValuesProducer delegate;
+
+    private SingletonNumericDocValuesProducer(NumericDocValuesProducer delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public SortedNumericDocValues getSortedNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      NumericDocValues docValues = delegate.getNumeric(data, maxDoc, merging);
+      return DocValues.singleton(docValues);
+    }
+  }
+
+  private abstract static class BaseSortedNumericDocValuesProducer
+      extends SortedNumericDocValuesProducer {
+
+    private final long addressesOffset;
+    private final long addressesLength;
+
+    protected BaseSortedNumericDocValuesProducer(long addressesOffset, long addressesLength) {
+      this.addressesOffset = addressesOffset;
+      this.addressesLength = addressesLength;
+    }
+
+    protected RandomAccessInput addressesInput(IndexInput data) throws IOException {
+      final RandomAccessInput addressesInput =
+          data.randomAccessSlice(addressesOffset, addressesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (addressesInput.length() > 0) {
+        addressesInput.prefetch(0, 1);
+      }
+      return addressesInput;
+    }
+  }
+
+  private static class DenseSortedNumericDocValuesProducer
+      extends BaseSortedNumericDocValuesProducer {
+
+    private final DirectMonotonicReader.Meta addressesMeta;
+    private final LongValuesProducer valuesProducer;
+
+    private DenseSortedNumericDocValuesProducer(
+        Lucene90DocValuesProducer.SortedNumericEntry entry) {
+      super(entry.addressesOffset, entry.addressesLength);
+      this.addressesMeta = entry.addressesMeta;
+      this.valuesProducer = LongValuesProducer.create(entry);
+    }
+
+    @Override
+    public SortedNumericDocValues getSortedNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput addressesInput = addressesInput(data);
+      final LongValues addresses =
+          DirectMonotonicReader.getInstance(addressesMeta, addressesInput, merging);
+      final LongValues values = valuesProducer.getLongValues(data, maxDoc, merging);
+      return new SortedNumericDocValues() {
+
+        int doc = -1;
+        long start, end;
+        int count;
+
+        @Override
+        public int nextDoc() {
+          return advance(doc + 1);
+        }
+
+        @Override
+        public int docID() {
+          return doc;
+        }
+
+        @Override
+        public long cost() {
+          return maxDoc;
+        }
+
+        @Override
+        public int advance(int target) {
+          if (target >= maxDoc) {
+            return doc = NO_MORE_DOCS;
+          }
+          start = addresses.get(target);
+          end = addresses.get(target + 1L);
+          count = (int) (end - start);
+          return doc = target;
+        }
+
+        @Override
+        public boolean advanceExact(int target) {
+          start = addresses.get(target);
+          end = addresses.get(target + 1L);
+          count = (int) (end - start);
+          doc = target;
+          return true;
+        }
+
+        @Override
+        public long nextValue() {
+          return values.get(start++);
+        }
+
+        @Override
+        public int docValueCount() {
+          return count;
+        }
+      };
+    }
+  }
+
+  private static class SparseSortedNumericDocValuesProducer
+      extends BaseSortedNumericDocValuesProducer {
+    private final DirectMonotonicReader.Meta addressesMeta;
+    private final long docsWithFieldOffset;
+    private final long docsWithFieldLength;
+    private final int jumpTableEntryCount;
+    private final byte denseRankPower;
+    private final int numDocsWithField;
+    private final LongValuesProducer valuesProducer;
+
+    private SparseSortedNumericDocValuesProducer(
+        Lucene90DocValuesProducer.SortedNumericEntry entry) {
+      super(entry.addressesOffset, entry.addressesLength);
+      this.addressesMeta = entry.addressesMeta;
+      this.docsWithFieldOffset = entry.docsWithFieldOffset;
+      this.docsWithFieldLength = entry.docsWithFieldLength;
+      this.jumpTableEntryCount = entry.jumpTableEntryCount;
+      this.denseRankPower = entry.denseRankPower;
+      this.numDocsWithField = entry.numDocsWithField;
+      this.valuesProducer = LongValuesProducer.create(entry);
+    }
+
+    @Override
+    public SortedNumericDocValues getSortedNumeric(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput addressesInput = addressesInput(data);
+      final LongValues addresses =
+          DirectMonotonicReader.getInstance(addressesMeta, addressesInput, merging);
+      final LongValues values = valuesProducer.getLongValues(data, maxDoc, merging);
+      final IndexedDISI disi =
+          new IndexedDISI(
+              data,
+              docsWithFieldOffset,
+              docsWithFieldLength,
+              jumpTableEntryCount,
+              denseRankPower,
+              numDocsWithField);
+      return new SortedNumericDocValues() {
+
+        boolean set;
+        long start, end;
+        int count;
+
+        @Override
+        public int nextDoc() throws IOException {
+          set = false;
+          return disi.nextDoc();
+        }
+
+        @Override
+        public int docID() {
+          return disi.docID();
+        }
+
+        @Override
+        public long cost() {
+          return disi.cost();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+          set = false;
+          return disi.advance(target);
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          set = false;
+          return disi.advanceExact(target);
+        }
+
+        @Override
+        public long nextValue() {
+          set();
+          return values.get(start++);
+        }
+
+        @Override
+        public int docValueCount() {
+          set();
+          return count;
+        }
+
+        private void set() {
+          if (set == false) {
+            final int index = disi.index();
+            start = addresses.get(index);
+            end = addresses.get(index + 1L);
+            count = (int) (end - start);
+            set = true;
+          }
+        }
+      };
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedNumericDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedNumericDocValuesProducer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.codecs.lucene90;
 
 import java.io.IOException;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedSetDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedSetDocValuesProducer.java
@@ -1,0 +1,372 @@
+package org.apache.lucene.codecs.lucene90;
+
+import java.io.IOException;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongValues;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+import org.apache.lucene.util.packed.DirectReader;
+
+/** Reads sorted set doc values values for {@link Lucene90DocValuesFormat} */
+abstract class SortedSetDocValuesProducer {
+
+  public abstract SortedSetDocValues getSortedSet(IndexInput data, int maxDoc, boolean merging)
+      throws IOException;
+
+  public static SortedSetDocValuesProducer create(Lucene90DocValuesProducer.SortedSetEntry entry)
+      throws IOException {
+    if (entry.singleValueEntry != null) {
+      return new SingletonSortedDocValuesProducer(entry.singleValueEntry);
+    }
+    // Specialize the common case for ordinals: single block of packed integers.
+    Lucene90DocValuesProducer.SortedNumericEntry ordsEntry = entry.ordsEntry;
+    if (ordsEntry.blockShift < 0 && ordsEntry.bitsPerValue > 0) {
+      if (ordsEntry.gcd != 1 || ordsEntry.minValue != 0 || ordsEntry.table != null) {
+        throw new IllegalStateException("Ordinals shouldn't use GCD, offset or table compression");
+      }
+      if (ordsEntry.docsWithFieldOffset == -1) { // dense
+        return new DenseSingleBlockSortedSetDocValuesProducer(entry);
+      } else if (ordsEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
+        return new SparseSingleBlockSortedSetDocValuesProducer(entry);
+      }
+    }
+    return new OrdsSortedSetDocValuesProducer(entry.ordsEntry, entry.termsDictEntry);
+  }
+
+  private static class SingletonSortedDocValuesProducer extends SortedSetDocValuesProducer {
+    final SortedDocValuesProducer delegate;
+
+    private SingletonSortedDocValuesProducer(SortedDocValuesProducer delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSet(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      SortedDocValues docValues = delegate.getSorted(data, maxDoc, merging);
+      return DocValues.singleton(docValues);
+    }
+  }
+
+  private static class DenseSingleBlockSortedSetDocValuesProducer
+      extends SortedSetDocValuesProducer {
+
+    private final long addressesOffset;
+    private final long addressesLength;
+    private final DirectMonotonicReader.Meta addressesMeta;
+    private final long valuesOffset;
+    private final long valuesLength;
+    private final byte bitsPerValue;
+    private final Lucene90DocValuesProducer.TermsDictEntry termsDictEntry;
+
+    private DenseSingleBlockSortedSetDocValuesProducer(
+        Lucene90DocValuesProducer.SortedSetEntry sortedEntry) {
+      Lucene90DocValuesProducer.SortedNumericEntry ordsEntry = sortedEntry.ordsEntry;
+      this.addressesOffset = ordsEntry.addressesOffset;
+      this.addressesLength = ordsEntry.addressesLength;
+      this.addressesMeta = ordsEntry.addressesMeta;
+      this.valuesOffset = ordsEntry.valuesOffset;
+      this.valuesLength = ordsEntry.valuesLength;
+      this.bitsPerValue = ordsEntry.bitsPerValue;
+      this.termsDictEntry = sortedEntry.termsDictEntry;
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSet(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput addressesInput =
+          data.randomAccessSlice(addressesOffset, addressesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (addressesInput.length() > 0) {
+        addressesInput.prefetch(0, 1);
+      }
+      final LongValues addresses = DirectMonotonicReader.getInstance(addressesMeta, addressesInput);
+
+      final RandomAccessInput slice = data.randomAccessSlice(valuesOffset, valuesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (slice.length() > 0) {
+        slice.prefetch(0, 1);
+      }
+      final LongValues values = DirectReader.getInstance(slice, bitsPerValue);
+
+      return new BaseSortedSetDocValues(termsDictEntry, data, merging) {
+
+        private int doc = -1;
+        private long curr;
+        private int count;
+
+        @Override
+        public long nextOrd() {
+          return values.get(curr++);
+        }
+
+        @Override
+        public boolean advanceExact(int target) {
+          curr = addresses.get(target);
+          long end = addresses.get(target + 1L);
+          count = (int) (end - curr);
+          doc = target;
+          return true;
+        }
+
+        @Override
+        public int docValueCount() {
+          return count;
+        }
+
+        @Override
+        public int docID() {
+          return doc;
+        }
+
+        @Override
+        public int nextDoc() {
+          return advance(doc + 1);
+        }
+
+        @Override
+        public int advance(int target) {
+          if (target >= maxDoc) {
+            return doc = NO_MORE_DOCS;
+          }
+          curr = addresses.get(target);
+          long end = addresses.get(target + 1L);
+          count = (int) (end - curr);
+          return doc = target;
+        }
+
+        @Override
+        public long cost() {
+          return maxDoc;
+        }
+      };
+    }
+  }
+
+  private static class SparseSingleBlockSortedSetDocValuesProducer
+      extends SortedSetDocValuesProducer {
+
+    private final long addressesOffset;
+    private final long addressesLength;
+    private final DirectMonotonicReader.Meta addressesMeta;
+    private final long valuesOffset;
+    private final long valuesLength;
+    private final byte bitsPerValue;
+    private final long docsWithFieldOffset;
+    private final long docsWithFieldLength;
+    private final int jumpTableEntryCount;
+    private final byte denseRankPower;
+    private final Lucene90DocValuesProducer.TermsDictEntry termsDictEntry;
+    private final long numValues;
+
+    private SparseSingleBlockSortedSetDocValuesProducer(
+        Lucene90DocValuesProducer.SortedSetEntry sortedEntry) {
+      Lucene90DocValuesProducer.SortedNumericEntry ordsEntry = sortedEntry.ordsEntry;
+      this.addressesOffset = ordsEntry.addressesOffset;
+      this.addressesLength = ordsEntry.addressesLength;
+      this.addressesMeta = ordsEntry.addressesMeta;
+      this.valuesOffset = ordsEntry.valuesOffset;
+      this.valuesLength = ordsEntry.valuesLength;
+      this.bitsPerValue = ordsEntry.bitsPerValue;
+      this.termsDictEntry = sortedEntry.termsDictEntry;
+      this.docsWithFieldOffset = ordsEntry.docsWithFieldOffset;
+      this.docsWithFieldLength = ordsEntry.docsWithFieldLength;
+      this.jumpTableEntryCount = ordsEntry.jumpTableEntryCount;
+      this.denseRankPower = ordsEntry.denseRankPower;
+      this.numValues = ordsEntry.numValues;
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSet(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final RandomAccessInput addressesInput =
+          data.randomAccessSlice(addressesOffset, addressesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (addressesInput.length() > 0) {
+        addressesInput.prefetch(0, 1);
+      }
+      final LongValues addresses = DirectMonotonicReader.getInstance(addressesMeta, addressesInput);
+
+      final RandomAccessInput slice = data.randomAccessSlice(valuesOffset, valuesLength);
+      // Prefetch the first page of data. Following pages are expected to get prefetched through
+      // read-ahead.
+      if (slice.length() > 0) {
+        slice.prefetch(0, 1);
+      }
+      final LongValues values = DirectReader.getInstance(slice, bitsPerValue);
+
+      final IndexedDISI disi =
+          new IndexedDISI(
+              data,
+              docsWithFieldOffset,
+              docsWithFieldLength,
+              jumpTableEntryCount,
+              denseRankPower,
+              numValues);
+
+      return new BaseSortedSetDocValues(termsDictEntry, data, merging) {
+
+        boolean set;
+        long curr;
+        int count;
+
+        @Override
+        public long nextOrd() {
+          set();
+          return values.get(curr++);
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          set = false;
+          return disi.advanceExact(target);
+        }
+
+        @Override
+        public int docValueCount() {
+          set();
+          return count;
+        }
+
+        @Override
+        public int docID() {
+          return disi.docID();
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+          set = false;
+          return disi.nextDoc();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+          set = false;
+          return disi.advance(target);
+        }
+
+        @Override
+        public long cost() {
+          return disi.cost();
+        }
+
+        private void set() {
+          if (set == false) {
+            final int index = disi.index();
+            curr = addresses.get(index);
+            long end = addresses.get(index + 1L);
+            count = (int) (end - curr);
+            set = true;
+          }
+        }
+      };
+    }
+  }
+
+  private static class OrdsSortedSetDocValuesProducer extends SortedSetDocValuesProducer {
+
+    private final SortedNumericDocValuesProducer numeric;
+    private final Lucene90DocValuesProducer.TermsDictEntry entry;
+
+    private OrdsSortedSetDocValuesProducer(
+        Lucene90DocValuesProducer.SortedNumericEntry numericEntry,
+        Lucene90DocValuesProducer.TermsDictEntry termsDictEntry) {
+      this.numeric = SortedNumericDocValuesProducer.create(numericEntry);
+      this.entry = termsDictEntry;
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSet(IndexInput data, int maxDoc, boolean merging)
+        throws IOException {
+      final SortedNumericDocValues ords = numeric.getSortedNumeric(data, maxDoc, merging);
+      return new BaseSortedSetDocValues(entry, data, merging) {
+
+        @Override
+        public long nextOrd() throws IOException {
+          return ords.nextValue();
+        }
+
+        @Override
+        public int docValueCount() {
+          return ords.docValueCount();
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+          return ords.advanceExact(target);
+        }
+
+        @Override
+        public int docID() {
+          return ords.docID();
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+          return ords.nextDoc();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+          return ords.advance(target);
+        }
+
+        @Override
+        public long cost() {
+          return ords.cost();
+        }
+      };
+    }
+  }
+
+  private abstract static class BaseSortedSetDocValues extends SortedSetDocValues {
+
+    final Lucene90DocValuesProducer.TermsDictEntry entry;
+    final IndexInput data;
+    final TermsEnum termsEnum;
+    final boolean merging;
+
+    BaseSortedSetDocValues(
+        Lucene90DocValuesProducer.TermsDictEntry entry, IndexInput data, boolean merging)
+        throws IOException {
+      this.entry = entry;
+      this.data = data;
+      this.merging = merging;
+      this.termsEnum = termsEnum();
+    }
+
+    @Override
+    public long getValueCount() {
+      return entry.termsDictSize;
+    }
+
+    @Override
+    public BytesRef lookupOrd(long ord) throws IOException {
+      termsEnum.seekExact(ord);
+      return termsEnum.term();
+    }
+
+    @Override
+    public long lookupTerm(BytesRef key) throws IOException {
+      TermsEnum.SeekStatus status = termsEnum.seekCeil(key);
+      return switch (status) {
+        case FOUND -> termsEnum.ord();
+        default -> -1L - termsEnum.ord();
+      };
+    }
+
+    @Override
+    public TermsEnum termsEnum() throws IOException {
+      return new SortedDocValuesProducer.TermsDict(entry, data, merging);
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedSetDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/SortedSetDocValuesProducer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.codecs.lucene90;
 
 import java.io.IOException;
@@ -358,10 +374,14 @@ abstract class SortedSetDocValuesProducer {
     @Override
     public long lookupTerm(BytesRef key) throws IOException {
       TermsEnum.SeekStatus status = termsEnum.seekCeil(key);
-      return switch (status) {
-        case FOUND -> termsEnum.ord();
-        default -> -1L - termsEnum.ord();
-      };
+      switch (status) {
+        case FOUND:
+          return Math.toIntExact(termsEnum.ord());
+        case NOT_FOUND:
+        case END:
+        default:
+          return Math.toIntExact(-1L - termsEnum.ord());
+      }
     }
 
     @Override


### PR DESCRIPTION
Lucene90DocValuesProducer holds all the metadata found on the meta file on heap . At runtime, it processes that metadata to produce the right doc value flavour, e.g dense vs  sparse.  This is a bit wasteful as we are holding more data that it is required when we can process that metadata as soon as we read it. 

This commit proposes to process the metadata as soon as it is read in order to keep just the necessary metadata required to build each doc values flavour. In order to do that,  it introduces DocValuesProducer for each doc value type. Each producer contains the logic to parse the metadata and generate a factory that holds just the necessary metadata for each doc value flavour.  

This change should reduce the footprint for  Lucene90DocValuesProducer and  IMHO it makes the code a bit easier to follow.

  
 