### PR TITLE
deps: set pip/actions to monthly, unbottleneck

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,9 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    open-pull-requests-limit: 20
     schedule:
-      interval: weekly
-      day: tuesday
+      interval: monthly
     commit-message:
       prefix: ci
     labels: [dependencies]
@@ -12,15 +12,16 @@ updates:
   # python dependencies in /dev-tools/scripts
   - package-ecosystem: pip
     directory: /dev-tools/scripts/
+    open-pull-requests-limit: 20
     schedule:
-      interval: weekly
-      day: tuesday
+      interval: monthly
     commit-message:
       prefix: build(deps)
     labels: [dependencies]
 
   - package-ecosystem: gradle
     directory: /
+    open-pull-requests-limit: 20
     schedule:
       interval: weekly
       day: tuesday

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 25
     schedule:
       interval: monthly
     commit-message:
@@ -12,7 +12,7 @@ updates:
   # python dependencies in /dev-tools/scripts
   - package-ecosystem: pip
     directory: /dev-tools/scripts/
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 25
     schedule:
       interval: monthly
     commit-message:
@@ -21,7 +21,7 @@ updates:
 
   - package-ecosystem: gradle
     directory: /
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 25
     schedule:
       interval: weekly
       day: tuesday


### PR DESCRIPTION
pip and actions aren't the primary focus of the project, set PRs to monthly. It should still serve the purpose of keeping dependencies up to date, while reducing the noise (there will be less PRs). Some of the dependencies release quite frequently.

pip dependencies and actions are "caught up": there are only a handful of dependencies in each ecosystem, so the default of 5 open pull requests hasn't posed any problem. Increase limit just for consistency, especially with a monthly interval, we don't want to get bottlenecked.

increase open-PR limit for java dependencies from the default of 5 to 20 in order try to help get "caught up". For now these are still weekly, we may need to configure/tune them differently as well.
