### PR TITLE
Refactor doc values to expose a `DocIdSetIterator` instead of extending `DocIdSetIterator`.

### DIFF
--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80NormsProducer.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene80/Lucene80NormsProducer.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
@@ -142,40 +143,22 @@ final class Lucene80NormsProducer extends NormsProducer implements Cloneable {
 
   abstract static class DenseNormsIterator extends NumericDocValues {
 
-    final int maxDoc;
-    int doc = -1;
+    final DocIdSetIterator iterator;
 
     DenseNormsIterator(int maxDoc) {
-      this.maxDoc = maxDoc;
+      this.iterator = DocIdSetIterator.all(maxDoc);
     }
 
     @Override
-    public int docID() {
-      return doc;
-    }
-
-    @Override
-    public int nextDoc() throws IOException {
-      return advance(doc + 1);
-    }
-
-    @Override
-    public int advance(int target) throws IOException {
-      if (target >= maxDoc) {
-        return doc = NO_MORE_DOCS;
-      }
-      return doc = target;
+    public DocIdSetIterator iterator() {
+      return iterator;
     }
 
     @Override
     public boolean advanceExact(int target) throws IOException {
-      this.doc = target;
+      int r = iterator.advance(target);
+      assert r == target;
       return true;
-    }
-
-    @Override
-    public long cost() {
-      return maxDoc;
     }
   }
 
@@ -188,28 +171,13 @@ final class Lucene80NormsProducer extends NormsProducer implements Cloneable {
     }
 
     @Override
-    public int docID() {
-      return disi.docID();
-    }
-
-    @Override
-    public int nextDoc() throws IOException {
-      return disi.nextDoc();
-    }
-
-    @Override
-    public int advance(int target) throws IOException {
-      return disi.advance(target);
+    public DocIdSetIterator iterator() {
+      return disi;
     }
 
     @Override
     public boolean advanceExact(int target) throws IOException {
       return disi.advanceExact(target);
-    }
-
-    @Override
-    public long cost() {
-      return disi.cost();
     }
   }
 
@@ -387,28 +355,28 @@ final class Lucene80NormsProducer extends NormsProducer implements Cloneable {
           return new DenseNormsIterator(maxDoc) {
             @Override
             public long longValue() throws IOException {
-              return slice.readByte(doc);
+              return slice.readByte(iterator.docID());
             }
           };
         case 2:
           return new DenseNormsIterator(maxDoc) {
             @Override
             public long longValue() throws IOException {
-              return slice.readShort(((long) doc) << 1);
+              return slice.readShort(((long) iterator.docID()) << 1);
             }
           };
         case 4:
           return new DenseNormsIterator(maxDoc) {
             @Override
             public long longValue() throws IOException {
-              return slice.readInt(((long) doc) << 2);
+              return slice.readInt(((long) iterator.docID()) << 2);
             }
           };
         case 8:
           return new DenseNormsIterator(maxDoc) {
             @Override
             public long longValue() throws IOException {
-              return slice.readLong(((long) doc) << 3);
+              return slice.readLong(((long) iterator.docID()) << 3);
             }
           };
         default:

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextDocValuesWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextDocValuesWriter.java
@@ -37,6 +37,7 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FilterDocIdSetIterator;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
@@ -386,27 +387,22 @@ class SimpleTextDocValuesWriter extends DocValuesConsumer {
             return new BinaryDocValues() {
 
               @Override
-              public int nextDoc() throws IOException {
-                int doc = values.nextDoc();
-                setCurrentDoc();
-                return doc;
-              }
+              public DocIdSetIterator iterator() {
+                return new FilterDocIdSetIterator(values) {
+                  @Override
+                  public int nextDoc() throws IOException {
+                    int doc = values.nextDoc();
+                    setCurrentDoc();
+                    return doc;
+                  }
 
-              @Override
-              public int docID() {
-                return values.docID();
-              }
-
-              @Override
-              public long cost() {
-                return values.cost();
-              }
-
-              @Override
-              public int advance(int target) throws IOException {
-                int doc = values.advance(target);
-                setCurrentDoc();
-                return doc;
+                  @Override
+                  public int advance(int target) throws IOException {
+                    int doc = values.advance(target);
+                    setCurrentDoc();
+                    return doc;
+                  }
+                };
               }
 
               @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/DocValuesConsumer.java
@@ -42,6 +42,7 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.TermState;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
@@ -169,7 +170,7 @@ public abstract class DocValuesConsumer implements Closeable {
 
     @Override
     public int nextDoc() throws IOException {
-      return values.nextDoc();
+      return values.iterator().nextDoc();
     }
   }
 
@@ -227,34 +228,39 @@ public abstract class DocValuesConsumer implements Closeable {
       private NumericDocValuesSub current;
 
       @Override
-      public int docID() {
-        return docID;
-      }
+      public DocIdSetIterator iterator() {
+        return new DocIdSetIterator() {
+          @Override
+          public int docID() {
+            return docID;
+          }
 
-      @Override
-      public int nextDoc() throws IOException {
-        current = docIDMerger.next();
-        if (current == null) {
-          docID = NO_MORE_DOCS;
-        } else {
-          docID = current.mappedDocID;
-        }
-        return docID;
-      }
+          @Override
+          public int nextDoc() throws IOException {
+            current = docIDMerger.next();
+            if (current == null) {
+              docID = NO_MORE_DOCS;
+            } else {
+              docID = current.mappedDocID;
+            }
+            return docID;
+          }
 
-      @Override
-      public int advance(int target) throws IOException {
-        throw new UnsupportedOperationException();
+          @Override
+          public int advance(int target) throws IOException {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public long cost() {
+            return finalCost;
+          }
+        };
       }
 
       @Override
       public boolean advanceExact(int target) throws IOException {
         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public long cost() {
-        return finalCost;
       }
 
       @Override
@@ -326,34 +332,39 @@ public abstract class DocValuesConsumer implements Closeable {
               private int docID = -1;
 
               @Override
-              public int docID() {
-                return docID;
-              }
+              public DocIdSetIterator iterator() {
+                return new DocIdSetIterator() {
+                  @Override
+                  public int docID() {
+                    return docID;
+                  }
 
-              @Override
-              public int nextDoc() throws IOException {
-                current = docIDMerger.next();
-                if (current == null) {
-                  docID = NO_MORE_DOCS;
-                } else {
-                  docID = current.mappedDocID;
-                }
-                return docID;
-              }
+                  @Override
+                  public int nextDoc() throws IOException {
+                    current = docIDMerger.next();
+                    if (current == null) {
+                      docID = NO_MORE_DOCS;
+                    } else {
+                      docID = current.mappedDocID;
+                    }
+                    return docID;
+                  }
 
-              @Override
-              public int advance(int target) throws IOException {
-                throw new UnsupportedOperationException();
+                  @Override
+                  public int advance(int target) throws IOException {
+                    throw new UnsupportedOperationException();
+                  }
+
+                  @Override
+                  public long cost() {
+                    return finalCost;
+                  }
+                };
               }
 
               @Override
               public boolean advanceExact(int target) throws IOException {
                 throw new UnsupportedOperationException();
-              }
-
-              @Override
-              public long cost() {
-                return finalCost;
               }
 
               @Override
@@ -449,25 +460,35 @@ public abstract class DocValuesConsumer implements Closeable {
               private SortedNumericDocValuesSub currentSub;
 
               @Override
-              public int docID() {
-                return docID;
-              }
+              public DocIdSetIterator iterator() {
+                return new DocIdSetIterator() {
+                  @Override
+                  public int docID() {
+                    return docID;
+                  }
 
-              @Override
-              public int nextDoc() throws IOException {
-                currentSub = docIDMerger.next();
-                if (currentSub == null) {
-                  docID = NO_MORE_DOCS;
-                } else {
-                  docID = currentSub.mappedDocID;
-                }
+                  @Override
+                  public int nextDoc() throws IOException {
+                    currentSub = docIDMerger.next();
+                    if (currentSub == null) {
+                      docID = NO_MORE_DOCS;
+                    } else {
+                      docID = currentSub.mappedDocID;
+                    }
 
-                return docID;
-              }
+                    return docID;
+                  }
 
-              @Override
-              public int advance(int target) throws IOException {
-                throw new UnsupportedOperationException();
+                  @Override
+                  public int advance(int target) throws IOException {
+                    throw new UnsupportedOperationException();
+                  }
+
+                  @Override
+                  public long cost() {
+                    return finalCost;
+                  }
+                };
               }
 
               @Override
@@ -478,11 +499,6 @@ public abstract class DocValuesConsumer implements Closeable {
               @Override
               public int docValueCount() {
                 return currentSub.values.docValueCount();
-              }
-
-              @Override
-              public long cost() {
-                return finalCost;
               }
 
               @Override
@@ -703,19 +719,34 @@ public abstract class DocValuesConsumer implements Closeable {
       private SortedDocValuesSub current;
 
       @Override
-      public int docID() {
-        return docID;
-      }
+      public DocIdSetIterator iterator() {
+        return new DocIdSetIterator() {
+          @Override
+          public int docID() {
+            return docID;
+          }
 
-      @Override
-      public int nextDoc() throws IOException {
-        current = docIDMerger.next();
-        if (current == null) {
-          docID = NO_MORE_DOCS;
-        } else {
-          docID = current.mappedDocID;
-        }
-        return docID;
+          @Override
+          public int nextDoc() throws IOException {
+            current = docIDMerger.next();
+            if (current == null) {
+              docID = NO_MORE_DOCS;
+            } else {
+              docID = current.mappedDocID;
+            }
+            return docID;
+          }
+
+          @Override
+          public int advance(int target) {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public long cost() {
+            return finalCost;
+          }
+        };
       }
 
       @Override
@@ -726,18 +757,8 @@ public abstract class DocValuesConsumer implements Closeable {
       }
 
       @Override
-      public int advance(int target) {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
       public boolean advanceExact(int target) throws IOException {
         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public long cost() {
-        return finalCost;
       }
 
       @Override
@@ -902,25 +923,35 @@ public abstract class DocValuesConsumer implements Closeable {
               private SortedSetDocValuesSub currentSub;
 
               @Override
-              public int docID() {
-                return docID;
-              }
+              public DocIdSetIterator iterator() {
+                return new DocIdSetIterator() {
+                  @Override
+                  public int docID() {
+                    return docID;
+                  }
 
-              @Override
-              public int nextDoc() throws IOException {
-                currentSub = docIDMerger.next();
-                if (currentSub == null) {
-                  docID = NO_MORE_DOCS;
-                } else {
-                  docID = currentSub.mappedDocID;
-                }
+                  @Override
+                  public int nextDoc() throws IOException {
+                    currentSub = docIDMerger.next();
+                    if (currentSub == null) {
+                      docID = NO_MORE_DOCS;
+                    } else {
+                      docID = currentSub.mappedDocID;
+                    }
 
-                return docID;
-              }
+                    return docID;
+                  }
 
-              @Override
-              public int advance(int target) throws IOException {
-                throw new UnsupportedOperationException();
+                  @Override
+                  public int advance(int target) throws IOException {
+                    throw new UnsupportedOperationException();
+                  }
+
+                  @Override
+                  public long cost() {
+                    return finalCost;
+                  }
+                };
               }
 
               @Override
@@ -937,11 +968,6 @@ public abstract class DocValuesConsumer implements Closeable {
               @Override
               public int docValueCount() {
                 return currentSub.values.docValueCount();
-              }
-
-              @Override
-              public long cost() {
-                return finalCost;
               }
 
               @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/NormsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/NormsConsumer.java
@@ -25,6 +25,7 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.search.DocIdSetIterator;
 
 /**
  * Abstract API that consumes normalization values. Concrete implementations of this actually do
@@ -137,34 +138,40 @@ public abstract class NormsConsumer implements Closeable {
               private NumericDocValuesSub current;
 
               @Override
-              public int docID() {
-                return docID;
-              }
+              public DocIdSetIterator iterator() {
+                return new DocIdSetIterator() {
 
-              @Override
-              public int nextDoc() throws IOException {
-                current = docIDMerger.next();
-                if (current == null) {
-                  docID = NO_MORE_DOCS;
-                } else {
-                  docID = current.mappedDocID;
-                }
-                return docID;
-              }
+                  @Override
+                  public int docID() {
+                    return docID;
+                  }
 
-              @Override
-              public int advance(int target) throws IOException {
-                throw new UnsupportedOperationException();
+                  @Override
+                  public int nextDoc() throws IOException {
+                    current = docIDMerger.next();
+                    if (current == null) {
+                      docID = NO_MORE_DOCS;
+                    } else {
+                      docID = current.mappedDocID;
+                    }
+                    return docID;
+                  }
+
+                  @Override
+                  public int advance(int target) throws IOException {
+                    throw new UnsupportedOperationException();
+                  }
+
+                  @Override
+                  public long cost() {
+                    return 0;
+                  }
+                };
               }
 
               @Override
               public boolean advanceExact(int target) throws IOException {
                 throw new UnsupportedOperationException();
-              }
-
-              @Override
-              public long cost() {
-                return 0;
               }
 
               @Override

--- a/lucene/core/src/java/org/apache/lucene/document/BinaryRangeFieldRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/BinaryRangeFieldRangeQuery.java
@@ -120,7 +120,7 @@ abstract class BinaryRangeFieldRangeQuery extends Query {
         iterator =
             new TwoPhaseIterator(values) {
               @Override
-              public boolean matches() {
+              public boolean matches() throws IOException {
                 return queryType.matches(
                     queryPackedValue,
                     values.getPackedValue(),

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceFeatureQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceFeatureQuery.java
@@ -166,41 +166,26 @@ final class LatLonPointDistanceFeatureQuery extends Query {
         }
         return new NumericDocValues() {
 
+          int lastDoc = -1;
           long value;
 
           @Override
+          public DocIdSetIterator iterator() {
+            return multiDocValues;
+          }
+
+          @Override
           public long longValue() throws IOException {
+            if (lastDoc != multiDocValues.iterator().docID()) {
+              value = selectValue(multiDocValues);
+              lastDoc = multiDocValues.iterator().docID();
+            }
             return value;
           }
 
           @Override
           public boolean advanceExact(int target) throws IOException {
-            if (multiDocValues.advanceExact(target)) {
-              value = selectValue(multiDocValues);
-              return true;
-            } else {
-              return false;
-            }
-          }
-
-          @Override
-          public int docID() {
-            return multiDocValues.docID();
-          }
-
-          @Override
-          public int nextDoc() throws IOException {
-            return multiDocValues.nextDoc();
-          }
-
-          @Override
-          public int advance(int target) throws IOException {
-            return multiDocValues.advance(target);
-          }
-
-          @Override
-          public long cost() {
-            return multiDocValues.cost();
+            return multiDocValues.advanceExact(target);
           }
         };
       }

--- a/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
@@ -160,41 +160,26 @@ final class LongDistanceFeatureQuery extends Query {
         }
         return new NumericDocValues() {
 
+          int lastDoc = -1;
           long value;
 
           @Override
+          public DocIdSetIterator iterator() {
+            return multiDocValues.iterator();
+          }
+
+          @Override
           public long longValue() throws IOException {
+            if (lastDoc != multiDocValues.iterator().docID()) {
+              value = selectValue(multiDocValues);
+              lastDoc = multiDocValues.iterator().docID();
+            }
             return value;
           }
 
           @Override
           public boolean advanceExact(int target) throws IOException {
-            if (multiDocValues.advanceExact(target)) {
-              value = selectValue(multiDocValues);
-              return true;
-            } else {
-              return false;
-            }
-          }
-
-          @Override
-          public int docID() {
-            return multiDocValues.docID();
-          }
-
-          @Override
-          public int nextDoc() throws IOException {
-            return multiDocValues.nextDoc();
-          }
-
-          @Override
-          public int advance(int target) throws IOException {
-            return multiDocValues.advance(target);
-          }
-
-          @Override
-          public long cost() {
-            return multiDocValues.cost();
+            return multiDocValues.advanceExact(target);
           }
         };
       }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValues.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Arrays;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 
 /** This class contains utility methods and constants for DocValues */
@@ -26,35 +27,50 @@ public final class DocValues {
   /* no instantiation */
   private DocValues() {}
 
+  private static class EmptyDocIdSetIterator extends DocIdSetIterator {
+
+    private int doc = -1;
+
+    @Override
+    public int advance(int target) {
+      return doc = NO_MORE_DOCS;
+    }
+
+    public boolean advanceExact(int target) throws IOException {
+      doc = target;
+      return false;
+    }
+
+    @Override
+    public int docID() {
+      return doc;
+    }
+
+    @Override
+    public int nextDoc() {
+      return doc = NO_MORE_DOCS;
+    }
+
+    @Override
+    public long cost() {
+      return 0;
+    }
+  }
+
   /** An empty {@link BinaryDocValues} which returns no documents */
   public static final BinaryDocValues emptyBinary() {
     return new BinaryDocValues() {
-      private int doc = -1;
+
+      private final EmptyDocIdSetIterator iterator = new EmptyDocIdSetIterator();
 
       @Override
-      public int advance(int target) {
-        return doc = NO_MORE_DOCS;
+      public DocIdSetIterator iterator() {
+        return iterator;
       }
 
       @Override
       public boolean advanceExact(int target) throws IOException {
-        doc = target;
-        return false;
-      }
-
-      @Override
-      public int docID() {
-        return doc;
-      }
-
-      @Override
-      public int nextDoc() {
-        return doc = NO_MORE_DOCS;
-      }
-
-      @Override
-      public long cost() {
-        return 0;
+        return iterator.advanceExact(target);
       }
 
       @Override
@@ -68,32 +84,17 @@ public final class DocValues {
   /** An empty NumericDocValues which returns no documents */
   public static final NumericDocValues emptyNumeric() {
     return new NumericDocValues() {
-      private int doc = -1;
+
+      private final EmptyDocIdSetIterator iterator = new EmptyDocIdSetIterator();
 
       @Override
-      public int advance(int target) {
-        return doc = NO_MORE_DOCS;
+      public DocIdSetIterator iterator() {
+        return iterator;
       }
 
       @Override
       public boolean advanceExact(int target) throws IOException {
-        doc = target;
-        return false;
-      }
-
-      @Override
-      public int docID() {
-        return doc;
-      }
-
-      @Override
-      public int nextDoc() {
-        return doc = NO_MORE_DOCS;
-      }
-
-      @Override
-      public long cost() {
-        return 0;
+        return iterator.advanceExact(target);
       }
 
       @Override
@@ -109,32 +110,16 @@ public final class DocValues {
     final BytesRef empty = new BytesRef();
     return new SortedDocValues() {
 
-      private int doc = -1;
+      private final EmptyDocIdSetIterator iterator = new EmptyDocIdSetIterator();
 
       @Override
-      public int advance(int target) {
-        return doc = NO_MORE_DOCS;
+      public DocIdSetIterator iterator() {
+        return iterator;
       }
 
       @Override
       public boolean advanceExact(int target) throws IOException {
-        doc = target;
-        return false;
-      }
-
-      @Override
-      public int docID() {
-        return doc;
-      }
-
-      @Override
-      public int nextDoc() {
-        return doc = NO_MORE_DOCS;
-      }
-
-      @Override
-      public long cost() {
-        return 0;
+        return iterator.advanceExact(target);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesFieldUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesFieldUpdates.java
@@ -44,12 +44,7 @@ abstract class DocValuesFieldUpdates implements Accountable {
    * An iterator over documents and their updated values. Only documents with updates are returned
    * by this iterator, and the documents are returned in increasing order.
    */
-  abstract static class Iterator extends DocValuesIterator {
-
-    @Override
-    public final boolean advanceExact(int target) {
-      throw new UnsupportedOperationException();
-    }
+  abstract static class Iterator extends DocIdSetIterator {
 
     @Override
     public final int advance(int target) {
@@ -81,9 +76,10 @@ abstract class DocValuesFieldUpdates implements Accountable {
     /** Wraps the given iterator as a BinaryDocValues instance. */
     static BinaryDocValues asBinaryDocValues(Iterator iterator) {
       return new BinaryDocValues() {
+
         @Override
-        public int docID() {
-          return iterator.docID();
+        public DocIdSetIterator iterator() {
+          return iterator;
         }
 
         @Override
@@ -93,22 +89,7 @@ abstract class DocValuesFieldUpdates implements Accountable {
 
         @Override
         public boolean advanceExact(int target) {
-          return iterator.advanceExact(target);
-        }
-
-        @Override
-        public int nextDoc() {
-          return iterator.nextDoc();
-        }
-
-        @Override
-        public int advance(int target) {
-          return iterator.advance(target);
-        }
-
-        @Override
-        public long cost() {
-          return iterator.cost();
+          throw new UnsupportedOperationException();
         }
       };
     }
@@ -117,6 +98,11 @@ abstract class DocValuesFieldUpdates implements Accountable {
     static NumericDocValues asNumericDocValues(Iterator iterator) {
       return new NumericDocValues() {
         @Override
+        public DocIdSetIterator iterator() {
+          return iterator;
+        }
+
+        @Override
         public long longValue() {
           return iterator.longValue();
         }
@@ -124,26 +110,6 @@ abstract class DocValuesFieldUpdates implements Accountable {
         @Override
         public boolean advanceExact(int target) {
           throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public int docID() {
-          return iterator.docID();
-        }
-
-        @Override
-        public int nextDoc() {
-          return iterator.nextDoc();
-        }
-
-        @Override
-        public int advance(int target) {
-          return iterator.advance(target);
-        }
-
-        @Override
-        public long cost() {
-          return iterator.cost();
         }
       };
     }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
@@ -21,11 +21,62 @@ import org.apache.lucene.search.DocIdSetIterator;
 
 abstract class DocValuesIterator extends DocIdSetIterator {
 
+  /** Return an iterator for these doc values. */
+  public abstract DocIdSetIterator iterator();
+
   /**
    * Advance the iterator to exactly {@code target} and return whether {@code target} has a value.
    * {@code target} must be greater than or equal to the current {@link #docID() doc ID} and must be
-   * a valid doc ID, ie. &ge; 0 and &lt; {@code maxDoc}. After this method returns, {@link #docID()}
-   * returns {@code target}.
+   * a valid doc ID, ie. &ge; 0 and &lt; {@code maxDoc}. After this method returns, calling {@link
+   * #docID()} on the {@link #iterator()} returns {@code target}.
    */
   public abstract boolean advanceExact(int target) throws IOException;
+
+  /**
+   * Advance to the next document and return it.
+   *
+   * @see #iterator()
+   * @deprecated Call iterator().nextDoc() instead.
+   */
+  @Deprecated
+  @Override
+  public int nextDoc() throws IOException {
+    return iterator().nextDoc();
+  }
+
+  /**
+   * Advance to the next document on or after {@code target}.
+   *
+   * @see #iterator()
+   * @deprecated Call iterator().advance(target) instead.
+   */
+  @Deprecated
+  @Override
+  public int advance(int target) throws IOException {
+    return iterator().advance(target);
+  }
+
+  /**
+   * Return the current doc ID.
+   *
+   * @see #iterator()
+   * @deprecated Call iterator().docID() instead.
+   */
+  @Deprecated
+  @Override
+  public int docID() {
+    return iterator().docID();
+  }
+
+  /**
+   * Return the cost of this iterator.
+   *
+   * @see #iterator()
+   * @deprecated Call iterator().cost() instead.
+   */
+  @Deprecated
+  @Override
+  public long cost() {
+    return iterator().cost();
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/FilterBinaryDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterBinaryDocValues.java
@@ -19,6 +19,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Objects;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 
 /** Delegates all methods to a wrapped {@link BinaryDocValues}. */
@@ -34,28 +35,13 @@ public abstract class FilterBinaryDocValues extends BinaryDocValues {
   }
 
   @Override
-  public int docID() {
-    return in.docID();
-  }
-
-  @Override
-  public int nextDoc() throws IOException {
-    return in.nextDoc();
-  }
-
-  @Override
-  public int advance(int target) throws IOException {
-    return in.advance(target);
+  public DocIdSetIterator iterator() {
+    return in.iterator();
   }
 
   @Override
   public boolean advanceExact(int target) throws IOException {
     return in.advanceExact(target);
-  }
-
-  @Override
-  public long cost() {
-    return in.cost();
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/FilterNumericDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterNumericDocValues.java
@@ -19,6 +19,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Objects;
+import org.apache.lucene.search.DocIdSetIterator;
 
 /** Delegates all methods to a wrapped {@link NumericDocValues}. */
 public abstract class FilterNumericDocValues extends NumericDocValues {
@@ -33,28 +34,13 @@ public abstract class FilterNumericDocValues extends NumericDocValues {
   }
 
   @Override
-  public int docID() {
-    return in.docID();
-  }
-
-  @Override
-  public int nextDoc() throws IOException {
-    return in.nextDoc();
-  }
-
-  @Override
-  public int advance(int target) throws IOException {
-    return in.advance(target);
+  public DocIdSetIterator iterator() {
+    return in.iterator();
   }
 
   @Override
   public boolean advanceExact(int target) throws IOException {
     return in.advanceExact(target);
-  }
-
-  @Override
-  public long cost() {
-    return in.cost();
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/FilterSortedDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterSortedDocValues.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Objects;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 
@@ -31,6 +32,11 @@ public abstract class FilterSortedDocValues extends SortedDocValues {
   public FilterSortedDocValues(SortedDocValues in) {
     Objects.requireNonNull(in);
     this.in = in;
+  }
+
+  @Override
+  public DocIdSetIterator iterator() {
+    return in.iterator();
   }
 
   @Override
@@ -66,25 +72,5 @@ public abstract class FilterSortedDocValues extends SortedDocValues {
   @Override
   public TermsEnum intersect(CompiledAutomaton automaton) throws IOException {
     return in.intersect(automaton);
-  }
-
-  @Override
-  public int docID() {
-    return in.docID();
-  }
-
-  @Override
-  public int nextDoc() throws IOException {
-    return in.nextDoc();
-  }
-
-  @Override
-  public int advance(int target) throws IOException {
-    return in.advance(target);
-  }
-
-  @Override
-  public long cost() {
-    return in.cost();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/FilterSortedNumericDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterSortedNumericDocValues.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Objects;
+import org.apache.lucene.search.DocIdSetIterator;
 
 /** Delegates all methods to a wrapped {@link SortedNumericDocValues}. */
 public abstract class FilterSortedNumericDocValues extends SortedNumericDocValues {
@@ -29,6 +30,11 @@ public abstract class FilterSortedNumericDocValues extends SortedNumericDocValue
   public FilterSortedNumericDocValues(SortedNumericDocValues in) {
     Objects.requireNonNull(in);
     this.in = in;
+  }
+
+  @Override
+  public DocIdSetIterator iterator() {
+    return in.iterator();
   }
 
   @Override
@@ -44,25 +50,5 @@ public abstract class FilterSortedNumericDocValues extends SortedNumericDocValue
   @Override
   public int docValueCount() {
     return in.docValueCount();
-  }
-
-  @Override
-  public int docID() {
-    return in.docID();
-  }
-
-  @Override
-  public int nextDoc() throws IOException {
-    return in.nextDoc();
-  }
-
-  @Override
-  public int advance(int target) throws IOException {
-    return in.advance(target);
-  }
-
-  @Override
-  public long cost() {
-    return in.cost();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/FilterSortedSetDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterSortedSetDocValues.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Objects;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 
@@ -31,6 +32,11 @@ public class FilterSortedSetDocValues extends SortedSetDocValues {
   public FilterSortedSetDocValues(SortedSetDocValues in) {
     Objects.requireNonNull(in);
     this.in = in;
+  }
+
+  @Override
+  public DocIdSetIterator iterator() {
+    return in.iterator();
   }
 
   @Override
@@ -71,25 +77,5 @@ public class FilterSortedSetDocValues extends SortedSetDocValues {
   @Override
   public TermsEnum intersect(CompiledAutomaton automaton) throws IOException {
     return in.intersect(automaton);
-  }
-
-  @Override
-  public int docID() {
-    return in.docID();
-  }
-
-  @Override
-  public int nextDoc() throws IOException {
-    return in.nextDoc();
-  }
-
-  @Override
-  public int advance(int target) throws IOException {
-    return in.advance(target);
-  }
-
-  @Override
-  public long cost() {
-    return in.cost();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/NormValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NormValuesWriter.java
@@ -118,6 +118,11 @@ class NormValuesWriter {
     }
 
     @Override
+    public DocIdSetIterator iterator() {
+      return docsWithField;
+    }
+
+    @Override
     public int docID() {
       return docsWithField.docID();
     }

--- a/lucene/core/src/java/org/apache/lucene/index/SingletonSortedNumericDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SingletonSortedNumericDocValues.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import org.apache.lucene.search.DocIdSetIterator;
 
 /**
  * Exposes multi-valued view over a single-valued instance.
@@ -43,28 +44,13 @@ final class SingletonSortedNumericDocValues extends SortedNumericDocValues {
   }
 
   @Override
-  public int docID() {
-    return in.docID();
-  }
-
-  @Override
-  public int nextDoc() throws IOException {
-    return in.nextDoc();
-  }
-
-  @Override
-  public int advance(int target) throws IOException {
-    return in.advance(target);
+  public DocIdSetIterator iterator() {
+    return in.iterator();
   }
 
   @Override
   public boolean advanceExact(int target) throws IOException {
     return in.advanceExact(target);
-  }
-
-  @Override
-  public long cost() {
-    return in.cost();
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/SingletonSortedSetDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SingletonSortedSetDocValues.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -27,7 +28,6 @@ import org.apache.lucene.util.BytesRef;
  */
 final class SingletonSortedSetDocValues extends SortedSetDocValues {
   private final SortedDocValues in;
-  private long ord;
 
   /** Creates a multi-valued view over the provided SortedDocValues */
   public SingletonSortedSetDocValues(SortedDocValues in) {
@@ -46,13 +46,13 @@ final class SingletonSortedSetDocValues extends SortedSetDocValues {
   }
 
   @Override
-  public int docID() {
-    return in.docID();
+  public DocIdSetIterator iterator() {
+    return in.iterator();
   }
 
   @Override
-  public long nextOrd() {
-    return ord;
+  public long nextOrd() throws IOException {
+    return in.ordValue();
   }
 
   @Override
@@ -61,30 +61,8 @@ final class SingletonSortedSetDocValues extends SortedSetDocValues {
   }
 
   @Override
-  public int nextDoc() throws IOException {
-    int docID = in.nextDoc();
-    if (docID != NO_MORE_DOCS) {
-      ord = in.ordValue();
-    }
-    return docID;
-  }
-
-  @Override
-  public int advance(int target) throws IOException {
-    int docID = in.advance(target);
-    if (docID != NO_MORE_DOCS) {
-      ord = in.ordValue();
-    }
-    return docID;
-  }
-
-  @Override
   public boolean advanceExact(int target) throws IOException {
-    if (in.advanceExact(target)) {
-      ord = in.ordValue();
-      return true;
-    }
-    return false;
+    return in.advanceExact(target);
   }
 
   @Override
@@ -106,10 +84,5 @@ final class SingletonSortedSetDocValues extends SortedSetDocValues {
   @Override
   public TermsEnum termsEnum() throws IOException {
     return in.termsEnum();
-  }
-
-  @Override
-  public long cost() {
-    return in.cost();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/DoubleValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DoubleValuesSource.java
@@ -623,6 +623,12 @@ public abstract class DoubleValuesSource implements SegmentCacheable {
   private static NumericDocValues asNumericDocValues(
       DoubleValuesHolder in, DoubleToLongFunction converter) {
     return new NumericDocValues() {
+
+      @Override
+      public DocIdSetIterator iterator() {
+        throw new UnsupportedOperationException();
+      }
+
       @Override
       public long longValue() throws IOException {
         return converter.applyAsLong(in.values.doubleValue());
@@ -631,26 +637,6 @@ public abstract class DoubleValuesSource implements SegmentCacheable {
       @Override
       public boolean advanceExact(int target) throws IOException {
         return in.values.advanceExact(target);
-      }
-
-      @Override
-      public int docID() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public int nextDoc() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public int advance(int target) throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public long cost() {
-        throw new UnsupportedOperationException();
       }
     };
   }

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -58,19 +58,19 @@ public class FieldExistsQuery extends Query {
           iterator = null;
           break;
         case NUMERIC:
-          iterator = reader.getNumericDocValues(field);
+          iterator = reader.getNumericDocValues(field).iterator();
           break;
         case BINARY:
-          iterator = reader.getBinaryDocValues(field);
+          iterator = reader.getBinaryDocValues(field).iterator();
           break;
         case SORTED:
-          iterator = reader.getSortedDocValues(field);
+          iterator = reader.getSortedDocValues(field).iterator();
           break;
         case SORTED_NUMERIC:
-          iterator = reader.getSortedNumericDocValues(field);
+          iterator = reader.getSortedNumericDocValues(field).iterator();
           break;
         case SORTED_SET:
-          iterator = reader.getSortedSetDocValues(field);
+          iterator = reader.getSortedSetDocValues(field).iterator();
           break;
         default:
           throw new AssertionError();

--- a/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
@@ -380,6 +380,12 @@ public abstract class LongValuesSource implements SegmentCacheable {
 
   private static NumericDocValues asNumericDocValues(LongValuesHolder in) {
     return new NumericDocValues() {
+
+      @Override
+      public DocIdSetIterator iterator() {
+        throw new UnsupportedOperationException();
+      }
+
       @Override
       public long longValue() throws IOException {
         return in.values.longValue();
@@ -388,26 +394,6 @@ public abstract class LongValuesSource implements SegmentCacheable {
       @Override
       public boolean advanceExact(int target) throws IOException {
         return in.values.advanceExact(target);
-      }
-
-      @Override
-      public int docID() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public int nextDoc() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public int advance(int target) throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public long cost() {
-        throw new UnsupportedOperationException();
       }
     };
   }

--- a/lucene/core/src/java/org/apache/lucene/search/MultiNormsLeafSimScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiNormsLeafSimScorer.java
@@ -155,23 +155,28 @@ final class MultiNormsLeafSimScorer {
     }
 
     @Override
-    public int docID() {
-      return docID;
-    }
+    public DocIdSetIterator iterator() {
+      return new DocIdSetIterator() {
+        @Override
+        public int docID() {
+          return docID;
+        }
 
-    @Override
-    public int nextDoc() {
-      throw new UnsupportedOperationException();
-    }
+        @Override
+        public int nextDoc() {
+          throw new UnsupportedOperationException();
+        }
 
-    @Override
-    public int advance(int target) {
-      throw new UnsupportedOperationException();
-    }
+        @Override
+        public int advance(int target) {
+          throw new UnsupportedOperationException();
+        }
 
-    @Override
-    public long cost() {
-      throw new UnsupportedOperationException();
+        @Override
+        public long cost() {
+          throw new UnsupportedOperationException();
+        }
+      };
     }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
@@ -864,35 +864,17 @@ public class TestCodecs extends LuceneTestCase {
           public NumericDocValues getNorms(FieldInfo field) throws IOException {
             return new NumericDocValues() {
 
-              int doc = -1;
+              final DocIdSetIterator iterator = DocIdSetIterator.all(si.maxDoc());
 
               @Override
-              public int nextDoc() throws IOException {
-                return advance(doc + 1);
-              }
-
-              @Override
-              public int docID() {
-                return doc;
-              }
-
-              @Override
-              public long cost() {
-                return si.maxDoc();
-              }
-
-              @Override
-              public int advance(int target) throws IOException {
-                if (target >= si.maxDoc()) {
-                  return doc = NO_MORE_DOCS;
-                } else {
-                  return doc = target;
-                }
+              public DocIdSetIterator iterator() {
+                return iterator;
               }
 
               @Override
               public boolean advanceExact(int target) throws IOException {
-                doc = target;
+                int r = iterator.advance(target);
+                assert r == target;
                 return true;
               }
 

--- a/lucene/join/src/java/org/apache/lucene/search/join/GenericTermsCollector.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/GenericTermsCollector.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.search.join;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
@@ -26,7 +25,6 @@ import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.join.DocValuesTermsCollector.Function;
 import org.apache.lucene.search.join.TermsWithScoreCollector.MV;
 import org.apache.lucene.search.join.TermsWithScoreCollector.SV;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefHash;
 
 interface GenericTermsCollector extends Collector {
@@ -49,68 +47,6 @@ interface GenericTermsCollector extends Collector {
       default:
         return new MV(mvFunction, mode);
     }
-  }
-
-  static Function<SortedSetDocValues> verbose(
-      PrintStream out, Function<SortedSetDocValues> mvFunction) {
-    return (ctx) -> {
-      final SortedSetDocValues target = mvFunction.apply(ctx);
-      return new SortedSetDocValues() {
-
-        @Override
-        public int docID() {
-          return target.docID();
-        }
-
-        @Override
-        public int nextDoc() throws IOException {
-          int docID = target.nextDoc();
-          out.println("\nnextDoc doc# " + docID);
-          return docID;
-        }
-
-        @Override
-        public int advance(int dest) throws IOException {
-          int docID = target.advance(dest);
-          out.println("\nadvance(" + dest + ") -> doc# " + docID);
-          return docID;
-        }
-
-        @Override
-        public boolean advanceExact(int dest) throws IOException {
-          boolean exists = target.advanceExact(dest);
-          out.println("\nadvanceExact(" + dest + ") -> exists# " + exists);
-          return exists;
-        }
-
-        @Override
-        public long cost() {
-          return target.cost();
-        }
-
-        @Override
-        public long nextOrd() throws IOException {
-          return target.nextOrd();
-        }
-
-        @Override
-        public int docValueCount() {
-          return target.docValueCount();
-        }
-
-        @Override
-        public BytesRef lookupOrd(long ord) throws IOException {
-          final BytesRef val = target.lookupOrd(ord);
-          out.println(val.toString() + ", ");
-          return val;
-        }
-
-        @Override
-        public long getValueCount() {
-          return target.getValueCount();
-        }
-      };
-    };
   }
 
   static GenericTermsCollector createCollectorSV(

--- a/lucene/join/src/java/org/apache/lucene/search/join/ToParentDocValues.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/ToParentDocValues.java
@@ -51,8 +51,8 @@ class ToParentDocValues extends DocIdSetIterator {
     }
 
     @Override
-    public int docID() {
-      return iter.docID();
+    public DocIdSetIterator iterator() {
+      return iter;
     }
 
     @Override
@@ -69,16 +69,6 @@ class ToParentDocValues extends DocIdSetIterator {
       } else {
         throw new AssertionError();
       }
-    }
-
-    @Override
-    public int nextDoc() throws IOException {
-      return iter.nextDoc();
-    }
-
-    @Override
-    public int advance(int target) throws IOException {
-      return iter.advance(target);
     }
 
     @Override
@@ -99,11 +89,6 @@ class ToParentDocValues extends DocIdSetIterator {
     @Override
     public int getValueCount() {
       return values.getValueCount();
-    }
-
-    @Override
-    public long cost() {
-      return values.cost();
     }
   }
 
@@ -144,13 +129,8 @@ class ToParentDocValues extends DocIdSetIterator {
     }
 
     @Override
-    public int nextDoc() throws IOException {
-      return iter.nextDoc();
-    }
-
-    @Override
-    public int advance(int targetParentDocID) throws IOException {
-      return iter.advance(targetParentDocID);
+    public DocIdSetIterator iterator() {
+      return iter;
     }
 
     @Override
@@ -161,16 +141,6 @@ class ToParentDocValues extends DocIdSetIterator {
     @Override
     public long longValue() {
       return value;
-    }
-
-    @Override
-    public int docID() {
-      return iter.docID();
-    }
-
-    @Override
-    public long cost() {
-      return values.cost();
     }
   }
 

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -1342,30 +1342,16 @@ public class MemoryIndex {
   // Nested classes:
   ///////////////////////////////////////////////////////////////////////////////
 
-  private static class MemoryDocValuesIterator {
-
-    int doc = -1;
-
-    int advance(int doc) {
-      this.doc = doc;
-      return docId();
-    }
-
-    int nextDoc() {
-      doc++;
-      return docId();
-    }
-
-    int docId() {
-      return doc > 0 ? NumericDocValues.NO_MORE_DOCS : doc;
-    }
-  }
-
   private static SortedNumericDocValues numericDocValues(long[] values, int count) {
-    MemoryDocValuesIterator it = new MemoryDocValuesIterator();
+    DocIdSetIterator it = DocIdSetIterator.all(1);
     return new SortedNumericDocValues() {
 
       int ord = 0;
+
+      @Override
+      public DocIdSetIterator iterator() {
+        return it;
+      }
 
       @Override
       public long nextValue() throws IOException {
@@ -1382,31 +1368,11 @@ public class MemoryIndex {
         ord = 0;
         return it.advance(target) == target;
       }
-
-      @Override
-      public int docID() {
-        return it.docId();
-      }
-
-      @Override
-      public int nextDoc() throws IOException {
-        return it.nextDoc();
-      }
-
-      @Override
-      public int advance(int target) throws IOException {
-        return it.advance(target);
-      }
-
-      @Override
-      public long cost() {
-        return 1;
-      }
     };
   }
 
   private static NumericDocValues numericDocValues(long value) {
-    MemoryDocValuesIterator it = new MemoryDocValuesIterator();
+    DocIdSetIterator it = DocIdSetIterator.all(1);
     return new NumericDocValues() {
       @Override
       public long longValue() throws IOException {
@@ -1419,29 +1385,14 @@ public class MemoryIndex {
       }
 
       @Override
-      public int docID() {
-        return it.docId();
-      }
-
-      @Override
-      public int nextDoc() throws IOException {
-        return it.nextDoc();
-      }
-
-      @Override
-      public int advance(int target) throws IOException {
-        return it.advance(target);
-      }
-
-      @Override
-      public long cost() {
-        return 1;
+      public DocIdSetIterator iterator() {
+        return it;
       }
     };
   }
 
   private static SortedDocValues sortedDocValues(BytesRef value) {
-    MemoryDocValuesIterator it = new MemoryDocValuesIterator();
+    DocIdSetIterator it = DocIdSetIterator.all(1);
     return new SortedDocValues() {
       @Override
       public int ordValue() {
@@ -1464,29 +1415,14 @@ public class MemoryIndex {
       }
 
       @Override
-      public int docID() {
-        return it.docId();
-      }
-
-      @Override
-      public int nextDoc() throws IOException {
-        return it.nextDoc();
-      }
-
-      @Override
-      public int advance(int target) throws IOException {
-        return it.advance(target);
-      }
-
-      @Override
-      public long cost() {
-        return 1;
+      public DocIdSetIterator iterator() {
+        return it;
       }
     };
   }
 
   private static SortedSetDocValues sortedSetDocValues(BytesRefHash values, int[] bytesIds) {
-    MemoryDocValuesIterator it = new MemoryDocValuesIterator();
+    DocIdSetIterator it = DocIdSetIterator.all(1);
     BytesRef scratch = new BytesRef();
     return new SortedSetDocValues() {
       int ord = 0;
@@ -1518,23 +1454,8 @@ public class MemoryIndex {
       }
 
       @Override
-      public int docID() {
-        return it.docId();
-      }
-
-      @Override
-      public int nextDoc() throws IOException {
-        return it.nextDoc();
-      }
-
-      @Override
-      public int advance(int target) throws IOException {
-        return it.advance(target);
-      }
-
-      @Override
-      public long cost() {
-        return 1;
+      public DocIdSetIterator iterator() {
+        return it;
       }
     };
   }
@@ -1638,23 +1559,8 @@ public class MemoryIndex {
         }
 
         @Override
-        public int docID() {
-          return in.docID();
-        }
-
-        @Override
-        public int nextDoc() throws IOException {
-          return in.nextDoc();
-        }
-
-        @Override
-        public int advance(int target) throws IOException {
-          return in.advance(target);
-        }
-
-        @Override
-        public long cost() {
-          return in.cost();
+        public DocIdSetIterator iterator() {
+          return in.iterator();
         }
       };
     }

--- a/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
+++ b/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
@@ -315,7 +315,7 @@ public class TestMemoryIndex extends LuceneTestCase {
     assertEquals("c", sortedSetDocValues.lookupOrd(0L).utf8ToString());
     assertEquals("d", sortedSetDocValues.lookupOrd(1L).utf8ToString());
     assertEquals("f", sortedSetDocValues.lookupOrd(2L).utf8ToString());
-    assertEquals(DocIdSetIterator.NO_MORE_DOCS, sortedDocValues.nextDoc());
+    assertEquals(DocIdSetIterator.NO_MORE_DOCS, sortedSetDocValues.nextDoc());
   }
 
   public void testDocValues_resetIterator() throws Exception {

--- a/lucene/misc/src/test/org/apache/lucene/misc/search/TestDiversifiedTopDocsCollector.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/search/TestDiversifiedTopDocsCollector.java
@@ -149,29 +149,37 @@ public class TestDiversifiedTopDocsCollector extends LuceneTestCase {
 
       return new NumericDocValues() {
 
-        @Override
-        public int docID() {
-          return sdv.docID() - context.docBase;
-        }
+        final DocIdSetIterator iterator =
+            new DocIdSetIterator() {
+              @Override
+              public int docID() {
+                return sdv.docID() - context.docBase;
+              }
+
+              @Override
+              public int nextDoc() throws IOException {
+                return sdv.nextDoc() - context.docBase;
+              }
+
+              @Override
+              public int advance(int target) throws IOException {
+                return sdv.advance(target + context.docBase);
+              }
+
+              @Override
+              public long cost() {
+                return 0;
+              }
+            };
 
         @Override
-        public int nextDoc() throws IOException {
-          return sdv.nextDoc() - context.docBase;
-        }
-
-        @Override
-        public int advance(int target) throws IOException {
-          return sdv.advance(target + context.docBase);
+        public DocIdSetIterator iterator() {
+          return iterator;
         }
 
         @Override
         public boolean advanceExact(int target) throws IOException {
           return sdv.advanceExact(target + context.docBase);
-        }
-
-        @Override
-        public long cost() {
-          return 0;
         }
 
         @Override
@@ -201,28 +209,13 @@ public class TestDiversifiedTopDocsCollector extends LuceneTestCase {
     protected NumericDocValues getKeys(LeafReaderContext context) {
       return new NumericDocValues() {
         @Override
-        public int docID() {
-          return vals.docID();
-        }
-
-        @Override
-        public int nextDoc() throws IOException {
-          return vals.nextDoc();
-        }
-
-        @Override
-        public int advance(int target) throws IOException {
-          return vals.advance(target);
+        public DocIdSetIterator iterator() {
+          return vals;
         }
 
         @Override
         public boolean advanceExact(int target) throws IOException {
           return vals.advanceExact(target);
-        }
-
-        @Override
-        public long cost() {
-          return vals.cost();
         }
 
         @Override

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiNormsLeafSimScorer.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/MultiNormsLeafSimScorer.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.sandbox.search.CombinedFieldQuery.FieldAndWeight;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.similarities.Similarity.SimScorer;
 import org.apache.lucene.util.SmallFloat;
@@ -161,17 +162,7 @@ final class MultiNormsLeafSimScorer {
     }
 
     @Override
-    public int nextDoc() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int advance(int target) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public long cost() {
+    public DocIdSetIterator iterator() {
       throw new UnsupportedOperationException();
     }
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -715,43 +715,60 @@ public class AssertingLeafReader extends FilterLeafReader {
     private final int maxDoc;
     private int lastDocID = -1;
     private boolean exists;
+    private final DocIdSetIterator iterator;
 
     public AssertingNumericDocValues(NumericDocValues in, int maxDoc) {
       this.in = in;
       this.maxDoc = maxDoc;
       // should start unpositioned:
       assert in.docID() == -1;
+      this.iterator =
+          new DocIdSetIterator() {
+            @Override
+            public int docID() {
+              assertThread("Numeric doc values", creationThread);
+              return in.docID();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+              assertThread("Numeric doc values", creationThread);
+              int docID = in.nextDoc();
+              assert docID > lastDocID;
+              assert docID == NO_MORE_DOCS || docID < maxDoc;
+              assert docID == in.docID();
+              lastDocID = docID;
+              exists = docID != NO_MORE_DOCS;
+              return docID;
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+              assertThread("Numeric doc values", creationThread);
+              assert target >= 0;
+              assert target > in.docID();
+              int docID = in.advance(target);
+              assert docID >= target;
+              assert docID == NO_MORE_DOCS || docID < maxDoc;
+              lastDocID = docID;
+              exists = docID != NO_MORE_DOCS;
+              return docID;
+            }
+
+            @Override
+            public long cost() {
+              assertThread("Numeric doc values", creationThread);
+              long cost = in.cost();
+              assert cost >= 0;
+              return cost;
+            }
+          };
     }
 
     @Override
-    public int docID() {
+    public DocIdSetIterator iterator() {
       assertThread("Numeric doc values", creationThread);
-      return in.docID();
-    }
-
-    @Override
-    public int nextDoc() throws IOException {
-      assertThread("Numeric doc values", creationThread);
-      int docID = in.nextDoc();
-      assert docID > lastDocID;
-      assert docID == NO_MORE_DOCS || docID < maxDoc;
-      assert docID == in.docID();
-      lastDocID = docID;
-      exists = docID != NO_MORE_DOCS;
-      return docID;
-    }
-
-    @Override
-    public int advance(int target) throws IOException {
-      assertThread("Numeric doc values", creationThread);
-      assert target >= 0;
-      assert target > in.docID();
-      int docID = in.advance(target);
-      assert docID >= target;
-      assert docID == NO_MORE_DOCS || docID < maxDoc;
-      lastDocID = docID;
-      exists = docID != NO_MORE_DOCS;
-      return docID;
+      return iterator;
     }
 
     @Override
@@ -764,14 +781,6 @@ public class AssertingLeafReader extends FilterLeafReader {
       assert in.docID() == target;
       lastDocID = target;
       return exists;
-    }
-
-    @Override
-    public long cost() {
-      assertThread("Numeric doc values", creationThread);
-      long cost = in.cost();
-      assert cost >= 0;
-      return cost;
     }
 
     @Override
@@ -794,43 +803,60 @@ public class AssertingLeafReader extends FilterLeafReader {
     private final int maxDoc;
     private int lastDocID = -1;
     private boolean exists;
+    private final DocIdSetIterator iterator;
 
     public AssertingBinaryDocValues(BinaryDocValues in, int maxDoc) {
       this.in = in;
       this.maxDoc = maxDoc;
       // should start unpositioned:
       assert in.docID() == -1;
+      this.iterator =
+          new DocIdSetIterator() {
+            @Override
+            public int docID() {
+              assertThread("Binary doc values", creationThread);
+              return in.docID();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+              assertThread("Binary doc values", creationThread);
+              int docID = in.nextDoc();
+              assert docID > lastDocID;
+              assert docID == NO_MORE_DOCS || docID < maxDoc;
+              assert docID == in.docID();
+              lastDocID = docID;
+              exists = docID != NO_MORE_DOCS;
+              return docID;
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+              assertThread("Binary doc values", creationThread);
+              assert target >= 0;
+              assert target > in.docID();
+              int docID = in.advance(target);
+              assert docID >= target;
+              assert docID == NO_MORE_DOCS || docID < maxDoc;
+              lastDocID = docID;
+              exists = docID != NO_MORE_DOCS;
+              return docID;
+            }
+
+            @Override
+            public long cost() {
+              assertThread("Binary doc values", creationThread);
+              long cost = in.cost();
+              assert cost >= 0;
+              return cost;
+            }
+          };
     }
 
     @Override
-    public int docID() {
-      assertThread("Binary doc values", creationThread);
-      return in.docID();
-    }
-
-    @Override
-    public int nextDoc() throws IOException {
-      assertThread("Binary doc values", creationThread);
-      int docID = in.nextDoc();
-      assert docID > lastDocID;
-      assert docID == NO_MORE_DOCS || docID < maxDoc;
-      assert docID == in.docID();
-      lastDocID = docID;
-      exists = docID != NO_MORE_DOCS;
-      return docID;
-    }
-
-    @Override
-    public int advance(int target) throws IOException {
-      assertThread("Binary doc values", creationThread);
-      assert target >= 0;
-      assert target > in.docID();
-      int docID = in.advance(target);
-      assert docID >= target;
-      assert docID == NO_MORE_DOCS || docID < maxDoc;
-      lastDocID = docID;
-      exists = docID != NO_MORE_DOCS;
-      return docID;
+    public DocIdSetIterator iterator() {
+      assertThread("Numeric doc values", creationThread);
+      return iterator;
     }
 
     @Override
@@ -843,14 +869,6 @@ public class AssertingLeafReader extends FilterLeafReader {
       assert in.docID() == target;
       lastDocID = target;
       return exists;
-    }
-
-    @Override
-    public long cost() {
-      assertThread("Binary doc values", creationThread);
-      long cost = in.cost();
-      assert cost >= 0;
-      return cost;
     }
 
     @Override
@@ -874,43 +892,60 @@ public class AssertingLeafReader extends FilterLeafReader {
     private final int valueCount;
     private int lastDocID = -1;
     private boolean exists;
+    private final DocIdSetIterator iterator;
 
     public AssertingSortedDocValues(SortedDocValues in, int maxDoc) {
       this.in = in;
       this.maxDoc = maxDoc;
       this.valueCount = in.getValueCount();
       assert valueCount >= 0 && valueCount <= maxDoc;
+      this.iterator =
+          new DocIdSetIterator() {
+            @Override
+            public int docID() {
+              assertThread("Sorted doc values", creationThread);
+              return in.docID();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+              assertThread("Sorted doc values", creationThread);
+              int docID = in.nextDoc();
+              assert docID > lastDocID;
+              assert docID == NO_MORE_DOCS || docID < maxDoc;
+              assert docID == in.docID();
+              lastDocID = docID;
+              exists = docID != NO_MORE_DOCS;
+              return docID;
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+              assertThread("Sorted doc values", creationThread);
+              assert target >= 0;
+              assert target > in.docID();
+              int docID = in.advance(target);
+              assert docID >= target;
+              assert docID == NO_MORE_DOCS || docID < maxDoc;
+              lastDocID = docID;
+              exists = docID != NO_MORE_DOCS;
+              return docID;
+            }
+
+            @Override
+            public long cost() {
+              assertThread("Sorted doc values", creationThread);
+              long cost = in.cost();
+              assert cost >= 0;
+              return cost;
+            }
+          };
     }
 
     @Override
-    public int docID() {
-      assertThread("Sorted doc values", creationThread);
-      return in.docID();
-    }
-
-    @Override
-    public int nextDoc() throws IOException {
-      assertThread("Sorted doc values", creationThread);
-      int docID = in.nextDoc();
-      assert docID > lastDocID;
-      assert docID == NO_MORE_DOCS || docID < maxDoc;
-      assert docID == in.docID();
-      lastDocID = docID;
-      exists = docID != NO_MORE_DOCS;
-      return docID;
-    }
-
-    @Override
-    public int advance(int target) throws IOException {
-      assertThread("Sorted doc values", creationThread);
-      assert target >= 0;
-      assert target > in.docID();
-      int docID = in.advance(target);
-      assert docID >= target;
-      assert docID == NO_MORE_DOCS || docID < maxDoc;
-      lastDocID = docID;
-      exists = docID != NO_MORE_DOCS;
-      return docID;
+    public DocIdSetIterator iterator() {
+      assertThread("Numeric doc values", creationThread);
+      return iterator;
     }
 
     @Override
@@ -923,14 +958,6 @@ public class AssertingLeafReader extends FilterLeafReader {
       assert in.docID() == target;
       lastDocID = target;
       return exists;
-    }
-
-    @Override
-    public long cost() {
-      assertThread("Sorted doc values", creationThread);
-      long cost = in.cost();
-      assert cost >= 0;
-      return cost;
     }
 
     @Override
@@ -972,17 +999,6 @@ public class AssertingLeafReader extends FilterLeafReader {
 
   /** Wraps a SortedNumericDocValues but with additional asserts */
   public static class AssertingSortedNumericDocValues extends SortedNumericDocValues {
-    private final Thread creationThread = Thread.currentThread();
-    private final SortedNumericDocValues in;
-    private final int maxDoc;
-    private int lastDocID = -1;
-    private int valueUpto;
-    private boolean exists;
-
-    private AssertingSortedNumericDocValues(SortedNumericDocValues in, int maxDoc) {
-      this.in = in;
-      this.maxDoc = maxDoc;
-    }
 
     public static SortedNumericDocValues create(SortedNumericDocValues in, int maxDoc) {
       NumericDocValues singleDocValues = DocValues.unwrapSingleton(in);
@@ -995,37 +1011,66 @@ public class AssertingLeafReader extends FilterLeafReader {
       }
     }
 
-    @Override
-    public int docID() {
-      return in.docID();
+    private final Thread creationThread = Thread.currentThread();
+    private final SortedNumericDocValues in;
+    private final int maxDoc;
+    private int lastDocID = -1;
+    private int valueUpto;
+    private boolean exists;
+    private final DocIdSetIterator iterator;
+
+    private AssertingSortedNumericDocValues(SortedNumericDocValues in, int maxDoc) {
+      this.in = in;
+      this.maxDoc = maxDoc;
+      this.iterator =
+          new DocIdSetIterator() {
+            @Override
+            public int docID() {
+              return in.docID();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+              assertThread("Sorted numeric doc values", creationThread);
+              int docID = in.nextDoc();
+              assert docID > lastDocID;
+              assert docID == NO_MORE_DOCS || docID < maxDoc;
+              assert docID == in.docID();
+              lastDocID = docID;
+              valueUpto = 0;
+              exists = docID != NO_MORE_DOCS;
+              return docID;
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+              assertThread("Sorted numeric doc values", creationThread);
+              assert target >= 0;
+              assert target > in.docID();
+              int docID = in.advance(target);
+              assert docID == in.docID();
+              assert docID >= target;
+              assert docID == NO_MORE_DOCS || docID < maxDoc;
+              lastDocID = docID;
+              valueUpto = 0;
+              exists = docID != NO_MORE_DOCS;
+              return docID;
+            }
+
+            @Override
+            public long cost() {
+              assertThread("Sorted numeric doc values", creationThread);
+              long cost = in.cost();
+              assert cost >= 0;
+              return cost;
+            }
+          };
     }
 
     @Override
-    public int nextDoc() throws IOException {
-      assertThread("Sorted numeric doc values", creationThread);
-      int docID = in.nextDoc();
-      assert docID > lastDocID;
-      assert docID == NO_MORE_DOCS || docID < maxDoc;
-      assert docID == in.docID();
-      lastDocID = docID;
-      valueUpto = 0;
-      exists = docID != NO_MORE_DOCS;
-      return docID;
-    }
-
-    @Override
-    public int advance(int target) throws IOException {
-      assertThread("Sorted numeric doc values", creationThread);
-      assert target >= 0;
-      assert target > in.docID();
-      int docID = in.advance(target);
-      assert docID == in.docID();
-      assert docID >= target;
-      assert docID == NO_MORE_DOCS || docID < maxDoc;
-      lastDocID = docID;
-      valueUpto = 0;
-      exists = docID != NO_MORE_DOCS;
-      return docID;
+    public DocIdSetIterator iterator() {
+      assertThread("Numeric doc values", creationThread);
+      return iterator;
     }
 
     @Override
@@ -1039,14 +1084,6 @@ public class AssertingLeafReader extends FilterLeafReader {
       lastDocID = target;
       valueUpto = 0;
       return exists;
-    }
-
-    @Override
-    public long cost() {
-      assertThread("Sorted numeric doc values", creationThread);
-      long cost = in.cost();
-      assert cost >= 0;
-      return cost;
     }
 
     @Override
@@ -1070,20 +1107,6 @@ public class AssertingLeafReader extends FilterLeafReader {
 
   /** Wraps a SortedSetDocValues but with additional asserts */
   public static class AssertingSortedSetDocValues extends SortedSetDocValues {
-    private final Thread creationThread = Thread.currentThread();
-    private final SortedSetDocValues in;
-    private final int maxDoc;
-    private final long valueCount;
-    private int lastDocID = -1;
-    private int ordsRetrieved;
-    private boolean exists;
-
-    private AssertingSortedSetDocValues(SortedSetDocValues in, int maxDoc) {
-      this.in = in;
-      this.maxDoc = maxDoc;
-      this.valueCount = in.getValueCount();
-      assert valueCount >= 0;
-    }
 
     public static SortedSetDocValues create(SortedSetDocValues in, int maxDoc) {
       SortedDocValues singleDocValues = DocValues.unwrapSingleton(in);
@@ -1095,38 +1118,70 @@ public class AssertingLeafReader extends FilterLeafReader {
       }
     }
 
-    @Override
-    public int docID() {
-      assertThread("Sorted set doc values", creationThread);
-      return in.docID();
+    private final Thread creationThread = Thread.currentThread();
+    private final SortedSetDocValues in;
+    private final int maxDoc;
+    private final long valueCount;
+    private int lastDocID = -1;
+    private int ordsRetrieved;
+    private boolean exists;
+    private final DocIdSetIterator iterator;
+
+    private AssertingSortedSetDocValues(SortedSetDocValues in, int maxDoc) {
+      this.in = in;
+      this.maxDoc = maxDoc;
+      this.valueCount = in.getValueCount();
+      assert valueCount >= 0;
+      this.iterator =
+          new DocIdSetIterator() {
+            @Override
+            public int docID() {
+              assertThread("Sorted set doc values", creationThread);
+              return in.docID();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+              assertThread("Sorted set doc values", creationThread);
+              int docID = in.nextDoc();
+              assert docID > lastDocID;
+              assert docID == NO_MORE_DOCS || docID < maxDoc;
+              assert docID == in.docID();
+              lastDocID = docID;
+              exists = docID != NO_MORE_DOCS;
+              ordsRetrieved = 0;
+              return docID;
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+              assertThread("Sorted set doc values", creationThread);
+              assert target >= 0;
+              assert target > in.docID();
+              int docID = in.advance(target);
+              assert docID == in.docID();
+              assert docID >= target;
+              assert docID == NO_MORE_DOCS || docID < maxDoc;
+              lastDocID = docID;
+              exists = docID != NO_MORE_DOCS;
+              ordsRetrieved = 0;
+              return docID;
+            }
+
+            @Override
+            public long cost() {
+              assertThread("Sorted set doc values", creationThread);
+              long cost = in.cost();
+              assert cost >= 0;
+              return cost;
+            }
+          };
     }
 
     @Override
-    public int nextDoc() throws IOException {
-      assertThread("Sorted set doc values", creationThread);
-      int docID = in.nextDoc();
-      assert docID > lastDocID;
-      assert docID == NO_MORE_DOCS || docID < maxDoc;
-      assert docID == in.docID();
-      lastDocID = docID;
-      exists = docID != NO_MORE_DOCS;
-      ordsRetrieved = 0;
-      return docID;
-    }
-
-    @Override
-    public int advance(int target) throws IOException {
-      assertThread("Sorted set doc values", creationThread);
-      assert target >= 0;
-      assert target > in.docID();
-      int docID = in.advance(target);
-      assert docID == in.docID();
-      assert docID >= target;
-      assert docID == NO_MORE_DOCS || docID < maxDoc;
-      lastDocID = docID;
-      exists = docID != NO_MORE_DOCS;
-      ordsRetrieved = 0;
-      return docID;
+    public DocIdSetIterator iterator() {
+      assertThread("Numeric doc values", creationThread);
+      return iterator;
     }
 
     @Override
@@ -1140,14 +1195,6 @@ public class AssertingLeafReader extends FilterLeafReader {
       lastDocID = target;
       ordsRetrieved = 0;
       return exists;
-    }
-
-    @Override
-    public long cost() {
-      assertThread("Sorted set doc values", creationThread);
-      long cost = in.cost();
-      assert cost >= 0;
-      return cost;
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
@@ -77,6 +77,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.internal.tests.IndexWriterAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
@@ -436,37 +437,19 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
           new EmptyDocValuesProducer() {
             @Override
             public NumericDocValues getNumeric(FieldInfo field) {
+              final DocIdSetIterator iterator = DocIdSetIterator.all(1);
               return new NumericDocValues() {
-                int docID = -1;
 
                 @Override
-                public int docID() {
-                  return docID;
-                }
-
-                @Override
-                public int nextDoc() {
-                  docID++;
-                  if (docID == 1) {
-                    docID = NO_MORE_DOCS;
-                  }
-                  return docID;
-                }
-
-                @Override
-                public int advance(int target) {
-                  if (docID <= 0 && target == 0) {
-                    docID = 0;
-                  } else {
-                    docID = NO_MORE_DOCS;
-                  }
-                  return docID;
+                public DocIdSetIterator iterator() {
+                  return iterator;
                 }
 
                 @Override
                 public boolean advanceExact(int target) throws IOException {
-                  docID = target;
-                  return target == 0;
+                  int r = iterator.advance(target);
+                  assert r == target;
+                  return true;
                 }
 
                 @Override
@@ -496,37 +479,19 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
           new NormsProducer() {
             @Override
             public NumericDocValues getNorms(FieldInfo field) {
+              final DocIdSetIterator iterator = DocIdSetIterator.all(1);
               return new NumericDocValues() {
-                int docID = -1;
 
                 @Override
-                public int docID() {
-                  return docID;
-                }
-
-                @Override
-                public int nextDoc() {
-                  docID++;
-                  if (docID == 1) {
-                    docID = NO_MORE_DOCS;
-                  }
-                  return docID;
-                }
-
-                @Override
-                public int advance(int target) {
-                  if (docID <= 0 && target == 0) {
-                    docID = 0;
-                  } else {
-                    docID = NO_MORE_DOCS;
-                  }
-                  return docID;
+                public DocIdSetIterator iterator() {
+                  return iterator;
                 }
 
                 @Override
                 public boolean advanceExact(int target) throws IOException {
-                  docID = target;
-                  return target == 0;
+                  int r = iterator.advance(target);
+                  assert r == target;
+                  return true;
                 }
 
                 @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
@@ -776,43 +776,24 @@ public class RandomPostingsTester {
           @Override
           public NumericDocValues getNorms(FieldInfo field) throws IOException {
             if (newFieldInfos.fieldInfo(field.number).hasNorms()) {
+              final DocIdSetIterator iterator = DocIdSetIterator.all(segmentInfo.maxDoc());
               return new NumericDocValues() {
 
-                int doc = -1;
-
                 @Override
-                public int nextDoc() throws IOException {
-                  if (++doc == segmentInfo.maxDoc()) {
-                    return doc = NO_MORE_DOCS;
-                  }
-                  return doc;
-                }
-
-                @Override
-                public int docID() {
-                  return doc;
-                }
-
-                @Override
-                public long cost() {
-                  return segmentInfo.maxDoc();
-                }
-
-                @Override
-                public int advance(int target) throws IOException {
-                  return doc =
-                      target >= segmentInfo.maxDoc() ? DocIdSetIterator.NO_MORE_DOCS : target;
+                public DocIdSetIterator iterator() {
+                  return iterator;
                 }
 
                 @Override
                 public boolean advanceExact(int target) throws IOException {
-                  doc = target;
+                  int r = iterator.advance(target);
+                  assert r == target;
                   return true;
                 }
 
                 @Override
                 public long longValue() throws IOException {
-                  return DOC_TO_NORM.applyAsLong(doc);
+                  return DOC_TO_NORM.applyAsLong(iterator.docID());
                 }
               };
             } else {


### PR DESCRIPTION
This should help reduce polymorphism of `DocIdSetIterator` as doc values would then only expose 2 classes as `DocIdSetIterator`s: dense iterators and `IndexedDISI` for the sparse case.

This change almost only touches implementations of doc values, a separate change will be needed to fix call sites of `docValues#nextDoc()` and similar `DocIdSetIterator` APIs to go through `docValues#iterator()` instead.

Relates #14450