### PR TITLE
Add an IndexDeletion policy that retains the last N commits

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -67,7 +67,7 @@ New Features
 
 Improvements
 ---------------------
-(No changes)
+* GITHUB#14458 : Add an IndexDeletion policy that retains the last N commits. (Owais Kazi)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/index/KeepLastNCommitsDeletionPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/KeepLastNCommitsDeletionPolicy.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * This {@link IndexDeletionPolicy} implementation keeps the last N commits and removes all prior
+ * commits after a new commit is done. This policy can be useful for maintaining a history of recent
+ * commits while still managing index size.
+ */
+public class KeepLastNCommitsDeletionPolicy extends IndexDeletionPolicy {
+
+  private final int numCommitsToKeep;
+
+  /**
+   * Constructor that sets the number of commits to keep.
+   *
+   * @param numCommitsToKeep the number of most recent commits to retain
+   * @throws IllegalArgumentException if numCommitsToKeep is not positive
+   */
+  public KeepLastNCommitsDeletionPolicy(int numCommitsToKeep) {
+    if (numCommitsToKeep <= 0) {
+      throw new IllegalArgumentException("number of recent commits to keep must be positive");
+    }
+    this.numCommitsToKeep = numCommitsToKeep;
+  }
+
+  @Override
+  public void onInit(List<? extends IndexCommit> commits) throws IOException {
+    onCommit(commits);
+  }
+
+  /** Deletes all but the last N commits. */
+  @Override
+  public void onCommit(List<? extends IndexCommit> commits) throws IOException {
+    // The commits list is already sorted from oldest to newest
+    int size = commits.size();
+    for (int i = 0; i < size - numCommitsToKeep; i++) {
+      commits.get(i).delete();
+    }
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/index/TestDeletionPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDeletionPolicy.java
@@ -766,6 +766,45 @@ public class TestDeletionPolicy extends LuceneTestCase {
     }
   }
 
+  public void testKeepLastNCommitsDeletionPolicy() throws IOException {
+
+    int numCommitsToKeep = 3;
+    IndexWriterConfig conf = new IndexWriterConfig(new MockAnalyzer(random()));
+    conf.setIndexDeletionPolicy(new KeepLastNCommitsDeletionPolicy(numCommitsToKeep));
+
+    assertEquals(KeepLastNCommitsDeletionPolicy.class, conf.getIndexDeletionPolicy().getClass());
+
+    // Create an index and make several commits
+    Directory dir = newDirectory();
+    IndexWriter writer = new IndexWriter(dir, conf);
+
+    for (int i = 0; i < 5; i++) {
+      addDoc(writer);
+      writer.commit();
+    }
+
+    writer.close();
+
+    // Check that only the last N commits are kept
+    List<IndexCommit> commits = DirectoryReader.listCommits(dir);
+    assertEquals(numCommitsToKeep, commits.size());
+
+    // Verify that we can open and read from each of the remaining commits
+    for (IndexCommit commit : commits) {
+      try (DirectoryReader reader = DirectoryReader.open(commit)) {
+        assertTrue(reader.numDocs() > 0);
+      }
+    }
+
+    // Check that the retained commits are the most recent ones
+    long latestGen = commits.getLast().getGeneration();
+    for (int i = 0; i < numCommitsToKeep; i++) {
+      assertEquals(latestGen - i, commits.get(commits.size() - 1 - i).getGeneration());
+    }
+
+    dir.close();
+  }
+
   private void addDocWithID(IndexWriter writer, int id) throws IOException {
     Document doc = new Document();
     doc.add(newTextField("content", "aaa", Field.Store.NO));

--- a/lucene/core/src/test/org/apache/lucene/index/TestDeletionPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDeletionPolicy.java
@@ -805,6 +805,17 @@ public class TestDeletionPolicy extends LuceneTestCase {
     dir.close();
   }
 
+  public void testKeepLastNCommitsDeletionPolicyWithZeroCommits() throws IOException {
+    int numCommitsToKeep = 0;
+    IndexWriterConfig conf = new IndexWriterConfig(new MockAnalyzer(random()));
+    IllegalArgumentException expected =
+        expectThrows(
+            IllegalArgumentException.class,
+            () ->
+                conf.setIndexDeletionPolicy(new KeepLastNCommitsDeletionPolicy(numCommitsToKeep)));
+    assertTrue(expected.getMessage().contains("number of recent commits to keep must be positive"));
+  }
+
   private void addDocWithID(IndexWriter writer, int id) throws IOException {
     Document doc = new Document();
     doc.add(newTextField("content", "aaa", Field.Store.NO));


### PR DESCRIPTION
### Description
This change introduces a new IndexDeletion policy called as `KeepLastNCommitsDeletionPolicy` that retains the last N commits and removes all prior commits after a new commit is done.

Issue

Relates to https://github.com/apache/lucene/issues/14444
