### PR TITLE
[10x] Move some DocValuesConsumer merge logic to helper methods.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -44,6 +44,7 @@ Build
 Other
 ---------------------
 * GITHUB#14474: Minor refactor of ComponentTree (Ankit Jain)
+* GITHUB#14459: Minor refactoring of DocValuesConsumer to allow subclasses to reuse some of its merge logic. (Martijn van Groningen)
 
 ======================= Lucene 10.2.0 =======================
 


### PR DESCRIPTION
Backporting #14459 to `branch_10x` branch.

Move code that creates merged doc value instances and ordinal map to protected helper methods. This will allow custom DocValuesConsumer implementations to reuse these helper methods while providing custom merging logic.