### PR TITLE
test: AwaitFix TestIndexWriterMergePolicy.stressUpdateSameDocumentWithMergeOnX

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMergePolicy.java
@@ -737,11 +737,15 @@ public class TestIndexWriterMergePolicy extends LuceneTestCase {
     }
   }
 
+  // TODO: tests using stressUpdateSameDocumentWithMergeOnX have resource issues
+  @AwaitsFix(bugUrl = "https://github.com/apache/lucene/issues/14483")
   public void testStressUpdateSameDocumentWithMergeOnGetReader()
       throws IOException, InterruptedException {
     stressUpdateSameDocumentWithMergeOnX(true);
   }
 
+  // TODO: tests using stressUpdateSameDocumentWithMergeOnX have resource issues
+  @AwaitsFix(bugUrl = "https://github.com/apache/lucene/issues/14483")
   public void testStressUpdateSameDocumentWithMergeOnCommit()
       throws IOException, InterruptedException {
     stressUpdateSameDocumentWithMergeOnX(false);


### PR DESCRIPTION
Two tests use this helper method:
- testStressUpdateSameDocumentWithMergeOnCommit()
- testStressUpdateSameDocumentWithMergeOnGetReader()

Both have been failing Jenkins builds with resource limits, particularly open file limits. The test indexes a seemingly-unbounded number of documents, waiting for special conditions to happen.

The artificial limits on number of open files (@MaxOpenHandles) is increased in the test, which only hides the bugs and defeats its purpose. The tests still fail, just less often.

Disable the tests until we have a better solution.

Relates: #14483

