### PR TITLE
tests: set a socket timeout on replicator tests

### DIFF
--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/Connection.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/Connection.java
@@ -41,6 +41,7 @@ class Connection implements Closeable {
   public Connection(int tcpPort) throws IOException {
     this.destTCPPort = tcpPort;
     this.s = new Socket(InetAddress.getLoopbackAddress(), tcpPort);
+    this.s.setSoTimeout(30000);
     this.sockIn = s.getInputStream();
     this.in = new InputStreamDataInput(sockIn);
     this.bos = new BufferedOutputStream(s.getOutputStream());


### PR DESCRIPTION
These nightly tests sometimes hang and are killed by timeout, instead of passing or failing. Upon inspection of one of the failures, the hung thread is stuck in `SocketDispatcher.read0()` native code, presumably waiting for bytes that will never appear.

Instead, set a socket timeout for these tests, so that infinite hangs (of this sort) will no longer happen: they may become failures instead. Failures are better than hangs for many reasons.

Relates: #14454

