### PR TITLE
New IndexReaderFunctions.positionLength from the norm

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/LongValues.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LongValues.java
@@ -31,4 +31,20 @@ public abstract class LongValues {
    * @return true if there is a value for this document
    */
   public abstract boolean advanceExact(int doc) throws IOException;
+
+  /**
+   * An empty LongValues instance that always returns {@code false} from {@link #advanceExact(int)}
+   */
+  public static final LongValues EMPTY =
+      new LongValues() {
+        @Override
+        public long longValue() throws IOException {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+          return false;
+        }
+      };
 }

--- a/lucene/core/src/java/org/apache/lucene/search/similarities/Similarity.java
+++ b/lucene/core/src/java/org/apache/lucene/search/similarities/Similarity.java
@@ -132,7 +132,8 @@ public abstract class Similarity {
    *
    * <p><b>WARNING</b>: The default implementation is used by Lucene's supplied Similarity classes,
    * which means you can change the Similarity at runtime without reindexing. If you override this
-   * method, you'll need to re-index documents for it to take effect.
+   * method, you'll need to re-index documents for it to take effect. Also be sure to override
+   * {@link #decodeNormToLength(long)}.
    *
    * <p>Matches in longer fields are less precise, so implementations of this method usually set
    * smaller values when <code>state.getLength()</code> is large, and larger values when <code>
@@ -159,6 +160,17 @@ public abstract class Similarity {
       numTerms = state.getLength();
     }
     return SmallFloat.intToByte4(numTerms);
+  }
+
+  /**
+   * Decodes the normalization value as computed by {@link #computeNorm(FieldInvertState)}, yielding
+   * the field's position length.
+   *
+   * @param norm from {@link org.apache.lucene.index.NumericDocValues#longValue()} of the norm.
+   * @return position length
+   */
+  public long decodeNormToLength(long norm) {
+    return SmallFloat.byte4ToInt((byte) norm);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/similarities/Similarity.java
+++ b/lucene/core/src/java/org/apache/lucene/search/similarities/Similarity.java
@@ -133,7 +133,7 @@ public abstract class Similarity {
    * <p><b>WARNING</b>: The default implementation is used by Lucene's supplied Similarity classes,
    * which means you can change the Similarity at runtime without reindexing. If you override this
    * method, you'll need to re-index documents for it to take effect. Also be sure to override
-   * {@link #decodeNormToLength(long)}.
+   * {@link #decodeNorm(long)}.
    *
    * <p>Matches in longer fields are less precise, so implementations of this method usually set
    * smaller values when <code>state.getLength()</code> is large, and larger values when <code>
@@ -163,13 +163,14 @@ public abstract class Similarity {
   }
 
   /**
-   * Decodes the normalization value as computed by {@link #computeNorm(FieldInvertState)}, yielding
-   * the field's position length.
+   * Decodes the normalization value as computed by {@link #computeNorm(FieldInvertState)}. The
+   * meaning is Similarity-dependent. The default meaning is the field length measured in positions,
+   * approximated.
    *
+   * @lucene.experimental
    * @param norm from {@link org.apache.lucene.index.NumericDocValues#longValue()} of the norm.
-   * @return position length
    */
-  public long decodeNormToLength(long norm) {
+  public long decodeNorm(long norm) {
     return SmallFloat.byte4ToInt((byte) norm);
   }
 

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestIndexReaderFunctions.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestIndexReaderFunctions.java
@@ -187,6 +187,13 @@ public class TestIndexReaderFunctions extends LuceneTestCase {
     assertCacheable(vs, false);
   }
 
+  public void testPositionLength() throws Exception {
+    LongValuesSource vs = IndexReaderFunctions.positionLength("text");
+    assertHits(vs.toDoubleValuesSource(), new float[] {6, 2});
+    assertEquals("posLen(text)", vs.toString());
+    assertCacheable(vs, true);
+  }
+
   void assertCacheable(DoubleValuesSource vs, boolean expected) throws Exception {
     Query q = new FunctionScoreQuery(new MatchAllDocsQuery(), vs);
     Weight w = searcher.createWeight(q, ScoreMode.COMPLETE, 1);

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestIndexReaderFunctions.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestIndexReaderFunctions.java
@@ -187,10 +187,10 @@ public class TestIndexReaderFunctions extends LuceneTestCase {
     assertCacheable(vs, false);
   }
 
-  public void testFieldLength() throws Exception {
-    LongValuesSource vs = IndexReaderFunctions.fieldLength("text");
+  public void testNorm() throws Exception {
+    LongValuesSource vs = IndexReaderFunctions.norm("text");
     assertHits(vs.toDoubleValuesSource(), new float[] {6, 2});
-    assertEquals("fieldLength(text)", vs.toString());
+    assertEquals("norm(text)", vs.toString());
     assertCacheable(vs, true);
   }
 

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestIndexReaderFunctions.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestIndexReaderFunctions.java
@@ -187,10 +187,10 @@ public class TestIndexReaderFunctions extends LuceneTestCase {
     assertCacheable(vs, false);
   }
 
-  public void testPositionLength() throws Exception {
-    LongValuesSource vs = IndexReaderFunctions.positionLength("text");
+  public void testFieldLength() throws Exception {
+    LongValuesSource vs = IndexReaderFunctions.fieldLength("text");
     assertHits(vs.toDoubleValuesSource(), new float[] {6, 2});
-    assertEquals("posLen(text)", vs.toString());
+    assertEquals("fieldLength(text)", vs.toString());
     assertCacheable(vs, true);
   }
 


### PR DESCRIPTION
### Description

Introduces `org.apache.lucene.queries.function.IndexReaderFunctions#positionLength`

Javadocs:
> Creates a value source that returns the position length (number of terms) of a field, approximated from the "norm".