### PR TITLE
Fix for changelog verifier and milestone setter automation

### DIFF
--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: ChangeLog Entry Verifier and Milestone Setter
         run: |
@@ -38,9 +38,10 @@ jobs:
           echo -e "\n"
           echo "################## STEP 2 ##################"
           echo "Checking for change log entry in ${{ env.CHANGE_LOG_FILE }}"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git log  --pretty=oneline | tail -n 2 | cat
-          echo "merge base sha: ${{ github.event.pull_request.base.sha }}, merge head sha: ${{ github.event.pull_request.head.sha }}"
+          git pull --unshallow origin ${{ github.event.pull_request.head.ref }}
+          git log  --pretty=oneline | head -n 25 | cat
+          echo "merge base ref: ${{ github.event.pull_request.base.ref }}, head ref: ${{ github.event.pull_request.head.ref }}"
+          echo "merge base sha: ${{ github.event.pull_request.base.sha }}, head sha: ${{ github.event.pull_request.head.sha }}"
           if ! git diff ${{ github.event.pull_request.base.sha }} --name-only | grep -q "${{ env.CHANGE_LOG_FILE }}"; then
             echo "Change log file:${{ env.CHANGE_LOG_FILE }} does not contains an entry corresponding to changes introduced in PR. Please add a changelog entry."
             exit 0

--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: ChangeLog Entry Verifier and Milestone Setter
         run: |


### PR DESCRIPTION
### Description
This pull request contains a fix for changelog automation that has been added recently. We have seen failures where either diff calculation wrt base commit was wrong or base commit was not even available leading to fatal error. 

This happens because we are using `pull_request_target` event type which checks out `merge base commit` where as we want to checkout `head commit` to do proper diff calculation wrt changelog file. My initial testing was based on `pull_request` which worked as expected since it checkouts `merge head commit`.

We tried a fix for this here: https://github.com/apache/lucene/pull/14355. But we didn't fetch the full history appropriately. This PR adds a fix for this by pulling all the associated history using `git pull --unshallow origin ${{ github.event.pull_request.head.ref }}`.

Tested all the changes here: https://github.com/pseudo-nymous/lucene/pull/22

Addresses: https://github.com/apache/lucene/issues/13898 https://github.com/apache/lucene/issues/14190

