### PR TITLE
Specialise DirectMonotonicReader when it only contains one block

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicReader.java
@@ -169,6 +169,7 @@ public abstract sealed class DirectMonotonicReader extends LongValues
     }
   }
 
+  /** A DirectMonotonicReader that reads from a single block. */
   protected static final class SingleBlockDirectMonotonicReader extends DirectMonotonicReader {
     private final LongValues reader;
     private final long min;
@@ -234,6 +235,7 @@ public abstract sealed class DirectMonotonicReader extends LongValues
     }
   }
 
+  /** A DirectMonotonicReader that reads from multiple blocks. */
   protected static final class MultiBlockDirectMonotonicReader extends DirectMonotonicReader {
     private final int blockShift;
     private final long blockMask;

--- a/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/DirectMonotonicReader.java
@@ -27,130 +27,23 @@ import org.apache.lucene.util.LongValues;
  *
  * @see DirectMonotonicWriter
  */
-public final class DirectMonotonicReader extends LongValues {
+public abstract sealed class DirectMonotonicReader extends LongValues
+    permits DirectMonotonicReader.MultiBlockDirectMonotonicReader,
+        DirectMonotonicReader.SingleBlockDirectMonotonicReader {
+
+  private static final Meta SINGLE_ZERO_BLOCK = new SingleBlockMeta(0L, 0.0f, (byte) 0, 0L);
 
   /**
    * In-memory metadata that needs to be kept around for {@link DirectMonotonicReader} to read data
    * from disk.
    */
-  public static class Meta {
+  public abstract static sealed class Meta permits SingleBlockMeta, MultiBlockMeta {
 
-    // Use a shift of 63 so that there would be a single block regardless of the number of values.
-    private static final Meta SINGLE_ZERO_BLOCK = new Meta(1L, 63);
-
-    private final int blockShift;
-    private final int numBlocks;
-    private final long[] mins;
-    private final float[] avgs;
-    private final byte[] bpvs;
-    private final long[] offsets;
-
-    Meta(long numValues, int blockShift) {
-      this.blockShift = blockShift;
-      long numBlocks = numValues >>> blockShift;
-      if ((numBlocks << blockShift) < numValues) {
-        numBlocks += 1;
-      }
-      this.numBlocks = (int) numBlocks;
-      this.mins = new long[this.numBlocks];
-      this.avgs = new float[this.numBlocks];
-      this.bpvs = new byte[this.numBlocks];
-      this.offsets = new long[this.numBlocks];
-    }
-  }
-
-  /**
-   * Load metadata from the given {@link IndexInput}.
-   *
-   * @see DirectMonotonicReader#getInstance(Meta, RandomAccessInput)
-   */
-  public static Meta loadMeta(IndexInput metaIn, long numValues, int blockShift)
-      throws IOException {
-    boolean allValuesZero = true;
-    Meta meta = new Meta(numValues, blockShift);
-    for (int i = 0; i < meta.numBlocks; ++i) {
-      long min = metaIn.readLong();
-      meta.mins[i] = min;
-      int avgInt = metaIn.readInt();
-      meta.avgs[i] = Float.intBitsToFloat(avgInt);
-      meta.offsets[i] = metaIn.readLong();
-      byte bpvs = metaIn.readByte();
-      meta.bpvs[i] = bpvs;
-      allValuesZero = allValuesZero && min == 0L && avgInt == 0 && bpvs == 0;
-    }
-    // save heap in case all values are zero
-    return allValuesZero ? Meta.SINGLE_ZERO_BLOCK : meta;
-  }
-
-  /** Retrieves a non-merging instance from the specified slice. */
-  public static DirectMonotonicReader getInstance(Meta meta, RandomAccessInput data)
-      throws IOException {
-    return getInstance(meta, data, false);
-  }
-
-  /** Retrieves an instance from the specified slice. */
-  public static DirectMonotonicReader getInstance(
-      Meta meta, RandomAccessInput data, boolean merging) throws IOException {
-    final LongValues[] readers = new LongValues[meta.numBlocks];
-    for (int i = 0; i < meta.numBlocks; ++i) {
-      if (meta.bpvs[i] == 0) {
-        readers[i] = LongValues.ZEROES;
-      } else if (merging
-          && i < meta.numBlocks - 1 // we only know the number of values for the last block
-          && meta.blockShift >= DirectReader.MERGE_BUFFER_SHIFT) {
-        readers[i] =
-            DirectReader.getMergeInstance(
-                data, meta.bpvs[i], meta.offsets[i], 1L << meta.blockShift);
-      } else {
-        readers[i] = DirectReader.getInstance(data, meta.bpvs[i], meta.offsets[i]);
-      }
-    }
-
-    return new DirectMonotonicReader(meta.blockShift, readers, meta.mins, meta.avgs, meta.bpvs);
-  }
-
-  private final int blockShift;
-  private final long blockMask;
-  private final LongValues[] readers;
-  private final long[] mins;
-  private final float[] avgs;
-  private final byte[] bpvs;
-
-  private DirectMonotonicReader(
-      int blockShift, LongValues[] readers, long[] mins, float[] avgs, byte[] bpvs) {
-    this.blockShift = blockShift;
-    this.blockMask = (1L << blockShift) - 1;
-    this.readers = readers;
-    this.mins = mins;
-    this.avgs = avgs;
-    this.bpvs = bpvs;
-    if (readers.length != mins.length
-        || readers.length != avgs.length
-        || readers.length != bpvs.length) {
-      throw new IllegalArgumentException();
-    }
-  }
-
-  @Override
-  public long get(long index) {
-    final int block = (int) (index >>> blockShift);
-    final long blockIndex = index & blockMask;
-    final long delta = readers[block].get(blockIndex);
-    return mins[block] + (long) (avgs[block] * blockIndex) + delta;
+    protected abstract DirectMonotonicReader getInstance(RandomAccessInput data, boolean merging);
   }
 
   /** Get lower/upper bounds for the value at a given index without hitting the direct reader. */
-  private long[] getBounds(long index) {
-    final int block = Math.toIntExact(index >>> blockShift);
-    final long blockIndex = index & blockMask;
-    final long lowerBound = mins[block] + (long) (avgs[block] * blockIndex);
-    final long upperBound = lowerBound + (1L << bpvs[block]) - 1;
-    if (bpvs[block] == 64 || upperBound < lowerBound) { // overflow
-      return new long[] {Long.MIN_VALUE, Long.MAX_VALUE};
-    } else {
-      return new long[] {lowerBound, upperBound};
-    }
-  }
+  protected abstract long[] getBounds(long mid);
 
   /**
    * Return the index of a key if it exists, or its insertion point otherwise like {@link
@@ -158,7 +51,7 @@ public final class DirectMonotonicReader extends LongValues {
    *
    * @see Arrays#binarySearch(long[], int, int, long)
    */
-  public long binarySearch(long fromIndex, long toIndex, long key) {
+  public final long binarySearch(long fromIndex, long toIndex, long key) {
     if (fromIndex < 0 || fromIndex > toIndex) {
       throw new IllegalArgumentException("fromIndex=" + fromIndex + ",toIndex=" + toIndex);
     }
@@ -185,7 +78,205 @@ public final class DirectMonotonicReader extends LongValues {
         }
       }
     }
-
     return -1 - lo;
+  }
+
+  /**
+   * Load metadata from the given {@link IndexInput}.
+   *
+   * @see DirectMonotonicReader#getInstance(Meta, RandomAccessInput)
+   */
+  public static Meta loadMeta(IndexInput metaIn, long numValues, int blockShift)
+      throws IOException {
+    final int numBlocks = numBlocks(numValues, blockShift);
+    if (numBlocks == 1) {
+      return loadSingleBlockMeta(metaIn);
+    } else {
+      return loadMultiBlockMeta(metaIn, numBlocks, blockShift);
+    }
+  }
+
+  private static int numBlocks(long numValues, int blockShift) {
+    long numBlocks = numValues >>> blockShift;
+    if ((numBlocks << blockShift) < numValues) {
+      numBlocks += 1;
+    }
+    return (int) numBlocks;
+  }
+
+  private static Meta loadSingleBlockMeta(IndexInput metaIn) throws IOException {
+    final long min = metaIn.readLong();
+    final float avgInt = Float.intBitsToFloat(metaIn.readInt());
+    final long offsets = metaIn.readLong();
+    final byte bpvs = metaIn.readByte();
+    final boolean allValuesZero = min == 0L && avgInt == 0 && bpvs == 0;
+    // save heap in case all values are zero
+    return allValuesZero ? SINGLE_ZERO_BLOCK : new SingleBlockMeta(min, avgInt, bpvs, offsets);
+  }
+
+  private static Meta loadMultiBlockMeta(IndexInput metaIn, int numBlocks, int blockShift)
+      throws IOException {
+    final MultiBlockMeta meta = new MultiBlockMeta(numBlocks, blockShift);
+    boolean allValuesZero = true;
+    for (int i = 0; i < numBlocks; ++i) {
+      final long min = metaIn.readLong();
+      meta.mins[i] = min;
+      final int avgInt = metaIn.readInt();
+      meta.avgs[i] = Float.intBitsToFloat(avgInt);
+      meta.offsets[i] = metaIn.readLong();
+      final byte bpvs = metaIn.readByte();
+      meta.bpvs[i] = bpvs;
+      allValuesZero = allValuesZero && min == 0L && avgInt == 0 && bpvs == 0;
+    }
+    // save heap in case all values are zero
+    return allValuesZero ? SINGLE_ZERO_BLOCK : meta;
+  }
+
+  /** Retrieves a non-merging instance from the specified slice. */
+  public static DirectMonotonicReader getInstance(Meta meta, RandomAccessInput data)
+      throws IOException {
+    return getInstance(meta, data, false);
+  }
+
+  /** Retrieves an instance from the specified slice. */
+  public static DirectMonotonicReader getInstance(
+      Meta meta, RandomAccessInput data, boolean merging) {
+    return meta.getInstance(data, merging);
+  }
+
+  private static final class SingleBlockMeta extends Meta {
+    private final long min;
+    private final float avg;
+    private final byte bpv;
+    private final long offset;
+
+    private SingleBlockMeta(long min, float avg, byte bpv, long offset) {
+      this.min = min;
+      this.avg = avg;
+      this.bpv = bpv;
+      // TODO is this always zero?
+      this.offset = offset;
+    }
+
+    @Override
+    protected DirectMonotonicReader getInstance(RandomAccessInput data, boolean merging) {
+      LongValues reader;
+      if (bpv == 0) {
+        reader = LongValues.ZEROES;
+      } else {
+        reader = DirectReader.getInstance(data, bpv, offset);
+      }
+      return new SingleBlockDirectMonotonicReader(reader, min, avg, bpv);
+    }
+  }
+
+  protected static final class SingleBlockDirectMonotonicReader extends DirectMonotonicReader {
+    private final LongValues reader;
+    private final long min;
+    private final float avg;
+    private final byte bpv;
+
+    private SingleBlockDirectMonotonicReader(LongValues reader, long min, float avg, byte bpv) {
+      this.reader = reader;
+      this.min = min;
+      this.avg = avg;
+      this.bpv = bpv;
+    }
+
+    @Override
+    public long get(long index) {
+      final long delta = reader.get(index);
+      return min + (long) (avg * index) + delta;
+    }
+
+    @Override
+    protected long[] getBounds(long index) {
+      final long lowerBound = min + (long) (avg * index);
+      final long upperBound = lowerBound + (1L << bpv) - 1;
+      if (bpv == 64 || upperBound < lowerBound) { // overflow
+        return new long[] {Long.MIN_VALUE, Long.MAX_VALUE};
+      } else {
+        return new long[] {lowerBound, upperBound};
+      }
+    }
+  }
+
+  private static final class MultiBlockMeta extends Meta {
+    private final int blockShift;
+    private final long[] mins;
+    private final float[] avgs;
+    private final byte[] bpvs;
+    private final long[] offsets;
+
+    private MultiBlockMeta(int numBlocks, int blockShift) {
+      this.blockShift = blockShift;
+      this.mins = new long[numBlocks];
+      this.avgs = new float[numBlocks];
+      this.bpvs = new byte[numBlocks];
+      this.offsets = new long[numBlocks];
+    }
+
+    @Override
+    protected DirectMonotonicReader getInstance(RandomAccessInput data, boolean merging) {
+      final int numBlocks = mins.length;
+      final LongValues[] readers = new LongValues[numBlocks];
+      for (int i = 0; i < numBlocks; ++i) {
+        if (bpvs[i] == 0) {
+          readers[i] = LongValues.ZEROES;
+        } else if (merging
+            && i < numBlocks - 1 // we only know the number of values for the last block
+            && blockShift >= DirectReader.MERGE_BUFFER_SHIFT) {
+          readers[i] = DirectReader.getMergeInstance(data, bpvs[i], offsets[i], 1L << blockShift);
+        } else {
+          readers[i] = DirectReader.getInstance(data, bpvs[i], offsets[i]);
+        }
+      }
+      return new MultiBlockDirectMonotonicReader(blockShift, readers, mins, avgs, bpvs);
+    }
+  }
+
+  protected static final class MultiBlockDirectMonotonicReader extends DirectMonotonicReader {
+    private final int blockShift;
+    private final long blockMask;
+    private final LongValues[] readers;
+    private final long[] mins;
+    private final float[] avgs;
+    private final byte[] bpvs;
+
+    private MultiBlockDirectMonotonicReader(
+        int blockShift, LongValues[] readers, long[] mins, float[] avgs, byte[] bpvs) {
+      this.blockMask = (1L << blockShift) - 1;
+      this.blockShift = blockShift;
+      this.readers = readers;
+      this.mins = mins;
+      this.avgs = avgs;
+      this.bpvs = bpvs;
+      if (readers.length != mins.length
+          || readers.length != avgs.length
+          || readers.length != bpvs.length) {
+        throw new IllegalArgumentException();
+      }
+    }
+
+    @Override
+    public long get(long index) {
+      final int block = (int) (index >>> blockShift);
+      final long blockIndex = index & blockMask;
+      final long delta = readers[block].get(blockIndex);
+      return mins[block] + (long) (avgs[block] * blockIndex) + delta;
+    }
+
+    @Override
+    protected long[] getBounds(long index) {
+      final int block = Math.toIntExact(index >>> blockShift);
+      final long blockIndex = index & blockMask;
+      final long lowerBound = mins[block] + (long) (avgs[block] * blockIndex);
+      final long upperBound = lowerBound + (1L << bpvs[block]) - 1;
+      if (bpvs[block] == 64 || upperBound < lowerBound) { // overflow
+        return new long[] {Long.MIN_VALUE, Long.MAX_VALUE};
+      } else {
+        return new long[] {lowerBound, upperBound};
+      }
+    }
   }
 }


### PR DESCRIPTION
While looking into some heap dumps, I notice in the DirectMonotonicReader.Meta objects hold by segments that the case of single value block is actually common. I wondered if we could specialize that case so we can create a faster, light weigh single block version.

This commit makes DirectMonotonicReader a sealed abstractions with two possible implementations, one for multi-blocks and the other for single blocks. The multi-block implementation is very similar to the current implementation while the single block is more lightweight as it does not need to be holding arrays. The only side effect is that DirectMonotonicReader is bimorphic now, but that should be ok.

I ran luceneutil and didnt' see much change:  

```
                           TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                    OrHighNotMed      168.35      (4.3%)      163.80      (4.9%)   -2.7% ( -11% -    6%) 0.064
               HighTermTitleSort       36.96      (2.4%)       36.04      (4.2%)   -2.5% (  -8% -    4%) 0.023
                        PKLookup      105.78      (6.1%)      103.28      (8.4%)   -2.4% ( -15% -   12%) 0.306
                        HighTerm      228.90      (4.3%)      223.90      (5.3%)   -2.2% ( -11% -    7%) 0.154
                       OrHighLow      330.01      (3.9%)      324.79      (3.5%)   -1.6% (  -8% -    6%) 0.181
                     LowSpanNear       32.10      (6.5%)       31.61      (6.9%)   -1.5% ( -13% -   12%) 0.469
                        Wildcard      103.26      (5.3%)      101.68      (7.1%)   -1.5% ( -13% -   11%) 0.443
                    HighSpanNear        4.70      (4.7%)        4.63      (4.6%)   -1.5% ( -10% -    8%) 0.309
                    OrNotHighLow      451.15      (3.5%)      444.47      (4.0%)   -1.5% (  -8% -    6%) 0.215
                HighSloppyPhrase        4.71      (4.8%)        4.64      (5.7%)   -1.4% ( -11% -    9%) 0.415
                          Fuzzy2       36.81      (4.8%)       36.31      (5.9%)   -1.4% ( -11% -    9%) 0.423
                          Fuzzy1       40.34      (2.9%)       39.81      (4.1%)   -1.3% (  -8% -    5%) 0.233
                      OrHighHigh       75.21      (5.2%)       74.22      (5.1%)   -1.3% ( -11% -    9%) 0.418
                     AndHighHigh       59.33      (5.0%)       58.57      (5.1%)   -1.3% ( -10% -    9%) 0.426
                      AndHighMed      131.70      (3.2%)      130.05      (4.1%)   -1.2% (  -8% -    6%) 0.286
                           range     2006.77      (7.0%)     1983.01      (8.5%)   -1.2% ( -15% -   15%) 0.630
                         MedTerm      333.14      (4.2%)      329.23      (5.2%)   -1.2% ( -10% -    8%) 0.429
             LowIntervalsOrdered        6.16      (5.8%)        6.09      (6.5%)   -1.1% ( -12% -   11%) 0.564
                   OrHighNotHigh      206.93      (3.4%)      204.61      (4.4%)   -1.1% (  -8% -    6%) 0.366
                     MedSpanNear       15.36      (2.9%)       15.20      (3.7%)   -1.0% (  -7% -    5%) 0.323
                       OrHighMed      135.41      (3.2%)      134.25      (2.8%)   -0.9% (  -6% -    5%) 0.373
                         LowTerm      528.68      (4.1%)      524.30      (4.8%)   -0.8% (  -9% -    8%) 0.556
                    OrHighNotLow      238.88      (4.2%)      237.11      (4.7%)   -0.7% (  -9% -    8%) 0.599
                 MedSloppyPhrase       38.80      (2.7%)       38.55      (3.0%)   -0.6% (  -6% -    5%) 0.483
             MedIntervalsOrdered       43.96      (9.3%)       43.68      (9.2%)   -0.6% ( -17% -   19%) 0.831
                   OrNotHighHigh      301.25      (2.5%)      299.46      (3.2%)   -0.6% (  -6% -    5%) 0.520
            HighIntervalsOrdered        7.35      (6.1%)        7.31      (6.8%)   -0.5% ( -12% -   13%) 0.792
       BrowseDayOfYearTaxoFacets        2.03     (13.2%)        2.02     (14.7%)   -0.4% ( -25% -   31%) 0.920
                    OrNotHighMed      229.85      (2.8%)      228.86      (4.2%)   -0.4% (  -7% -    6%) 0.701
            BrowseDateTaxoFacets        2.01     (12.5%)        2.00     (15.0%)   -0.4% ( -24% -   30%) 0.922
                       MedPhrase       77.28      (2.9%)       77.10      (3.1%)   -0.2% (  -6% -    5%) 0.799
     BrowseRandomLabelTaxoFacets        1.49     (12.2%)        1.49     (16.4%)   -0.2% ( -25% -   32%) 0.960
                         Respell       22.59      (3.9%)       22.55      (4.1%)   -0.1% (  -7% -    8%) 0.908
                 LowSloppyPhrase       76.40      (2.7%)       76.35      (3.2%)   -0.1% (  -5% -    6%) 0.938
                      AndHighLow      478.69      (5.3%)      479.27      (7.1%)    0.1% ( -11% -   13%) 0.951
                          IntSet      253.58      (4.6%)      254.02      (5.8%)    0.2% (  -9% -   11%) 0.915
         AndHighMedDayTaxoFacets       71.03      (2.9%)       71.30      (5.3%)    0.4% (  -7% -    8%) 0.780
           BrowseMonthTaxoFacets        2.11     (11.6%)        2.12      (9.6%)    0.4% ( -18% -   24%) 0.902
               HighTermMonthSort      640.17      (4.0%)      643.80      (4.9%)    0.6% (  -8% -    9%) 0.690
                         Prefix3      401.26      (8.0%)      403.59      (9.4%)    0.6% ( -15% -   19%) 0.834
           BrowseMonthSSDVFacets        2.52     (13.7%)        2.54     (14.3%)    0.9% ( -23% -   33%) 0.837
                      HighPhrase       31.52      (3.0%)       31.83      (5.2%)    1.0% (  -7% -    9%) 0.465
            HighTermTitleBDVSort       20.13      (3.8%)       20.33      (4.8%)    1.0% (  -7% -    9%) 0.455
                       LowPhrase       91.85      (4.1%)       93.07      (3.3%)    1.3% (  -5% -    9%) 0.258
       BrowseDayOfYearSSDVFacets        2.54     (14.9%)        2.58     (14.7%)    1.3% ( -24% -   36%) 0.776
     BrowseRandomLabelSSDVFacets        1.60      (8.3%)        1.63      (7.3%)    1.5% ( -13% -   18%) 0.555
                          IntNRQ      167.29      (4.0%)      169.92      (4.1%)    1.6% (  -6% -   10%) 0.220
        AndHighHighDayTaxoFacets       11.05      (3.9%)       11.24      (3.7%)    1.8% (  -5% -    9%) 0.139
          OrHighMedDayTaxoFacets        1.74      (4.6%)        1.77      (6.1%)    1.9% (  -8% -   13%) 0.268
                      TermDTSort       82.17      (4.0%)       84.11      (6.1%)    2.4% (  -7% -   13%) 0.148
            MedTermDayTaxoFacets        9.83      (7.2%)       10.08      (4.2%)    2.5% (  -8% -   14%) 0.183
           HighTermDayOfYearSort       72.30      (4.7%)       74.29      (5.7%)    2.8% (  -7% -   13%) 0.094
            BrowseDateSSDVFacets        0.58     (13.0%)        0.61     (17.2%)    5.8% ( -21% -   41%) 0.227
```