### PR TITLE
For hnsw merger, do not pop from empty heap

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/UpdateGraphsUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/UpdateGraphsUtils.java
@@ -55,7 +55,7 @@ public class UpdateGraphsUtils {
     }
 
     long gTot = 0L;
-    while (gTot < gExit) {
+    while (gTot < gExit && heap.size() > 0) {
       long el = heap.pop();
       int gain = decodeValue1(el);
       int v = decodeValue2(el);


### PR DESCRIPTION
It seems there are edge cases when the heap is empty. This prevents us from attempting to pop from an empty heap.

This bug fix should go into 10.2 to make the 10.2.0 release.

closes: https://github.com/apache/lucene/issues/14407