### PR TITLE
Advance doc instead of offset in competitive iterator

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -107,7 +107,7 @@ Bug Fixes
 * GITHUB#14522: Fix DISIDocIdStream::count so that it does not try to count beyond max.
   (Chris Hegarty)
 
-* GITHUB#14523: Correct TermOrdValComparator competitive iterator so that it forces sparse
+* GITHUB#14523, GITHUB#14530: Correct TermOrdValComparator competitive iterator so that it forces sparse
   field iteration to be at least scoring window baseline when doing intoBitSet. (Ben Trent, Adrien Grand)
 
 ======================= Lucene 10.2.0 =======================

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
@@ -533,8 +533,8 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
       if (disjunction == null) {
         if (docsWithField != null) {
           // we need to be absolutely sure that the iterator is at least at offset
-          if (docsWithField.docID() < offset) {
-            docsWithField.advance(offset);
+          if (docsWithField.docID() < doc) {
+            docsWithField.advance(doc);
           }
           docsWithField.intoBitSet(upTo, bitSet, offset);
           doc = docsWithField.docID();


### PR DESCRIPTION
https://github.com/apache/lucene/pull/14523#discussion_r2051658845

Should we include this in 10.2.1?