### PR TITLE
Disable sort optimization when tracking all docs

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -61,7 +61,7 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
       }
       if (countAllDocs == null) {
         final int maxDoc = ReaderUtil.getTopLevelContext(context).reader().maxDoc();
-        if (countAllDocs = totalHitsThreshold >= maxDoc) {
+        if (countAllDocs = (totalHitsThreshold >= maxDoc)) {
           firstComparator.disableSkipping();
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -61,7 +61,8 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
       }
       if (countAllDocs == null) {
         final int maxDoc = ReaderUtil.getTopLevelContext(context).reader().maxDoc();
-        if (countAllDocs = (totalHitsThreshold >= maxDoc)) {
+        countAllDocs = totalHitsThreshold >= maxDoc;
+        if (countAllDocs) {
           firstComparator.disableSkipping();
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -59,6 +59,12 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
           firstComparator.disableSkipping();
         }
       }
+      if (countAllDocs == null) {
+        final int maxDoc = ReaderUtil.getTopLevelContext(context).reader().maxDoc();
+        if (countAllDocs = totalHitsThreshold >= maxDoc) {
+          firstComparator.disableSkipping();
+        }
+      }
       LeafFieldComparator[] comparators = queue.getComparators(context);
       int[] reverseMuls = queue.getReverseMul();
       if (comparators.length == 1) {
@@ -305,6 +311,7 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
   final boolean canSetMinScore;
 
   Boolean searchSortPartOfIndexSort = null; // shows if Search Sort if a part of the Index Sort
+  Boolean countAllDocs = null;
 
   // an accumulator that maintains the maximum of the segment's minimum competitive scores
   final MaxScoreAccumulator minScoreAcc;

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -739,31 +739,42 @@ public class TestSortOptimization extends LuceneTestCase {
     doc.add(new NumericDocValuesField("intRange", 4));
 
     writer.addDocument(doc);
+
+    doc = new Document();
+    doc.add(new IntPoint("intField", 4));
+    doc.add(new NumericDocValuesField("intField", 4));
+    writer.addDocument(doc);
     DirectoryReader reader = writer.getReader();
     writer.close();
 
     IndexSearcher searcher = newSearcher(reader, random().nextBoolean(), random().nextBoolean());
 
     SortField longSortOnIntField = new SortField("intField", SortField.Type.LONG);
+    TopFieldCollectorManager longSortOnIntFieldCM =
+        new TopFieldCollectorManager(new Sort(longSortOnIntField), 1, 1);
     assertThrows(
         IllegalArgumentException.class,
-        () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(longSortOnIntField)));
+        () -> searcher.search(new MatchAllDocsQuery(), longSortOnIntFieldCM));
     // assert that when sort optimization is disabled we can use LONG sort on int field
     longSortOnIntField.setOptimizeSortWithIndexedData(false);
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(longSortOnIntField));
 
     SortField intSortOnLongField = new SortField("longField", SortField.Type.INT);
+    TopFieldCollectorManager intSortOnLongFieldCM =
+        new TopFieldCollectorManager(new Sort(intSortOnLongField), 1, 1);
     assertThrows(
         IllegalArgumentException.class,
-        () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnLongField)));
+        () -> searcher.search(new MatchAllDocsQuery(), intSortOnLongFieldCM));
     // assert that when sort optimization is disabled we can use INT sort on long field
     intSortOnLongField.setOptimizeSortWithIndexedData(false);
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnLongField));
 
     SortField intSortOnIntRangeField = new SortField("intRange", SortField.Type.INT);
+    TopFieldCollectorManager intSortOnIntRangeFieldCM =
+        new TopFieldCollectorManager(new Sort(intSortOnIntRangeField), 1, 1);
     assertThrows(
         IllegalArgumentException.class,
-        () -> searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnIntRangeField)));
+        () -> searcher.search(new MatchAllDocsQuery(), intSortOnIntRangeFieldCM));
     // assert that when sort optimization is disabled we can use INT sort on intRange field
     intSortOnIntRangeField.setOptimizeSortWithIndexedData(false);
     searcher.search(new MatchAllDocsQuery(), 1, new Sort(intSortOnIntRangeField));


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

When `totalHitsThreshold` is greater than or equal to number of docs, we can disable the sort optimization.