### PR TITLE
Reduce polymorphism of DocIdSetIterator#docID().

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -19,6 +19,7 @@ package org.apache.lucene.codecs.lucene90;
 import java.io.DataInput;
 import java.io.IOException;
 import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
@@ -91,7 +92,7 @@ import org.apache.lucene.util.RoaringDocIdSet;
  *
  * @lucene.internal
  */
-public final class IndexedDISI extends DocIdSetIterator {
+public final class IndexedDISI extends AbstractDocIdSetIterator {
 
   // jump-table time/space trade-offs to consider:
   // The block offsets and the block indexes could be stored in more compressed form with
@@ -422,7 +423,6 @@ public final class IndexedDISI extends DocIdSetIterator {
   int nextBlockIndex = -1;
   Method method;
 
-  int doc = -1;
   int index = -1;
 
   // SPARSE variables
@@ -472,11 +472,6 @@ public final class IndexedDISI extends DocIdSetIterator {
         return disi.cost();
       }
     };
-  }
-
-  @Override
-  public int docID() {
-    return doc;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractDocIdSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractDocIdSetIterator.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+/**
+ * Abstract implementation of a {@link DocIdSetIterator} that tracks the current doc ID.
+ * Implementing {@link DocIdSetIterator} by extending either this class or {@link
+ * FilterDocIdSetIterator} is a good idea in order to reduce polymorphism of call sites to {@link
+ * DocIdSetIterator#docID()}.
+ */
+public abstract class AbstractDocIdSetIterator extends DocIdSetIterator {
+
+  /** The current doc ID, initialized at -1. */
+  protected int doc = -1;
+
+  /** Sole constructor, invoked by sub-classes. */
+  protected AbstractDocIdSetIterator() {}
+
+  @Override
+  public final int docID() {
+    return doc;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionScorer.java
@@ -97,20 +97,10 @@ final class BlockMaxConjunctionScorer extends Scorer {
   private DocIdSetIterator approximation() {
     final DocIdSetIterator lead = approximations[0];
 
-    return new DocIdSetIterator() {
+    return new FilterDocIdSetIterator(lead) {
 
       float maxScore;
       int upTo = -1;
-
-      @Override
-      public int docID() {
-        return lead.docID();
-      }
-
-      @Override
-      public long cost() {
-        return lead.cost();
-      }
 
       private void moveToNextBlock(int target) throws IOException {
         if (minScore == 0) {

--- a/lucene/core/src/java/org/apache/lucene/search/ConjunctionDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ConjunctionDISI.java
@@ -127,7 +127,7 @@ final class ConjunctionDISI extends FilterDocIdSetIterator {
     if (iterators.size() == 1) {
       disi = iterators.get(0);
     } else {
-      // Sort the array the first time to allow the least frequent DocsEnum to lead the matching.
+      // Sort the list first to allow the sparser iterator to lead the matching.
       CollectionUtil.timSort(iterators, (o1, o2) -> Long.compare(o1.cost(), o2.cost()));
       disi = new ConjunctionDISI(iterators);
     }

--- a/lucene/core/src/java/org/apache/lucene/search/ConjunctionDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ConjunctionDISI.java
@@ -33,7 +33,7 @@ import org.apache.lucene.util.CollectionUtil;
  *
  * @lucene.internal
  */
-final class ConjunctionDISI extends DocIdSetIterator {
+final class ConjunctionDISI extends FilterDocIdSetIterator {
 
   /**
    * Adds the scorer, possibly splitting up into two phases or collapsing if it is another
@@ -127,6 +127,8 @@ final class ConjunctionDISI extends DocIdSetIterator {
     if (iterators.size() == 1) {
       disi = iterators.get(0);
     } else {
+      // Sort the array the first time to allow the least frequent DocsEnum to lead the matching.
+      CollectionUtil.timSort(iterators, (o1, o2) -> Long.compare(o1.cost(), o2.cost()));
       disi = new ConjunctionDISI(iterators);
     }
 
@@ -152,11 +154,9 @@ final class ConjunctionDISI extends DocIdSetIterator {
   final DocIdSetIterator[] others;
 
   private ConjunctionDISI(List<? extends DocIdSetIterator> iterators) {
+    super(iterators.get(0));
     assert iterators.size() >= 2;
 
-    // Sort the array the first time to allow the least frequent DocsEnum to
-    // lead the matching.
-    CollectionUtil.timSort(iterators, (o1, o2) -> Long.compare(o1.cost(), o2.cost()));
     lead1 = iterators.get(0);
     lead2 = iterators.get(1);
     others = iterators.subList(2, iterators.size()).toArray(new DocIdSetIterator[0]);
@@ -206,20 +206,10 @@ final class ConjunctionDISI extends DocIdSetIterator {
   }
 
   @Override
-  public int docID() {
-    return lead1.docID();
-  }
-
-  @Override
   public int nextDoc() throws IOException {
     assert assertItersOnSameDoc()
         : "Sub-iterators of ConjunctionDISI are not on the same document!";
     return doNext(lead1.nextDoc());
-  }
-
-  @Override
-  public long cost() {
-    return lead1.cost(); // overestimate
   }
 
   // Returns {@code true} if all sub-iterators are on the same doc ID, {@code false} otherwise
@@ -233,7 +223,7 @@ final class ConjunctionDISI extends DocIdSetIterator {
   }
 
   /** Conjunction between a {@link DocIdSetIterator} and one or more {@link BitSetIterator}s. */
-  private static class BitSetConjunctionDISI extends DocIdSetIterator {
+  private static class BitSetConjunctionDISI extends FilterDocIdSetIterator {
 
     private final DocIdSetIterator lead;
     private final BitSetIterator[] bitSetIterators;
@@ -241,6 +231,7 @@ final class ConjunctionDISI extends DocIdSetIterator {
     private final int minLength;
 
     BitSetConjunctionDISI(DocIdSetIterator lead, Collection<BitSetIterator> bitSetIterators) {
+      super(lead);
       this.lead = lead;
       assert bitSetIterators.size() > 0;
 
@@ -255,11 +246,6 @@ final class ConjunctionDISI extends DocIdSetIterator {
         minLen = Math.min(minLen, bitSet.length());
       }
       this.minLength = minLen;
-    }
-
-    @Override
-    public int docID() {
-      return lead.docID();
     }
 
     @Override
@@ -295,11 +281,6 @@ final class ConjunctionDISI extends DocIdSetIterator {
         }
         return doc;
       }
-    }
-
-    @Override
-    public long cost() {
-      return lead.cost();
     }
 
     // Returns {@code true} if all sub-iterators are on the same doc ID, {@code false} otherwise

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionDISIApproximation.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionDISIApproximation.java
@@ -29,7 +29,7 @@ import org.apache.lucene.util.FixedBitSet;
  *
  * @lucene.internal
  */
-public final class DisjunctionDISIApproximation extends DocIdSetIterator {
+public final class DisjunctionDISIApproximation extends AbstractDocIdSetIterator {
 
   public static DisjunctionDISIApproximation of(
       Collection<? extends DisiWrapper> subIterators, long leadCost) {
@@ -112,11 +112,6 @@ public final class DisjunctionDISIApproximation extends DocIdSetIterator {
   }
 
   @Override
-  public int docID() {
-    return Math.min(minOtherDoc, leadTop.doc);
-  }
-
-  @Override
   public int nextDoc() throws IOException {
     if (leadTop.doc < minOtherDoc) {
       int curDoc = leadTop.doc;
@@ -124,7 +119,7 @@ public final class DisjunctionDISIApproximation extends DocIdSetIterator {
         leadTop.doc = leadTop.approximation.nextDoc();
         leadTop = leadIterators.updateTop();
       } while (leadTop.doc == curDoc);
-      return Math.min(leadTop.doc, minOtherDoc);
+      return doc = Math.min(leadTop.doc, minOtherDoc);
     } else {
       return advance(minOtherDoc + 1);
     }
@@ -145,7 +140,7 @@ public final class DisjunctionDISIApproximation extends DocIdSetIterator {
       minOtherDoc = Math.min(minOtherDoc, w.doc);
     }
 
-    return Math.min(leadTop.doc, minOtherDoc);
+    return doc = Math.min(leadTop.doc, minOtherDoc);
   }
 
   @Override
@@ -162,6 +157,8 @@ public final class DisjunctionDISIApproximation extends DocIdSetIterator {
       w.doc = w.approximation.docID();
       minOtherDoc = Math.min(minOtherDoc, w.doc);
     }
+
+    doc = Math.min(leadTop.doc, minOtherDoc);
   }
 
   /** Return the linked list of iterators positioned on the current doc. */

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdSetIterator.java
@@ -61,13 +61,7 @@ public abstract class DocIdSetIterator {
 
   /** A {@link DocIdSetIterator} that matches all documents up to {@code maxDoc - 1}. */
   public static DocIdSetIterator all(int maxDoc) {
-    return new DocIdSetIterator() {
-      int doc = -1;
-
-      @Override
-      public int docID() {
-        return doc;
-      }
+    return new AbstractDocIdSetIterator() {
 
       @Override
       public int nextDoc() {
@@ -117,13 +111,7 @@ public abstract class DocIdSetIterator {
     if (minDoc < 0) {
       throw new IllegalArgumentException("minDoc must be >= 0 but got minDoc=" + minDoc);
     }
-    return new DocIdSetIterator() {
-      private int doc = -1;
-
-      @Override
-      public int docID() {
-        return doc;
-      }
+    return new AbstractDocIdSetIterator() {
 
       @Override
       public int nextDoc() {

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
@@ -57,15 +57,13 @@ public final class DocValuesRangeIterator extends TwoPhaseIterator {
     this.innerTwoPhase = twoPhase;
   }
 
-  abstract static class Approximation extends DocIdSetIterator {
+  abstract static class Approximation extends AbstractDocIdSetIterator {
 
     private final DocIdSetIterator innerApproximation;
 
     protected final DocValuesSkipper skipper;
     protected final long lowerValue;
     protected final long upperValue;
-
-    private int doc = -1;
 
     // Track a decision for all doc IDs between the current doc ID and upTo inclusive.
     Match match = Match.MAYBE;
@@ -80,11 +78,6 @@ public final class DocValuesRangeIterator extends TwoPhaseIterator {
       this.skipper = skipper;
       this.lowerValue = lowerValue;
       this.upperValue = upperValue;
-    }
-
-    @Override
-    public int docID() {
-      return doc;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/FilteredDocIdSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FilteredDocIdSetIterator.java
@@ -22,9 +22,8 @@ import java.io.IOException;
  * Abstract decorator class of a DocIdSetIterator implementation that provides on-demand
  * filter/validation mechanism on an underlying DocIdSetIterator.
  */
-public abstract class FilteredDocIdSetIterator extends DocIdSetIterator {
+public abstract class FilteredDocIdSetIterator extends AbstractDocIdSetIterator {
   protected DocIdSetIterator _innerIter;
-  private int doc;
 
   /**
    * Constructor.
@@ -52,11 +51,6 @@ public abstract class FilteredDocIdSetIterator extends DocIdSetIterator {
    * @see #FilteredDocIdSetIterator(DocIdSetIterator)
    */
   protected abstract boolean match(int doc) throws IOException;
-
-  @Override
-  public int docID() {
-    return doc;
-  }
 
   @Override
   public int nextDoc() throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/search/ImpactsDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ImpactsDISI.java
@@ -25,9 +25,8 @@ import java.io.IOException;
  *
  * @lucene.internal
  */
-public final class ImpactsDISI extends DocIdSetIterator {
+public final class ImpactsDISI extends FilterDocIdSetIterator {
 
-  private final DocIdSetIterator in;
   private final MaxScoreCache maxScoreCache;
   private float minCompetitiveScore = 0;
   private int upTo = DocIdSetIterator.NO_MORE_DOCS;
@@ -40,7 +39,7 @@ public final class ImpactsDISI extends DocIdSetIterator {
    * @param maxScoreCache the cache of maximum scores, typically computed from the same ImpactsEnum
    */
   public ImpactsDISI(DocIdSetIterator in, MaxScoreCache maxScoreCache) {
-    this.in = in;
+    super(in);
     this.maxScoreCache = maxScoreCache;
   }
 
@@ -111,15 +110,5 @@ public final class ImpactsDISI extends DocIdSetIterator {
       return in.nextDoc();
     }
     return advance(in.docID() + 1);
-  }
-
-  @Override
-  public int docID() {
-    return in.docID();
-  }
-
-  @Override
-  public long cost() {
-    return in.cost();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -685,12 +685,10 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
    * A doc ID set iterator that wraps a delegate iterator and only returns doc IDs in the range
    * [firstDocInclusive, lastDoc).
    */
-  private static class BoundedDocIdSetIterator extends DocIdSetIterator {
+  private static class BoundedDocIdSetIterator extends AbstractDocIdSetIterator {
     private final int firstDoc;
     private final int lastDoc;
     private final DocIdSetIterator delegate;
-
-    private int docID = -1;
 
     BoundedDocIdSetIterator(int firstDoc, int lastDoc, DocIdSetIterator delegate) {
       assert delegate != null;
@@ -700,13 +698,8 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
     }
 
     @Override
-    public int docID() {
-      return docID;
-    }
-
-    @Override
     public int nextDoc() throws IOException {
-      return advance(docID + 1);
+      return advance(doc + 1);
     }
 
     @Override
@@ -717,11 +710,11 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
 
       int result = delegate.advance(target);
       if (result < lastDoc) {
-        docID = result;
+        doc = result;
       } else {
-        docID = NO_MORE_DOCS;
+        doc = NO_MORE_DOCS;
       }
-      return docID;
+      return doc;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/ReqOptSumScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ReqOptSumScorer.java
@@ -73,7 +73,7 @@ class ReqOptSumScorer extends Scorer {
       optScorer.advanceShallow(0);
       this.reqMaxScore = reqScorer.getMaxScore(NO_MORE_DOCS);
       this.approximation =
-          new DocIdSetIterator() {
+          new FilterDocIdSetIterator(reqApproximation) {
             int upTo = -1;
             float maxScore;
 
@@ -162,16 +162,6 @@ class ReqOptSumScorer extends Scorer {
                   }
                 }
               }
-            }
-
-            @Override
-            public int docID() {
-              return reqApproximation.docID();
-            }
-
-            @Override
-            public long cost() {
-              return reqApproximation.cost();
             }
           };
     }

--- a/lucene/core/src/java/org/apache/lucene/search/TwoPhaseIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TwoPhaseIterator.java
@@ -53,44 +53,33 @@ public abstract class TwoPhaseIterator {
     }
   }
 
-  private static class TwoPhaseIteratorAsDocIdSetIterator extends DocIdSetIterator {
+  private static class TwoPhaseIteratorAsDocIdSetIterator extends FilterDocIdSetIterator {
 
     final TwoPhaseIterator twoPhaseIterator;
-    final DocIdSetIterator approximation;
 
     TwoPhaseIteratorAsDocIdSetIterator(TwoPhaseIterator twoPhaseIterator) {
+      super(twoPhaseIterator.approximation());
       this.twoPhaseIterator = twoPhaseIterator;
-      this.approximation = twoPhaseIterator.approximation;
-    }
-
-    @Override
-    public int docID() {
-      return approximation.docID();
     }
 
     @Override
     public int nextDoc() throws IOException {
-      return doNext(approximation.nextDoc());
+      return doNext(in.nextDoc());
     }
 
     @Override
     public int advance(int target) throws IOException {
-      return doNext(approximation.advance(target));
+      return doNext(in.advance(target));
     }
 
     private int doNext(int doc) throws IOException {
-      for (; ; doc = approximation.nextDoc()) {
+      for (; ; doc = in.nextDoc()) {
         if (doc == NO_MORE_DOCS) {
           return NO_MORE_DOCS;
         } else if (twoPhaseIterator.matches()) {
           return doc;
         }
       }
-    }
-
-    @Override
-    public long cost() {
-      return approximation.cost();
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
@@ -19,6 +19,7 @@ package org.apache.lucene.search.comparators;
 
 import java.io.IOException;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.LeafFieldComparator;
@@ -131,17 +132,15 @@ public class DocComparator extends FieldComparator<Integer> {
       if (enableSkipping == false) {
         return null;
       } else {
-        return new DocIdSetIterator() {
-          private int docID = competitiveIterator.docID();
+        return new AbstractDocIdSetIterator() {
 
-          @Override
-          public int nextDoc() throws IOException {
-            return advance(docID + 1);
+          {
+            doc = competitiveIterator.docID();
           }
 
           @Override
-          public int docID() {
-            return docID;
+          public int nextDoc() throws IOException {
+            return advance(doc + 1);
           }
 
           @Override
@@ -151,7 +150,7 @@ public class DocComparator extends FieldComparator<Integer> {
 
           @Override
           public int advance(int target) throws IOException {
-            return docID = competitiveIterator.advance(target);
+            return doc = competitiveIterator.advance(target);
           }
         };
       }

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/MinDocIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/MinDocIterator.java
@@ -18,22 +18,16 @@
 package org.apache.lucene.search.comparators;
 
 import java.io.IOException;
-import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 
 /** Docs iterator that starts iterating from a configurable minimum document */
-public class MinDocIterator extends DocIdSetIterator {
+public class MinDocIterator extends AbstractDocIdSetIterator {
   final int segmentMinDoc;
   final int maxDoc;
-  int doc = -1;
 
   MinDocIterator(int segmentMinDoc, int maxDoc) {
     this.segmentMinDoc = segmentMinDoc;
     this.maxDoc = maxDoc;
-  }
-
-  @Override
-  public int docID() {
-    return doc;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.LeafFieldComparator;
@@ -405,17 +406,15 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     @Override
     public DocIdSetIterator competitiveIterator() {
       if (enableSkipping == false) return null;
-      return new DocIdSetIterator() {
-        private int docID = competitiveIterator.docID();
+      return new AbstractDocIdSetIterator() {
 
-        @Override
-        public int nextDoc() throws IOException {
-          return advance(docID + 1);
+        {
+          doc = competitiveIterator.docID();
         }
 
         @Override
-        public int docID() {
-          return docID;
+        public int nextDoc() throws IOException {
+          return advance(doc + 1);
         }
 
         @Override
@@ -425,18 +424,18 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
 
         @Override
         public int advance(int target) throws IOException {
-          return docID = competitiveIterator.advance(target);
+          return doc = competitiveIterator.advance(target);
         }
 
         @Override
         public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
           // The competitive iterator is usually a BitSetIterator, which has an optimized
           // implementation of #intoBitSet.
-          if (competitiveIterator.docID() < docID) {
-            competitiveIterator.advance(docID);
+          if (competitiveIterator.docID() < doc) {
+            competitiveIterator.advance(doc);
           }
           competitiveIterator.intoBitSet(upTo, bitSet, offset);
-          docID = competitiveIterator.docID();
+          doc = competitiveIterator.docID();
         }
       };
     }

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
@@ -26,6 +26,7 @@ import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.IndexSearcher;
@@ -467,7 +468,7 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
 
   private record PostingsEnumAndOrd(PostingsEnum postings, int ord) {}
 
-  private class CompetitiveIterator extends DocIdSetIterator {
+  private class CompetitiveIterator extends AbstractDocIdSetIterator {
 
     private static final int MAX_TERMS = 1024;
 
@@ -476,7 +477,6 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
     private final String field;
     private final boolean dense;
     private final TermsEnum docValuesTerms;
-    private int doc = -1;
     private ArrayDeque<PostingsEnumAndOrd> postings;
     private DocIdSetIterator docsWithField;
     private PriorityQueue<PostingsEnumAndOrd> disjunction;
@@ -488,11 +488,6 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
       this.field = field;
       this.dense = dense;
       this.docValuesTerms = docValuesTerms;
-    }
-
-    @Override
-    public int docID() {
-      return doc;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/BitSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitSetIterator.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.util;
 
 import java.io.IOException;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.DocIdSetIterator;
 
 /**
@@ -24,7 +25,7 @@ import org.apache.lucene.search.DocIdSetIterator;
  *
  * @lucene.internal
  */
-public class BitSetIterator extends DocIdSetIterator {
+public class BitSetIterator extends AbstractDocIdSetIterator {
 
   private static <T extends BitSet> T getBitSet(
       DocIdSetIterator iterator, Class<? extends T> clazz) {
@@ -53,7 +54,6 @@ public class BitSetIterator extends DocIdSetIterator {
   private final BitSet bits;
   private final int length;
   private final long cost;
-  private int doc = -1;
 
   /** Sole constructor. */
   public BitSetIterator(BitSet bits, long cost) {
@@ -68,11 +68,6 @@ public class BitSetIterator extends DocIdSetIterator {
   /** Return the wrapped {@link BitSet}. */
   public BitSet getBitSet() {
     return bits;
-  }
-
-  @Override
-  public int docID() {
-    return doc;
   }
 
   /** Set the current doc id that this iterator is on. */

--- a/lucene/core/src/java/org/apache/lucene/util/DocBaseBitSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocBaseBitSetIterator.java
@@ -17,19 +17,19 @@
 package org.apache.lucene.util;
 
 import java.io.IOException;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.DocIdSetIterator;
 
 /**
- * A {@link DocIdSetIterator} like {@link BitSetIterator} but has a doc base in onder to avoid
+ * A {@link DocIdSetIterator} like {@link BitSetIterator} but has a doc base in order to avoid
  * storing previous 0s.
  */
-public class DocBaseBitSetIterator extends DocIdSetIterator {
+public class DocBaseBitSetIterator extends AbstractDocIdSetIterator {
 
   private final FixedBitSet bits;
   private final int length;
   private final long cost;
   private final int docBase;
-  private int doc = -1;
 
   public DocBaseBitSetIterator(FixedBitSet bits, long cost, int docBase) {
     if (cost < 0) {
@@ -52,11 +52,6 @@ public class DocBaseBitSetIterator extends DocIdSetIterator {
    */
   public FixedBitSet getBitSet() {
     return bits;
-  }
-
-  @Override
-  public int docID() {
-    return doc;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/IntArrayDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntArrayDocIdSet.java
@@ -18,6 +18,7 @@ package org.apache.lucene.util;
 
 import java.io.IOException;
 import java.util.Arrays;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -59,21 +60,15 @@ final class IntArrayDocIdSet extends DocIdSet {
     return new IntArrayDocIdSetIterator(docs, length);
   }
 
-  static class IntArrayDocIdSetIterator extends DocIdSetIterator {
+  static class IntArrayDocIdSetIterator extends AbstractDocIdSetIterator {
 
     private final int[] docs;
     private final int length;
     private int i = 0;
-    private int doc = -1;
 
     IntArrayDocIdSetIterator(int[] docs, int length) {
       this.docs = docs;
       this.length = length;
-    }
-
-    @Override
-    public int docID() {
-      return doc;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/NotDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/NotDocIdSet.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.util;
 
 import java.io.IOException;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -48,9 +49,8 @@ public final class NotDocIdSet extends DocIdSet {
   @Override
   public DocIdSetIterator iterator() {
     final DocIdSetIterator inIterator = in.iterator();
-    return new DocIdSetIterator() {
+    return new AbstractDocIdSetIterator() {
 
-      int doc = -1;
       int nextSkippedDoc = -1;
 
       @Override
@@ -75,11 +75,6 @@ public final class NotDocIdSet extends DocIdSet {
           doc += 1;
           nextSkippedDoc = inIterator.nextDoc();
         }
-      }
-
-      @Override
-      public int docID() {
-        return doc;
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.util;
 
 import java.io.IOException;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -168,10 +169,9 @@ public class RoaringDocIdSet extends DocIdSet {
 
     @Override
     public DocIdSetIterator iterator() {
-      return new DocIdSetIterator() {
+      return new AbstractDocIdSetIterator() {
 
         int i = -1; // this is the index of the current document in the array
-        int doc = -1;
 
         private int docId(int i) {
           return docIDs[i] & 0xFFFF;
@@ -183,11 +183,6 @@ public class RoaringDocIdSet extends DocIdSet {
             return doc = NO_MORE_DOCS;
           }
           return doc = docId(i);
-        }
-
-        @Override
-        public int docID() {
-          return doc;
         }
 
         @Override
@@ -264,21 +259,14 @@ public class RoaringDocIdSet extends DocIdSet {
     return new Iterator();
   }
 
-  private class Iterator extends DocIdSetIterator {
+  private class Iterator extends AbstractDocIdSetIterator {
 
     int block;
     DocIdSetIterator sub;
-    int doc;
 
     Iterator() {
-      doc = -1;
       block = -1;
       sub = DocIdSetIterator.empty();
-    }
-
-    @Override
-    public int docID() {
-      return doc;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.ArrayUtil;
@@ -1027,12 +1028,11 @@ public class BKDReader extends PointValues {
   }
 
   /** Reusable {@link DocIdSetIterator} to handle low cardinality leaves. */
-  private static class BKDReaderDocIDSetIterator extends DocIdSetIterator {
+  private static class BKDReaderDocIDSetIterator extends AbstractDocIdSetIterator {
 
     private int idx;
     private int length;
     private int offset;
-    private int docID;
     final int[] docIDs;
     private final DocIdsWriter docIdsWriter;
 
@@ -1041,28 +1041,23 @@ public class BKDReader extends PointValues {
       this.docIdsWriter = new DocIdsWriter(maxPointsInLeafNode, version);
     }
 
-    @Override
-    public int docID() {
-      return docID;
-    }
-
     private void reset(int offset, int length) {
       this.offset = offset;
       this.length = length;
       assert offset + length <= docIDs.length;
-      this.docID = -1;
+      this.doc = -1;
       this.idx = 0;
     }
 
     @Override
     public int nextDoc() throws IOException {
       if (idx == length) {
-        docID = DocIdSetIterator.NO_MORE_DOCS;
+        doc = DocIdSetIterator.NO_MORE_DOCS;
       } else {
-        docID = docIDs[offset + idx];
+        doc = docIDs[offset + idx];
         idx++;
       }
-      return docID;
+      return doc;
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/search/IntArrayDocIdSet.java
+++ b/lucene/core/src/test/org/apache/lucene/search/IntArrayDocIdSet.java
@@ -45,14 +45,8 @@ class IntArrayDocIdSet extends DocIdSet {
 
   @Override
   public DocIdSetIterator iterator() {
-    return new DocIdSetIterator() {
+    return new AbstractDocIdSetIterator() {
       int i = 0;
-      int doc = -1;
-
-      @Override
-      public int docID() {
-        return doc;
-      }
 
       @Override
       public int nextDoc() {

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetUtils.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetUtils.java
@@ -19,6 +19,7 @@ package org.apache.lucene.facet;
 
 import java.io.IOException;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FilterDocIdSetIterator;
 import org.apache.lucene.util.Bits;
 
 /**
@@ -50,12 +51,7 @@ public final class FacetUtils {
    */
   public static DocIdSetIterator liveDocsDISI(DocIdSetIterator it, Bits liveDocs) {
 
-    return new DocIdSetIterator() {
-      @Override
-      public int docID() {
-        return it.docID();
-      }
-
+    return new FilterDocIdSetIterator(it) {
       private int doNext(int doc) throws IOException {
         assert doc == it.docID();
         // Find next document that is not deleted until we exhaust all documents
@@ -73,11 +69,6 @@ public final class FacetUtils {
       @Override
       public int advance(int target) throws IOException {
         return doNext(it.advance(target));
-      }
-
-      @Override
-      public long cost() {
-        return it.cost();
       }
     };
   }

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestToParentJoinKnnResults.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestToParentJoinKnnResults.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BitSet;
@@ -110,21 +110,15 @@ public class TestToParentJoinKnnResults extends LuceneTestCase {
     }
   }
 
-  static class IntArrayDocIdSetIterator extends DocIdSetIterator {
+  static class IntArrayDocIdSetIterator extends AbstractDocIdSetIterator {
 
     private final int[] docs;
     private final int length;
     private int i = 0;
-    private int doc = -1;
 
     IntArrayDocIdSetIterator(int[] docs, int length) {
       this.docs = docs;
       this.length = length;
-    }
-
-    @Override
-    public int docID() {
-      return doc;
     }
 
     @Override

--- a/lucene/queries/src/test/org/apache/lucene/queries/spans/AssertingSpans.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/spans/AssertingSpans.java
@@ -18,6 +18,7 @@ package org.apache.lucene.queries.spans;
 
 import java.io.IOException;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FilterDocIdSetIterator;
 import org.apache.lucene.search.TwoPhaseIterator;
 
 /** Wraps a Spans with additional asserts */
@@ -246,11 +247,10 @@ class AssertingSpans extends Spans {
     }
   }
 
-  class AssertingDISI extends DocIdSetIterator {
-    final DocIdSetIterator in;
+  class AssertingDISI extends FilterDocIdSetIterator {
 
     AssertingDISI(DocIdSetIterator in) {
-      this.in = in;
+      super(in);
     }
 
     @Override
@@ -287,11 +287,6 @@ class AssertingSpans extends Spans {
       }
       doc = advanced;
       return docID();
-    }
-
-    @Override
-    public long cost() {
-      return in.cost();
     }
   }
 }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerScorer.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/QueryProfilerScorer.java
@@ -20,6 +20,7 @@ package org.apache.lucene.sandbox.search;
 import java.io.IOException;
 import java.util.Collection;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FilterDocIdSetIterator;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
 
@@ -73,7 +74,7 @@ class QueryProfilerScorer extends Scorer {
   @Override
   public DocIdSetIterator iterator() {
     final DocIdSetIterator in = scorer.iterator();
-    return new DocIdSetIterator() {
+    return new FilterDocIdSetIterator(in) {
 
       @Override
       public int advance(int target) throws IOException {
@@ -93,16 +94,6 @@ class QueryProfilerScorer extends Scorer {
         } finally {
           nextDocTimer.stop();
         }
-      }
-
-      @Override
-      public int docID() {
-        return in.docID();
-      }
-
-      @Override
-      public long cost() {
-        return in.cost();
       }
     };
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import org.apache.lucene.search.CheckedIntConsumer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.DocIdStream;
+import org.apache.lucene.search.FilterDocIdSetIterator;
 import org.apache.lucene.search.FilterLeafCollector;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
@@ -75,23 +76,13 @@ class AssertingLeafCollector extends FilterLeafCollector {
     if (in == null) {
       return null;
     }
-    return new DocIdSetIterator() {
+    return new FilterDocIdSetIterator(in) {
 
       @Override
       public int nextDoc() throws IOException {
         assert in.docID() < max
             : "advancing beyond the end of the scored window: docID=" + in.docID() + ", max=" + max;
         return in.nextDoc();
-      }
-
-      @Override
-      public int docID() {
-        return in.docID();
-      }
-
-      @Override
-      public long cost() {
-        return in.cost();
       }
 
       @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingScorer.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingScorer.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Random;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FilterDocIdSetIterator;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
@@ -148,7 +149,7 @@ public class AssertingScorer extends Scorer {
   public DocIdSetIterator iterator() {
     final DocIdSetIterator in = this.in.iterator();
     assert in != null;
-    return new DocIdSetIterator() {
+    return new FilterDocIdSetIterator(in) {
 
       @Override
       public int docID() {
@@ -190,11 +191,6 @@ public class AssertingScorer extends Scorer {
       }
 
       @Override
-      public long cost() {
-        return in.cost();
-      }
-
-      @Override
       public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
         assert docID() != -1;
         assert offset <= docID();
@@ -221,12 +217,7 @@ public class AssertingScorer extends Scorer {
     final DocIdSetIterator inApproximation = in.approximation();
     assert inApproximation.docID() == doc;
     final DocIdSetIterator assertingApproximation =
-        new DocIdSetIterator() {
-
-          @Override
-          public int docID() {
-            return inApproximation.docID();
-          }
+        new FilterDocIdSetIterator(inApproximation) {
 
           @Override
           public int nextDoc() throws IOException {
@@ -257,11 +248,6 @@ public class AssertingScorer extends Scorer {
             }
             assert inApproximation.docID() == advanced;
             return doc = advanced;
-          }
-
-          @Override
-          public long cost() {
-            return inApproximation.cost();
           }
         };
     return new TwoPhaseIterator(assertingApproximation) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/RandomApproximationQuery.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/RandomApproximationQuery.java
@@ -20,6 +20,7 @@ import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import java.io.IOException;
 import java.util.Random;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.AbstractDocIdSetIterator;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FilterWeight;
 import org.apache.lucene.search.IndexSearcher;
@@ -193,21 +194,14 @@ public class RandomApproximationQuery extends Query {
     }
   }
 
-  private static class RandomApproximation extends DocIdSetIterator {
+  private static class RandomApproximation extends AbstractDocIdSetIterator {
 
     private final Random random;
     private final DocIdSetIterator disi;
 
-    int doc = -1;
-
     public RandomApproximation(Random random, DocIdSetIterator disi) {
       this.random = random;
       this.disi = disi;
-    }
-
-    @Override
-    public int docID() {
-      return doc;
     }
 
     @Override


### PR DESCRIPTION
This introduces a new `AbstractDocIdSetIterator` abstract class that tracks the current doc IDs and refactors several `DocIdSetIterator` implementations to extend either this `AbstractDocIdSetIterator` or `FilterDocIdSetIterator`, in order to reduce polymorphism of call sites of `DocIdSetIterator#docID()`.
