### PR TITLE
Implement #docIDRunEnd() on PostingsEnum.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
@@ -1059,6 +1059,29 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
       }
     }
 
+    @Override
+    public int docIDRunEnd() throws IOException {
+      // Note: this assumes that BLOCK_SIZE == 128, this bit of the code would need to be changed if
+      // the block size was changed.
+      boolean level0IsDense =
+          encoding == DeltaEncoding.UNARY
+              && docBitSet.getBits()[0] == -1L
+              && docBitSet.getBits()[1] == -1L;
+      if (level0IsDense) {
+
+        int level0DocCountUpto = docFreq - docCountLeft;
+        boolean level1IsDense =
+            level1LastDocID - level0LastDocID == level1DocCountUpto - level0DocCountUpto;
+        if (level1IsDense) {
+          return level1LastDocID + 1;
+        }
+
+        return level0LastDocID + 1;
+      }
+
+      return super.docIDRunEnd();
+    }
+
     private void skipPositions(int freq) throws IOException {
       // Skip positions now:
       int toSkip = posPendingCount - freq;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene101/Lucene101PostingsReader.java
@@ -1063,6 +1063,9 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
     public int docIDRunEnd() throws IOException {
       // Note: this assumes that BLOCK_SIZE == 128, this bit of the code would need to be changed if
       // the block size was changed.
+      // Hack to avoid compiler warning that both sides of the equal sign are identical.
+      long blockSize = BLOCK_SIZE;
+      assert blockSize == 2 * Long.SIZE;
       boolean level0IsDense =
           encoding == DeltaEncoding.UNARY
               && docBitSet.getBits()[0] == -1L


### PR DESCRIPTION
This implements `BlockPostingsEnum#docIDRunEnd()` by comparing the delta between doc IDs and between doc counts on the various skip levels.
