### PR TITLE
Enabling histogram collection for PointRangeQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -78,7 +78,7 @@ Optimizations
 ---------------------
 * GITHUB#14418: Quick exit on filter query matching no docs when rewriting knn query. (Pan Guixin)
 
-* GITHUB#14439: Efficient Histogram Collection using multi range traversal over PointTrees (Ankit Jain)
+* GITHUB#14439, GITHUB#14560: Efficient Histogram Collection using multi range traversal over PointTrees (Ankit Jain)
 
 * GITHUB#14268: PointInSetQuery early exit on non-matching segments. (hanbj)
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/plain/histograms/PointTreeBulkCollector.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/plain/histograms/PointTreeBulkCollector.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.internal.hppc.LongIntHashMap;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.util.NumericUtils;
 
 /**
@@ -76,15 +77,23 @@ class PointTreeBulkCollector {
 
   static void collect(
       final PointValues pointValues,
+      final PointRangeQuery prq,
       final long bucketWidth,
       final LongIntHashMap collectorCounts,
       final int maxBuckets)
       throws IOException {
     final Function<byte[], Long> byteToLong = bytesToLong(pointValues.getBytesPerDimension());
+    long leafMin = byteToLong.apply(pointValues.getMinPackedValue());
+    long leafMax = byteToLong.apply(pointValues.getMaxPackedValue());
+    if (prq != null) {
+      leafMin = Math.max(leafMin, byteToLong.apply(prq.getLowerPoint()));
+      leafMax = Math.min(leafMax, byteToLong.apply(prq.getUpperPoint()));
+    }
     BucketManager collector =
         new BucketManager(
             collectorCounts,
-            byteToLong.apply(pointValues.getMinPackedValue()),
+            leafMin,
+            leafMax + 1, // the max value is exclusive for collector
             bucketWidth,
             byteToLong,
             maxBuckets);
@@ -160,6 +169,11 @@ class PointTreeBulkCollector {
         // try to find the first range that may collect values from this cell
         if (!collector.withinUpperBound(minPackedValue)) {
           collector.finalizePreviousBucket(minPackedValue);
+          // If the minPackedValue is not within upper bound even after updating upper bound,
+          // we have exhausted the max value and should throw early termination error
+          if (!collector.withinUpperBound(minPackedValue)) {
+            return PointValues.Relation.CELL_OUTSIDE_QUERY;
+          }
         }
 
         // Not possible to have the CELL_OUTSIDE_QUERY, as bucket lower bound is updated
@@ -176,6 +190,7 @@ class PointTreeBulkCollector {
     private final LongIntHashMap collectorCounts;
     private int counter = 0;
     private long startValue;
+    private long maxValue;
     private long endValue;
     private int nonZeroBuckets = 0;
     private int maxBuckets;
@@ -185,13 +200,16 @@ class PointTreeBulkCollector {
     public BucketManager(
         LongIntHashMap collectorCounts,
         long minValue,
+        long maxValue,
         long bucketWidth,
         Function<byte[], Long> byteToLong,
         int maxBuckets) {
       this.collectorCounts = collectorCounts;
       this.bucketWidth = bucketWidth;
-      this.startValue = Math.floorDiv(minValue, bucketWidth) * bucketWidth;
-      this.endValue = startValue + bucketWidth;
+      this.startValue = minValue;
+      this.endValue =
+          Math.min((Math.floorDiv(startValue, bucketWidth) + 1) * bucketWidth, maxValue);
+      this.maxValue = maxValue;
       this.byteToLong = byteToLong;
       this.maxBuckets = maxBuckets;
     }
@@ -210,9 +228,7 @@ class PointTreeBulkCollector {
         collectorCounts.addTo(Math.floorDiv(startValue, bucketWidth), counter);
         if (packedValue != null) {
           startValue = byteToLong.apply(packedValue);
-          // Align the start value with bucket width
-          startValue = Math.floorDiv(startValue, bucketWidth) * bucketWidth;
-          endValue = startValue + bucketWidth;
+          endValue = Math.min((Math.floorDiv(startValue, bucketWidth) + 1) * bucketWidth, maxValue);
         }
         nonZeroBuckets++;
         counter = 0;

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/plain/histograms/PointTreeBulkCollector.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/plain/histograms/PointTreeBulkCollector.java
@@ -234,6 +234,8 @@ class PointTreeBulkCollector {
     }
 
     private void finalizePreviousBucket(byte[] packedValue) {
+      // counter can be 0 for first bucket in case
+      // of Point Range Query
       if (counter > 0) {
         collectorCounts.addTo(Math.floorDiv(startValue, bucketWidth), counter);
         nonZeroBuckets++;


### PR DESCRIPTION
### Description
Enables efficient histogram collection using point range query, when querying field is same as the histogram field

Resolves https://github.com/apache/lucene/issues/14535


### Testing
Successfully ran the tests 10k times.

```
> Task :lucene:sandbox:test
:lucene:sandbox:test (SUCCESS): 10000 test(s)

> Task :lucene:sandbox:wipeTaskTemp
The slowest suites (exceeding 1s) during this run:
  109.33s TestHistogramCollectorManager (:lucene:sandbox)

BUILD SUCCESSFUL in 1m 53s
246 actionable tasks: 92 executed, 154 up-to-date
```

Initially they were failing due to first bucket occasionally not having any documents, causing `finalizePreviousBucket` to not move to the next bucket. That also addresses the TODO from earlier
```
java.lang.AssertionError: expected:<[2=>1041, 3=>671, 1=>1007]> but was:<[]>
```
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
