### PR TITLE
removing constructor with deprecated attribute 'onlyLongestMatch

### DIFF
--- a/lucene/analysis/common/src/java/module-info.java
+++ b/lucene/analysis/common/src/java/module-info.java
@@ -19,6 +19,7 @@
 module org.apache.lucene.analysis.common {
   requires java.xml;
   requires org.apache.lucene.core;
+  requires java.logging;
 
   exports org.apache.lucene.analysis.ar;
   exports org.apache.lucene.analysis.bg;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/DictionaryCompoundWordTokenFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/DictionaryCompoundWordTokenFilter.java
@@ -51,36 +51,6 @@ public class DictionaryCompoundWordTokenFilter extends CompoundWordTokenFilterBa
    * @param minWordSize only words longer than this get processed
    * @param minSubwordSize only subwords longer than this get to the output stream
    * @param maxSubwordSize only subwords shorter than this get to the output stream
-   * @param onlyLongestMatch deprecated, use parameter onlyLongestMatchIgnoreSubwords instead
-   * @param onlyLongestMatchIgnoreSubwords Subwords are igored, e.g. if a word contains 'schwein',
-   *     only the longer word 'schwein' will be extracted, the subword 'wein' will be ignored.
-   *     Supersede parameter onlyLongestMatch
-   */
-  @Deprecated
-  public DictionaryCompoundWordTokenFilter(
-      TokenStream input,
-      CharArraySet dictionary,
-      int minWordSize,
-      int minSubwordSize,
-      int maxSubwordSize,
-      boolean onlyLongestMatch,
-      boolean onlyLongestMatchIgnoreSubwords) {
-    super(input, dictionary, minWordSize, minSubwordSize, maxSubwordSize, onlyLongestMatch);
-    this.onlyLongestMatchNoSubwords = onlyLongestMatchIgnoreSubwords;
-
-    if (dictionary == null) {
-      throw new IllegalArgumentException("dictionary must not be null");
-    }
-  }
-
-  /**
-   * Creates a new {@link DictionaryCompoundWordTokenFilter}
-   *
-   * @param input the {@link org.apache.lucene.analysis.TokenStream} to process
-   * @param dictionary the word dictionary to match against.
-   * @param minWordSize only words longer than this get processed
-   * @param minSubwordSize only subwords longer than this get to the output stream
-   * @param maxSubwordSize only subwords shorter than this get to the output stream
    * @param onlyLongestMatchIgnoreSubwords Subwords are igored, e.g. if a word contains 'schwein',
    *     only the longer word 'schwein' will be extracted, the subword 'wein' will be ignored.
    *     Supersede parameter onlyLongestMatch

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/DictionaryCompoundWordTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/DictionaryCompoundWordTokenFilterFactory.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.compound;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.logging.Logger;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.TokenFilterFactory;
 import org.apache.lucene.analysis.TokenStream;
@@ -42,6 +43,9 @@ import org.apache.lucene.util.ResourceLoaderAware;
 public class DictionaryCompoundWordTokenFilterFactory extends TokenFilterFactory
     implements ResourceLoaderAware {
 
+  private static final Logger LOG =
+      Logger.getLogger(DictionaryCompoundWordTokenFilterFactory.class.getName());
+
   /** SPI name */
   public static final String NAME = "dictionaryCompoundWord";
 
@@ -50,7 +54,6 @@ public class DictionaryCompoundWordTokenFilterFactory extends TokenFilterFactory
   private final int minWordSize;
   private final int minSubwordSize;
   private final int maxSubwordSize;
-  private final boolean onlyLongestMatch;
   private final boolean onlyLongestMatchIgnoreSubwords;
 
   /** Creates a new DictionaryCompoundWordTokenFilterFactory */
@@ -62,7 +65,12 @@ public class DictionaryCompoundWordTokenFilterFactory extends TokenFilterFactory
         getInt(args, "minSubwordSize", CompoundWordTokenFilterBase.DEFAULT_MIN_SUBWORD_SIZE);
     maxSubwordSize =
         getInt(args, "maxSubwordSize", CompoundWordTokenFilterBase.DEFAULT_MAX_SUBWORD_SIZE);
-    onlyLongestMatch = getBoolean(args, "onlyLongestMatch", true);
+
+    boolean onlyLongestMatch = getBoolean(args, "onlyLongestMatch", true);
+    if (onlyLongestMatch)
+      LOG.warning(
+          "onlyLongestMatch has been removed and replaced by onlyLongestMatchIgnoreSubwords");
+
     onlyLongestMatchIgnoreSubwords = getBoolean(args, "onlyLongestMatchIgnoreSubwords", true);
 
     if (!args.isEmpty()) {
@@ -92,7 +100,6 @@ public class DictionaryCompoundWordTokenFilterFactory extends TokenFilterFactory
         minWordSize,
         minSubwordSize,
         maxSubwordSize,
-        onlyLongestMatch,
         onlyLongestMatchIgnoreSubwords);
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/TestCompoundWordTokenFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/TestCompoundWordTokenFilter.java
@@ -251,14 +251,11 @@ public class TestCompoundWordTokenFilter extends BaseTokenStreamTestCase {
             CompoundWordTokenFilterBase.DEFAULT_MIN_WORD_SIZE,
             CompoundWordTokenFilterBase.DEFAULT_MIN_SUBWORD_SIZE,
             CompoundWordTokenFilterBase.DEFAULT_MAX_SUBWORD_SIZE,
-            true,
-            false);
+            true);
 
     assertTokenStreamContents(
         tf,
-        new String[] {
-          "Basfiolsfodralmakaregesäll", "Bas", "fiolsfodral", "fodral", "makare", "gesäll"
-        },
+        new String[] {"Basfiolsfodralmakaregesäll", "Bas", "fiolsfodral", "makare", "gesäll"},
         new int[] {0, 0, 0, 0, 0, 0},
         new int[] {26, 26, 26, 26, 26, 26},
         new int[] {1, 0, 0, 0, 0, 0});
