### PR TITLE
Disable HNSW connectedComponents (#14214)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -252,6 +252,8 @@ Bug Fixes
 
 * GITHUB#14320: Fix DirectIOIndexInput seek to not read when position is within buffer (Chris Hegarty)
 
+* GITHUB#14436: Disable connectedComponents logic in HNSW graph building. Relates to GITHUB#14214, GITHUB#12627, GITHUB#13566. (Ben Trent)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14189: Bump floor segment size to 16MB in TieredMergePolicy and

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -440,10 +440,13 @@ public class HnswGraphBuilder implements HnswBuilder {
 
   void finish() throws IOException {
     // System.out.println("finish " + frozen);
-    connectComponents();
+    // TODO: Connect components can be exceptionally expensive, disabling
+    //  see: https://github.com/apache/lucene/issues/14214
+    // connectComponents();
     frozen = true;
   }
 
+  @SuppressWarnings("unused")
   private void connectComponents() throws IOException {
     long start = System.nanoTime();
     for (int level = 0; level < hnsw.numLevels(); level++) {


### PR DESCRIPTION
Connected components can take until the "heat death of the universe" when it is most needed. Consequently it seems like it will be best to disable it as a bug fix until it can be corrected.

issue: https://github.com/apache/lucene/issues/14214

related: https://github.com/apache/lucene/pull/14411