### PR TITLE
Fix broken intellij 2025.1 gradle import.

### DIFF
--- a/gradle/java/core-mrjar.gradle
+++ b/gradle/java/core-mrjar.gradle
@@ -41,8 +41,7 @@ configure(project(":lucene:core")) {
           "--add-exports", "java.base/jdk.incubator.vector=ALL-UNNAMED",
         ]
 
-        def argsProvider = new CompilerArgsProvider()
-        argsProvider.apiJarFile = objects.fileProperty()
+        def argsProvider = objects.newInstance(CompilerArgsProvider)
         argsProvider.apiJarFile.set(apijar)
         options.compilerArgumentProviders.add(argsProvider)
       }
@@ -69,10 +68,10 @@ configure(project(":lucene:core")) {
   }
 }
 
-class CompilerArgsProvider implements CommandLineArgumentProvider {
+abstract class CompilerArgsProvider implements CommandLineArgumentProvider {
   @InputFile
   @PathSensitive(PathSensitivity.RELATIVE)
-  RegularFileProperty apiJarFile
+  abstract RegularFileProperty getApiJarFile()
 
   @Override
   Iterable<String> asArguments() {

--- a/gradle/java/core-mrjar.gradle
+++ b/gradle/java/core-mrjar.gradle
@@ -41,7 +41,10 @@ configure(project(":lucene:core")) {
           "--add-exports", "java.base/jdk.incubator.vector=ALL-UNNAMED",
         ]
 
-        options.compilerArgumentProviders.add(new CompilerArgsProvider(apiJarFile: apijar))
+        def argsProvider = new CompilerArgsProvider()
+        argsProvider.apiJarFile = objects.fileProperty()
+        argsProvider.apiJarFile.set(apijar)
+        options.compilerArgumentProviders.add(argsProvider)
       }
     }
     
@@ -67,13 +70,12 @@ configure(project(":lucene:core")) {
 }
 
 class CompilerArgsProvider implements CommandLineArgumentProvider {
-
   @InputFile
   @PathSensitive(PathSensitivity.RELATIVE)
-  RegularFile apiJarFile
+  RegularFileProperty apiJarFile
 
   @Override
   Iterable<String> asArguments() {
-    return ["--patch-module", "java.base=${apiJarFile}"]
+    return ["--patch-module", "java.base=${apiJarFile.get().asFile.absolutePath}"]
   }
 }


### PR DESCRIPTION
Intellij 2025.1 was failing to import Lucene after an upgrade:
```
* What went wrong:
java.io.NotSerializableException: org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedFile
org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedFile
```

The attached PR makes the import pass again.