### PR TITLE
ci: pin github actions versions in use

### DIFF
--- a/.github/actions/prepare-for-build/action.yml
+++ b/.github/actions/prepare-for-build/action.yml
@@ -19,7 +19,7 @@ runs:
  using: "composite"
  steps:
     - name: Set up Java (${{ inputs.java-distribution }}, ${{ inputs.java-version }})"
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}

--- a/.github/workflows/activity-report.yml
+++ b/.github/workflows/activity-report.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -18,6 +18,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           sync-labels: true

--- a/.github/workflows/mark-stale-PRs.yml
+++ b/.github/workflows/mark-stale-PRs.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@99b6c709598e2b0d0841cd037aaf1ba07a4410bd # v5.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Correct git autocrlf
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/prepare-for-build
 
       - name: Run gradle check (without tests)
@@ -62,7 +62,7 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/prepare-for-build
 
       - name: Run gradle tests

--- a/.github/workflows/run-checks-gradle-upgrade.yml
+++ b/.github/workflows/run-checks-gradle-upgrade.yml
@@ -39,7 +39,7 @@ jobs:
       ALT_JAVA_DIR: /tmp/alt-java
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/prepare-for-build
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/run-checks-mod-analysis-common-hunspell.yml
+++ b/.github/workflows/run-checks-mod-analysis-common-hunspell.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/prepare-for-build
 
       - name: Run Hunspell regression tests

--- a/.github/workflows/run-checks-mod-distribution.tests.yml
+++ b/.github/workflows/run-checks-mod-distribution.tests.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/prepare-for-build
 
       - name: Run 'gradlew lucene/distribution.tests test' (on ${{ matrix.os }})

--- a/.github/workflows/run-checks-python.yml
+++ b/.github/workflows/run-checks-python.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: "3.12.6"
 

--- a/.github/workflows/run-nightly-smoketester.yml
+++ b/.github/workflows/run-nightly-smoketester.yml
@@ -27,9 +27,9 @@ jobs:
       TMP_DIR: /tmp/lucene-tmp-dir
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: 'temurin'
           java-package: jdk
@@ -67,7 +67,7 @@ jobs:
 
       - name: "Store smoke tester logs"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: smoke-tester-logs-jdk-${{ matrix.java-version }}
           path: |

--- a/.github/workflows/run-scheduled-hunspell.yml
+++ b/.github/workflows/run-scheduled-hunspell.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/prepare-for-build
 
       - name: Run Hunspell regression tests against latest commits in dictionary repositories
         run: >
-          ./gradlew -p lucene/analysis/common 
+          ./gradlew -p lucene/analysis/common
           -Ptests.hunspell.regressions=true
           -Ptests.verbose=true
           -Ptests.hunspell.libreoffice.ref=master
           -Ptests.hunspell.woorm.ref=main
-          test 
+          test
           --tests "TestAllDictionaries"

--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
Currently the github actions are pinned to major versions only, which means the code changes out from under us, without notice.

Instead pin the versions exactly, and have dependabot send us PR updates when things change. This isn't just about breaking changes, it also alerts you to new functionality that may be useful.

Frequency of updates can always be changed, for example, to only send us monthly PRs for the actions changes. But it is best to have no changes without a PR.

Closes #14491