@@ -276,7 +273,6 @@ public class TestCompoundWordTokenFilter extends BaseTokenStreamTestCase {
             CompoundWordTokenFilterBase.DEFAULT_MIN_WORD_SIZE,
             CompoundWordTokenFilterBase.DEFAULT_MIN_SUBWORD_SIZE,
             CompoundWordTokenFilterBase.DEFAULT_MAX_SUBWORD_SIZE,
-            false,
             false);
 
     assertTokenStreamContents(
@@ -299,7 +295,6 @@ public class TestCompoundWordTokenFilter extends BaseTokenStreamTestCase {
             CompoundWordTokenFilterBase.DEFAULT_MIN_WORD_SIZE,
             CompoundWordTokenFilterBase.DEFAULT_MIN_SUBWORD_SIZE,
             CompoundWordTokenFilterBase.DEFAULT_MAX_SUBWORD_SIZE,
-            false,
             false);
 
     // since "d" is shorter than the minimum subword size, it should not be added to the token
@@ -326,7 +321,6 @@ public class TestCompoundWordTokenFilter extends BaseTokenStreamTestCase {
             CompoundWordTokenFilterBase.DEFAULT_MIN_WORD_SIZE,
             CompoundWordTokenFilterBase.DEFAULT_MIN_SUBWORD_SIZE,
             CompoundWordTokenFilterBase.DEFAULT_MAX_SUBWORD_SIZE,
-            false,
             false);
 
     CharTermAttribute termAtt = tf.getAttribute(CharTermAttribute.class);
@@ -355,7 +349,6 @@ public class TestCompoundWordTokenFilter extends BaseTokenStreamTestCase {
             CompoundWordTokenFilterBase.DEFAULT_MIN_WORD_SIZE,
             CompoundWordTokenFilterBase.DEFAULT_MIN_SUBWORD_SIZE,
             CompoundWordTokenFilterBase.DEFAULT_MAX_SUBWORD_SIZE,
-            false,
             false);
     MockRetainAttribute retAtt = stream.addAttribute(MockRetainAttribute.class);
     stream.reset();
@@ -695,7 +688,7 @@ public class TestCompoundWordTokenFilter extends BaseTokenStreamTestCase {
     Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
     String searchTerm = "schweinefleisch";
     DictionaryCompoundWordTokenFilter tf =
-        getDictionaryCompoundWordTokenFilter(tokenizer, searchTerm, dict, true);
+        getDictionaryCompoundWordTokenFilter(tokenizer, searchTerm, dict);
 
     assertTokenStreamContents(tf, new String[] {searchTerm, "schwein", "fleisch"});
   }
@@ -707,13 +700,13 @@ public class TestCompoundWordTokenFilter extends BaseTokenStreamTestCase {
     String searchTerm = "nahkampfwaffen";
 
     DictionaryCompoundWordTokenFilter tf =
-        getDictionaryCompoundWordTokenFilter(tokenizer, searchTerm, dict, true);
+        getDictionaryCompoundWordTokenFilter(tokenizer, searchTerm, dict);
 
     assertTokenStreamContents(tf, new String[] {searchTerm, "kampf", "waffe"});
   }
 
   private DictionaryCompoundWordTokenFilter getDictionaryCompoundWordTokenFilter(
-      Tokenizer tokenizer, String searchTerm, CharArraySet dict, boolean onlyLongestMatch) {
+      Tokenizer tokenizer, String searchTerm, CharArraySet dict) {
     tokenizer.setReader(new StringReader(searchTerm));
     return new DictionaryCompoundWordTokenFilter(
         tokenizer,
@@ -721,7 +714,6 @@ public class TestCompoundWordTokenFilter extends BaseTokenStreamTestCase {
         CompoundWordTokenFilterBase.DEFAULT_MIN_WORD_SIZE,
         CompoundWordTokenFilterBase.DEFAULT_MIN_SUBWORD_SIZE,
         CompoundWordTokenFilterBase.DEFAULT_MAX_SUBWORD_SIZE,
-        onlyLongestMatch,
         true);
   }
 }


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
