### PR TITLE
Upgrade to gradle 8.14-rc-2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ jmh = "1.37"
 jts = "1.17.0"
 junit = "4.13.1"
 # @keep Minimum gradle version to run the build
-minGradle = "8.10"
+minGradle = "8.14-rc-2"
 # @keep This is the minimum required Java version.
 minJava = "23"
 morfologik = "2.1.9"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-rc-2-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

I was trying to do a fresh import of Lucene into Intellij 2025.1 when it threw 

```
java.lang.ClassCastException: class org.codehaus.groovy.runtime.GStringImpl cannot be cast to class java.lang.String (org.codehaus.groovy.runtime.GStringImpl is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader @2280cdac; java.lang.String is in module java.base of loader 'bootstrap')
    in ToolingStreamApiUtils.writeCollection(ToolingStreamApiUtils.java:145)
FAILURE: Build failed with an exception.
* What went wrong:
java.io.NotSerializableException: org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedFile
org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedFile
```

Looks like the issue is related to https://github.com/gradle/gradle/issues/32606 and is fixed in gradle 8.14. Raising this PR if we would want to upgrade to 8.14