### PR TITLE
Backport: KeywordField.newSetQuery() to reuse prefixed terms in IndexOrDocValue…

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -24,6 +24,8 @@ Optimizations
 
 * GITHUB#14268: PointInSetQuery early exit on non-matching segments. (hanbj)
 
+* GITHUB#14425: KeywordField.newSetQuery() reuses prefixed terms (Mikhail Khludnev)
+
 Bug Fixes
 ---------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KeywordField.java
@@ -22,7 +22,6 @@ import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
@@ -175,9 +174,8 @@ public class KeywordField extends Field {
   public static Query newSetQuery(String field, Collection<BytesRef> values) {
     Objects.requireNonNull(field, "field must not be null");
     Objects.requireNonNull(values, "values must not be null");
-    Query indexQuery = new TermInSetQuery(field, values);
-    Query dvQuery = new TermInSetQuery(MultiTermQuery.DOC_VALUES_REWRITE, field, values);
-    return new IndexOrDocValuesQuery(indexQuery, dvQuery);
+    return TermInSetQuery.newIndexOrDocValuesQuery(
+        MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE, field, values);
   }
 
   /**


### PR DESCRIPTION
…sQuery (#14435)

* KeywordField.newSetQuery() reuses prefixed terms.

fix #14425

### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
