### PR TITLE
Reference managed MultiReader

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexReader.java
@@ -225,7 +225,7 @@ public abstract sealed class IndexReader implements Closeable permits CompositeR
    * @see #decRef
    * @see #incRef
    */
-  public final boolean tryIncRef() {
+  public final boolean   tryIncRef() {
     int count;
     while ((count = refCount.get()) > 0) {
       if (refCount.compareAndSet(count, count + 1)) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexReader.java
@@ -225,7 +225,7 @@ public abstract sealed class IndexReader implements Closeable permits CompositeR
    * @see #decRef
    * @see #incRef
    */
-  public final boolean   tryIncRef() {
+  public final boolean tryIncRef() {
     int count;
     while ((count = refCount.get()) > 0) {
       if (refCount.compareAndSet(count, count + 1)) {

--- a/lucene/core/src/java/org/apache/lucene/index/MultiReaderManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiReaderManager.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.search.SearcherManager;
+import org.apache.lucene.store.Directory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class to safely share {@link MultiReader} instances across multiple threads, while
+ * periodically reopening. This class ensures each multi-reader is closed only once all threads have
+ * finished using it. Sub-readers for the reference managed multi-reader are instances of {@link DirectoryReader}
+ *
+ * @see SearcherManager
+ * @lucene.experimental
+ */
+public final class MultiReaderManager extends ReferenceManager<MultiReader> {
+
+  /**
+   * Creates and returns a new ReaderManager from the given {@link Directory}.
+   *
+   * @param dir directories to open the DirectoryReader(s) on.
+   * @throws IOException If there is a low-level I/O error
+   */
+  public MultiReaderManager(Directory... dir) throws IOException {
+    IndexReader[] subReaders = new IndexReader[dir.length];
+    for (int i = 0; i < dir.length; i++) {
+      subReaders[i] = DirectoryReader.open(dir[i]);
+    }
+    current = new MultiReader(subReaders);
+  }
+
+  /**
+   * Creates and returns a new ReaderManager from the given already-opened {@link DirectoryReader},
+   * stealing the incoming reference.
+   *
+   * @param subReaders the directoryReader(s) to use for future reopens
+   * @throws IOException If there is a low-level I/O error
+   */
+  public MultiReaderManager(DirectoryReader... subReaders) throws IOException {
+    current = new MultiReader(subReaders);
+  }
+//
+//  @Override
+//  protected void decRef(DirectoryReader reference) throws IOException {
+//    reference.decRef();
+//  }
+//
+//  @Override
+//  protected DirectoryReader refreshIfNeeded(DirectoryReader referenceToRefresh) throws IOException {
+//    return DirectoryReader.openIfChanged(referenceToRefresh);
+//  }
+//
+//  @Override
+//  protected boolean tryIncRef(DirectoryReader reference) {
+//    return reference.tryIncRef();
+//  }
+//
+//  @Override
+//  protected int getRefCount(DirectoryReader reference) {
+//    return reference.getRefCount();
+//  }
+
+  @Override
+  protected void decRef(MultiReader reference) throws IOException {
+    for (IndexReader reader: current.getSequentialSubReaders()) {
+      reader.decRef();
+    }
+  }
+
+  @Override
+  protected MultiReader refreshIfNeeded(MultiReader referenceToRefresh) throws IOException {
+    return null;
+  }
+
+  /**
+   * Tries to increment references on each of the sub-readers.
+   * Returns true if *all* sub-reader references can be incremented, false otherwise.
+   */
+  @Override
+  protected boolean tryIncRef(MultiReader reference) throws IOException {
+    List<IndexReader> refIncReaders = new ArrayList<>();
+    boolean success = false;
+    try {
+      for (IndexReader reader : current.getSequentialSubReaders()) {
+        if (reader.tryIncRef()) {
+          refIncReaders.add(reader);
+        } else {
+          break;
+        }
+      }
+      if (refIncReaders.size() == current.getSequentialSubReaders().size()) {
+        success = true;
+      }
+    } finally {
+      if (success == false) {
+        for (IndexReader reader : refIncReaders) {
+          reader.decRef();
+        }
+      }
+    }
+    return success;
+  }
+
+  /**
+   * Returns the lowest reference count across all sub-readers.
+   * The multi-reader is closed if reference count for any of its sub-readers drops
+   * to 0. The minimum refCount returned here is hence, the number of references
+   * pending release before the MultiReader is closed.
+   */
+  @Override
+  protected int getRefCount(MultiReader reference) {
+    int minRefCount = Integer.MAX_VALUE;
+    for (IndexReader reader : current.getSequentialSubReaders()) {
+      if (minRefCount > reader.getRefCount()) {
+        minRefCount = reader.getRefCount();
+      }
+    }
+    return minRefCount;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/MultiReaderManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiReaderManager.java
@@ -16,21 +16,21 @@
  */
 package org.apache.lucene.index;
 
-import org.apache.lucene.search.ReferenceManager;
-import org.apache.lucene.search.SearcherManager;
-import org.apache.lucene.store.Directory;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.search.SearcherManager;
+import org.apache.lucene.store.Directory;
 
 /**
  * Utility class to safely share {@link MultiReader} instances across multiple threads, while
  * periodically reopening. This class ensures each multi-reader is closed only once all threads have
  * finished using each of its sub-readers.
  *
- * <p>Sub-readers for the reference managed multi-reader must be instances of {@link DirectoryReader}.
+ * <p>Sub-readers for the reference managed multi-reader must be instances of {@link
+ * DirectoryReader}.
  *
  * @see SearcherManager
  * @lucene.experimental
@@ -52,8 +52,8 @@ public final class MultiReaderManager extends ReferenceManager<MultiReader> {
   }
 
   /**
-   * Creates and returns a new MultiReaderManager from the given already-opened {@link DirectoryReader}s,
-   * stealing the incoming reference.
+   * Creates and returns a new MultiReaderManager from the given already-opened {@link
+   * DirectoryReader}s, stealing the incoming reference.
    *
    * @param subReaders the directoryReader(s) to use for future reopens
    * @throws IOException If there is a low-level I/O error
@@ -62,28 +62,27 @@ public final class MultiReaderManager extends ReferenceManager<MultiReader> {
     current = new MultiReader(subReaders, null, false);
   }
 
-  public MultiReaderManager(DirectoryReader[] subReaders, Comparator<IndexReader> subReadersSorter) throws IOException {
+  public MultiReaderManager(DirectoryReader[] subReaders, Comparator<IndexReader> subReadersSorter)
+      throws IOException {
     current = new MultiReader(subReaders, subReadersSorter, false);
   }
 
-  /**
-   * Decrements reference count for each sub-reader in the provided reference.
-   */
+  /** Decrements reference count for each sub-reader in the provided reference. */
   @Override
   protected void decRef(MultiReader reference) throws IOException {
-    for (IndexReader reader: reference.getSequentialSubReaders()) {
+    for (IndexReader reader : reference.getSequentialSubReaders()) {
       reader.decRef();
     }
   }
 
   /**
-   * Refreshes sub-readers if needed.
-   * Returns a new MultiReader that references the refreshed sub-readers. If none of the
-   * sub-readers have changes, returns null.
+   * Refreshes sub-readers if needed. Returns a new MultiReader that references the refreshed
+   * sub-readers. If none of the sub-readers have changes, returns null.
    */
   @Override
   protected MultiReader refreshIfNeeded(MultiReader referenceToRefresh) throws IOException {
-    IndexReader[] newSubReaders = new IndexReader[referenceToRefresh.getSequentialSubReaders().size()];
+    IndexReader[] newSubReaders =
+        new IndexReader[referenceToRefresh.getSequentialSubReaders().size()];
     boolean refreshed = false;
     for (int i = 0; i < referenceToRefresh.getSequentialSubReaders().size(); i++) {
       DirectoryReader old = (DirectoryReader) referenceToRefresh.getSequentialSubReaders().get(i);
@@ -102,8 +101,8 @@ public final class MultiReaderManager extends ReferenceManager<MultiReader> {
   }
 
   /**
-   * Tries to increment references on each of the sub-readers.
-   * Returns true if *all* sub-reader references can be incremented, false otherwise.
+   * Tries to increment references on each of the sub-readers. Returns true if *all* sub-reader
+   * references can be incremented, false otherwise.
    */
   @Override
   protected boolean tryIncRef(MultiReader reference) throws IOException {
@@ -132,9 +131,10 @@ public final class MultiReaderManager extends ReferenceManager<MultiReader> {
 
   /**
    * Returns the lowest reference count across all sub-readers.
-   * The multi-reader is closed if reference count for any of its sub-readers drops
-   * to 0. The minimum refCount returned here is hence, the number of references
-   * pending release before the MultiReader is closed.
+   *
+   * <p>The multi-reader is closed if reference count for any of its sub-readers drops to 0. The
+   * minimum refCount returned here is hence, the number of references pending release before the
+   * MultiReader is closed.
    */
   @Override
   protected int getRefCount(MultiReader reference) {

--- a/lucene/core/src/java/org/apache/lucene/index/MultiReaderManager.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiReaderManager.java
@@ -62,6 +62,15 @@ public final class MultiReaderManager extends ReferenceManager<MultiReader> {
     current = new MultiReader(subReaders, null, false);
   }
 
+  /**
+   * Creates and returns a new MultiReaderManager from the given already-opened {@link
+   * DirectoryReader}s, stealing their incoming reference. Accepts a sorter for the incoming
+   * subReaders.
+   *
+   * @param subReaders the directoryReader(s) to use for future reopens
+   * @param subReadersSorter a comparator, that if not {@code null} is used for sorting sub readers
+   * @throws IOException if there is a low-level I/O error
+   */
   public MultiReaderManager(DirectoryReader[] subReaders, Comparator<IndexReader> subReadersSorter)
       throws IOException {
     current = new MultiReader(subReaders, subReadersSorter, false);


### PR DESCRIPTION
Going by #13976 and this [dated stack overflow thread](https://stackoverflow.com/questions/49817453/searchermanager-and-multireader-in-lucene), it seems like there is desire for a reference managed MultiReader. 

The implementation should provide a way to safely share a multi-reader across multiple threads, refresh underlying sub-readers periodically to pick new changes, and ensure that sub-readers are not closed until all threads have finished using them. I hacked together a quick prototype based on my understanding of the requirements. If this seems useful, I can add some tests and refine it. Or, @Shibi-bala, since you wrote the initial PR, feel free to take this further if you like.

Following discussions from the PR, this manager exposes a Multi-Reader and expects users to create their own IndexSearcher on top of it. The managed multi-reader uses `DirectoryReader.openIfChanged` to refresh its sub-readers, and as such, requires its sub-readers to be `DirectoryReader` instances. I'm not sure if there are non DirectoryReader implementations that we want to handle via this manager. 

This manager will increase / decrease refCount for each subReader on acquire and release. `acquire` will fail if refCount cannot be incremented for any of the subReaders, i.e. if any of the sub-readers have closed.
