### PR TITLE
Use the same DocIdSetIterator impl for #all, #range and #empty.

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestDocIdSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocIdSetIterator.java
@@ -24,6 +24,19 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.FixedBitSet;
 
 public class TestDocIdSetIterator extends LuceneTestCase {
+
+  public void testEmpty() throws IOException {
+    DocIdSetIterator disi = DocIdSetIterator.empty();
+    assertEquals(-1, disi.docID());
+    assertEquals(NO_MORE_DOCS, disi.nextDoc());
+    assertEquals(NO_MORE_DOCS, disi.docID());
+
+    disi = DocIdSetIterator.empty();
+    assertEquals(-1, disi.docID());
+    assertEquals(NO_MORE_DOCS, disi.advance(42));
+    assertEquals(NO_MORE_DOCS, disi.docID());
+  }
+
   public void testRangeBasic() throws Exception {
     DocIdSetIterator disi = DocIdSetIterator.range(5, 8);
     assertEquals(-1, disi.docID());
@@ -41,7 +54,7 @@ public class TestDocIdSetIterator extends LuceneTestCase {
         });
   }
 
-  public void testInvalidMin() throws Exception {
+  public void testInvalidRangeMin() throws Exception {
     expectThrows(
         IllegalArgumentException.class,
         () -> {
@@ -49,7 +62,7 @@ public class TestDocIdSetIterator extends LuceneTestCase {
         });
   }
 
-  public void testEmpty() throws Exception {
+  public void testEmptyRange() throws Exception {
     expectThrows(
         IllegalArgumentException.class,
         () -> {
@@ -57,7 +70,7 @@ public class TestDocIdSetIterator extends LuceneTestCase {
         });
   }
 
-  public void testAdvance() throws Exception {
+  public void testRangeAdvance() throws Exception {
     DocIdSetIterator disi = DocIdSetIterator.range(5, 20);
     assertEquals(-1, disi.docID());
     assertEquals(5, disi.nextDoc());
@@ -117,7 +130,7 @@ public class TestDocIdSetIterator extends LuceneTestCase {
     }
   }
 
-  public void testDocIDRunEnd() throws IOException {
+  public void testDocIDRunEndAll() throws IOException {
     DocIdSetIterator it = DocIdSetIterator.all(13);
     assertEquals(0, it.nextDoc());
     assertEquals(13, it.docIDRunEnd());


### PR DESCRIPTION
This helps reduce polymorphism of call sites to `DocIdSetIterator` methods.

Relates #14450