### PR TITLE
Remove slices creation overhead from IndexSearcher constructor

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -220,7 +220,7 @@ public class IndexSearcher {
         : "IndexSearcher's ReaderContext must be topLevel for reader " + context.reader();
     reader = context.reader();
     this.taskExecutor =
-        executor == null ? new TaskExecutor(Runnable::run) : new TaskExecutor(executor);
+        executor == null ? TaskExecutor.DIRECT_TASK_EXECUTOR : new TaskExecutor(executor);
     this.readerContext = context;
     leafContexts = context.leaves();
   }

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -529,7 +529,8 @@ public class IndexSearcher {
     LeafSlice[] res = leafSlices;
     if (res == null) {
       if (taskExecutor == TaskExecutor.DIRECT_TASK_EXECUTOR) {
-        res = leafContexts.isEmpty()
+        res =
+            leafContexts.isEmpty()
                 ? new LeafSlice[0]
                 : new LeafSlice[] {LeafSlice.entireSegments(leafContexts)};
       } else {

--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -45,6 +45,8 @@ import org.apache.lucene.util.ThreadInterruptedException;
  * @lucene.experimental
  */
 public final class TaskExecutor {
+  public static final TaskExecutor DIRECT_TASK_EXECUTOR = new TaskExecutor(Runnable::run);
+
   private final Executor executor;
 
   /**


### PR DESCRIPTION
We simplified the slices creation in IndexSearcher with #13893. That removed the need for a caching supplier, but had an unexpected effect: we eagerly create slices now for the case where no executor is provided, and that may cause some overhead.

There are situations in which a searcher is created, although search methods that trigger the creation of slices are never called. We can in that case avoid going through that trouble.