### PR TITLE
Handle NaN results in TestVectorUtilSupport.testBinaryVectors

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -210,9 +210,15 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
   }
 
   private void assertFloatReturningProviders(ToDoubleFunction<VectorUtilSupport> func) {
-    assertThat(
-        func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport()),
-        closeTo(func.applyAsDouble(LUCENE_PROVIDER.getVectorUtilSupport()), delta));
+    double luceneValue =
+        func.applyAsDouble(LUCENE_PROVIDER.getVectorUtilSupport());
+    double panamaValue =
+        func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport());
+    if (Double.isNaN(luceneValue)){
+      assertTrue(Double.isNaN(panamaValue));
+    } else {
+      assertThat(panamaValue, closeTo(luceneValue, delta));
+    }
   }
 
   private void assertIntReturningProviders(ToIntFunction<VectorUtilSupport> func) {

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -209,8 +209,8 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
 
   private void assertFloatReturningProviders(ToDoubleFunction<VectorUtilSupport> func) {
     assertEquals(
-        func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport()),
         func.applyAsDouble(LUCENE_PROVIDER.getVectorUtilSupport()),
+        func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport()),
         delta);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -210,11 +210,9 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
   }
 
   private void assertFloatReturningProviders(ToDoubleFunction<VectorUtilSupport> func) {
-    double luceneValue =
-        func.applyAsDouble(LUCENE_PROVIDER.getVectorUtilSupport());
-    double panamaValue =
-        func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport());
-    if (Double.isNaN(luceneValue)){
+    double luceneValue = func.applyAsDouble(LUCENE_PROVIDER.getVectorUtilSupport());
+    double panamaValue = func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport());
+    if (Double.isNaN(luceneValue)) {
       assertTrue(Double.isNaN(panamaValue));
     } else {
       assertThat(panamaValue, closeTo(luceneValue, delta));

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -16,8 +16,6 @@
  */
 package org.apache.lucene.internal.vectorization;
 
-import static org.hamcrest.Matchers.closeTo;
-
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -210,13 +208,10 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
   }
 
   private void assertFloatReturningProviders(ToDoubleFunction<VectorUtilSupport> func) {
-    double luceneValue = func.applyAsDouble(LUCENE_PROVIDER.getVectorUtilSupport());
-    double panamaValue = func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport());
-    if (Double.isNaN(luceneValue)) {
-      assertTrue(Double.isNaN(panamaValue));
-    } else {
-      assertThat(panamaValue, closeTo(luceneValue, delta));
-    }
+    assertEquals(
+        func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport()),
+        func.applyAsDouble(LUCENE_PROVIDER.getVectorUtilSupport()),
+        delta);
   }
 
   private void assertIntReturningProviders(ToIntFunction<VectorUtilSupport> func) {


### PR DESCRIPTION
I notice the following error in CI:

```
./gradlew test --tests TestVectorUtilSupport.testBinaryVectors -Dtests.seed=B12D50704230E803 -Dtests.locale=ce -Dtests.timezone=SystemV/AST4 -Dtests.asserts=true -Dtests.file.encoding=UTF-8

  >     java.lang.AssertionError: 
   >     Expected: a numeric value within <1.0E-5> of <NaN>
   >          but: <NaN> differed by <NaN> more than delta <1.0E-5>
   >         at __randomizedtesting.SeedInfo.seed([B12D50704230E803:FF2F6188C28072F0]:0)
   >         at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
   >         at org.junit.Assert.assertThat(Assert.java:964)
   >         at org.junit.Assert.assertThat(Assert.java:930)
   >         at org.apache.lucene.internal.vectorization.TestVectorUtilSupport.assertFloatReturningProviders(TestVectorUtilSupport.java:213)
   >         at org.apache.lucene.internal.vectorization.TestVectorUtilSupport.testBinaryVectors(TestVectorUtilSupport.java:71)
   >         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```

To avoid this, this commit makes `assertFloatReturningProviders` resilient to NaN results.
