### PR TITLE
[Bug] Fix for postings force merge regression

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/FieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/FieldsConsumer.java
@@ -93,6 +93,15 @@ public abstract class FieldsConsumer implements Closeable {
             new MultiFields(
                 fields.toArray(Fields.EMPTY_ARRAY), slices.toArray(ReaderSlice.EMPTY_ARRAY)));
     write(mergedFields, norms);
+    finishMerge(mergeState);
+  }
+
+  private void finishMerge(MergeState mergeState) throws IOException {
+    for (FieldsProducer reader : mergeState.fieldsProducers) {
+      if (reader != null) {
+        reader.finishMerge();
+      }
+    }
   }
 
   // NOTE: strange but necessary so javadocs linting is happy:

--- a/lucene/core/src/java/org/apache/lucene/codecs/FieldsProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/FieldsProducer.java
@@ -51,4 +51,11 @@ public abstract class FieldsProducer extends Fields implements Closeable {
   public FieldsProducer getMergeInstance() {
     return this;
   }
+
+  /**
+   * Optional: reset or close merge resources used in the reader
+   *
+   * <p>The default implementation is empty
+   */
+  public void finishMerge() throws IOException {}
 }


### PR DESCRIPTION
### Description
https://github.com/apache/lucene/issues/14514

TermsIn in `Lucene90BlockTreeTermsReader.java` uses defaultReadAdvice which changed to random with Lucene 10.0.

This caused regression in force merge operation upto 20-30%.

This PR fixes it by updating read advice similar to https://github.com/apache/lucene/pull/13985 and https://github.com/apache/lucene/pull/14512

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
