### PR TITLE
deps: configure dependabot to run weekly instead of daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
     commit-message:
       prefix: ci
     labels: [dependencies]
@@ -13,7 +14,8 @@ updates:
   - package-ecosystem: pip
     directory: /dev-tools/scripts/
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
     commit-message:
       prefix: build(deps)
     labels:


### PR DESCRIPTION
This should reduce noise and hassles as some packages such as pyright release quite often.

I thought the dependencies would put up more of a fight, but it seems to be in decent order.