### PR TITLE
Make task executor non-final

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TaskExecutor.java
@@ -44,7 +44,7 @@ import org.apache.lucene.util.ThreadInterruptedException;
  *
  * @lucene.experimental
  */
-public final class TaskExecutor {
+public class TaskExecutor {
   private final Executor executor;
 
   /**


### PR DESCRIPTION
### Description

The new task executor implementation from https://github.com/apache/lucene/pull/13472 means users can't exactly control the parallelism of the tasks being run. I think it is fair to allow task executor to be overridden in cases where users want the old or slightly different behavior.

One example of this change breaking consumers: if I had an executor service that I wanted to use to fairly control the execution of tasks across various queries, the calling thread would bypass this fair task handling completely. 

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
