### PR TITLE
Adjust equivalent min similarity HNSW exploration logic

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -191,7 +191,7 @@ Bug Fixes
 * GITHUB#14126: Avoid overflow in index input slices invariant checks
   (Chris Hegarty)
 
-* GITHUB#14215: Fix degenerate case in HNSW where all vectors have the same score. (Ben Trent)
+* GITHUB#14215, GITHUB#14249, GITHUB#14366: Fix degenerate case in HNSW where all vectors have the same score. (Ben Trent, Ignacio Vera)
 
 * GITHUB#14320: Fix DirectIOIndexInput seek to not read when position is within buffer (Chris Hegarty)
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -272,11 +272,11 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
       // get the best candidate (closest or best scoring)
       float topCandidateSimilarity = candidates.topScore();
       if (topCandidateSimilarity < minAcceptedSimilarity) {
-        // if the similarity is equivalent to the minAcceptedSimilarity, we should explore one
-        // candidate
-        // however, running into many duplicates can be expensive, so we should stop exploring if
-        // equivalent minimum scores are found
-        if (shouldExploreMinSim && Math.nextUp(candidates.topScore()) == minAcceptedSimilarity) {
+        // if the similarity is equivalent to the minAcceptedSimilarity,
+        // we should explore one candidate
+        // however, running into many duplicates can be expensive,
+        // so we should stop exploring if equivalent minimum scores are found
+        if (shouldExploreMinSim && Math.nextUp(topCandidateSimilarity) == minAcceptedSimilarity) {
           shouldExploreMinSim = false;
         } else {
           break;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -266,11 +266,21 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
     // A bound that holds the minimum similarity to the query vector that a candidate vector must
     // have to be considered.
     float minAcceptedSimilarity = Math.nextUp(results.minCompetitiveSimilarity());
+    // We should allow exploring equivalent minAcceptedSimilarity values at least once
+    boolean shouldExploreMinSim = true;
     while (candidates.size() > 0 && results.earlyTerminated() == false) {
       // get the best candidate (closest or best scoring)
       float topCandidateSimilarity = candidates.topScore();
       if (topCandidateSimilarity < minAcceptedSimilarity) {
-        break;
+        // if the similarity is equivalent to the minAcceptedSimilarity, we should explore one
+        // candidate
+        // however, running into many duplicates can be expensive, so we should stop exploring if
+        // equivalent minimum scores are found
+        if (shouldExploreMinSim && Math.nextUp(candidates.topScore()) == minAcceptedSimilarity) {
+          shouldExploreMinSim = false;
+        } else {
+          break;
+        }
       }
 
       int topCandidateNode = candidates.pop();
@@ -291,7 +301,13 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
           candidates.add(friendOrd, friendSimilarity);
           if (acceptOrds == null || acceptOrds.get(friendOrd)) {
             if (results.collect(friendOrd, friendSimilarity)) {
+              float oldMinAcceptedSimilarity = minAcceptedSimilarity;
               minAcceptedSimilarity = Math.nextUp(results.minCompetitiveSimilarity());
+              if (minAcceptedSimilarity > oldMinAcceptedSimilarity) {
+                // we adjusted our minAcceptedSimilarity, so we should explore the next equivalent
+                // if necessary
+                shouldExploreMinSim = true;
+              }
             }
           }
         }


### PR DESCRIPTION
It was tempting to just adjust the test data, but this seems like something the searcher should do regardless...

While the previous bug fix addressed the heat-death of the universe runtime of indexing many equal vectors, it added another weird edge case that tests picked up.

We would actually not explore a single valid candidate if it was the one that actually set the minimum score for exploration. While we shouldn't explore ALL the candidates that have the same score as the minimally accepted score, we should explore at least the first one.

This closes: https://github.com/apache/lucene/issues/14327

Its directly related to:

 - https://github.com/apache/lucene/pull/14215
 - https://github.com/apache/lucene/pull/14249