### PR TITLE
Make DenseConjunctionBulkScorer align scoring windows with #docIDRunEnd().

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/DenseConjunctionBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DenseConjunctionBulkScorer.java
@@ -180,9 +180,10 @@ final class DenseConjunctionBulkScorer extends BulkScorer {
     // data, which helps evaluate fewer clauses per window - without allowing windows to become too
     // small thanks to the WINDOW_SIZE/2 threshold.
     int minDocIDRunEnd = max;
+    final int minRunEndThreshold = (int) Math.min((long) min + WINDOW_SIZE / 2, max);
     for (DisiWrapper w : iterators) {
       int docIdRunEnd = w.docIDRunEnd();
-      if (w.docID() > min || (docIdRunEnd - min) < WINDOW_SIZE / 2) {
+      if (w.docID() > min || docIdRunEnd < minRunEndThreshold) {
         windowApproximations.add(w.approximation());
         if (w.twoPhase() != null) {
           windowTwoPhases.add(w.twoPhase());


### PR DESCRIPTION
This improves the way how `DenseConjunctionBulkScorer` computes scoring windows by aligning the end of the window with the `#docIDRunEnd()` of its clauses, as long as it would result in a window that is at least half the expected size.

This helps reduce the number of clauses to evaluate per window in some cases.