### PR TITLE
Use FixedLengthBytesRefArray in OneDimensionBKDWriter to hold split values

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -193,6 +193,8 @@ Optimizations
 
 * GITHUB#14331: Speedup merging of HNSW graphs. (Mayya Sharipova, Tom Veasey)
 
+* GITHUB#14383: Use FixedLengthBytesRefArray in OneDimensionBKDWriter to hold split values. (Ignacio Vera)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/util/FixedLengthBytesRefArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedLengthBytesRefArray.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.util;
 
 import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * Just like {@link BytesRefArray} except all values have the same length.
@@ -26,7 +27,7 @@ import java.util.Comparator;
  * @lucene.internal
  * @lucene.experimental
  */
-final class FixedLengthBytesRefArray implements SortableBytesRefArray {
+public final class FixedLengthBytesRefArray implements SortableBytesRefArray {
   private final int valueLength;
   private final int valuesPerBlock;
 
@@ -88,6 +89,24 @@ final class FixedLengthBytesRefArray implements SortableBytesRefArray {
     nextEntry++;
 
     return size++;
+  }
+
+  /**
+   * Returns the <i>n'th</i> element of this {@link FixedLengthBytesRefArray}
+   *
+   * @param spare a spare {@link BytesRef} instance. The length of this spare should be equal to the
+   *     fixed length.
+   * @param index the elements index to retrieve
+   * @return the <i>n'th</i> element of this {@link FixedLengthBytesRefArray}
+   */
+  public BytesRef get(BytesRef spare, int index) {
+    Objects.checkIndex(index, size);
+    assert spare.length == valueLength;
+    final int block = index / valuesPerBlock;
+    final int pos = index % valuesPerBlock;
+    spare.bytes = blocks[block];
+    spare.offset = pos * valueLength;
+    return spare;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -819,6 +819,7 @@ public class BKDWriter implements Closeable {
         // value index in the end:
         scratchBytesRef1.bytes = leafValues;
         scratchBytesRef1.offset = 0;
+        scratchBytesRef1.length = config.packedBytesLength();
         leafBlockStartValues.append(scratchBytesRef1);
       }
       leafBlockFPs.add(dataOut.getFilePointer());

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -679,7 +679,7 @@ public class BKDWriter implements Closeable {
     final IndexOutput metaOut, indexOut, dataOut;
     final long dataStartFP;
     final LongArrayList leafBlockFPs = new LongArrayList();
-    FixedLengthBytesRefArray leafBlockStartValues =
+    final FixedLengthBytesRefArray leafBlockStartValues =
         new FixedLengthBytesRefArray(config.packedBytesLength());
     final byte[] leafValues = new byte[config.maxPointsInLeafNode() * config.packedBytesLength()];
     final int[] leafDocs = new int[config.maxPointsInLeafNode()];

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -680,7 +680,7 @@ public class BKDWriter implements Closeable {
     final long dataStartFP;
     final LongArrayList leafBlockFPs = new LongArrayList();
     final FixedLengthBytesRefArray leafBlockStartValues =
-        new FixedLengthBytesRefArray(config.packedBytesLength());
+        new FixedLengthBytesRefArray(config.packedIndexBytesLength());
     final byte[] leafValues = new byte[config.maxPointsInLeafNode() * config.packedBytesLength()];
     final int[] leafDocs = new int[config.maxPointsInLeafNode()];
     private long valueCount;
@@ -770,7 +770,7 @@ public class BKDWriter implements Closeable {
 
       pointCount = valueCount;
 
-      scratchBytesRef1.length = config.bytesPerDim();
+      scratchBytesRef1.length = config.packedIndexBytesLength();
       scratchBytesRef1.offset = 0;
       assert leafBlockStartValues.size() + 1 == leafBlockFPs.size();
       BKDTreeLeafNodes leafNodes =
@@ -819,7 +819,7 @@ public class BKDWriter implements Closeable {
         // value index in the end:
         scratchBytesRef1.bytes = leafValues;
         scratchBytesRef1.offset = 0;
-        scratchBytesRef1.length = config.packedBytesLength();
+        scratchBytesRef1.length = config.packedIndexBytesLength();
         leafBlockStartValues.append(scratchBytesRef1);
       }
       leafBlockFPs.add(dataOut.getFilePointer());

--- a/lucene/core/src/test/org/apache/lucene/util/TestFixedLengthBytesRefArray.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFixedLengthBytesRefArray.java
@@ -18,7 +18,6 @@
 package org.apache.lucene.util;
 
 import java.util.Arrays;
-import java.util.Comparator;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 
@@ -32,15 +31,7 @@ public class TestFixedLengthBytesRefArray extends LuceneTestCase {
       a.append(new BytesRef(bytes));
     }
 
-    BytesRefIterator iterator =
-        a.iterator(
-            new Comparator<BytesRef>() {
-              @Override
-              public int compare(BytesRef a, BytesRef b) {
-                return a.compareTo(b);
-              }
-            });
-
+    BytesRefIterator iterator = a.iterator(BytesRef::compareTo);
     BytesRef last = null;
 
     int count = 0;
@@ -64,6 +55,8 @@ public class TestFixedLengthBytesRefArray extends LuceneTestCase {
     int length = TestUtil.nextInt(random(), 4, 10);
     int count = atLeast(10000);
     BytesRef[] values = new BytesRef[count];
+    BytesRef scratch = new BytesRef();
+    scratch.length = length;
 
     FixedLengthBytesRefArray a = new FixedLengthBytesRefArray(length);
     for (int i = 0; i < count; i++) {
@@ -73,15 +66,12 @@ public class TestFixedLengthBytesRefArray extends LuceneTestCase {
       a.append(value);
     }
 
+    for (int i = 0; i < count; i++) {
+      assertEquals(values[i], a.get(scratch, i));
+    }
+
     Arrays.sort(values);
-    BytesRefIterator iterator =
-        a.iterator(
-            new Comparator<BytesRef>() {
-              @Override
-              public int compare(BytesRef a, BytesRef b) {
-                return a.compareTo(b);
-              }
-            });
+    BytesRefIterator iterator = a.iterator(BytesRef::compareTo);
     for (int i = 0; i < count; i++) {
       BytesRef next = iterator.next();
       assertNotNull(next);


### PR DESCRIPTION
We are currently using a list which feels wasteful. For example looking into the heap dump on an IP field, we were using almost double of the heap necessary to hold the split values:

<img width="1761" alt="image" src="https://github.com/user-attachments/assets/d839b0f4-ed6b-43bf-8060-47560b68be2a" />

Using FixedLengthBytesRefArray should reduce memory usage and avoid humongous allocations.

relates https://github.com/apache/lucene/issues/14382
