### PR TITLE
Support modifying segmentInfos.counter in IndexWriter

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -22,8 +22,6 @@ API Changes
 
 * GITHUB#14291: Remove IOException from ScorerSupplier#setTopLevelScoringClause signature (Luca Cavanna)
 
-* GITHUB#14417: Support modifying segmentInfos.counter in IndexWriter (Jialiang Guo)
-
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)
@@ -60,6 +58,8 @@ API Changes
 ---------------------
 * GITHUB#14401: Added LeafCollector#collectRange to enable collector to take
   advantage of pre-aggregated data to speed up faceting. (Adrien Grand)
+
+* GITHUB#14417: Support modifying segmentInfos.counter in IndexWriter (Jialiang Guo)
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -22,6 +22,8 @@ API Changes
 
 * GITHUB#14291: Remove IOException from ScorerSupplier#setTopLevelScoringClause signature (Luca Cavanna)
 
+* GITHUB#14417: Support modifying segmentInfos.counter in IndexWriter (Jialiang Guo)
+
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1437,10 +1437,11 @@ public class IndexWriter
     if (segmentInfos.counter < newCounter) {
       segmentInfos.counter = newCounter;
     }
+    changed();
   }
 
   /** Returns the {@link SegmentInfos#counter}. */
-  public synchronized long getSegmentInfosCounter() {
+  public long getSegmentInfosCounter() {
     this.ensureOpen();
     return segmentInfos.counter;
   }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1428,6 +1428,24 @@ public class IndexWriter
   }
 
   /**
+   * If {@link SegmentInfos#counter} is below {@code newCounter} then update it to this value.
+   *
+   * @lucene.internal
+   */
+  public synchronized void advanceSegmentInfosCounter(long newCounter) {
+    this.ensureOpen();
+    if (segmentInfos.counter < newCounter) {
+      segmentInfos.counter = newCounter;
+    }
+  }
+
+  /** Returns the {@link SegmentInfos#counter}. */
+  public synchronized long getSegmentInfosCounter() {
+    this.ensureOpen();
+    return segmentInfos.counter;
+  }
+
+  /**
    * Returns true if this index has deletions (including buffered deletions). Note that this will
    * return true if there are buffered Term/Query deletions, even if it turns out those buffered
    * deletions don't match any documents.

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -5064,7 +5064,9 @@ public class TestIndexWriter extends LuceneTestCase {
       writer.commit();
     }
 
-    assertEquals(1041, writer.getSegmentInfosCounter());
+    // There may be merge operations in the background, here only verifies that the current segment
+    // counter is greater than 1000.
+    assertTrue(writer.getSegmentInfosCounter() > 1000);
 
     IndexWriter.DocStats docStats = writer.getDocStats();
     assertEquals(50, docStats.maxDoc);

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -5040,10 +5040,8 @@ public class TestIndexWriter extends LuceneTestCase {
 
   public void testAdvanceSegmentInfosCounter() throws IOException {
     Directory dir = newDirectory();
-
     IndexWriter writer;
     IndexReader reader;
-
     writer = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
 
     // add 10 documents
@@ -5075,6 +5073,51 @@ public class TestIndexWriter extends LuceneTestCase {
     assertEquals(50, reader.maxDoc());
     assertEquals(50, reader.numDocs());
     reader.close();
+    dir.close();
+  }
+
+  public void testAdvanceSegmentCounterInCrashAndRecoveryScenario() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter writer;
+    IndexReader reader;
+    writer = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    // add 100 documents
+    for (int i = 0; i < 100; i++) {
+      addDocWithIndex(writer, i);
+      if (random().nextBoolean()) {
+        writer.commit();
+      }
+    }
+    IndexWriter.DocStats docStats = writer.getDocStats();
+    assertEquals(100, docStats.maxDoc);
+    assertEquals(100, docStats.numDocs);
+    writer.commit();
+    writer.close();
+
+    // recovery and advance segment counter
+    writer = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+    assertEquals(100, writer.getDocStats().numDocs);
+    long newSegmentCounter = writer.getSegmentInfosCounter() + 1000;
+    writer.advanceSegmentInfosCounter(newSegmentCounter);
+
+    // add 10 documents
+    for (int i = 0; i < 10; i++) {
+      addDocWithIndex(writer, i);
+      if (random().nextBoolean()) {
+        writer.commit();
+      }
+    }
+
+    assertTrue(writer.getSegmentInfosCounter() >= newSegmentCounter);
+
+    assertEquals(110, writer.getDocStats().numDocs);
+    // check that the index reader gives the same numbers.
+    reader = DirectoryReader.open(dir);
+    assertEquals(110, reader.maxDoc());
+    assertEquals(110, reader.numDocs());
+    reader.close();
+    writer.close();
     dir.close();
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -5113,6 +5113,7 @@ public class TestIndexWriter extends LuceneTestCase {
 
     assertEquals(110, writer.getDocStats().numDocs);
     // check that the index reader gives the same numbers.
+    writer.commit();
     reader = DirectoryReader.open(dir);
     assertEquals(110, reader.maxDoc());
     assertEquals(110, reader.numDocs());

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -5051,13 +5051,10 @@ public class TestIndexWriter extends LuceneTestCase {
       addDocWithIndex(writer, i);
       writer.commit();
     }
-    long beforeAdvanceSegmentCounter = writer.getSegmentInfosCounter();
     writer.advanceSegmentInfosCounter(1);
-    assertEquals(beforeAdvanceSegmentCounter, writer.getSegmentInfosCounter());
+    assertTrue(writer.getSegmentInfosCounter() >= 1);
 
     writer.advanceSegmentInfosCounter(1000);
-    assertEquals(1000, writer.getSegmentInfosCounter());
-
     // add 40 documents
     for (int i = 10; i < 50; i++) {
       addDocWithIndex(writer, i);
@@ -5066,7 +5063,7 @@ public class TestIndexWriter extends LuceneTestCase {
 
     // There may be merge operations in the background, here only verifies that the current segment
     // counter is greater than 1000.
-    assertTrue(writer.getSegmentInfosCounter() > 1000);
+    assertTrue(writer.getSegmentInfosCounter() >= 1000);
 
     IndexWriter.DocStats docStats = writer.getDocStats();
     assertEquals(50, docStats.maxDoc);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/ThreadedIndexingAndSearchingTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/ThreadedIndexingAndSearchingTestCase.java
@@ -82,6 +82,7 @@ public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCas
   protected final AtomicInteger addCount = new AtomicInteger();
   protected final AtomicInteger delCount = new AtomicInteger();
   protected final AtomicInteger packCount = new AtomicInteger();
+  protected AtomicLong maxAdvancedSegmentCounter = new AtomicLong(0);
 
   protected Directory dir;
   protected IndexWriter writer;
@@ -187,6 +188,19 @@ public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCas
                     doc.add(newTextField(addedField, "a random field", Field.Store.YES));
                   } else {
                     addedField = null;
+                  }
+
+                  // Maybe advance segment counter
+                  if (random().nextBoolean()) {
+                    long newSegmentCounter = writer.getSegmentInfosCounter() + 100;
+                    writer.advanceSegmentInfosCounter(newSegmentCounter);
+                    if (VERBOSE) {
+                      System.out.println(
+                          Thread.currentThread().getName()
+                              + " advance segment counter to "
+                              + newSegmentCounter);
+                    }
+                    maxAdvancedSegmentCounter.accumulateAndGet(newSegmentCounter, Math::max);
                   }
 
                   if (random().nextBoolean()) {
@@ -606,6 +620,8 @@ public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCas
       thread.join();
     }
 
+    assertTrue(writer.getSegmentInfosCounter() >= maxAdvancedSegmentCounter.get());
+
     if (VERBOSE) {
       System.out.println(
           "TEST: done join indexing threads ["
@@ -613,7 +629,9 @@ public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCas
               + " ms]; addCount="
               + addCount
               + " delCount="
-              + delCount);
+              + delCount
+              + " segmentCounter="
+              + writer.getSegmentInfosCounter());
     }
 
     final IndexSearcher s = getFinalSearcher();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/ThreadedIndexingAndSearchingTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/ThreadedIndexingAndSearchingTestCase.java
@@ -190,8 +190,9 @@ public abstract class ThreadedIndexingAndSearchingTestCase extends LuceneTestCas
                     addedField = null;
                   }
 
-                  // Maybe advance segment counter
-                  if (random().nextBoolean()) {
+                  // Maybe advance segment counter. Run with a relatively low probability to avoid
+                  // testing slowdowns caused by synchronous operations.
+                  if (random().nextInt(7) == 5) {
                     long newSegmentCounter = writer.getSegmentInfosCounter() + 100;
                     writer.advanceSegmentInfosCounter(newSegmentCounter);
                     if (VERBOSE) {


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

This PR aims to address issue [14362](https://github.com/apache/lucene/issues/14362). This issue includes a discussion of the benefits of this modification.

### Tests

- simple scenario
  - I added test `TestIndexWriter#testAdvanceSegmentInfosCounter`, the writer index a bunch of docs, then advance its counter.
- crash and recovery scenario
  - I added test `TestIndexWriter#testAdvanceSegmentCounterInCrashAndRecoveryScenario`, the writer index a bunch of docs, then close it, start a new writer on the same index, and advance its counter.
- Concurrent writing and modification scenario
  - Modified the test `ThreadedIndexingAndSearchingTestCase`, in the concurrent write thread, increased the logic of randomly modifying the segment counter, and checked after all write threads ended.


### Checklist
- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have given Lucene maintainers [access](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the main branch.
- [x] I have run ./gradlew check.
- [x] I have added tests for my changes.
