### PR TITLE
Improve DenseConjunctionBulkScorer's sparse fallback.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/DenseConjunctionBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DenseConjunctionBulkScorer.java
@@ -223,18 +223,18 @@ final class DenseConjunctionBulkScorer extends BulkScorer {
             otherDoc = other.advance(doc);
           }
           if (doc != otherDoc) {
-            int clearUpTo = Math.min(WINDOW_SIZE, otherDoc - windowBase);
-            windowMatches.clear(windowMatch, clearUpTo);
-            windowMatch = advance(windowMatches, clearUpTo);
+            windowMatch = advance(windowMatches, otherDoc - windowBase);
             continue advanceHead;
           }
         }
+        collector.collect(doc);
         windowMatch = advance(windowMatches, windowMatch + 1);
       }
+    } else {
+      docIdStreamView.windowBase = windowBase;
+      collector.collect(docIdStreamView);
     }
 
-    docIdStreamView.windowBase = windowBase;
-    collector.collect(docIdStreamView);
     windowMatches.clear();
   }
 


### PR DESCRIPTION
`DenseConjunctionBulkScorer` has a fallback to sparse evaluation mode when the intersection of the clauses evaluated so far becomes sparse. Currently, this sparse evaluation mode clears bits in the window if they don't match new clauses.

This change proposes to treat the bitset like any clause and evaluate the conjunction in the traditional way, collecting matching docs one by one.