### PR TITLE
KeywordField.newSetQuery() to reuse prefixed terms in IndexOrDocValuesQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -73,6 +73,8 @@ Optimizations
 
 * GITHUB#14268: PointInSetQuery early exit on non-matching segments. (hanbj)
 
+* GITHUB#14425: KeywordField.newSetQuery() reuses prefixed terms (Mikhail Khludnev)
+
 Bug Fixes
 ---------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
@@ -22,7 +22,6 @@ import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
@@ -175,9 +174,8 @@ public class KeywordField extends Field {
   public static Query newSetQuery(String field, Collection<BytesRef> values) {
     Objects.requireNonNull(field, "field must not be null");
     Objects.requireNonNull(values, "values must not be null");
-    Query indexQuery = new TermInSetQuery(field, values);
-    Query dvQuery = new TermInSetQuery(MultiTermQuery.DOC_VALUES_REWRITE, field, values);
-    return new IndexOrDocValuesQuery(indexQuery, dvQuery);
+    return TermInSetQuery.newIndexOrDocValuesQuery(
+        MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE, field, values);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -84,8 +84,39 @@ public class TermInSetQuery extends MultiTermQuery implements Accountable {
     termDataHashCode = termData.hashCode();
   }
 
+  /**
+   * Creates a new {@link IndexOrDocValuesQuery} combining two {@link TermInSetQuery} with the same
+   * terms allowing to pack them only once that's faster. Doc Values query always uses {@link
+   * MultiTermQuery#DOC_VALUES_REWRITE}.
+   *
+   * @param field field name for indexed and doc values queries.
+   * @param indexRewriteMethod rewrite method used for indexed query.
+   * @param terms collection of {@link BytesRef}. Note: passing {@link SortedSet} with default
+   *     comparator let to bypass terms sorting.
+   */
+  public static IndexOrDocValuesQuery newIndexOrDocValuesQuery(
+      RewriteMethod indexRewriteMethod, String field, Collection<BytesRef> terms) {
+    PrefixCodedTerms packed = packTerms(field, terms);
+    Query indexQuery = new TermInSetQuery(indexRewriteMethod, field, packed);
+    Query dvQuery = new TermInSetQuery(MultiTermQuery.DOC_VALUES_REWRITE, field, packed);
+    return new IndexOrDocValuesQuery(indexQuery, dvQuery);
+  }
+
+  /**
+   * Creates a new {@link IndexOrDocValuesQuery} combining two {@link TermInSetQuery} with the same
+   * terms using {@link MultiTermQuery#CONSTANT_SCORE_BLENDED_REWRITE} for indexed query.
+   */
+  public static IndexOrDocValuesQuery newIndexOrDocValuesQuery(
+      String field, Collection<BytesRef> terms) {
+    return newIndexOrDocValuesQuery(MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE, field, terms);
+  }
+
   private TermInSetQuery(String field, PrefixCodedTerms termData) {
-    super(field, MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE);
+    this(MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE, field, termData);
+  }
+
+  private TermInSetQuery(RewriteMethod rewrite, String field, PrefixCodedTerms termData) {
+    super(field, rewrite);
     this.field = field;
     this.termData = termData;
     termDataHashCode = termData.hashCode();

--- a/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermInSetQuery.java
@@ -102,15 +102,6 @@ public class TermInSetQuery extends MultiTermQuery implements Accountable {
     return new IndexOrDocValuesQuery(indexQuery, dvQuery);
   }
 
-  /**
-   * Creates a new {@link IndexOrDocValuesQuery} combining two {@link TermInSetQuery} with the same
-   * terms using {@link MultiTermQuery#CONSTANT_SCORE_BLENDED_REWRITE} for indexed query.
-   */
-  public static IndexOrDocValuesQuery newIndexOrDocValuesQuery(
-      String field, Collection<BytesRef> terms) {
-    return newIndexOrDocValuesQuery(MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE, field, terms);
-  }
-
   private TermInSetQuery(String field, PrefixCodedTerms termData) {
     this(MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE, field, termData);
   }


### PR DESCRIPTION
fix #14425

### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
