### PR TITLE
Fix TestIndexWriterWithThreads#testIOExceptionDuringAbortWithThreadsOnlyOnce

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -5758,7 +5758,7 @@ public class IndexWriter
     }
   }
 
-  private void maybeCloseOnTragicEvent() throws IOException {
+  void maybeCloseOnTragicEvent() throws IOException {
     // We cannot hold IW's lock here else it can lead to deadlock:
     assert Thread.holdsLock(this) == false;
     assert Thread.holdsLock(fullFlushLock) == false;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -5758,7 +5758,7 @@ public class IndexWriter
     }
   }
 
-  void maybeCloseOnTragicEvent() throws IOException {
+  private void maybeCloseOnTragicEvent() throws IOException {
     // We cannot hold IW's lock here else it can lead to deadlock:
     assert Thread.holdsLock(this) == false;
     assert Thread.holdsLock(fullFlushLock) == false;

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -319,6 +320,140 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
           IOException ioe) {
         writer.rollback();
         failure.clearDoFail();
+      } finally {
+        writer.close();
+      }
+      if (VERBOSE) {
+        System.out.println("TEST: success=" + success);
+      }
+
+      if (success) {
+        IndexReader reader = DirectoryReader.open(dir);
+        final Bits delDocs = MultiBits.getLiveDocs(reader);
+        StoredFields storedFields = reader.storedFields();
+        TermVectors termVectors = reader.termVectors();
+        for (int j = 0; j < reader.maxDoc(); j++) {
+          if (delDocs == null || !delDocs.get(j)) {
+            storedFields.document(j);
+            termVectors.get(j);
+          }
+        }
+        reader.close();
+      }
+
+      dir.close();
+    }
+  }
+
+  public void _testMultipleThreadsFailureWithMergeNotEndLongTime(
+      MockDirectoryWrapper.Failure failure) throws Exception {
+    CountDownLatch mergeCloseCountDownLatch = new CountDownLatch(1);
+    CountDownLatch updateDocumentFailCountDownLatch = new CountDownLatch(1);
+    CountDownLatch mergeCountDownLatch = new CountDownLatch(1);
+    ConcurrentMergeScheduler mergeScheduler =
+        new ConcurrentMergeScheduler() {
+          @Override
+          public void close() throws IOException {
+            super.close();
+            try {
+              mergeCloseCountDownLatch.countDown();
+              // Let merge close not end for a long time, causing AlreadyClosedException exception
+              // thrown when writer.commit()
+              Thread.sleep(5000);
+            } catch (InterruptedException e) {
+              throw new RuntimeException(e);
+            }
+          }
+        };
+    // Prevent waiting in ConcurrentMergeScheduler#maybeStall from causing test deadlock
+    mergeScheduler.setMaxMergesAndThreads(Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+    int NUM_THREADS = 1;
+
+    for (int iter = 0; iter < 1; iter++) {
+      if (VERBOSE) {
+        System.out.println("TEST: iter=" + iter);
+      }
+      MockDirectoryWrapper dir = newMockDirectory();
+
+      IndexWriterConfig indexWriterConfig =
+          newIndexWriterConfig(new MockAnalyzer(random()))
+              .setMaxBufferedDocs(2)
+              .setMergeScheduler(mergeScheduler)
+              .setMergePolicy(newLogMergePolicy(4))
+              .setCommitOnClose(false);
+      indexWriterConfig.setReaderPooling(true);
+      IndexWriter writer =
+          new IndexWriter(dir, indexWriterConfig) {
+
+            @Override
+            void maybeCloseOnTragicEvent() throws IOException {
+              boolean isMerge = false;
+              for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+                final String className = element.getClassName();
+                final String methodName = element.getMethodName();
+                if (className.equals(IndexWriter.class.getName()) && methodName.equals("merge")) {
+                  isMerge = true;
+                  break;
+                }
+              }
+              if (isMerge == false) {
+                try {
+                  updateDocumentFailCountDownLatch.countDown();
+                  mergeCloseCountDownLatch.await();
+                } catch (InterruptedException e) {
+                  throw new RuntimeException(e);
+                }
+              }
+              super.maybeCloseOnTragicEvent();
+            }
+
+            @Override
+            protected void merge(MergePolicy.OneMerge merge) throws IOException {
+              try {
+                mergeCountDownLatch.countDown();
+                updateDocumentFailCountDownLatch.await();
+              } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+              super.merge(merge);
+            }
+          };
+      ((ConcurrentMergeScheduler) writer.getConfig().getMergeScheduler()).setSuppressExceptions();
+
+      CyclicBarrier syncStart = new CyclicBarrier(NUM_THREADS + 1);
+      IndexerThread[] threads = new IndexerThread[NUM_THREADS];
+      for (int i = 0; i < NUM_THREADS; i++) {
+        threads[i] = new IndexerThread(writer, true, syncStart);
+        threads[i].start();
+      }
+      syncStart.await();
+      mergeCountDownLatch.await();
+      dir.failOn(failure);
+      failure.setDoFail();
+
+      for (int i = 0; i < NUM_THREADS; i++) {
+        threads[i].join();
+        assertTrue("hit unexpected Throwable", threads[i].error == null);
+      }
+
+      boolean success = false;
+      try {
+        writer.commit();
+        writer.close();
+        success = true;
+      } catch (
+          @SuppressWarnings("unused")
+          AlreadyClosedException ace) {
+        // OK: abort closes the writer
+        assertTrue(writer.isDeleterClosed());
+      } catch (
+          @SuppressWarnings("unused")
+          IOException ioe) {
+        writer.rollback();
+        failure.clearDoFail();
+      } finally {
+        writer.close();
       }
       if (VERBOSE) {
         System.out.println("TEST: success=" + success);
@@ -450,6 +585,10 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
   // IOException during rollback(), with multiple threads, is OK:
   public void testIOExceptionDuringAbortWithThreadsOnlyOnce() throws Exception {
     _testMultipleThreadsFailure(new FailOnlyOnAbortOrFlush(true));
+  }
+
+  public void testIOExceptionWithMergeNotEndLongTime() throws Exception {
+    _testMultipleThreadsFailureWithMergeNotEndLongTime(new FailOnlyOnAbortOrFlush(true));
   }
 
   // Throws IOException during DocumentsWriter.writeSegment


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
This PR aims to address issue [14423](https://github.com/apache/lucene/issues/14423).

### Tests

1. In order to stabilize the reproduce problem, I added a test `TestIndexWriterWithThreads#testIOExceptionWithMergeNotEndLongTime`. I added the details of the test code to [14423](https://github.com/apache/lucene/issues/14423). Because the test `TestIndexWriterWithThreads#testIOExceptionWithMergeNotEndLongTime` requires changing `IndexWriter#maybeCloseOnTragicEvent` access permissions, I did not include it in the PR.
2. I fixed `TestIndexWriterWithThreads#testIOExceptionDuringAbortWithThreadsOnlyOnce`.

### Checklist
- [x] I have reviewed the guidelines for [How to Contribute](https://github.com/apache/lucene/blob/main/CONTRIBUTING.md) and my code conforms to the standards described there to the best of my ability.
- [x] I have given Lucene maintainers [access](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the main branch.
- [x] I have run ./gradlew check.
- [x] I have added tests for my changes.