### PR TITLE
Fetch PR branch to fix changelog workflow

### DIFF
--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: ChangeLog Entry Verifier and Milestone Setter
         run: |
@@ -37,9 +37,9 @@ jobs:
           echo -e "\n"
           echo "################## STEP 2 ##################"
           echo "Checking for change log entry in ${{ env.CHANGE_LOG_FILE }}"
+          git fetch origin ${{ github.event.pull_request.base.ref }}
           git log  --pretty=oneline | tail -n 2 | cat
           echo "merge base sha: ${{ github.event.pull_request.base.sha }}, merge head sha: ${{ github.event.pull_request.head.sha }}"
-          git diff ${{ github.event.pull_request.base.sha }} --name-only
           if ! git diff ${{ github.event.pull_request.base.sha }} --name-only | grep -q "${{ env.CHANGE_LOG_FILE }}"; then
             echo "Change log file:${{ env.CHANGE_LOG_FILE }} does not contains an entry corresponding to changes introduced in PR. Please add a changelog entry."
             exit 0


### PR DESCRIPTION
I've been debugging this and I think without the `ref`, our diff was effectively between a commit and itself. Now we're actually diffing the PR against the base merge commit.

Addresses #13898
