### PR TITLE
Fix RegExp.toString generating invalid RE for CHAR and CHAR_RANGE

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -854,6 +854,19 @@ public class RegExp {
     return b.toString();
   }
 
+  StringBuilder escapeCharIfNeeded(StringBuilder b, int codePoint) {
+    // From https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#bs
+    // "It is an error to use a backslash prior to any alphabetic character that does not denote
+    // an escaped
+    // construct;"
+    // Plus, ASCII characters conflict with character classes.
+    // Escape only characters which are NOT in [A-Za-z]
+    if (!((codePoint >= 65 && codePoint <= 90) || (codePoint >= 97 && codePoint <= 122))) {
+      b.append("\\");
+    }
+    return b.appendCodePoint(codePoint);
+  }
+
   void toStringBuilder(StringBuilder b) {
     switch (kind) {
       case REGEXP_UNION:
@@ -901,10 +914,14 @@ public class RegExp {
         b.append(")");
         break;
       case REGEXP_CHAR:
-        b.append("\\").appendCodePoint(c);
+        escapeCharIfNeeded(b, c);
         break;
       case REGEXP_CHAR_RANGE:
-        b.append("[\\").appendCodePoint(from[0]).append("-\\").appendCodePoint(to[0]).append("]");
+        b.append("[");
+        escapeCharIfNeeded(b, from[0]);
+        b.append("-");
+        escapeCharIfNeeded(b, to[0]);
+        b.append("]");
         break;
       case REGEXP_CHAR_CLASS:
         b.append("[");

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExpParsing.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExpParsing.java
@@ -57,7 +57,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testChar() {
     RegExp re = new RegExp("c");
-    assertEquals("\\c", re.toString());
+    assertEquals("c", re.toString());
     assertEquals("REGEXP_CHAR char=c\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
@@ -69,7 +69,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testCaseInsensitiveChar() {
     RegExp re = new RegExp("c", RegExp.NONE, RegExp.ASCII_CASE_INSENSITIVE);
-    assertEquals("\\c", re.toString());
+    assertEquals("c", re.toString());
     assertEquals("REGEXP_CHAR char=c\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
@@ -113,7 +113,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testCaseInsensitiveCharUpper() {
     RegExp re = new RegExp("C", RegExp.NONE, RegExp.ASCII_CASE_INSENSITIVE);
-    assertEquals("\\C", re.toString());
+    assertEquals("C", re.toString());
     assertEquals("REGEXP_CHAR char=C\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
@@ -174,7 +174,7 @@ public class TestRegExpParsing extends LuceneTestCase {
   public void testNegatedChar() {
     RegExp re = new RegExp("[^c]");
     // TODO: would be nice to emit negated class rather than this
-    assertEquals("(.&~(\\c))", re.toString());
+    assertEquals("(.&~(c))", re.toString());
     assertEquals(
         String.join(
             "\n",
@@ -211,7 +211,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testCharRange() {
     RegExp re = new RegExp("[b-d]");
-    assertEquals("[\\b-\\d]", re.toString());
+    assertEquals("[b-d]", re.toString());
     assertEquals("REGEXP_CHAR_RANGE from=b to=d\n", re.toStringTree());
 
     Automaton actual = re.toAutomaton();
@@ -224,7 +224,7 @@ public class TestRegExpParsing extends LuceneTestCase {
   public void testNegatedCharRange() {
     RegExp re = new RegExp("[^b-d]");
     // TODO: would be nice to emit negated class rather than this
-    assertEquals("(.&~([\\b-\\d]))", re.toString());
+    assertEquals("(.&~([b-d]))", re.toString());
     assertEquals(
         String.join(
             "\n",
@@ -514,7 +514,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testOptional() {
     RegExp re = new RegExp("a?");
-    assertEquals("(\\a)?", re.toString());
+    assertEquals("(a)?", re.toString());
     assertEquals(String.join("\n", "REGEXP_OPTIONAL", "  REGEXP_CHAR char=a\n"), re.toStringTree());
 
     Automaton actual = re.toAutomaton();
@@ -526,7 +526,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testRepeat0() {
     RegExp re = new RegExp("a*");
-    assertEquals("(\\a)*", re.toString());
+    assertEquals("(a)*", re.toString());
     assertEquals(String.join("\n", "REGEXP_REPEAT", "  REGEXP_CHAR char=a\n"), re.toStringTree());
 
     Automaton actual = re.toAutomaton();
@@ -538,7 +538,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testRepeat1() {
     RegExp re = new RegExp("a+");
-    assertEquals("(\\a){1,}", re.toString());
+    assertEquals("(a){1,}", re.toString());
     assertEquals(
         String.join("\n", "REGEXP_REPEAT_MIN min=1", "  REGEXP_CHAR char=a\n"), re.toStringTree());
 
@@ -553,7 +553,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testRepeatN() {
     RegExp re = new RegExp("a{5}");
-    assertEquals("(\\a){5,5}", re.toString());
+    assertEquals("(a){5,5}", re.toString());
     assertEquals(
         String.join("\n", "REGEXP_REPEAT_MINMAX min=5 max=5", "  REGEXP_CHAR char=a\n"),
         re.toStringTree());
@@ -567,7 +567,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testRepeatNPlus() {
     RegExp re = new RegExp("a{5,}");
-    assertEquals("(\\a){5,}", re.toString());
+    assertEquals("(a){5,}", re.toString());
     assertEquals(
         String.join("\n", "REGEXP_REPEAT_MIN min=5", "  REGEXP_CHAR char=a\n"), re.toStringTree());
 
@@ -582,7 +582,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testRepeatMN() {
     RegExp re = new RegExp("a{5,8}");
-    assertEquals("(\\a){5,8}", re.toString());
+    assertEquals("(a){5,8}", re.toString());
     assertEquals(
         String.join("\n", "REGEXP_REPEAT_MINMAX min=5 max=8", "  REGEXP_CHAR char=a\n"),
         re.toStringTree());
@@ -659,7 +659,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testConcatenation() {
     RegExp re = new RegExp("[b-c][e-f]");
-    assertEquals("[\\b-\\c][\\e-\\f]", re.toString());
+    assertEquals("[b-c][e-f]", re.toString());
     assertEquals(
         String.join(
             "\n",
@@ -679,7 +679,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testIntersection() {
     RegExp re = new RegExp("[b-f]&[e-f]");
-    assertEquals("([\\b-\\f]&[\\e-\\f])", re.toString());
+    assertEquals("([b-f]&[e-f])", re.toString());
     assertEquals(
         String.join(
             "\n",
@@ -714,7 +714,7 @@ public class TestRegExpParsing extends LuceneTestCase {
 
   public void testUnion() {
     RegExp re = new RegExp("[b-c]|[e-f]");
-    assertEquals("([\\b-\\c]|[\\e-\\f])", re.toString());
+    assertEquals("([b-c]|[e-f])", re.toString());
     assertEquals(
         String.join(
             "\n",

--- a/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestIntervals.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/intervals/TestIntervals.java
@@ -1224,7 +1224,7 @@ public class TestIntervals extends LuceneTestCase {
                 s.intervals("field1", ctx);
               }
             });
-    assertEquals("Automaton [\\p(.)*\\e] expanded to too many terms (limit 1)", e.getMessage());
+    assertEquals("Automaton [p(.)*e] expanded to too many terms (limit 1)", e.getMessage());
 
     checkVisits(source, 1);
   }


### PR DESCRIPTION
The `toString` on regexes that contain a CHAR or CHAR_RANGE has been broken since https://github.com/apache/lucene/commit/1efce5444dd40142c55c5a3a30eeebc7b86796c3 , because ASCII character like `s` becomes `\s`, which parses as character class.