### PR TITLE
skip keyword for GermanNormalizationFilter

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanNormalizationFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanNormalizationFilter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.KeywordAttribute;
 import org.apache.lucene.analysis.util.StemmerUtil;
 
 /**
@@ -44,6 +45,7 @@ public final class GermanNormalizationFilter extends TokenFilter {
   private static final int U = 2; /* umlaut state, allows e-deletion */
 
   private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+  private final KeywordAttribute keywordAttr = addAttribute(KeywordAttribute.class);
 
   public GermanNormalizationFilter(TokenStream input) {
     super(input);
@@ -52,6 +54,9 @@ public final class GermanNormalizationFilter extends TokenFilter {
   @Override
   public boolean incrementToken() throws IOException {
     if (input.incrementToken()) {
+      if (keywordAttr.isKeyword()) {
+        return true;
+      }
       int state = N;
       char[] buffer = termAtt.buffer();
       int length = termAtt.length();

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/de/TestGermanNormalizationFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/de/TestGermanNormalizationFilter.java
@@ -18,9 +18,11 @@ package org.apache.lucene.analysis.de;
 
 import java.io.IOException;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
+import org.apache.lucene.analysis.miscellaneous.SetKeywordMarkerFilter;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 
@@ -79,6 +81,21 @@ public class TestGermanNormalizationFilter extends BaseTokenStreamTestCase {
           }
         };
     checkOneTerm(a, "", "");
+    a.close();
+  }
+
+  public void testKeyword() throws IOException {
+    final CharArraySet exclusionSet = new CharArraySet(asSet("bär"), false);
+    Analyzer a =
+            new Analyzer() {
+              @Override
+              protected TokenStreamComponents createComponents(String fieldName) {
+                Tokenizer source = new MockTokenizer(MockTokenizer.WHITESPACE, false);
+                TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
+                return new TokenStreamComponents(source, new GermanNormalizationFilter(sink));
+              }
+            };
+    checkOneTerm(a, "bär", "bär");
     a.close();
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/de/TestGermanNormalizationFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/de/TestGermanNormalizationFilter.java
@@ -18,9 +18,11 @@ package org.apache.lucene.analysis.de;
 
 import java.io.IOException;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
+import org.apache.lucene.analysis.miscellaneous.SetKeywordMarkerFilter;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 
@@ -79,6 +81,21 @@ public class TestGermanNormalizationFilter extends BaseTokenStreamTestCase {
           }
         };
     checkOneTerm(a, "", "");
+    a.close();
+  }
+
+  public void testKeyword() throws IOException {
+    final CharArraySet exclusionSet = new CharArraySet(asSet("bär"), false);
+    Analyzer a =
+        new Analyzer() {
+          @Override
+          protected TokenStreamComponents createComponents(String fieldName) {
+            Tokenizer source = new MockTokenizer(MockTokenizer.WHITESPACE, false);
+            TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
+            return new TokenStreamComponents(source, new GermanNormalizationFilter(sink));
+          }
+        };
+    checkOneTerm(a, "bär", "bär");
     a.close();
   }
 }


### PR DESCRIPTION
Current GermanNormalizationFilter tries to normalize special German characters like ä to a, ü to u. For some words it makes sense to do so,  äpfel - > apfel  is like apples -> apple. But for some words, it doesn't make sense, Bär -> Bar is like Bear -> Bar. Adding KeywordAttribute to allow users to bypass normalization on some specific words.
