### PR TITLE
Impl intoBitset for IndexedDISI and Docvalues

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -811,8 +811,10 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
      * method returns true if there are remaining docs (gte upTo) in the block, otherwise false.
      * When false return, fp of {@link IndexedDISI#slice} is at {@link IndexedDISI#blockEnd} and
      * {@link IndexedDISI#index} is correct but other status vars are undefined. Caller should
-     * decode the header of next block by {@link #readBlockHeader()} and make sure {@link
-     * IndexedDISI#doc} greater than or equals to {@link IndexedDISI#block}.
+     * decode the header of next block by {@link #readBlockHeader()}.
+     *
+     * <p>Caller need to make sure {@link IndexedDISI#doc} greater than or equals to {@link
+     * IndexedDISI#block} when calling this.
      */
     abstract boolean intoBitSetWithinBlock(
         IndexedDISI disi, int upTo, FixedBitSet bitSet, int offset) throws IOException;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -590,7 +590,6 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
 
   enum Method {
     SPARSE {
-      private static final int BATCH_SIZE = 128;
 
       @Override
       boolean advanceWithinBlock(IndexedDISI disi, int target) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -733,10 +733,10 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
 
         int sourceFrom = disi.doc & 0xFFFF;
         int sourceTo = Math.min(upTo - disi.block, BLOCK_SIZE);
-        int destFrom = disi.block - offset + sourceFrom;
+        int destFrom = disi.doc - offset;
 
         long fp = disi.slice.getFilePointer();
-        disi.slice.seek(fp - Long.BYTES);
+        disi.slice.seek(fp - Long.BYTES); // seek back a long to include current word (disi.word).
         int numWords = FixedBitSet.bits2words(sourceTo) - disi.wordIndex;
         disi.slice.readLongs(disi.bitSet.getBits(), disi.wordIndex, numWords);
         FixedBitSet.orRange(disi.bitSet, sourceFrom, bitSet, destFrom, sourceTo - sourceFrom);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -590,7 +590,6 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
 
   enum Method {
     SPARSE {
-
       @Override
       boolean advanceWithinBlock(IndexedDISI disi, int target) throws IOException {
         final int targetInBlock = target & 0xFFFF;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -804,37 +804,37 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
      */
     abstract boolean intoBitSetWithinBlock(
         IndexedDISI disi, int upTo, FixedBitSet bitSet, int offset) throws IOException;
+  }
 
-    /**
-     * If the distance between the current position and the target is > 8 words, the rank cache will
-     * be used to guarantee a worst-case of 1 rank-lookup and 7 word-read-and-count-bits operations.
-     * Note: This does not guarantee a skip up to target, only up to nearest rank boundary. It is
-     * the responsibility of the caller to iterate further to reach target.
-     *
-     * @param disi standard DISI.
-     * @param targetInBlock lower 16 bits of the target
-     * @throws IOException if a DISI seek failed.
-     */
-    private static void rankSkip(IndexedDISI disi, int targetInBlock) throws IOException {
-      assert disi.denseRankPower >= 0 : disi.denseRankPower;
-      // Resolve the rank as close to targetInBlock as possible (maximum distance is 8 longs)
-      // Note: rankOrigoOffset is tracked on block open, so it is absolute (e.g. don't add origo)
-      final int rankIndex =
-          targetInBlock >> disi.denseRankPower; // Default is 9 (8 longs: 2^3 * 2^6 = 512 docIDs)
+  /**
+   * If the distance between the current position and the target is > 8 words, the rank cache will
+   * be used to guarantee a worst-case of 1 rank-lookup and 7 word-read-and-count-bits operations.
+   * Note: This does not guarantee a skip up to target, only up to nearest rank boundary. It is the
+   * responsibility of the caller to iterate further to reach target.
+   *
+   * @param disi standard DISI.
+   * @param targetInBlock lower 16 bits of the target
+   * @throws IOException if a DISI seek failed.
+   */
+  private static void rankSkip(IndexedDISI disi, int targetInBlock) throws IOException {
+    assert disi.denseRankPower >= 0 : disi.denseRankPower;
+    // Resolve the rank as close to targetInBlock as possible (maximum distance is 8 longs)
+    // Note: rankOrigoOffset is tracked on block open, so it is absolute (e.g. don't add origo)
+    final int rankIndex =
+        targetInBlock >> disi.denseRankPower; // Default is 9 (8 longs: 2^3 * 2^6 = 512 docIDs)
 
-      final int rank =
-          (disi.denseRankTable[rankIndex << 1] & 0xFF) << 8
-              | (disi.denseRankTable[(rankIndex << 1) + 1] & 0xFF);
+    final int rank =
+        (disi.denseRankTable[rankIndex << 1] & 0xFF) << 8
+            | (disi.denseRankTable[(rankIndex << 1) + 1] & 0xFF);
 
-      // Position the counting logic just after the rank point
-      final int rankAlignedWordIndex = rankIndex << disi.denseRankPower >> 6;
-      disi.slice.seek(disi.denseBitmapOffset + rankAlignedWordIndex * (long) Long.BYTES);
-      long rankWord = disi.slice.readLong();
-      int denseNOO = rank + Long.bitCount(rankWord);
+    // Position the counting logic just after the rank point
+    final int rankAlignedWordIndex = rankIndex << disi.denseRankPower >> 6;
+    disi.slice.seek(disi.denseBitmapOffset + rankAlignedWordIndex * (long) Long.BYTES);
+    long rankWord = disi.slice.readLong();
+    int denseNOO = rank + Long.bitCount(rankWord);
 
-      disi.wordIndex = rankAlignedWordIndex;
-      disi.word = rankWord;
-      disi.numberOfOnes = disi.denseOrigoIndex + denseNOO;
-    }
+    disi.wordIndex = rankAlignedWordIndex;
+    disi.word = rankWord;
+    disi.numberOfOnes = disi.denseOrigoIndex + denseNOO;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -659,7 +659,6 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
       }
     },
     DENSE {
-
       @Override
       boolean advanceWithinBlock(IndexedDISI disi, int target) throws IOException {
         final int targetInBlock = target & 0xFFFF;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -592,7 +592,6 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
   enum Method {
     SPARSE {
       private static final int BATCH_SIZE = 128;
-      private static long COUNTER = 0;
 
       @Override
       boolean advanceWithinBlock(IndexedDISI disi, int target) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -428,7 +428,6 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
   // SPARSE variables
   boolean exists;
   int nextExistDocInBlock = -1;
-  int[] sparseBuffer;
 
   // DENSE variables
   long word;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -642,7 +642,6 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
           throws IOException {
         if (disi.exists) {
           if (disi.doc >= upTo) {
-
             return true;
           }
           bitSet.set(disi.doc - offset);
@@ -660,7 +659,6 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
           }
           bitSet.set(doc - offset);
         }
-        disi.exists = false;
         return false;
       }
     },

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -744,10 +744,9 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
         int sourceTo = Math.min(upTo - disi.block, BLOCK_SIZE);
         int numWords = FixedBitSet.bits2words(sourceTo) - sourceStartWord;
 
-        if (disi.bitSet == null) {
-          disi.bitSet = new FixedBitSet(numWords << 6);
-        } else {
-          disi.bitSet = FixedBitSet.ensureCapacity(disi.bitSet, (numWords << 6) - 1);
+        if (disi.bitSet == null || disi.bitSet.getBits().length < numWords) {
+          int bits = Math.min(BLOCK_SIZE, ArrayUtil.oversize(numWords, Long.BYTES) << 6);
+          disi.bitSet = new FixedBitSet(bits);
         }
 
         long fp = disi.slice.getFilePointer();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -747,7 +747,7 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
         if (disi.bitSet == null) {
           disi.bitSet = new FixedBitSet(numWords << 6);
         } else {
-          disi.bitSet = FixedBitSet.ensureCapacity(disi.bitSet, numWords << 6);
+          disi.bitSet = FixedBitSet.ensureCapacity(disi.bitSet, (numWords << 6) - 1);
         }
 
         long fp = disi.slice.getFilePointer();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/IndexedDISI.java
@@ -602,11 +602,9 @@ public final class IndexedDISI extends AbstractDocIdSetIterator {
             disi.doc = disi.block | doc;
             disi.exists = true;
             disi.nextExistDocInBlock = doc;
-
             return true;
           }
         }
-
         return false;
       }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -50,6 +50,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.store.ReadAdvice;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LongValues;
 import org.apache.lucene.util.compress.LZ4;
@@ -501,6 +502,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     }
 
     @Override
+    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+      disi.intoBitSet(upTo, bitSet, offset);
+    }
+
+    @Override
     public long cost() {
       return disi.cost();
     }
@@ -781,6 +787,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     public boolean advanceExact(int target) throws IOException {
       return disi.advanceExact(target);
     }
+
+    @Override
+    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+      disi.intoBitSet(upTo, bitSet, offset);
+    }
   }
 
   @Override
@@ -985,6 +996,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
           @Override
           public int advance(int target) throws IOException {
             return disi.advance(target);
+          }
+
+          @Override
+          public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+            disi.intoBitSet(upTo, bitSet, offset);
           }
 
           @Override
@@ -1491,6 +1507,12 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
           return count;
         }
 
+        @Override
+        public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+          set = false;
+          disi.intoBitSet(upTo, bitSet, offset);
+        }
+
         private void set() {
           if (set == false) {
             final int index = disi.index();
@@ -1639,6 +1661,12 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
           public int advance(int target) throws IOException {
             set = false;
             return disi.advance(target);
+          }
+
+          @Override
+          public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+            set = false;
+            disi.intoBitSet(upTo, bitSet, offset);
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesIterator.java
@@ -26,6 +26,9 @@ abstract class DocValuesIterator extends DocIdSetIterator {
    * {@code target} must be greater than or equal to the current {@link #docID() doc ID} and must be
    * a valid doc ID, ie. &ge; 0 and &lt; {@code maxDoc}. After this method returns, {@link #docID()}
    * returns {@code target}.
+   *
+   * <p>Note: it is illegal to call {@link DocIdSetIterator#intoBitSet} or {@link
+   * DocIdSetIterator#docIDRunEnd()} when this method returns false.
    */
   public abstract boolean advanceExact(int target) throws IOException;
 }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestIndexedDISI.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestIndexedDISI.java
@@ -577,11 +577,7 @@ public class TestIndexedDISI extends LuceneTestCase {
       int offset = TestUtil.nextInt(random(), lastUpTo, upTo);
 
       if (disi.docID() < offset) {
-        if (random().nextBoolean()) {
-          disi.advance(offset);
-        } else {
-          disi.advanceExact(offset);
-        }
+        disi.advance(offset);
       }
       int doc = disi2.docID();
       while (doc < offset) {

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestIndexedDISI.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestIndexedDISI.java
@@ -592,6 +592,8 @@ public class TestIndexedDISI extends LuceneTestCase {
 
       disi.intoBitSet(upTo, set1, offset);
       assertEquals(index, disi.index());
+      assertEquals(disi2.docID(), disi.docID());
+
       BitSetIterator expected = new BitSetIterator(set2, set2.cardinality());
       BitSetIterator actual = new BitSetIterator(set1, set1.cardinality());
       for (int expectedDoc = expected.nextDoc();
@@ -601,6 +603,12 @@ public class TestIndexedDISI extends LuceneTestCase {
         assertEquals(expectedDoc + offset, actualDoc + offset); // plus offset for better message.
       }
       assertEquals(DocIdSetIterator.NO_MORE_DOCS, actual.nextDoc());
+
+      if (disi2.docID() != DocIdSetIterator.NO_MORE_DOCS) {
+        assertEquals(disi2.nextDoc(), disi.nextDoc());
+        assertEquals(++index, disi.index());
+      }
+
       set1.clear();
       set2.clear();
     }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestIndexedDISI.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestIndexedDISI.java
@@ -526,6 +526,16 @@ public class TestIndexedDISI extends LuceneTestCase {
       }
     }
 
+    for (int step : new int[] {100, 1000, 10000, 100000}) {
+      try (IndexInput in = dir.openInput("foo", IOContext.DEFAULT)) {
+        IndexedDISI disi =
+            new IndexedDISI(in, 0L, length, jumpTableentryCount, denseRankPower, cardinality);
+        BitSetIterator disi2 = new BitSetIterator(set, cardinality);
+        int disi2length = set.length();
+        assertIntoBitsetRandomized(disi, disi2, disi2length, step);
+      }
+    }
+
     dir.deleteFile("foo");
   }
 
@@ -552,6 +562,51 @@ public class TestIndexedDISI extends LuceneTestCase {
         assertEquals(index, disi.index());
         target = doc;
       }
+    }
+  }
+
+  private void assertIntoBitsetRandomized(
+      IndexedDISI disi, BitSetIterator disi2, int disi2length, int step) throws IOException {
+    int index = -1;
+    FixedBitSet set1 = new FixedBitSet(step);
+    FixedBitSet set2 = new FixedBitSet(step);
+
+    for (int upTo = 0; upTo < disi2length; ) {
+      int lastUpTo = upTo;
+      upTo += TestUtil.nextInt(random(), 0, step);
+      int offset = TestUtil.nextInt(random(), lastUpTo, upTo);
+
+      if (disi.docID() < offset) {
+        if (random().nextBoolean()) {
+          disi.advance(offset);
+        } else {
+          disi.advanceExact(offset);
+        }
+      }
+      int doc = disi2.docID();
+      while (doc < offset) {
+        index++;
+        doc = disi2.nextDoc();
+      }
+      while (doc < upTo) {
+        set2.set(doc - offset);
+        index++;
+        doc = disi2.nextDoc();
+      }
+
+      disi.intoBitSet(upTo, set1, offset);
+      assertEquals(index, disi.index());
+      BitSetIterator expected = new BitSetIterator(set2, set2.cardinality());
+      BitSetIterator actual = new BitSetIterator(set1, set1.cardinality());
+      for (int expectedDoc = expected.nextDoc();
+          expectedDoc != DocIdSetIterator.NO_MORE_DOCS;
+          expectedDoc = expected.nextDoc()) {
+        int actualDoc = actual.nextDoc();
+        assertEquals(expectedDoc + offset, actualDoc + offset); // plus offset for better message.
+      }
+      assertEquals(DocIdSetIterator.NO_MORE_DOCS, actual.nextDoc());
+      set1.clear();
+      set2.clear();
     }
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -53,6 +53,7 @@ import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOBooleanSupplier;
 import org.apache.lucene.util.VirtualMethod;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
@@ -767,6 +768,28 @@ public class AssertingLeafReader extends FilterLeafReader {
     }
 
     @Override
+    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+      assertThread("Numeric doc values", creationThread);
+      assert exists;
+      assert docID() != -1;
+      assert offset <= docID();
+      in.intoBitSet(upTo, bitSet, offset);
+      assert docID() >= upTo;
+      lastDocID = docID();
+    }
+
+    @Override
+    public int docIDRunEnd() throws IOException {
+      assertThread("Numeric doc values", creationThread);
+      assert docID() != -1;
+      assert docID() != DocIdSetIterator.NO_MORE_DOCS;
+      assert exists;
+      int nextNonMatchingDocID = in.docIDRunEnd();
+      assert nextNonMatchingDocID > docID();
+      return nextNonMatchingDocID;
+    }
+
+    @Override
     public long cost() {
       assertThread("Numeric doc values", creationThread);
       long cost = in.cost();
@@ -835,7 +858,7 @@ public class AssertingLeafReader extends FilterLeafReader {
 
     @Override
     public boolean advanceExact(int target) throws IOException {
-      assertThread("Numeric doc values", creationThread);
+      assertThread("Binary doc values", creationThread);
       assert target >= 0;
       assert target >= in.docID();
       assert target < maxDoc;
@@ -843,6 +866,28 @@ public class AssertingLeafReader extends FilterLeafReader {
       assert in.docID() == target;
       lastDocID = target;
       return exists;
+    }
+
+    @Override
+    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+      assertThread("Binary doc values", creationThread);
+      assert exists;
+      assert docID() != -1;
+      assert offset <= docID();
+      in.intoBitSet(upTo, bitSet, offset);
+      assert docID() >= upTo;
+      lastDocID = docID();
+    }
+
+    @Override
+    public int docIDRunEnd() throws IOException {
+      assertThread("Binary doc values", creationThread);
+      assert docID() != -1;
+      assert docID() != DocIdSetIterator.NO_MORE_DOCS;
+      assert exists;
+      int nextNonMatchingDocID = in.docIDRunEnd();
+      assert nextNonMatchingDocID > docID();
+      return nextNonMatchingDocID;
     }
 
     @Override
@@ -915,7 +960,7 @@ public class AssertingLeafReader extends FilterLeafReader {
 
     @Override
     public boolean advanceExact(int target) throws IOException {
-      assertThread("Numeric doc values", creationThread);
+      assertThread("Sorted doc values", creationThread);
       assert target >= 0;
       assert target >= in.docID();
       assert target < maxDoc;
@@ -923,6 +968,28 @@ public class AssertingLeafReader extends FilterLeafReader {
       assert in.docID() == target;
       lastDocID = target;
       return exists;
+    }
+
+    @Override
+    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+      assertThread("Sorted doc values", creationThread);
+      assert exists;
+      assert docID() != -1;
+      assert offset <= docID();
+      in.intoBitSet(upTo, bitSet, offset);
+      assert docID() >= upTo;
+      lastDocID = docID();
+    }
+
+    @Override
+    public int docIDRunEnd() throws IOException {
+      assertThread("Sorted doc values", creationThread);
+      assert docID() != -1;
+      assert docID() != DocIdSetIterator.NO_MORE_DOCS;
+      assert exists;
+      int nextNonMatchingDocID = in.docIDRunEnd();
+      assert nextNonMatchingDocID > docID();
+      return nextNonMatchingDocID;
     }
 
     @Override
@@ -1030,7 +1097,7 @@ public class AssertingLeafReader extends FilterLeafReader {
 
     @Override
     public boolean advanceExact(int target) throws IOException {
-      assertThread("Numeric doc values", creationThread);
+      assertThread("Sorted numeric doc values", creationThread);
       assert target >= 0;
       assert target >= in.docID();
       assert target < maxDoc;
@@ -1039,6 +1106,29 @@ public class AssertingLeafReader extends FilterLeafReader {
       lastDocID = target;
       valueUpto = 0;
       return exists;
+    }
+
+    @Override
+    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+      assertThread("Sorted numeric doc values", creationThread);
+      assert exists;
+      assert docID() != -1;
+      assert offset <= docID();
+      in.intoBitSet(upTo, bitSet, offset);
+      assert docID() >= upTo;
+      lastDocID = docID();
+      valueUpto = 0;
+    }
+
+    @Override
+    public int docIDRunEnd() throws IOException {
+      assertThread("Sorted numeric doc values", creationThread);
+      assert docID() != -1;
+      assert docID() != DocIdSetIterator.NO_MORE_DOCS;
+      assert exists;
+      int nextNonMatchingDocID = in.docIDRunEnd();
+      assert nextNonMatchingDocID > docID();
+      return nextNonMatchingDocID;
     }
 
     @Override
@@ -1131,7 +1221,7 @@ public class AssertingLeafReader extends FilterLeafReader {
 
     @Override
     public boolean advanceExact(int target) throws IOException {
-      assertThread("Numeric doc values", creationThread);
+      assertThread("Sorted numeric doc values", creationThread);
       assert target >= 0;
       assert target >= in.docID();
       assert target < maxDoc;
@@ -1140,6 +1230,29 @@ public class AssertingLeafReader extends FilterLeafReader {
       lastDocID = target;
       ordsRetrieved = 0;
       return exists;
+    }
+
+    @Override
+    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+      assertThread("Sorted set doc values", creationThread);
+      assert exists;
+      assert docID() != -1;
+      assert offset <= docID();
+      in.intoBitSet(upTo, bitSet, offset);
+      assert docID() >= upTo;
+      lastDocID = docID();
+      ordsRetrieved = 0;
+    }
+
+    @Override
+    public int docIDRunEnd() throws IOException {
+      assertThread("Sorted set doc values", creationThread);
+      assert docID() != -1;
+      assert docID() != DocIdSetIterator.NO_MORE_DOCS;
+      assert exists;
+      int nextNonMatchingDocID = in.docIDRunEnd();
+      assert nextNonMatchingDocID > docID();
+      return nextNonMatchingDocID;
     }
 
     @Override


### PR DESCRIPTION
Implement `intoBitset` for `IndexedDISI` and Docvalues.

`intoBitset` of Docvalues has already been called in competitive iterators, and can also be used to speed up soft delete operations.

Logic of this impl is different from default impl when calling `intoBitset` after `advanceExact` return false, where default impl starts from a not-existing doc but this impl starts from the next doc. I do not know which one is intended, maybe this should just be undefined.

relates: https://github.com/apache/lucene/issues/14521