### PR TITLE
Pack file pointers when merging BKD trees

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -200,6 +200,8 @@ Optimizations
 
 * GITHUB#14373: Optimized `ParallelLeafReader` to improve term vector fetching efficiency. (Divyansh Agrawal)
 
+* GITHUB#14393: Pack file pointers using the packed monotonic builder when building BKD trees. (Ignacio Vera)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -605,11 +605,13 @@ public class BKDWriter implements Closeable {
       String fieldName,
       MutablePointTree reader)
       throws IOException {
-    int size = Math.toIntExact(reader.size());
-    MutablePointTreeReaderUtils.sort(config, maxDoc, reader, 0, size);
-
+    MutablePointTreeReaderUtils.sort(config, maxDoc, reader, 0, Math.toIntExact(reader.size()));
+    final int numLeaves =
+        Math.toIntExact(
+            (reader.size() + config.maxPointsInLeafNode() - 1) / config.maxPointsInLeafNode());
+    checkMaxLeafNodeCount(numLeaves);
     final OneDimensionBKDWriter oneDimWriter =
-        new OneDimensionBKDWriter(metaOut, indexOut, dataOut, new ArrayLongAccumulator(size));
+        new OneDimensionBKDWriter(metaOut, indexOut, dataOut, new ArrayLongAccumulator(numLeaves));
 
     reader.visitDocValues(
         new IntersectVisitor() {
@@ -904,6 +906,7 @@ public class BKDWriter implements Closeable {
 
     @Override
     public LongValues getValues() {
+      assert count == values.length;
       return new LongValues() {
         @Override
         public long get(long index) {


### PR DESCRIPTION
We are currently using long arrays to hold file pointers. These arrays can get pretty big if the number of points is big which seems wasteful, moreover when those file pointers are monotonically increasing. This commit proposes to pack these arrays using existing lucene algorithms to save some heap during merging and to avoid humongous allocations. 

relates https://github.com/apache/lucene/issues/14382
