### PR TITLE
Use a hint to specify READONCE IOContext

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/IOContext.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IOContext.java
@@ -56,7 +56,7 @@ public interface IOContext {
    * <p>This context should only be used when the read operations will be performed in the same
    * thread as the thread that opens the underlying storage.
    */
-  IOContext READONCE = new DefaultIOContext(DataAccessHint.SEQUENTIAL);
+  IOContext READONCE = new DefaultIOContext(DataAccessHint.SEQUENTIAL, ReadOnceHint.INSTANCE);
 
   /** Returns an {@link IOContext} for merging with the specified {@link MergeInfo} */
   static IOContext merge(MergeInfo mergeInfo) {

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -310,7 +310,7 @@ public class MMapDirectory extends FSDirectory {
     path = Unwrappable.unwrapAll(path);
 
     boolean success = false;
-    final boolean confined = context == IOContext.READONCE;
+    final boolean confined = ReadOnceHint.isReadOnce(context);
     Function<IOContext, ReadAdvice> toReadAdvice =
         c -> readAdviceOverride.apply(name, c).orElseGet(() -> toReadAdvice(c));
     final Arena arena = confined ? Arena.ofConfined() : getSharedArena(name, arenas);

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -310,7 +310,7 @@ public class MMapDirectory extends FSDirectory {
     path = Unwrappable.unwrapAll(path);
 
     boolean success = false;
-    final boolean confined = ReadOnceHint.isReadOnce(context);
+    final boolean confined = context.hints().contains(ReadOnceHint.INSTANCE);
     Function<IOContext, ReadAdvice> toReadAdvice =
         c -> readAdviceOverride.apply(name, c).orElseGet(() -> toReadAdvice(c));
     final Arena arena = confined ? Arena.ofConfined() : getSharedArena(name, arenas);

--- a/lucene/core/src/java/org/apache/lucene/store/ReadOnceHint.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ReadOnceHint.java
@@ -18,9 +18,5 @@ package org.apache.lucene.store;
 
 /** A {@link IOContext.FileOpenHint} indicating the file will only be read once, sequentially */
 public enum ReadOnceHint implements IOContext.FileOpenHint {
-  INSTANCE;
-
-  public static boolean isReadOnce(IOContext context) {
-    return context.hints().contains(INSTANCE);
-  }
+  INSTANCE
 }

--- a/lucene/core/src/java/org/apache/lucene/store/ReadOnceHint.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ReadOnceHint.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.store;
+
+/** A {@link IOContext.FileOpenHint} indicating the file will only be read once, sequentially */
+public enum ReadOnceHint implements IOContext.FileOpenHint {
+  INSTANCE;
+
+  public static boolean isReadOnce(IOContext context) {
+    return context.hints().contains(INSTANCE);
+  }
+}

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockDirectoryWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockDirectoryWrapper.java
@@ -53,6 +53,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.Lock;
+import org.apache.lucene.store.ReadOnceHint;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.tests.util.ThrottledIndexOutput;
@@ -813,7 +814,7 @@ public class MockDirectoryWrapper extends BaseDirectoryWrapper {
     }
 
     context = LuceneTestCase.newIOContext(randomState, context);
-    final boolean confined = context == IOContext.READONCE;
+    final boolean confined = ReadOnceHint.isReadOnce(context);
     if (name.startsWith(IndexFileNames.SEGMENTS) && confined == false) {
       throw new RuntimeException(
           "MockDirectoryWrapper: opening segments file ["

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockDirectoryWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockDirectoryWrapper.java
@@ -814,7 +814,7 @@ public class MockDirectoryWrapper extends BaseDirectoryWrapper {
     }
 
     context = LuceneTestCase.newIOContext(randomState, context);
-    final boolean confined = ReadOnceHint.isReadOnce(context);
+    final boolean confined = context.hints().contains(ReadOnceHint.INSTANCE);
     if (name.startsWith(IndexFileNames.SEGMENTS) && confined == false) {
       throw new RuntimeException(
           "MockDirectoryWrapper: opening segments file ["

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -175,6 +175,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.MergeInfo;
 import org.apache.lucene.store.NRTCachingDirectory;
+import org.apache.lucene.store.ReadOnceHint;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.AlcoholicMergePolicy;
 import org.apache.lucene.tests.index.AssertingDirectoryReader;
@@ -1808,8 +1809,8 @@ public abstract class LuceneTestCase extends Assert {
 
   /** TODO: javadoc */
   public static IOContext newIOContext(Random random, IOContext oldContext) {
-    if (oldContext == IOContext.READONCE) {
-      return oldContext; // don't mess with the READONCE singleton
+    if (ReadOnceHint.isReadOnce(oldContext)) {
+      return oldContext; // just return as-is
     }
     final int randomNumDocs = random.nextInt(4192);
     final int size = random.nextInt(512) * randomNumDocs;
@@ -1829,7 +1830,7 @@ public abstract class LuceneTestCase extends Assert {
               random.nextBoolean(),
               TestUtil.nextInt(random, 1, 100)));
     } else {
-      // Make a totally random IOContext, except READONCE which has semantic implications
+      // Make a totally random IOContext
       final IOContext context;
       switch (random.nextInt(3)) {
         case 0:

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1809,7 +1809,7 @@ public abstract class LuceneTestCase extends Assert {
 
   /** TODO: javadoc */
   public static IOContext newIOContext(Random random, IOContext oldContext) {
-    if (ReadOnceHint.isReadOnce(oldContext)) {
+    if (oldContext.hints().contains(ReadOnceHint.INSTANCE)) {
       return oldContext; // just return as-is
     }
     final int randomNumDocs = random.nextInt(4192);


### PR DESCRIPTION
Use a hint to specify readonce IO, rather than checking for object identity (which we shouldn't really be doing with records anyway)