### PR TITLE
Add venv to rat gitignore

### DIFF
--- a/gradle/validation/rat-sources.gradle
+++ b/gradle/validation/rat-sources.gradle
@@ -86,6 +86,7 @@ allprojects {
 
                     // do not let RAT attempt to scan a python venv, it gets lost and confused...
                     exclude "dev-tools/aws-jmh/build/**"
+                    exclude "dev-tools/scripts/.venv/**"
                     break
 
                 case ":lucene:analysis:morfologik":


### PR DESCRIPTION
For the same reason the aws-jmh venv is ignored. Current rat version will go crazy on this.

We should look into the rat version, I think they may have improved .gitignore support in recent releases? Our version of rat is 0.14 but i see issues such as https://issues.apache.org/jira/browse/RAT-390 solved in 0.17