### PR TITLE
quick exit on filter query matching no docs when rewriting knn query

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -64,7 +64,7 @@ Improvements
 
 Optimizations
 ---------------------
-(No changes)
+* GITHUB#14418: Quick exit on filter query matching no docs when rewriting knn query. (Pan Guixin)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -81,6 +81,9 @@ abstract class AbstractKnnVectorQuery extends Query {
               .add(new FieldExistsQuery(field), BooleanClause.Occur.FILTER)
               .build();
       Query rewritten = indexSearcher.rewrite(booleanQuery);
+      if (rewritten.getClass() == MatchNoDocsQuery.class) {
+        return rewritten;
+      }
       filterWeight = indexSearcher.createWeight(rewritten, ScoreMode.COMPLETE_NO_SCORES, 1f);
     } else {
       filterWeight = null;


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
