### PR TITLE
Fix leadCost calculation in BooleanScorerSupplier.requiredBulkScorer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -110,6 +110,11 @@ Bug Fixes
 * GITHUB#14523, GITHUB#14530: Correct TermOrdValComparator competitive iterator so that it forces sparse
   field iteration to be at least scoring window baseline when doing intoBitSet. (Ben Trent, Adrien Grand)
 
+* GITHUB#14543: Fixed lead cost computations for bulk scorers of conjunctive
+  queries that mix MUST and FILTER clauses, and disjunctive queries that
+  configure a minimum number of matching SHOULD clauses.
+  (Peter Alfonsi, Adrien Grand)
+
 ======================= Lucene 10.2.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
@@ -359,10 +359,14 @@ final class BooleanScorerSupplier extends ScorerSupplier {
       return scorer;
     }
 
-    long leadCost =
+    long mustLeadCost =
         subs.get(Occur.MUST).stream().mapToLong(ScorerSupplier::cost).min().orElse(Long.MAX_VALUE);
-    leadCost =
-        subs.get(Occur.FILTER).stream().mapToLong(ScorerSupplier::cost).min().orElse(leadCost);
+    long filterLeadCost =
+        subs.get(Occur.FILTER).stream()
+            .mapToLong(ScorerSupplier::cost)
+            .min()
+            .orElse(Long.MAX_VALUE);
+    long leadCost = Math.min(mustLeadCost, filterLeadCost);
 
     List<Scorer> requiredNoScoring = new ArrayList<>();
     for (ScorerSupplier ss : subs.get(Occur.FILTER)) {

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
@@ -85,7 +85,6 @@ final class BooleanScorerSupplier extends ScorerSupplier {
     if (minRequiredCost.isPresent() && minShouldMatch == 0) {
       return minRequiredCost.getAsLong();
     } else {
-      final Collection<ScorerSupplier> optionalScorers = subs.get(Occur.SHOULD);
       final long shouldCost = computeShouldCost();
       return Math.min(minRequiredCost.orElse(Long.MAX_VALUE), shouldCost);
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2ScorerSupplier.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2ScorerSupplier.java
@@ -289,6 +289,9 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     new BooleanScorerSupplier(
             new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 0, 100)
         .get(Long.MAX_VALUE); // triggers assertions as a side-effect
+    new BooleanScorerSupplier(
+            new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 0, 100)
+        .bulkScorer();
 
     subs = new EnumMap<>(Occur.class);
     for (Occur occur : Occur.values()) {
@@ -315,6 +318,9 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     new BooleanScorerSupplier(
             new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 0, 100)
         .get(100); // triggers assertions as a side-effect
+    new BooleanScorerSupplier(
+            new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 0, 100)
+        .bulkScorer(); // triggers assertions as a side-effect
 
     subs.get(Occur.SHOULD).clear();
     subs.get(Occur.SHOULD).add(new FakeScorerSupplier(42, 20));
@@ -338,6 +344,9 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     new BooleanScorerSupplier(
             new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 2, 100)
         .get(100); // triggers assertions as a side-effect
+    new BooleanScorerSupplier(
+            new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 2, 100)
+        .bulkScorer(); // triggers assertions as a side-effect
 
     subs = new EnumMap<>(Occur.class);
     for (Occur occur : Occur.values()) {
@@ -364,6 +373,9 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     new BooleanScorerSupplier(
             new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 2, 100)
         .get(100); // triggers assertions as a side-effect
+    new BooleanScorerSupplier(
+            new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 2, 100)
+        .bulkScorer(); // triggers assertions as a side-effect
 
     subs = new EnumMap<>(Occur.class);
     for (Occur occur : Occur.values()) {
@@ -377,6 +389,9 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     new BooleanScorerSupplier(
             new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 3, 100)
         .get(100); // triggers assertions as a side-effect
+    new BooleanScorerSupplier(
+            new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 3, 100)
+        .bulkScorer(); // triggers assertions as a side-effect
   }
 
   public void testProhibitedLeadCost() throws IOException {
@@ -394,11 +409,27 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
 
     subs.get(Occur.MUST).clear();
     subs.get(Occur.MUST_NOT).clear();
+    subs.get(Occur.MUST).add(new FakeScorerSupplier(42, Long.MAX_VALUE));
+    subs.get(Occur.MUST_NOT).add(new FakeScorerSupplier(30, 42));
+    new BooleanScorerSupplier(
+            new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 0, 100)
+        .bulkScorer(); // triggers assertions as a side-effect
+
+    subs.get(Occur.MUST).clear();
+    subs.get(Occur.MUST_NOT).clear();
     subs.get(Occur.MUST).add(new FakeScorerSupplier(42, 42));
     subs.get(Occur.MUST_NOT).add(new FakeScorerSupplier(80, 42));
     new BooleanScorerSupplier(
             new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 0, 100)
         .get(100); // triggers assertions as a side-effect
+
+    subs.get(Occur.MUST).clear();
+    subs.get(Occur.MUST_NOT).clear();
+    subs.get(Occur.MUST).add(new FakeScorerSupplier(42, Long.MAX_VALUE));
+    subs.get(Occur.MUST_NOT).add(new FakeScorerSupplier(80, 42));
+    new BooleanScorerSupplier(
+            new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 0, 100)
+        .bulkScorer(); // triggers assertions as a side-effect
 
     subs.get(Occur.MUST).clear();
     subs.get(Occur.MUST_NOT).clear();
@@ -420,6 +451,8 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     subs.get(Occur.SHOULD).add(new FakeScorerSupplier(30, 42));
     new BooleanScorerSupplier(new FakeWeight(), subs, ScoreMode.COMPLETE, 0, 100)
         .get(100); // triggers assertions as a side-effect
+    new BooleanScorerSupplier(new FakeWeight(), subs, ScoreMode.COMPLETE, 0, 100)
+        .bulkScorer(); // triggers assertions as a side-effect
 
     subs.get(Occur.MUST).clear();
     subs.get(Occur.SHOULD).clear();
@@ -427,6 +460,8 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
     subs.get(Occur.SHOULD).add(new FakeScorerSupplier(80, 42));
     new BooleanScorerSupplier(new FakeWeight(), subs, ScoreMode.COMPLETE, 0, 100)
         .get(100); // triggers assertions as a side-effect
+    new BooleanScorerSupplier(new FakeWeight(), subs, ScoreMode.COMPLETE, 0, 100)
+        .bulkScorer(); // triggers assertions as a side-effect
 
     subs.get(Occur.MUST).clear();
     subs.get(Occur.SHOULD).clear();

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2ScorerSupplier.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2ScorerSupplier.java
@@ -304,7 +304,7 @@ public class TestBoolean2ScorerSupplier extends LuceneTestCase {
         .get(Long.MAX_VALUE); // triggers assertions as a side-effect
     new BooleanScorerSupplier(
             new FakeWeight(), subs, RandomPicks.randomFrom(random(), ScoreMode.values()), 0, 100)
-        .bulkScorer();
+        .bulkScorer(); // triggers assertions as a side-effect
 
     subs = new EnumMap<>(Occur.class);
     for (Occur occur : Occur.values()) {


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/lucene/issues/14542 by setting `leadCost` in `BooleanScorerSupplier.requiredBulkScorer` to the minimum of both MUST and FILTER clauses' costs. This bug caused performance regressions in some queries. More details are in the original issue. 
