### PR TITLE
Adjust visibility of NRTSuggester#load

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -218,6 +218,8 @@ Other
 
 * GITHUB#14279 : Add github action to verify changelog entry and set milestone to PRs. (Amir Raza)
 
+* GITHUB#14372: Reduce visibility of NRTSuggester#load from public to package private (Luca Cavanna)
+
 ======================= Lucene 10.1.0 =======================
 
 API Changes

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/NRTSuggester.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/NRTSuggester.java
@@ -325,7 +325,7 @@ public final class NRTSuggester implements Accountable {
    * Loads a {@link NRTSuggester} from {@link org.apache.lucene.store.IndexInput} on or off-heap
    * depending on the provided <code>fstLoadMode</code>
    */
-  public static NRTSuggester load(IndexInput input, FSTLoadMode fstLoadMode) throws IOException {
+  static NRTSuggester load(IndexInput input, FSTLoadMode fstLoadMode) throws IOException {
     final FST<Pair<Long, BytesRef>> fst;
     PairOutputs<Long, BytesRef> outputs =
         new PairOutputs<>(PositiveIntOutputs.getSingleton(), ByteSequenceOutputs.getSingleton());


### PR DESCRIPTION
load is a public static method, but its corresponding builder NRTSuggesterBuilder is package private. That means that there is no reason for load to be public.
