### PR TITLE
add Automaton.toMermaid() for emitting mermaid state charts

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automaton.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automaton.java
@@ -622,6 +622,50 @@ public class Automaton implements Accountable, TransitionAccessor {
     return b.toString();
   }
 
+  /**
+   * Returns the mermaidjs representation of the automaton.
+   * <p>
+   * This is not a serious tool but it works on github.
+   */
+  public String toMermaid() {
+    // mermaid start/end states are no good: not used.
+    // Instead there's just a style class of "accept"
+    StringBuilder b = new StringBuilder();
+    b.append("stateDiagram\n");
+    b.append("  direction LR\n");
+    b.append("  classDef accept border-width:5px;stroke-width:5px,stroke:#00FFFF\n");
+
+    final int numStates = getNumStates();
+    Transition t = new Transition();
+
+    for (int state = 0; state < numStates; state++) {
+      b.append("  ");
+      b.append(state);
+      b.append('\n');
+      if (isAccept(state)) {
+        b.append("  class ");
+        b.append(state);
+        b.append(" accept\n");
+      }
+      int numTransitions = initTransition(state, t);
+      for (int i = 0; i < numTransitions; i++) {
+        getNextTransition(t);
+        b.append("  ");
+        b.append(state);
+        b.append(" --> ");
+        b.append(t.dest);
+        b.append(':');
+        appendCharString(t.min, b);
+        if (t.max != t.min) {
+          b.append('-');
+          appendCharString(t.max, b);
+        }
+        b.append('\n');
+      }
+    }
+    return b.toString();
+  }
+
   /** Returns sorted array of all interval start points. */
   public int[] getStartPoints() {
     IntHashSet pointset = new IntHashSet();

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automaton.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automaton.java
@@ -624,8 +624,8 @@ public class Automaton implements Accountable, TransitionAccessor {
 
   /**
    * Returns the mermaidjs representation of the automaton.
-   * <p>
-   * This is not a serious tool but it works on github.
+   *
+   * <p>This is not a serious tool but it works on github.
    */
   public String toMermaid() {
     // mermaid start/end states are no good: not used.


### PR DESCRIPTION
Mermaid is state chart supported within fenced codeblocks by github. For some reason it doesn't support dotty but instead the latest js tool. I'm sure in 2 months it will be a different tool.

Beautification of any sort can happen at any time, this just makes it work correctly. Mermaid state diagram really isn't the best for this, just look at how start/end state works there. So we just define a "class" that makes accept states blue. I'd rather have double-circle but I'm not a CSS guy.

Closes #14351

```mermaid
stateDiagram
      direction LR
      classDef accept border-width:5px;stroke-width:5px,stroke:#00FFFF
      0
      0 --> 13:\\U00000000-k
      0 --> 1:l
      0 --> 13:m-t
      0 --> 19:u
      0 --> 13:v-\\U0010ffff
      1
      1 --> 14:\\U00000000-b
      1 --> 20:c
      1 --> 14:d-t
      1 --> 2:u
      1 --> 14:v-\\U0010ffff
      2
      2 --> 15:\\U00000000-b
      2 --> 3:c
      2 --> 15:d
      2 --> 21:e
      2 --> 15:f-\\U0010ffff
      3
      3 --> 16:\\U00000000-d
      3 --> 4:e
      3 --> 16:f-m
      3 --> 22:n
      3 --> 16:o-\\U0010ffff
      4
      4 --> 17:\\U00000000-d
      4 --> 23:e
      4 --> 17:f-m
      4 --> 5:n
      4 --> 17:o-\\U0010ffff
      5
      class 5 accept
      5 --> 18:\\U00000000-d
      5 --> 6:e
      5 --> 18:f-\\U0010ffff
      6
      class 6 accept
      6 --> 12:\\U00000000-\\U0010ffff
      7
      7 --> 8:u
      8
      8 --> 9:c
      9
      9 --> 10:e
      10
      10 --> 11:n
      11
      11 --> 12:e
      12
      class 12 accept
      13
      13 --> 7:l
      13 --> 8:u
      14
      14 --> 9:c
      14 --> 8:u
      15
      15 --> 9:c
      15 --> 10:e
      16
      16 --> 10:e
      16 --> 11:n
      17
      17 --> 12:e
      17 --> 11:n
      18
      class 18 accept
      18 --> 12:e
      19
      19 --> 9:c
      19 --> 7:l
      19 --> 8:u
      20
      20 --> 9:c
      20 --> 10:e
      20 --> 8:u
      21
      21 --> 9:c
      21 --> 10:e
      21 --> 11:n
      22
      22 --> 24:e
      22 --> 11:n
      23
      class 23 accept
      23 --> 12:e
      23 --> 11:n
      24
      class 24 accept
      24 --> 11:n
```
