### PR TITLE
Use a non-deprecated assertThat, and change several test assertions to use assertThat

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.PostingsFormat;
@@ -810,10 +810,7 @@ public class TestAddIndexes extends LuceneTestCase {
     }
     for (MergePolicy.OneMerge merge : merges) {
       if (merge.getMergeInfo() != null) {
-        assertFalse(
-            Arrays.stream(c.destDir.listAll())
-                .collect(Collectors.toSet())
-                .containsAll(merge.getMergeInfo().files()));
+        assertFalse(Set.of(c.destDir.listAll()).containsAll(merge.getMergeInfo().files()));
       }
     }
     c.closeAll();

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
@@ -16,6 +16,9 @@
  */
 package org.apache.lucene.search;
 
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.lucene.document.Document;
@@ -187,7 +190,7 @@ public class TestBooleanScorer extends LuceneTestCase {
     Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1);
     ScorerSupplier ss = weight.scorerSupplier(ctx);
     BulkScorer scorer = ((BooleanScorerSupplier) ss).booleanScorer();
-    assertTrue(scorer instanceof DefaultBulkScorer); // term scorer
+    assertThat(scorer, instanceOf(DefaultBulkScorer.class)); // term scorer
 
     // scores -> term scorer too
     query =
@@ -198,7 +201,7 @@ public class TestBooleanScorer extends LuceneTestCase {
     weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE, 1);
     ss = weight.scorerSupplier(ctx);
     scorer = ((BooleanScorerSupplier) ss).booleanScorer();
-    assertTrue(scorer instanceof DefaultBulkScorer); // term scorer
+    assertThat(scorer, instanceOf(DefaultBulkScorer.class)); // term scorer
 
     w.close();
     reader.close();
@@ -229,7 +232,7 @@ public class TestBooleanScorer extends LuceneTestCase {
     Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE, 1);
     ScorerSupplier ss = weight.scorerSupplier(ctx);
     BulkScorer scorer = ((BooleanScorerSupplier) ss).booleanScorer();
-    assertTrue(scorer instanceof ReqExclBulkScorer);
+    assertThat(scorer, instanceOf(ReqExclBulkScorer.class));
 
     query =
         new BooleanQuery.Builder()
@@ -240,7 +243,7 @@ public class TestBooleanScorer extends LuceneTestCase {
     weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE, 1);
     ss = weight.scorerSupplier(ctx);
     scorer = ((BooleanScorerSupplier) ss).booleanScorer();
-    assertTrue(scorer instanceof ReqExclBulkScorer);
+    assertThat(scorer, instanceOf(ReqExclBulkScorer.class));
 
     query =
         new BooleanQuery.Builder()
@@ -250,7 +253,7 @@ public class TestBooleanScorer extends LuceneTestCase {
     weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE, 1);
     ss = weight.scorerSupplier(ctx);
     scorer = ((BooleanScorerSupplier) ss).booleanScorer();
-    assertTrue(scorer instanceof ReqExclBulkScorer);
+    assertThat(scorer, instanceOf(ReqExclBulkScorer.class));
 
     query =
         new BooleanQuery.Builder()
@@ -260,7 +263,7 @@ public class TestBooleanScorer extends LuceneTestCase {
     weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE, 1);
     ss = weight.scorerSupplier(ctx);
     scorer = ((BooleanScorerSupplier) ss).booleanScorer();
-    assertTrue(scorer instanceof ReqExclBulkScorer);
+    assertThat(scorer, instanceOf(ReqExclBulkScorer.class));
 
     w.close();
     reader.close();
@@ -330,8 +333,8 @@ public class TestBooleanScorer extends LuceneTestCase {
               .add(new TermQuery(new Term("foo", "bar")), Occur.FILTER)
               .build();
       Query rewrite = searcher.rewrite(query);
-      assertTrue(rewrite instanceof BoostQuery);
-      assertTrue(((BoostQuery) rewrite).getQuery() instanceof ConstantScoreQuery);
+      assertThat(rewrite, instanceOf(BoostQuery.class));
+      assertThat(((BoostQuery) rewrite).getQuery(), instanceOf(ConstantScoreQuery.class));
     }
 
     Query[] queries =
