### PR TITLE
Align comments with upgraded postings format

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene912/Lucene912PostingsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene912/Lucene912PostingsReader.java
@@ -1770,9 +1770,8 @@ public final class Lucene912PostingsReader extends PostingsReaderBase {
     if (docIn.getFilePointer() != state.docStartFP) {
       // Don't prefetch if the input is already positioned at the right offset, which suggests that
       // the caller is streaming the entire inverted index (e.g. for merging), let the read-ahead
-      // logic do its work instead. Note that this heuristic doesn't work for terms that have skip
-      // data, since skip data is stored after the last term, but handling all terms that have <128
-      // docs is a good start already.
+      // logic do its work instead. Note that this heuristic also handles terms with skip data
+      // starting in version 912, where skip data was directly inlined into postings lists.
       docIn.prefetch(state.docStartFP, 1);
     }
     // Note: we don't prefetch positions or offsets, which are less likely to be needed.

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
@@ -1358,9 +1358,8 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     if (docIn.getFilePointer() != state.docStartFP) {
       // Don't prefetch if the input is already positioned at the right offset, which suggests that
       // the caller is streaming the entire inverted index (e.g. for merging), let the read-ahead
-      // logic do its work instead. Note that this heuristic doesn't work for terms that have skip
-      // data, since skip data is stored after the last term, but handling all terms that have <128
-      // docs is a good start already.
+      // logic do its work instead. Note that this heuristic also handles terms with skip data
+      // starting in version 912, where skip data was directly inlined into postings lists.
       docIn.prefetch(state.docStartFP, 1);
     }
     // Note: we don't prefetch positions or offsets, which are less likely to be needed.


### PR DESCRIPTION
### Description

Update prefetch heuristic comments to reflect that skip data is now inlined into postings lists.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
