### PR TITLE
tests: mark TestVectorScorer.testLarge() @Monster

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorScorer.java
@@ -307,7 +307,7 @@ public class TestVectorScorer extends LuceneTestCase {
   }
 
   // Tests with a large amount of data (> 2GB), which ensures that data offsets do not overflow
-  @Nightly
+  @Monster(value = "requires gigabytes of disk space")
   public void testLarge() throws IOException {
     try (Directory dir = new MMapDirectory(createTempDir("testLarge"))) {
       final int dims = 8192;


### PR DESCRIPTION
This test requires gigabytes of disk space to run.

Closes #14446 
