### PR TITLE
Removing unnecessary splitX in ComponentTree

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -69,6 +69,8 @@ Improvements
 ---------------------
 * GITHUB#14458 : Add an IndexDeletion policy that retains the last N commits. (Owais Kazi)
 
+* GITHUB#14476: Removing unnecessary splitX in ComponentTree (Ankit Jain)
+
 Optimizations
 ---------------------
 * GITHUB#14418: Quick exit on filter query matching no docs when rewriting knn query. (Pan Guixin)


### PR DESCRIPTION
### Description
IMO, storing splitX for every `TreeNode` makes sense, only if we are exposing API to partially search `ComponentTree` from arbitrary `TreeNode` which is not allowed today. Hence, makes sense to address the TODO and remove `splitX`.

Code without `splitX` looks reasonably straightforward to me, just follow the same structure as `createTree`. Start with `ROOT_SPLITX` and keep toggling `splitX` as we recurse through the levels

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
