### PR TITLE
Provide better impacts for fields indexed with IndexOptions.DOCS

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -90,7 +90,7 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+* GITHUB#14445 : Fix Term Query Slowness for fields with IndexOptions.DOCS ( Aniketh Jain )
 
 Build
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -114,6 +114,8 @@ Bug Fixes
 * GITHUB#14523, GITHUB#14530: Correct TermOrdValComparator competitive iterator so that it forces sparse
   field iteration to be at least scoring window baseline when doing intoBitSet. (Ben Trent, Adrien Grand)
 
+ * GITHUB#14445 : Provide better impacts for fields indexed with IndexOptions.DOCS GITHUB#14511 ( Aniketh Jain )
+
 ======================= Lucene 10.2.0 =======================
 
 API Changes

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -289,8 +289,6 @@ Bug Fixes
 
 * GITHUB#14436: Disable connectedComponents logic in HNSW graph building. Relates to GITHUB#14214, GITHUB#12627, GITHUB#13566. (Ben Trent)
 
-* GITHUB#14445 : Provide better impacts for fields indexed with IndexOptions.DOCS GITHUB#14511 ( Aniketh Jain )
-
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14189: Bump floor segment size to 16MB in TieredMergePolicy and

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -114,7 +114,7 @@ Bug Fixes
 * GITHUB#14523, GITHUB#14530: Correct TermOrdValComparator competitive iterator so that it forces sparse
   field iteration to be at least scoring window baseline when doing intoBitSet. (Ben Trent, Adrien Grand)
 
- * GITHUB#14445 : Provide better impacts for fields indexed with IndexOptions.DOCS GITHUB#14511 ( Aniketh Jain )
+* GITHUB#14445 : Provide better impacts for fields indexed with IndexOptions.DOCS GITHUB#14511 ( Aniketh Jain )
 
 ======================= Lucene 10.2.0 =======================
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -90,7 +90,7 @@ Optimizations
 
 Bug Fixes
 ---------------------
-* GITHUB#14445 : Fix Term Query Slowness for fields with IndexOptions.DOCS ( Aniketh Jain )
+(No changes)
 
 Build
 ---------------------
@@ -286,6 +286,8 @@ Bug Fixes
 * GITHUB#14320: Fix DirectIOIndexInput seek to not read when position is within buffer (Chris Hegarty)
 
 * GITHUB#14436: Disable connectedComponents logic in HNSW graph building. Relates to GITHUB#14214, GITHUB#12627, GITHUB#13566. (Ben Trent)
+
+* GITHUB#14445 : Provide better impacts for fields indexed with IndexOptions.DOCS GITHUB#14511 ( Aniketh Jain )
 
 Changes in Runtime Behavior
 ---------------------

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene101/Lucene101PostingsReader.java
@@ -1332,13 +1332,11 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
             if (indexHasFreq == false) {
               return DUMMY_IMPACTS_NO_FREQS;
             }
-            if (indexHasFreq) {
-              if (level == 0 && level0LastDocID != NO_MORE_DOCS) {
-                return readImpacts(level0SerializedImpacts, level0Impacts);
-              }
-              if (level == 1) {
-                return readImpacts(level1SerializedImpacts, level1Impacts);
-              }
+            if (level == 0 && level0LastDocID != NO_MORE_DOCS) {
+              return readImpacts(level0SerializedImpacts, level0Impacts);
+            }
+            if (level == 1) {
+              return readImpacts(level1SerializedImpacts, level1Impacts);
             }
             return DUMMY_IMPACTS;
           }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene101/Lucene101PostingsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene101/Lucene101PostingsReader.java
@@ -70,6 +70,10 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
   private static final List<Impact> DUMMY_IMPACTS =
       Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
 
+  // We stopped storing a placeholder impact with freq=1 for fields with DOCS after 9.12.0
+  private static final List<Impact> DUMMY_IMPACTS_NO_FREQS =
+      Collections.singletonList(new Impact(1, 1L));
+
   private final IndexInput docIn;
   private final IndexInput posIn;
   private final IndexInput payIn;