@@ -359,9 +362,9 @@ public class TestBooleanScorer extends LuceneTestCase {
         Weight weight = searcher.createWeight(rewrite, scoreMode, 1f);
         Scorer scorer = weight.scorer(reader.leaves().get(0));
         if (scoreMode == ScoreMode.TOP_SCORES) {
-          assertTrue(scorer instanceof ConstantScoreScorer);
+          assertThat(scorer, instanceOf(ConstantScoreScorer.class));
         } else {
-          assertFalse(scorer instanceof ConstantScoreScorer);
+          assertThat(scorer, not(instanceOf(ConstantScoreScorer.class)));
         }
       }
     }
@@ -391,7 +394,7 @@ public class TestBooleanScorer extends LuceneTestCase {
       for (ScoreMode scoreMode : ScoreMode.values()) {
         Weight weight = searcher.createWeight(rewrite, scoreMode, 1f);
         Scorer scorer = weight.scorer(reader.leaves().get(0));
-        assertFalse(scorer instanceof ConstantScoreScorer);
+        assertThat(scorer, not(instanceOf(ConstantScoreScorer.class)));
       }
     }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestArrayUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestArrayUtil.java
@@ -20,6 +20,12 @@ import static org.apache.lucene.util.ArrayUtil.copyOfSubArray;
 import static org.apache.lucene.util.ArrayUtil.growExact;
 import static org.apache.lucene.util.ArrayUtil.growInRange;
 import static org.apache.lucene.util.ArrayUtil.oversize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.sameInstance;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,11 +44,11 @@ public class TestArrayUtil extends LuceneTestCase {
     // Make sure ArrayUtil hits Integer.MAX_VALUE, if we insist:
     while (currentSize != ArrayUtil.MAX_ARRAY_LENGTH) {
       int nextSize = ArrayUtil.oversize(1 + currentSize, RamUsageEstimator.NUM_BYTES_OBJECT_REF);
-      assertTrue(nextSize > currentSize);
+      assertThat(nextSize, greaterThan(currentSize));
       if (currentSize > 0) {
         copyCost += currentSize;
         double copyCostPerElement = ((double) copyCost) / currentSize;
-        assertTrue("cost " + copyCostPerElement, copyCostPerElement < 10.0);
+        assertThat(copyCostPerElement, lessThan(10.0));
       }
       currentSize = nextSize;
     }
@@ -77,7 +83,7 @@ public class TestArrayUtil extends LuceneTestCase {
       final int minTargetSize = rnd.nextInt(ArrayUtil.MAX_ARRAY_LENGTH);
       final int elemSize = rnd.nextInt(11);
       final int v = ArrayUtil.oversize(minTargetSize, elemSize);
-      assertTrue(v >= minTargetSize);
+      assertThat(v, greaterThanOrEqualTo(minTargetSize));
     }
   }
 
@@ -113,16 +119,11 @@ public class TestArrayUtil extends LuceneTestCase {
           parseInt("0.34");
         });
 
-    int test = parseInt("1");
-    assertTrue(test + " does not equal: " + 1, test == 1);
-    test = parseInt("-10000");
-    assertTrue(test + " does not equal: " + -10000, test == -10000);
-    test = parseInt("1923");
-    assertTrue(test + " does not equal: " + 1923, test == 1923);
-    test = parseInt("-1");
-    assertTrue(test + " does not equal: " + -1, test == -1);
-    test = ArrayUtil.parseInt("foo 1923 bar".toCharArray(), 4, 4);
-    assertTrue(test + " does not equal: " + 1923, test == 1923);
+    assertThat(parseInt("1"), equalTo(1));
+    assertThat(parseInt("-10000"), equalTo(-10000));
+    assertThat(parseInt("1923"), equalTo(1923));
+    assertThat(parseInt("-1"), equalTo(-1));
+    assertThat(ArrayUtil.parseInt("foo 1923 bar".toCharArray(), 4, 4), equalTo(1923));
   }
 
   private Integer[] createRandomArray(int maxSize) {
@@ -232,9 +233,9 @@ public class TestArrayUtil extends LuceneTestCase {
       final Item act = items[i];
       if (act.order == 0) {
         // order of "equal" items should be not mixed up
-        assertTrue(act.val > last.val);
+        assertThat(act.val, greaterThan(last.val));
       }
-      assertTrue(act.order >= last.order);
+      assertThat(act.order, greaterThanOrEqualTo(last.order));
       last = act;
     }
   }
@@ -261,9 +262,9 @@ public class TestArrayUtil extends LuceneTestCase {
       final Item act = items[i];
       if (act.order == 0) {
         // order of "equal" items should be not mixed up
-        assertTrue(act.val > last.val);
+        assertThat(act.val, greaterThan(last.val));
       }
-      assertTrue(act.order >= last.order);
+      assertThat(act.order, greaterThanOrEqualTo(last.order));
       last = act;
     }
   }
