### PR TITLE
PointInSetQuery use reverse collection to improve performance

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
@@ -425,15 +425,17 @@ public abstract class PointInSetQuery extends Query implements Accountable {
     @Override
     public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
       Relation relation = super.compare(minPackedValue, maxPackedValue);
-      return switch (relation) {
-        case CELL_INSIDE_QUERY ->
-            // all points match, skip this subtree
-            Relation.CELL_OUTSIDE_QUERY;
-        case CELL_OUTSIDE_QUERY ->
-            // none of the points match, clear all documents
-            Relation.CELL_INSIDE_QUERY;
-        default -> relation;
-      };
+      switch (relation) {
+        case CELL_INSIDE_QUERY:
+          // all points match, skip this subtree
+          return Relation.CELL_OUTSIDE_QUERY;
+        case CELL_OUTSIDE_QUERY:
+          // none of the points match, clear all documents
+          return Relation.CELL_INSIDE_QUERY;
+        case CELL_CROSSES_QUERY:
+        default:
+          return relation;
+      }
     }
   }
 


### PR DESCRIPTION
### Description

Performance issues with terms number field encountered in production environments: high query time and very high CPU usage.

Through analysis and localization, it was found that the main time consumption is in the build_scorer stage. The main task of build_scorer is to collect document IDs and fill bitset in memory. When there are a large number of document IDs, it takes up a lot of CPU.

After reading the code and optimizing it, the performance of terms number field is improved by 5-10 times in low cardinality case.

1. values.getDocCount() == reader.maxDoc() : ensures that each document contains this field.
2. values.getDocCount() == values.size() : ensures that each document has only one value for this field.
3. cost() > reader.maxDoc() / 2 : ensure that more than half of the documents matched by all the points to be queried.

Because when each document has only one value for this field, the document id in the bkd tree will not be duplicated. There will be no collection of duplicate document IDs. Therefore, first determine the number of documents that match all the points to be queried. If it exceeds half, use reverse collection to reduce the number of collected document ids.

Another new thought is that I believe SinglePointVisitor is unnecessary, as processing each point separately will traverse the bkd tree multiple times. MergePointVisitor will only traverse the bkd tree once. Therefore, in most cases, SinglePointVisitor will result in slower performance. As long as MergePointVisitor supports both single and multiple dimensions, reverse collection optimization can be used.