@@ -1325,6 +1329,9 @@ public final class Lucene101PostingsReader extends PostingsReaderBase {
 
           @Override
           public List<Impact> getImpacts(int level) {
+            if (indexHasFreq == false) {
+              return DUMMY_IMPACTS_NO_FREQS;
+            }
             if (indexHasFreq) {
               if (level == 0 && level0LastDocID != NO_MORE_DOCS) {
                 return readImpacts(level0SerializedImpacts, level0Impacts);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -68,6 +68,14 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
 
   static final VectorizationProvider VECTORIZATION_PROVIDER = VectorizationProvider.getInstance();
 
+  // Dummy impacts, composed of the maximum possible term frequency and the lowest possible
+  // (unsigned) norm value. This is typically used on tail blocks, which don't actually record
+  // impacts as the storage overhead would not be worth any query evaluation speedup, since
+  // there's
+  // less than 128 docs left to evaluate anyway.
+  private static final List<Impact> DUMMY_IMPACTS =
+      Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
+
   // We stopped storing a placeholder impact with freq=1 for fields with IndexOptions.DOCS after
   // 9.12.0
   private static final List<Impact> NON_COMPETITIVE_IMPACTS =
@@ -1310,6 +1318,7 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
               if (level == 1) {
                 return readImpacts(level1SerializedImpacts, level1Impacts);
               }
+              return DUMMY_IMPACTS;
             }
             return NON_COMPETITIVE_IMPACTS;
           }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -67,17 +67,11 @@ import org.apache.lucene.util.VectorUtil;
 public final class Lucene103PostingsReader extends PostingsReaderBase {
 
   static final VectorizationProvider VECTORIZATION_PROVIDER = VectorizationProvider.getInstance();
-  // Dummy impacts, composed of the maximum possible term frequency and the lowest possible
-  // (unsigned) norm value. This is typically used on tail blocks, which don't actually record
-  // impacts as the storage overhead would not be worth any query evaluation speedup, since there's
-  // less than 128 docs left to evaluate anyway.
-  private static final List<Impact> DUMMY_IMPACTS =
-      Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
 
-  // We stopped storing a placeholder impact with freq=1 for fields with IndexOptions.DOCS
-  // from 9.12.0 onwards with @org.apache.lucene.backward_codecs.lucene912.Lucene912PostingsReader
+  // We stopped storing a placeholder impact with freq=1 for fields with IndexOptions.DOCS after
+  // 9.12.0
   private static final List<Impact> NON_COMPETITIVE_IMPACTS =
-          Collections.singletonList(new Impact(1, 1L));
+      Collections.singletonList(new Impact(1, 1L));
 
   private final IndexInput docIn;
   private final IndexInput posIn;

--- a/lucene/core/src/java/org/apache/lucene/index/SlowImpactsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowImpactsEnum.java
@@ -30,11 +30,6 @@ public final class SlowImpactsEnum extends ImpactsEnum {
 
   private static final Impacts DUMMY_IMPACTS =
       new Impacts() {
-        // Dummy impacts, composed of the maximum possible term frequency and the lowest possible
-        // (unsigned) norm value. This is typically used on tail blocks, which don't actually record
-        // impacts as the storage overhead would not be worth any query evaluation speedup, since
-        // there's
-        // less than 128 docs left to evaluate anyway.
         private final List<Impact> impacts =
             Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
 

--- a/lucene/core/src/java/org/apache/lucene/index/SlowImpactsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowImpactsEnum.java
@@ -30,6 +30,7 @@ public final class SlowImpactsEnum extends ImpactsEnum {
 
   private static final Impacts DUMMY_IMPACTS =
       new Impacts() {
+
         private final List<Impact> impacts =
             Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
 

--- a/lucene/core/src/java/org/apache/lucene/index/SlowImpactsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowImpactsEnum.java
@@ -30,7 +30,11 @@ public final class SlowImpactsEnum extends ImpactsEnum {
 
   private static final Impacts DUMMY_IMPACTS =
       new Impacts() {
-
+        // Dummy impacts, composed of the maximum possible term frequency and the lowest possible
+        // (unsigned) norm value. This is typically used on tail blocks, which don't actually record
+        // impacts as the storage overhead would not be worth any query evaluation speedup, since
+        // there's
+        // less than 128 docs left to evaluate anyway.
         private final List<Impact> impacts =
             Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
 


### PR DESCRIPTION
Postings always return impacts with freq=Integer.MAX_VALUE and norm=1 when frequencies are not indexed (IndexOptions.DOCS). This significantly overestimates the score upper bound of term queries, since the similarity scorer is effectively called with freq=1 all the time in this case (and either norm=1 if norms are not indexed, or the number of terms in the field otherwise).

This updates postings to always return impacts with freq=1 and norm=1 when frequencies are not indexed, which helps compute better score upper bounds, and in-turn makes dynamic pruning perform better.

Closes #14445