@@ -302,11 +303,11 @@ public class TestArrayUtil extends LuceneTestCase {
     assertEquals(expected[k], actual[k]);
     for (int i = 0; i < actual.length; ++i) {
       if (i < from || i >= to) {
-        assertSame(arr[i], actual[i]);
+        assertThat(actual[i], sameInstance(arr[i]));
       } else if (i <= k) {
-        assertTrue(actual[i].intValue() <= actual[k].intValue());
+        assertThat(actual[i], lessThanOrEqualTo(actual[k]));
       } else {
-        assertTrue(actual[i].intValue() >= actual[k].intValue());
+        assertThat(actual[i], greaterThanOrEqualTo(actual[k]));
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/util/TestPriorityQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestPriorityQueue.java
@@ -16,6 +16,10 @@
  */
 package org.apache.lucene.util;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -24,7 +28,6 @@ import java.util.NoSuchElementException;
 import java.util.Random;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 
 @SuppressWarnings("BoxedPrimitiveEquality")
@@ -94,7 +97,7 @@ public class TestPriorityQueue extends LuceneTestCase {
 
     // All elements are "equal" so we should have exactly the indexes of those elements that were
     // added first.
-    MatcherAssert.assertThat(indexes, Matchers.containsInAnyOrder(0, 1, 2, 3, 4));
+    assertThat(indexes, Matchers.containsInAnyOrder(0, 1, 2, 3, 4));
   }
 
   public void testPQ() throws Exception {
@@ -114,7 +117,7 @@ public class TestPriorityQueue extends LuceneTestCase {
     int last = Integer.MIN_VALUE;
     for (int i = 0; i < count; i++) {
       Integer next = pq.pop();
-      assertTrue(next.intValue() >= last);
+      assertThat(next, greaterThanOrEqualTo(last));
       last = next.intValue();
       sum2 += last;
     }
@@ -158,10 +161,10 @@ public class TestPriorityQueue extends LuceneTestCase {
     assertNull(pq.insertWithOverflow(i2));
     assertNull(pq.insertWithOverflow(i3));
     assertNull(pq.insertWithOverflow(i4));
-    assertTrue(pq.insertWithOverflow(i5) == i3); // i3 should have been dropped
-    assertTrue(pq.insertWithOverflow(i6) == i6); // i6 should not have been inserted
-    assertEquals(size, pq.size());
-    assertEquals((Integer) 2, pq.top());
+    assertThat(pq.insertWithOverflow(i5), equalTo(i3)); // i3 should have been dropped
+    assertThat(pq.insertWithOverflow(i6), equalTo(i6)); // i6 should not have been inserted
+    assertThat(pq.size(), equalTo(size));
+    assertThat(pq.top(), equalTo(2));
   }
 
   public void testAddAllToEmptyQueue() {
@@ -236,8 +239,8 @@ public class TestPriorityQueue extends LuceneTestCase {
       if ((lastLeast != null) && (newLeast != newEntry) && (newLeast != lastLeast)) {
         // If there has been a change of least entry and it wasn't our new
         // addition we expect the scores to increase
-        assertTrue(newLeast <= newEntry);
-        assertTrue(newLeast >= lastLeast);
+        assertThat(newLeast, lessThanOrEqualTo(newEntry));
+        assertThat(newLeast, greaterThanOrEqualTo(lastLeast));
       }
       lastLeast = newLeast;
     }
@@ -259,8 +262,8 @@ public class TestPriorityQueue extends LuceneTestCase {
         // If there has been a change of least entry and it wasn't our new
         // addition or the loss of our randomly removed entry we expect the
         // scores to increase
-        assertTrue(newLeast <= newEntry);
-        assertTrue(newLeast >= lastLeast);
+        assertThat(newLeast, lessThanOrEqualTo(newEntry));
+        assertThat(newLeast, greaterThanOrEqualTo(lastLeast));
       }
       lastLeast = newLeast;
     }

--- a/lucene/core/src/test/org/apache/lucene/util/TestRadixSelector.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRadixSelector.java
@@ -16,6 +16,11 @@
  */
 package org.apache.lucene.util;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.sameInstance;
+
 import java.util.Arrays;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
@@ -98,14 +103,14 @@ public class TestRadixSelector extends LuceneTestCase {
         };
     selector.select(from, to, k);
 
-    assertEquals(expected[k], actual[k]);
+    assertThat(actual[k], equalTo(expected[k]));
     for (int i = 0; i < actual.length; ++i) {
       if (i < from || i >= to) {
-        assertSame(arr[i], actual[i]);
+        assertThat(actual[i], sameInstance(arr[i]));
       } else if (i <= k) {
-        assertTrue(actual[i].compareTo(actual[k]) <= 0);
+        assertThat(actual[i], lessThanOrEqualTo(actual[k]));
       } else {
-        assertTrue(actual[i].compareTo(actual[k]) >= 0);
+        assertThat(actual[i], greaterThanOrEqualTo(actual[k]));
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestIntSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestIntSet.java
@@ -16,6 +16,9 @@
  */
 package org.apache.lucene.util.automaton;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
@@ -56,14 +59,14 @@ public class TestIntSet extends LuceneTestCase {
       set.incr(i);
     }
 
-    assertTrue(set.size() > 32);
+    assertThat(set.size(), greaterThan(32));
 
     for (int i = 0; i < 35; i++) {
       // This is pretty much the worst case, perf wise
       set.decr(i);
     }
 
-    assertTrue(set.size() == 0);
+    assertThat(set.size(), equalTo(0));
   }
 
   @Test

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
@@ -16,8 +16,13 @@
  */
 package org.apache.lucene.util.automaton;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.not;
+
 import java.util.Locale;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.automaton.AutomatonTestUtil;
@@ -97,19 +102,19 @@ public class TestRegExp extends LuceneTestCase {
   public void testRepeatWithEmptyString() throws Exception {
     Automaton a = new RegExp("[^y]*{1,2}").toAutomaton();
     // paranoia:
-    assertTrue(a.toString().length() > 0);
+    assertThat(a, hasToString(not(emptyString())));
   }
 
   public void testRepeatWithEmptyLanguage() throws Exception {
     Automaton a = new RegExp("#*").toAutomaton();
     // paranoia:
-    assertTrue(a.toString().length() > 0);
+    assertThat(a, hasToString(not(emptyString())));
     a = new RegExp("#+").toAutomaton();
-    assertTrue(a.toString().length() > 0);
+    assertThat(a, hasToString(not(emptyString())));
     a = new RegExp("#{2,10}").toAutomaton();
-    assertTrue(a.toString().length() > 0);
+    assertThat(a, hasToString(not(emptyString())));
     a = new RegExp("#?").toAutomaton();
-    assertTrue(a.toString().length() > 0);
+    assertThat(a, hasToString(not(emptyString())));
   }
 
   boolean caseSensitiveQuery = true;
@@ -140,7 +145,7 @@ public class TestRegExp extends LuceneTestCase {
               () -> {
                 new RegExp(illegalExpression);
               });
-      assertTrue(expected.getMessage().contains("invalid character class"));
+      assertThat(expected.getMessage(), containsString("invalid character class"));
     }
   }
 
@@ -160,7 +165,7 @@ public class TestRegExp extends LuceneTestCase {
             () -> {
               new RegExp("a{99,11}");
             });
-    assertTrue(expected.getMessage().contains("out of order"));
+    assertThat(expected.getMessage(), containsString("out of order"));
   }
 
   static String randomDocValue(int minLength, boolean includeUnicode) {
@@ -291,9 +296,7 @@ public class TestRegExp extends LuceneTestCase {
         caseSensitiveQuery
             ? Pattern.compile(regexPattern)
             : Pattern.compile(regexPattern, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
-    Matcher matcher = pattern.matcher(docValue);
-    assertTrue(
-        "Java regex " + regexPattern + " did not match doc value " + docValue, matcher.matches());
+    assertThat(docValue, matchesRegex(pattern));
 
     int matchFlags =
         caseSensitiveQuery ? 0 : RegExp.ASCII_CASE_INSENSITIVE | RegExp.CASE_INSENSITIVE;

--- a/lucene/test-framework/src/java/module-info.java
+++ b/lucene/test-framework/src/java/module-info.java
@@ -22,6 +22,7 @@ module org.apache.lucene.test_framework {
   requires org.apache.lucene.codecs;
   requires transitive junit;
   requires transitive randomizedtesting.runner;
+  requires org.hamcrest;
 
   // Open certain packages for junit because it scans methods via reflection.
   opens org.apache.lucene.tests.index to

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseCompressingDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseCompressingDocValuesFormatTestCase.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.tests.index;
 
+import static org.hamcrest.Matchers.lessThan;
+
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,7 +74,7 @@ public abstract class BaseCompressingDocValuesFormatTestCase extends BaseDocValu
       iwriter.forceMerge(1);
       final long size2 = dirSize(dir);
       // make sure the new longs did not cost 8 bytes each
-      assertTrue(size2 < size1 + 8 * 20);
+      assertThat(size2, lessThan(size1 + 8 * 20));
     }
   }
 
@@ -100,7 +102,7 @@ public abstract class BaseCompressingDocValuesFormatTestCase extends BaseDocValu
       iwriter.forceMerge(1);
       final long size2 = dirSize(dir);
       // make sure the new longs costed less than if they had only been packed
-      assertTrue(size2 < size1 + (PackedInts.bitsRequired(day) * 50) / 8);
+      assertThat(size2, lessThan(size1 + (PackedInts.bitsRequired(day) * 50) / 8));
     }
   }
 
@@ -123,7 +125,7 @@ public abstract class BaseCompressingDocValuesFormatTestCase extends BaseDocValu
       iwriter.forceMerge(1);
       final long size2 = dirSize(dir);
       // make sure the new value did not grow the bpv for every other value
-      assertTrue(size2 < size1 + (20000 * (63 - 10)) / 8);
+      assertThat(size2, lessThan(size1 + (20000 * (63 - 10)) / 8));
     }
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
@@ -17,6 +17,10 @@
 package org.apache.lucene.tests.store;
 
 import static com.carrotsearch.randomizedtesting.generators.RandomPicks.randomFrom;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.not;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.generators.RandomBytes;
@@ -67,7 +71,6 @@ import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.GroupVIntUtil;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.packed.PackedInts;
-import org.junit.Assert;
 
 /** Base class for {@link Directory} implementations. */
 public abstract class BaseDirectoryTestCase extends LuceneTestCase {
@@ -132,13 +135,13 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
   public void testDeleteFile() throws Exception {
     try (Directory dir = getDirectory(createTempDir("testDeleteFile"))) {
       String file = "foo.txt";
-      Assert.assertFalse(Arrays.asList(dir.listAll()).contains(file));
+      assertThat(dir.listAll(), not(hasItemInArray(file)));
 
       dir.createOutput("foo.txt", IOContext.DEFAULT).close();
-      Assert.assertTrue(Arrays.asList(dir.listAll()).contains(file));
+      assertThat(dir.listAll(), hasItemInArray(file));
 
       dir.deleteFile("foo.txt");
-      Assert.assertFalse(Arrays.asList(dir.listAll()).contains(file));
+      assertThat(dir.listAll(), not(hasItemInArray(file)));
 
       expectThrowsAnyOf(
           Arrays.asList(NoSuchFileException.class, FileNotFoundException.class),
@@ -681,7 +684,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
       String name = "file";
       dir.createOutput(name, newIOContext(random())).close();
       assertTrue(slowFileExists(dir, name));
-      assertTrue(Arrays.asList(dir.listAll()).contains(name));
+      assertThat(dir.listAll(), hasItemInArray(name));
     }
   }
 
@@ -1258,7 +1261,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
   public void testIndexOutputToString() throws Throwable {
     try (Directory dir = getDirectory(createTempDir())) {
       IndexOutput out = dir.createOutput("camelCase.txt", newIOContext(random()));
-      assertTrue(out.toString(), out.toString().contains("camelCase.txt"));
+      assertThat(out.toString(), containsString("camelCase.txt"));
       out.close();
     }
   }
@@ -1305,7 +1308,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
               .filter(file -> !ExtrasFS.isExtra(file)) // remove any ExtrasFS stuff.
               .collect(Collectors.toSet());
 
-      assertEquals(new HashSet<String>(names), files);
+      assertThat(files, containsInAnyOrder(names.toArray()));
     }
   }
 
@@ -1396,7 +1399,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
       }
 
       // Make sure listAll does NOT include the file:
-      assertFalse(Arrays.asList(fsDir.listAll()).contains(fileName));
+      assertThat(fsDir.listAll(), not(hasItemInArray(fileName)));
 
       // Make sure fileLength claims it's deleted:
       expectThrows(

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -205,6 +205,8 @@ import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
+import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -2084,6 +2086,15 @@ public abstract class LuceneTestCase extends Assert {
   /** Gets a resource from the test's classpath as {@link InputStream}. */
   protected InputStream getDataInputStream(String name) throws IOException {
     return IOUtils.requireResourceNonNull(this.getClass().getResourceAsStream(name), name);
+  }
+
+  // these hide the deprecated Assert.assertThat method
+  public static <T> void assertThat(T actual, Matcher<? super T> matcher) {
+    MatcherAssert.assertThat(actual, matcher);
+  }
+
+  public static <T> void assertThat(String reason, T actual, Matcher<? super T> matcher) {
+    MatcherAssert.assertThat(reason, actual, matcher);
   }
 
   public void assertReaderEquals(String info, IndexReader leftReader, IndexReader rightReader)

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestUtil.java
@@ -17,6 +17,13 @@
 package org.apache.lucene.tests.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
@@ -1478,29 +1485,34 @@ public final class TestUtil {
         "wrong total hits", expected.totalHits.value() == 0, actual.totalHits.value() == 0);
     if (expected.totalHits.relation() == TotalHits.Relation.EQUAL_TO) {
       if (actual.totalHits.relation() == TotalHits.Relation.EQUAL_TO) {
-        Assert.assertEquals(
-            "wrong total hits", expected.totalHits.value(), actual.totalHits.value());
+        assertThat(
+            "wrong total hits", actual.totalHits.value(), equalTo(expected.totalHits.value()));
       } else {
-        Assert.assertTrue(
-            "wrong total hits", expected.totalHits.value() >= actual.totalHits.value());
+        assertThat(
+            "wrong total hits",
+            actual.totalHits.value(),
+            lessThanOrEqualTo(expected.totalHits.value()));
       }
     } else if (actual.totalHits.relation() == TotalHits.Relation.EQUAL_TO) {
-      Assert.assertTrue("wrong total hits", expected.totalHits.value() <= actual.totalHits.value());
+      assertThat(
+          "wrong total hits",
+          actual.totalHits.value(),
+          greaterThanOrEqualTo(expected.totalHits.value()));
     }
-    Assert.assertEquals("wrong hit count", expected.scoreDocs.length, actual.scoreDocs.length);
+    assertThat("wrong hit count", actual.scoreDocs, arrayWithSize(expected.scoreDocs.length));
     for (int hitIDX = 0; hitIDX < expected.scoreDocs.length; hitIDX++) {
       final ScoreDoc expectedSD = expected.scoreDocs[hitIDX];
       final ScoreDoc actualSD = actual.scoreDocs[hitIDX];
-      Assert.assertEquals("wrong hit docID", expectedSD.doc, actualSD.doc);
+      assertThat("wrong hit docID", actualSD.doc, equalTo(expectedSD.doc));
       Assert.assertEquals("wrong hit score", expectedSD.score, actualSD.score, 0.0);
       if (expectedSD instanceof FieldDoc) {
-        Assert.assertTrue(actualSD instanceof FieldDoc);
+        assertThat(actualSD, instanceOf(FieldDoc.class));
         Assert.assertArrayEquals(
             "wrong sort field values",
             ((FieldDoc) expectedSD).fields,
             ((FieldDoc) actualSD).fields);
       } else {
-        Assert.assertFalse(actualSD instanceof FieldDoc);
+        assertThat(actualSD, not(instanceOf(FieldDoc.class)));
       }
     }
   }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/store/TestSerializedIOCountingDirectory.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/store/TestSerializedIOCountingDirectory.java
@@ -16,6 +16,9 @@
  */
 package org.apache.lucene.tests.store;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import org.apache.lucene.store.Directory;
@@ -47,7 +50,7 @@ public class TestSerializedIOCountingDirectory extends BaseDirectoryTestCase {
           in.readByte();
         }
         // Sequential reads are free with the normal advice
-        assertEquals(count, dir.count());
+        assertThat(dir.count(), equalTo(count));
       }
       try (IndexInput in =
           dir.openInput("test", IOContext.DEFAULT.withReadAdvice(ReadAdvice.RANDOM))) {
@@ -57,7 +60,7 @@ public class TestSerializedIOCountingDirectory extends BaseDirectoryTestCase {
           in.readByte();
         }
         // But not with the random advice
-        assertFalse(count == dir.count());
+        assertThat(dir.count(), not(equalTo(count)));
       }
     }
   }


### PR DESCRIPTION
The main reason for this PR is using an un-deprecated `assertThat` by default. I've also updated a few uses of old-style assertions to use `assertThat` and `Matchers` for readability and a more descriptive error message. There's obviously loads more that could be updated; this is a few to start with.