### PR TITLE
Let Decompressor implement the Closeable interface.

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/compressing/CompressionMode.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/compressing/CompressionMode.java
@@ -144,6 +144,11 @@ public abstract class CompressionMode {
         public Decompressor clone() {
           return this;
         }
+
+        @Override
+        public void close() throws IOException {
+          // no-op
+        }
       };
 
   private static final class LZ4FastCompressor extends Compressor {
@@ -242,6 +247,11 @@ public abstract class CompressionMode {
     @Override
     public Decompressor clone() {
       return new DeflateDecompressor();
+    }
+
+    @Override
+    public void close() throws IOException {
+      // no-op
     }
   }
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/compressing/Decompressor.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/compressing/Decompressor.java
@@ -16,12 +16,13 @@
  */
 package org.apache.lucene.backward_codecs.compressing;
 
+import java.io.Closeable;
 import java.io.IOException;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.util.BytesRef;
 
 /** A decompressor. */
-public abstract class Decompressor implements Cloneable {
+public abstract class Decompressor implements Cloneable, Closeable {
 
   /** Sole constructor, typically called from sub-classes. */
   protected Decompressor() {}

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/Lucene50StoredFieldsFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene50/Lucene50StoredFieldsFormat.java
@@ -231,5 +231,10 @@ public class Lucene50StoredFieldsFormat extends StoredFieldsFormat {
         public Decompressor clone() {
           return this;
         }
+
+        @Override
+        public void close() throws IOException {
+          // no-op
+        }
       };
 }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/DeflateWithPresetDictCompressionMode.java
@@ -156,6 +156,11 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
     public Decompressor clone() {
       return new DeflateWithPresetDictDecompressor();
     }
+
+    @Override
+    public void close() throws IOException {
+      // no-op
+    }
   }
 
   private static class DeflateWithPresetDictCompressor extends Compressor {

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene87/LZ4WithPresetDictCompressionMode.java
@@ -147,6 +147,11 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
     public Decompressor clone() {
       return new LZ4WithPresetDictDecompressor();
     }
+
+    @Override
+    public void close() throws IOException {
+      // no-op
+    }
   }
 
   private static class LZ4WithPresetDictCompressor extends Compressor {

--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressionMode.java
@@ -145,6 +145,11 @@ public abstract class CompressionMode {
         public Decompressor clone() {
           return this;
         }
+
+        @Override
+        public void close() throws IOException {
+          // no-op
+        }
       };
 
   private static final class LZ4FastCompressor extends Compressor {
@@ -249,6 +254,11 @@ public abstract class CompressionMode {
     @Override
     public Decompressor clone() {
       return new DeflateDecompressor();
+    }
+
+    @Override
+    public void close() throws IOException {
+      // no-op
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/Decompressor.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/Decompressor.java
@@ -16,12 +16,13 @@
  */
 package org.apache.lucene.codecs.compressing;
 
+import java.io.Closeable;
 import java.io.IOException;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.util.BytesRef;
 
 /** A decompressor. */
-public abstract class Decompressor implements Cloneable {
+public abstract class Decompressor implements Cloneable, Closeable {
 
   /** Sole constructor, typically called from sub-classes. */
   protected Decompressor() {}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
@@ -157,6 +157,11 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
     public Decompressor clone() {
       return new DeflateWithPresetDictDecompressor();
     }
+
+    @Override
+    public void close() throws IOException {
+      // no-op
+    }
   }
 
   private static class DeflateWithPresetDictCompressor extends Compressor {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -148,6 +148,11 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
     public Decompressor clone() {
       return new LZ4WithPresetDictDecompressor();
     }
+
+    @Override
+    public void close() throws IOException {
+      // no-op
+    }
   }
 
   private static class LZ4WithPresetDictCompressor extends Compressor {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
@@ -252,7 +252,7 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
   @Override
   public void close() throws IOException {
     if (!closed) {
-      IOUtils.close(indexReader, fieldsStream);
+      IOUtils.close(indexReader, fieldsStream, decompressor);
       closed = true;
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
@@ -72,6 +72,11 @@ final class SortingStoredFieldsConsumer extends StoredFieldsConsumer {
             public Decompressor clone() {
               return this;
             }
+
+            @Override
+            public void close() throws IOException {
+              // no-op
+            }
           };
         }
       };

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/compressing/dummy/DummyCompressingCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/compressing/dummy/DummyCompressingCodec.java
@@ -71,6 +71,11 @@ public class DummyCompressingCodec extends CompressingCodec {
         public Decompressor clone() {
           return this;
         }
+
+        @Override
+        public void close() throws IOException {
+          // no-op
+        }
       };
 
   private static final Compressor DUMMY_COMPRESSOR =


### PR DESCRIPTION
### Description

In the current implementation, the [Compressor](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/codecs/compressing/Compressor.java) class implements the `Closeable` interface, but the [Decompressor](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/codecs/compressing/Decompressor.java) class doesn’t. When using Named SPI to plug in custom compressors—like the ones from [OpenSearch/custom-codecs](https://github.com/opensearch-project/custom-codecs)—it’d be helpful if `Decompressor` also implemented `Closeable` so we can properly release resources (e.g. natively allocated resources). This PR aims to fix that.
