### PR TITLE
Remove dependabot pr limit=1 for java and actions ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
     commit-message:
       prefix: ci
     labels: [dependencies]
-    open-pull-requests-limit: 1
 
   # python dependencies in /dev-tools/scripts
   - package-ecosystem: pip
@@ -18,8 +17,7 @@ updates:
       day: tuesday
     commit-message:
       prefix: build(deps)
-    labels:
-      - dependencies
+    labels: [dependencies]
 
   - package-ecosystem: gradle
     directory: /
@@ -29,4 +27,3 @@ updates:
     commit-message:
       prefix: deps(java)
     labels: [dependencies]
-    open-pull-requests-limit: 1


### PR DESCRIPTION
We'll never upgrade anything in this way, you can bottleneck the entire process on a single dependency.

