### PR TITLE
Revert "Add UnwrappingReuseStrategy for AnalyzerWrapper (#14154)"

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -167,10 +167,6 @@ Improvements
   mergeFactor segments together when the merge is below the min merge size.
   (Adrien Grand)
 
-* GITHUB#14154: Add UnwrappingReuseStrategy for AnalyzerWrapper that consults
-  the wrapped analyzer's strategy to decide if components can be reused or need
-  to be updated. (Mayya Sharipova)
-
 * GITHUB#14192: Added support for RegExp to handle case insensitive matching
   across the full set of Unicode characters. (John Wagster)
 

--- a/lucene/core/src/java/org/apache/lucene/analysis/Analyzer.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/Analyzer.java
@@ -342,7 +342,7 @@ public abstract class Analyzer implements Closeable {
    * TokenFilter} which also serves as the {@link TokenStream} returned by {@link
    * Analyzer#tokenStream(String, Reader)}.
    */
-  public static class TokenStreamComponents {
+  public static final class TokenStreamComponents {
     /** Original source of the tokens. */
     protected final Consumer<Reader> source;
 

--- a/lucene/core/src/java/org/apache/lucene/analysis/AnalyzerWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/AnalyzerWrapper.java
@@ -41,6 +41,7 @@ import org.apache.lucene.util.AttributeFactory;
  * @since 4.0.0
  */
 public abstract class AnalyzerWrapper extends Analyzer {
+
   /**
    * Creates a new AnalyzerWrapper with the given reuse strategy.
    *
@@ -52,10 +53,7 @@ public abstract class AnalyzerWrapper extends Analyzer {
    * @see #getReuseStrategy()
    */
   protected AnalyzerWrapper(ReuseStrategy reuseStrategy) {
-    super(
-        reuseStrategy instanceof DelegatingAnalyzerWrapper.DelegatingReuseStrategy
-            ? reuseStrategy
-            : new UnwrappingReuseStrategy(reuseStrategy));
+    super(reuseStrategy);
   }
 
   /**
@@ -119,10 +117,7 @@ public abstract class AnalyzerWrapper extends Analyzer {
 
   @Override
   protected final TokenStreamComponents createComponents(String fieldName) {
-    TokenStreamComponents wrappedComponents =
-        getWrappedAnalyzer(fieldName).createComponents(fieldName);
-    TokenStreamComponents wrapperComponents = wrapComponents(fieldName, wrappedComponents);
-    return new TokenStreamComponentsWrapper(wrapperComponents, wrappedComponents);
+    return wrapComponents(fieldName, getWrappedAnalyzer(fieldName).createComponents(fieldName));
   }
 
   @Override
@@ -155,64 +150,5 @@ public abstract class AnalyzerWrapper extends Analyzer {
   @Override
   protected final AttributeFactory attributeFactory(String fieldName) {
     return getWrappedAnalyzer(fieldName).attributeFactory(fieldName);
-  }
-
-  /**
-   * A {@link org.apache.lucene.analysis.Analyzer.ReuseStrategy} that checks the wrapped analyzer's
-   * strategy for reusability. If the wrapped analyzer's strategy returns null, components need to
-   * be re-created.
-   */
-  public static final class UnwrappingReuseStrategy extends ReuseStrategy {
-    private final ReuseStrategy reuseStrategy;
-
-    public UnwrappingReuseStrategy(ReuseStrategy reuseStrategy) {
-      this.reuseStrategy = reuseStrategy;
-    }
-
-    @Override
-    public TokenStreamComponents getReusableComponents(Analyzer analyzer, String fieldName) {
-      if (analyzer instanceof AnalyzerWrapper wrapper) {
-        final Analyzer wrappedAnalyzer = wrapper.getWrappedAnalyzer(fieldName);
-        if (wrappedAnalyzer.getReuseStrategy().getReusableComponents(wrappedAnalyzer, fieldName)
-            == null) {
-          return null;
-        }
-      }
-      return reuseStrategy.getReusableComponents(analyzer, fieldName);
-    }
-
-    @Override
-    public void setReusableComponents(
-        Analyzer analyzer, String fieldName, TokenStreamComponents components) {
-      reuseStrategy.setReusableComponents(analyzer, fieldName, components);
-
-      if (analyzer instanceof AnalyzerWrapper wrapper) {
-        assert components instanceof TokenStreamComponentsWrapper;
-        final TokenStreamComponentsWrapper wrapperComponents =
-            (TokenStreamComponentsWrapper) components;
-        final Analyzer wrappedAnalyzer = wrapper.getWrappedAnalyzer(fieldName);
-        wrappedAnalyzer
-            .getReuseStrategy()
-            .setReusableComponents(
-                wrappedAnalyzer, fieldName, wrapperComponents.getWrappedComponents());
-      }
-    }
-  }
-
-  /**
-   * A {@link Analyzer.TokenStreamComponents} that decorates the wrapper with access to the wrapped
-   * components.
-   */
-  static final class TokenStreamComponentsWrapper extends TokenStreamComponents {
-    private final TokenStreamComponents wrapped;
-
-    TokenStreamComponentsWrapper(TokenStreamComponents wrapper, TokenStreamComponents wrapped) {
-      super(wrapper.getSource(), wrapper.getTokenStream());
-      this.wrapped = wrapped;
-    }
-
-    TokenStreamComponents getWrappedComponents() {
-      return wrapped;
-    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/analysis/DelegatingAnalyzerWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/DelegatingAnalyzerWrapper.java
@@ -69,11 +69,7 @@ public abstract class DelegatingAnalyzerWrapper extends AnalyzerWrapper {
     return super.wrapReaderForNormalization(fieldName, reader);
   }
 
-  /**
-   * A {@link org.apache.lucene.analysis.Analyzer.ReuseStrategy} that delegates to the wrapped
-   * analyzer's strategy for reusability of components.
-   */
-  static final class DelegatingReuseStrategy extends ReuseStrategy {
+  private static final class DelegatingReuseStrategy extends ReuseStrategy {
     DelegatingAnalyzerWrapper wrapper;
     private final ReuseStrategy fallbackStrategy;
 

--- a/lucene/core/src/test/org/apache/lucene/analysis/TestAnalyzerWrapper.java
+++ b/lucene/core/src/test/org/apache/lucene/analysis/TestAnalyzerWrapper.java
@@ -17,12 +17,8 @@
 
 package org.apache.lucene.analysis;
 
-import static org.apache.lucene.analysis.Analyzer.PER_FIELD_REUSE_STRATEGY;
-
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.lucene.analysis.Analyzer.ReuseStrategy;
-import org.apache.lucene.analysis.Analyzer.TokenStreamComponents;
 import org.apache.lucene.tests.analysis.CannedTokenStream;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
@@ -44,7 +40,7 @@ public class TestAnalyzerWrapper extends LuceneTestCase {
           }
         };
 
-    Analyzer wrapper =
+    Analyzer wrapped =
         new AnalyzerWrapper(analyzer.getReuseStrategy()) {
           @Override
           protected Analyzer getWrappedAnalyzer(String fieldName) {
@@ -59,73 +55,9 @@ public class TestAnalyzerWrapper extends LuceneTestCase {
           }
         };
 
-    try (TokenStream ts = wrapper.tokenStream("", "text")) {
+    try (TokenStream ts = wrapped.tokenStream("", "text")) {
       assert ts != null;
       assertTrue(sourceCalled.get());
     }
-  }
-
-  /**
-   * Test that {@link AnalyzerWrapper.UnwrappingReuseStrategy} consults the wrapped analyzer's reuse
-   * strategy if components can be reused or need to be updated.
-   */
-  public void testUnwrappingReuseStrategy() {
-    AtomicBoolean reuse = new AtomicBoolean(true);
-
-    final ReuseStrategy wrappedAnalyzerStrategy =
-        new ReuseStrategy() {
-          @Override
-          public TokenStreamComponents getReusableComponents(Analyzer analyzer, String fieldName) {
-            if (reuse.get() == false) {
-              return null;
-            } else {
-              return (TokenStreamComponents) getStoredValue(analyzer);
-            }
-          }
-
-          @Override
-          public void setReusableComponents(
-              Analyzer analyzer, String fieldName, TokenStreamComponents components) {
-            setStoredValue(analyzer, components);
-          }
-        };
-    Analyzer wrappedAnalyzer =
-        new Analyzer(wrappedAnalyzerStrategy) {
-          @Override
-          protected TokenStreamComponents createComponents(String fieldName) {
-            return new TokenStreamComponents(_ -> {}, new CannedTokenStream());
-          }
-        };
-
-    AnalyzerWrapper wrapperAnalyzer =
-        new AnalyzerWrapper(PER_FIELD_REUSE_STRATEGY) {
-          @Override
-          protected Analyzer getWrappedAnalyzer(String fieldName) {
-            return wrappedAnalyzer;
-          }
-
-          @Override
-          protected TokenStreamComponents wrapComponents(
-              String fieldName, TokenStreamComponents components) {
-            return new TokenStreamComponents(
-                components.getSource(), new LowerCaseFilter(components.getTokenStream()));
-          }
-        };
-
-    TokenStream ts = wrapperAnalyzer.tokenStream("", "text");
-    TokenStream ts2 = wrapperAnalyzer.tokenStream("", "text");
-    assertEquals(ts2, ts);
-
-    reuse.set(false);
-    TokenStream ts3 = wrapperAnalyzer.tokenStream("", "text");
-    assertNotSame(ts3, ts2);
-    TokenStream ts4 = wrapperAnalyzer.tokenStream("", "text");
-    assertNotSame(ts4, ts3);
-
-    reuse.set(true);
-    TokenStream ts5 = wrapperAnalyzer.tokenStream("", "text");
-    assertEquals(ts5, ts4);
-    TokenStream ts6 = wrapperAnalyzer.tokenStream("", "text");
-    assertEquals(ts6, ts5);
   }
 }


### PR DESCRIPTION
This reverts commit ce2a917cf2c2f40b3996656f3b294e3c01d25e5b.

### Description

In Elasticsearch (and probably other applications) we reuse the same analyzer across fields. And this change breaks it. 

 A fix in Lucene is trivial to make a default reuse strategy per_field:

![image (2)](https://github.com/user-attachments/assets/f13ad4f7-6df0-44d2-88d1-ab2a818ef10a)

But I don't know all the implications for this. So I will revert my change for now .


For example, the test below will fail currently:
```java
private static class PhraseWrappedAnalyzer extends AnalyzerWrapper {

        private final Analyzer delegate;
        private final int posIncGap;

        PhraseWrappedAnalyzer(Analyzer delegate, int posIncGap) {
            super(delegate.getReuseStrategy());
            this.delegate = delegate;
            this.posIncGap = posIncGap;
        }

        @Override
        public int getPositionIncrementGap(String fieldName) {
            // Delegate or return fixed value? Original test didn't rely on this.
            // Returning the passed value is consistent with the constructor.
            // Delegating might be safer generally: return delegate.getPositionIncrementGap(fieldName);
            return posIncGap;
        }

        @Override
        public int getOffsetGap(String fieldName) {
            // Delegate offset gap as well for completeness
            return delegate.getOffsetGap(fieldName);
        }


        @Override
        protected Analyzer getWrappedAnalyzer(String fieldName) {
            return delegate;
        }

        @Override
        protected TokenStreamComponents wrapComponents(String fieldName, TokenStreamComponents components) {
            // Wrap the delegate's token stream with FixedShingleFilter for bigrams
            return new TokenStreamComponents(components.getSource(),
                    new ShingleFilter(components.getTokenStream(), 2));
        }


    }


    public void testIndexDiffFieldsSameAnalyzer() throws IOException {
        final Analyzer textAnalyzer = new StandardAnalyzer();
        final Analyzer phraseAnalyzer = new PhraseWrappedAnalyzer(textAnalyzer, 0);

        FieldType textVectorType = new FieldType(TextField.TYPE_NOT_STORED);
        textVectorType.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS);
        textVectorType.freeze();
        Map<String, Analyzer> analyzerMap = new HashMap<>();
        analyzerMap.put("text", textAnalyzer);
        analyzerMap.put("text_phrases", phraseAnalyzer); // Use this field to store phrase tokens
        Analyzer perFieldAnalyzer = new PerFieldAnalyzerWrapper(new StandardAnalyzer(), analyzerMap);
        Directory dir = newDirectory();
        IndexWriterConfig iwc = newIndexWriterConfig(perFieldAnalyzer);
        IndexWriter writer = new IndexWriter(dir, iwc);

        int maxDocs = 4;
        String content = "the quick brown fox jumped over the lazy dog";

        for (int i = 0; i < maxDocs; i++) {
            Document doc = new Document();
            doc.add(new Field("text", content, textVectorType));
            doc.add(new Field("text_phrases", content, textVectorType));
            writer.addDocument(doc);
        }
        writer.commit();

        try (IndexReader reader = DirectoryReader.open(writer)) {
            assertEquals("Should have indexed maxDocs documents", maxDocs, reader.numDocs());

            // Verify term frequencies for the 'text' field
            Terms textTerms = MultiTerms.getTerms(reader, "text");
            assertNotNull("Terms should exist for 'text' field", textTerms);
            TermsEnum textTermsEnum = textTerms.iterator();
            BytesRef term;
            int termCount = 0;
            while ((term = textTermsEnum.next()) != null) {
                assertEquals("Incorrect docFreq for term '" + term.utf8ToString() + "' in field 'text'",
                        maxDocs, textTermsEnum.docFreq());
                termCount++;
            }
            assertTrue("Should find terms in 'text' field", termCount > 0);

            // Verify term frequencies for the 'text_phrases' field (shingles)
            Terms phraseTerms = MultiTerms.getTerms(reader, "text_phrases");
            assertNotNull("Terms should exist for 'text_phrases' field", phraseTerms);
            TermsEnum phraseTermsEnum = phraseTerms.iterator();
            BytesRef phrase;
            int phraseCount = 0;
            while ((phrase = phraseTermsEnum.next()) != null) {
                assertEquals("Incorrect docFreq for phrase '" + phrase.utf8ToString() + "' in field 'text_phrases'",
                        maxDocs, phraseTermsEnum.docFreq());
                phraseCount++;
            }
            assertTrue("Should find phrases (shingles) in 'text_phrases' field", phraseCount > 0);

        } finally {
            writer.close();
            dir.close();
            perFieldAnalyzer.close();
        }
    }
```
