### PR TITLE
deps: remove unused python 'six' dependency

### DIFF
--- a/dev-tools/scripts/requirements.txt
+++ b/dev-tools/scripts/requirements.txt
@@ -1,4 +1,3 @@
-six==1.16.0
 Jinja2==3.1.6
 PyYAML==6.0.2
 holidays==0.70


### PR DESCRIPTION
None of the python 2 compatibility functions provided by this library are in use.

