### PR TITLE
Support adaptive refresh in Searcher Managers.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -90,6 +90,8 @@ Improvements
 * GITHUB#14602: Refactor the expressions compiler to use official ClassData BSM with indexed lookup
   (Uwe Schindler)
 
+* GITHUB#14443: Support adaptive refresh in Searcher Managers (Vigya Sharma)
+
 Optimizations
 ---------------------
 * GITHUB#14418: Quick exit on filter query matching no docs when rewriting knn query. (Pan Guixin)

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderManager.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
-import java.util.List;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.RefreshCommitSupplier;
@@ -98,8 +97,7 @@ public final class ReaderManager extends ReferenceManager<DirectoryReader> {
 
   @Override
   protected DirectoryReader refreshIfNeeded(DirectoryReader referenceToRefresh) throws IOException {
-    IndexCommit refreshCommit =
-        refreshCommitSupplier.getSearcherRefreshCommit(referenceToRefresh);
+    IndexCommit refreshCommit = refreshCommitSupplier.getSearcherRefreshCommit(referenceToRefresh);
     return DirectoryReader.openIfChanged(referenceToRefresh, refreshCommit);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderManager.java
@@ -19,7 +19,6 @@ package org.apache.lucene.index;
 import java.io.IOException;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ReferenceManager;
-import org.apache.lucene.search.RefreshCommitSupplier;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.store.Directory;
 
@@ -32,8 +31,6 @@ import org.apache.lucene.store.Directory;
  * @lucene.experimental
  */
 public final class ReaderManager extends ReferenceManager<DirectoryReader> {
-
-  private RefreshCommitSupplier refreshCommitSupplier = new RefreshCommitSupplier() {};
 
   /**
    * Creates and returns a new ReaderManager from the given {@link IndexWriter}.
@@ -86,11 +83,6 @@ public final class ReaderManager extends ReferenceManager<DirectoryReader> {
     current = reader;
   }
 
-  /** Set supplier for selecting commits to refresh on */
-  public void setRefreshCommitSupplier(RefreshCommitSupplier refreshCommitSupplier) {
-    this.refreshCommitSupplier = refreshCommitSupplier;
-  }
-
   @Override
   protected void decRef(DirectoryReader reference) throws IOException {
     reference.decRef();
@@ -98,8 +90,7 @@ public final class ReaderManager extends ReferenceManager<DirectoryReader> {
 
   @Override
   protected DirectoryReader refreshIfNeeded(DirectoryReader referenceToRefresh) throws IOException {
-    IndexCommit refreshCommit = refreshCommitSupplier.getSearcherRefreshCommit(referenceToRefresh);
-    return DirectoryReader.openIfChanged(referenceToRefresh, refreshCommit);
+    return DirectoryReader.openIfChanged(referenceToRefresh);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderManager.java
@@ -98,10 +98,8 @@ public final class ReaderManager extends ReferenceManager<DirectoryReader> {
 
   @Override
   protected DirectoryReader refreshIfNeeded(DirectoryReader referenceToRefresh) throws IOException {
-    List<IndexCommit> commits = DirectoryReader.listCommits(referenceToRefresh.directory());
     IndexCommit refreshCommit =
-        refreshCommitSupplier.getSearcherRefreshCommit(
-            commits, referenceToRefresh.getIndexCommit());
+        refreshCommitSupplier.getSearcherRefreshCommit(referenceToRefresh);
     return DirectoryReader.openIfChanged(referenceToRefresh, refreshCommit);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderManager.java
@@ -86,6 +86,7 @@ public final class ReaderManager extends ReferenceManager<DirectoryReader> {
     current = reader;
   }
 
+  /** Set supplier for selecting commits to refresh on */
   public void setRefreshCommitSupplier(RefreshCommitSupplier refreshCommitSupplier) {
     this.refreshCommitSupplier = refreshCommitSupplier;
   }

--- a/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.search;
 
 import java.util.List;

--- a/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
@@ -36,23 +36,4 @@ public interface RefreshCommitSupplier {
   default IndexCommit getSearcherRefreshCommit(DirectoryReader reader) throws IOException {
     return null;
   }
-
-  /**
-   * Determines if taxonomy reader is ready for refresh on the latest commit
-   *
-   * <p>Expert: Taxonomy readers are always refreshed on the latest commit. Use this function to
-   * skip taxonomy refresh if the searcher commit returned by {@link
-   * RefreshCommitSupplier#getSearcherRefreshCommit(DirectoryReader)} is not yet ready for the
-   * latest taxonomy changes. Otherwise, you might get a new reader that references ords not yet
-   * known to the taxonomy reader
-   *
-   * <p>For example, a possible implementation could be to return false as long as
-   * getSearcherRefreshCommit selects a non-latest directory commit, and return true when it finally
-   * selects the latest commit.
-   *
-   * @return true if taxonomy reader should be refreshed to latest commit, false otherwise.
-   */
-  default boolean refreshTaxonomy() {
-    return true;
-  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
@@ -16,10 +16,9 @@
  */
 package org.apache.lucene.search;
 
+import java.io.IOException;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
-
-import java.io.IOException;
 
 /**
  * Expert: Interface to supply commit for searcher refresh.

--- a/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
@@ -17,6 +17,8 @@
 package org.apache.lucene.search;
 
 import java.util.List;
+
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
 
 /**
@@ -30,11 +32,9 @@ public interface RefreshCommitSupplier {
    * Expert: Returns the index commit that searcher should refresh on. A null return value (default)
    * indicates reader should refresh on the latest commit.
    *
-   * @param commits List of commits from searcher directory.
-   * @param currentCommit Current searcher commit.
+   * @param reader DirectoryReader to refresh
    */
-  default IndexCommit getSearcherRefreshCommit(
-      List<IndexCommit> commits, IndexCommit currentCommit) {
+  default IndexCommit getSearcherRefreshCommit(DirectoryReader reader) {
     return null;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
@@ -43,7 +43,7 @@ public interface RefreshCommitSupplier {
    *
    * <p>Expert: Taxonomy readers are always refreshed on the latest commit. Use this function to
    * skip taxonomy refresh if the searcher commit returned by {@link
-   * RefreshCommitSupplier#getSearcherRefreshCommit(List, IndexCommit)} is not yet ready for the
+   * RefreshCommitSupplier#getSearcherRefreshCommit(DirectoryReader)} is not yet ready for the
    * latest taxonomy changes. Otherwise, you might get a new reader that references ords not yet
    * known to the taxonomy reader
    *

--- a/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
@@ -1,0 +1,43 @@
+package org.apache.lucene.search;
+
+import java.util.List;
+import org.apache.lucene.index.IndexCommit;
+
+/**
+ * Expert: Interface to supply commit for searcher refresh.
+ *
+ * @lucene.experimental
+ */
+public interface RefreshCommitSupplier {
+
+  /**
+   * Expert: Returns the index commit that searcher should refresh on. A null return value (default)
+   * indicates reader should refresh on the latest commit.
+   *
+   * @param commits List of commits from searcher directory.
+   * @param currentCommit Current searcher commit.
+   */
+  default IndexCommit getSearcherRefreshCommit(
+      List<IndexCommit> commits, IndexCommit currentCommit) {
+    return null;
+  }
+
+  /**
+   * Determines if taxonomy reader is ready for refresh on the latest commit
+   *
+   * <p>Expert: Taxonomy readers are always refreshed on the latest commit. Use this function to
+   * skip taxonomy refresh if the searcher commit returned by {@link
+   * RefreshCommitSupplier#getSearcherRefreshCommit(List, IndexCommit)} is not yet ready for the
+   * latest taxonomy changes. Otherwise, you might get a new reader that references ords not yet
+   * known to the taxonomy reader
+   *
+   * <p>For example, a possible implementation could be to return false as long as
+   * getSearcherRefreshCommit selects a non-latest directory commit, and return true when it finally
+   * selects the latest commit.
+   *
+   * @return true if taxonomy reader should be refreshed to latest commit, false otherwise.
+   */
+  default boolean refreshTaxonomy() {
+    return true;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
@@ -19,6 +19,8 @@ package org.apache.lucene.search;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
 
+import java.io.IOException;
+
 /**
  * Expert: Interface to supply commit for searcher refresh.
  *
@@ -32,7 +34,7 @@ public interface RefreshCommitSupplier {
    *
    * @param reader DirectoryReader to refresh
    */
-  default IndexCommit getSearcherRefreshCommit(DirectoryReader reader) {
+  default IndexCommit getSearcherRefreshCommit(DirectoryReader reader) throws IOException {
     return null;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RefreshCommitSupplier.java
@@ -16,8 +16,6 @@
  */
 package org.apache.lucene.search;
 
-import java.util.List;
-
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
 

--- a/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
-import java.util.List;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexReader;

--- a/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
@@ -90,6 +90,34 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
       boolean writeAllDeletes,
       SearcherFactory searcherFactory)
       throws IOException {
+    this(writer, applyAllDeletes, writeAllDeletes, searcherFactory, null);
+  }
+
+  /**
+   * Expert: creates and returns a new SearcherManager from the given {@link IndexWriter},
+   * controlling whether past deletions should be applied.
+   *
+   * @param writer the IndexWriter to open the IndexReader from.
+   * @param applyAllDeletes If <code>true</code>, all buffered deletes will be applied (made
+   *     visible) in the {@link IndexSearcher} / {@link DirectoryReader}. If <code>false</code>, the
+   *     deletes may or may not be applied, but remain buffered (in IndexWriter) so that they will
+   *     be applied in the future. Applying deletes can be costly, so if your app can tolerate
+   *     deleted documents being returned you might gain some performance by passing <code>false
+   *     </code>. See {@link DirectoryReader#openIfChanged(DirectoryReader, IndexWriter, boolean)}.
+   * @param writeAllDeletes If <code>true</code>, new deletes will be forcefully written to index
+   *     files.
+   * @param searcherFactory An optional {@link SearcherFactory}. Pass <code>null</code> if you don't
+   *     require the searcher to be warmed before going live or other custom behavior.
+   * @param refreshCommitSupplier supplier for providing the commit to refresh on
+   * @throws IOException if there is a low-level I/O error
+   */
+  public SearcherManager(
+      IndexWriter writer,
+      boolean applyAllDeletes,
+      boolean writeAllDeletes,
+      SearcherFactory searcherFactory,
+      RefreshCommitSupplier refreshCommitSupplier)
+      throws IOException {
     if (searcherFactory == null) {
       searcherFactory = new SearcherFactory();
     }
@@ -97,6 +125,9 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
     current =
         getSearcher(
             searcherFactory, DirectoryReader.open(writer, applyAllDeletes, writeAllDeletes), null);
+    if (refreshCommitSupplier != null) {
+      this.refreshCommitSupplier = refreshCommitSupplier;
+    }
   }
 
   /**
@@ -126,29 +157,34 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
    */
   public SearcherManager(DirectoryReader reader, SearcherFactory searcherFactory)
       throws IOException {
+    this(reader, searcherFactory, null);
+  }
+
+  /**
+   * Creates and returns a new SearcherManager from an existing {@link DirectoryReader}. Note that
+   * this steals the incoming reference.
+   *
+   * @param reader the DirectoryReader.
+   * @param searcherFactory An optional {@link SearcherFactory}. Pass <code>null</code> if you don't
+   *     require the searcher to be warmed before going live or other custom behavior.
+   * @param refreshCommitSupplier supplier for providing the commit to refresh on
+   * @throws IOException if there is a low-level I/O error
+   */
+  public SearcherManager(DirectoryReader reader, SearcherFactory searcherFactory, RefreshCommitSupplier refreshCommitSupplier)
+      throws IOException {
     if (searcherFactory == null) {
       searcherFactory = new SearcherFactory();
     }
     this.searcherFactory = searcherFactory;
     this.current = getSearcher(searcherFactory, reader, null);
-  }
-
-  /** Set supplier for selecting commits to refresh on */
-  public void setRefreshCommitSupplier(RefreshCommitSupplier refreshCommitSupplier) {
-    this.refreshCommitSupplier = refreshCommitSupplier;
+    if (refreshCommitSupplier != null) {
+      this.refreshCommitSupplier = refreshCommitSupplier;
+    }
   }
 
   @Override
   protected void decRef(IndexSearcher reference) throws IOException {
     reference.getIndexReader().decRef();
-  }
-
-  /** Return index commit generation for current searcher */
-  public long getSearcherCommitGeneration() throws IOException {
-    IndexSearcher s = acquire();
-    long gen = ((DirectoryReader) s.getIndexReader()).getIndexCommit().getGeneration();
-    release(s);
-    return gen;
   }
 
   @Override
@@ -177,12 +213,24 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
   }
 
   /**
+   * Return index commit generation for current searcher
+   * pkg-private for testing
+   */
+  long getSearcherCommitGeneration() throws IOException {
+    IndexSearcher s = acquire();
+    long gen = ((DirectoryReader) s.getIndexReader()).getIndexCommit().getGeneration();
+    release(s);
+    return gen;
+  }
+
+  /**
    * Returns <code>true</code> if no changes have occurred since this searcher ie. reader was
    * opened, otherwise <code>false</code>.
+   * pkg-private for testing
    *
    * @see DirectoryReader#isCurrent()
    */
-  public boolean isSearcherCurrent() throws IOException {
+  boolean isSearcherCurrent() throws IOException {
     final IndexSearcher searcher = acquire();
     try {
       final IndexReader r = searcher.getIndexReader();

--- a/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
@@ -149,9 +149,7 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
     assert r instanceof DirectoryReader
         : "searcher's IndexReader should be a DirectoryReader, but got " + r;
     DirectoryReader dr = (DirectoryReader) r;
-    List<IndexCommit> commits = DirectoryReader.listCommits(dr.directory());
-    IndexCommit refreshCommit =
-        refreshCommitSupplier.getSearcherRefreshCommit(commits, dr.getIndexCommit());
+    IndexCommit refreshCommit = refreshCommitSupplier.getSearcherRefreshCommit(dr);
     final IndexReader newReader = DirectoryReader.openIfChanged(dr, refreshCommit);
     if (newReader == null) {
       return null;

--- a/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
@@ -133,6 +133,7 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
     this.current = getSearcher(searcherFactory, reader, null);
   }
 
+  /** Set supplier for selecting commits to refresh on */
   public void setRefreshCommitSupplier(RefreshCommitSupplier refreshCommitSupplier) {
     this.refreshCommitSupplier = refreshCommitSupplier;
   }

--- a/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
@@ -144,7 +144,7 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
   }
 
   /** Return index commit generation for current searcher */
-  public long getCurrentCommitGen() throws IOException {
+  public long getSearcherCommitGeneration() throws IOException {
     IndexSearcher s = acquire();
     long gen = ((DirectoryReader) s.getIndexReader()).getIndexCommit().getGeneration();
     release(s);

--- a/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
@@ -170,7 +170,10 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
    * @param refreshCommitSupplier supplier for providing the commit to refresh on
    * @throws IOException if there is a low-level I/O error
    */
-  public SearcherManager(DirectoryReader reader, SearcherFactory searcherFactory, RefreshCommitSupplier refreshCommitSupplier)
+  public SearcherManager(
+      DirectoryReader reader,
+      SearcherFactory searcherFactory,
+      RefreshCommitSupplier refreshCommitSupplier)
       throws IOException {
     if (searcherFactory == null) {
       searcherFactory = new SearcherFactory();
@@ -212,10 +215,7 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
     return reference.getIndexReader().getRefCount();
   }
 
-  /**
-   * Return index commit generation for current searcher
-   * pkg-private for testing
-   */
+  /** Return index commit generation for current searcher. pkg-private for testing */
   long getSearcherCommitGeneration() throws IOException {
     IndexSearcher s = acquire();
     long gen = ((DirectoryReader) s.getIndexReader()).getIndexCommit().getGeneration();
@@ -225,8 +225,7 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
 
   /**
    * Returns <code>true</code> if no changes have occurred since this searcher ie. reader was
-   * opened, otherwise <code>false</code>.
-   * pkg-private for testing
+   * opened, otherwise <code>false</code>. pkg-private for testing
    *
    * @see DirectoryReader#isCurrent()
    */

--- a/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SearcherManager.java
@@ -143,6 +143,14 @@ public final class SearcherManager extends ReferenceManager<IndexSearcher> {
     reference.getIndexReader().decRef();
   }
 
+  /** Return index commit generation for current searcher */
+  public long getCurrentCommitGen() throws IOException {
+    IndexSearcher s = acquire();
+    long gen = ((DirectoryReader) s.getIndexReader()).getIndexCommit().getGeneration();
+    release(s);
+    return gen;
+  }
+
   @Override
   protected IndexSearcher refreshIfNeeded(IndexSearcher referenceToRefresh) throws IOException {
     final IndexReader r = referenceToRefresh.getIndexReader();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -796,10 +796,10 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
     // maybeRefresh only refreshes on the next incremental commit
     // so it takes us numCommits to get to latest
     int stepsToCurrent = 0;
-    while (isSearcherManagerCurrent(sm) == false) {
-      long oldGen = getSearcherManagerGen(sm);
+    while (sm.isSearcherCurrent() == false) {
+      long oldGen = sm.getCurrentCommitGen();
       sm.maybeRefreshBlocking();
-      long newGen = getSearcherManagerGen(sm);
+      long newGen = sm.getCurrentCommitGen();
       assertTrue(newGen == oldGen + 1);
       stepsToCurrent++;
     }
@@ -807,21 +807,5 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
     sm.close();
     w.close();
     dir.close();
-  }
-
-  private boolean isSearcherManagerCurrent(SearcherManager sm) throws IOException {
-    IndexSearcher s = sm.acquire();
-    DirectoryReader dr = (DirectoryReader) s.getIndexReader();
-    boolean isCurrent = dr.isCurrent();
-    sm.release(s);
-    return isCurrent;
-  }
-
-  private long getSearcherManagerGen(SearcherManager sm) throws IOException {
-    IndexSearcher s = sm.acquire();
-    DirectoryReader dr = (DirectoryReader) s.getIndexReader();
-    long gen = dr.getIndexCommit().getGeneration();
-    sm.release(s);
-    return gen;
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -782,7 +782,8 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
       w.addDocument(doc);
     }
     w.commit();
-    SearcherManager sm = new SearcherManager(DirectoryReader.open(dir), null, new NextCommitSelector());
+    SearcherManager sm =
+        new SearcherManager(DirectoryReader.open(dir), null, new NextCommitSelector());
     final int numCommits = 5;
     for (int i = 0; i < numCommits; i++) {
       for (int j = 0; j < 20; j++) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -782,7 +782,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
       w.addDocument(doc);
     }
     w.commit();
-    SearcherManager sm = new SearcherManager(dir, null);
+    SearcherManager sm = new SearcherManager(DirectoryReader.open(dir), null, new NextCommitSelector());
     final int numCommits = 5;
     for (int i = 0; i < numCommits; i++) {
       for (int j = 0; j < 20; j++) {
@@ -792,7 +792,6 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
       }
       w.commit();
     }
-    sm.setRefreshCommitSupplier(new NextCommitSelector());
 
     // maybeRefresh only refreshes on the next incremental commit
     // so it takes us numCommits to get to latest

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -797,9 +797,9 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
     // so it takes us numCommits to get to latest
     int stepsToCurrent = 0;
     while (sm.isSearcherCurrent() == false) {
-      long oldGen = sm.getCurrentCommitGen();
+      long oldGen = sm.getSearcherCommitGeneration();
       sm.maybeRefreshBlocking();
-      long newGen = sm.getCurrentCommitGen();
+      long newGen = sm.getSearcherCommitGeneration();
       assertTrue(newGen == oldGen + 1);
       stepsToCurrent++;
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -816,5 +816,4 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
     sm.release(s);
     return gen;
   }
-
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -769,10 +769,11 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
 
   public void testStepWiseCommitRefresh() throws Exception {
     Directory dir = newDirectory();
-    IndexWriter w = new IndexWriter(
+    IndexWriter w =
+        new IndexWriter(
             dir,
             newIndexWriterConfig(new MockAnalyzer(random()))
-                    .setIndexDeletionPolicy(NoDeletionPolicy.INSTANCE));
+                .setIndexDeletionPolicy(NoDeletionPolicy.INSTANCE));
     int docId = 0;
     // create initial commit
     for (int i = 0; i < 20; i++) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -777,11 +777,6 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
     }
     w.commit();
     SearcherManager sm = new SearcherManager(dir, null);
-    IndexSearcher s = sm.acquire();
-    DirectoryReader dr = (DirectoryReader) s.getIndexReader();
-    long startGen = dr.getIndexCommit().getGeneration();
-    sm.release(s);
-
     final int numCommits = 5;
     for (int i = 0; i < numCommits; i++) {
       for (int j = 0; j < 20; j++) {

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
@@ -188,11 +188,11 @@ public class SearcherTaxonomyManager
       } else if (taxoWriter != null && taxoWriter.getTaxonomyEpoch() != taxoEpoch) {
         IOUtils.close(newReader, tr);
         throw new IllegalStateException(
-                "DirectoryTaxonomyWriter.replaceTaxonomy was called, which is not allowed when using SearcherTaxonomyManager");
+            "DirectoryTaxonomyWriter.replaceTaxonomy was called, which is not allowed when using SearcherTaxonomyManager");
       }
 
       return new SearcherAndTaxonomy(
-              SearcherManager.getSearcher(searcherFactory, newReader, r), tr);
+          SearcherManager.getSearcher(searcherFactory, newReader, r), tr);
     }
   }
 
@@ -213,8 +213,8 @@ public class SearcherTaxonomyManager
   }
 
   /**
-   * Returns <code>true</code> if no new changes have occurred since the current
-   * searcher (i.e. reader) was opened; <code>false</code> otherwise
+   * Returns <code>true</code> if no new changes have occurred since the current searcher (i.e.
+   * reader) was opened; <code>false</code> otherwise
    *
    * @see DirectoryReader#isCurrent()
    */
@@ -223,7 +223,7 @@ public class SearcherTaxonomyManager
     try {
       final IndexReader r = sat.searcher.getIndexReader();
       assert r instanceof DirectoryReader
-              : "searcher's IndexReader should be a DirectoryReader, but got " + r;
+          : "searcher's IndexReader should be a DirectoryReader, but got " + r;
       return ((DirectoryReader) r).isCurrent();
     } finally {
       release(sat);
@@ -231,8 +231,8 @@ public class SearcherTaxonomyManager
   }
 
   /**
-   * Returns <code>true</code> if no new changes have occurred since the current
-   * taxonomy reader was opened; <code>false</code> otherwise
+   * Returns <code>true</code> if no new changes have occurred since the current taxonomy reader was
+   * opened; <code>false</code> otherwise
    *
    * @see DirectoryReader#isCurrent()
    */

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.facet.taxonomy;
 
 import java.io.IOException;
-import java.util.List;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
 import org.apache.lucene.index.DirectoryReader;

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
@@ -163,9 +163,7 @@ public class SearcherTaxonomyManager
     // taxonomy reader:
     final IndexReader r = ref.searcher.getIndexReader();
     DirectoryReader dr = (DirectoryReader) r;
-    List<IndexCommit> commits = DirectoryReader.listCommits(dr.directory());
-    IndexCommit refreshCommit =
-        refreshCommitSupplier.getSearcherRefreshCommit(commits, dr.getIndexCommit());
+    IndexCommit refreshCommit = refreshCommitSupplier.getSearcherRefreshCommit(dr);
     IndexReader newReader = DirectoryReader.openIfChanged(dr, refreshCommit);
     DirectoryTaxonomyReader tr = null;
     if (refreshCommitSupplier.refreshTaxonomy() == true) {

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
@@ -125,6 +125,7 @@ public class SearcherTaxonomyManager
     taxoEpoch = -1;
   }
 
+  /** Set supplier for selecting commits to refresh on */
   public void setRefreshCommitSupplier(RefreshCommitSupplier refreshCommitSupplier) {
     this.refreshCommitSupplier = refreshCommitSupplier;
   }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
@@ -139,7 +139,10 @@ public class SearcherTaxonomyManager
    * instances. Note that the incoming readers will be closed when you call {@link #close}.
    */
   public SearcherTaxonomyManager(
-      IndexReader reader, DirectoryTaxonomyReader taxoReader, SearcherFactory searcherFactory, RefreshCommitSupplier refreshCommitSupplier)
+      IndexReader reader,
+      DirectoryTaxonomyReader taxoReader,
+      SearcherFactory searcherFactory,
+      RefreshCommitSupplier refreshCommitSupplier)
       throws IOException {
     if (searcherFactory == null) {
       searcherFactory = new SearcherFactory();
@@ -221,10 +224,7 @@ public class SearcherTaxonomyManager
     }
   }
 
-  /**
-   * Return index commit generation for current searcher
-   * pkg-private for testing
-   */
+  /** Return index commit generation for current searcher. pkg-private for testing */
   long getSearcherCommitGeneration() throws IOException {
     SearcherAndTaxonomy sat = acquire();
     long gen = ((DirectoryReader) sat.searcher.getIndexReader()).getIndexCommit().getGeneration();
@@ -234,8 +234,7 @@ public class SearcherTaxonomyManager
 
   /**
    * Returns <code>true</code> if no new changes have occurred since the current searcher (i.e.
-   * reader) was opened; <code>false</code> otherwise
-   * pkg-private for testing
+   * reader) was opened, <code>false</code> otherwise. pkg-private for testing
    *
    * @see DirectoryReader#isCurrent()
    */
@@ -253,8 +252,7 @@ public class SearcherTaxonomyManager
 
   /**
    * Returns <code>true</code> if no new changes have occurred since the current taxonomy reader was
-   * opened; <code>false</code> otherwise
-   * pkg-private for testing
+   * opened, <code>false</code> otherwise. pkg-private for testing
    *
    * @see DirectoryReader#isCurrent()
    */

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
@@ -169,18 +169,18 @@ public class SearcherTaxonomyManager
       return null;
     } else {
       DirectoryTaxonomyReader tr = null;
-      // refresh taxonomy is searcher was refreshed to latest commit
-      if (((DirectoryReader) newReader).isCurrent()) {
+      // taxonomy should always be ahead of searchers. Otherwise, searchers
+      // might reference ordinals that taxonomy doesn't know of.
+      // To ensure this, we always refresh taxonomy on the latest commit.
+      try {
+        tr = TaxonomyReader.openIfChanged(ref.taxonomyReader);
+      } catch (Throwable t1) {
         try {
-          tr = TaxonomyReader.openIfChanged(ref.taxonomyReader);
-        } catch (Throwable t1) {
-          try {
-            IOUtils.close(newReader);
-          } catch (Throwable t2) {
-            t2.addSuppressed(t2);
-          }
-          throw t1;
+          IOUtils.close(newReader);
+        } catch (Throwable t2) {
+          t2.addSuppressed(t2);
         }
+        throw t1;
       }
       if (tr == null) {
         ref.taxonomyReader.incRef();

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/SearcherTaxonomyManager.java
@@ -166,7 +166,7 @@ public class SearcherTaxonomyManager
     IndexCommit refreshCommit = refreshCommitSupplier.getSearcherRefreshCommit(dr);
     IndexReader newReader = DirectoryReader.openIfChanged(dr, refreshCommit);
     DirectoryTaxonomyReader tr = null;
-    if (refreshCommitSupplier.refreshTaxonomy() == true) {
+    if (((DirectoryReader) newReader).isCurrent()) {
       try {
         tr = TaxonomyReader.openIfChanged(ref.taxonomyReader);
       } catch (Throwable t1) {

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
@@ -397,15 +397,17 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
     w.commit();
     tw.commit();
 
+    int colorIndex = 0;
+    final String[] colors = new String[] {"red", "green", "blue", "yellow"};
+    FacetsConfig config = new FacetsConfig();
     SearcherTaxonomyManager sat = new SearcherTaxonomyManager(dir, taxoDir, null);
     final int numCommits = 5;
-    final String[] colors = new String[] {"red", "green", "blue", "yellow"};
-    int colorIndex = 0;
     for (int i = 0; i < numCommits; i++) {
       for (int j = 0; j < 20; j++) {
         Document doc = new Document();
         doc.add(newStringField("docId", "doc-" + docId++, Field.Store.YES));
         doc.add(new FacetField("Color", colors[colorIndex++ % colors.length]));
+        doc = config.build(tw, doc);
         w.addDocument(doc);
       }
       w.commit();

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.facet.FacetField;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.FacetTestCase;
@@ -32,13 +33,17 @@ import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexNotFoundException;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoDeletionPolicy;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.search.RefreshCommitSupplier;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -355,5 +360,77 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
     taxoDir.deleteFile(infos.getSegmentsFileName());
     expectThrows(IndexNotFoundException.class, mgr::maybeRefreshBlocking);
     IOUtils.close(w, tw, mgr, indexDir, taxoDir);
+  }
+
+  /** Returns the first commit with generation higher than current reader commit */
+  public static class NextCommitSelector implements RefreshCommitSupplier {
+    @Override
+    public IndexCommit getSearcherRefreshCommit(DirectoryReader reader) throws IOException {
+      List<IndexCommit> commits = DirectoryReader.listCommits(reader.directory());
+      IndexCommit current = reader.getIndexCommit();
+      for (int i = 0; i < commits.size(); i++) {
+        IndexCommit commit = commits.get(i);
+        if (commit.getGeneration() > current.getGeneration()) {
+          return commit;
+        }
+      }
+      // we're already on latest commit
+      return null;
+    }
+  }
+
+  public void testStepWiseCommitRefresh() throws Exception {
+    Directory dir = newDirectory();
+    Directory taxoDir = newDirectory();
+    IndexWriter w = new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                    .setIndexDeletionPolicy(NoDeletionPolicy.INSTANCE));
+    DirectoryTaxonomyWriter tw = new DirectoryTaxonomyWriter(taxoDir);
+    int docId = 0;
+    // create initial commit
+    for (int i = 0; i < 20; i++) {
+      Document doc = new Document();
+      doc.add(newStringField("docId", "doc-" + docId++, Field.Store.YES));
+      w.addDocument(doc);
+    }
+    w.commit();
+    tw.commit();
+
+    SearcherTaxonomyManager sat = new SearcherTaxonomyManager(dir, taxoDir, null);
+    final int numCommits = 5;
+    final String[] colors = new String[] {"red", "green", "blue", "yellow"};
+    int colorIndex = 0;
+    for (int i = 0; i < numCommits; i++) {
+      for (int j = 0; j < 20; j++) {
+        Document doc = new Document();
+        doc.add(newStringField("docId", "doc-" + docId++, Field.Store.YES));
+        doc.add(new FacetField("Color", colors[colorIndex++ % colors.length]));
+        w.addDocument(doc);
+      }
+      w.commit();
+      tw.commit();
+    }
+    sat.setRefreshCommitSupplier(new NextCommitSelector());
+
+    // maybeRefresh only refreshes on the next incremental commit
+    // so it takes us numCommits to get to latest
+    int stepsToCurrent = 0;
+    while (sat.isSearcherCurrent() == false) {
+      long oldGen = sat.getSearcherCommitGeneration();
+      sat.maybeRefreshBlocking();
+      long newGen = sat.getSearcherCommitGeneration();
+        assertEquals(newGen, oldGen + 1);
+      stepsToCurrent++;
+      // taxonomy should refresh to latest commit only after searcher
+      // becomes current
+      assertEquals(sat.isSearcherCurrent(), sat.isTaxonomyCurrent());
+    }
+    assertEquals(numCommits, stepsToCurrent);
+    sat.close();
+    w.close();
+    tw.close();
+    dir.close();
+    taxoDir.close();
   }
 }

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
@@ -425,9 +425,7 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
       long newGen = sat.getSearcherCommitGeneration();
       assertEquals(newGen, oldGen + 1);
       stepsToCurrent++;
-      // taxonomy should refresh to latest commit only after searcher
-      // becomes current
-      assertEquals(sat.isSearcherCurrent(), sat.isTaxonomyCurrent());
+      assertTrue(sat.isTaxonomyCurrent());
     }
     assertEquals(numCommits, stepsToCurrent);
     sat.close();

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
@@ -382,10 +382,11 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
   public void testStepWiseCommitRefresh() throws Exception {
     Directory dir = newDirectory();
     Directory taxoDir = newDirectory();
-    IndexWriter w = new IndexWriter(
+    IndexWriter w =
+        new IndexWriter(
             dir,
             newIndexWriterConfig(new MockAnalyzer(random()))
-                    .setIndexDeletionPolicy(NoDeletionPolicy.INSTANCE));
+                .setIndexDeletionPolicy(NoDeletionPolicy.INSTANCE));
     DirectoryTaxonomyWriter tw = new DirectoryTaxonomyWriter(taxoDir);
     int docId = 0;
     // create initial commit
@@ -422,7 +423,7 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
       long oldGen = sat.getSearcherCommitGeneration();
       sat.maybeRefreshBlocking();
       long newGen = sat.getSearcherCommitGeneration();
-        assertEquals(newGen, oldGen + 1);
+      assertEquals(newGen, oldGen + 1);
       stepsToCurrent++;
       // taxonomy should refresh to latest commit only after searcher
       // becomes current

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
@@ -403,7 +403,9 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
     final String[] colors = new String[] {"red", "green", "blue", "yellow"};
     FacetsConfig config = new FacetsConfig();
     DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
-    SearcherTaxonomyManager sat = new SearcherTaxonomyManager(DirectoryReader.open(dir), taxoReader, null, new NextCommitSelector());
+    SearcherTaxonomyManager sat =
+        new SearcherTaxonomyManager(
+            DirectoryReader.open(dir), taxoReader, null, new NextCommitSelector());
 
     final int numCommits = 5;
     for (int i = 0; i < numCommits; i++) {

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
@@ -32,6 +32,7 @@ import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.facet.FacetsCollectorManager;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager.SearcherAndTaxonomy;
+import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
@@ -401,7 +402,9 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
     int colorIndex = 0;
     final String[] colors = new String[] {"red", "green", "blue", "yellow"};
     FacetsConfig config = new FacetsConfig();
-    SearcherTaxonomyManager sat = new SearcherTaxonomyManager(dir, taxoDir, null);
+    DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
+    SearcherTaxonomyManager sat = new SearcherTaxonomyManager(DirectoryReader.open(dir), taxoReader, null, new NextCommitSelector());
+
     final int numCommits = 5;
     for (int i = 0; i < numCommits; i++) {
       for (int j = 0; j < 20; j++) {
@@ -414,7 +417,6 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
       w.commit();
       tw.commit();
     }
-    sat.setRefreshCommitSupplier(new NextCommitSelector());
 
     // maybeRefresh only refreshes on the next incremental commit
     // so it takes us numCommits to get to latest


### PR DESCRIPTION
In segment based replication systems, a large replication payload (checkpoint) can induce heavy page faults, cause thrashing for in-flight search requests, and affect overall search performance. 

A potential way to handle these bursts, is to leverage multiple commit points in the Lucene index. Instead of refreshing to the latest commit for a large replication payload, searchers can intelligently select the commit point that they can safely absorb. By processing through multiple such points, searchers can eventually get to the latest commit, without incurring too many page faults.

This change lets users define a commit selection strategy, controlling which commit the searcher manager refreshes on. Addresses #14219 


**Usage:**
To incrementally refresh through multiple commit points until searcher is current with its directory:
- Define a commit selection strategy using the `RefreshCommitSupplier` interface.
- Update searcher managers with this strategy via `setRefreshCommitSupplier()`
- Invoke `maybeRefresh()` or `maybeRefreshBlocking` in a loop until `isSearcherCurrent()` returns true.

