### PR TITLE
Allow skip cache factor to be updated dynamically

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -47,6 +47,7 @@ Other
 ---------------------
 
 * GITHUB#14229: Bump minimum required Java version to 25
+* GITHUB#14412: Allow skip cache factor to be updated dynamically. (Sagar Upadhyaya)
 
 ======================= Lucene 10.2.0 =======================
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -47,7 +47,6 @@ Other
 ---------------------
 
 * GITHUB#14229: Bump minimum required Java version to 25
-* GITHUB#14412: Allow skip cache factor to be updated dynamically. (Sagar Upadhyaya)
 
 ======================= Lucene 10.2.0 =======================
 
@@ -103,6 +102,8 @@ New Features
 
 * GITHUB#13470: Added `TopDocs#rrf` to combine multiple TopDocs instances using
   reciprocal rank fusion. (Haren Lin, Adrien Grand)
+
+* GITHUB#14412: Allow skip cache factor to be updated dynamically. (Sagar Upadhyaya)
 
 Improvements
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -125,9 +125,7 @@ public class LRUQueryCache implements QueryCache, Accountable {
     this.maxSize = maxSize;
     this.maxRamBytesUsed = maxRamBytesUsed;
     this.leavesToCache = leavesToCache;
-    if (skipCacheFactor >= 1 == false) { //
-      // NaN >= 1
-      // evaluates false
+    if (skipCacheFactor >= 1 == false) { // NaN >= 1 evaluates false
       throw new IllegalArgumentException(
           "skipCacheFactor must be no less than 1, get " + skipCacheFactor);
     }

--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -279,8 +279,8 @@ public class LRUQueryCache implements QueryCache, Accountable {
   }
 
   CacheAndCount get(Query key, IndexReader.CacheHelper cacheHelper) {
-    assert !(key instanceof BoostQuery);
-    assert !(key instanceof ConstantScoreQuery);
+    assert key instanceof BoostQuery == false;
+    assert key instanceof ConstantScoreQuery == false;
     final IndexReader.CacheKey readerKey = cacheHelper.getKey();
     final LeafCache leafCache = cache.get(readerKey);
     if (leafCache == null) {

--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -125,7 +125,7 @@ public class LRUQueryCache implements QueryCache, Accountable {
     this.maxSize = maxSize;
     this.maxRamBytesUsed = maxRamBytesUsed;
     this.leavesToCache = leavesToCache;
-    if (skipCacheFactor < 1) { //
+    if (skipCacheFactor >= 1 == false) { //
       // NaN >= 1
       // evaluates false
       throw new IllegalArgumentException(
@@ -148,6 +148,12 @@ public class LRUQueryCache implements QueryCache, Accountable {
     return skipCacheFactor;
   }
 
+  /**
+   * This setter enables the skipCacheFactor to be updated dynamically.
+   *
+   * @param skipCacheFactor determines whether we need to skip the cache operation based on cost and
+   *     lead cost.
+   */
   public void setSkipCacheFactor(float skipCacheFactor) {
     this.skipCacheFactor = skipCacheFactor;
   }

--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -142,6 +142,11 @@ public class LRUQueryCache implements QueryCache, Accountable {
     missCount = new LongAdder();
   }
 
+  /**
+   * Get the skip cache factor
+   *
+   * @return #setSkipCacheFactor
+   */
   public float getSkipCacheFactor() {
     return skipCacheFactor;
   }
@@ -149,8 +154,8 @@ public class LRUQueryCache implements QueryCache, Accountable {
   /**
    * This setter enables the skipCacheFactor to be updated dynamically.
    *
-   * @param skipCacheFactor determines whether we need to skip the cache operation based on cost and
-   *     lead cost.
+   * @param skipCacheFactor clauses whose cost is {@code skipCacheFactor} times more than the cost
+   *     of the * top-level query will not be cached in order to not slow down queries too much.
    */
   public void setSkipCacheFactor(float skipCacheFactor) {
     this.skipCacheFactor = skipCacheFactor;

--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -155,7 +155,7 @@ public class LRUQueryCache implements QueryCache, Accountable {
    * This setter enables the skipCacheFactor to be updated dynamically.
    *
    * @param skipCacheFactor clauses whose cost is {@code skipCacheFactor} times more than the cost
-   *     of the * top-level query will not be cached in order to not slow down queries too much.
+   *     of the top-level query will not be cached in order to not slow down queries too much.
    */
   public void setSkipCacheFactor(float skipCacheFactor) {
     this.skipCacheFactor = skipCacheFactor;

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -2131,4 +2131,68 @@ public class TestLRUQueryCache extends LuceneTestCase {
     w.close();
     dir.close();
   }
+
+  public void testSkipCacheFactorWithDynamicValues() throws IOException {
+    Directory dir = newDirectory();
+    final RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+    Document doc1 = new Document();
+    doc1.add(new StringField("name", "tom", Store.YES));
+    doc1.add(new StringField("hobby", "movie", Store.YES));
+    Document doc2 = new Document();
+    doc2.add(new StringField("name", "alice", Store.YES));
+    doc2.add(new StringField("hobby", "book", Store.YES));
+    Document doc3 = new Document();
+    doc3.add(new StringField("name", "alice", Store.YES));
+    doc3.add(new StringField("hobby", "movie", Store.YES));
+    w.addDocuments(Arrays.asList(doc1, doc2, doc3));
+    final IndexReader reader = w.getReader();
+    final IndexSearcher searcher = newSearcher(reader);
+    final QueryCachingPolicy policy =
+        new QueryCachingPolicy() {
+
+          @Override
+          public boolean shouldCache(Query query) throws IOException {
+            return query.getClass() != TermQuery.class;
+          }
+
+          @Override
+          public void onUse(Query query) {
+            // no-op
+          }
+        };
+    searcher.setQueryCachingPolicy(policy);
+    w.close();
+
+    // lead cost is 2, cost of subQuery1 is 3, cost of subQuery2 is 2
+    BooleanQuery.Builder inner = new BooleanQuery.Builder();
+    TermQuery innerSubQuery1 = new TermQuery(new Term("hobby", "book"));
+    TermQuery innerSubQuery2 = new TermQuery(new Term("hobby", "movie"));
+    BooleanQuery subQuery1 =
+        inner.add(innerSubQuery1, Occur.SHOULD).add(innerSubQuery2, Occur.SHOULD).build();
+
+    BooleanQuery.Builder bq = new BooleanQuery.Builder();
+    TermQuery subQuery2 = new TermQuery(new Term("name", "alice"));
+    BooleanQuery query =
+        bq.add(new ConstantScoreQuery(subQuery1), Occur.FILTER)
+            .add(subQuery2, Occur.FILTER)
+            .build();
+    Set<Query> cacheSet = new HashSet<>();
+
+    // Define skip cache factor to be 1, so that query is not cached.
+    AtomicReference<Float> skipCacheFactor = new AtomicReference<>(1.0f);
+    final LRUQueryCache cache = new LRUQueryCache(1000000, 10000000, _ -> true, skipCacheFactor);
+    searcher.setQueryCache(cache);
+    searcher.search(query, 1);
+    assertEquals(cacheSet, new HashSet<>(cache.cachedQueries()));
+    assertEquals(1.0, cache.getSkipCacheFactor().get().floatValue(), 0);
+
+    // Now change the skipCacheFactor to 3.0f, now same query should get cached.
+    skipCacheFactor.set(3.0f);
+    searcher.search(query, 1);
+    assertEquals(new HashSet<>(List.of(subQuery1)), new HashSet<>(cache.cachedQueries()));
+    assertEquals(3.0, cache.getSkipCacheFactor().get().floatValue(), 0);
+
+    reader.close();
+    dir.close();
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -2179,18 +2179,17 @@ public class TestLRUQueryCache extends LuceneTestCase {
     Set<Query> cacheSet = new HashSet<>();
 
     // Define skip cache factor to be 1, so that query is not cached.
-    AtomicReference<Float> skipCacheFactor = new AtomicReference<>(1.0f);
-    final LRUQueryCache cache = new LRUQueryCache(1000000, 10000000, _ -> true, skipCacheFactor);
+    final LRUQueryCache cache = new LRUQueryCache(1000000, 10000000, _ -> true, 1.0f);
     searcher.setQueryCache(cache);
     searcher.search(query, 1);
     assertEquals(cacheSet, new HashSet<>(cache.cachedQueries()));
-    assertEquals(1.0, cache.getSkipCacheFactor().get().floatValue(), 0);
+    assertEquals(1.0, cache.getSkipCacheFactor(), 0);
 
     // Now change the skipCacheFactor to 3.0f, now same query should get cached.
-    skipCacheFactor.set(3.0f);
+    cache.setSkipCacheFactor(3.0f);
     searcher.search(query, 1);
     assertEquals(new HashSet<>(List.of(subQuery1)), new HashSet<>(cache.cachedQueries()));
-    assertEquals(3.0, cache.getSkipCacheFactor().get().floatValue(), 0);
+    assertEquals(3.0, cache.getSkipCacheFactor(), 0);
 
     reader.close();
     dir.close();


### PR DESCRIPTION
### Description
Related issue - https://github.com/apache/lucene/issues/14183

This change allows skip cache factor to be updated dynamically within LRU query cache. This can be done via getter/setter

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
