### PR TITLE
Remove RANDOM_PRELOAD read advice, which is not actually used

### DIFF
--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -236,7 +236,7 @@ enum.
 ### IOContext.LOAD and IOContext.READ removed
 
 `IOContext#LOAD` has been removed, it should be replaced with
-`ioContext.withReadAdvice(ReadAdvice.RANDOM_PRELOAD)`.
+`ioContext.withReadAdvice(ReadAdvice.NORMAL)`.
 
 `IOContext.READ` has been removed, it should be replaced with `IOContext.DEFAULT`.
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
@@ -146,8 +146,7 @@ public final class Lucene90BlockTreeTermsReader extends FieldsProducer {
       String indexName =
           IndexFileNames.segmentFileName(segment, state.segmentSuffix, TERMS_INDEX_EXTENSION);
       indexIn =
-          state.directory.openInput(
-              indexName, state.context.withReadAdvice(ReadAdvice.NORMAL));
+          state.directory.openInput(indexName, state.context.withReadAdvice(ReadAdvice.NORMAL));
       CodecUtil.checkIndexHeader(
           indexIn,
           TERMS_INDEX_CODEC_NAME,

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
@@ -147,7 +147,7 @@ public final class Lucene90BlockTreeTermsReader extends FieldsProducer {
           IndexFileNames.segmentFileName(segment, state.segmentSuffix, TERMS_INDEX_EXTENSION);
       indexIn =
           state.directory.openInput(
-              indexName, state.context.withReadAdvice(ReadAdvice.RANDOM_PRELOAD));
+              indexName, state.context.withReadAdvice(ReadAdvice.NORMAL));
       CodecUtil.checkIndexHeader(
           indexIn,
           TERMS_INDEX_CODEC_NAME,

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
@@ -76,7 +76,7 @@ public class FSTTermsReader extends FieldsProducer {
     this.postingsReader = postingsReader;
     this.fstTermsInput =
         state.directory.openInput(
-            termsFileName, state.context.withReadAdvice(ReadAdvice.RANDOM_PRELOAD));
+            termsFileName, state.context.withReadAdvice(ReadAdvice.NORMAL));
 
     IndexInput in = this.fstTermsInput;
 

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
@@ -75,8 +75,7 @@ public class FSTTermsReader extends FieldsProducer {
 
     this.postingsReader = postingsReader;
     this.fstTermsInput =
-        state.directory.openInput(
-            termsFileName, state.context.withReadAdvice(ReadAdvice.NORMAL));
+        state.directory.openInput(termsFileName, state.context.withReadAdvice(ReadAdvice.NORMAL));
 
     IndexInput in = this.fstTermsInput;
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/Lucene103BlockTreeTermsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/Lucene103BlockTreeTermsReader.java
@@ -128,7 +128,7 @@ public final class Lucene103BlockTreeTermsReader extends FieldsProducer {
           IndexFileNames.segmentFileName(segment, state.segmentSuffix, TERMS_INDEX_EXTENSION);
       indexIn =
           state.directory.openInput(
-              indexName, state.context.withReadAdvice(ReadAdvice.RANDOM_PRELOAD));
+              indexName, state.context.withReadAdvice(ReadAdvice.NORMAL));
       CodecUtil.checkIndexHeader(
           indexIn,
           TERMS_INDEX_CODEC_NAME,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/Lucene103BlockTreeTermsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/Lucene103BlockTreeTermsReader.java
@@ -127,8 +127,7 @@ public final class Lucene103BlockTreeTermsReader extends FieldsProducer {
       String indexName =
           IndexFileNames.segmentFileName(segment, state.segmentSuffix, TERMS_INDEX_EXTENSION);
       indexIn =
-          state.directory.openInput(
-              indexName, state.context.withReadAdvice(ReadAdvice.NORMAL));
+          state.directory.openInput(indexName, state.context.withReadAdvice(ReadAdvice.NORMAL));
       CodecUtil.checkIndexHeader(
           indexIn,
           TERMS_INDEX_CODEC_NAME,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsReader.java
@@ -61,7 +61,7 @@ public class Lucene90PointsReader extends PointsReader {
     try {
       indexIn =
           readState.directory.openInput(
-              indexFileName, readState.context.withReadAdvice(ReadAdvice.RANDOM_PRELOAD));
+              indexFileName, readState.context.withReadAdvice(ReadAdvice.NORMAL));
       CodecUtil.checkIndexHeader(
           indexIn,
           Lucene90PointsFormat.INDEX_CODEC_NAME,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/FieldsIndexReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/FieldsIndexReader.java
@@ -69,7 +69,7 @@ final class FieldsIndexReader extends FieldsIndex {
     indexInput =
         dir.openInput(
             IndexFileNames.segmentFileName(name, suffix, extension),
-            context.withReadAdvice(ReadAdvice.RANDOM_PRELOAD));
+            context.withReadAdvice(ReadAdvice.NORMAL));
     boolean success = false;
     try {
       CodecUtil.checkIndexHeader(

--- a/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
+++ b/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
@@ -157,7 +157,6 @@ final class PosixNativeAccess extends NativeAccess {
       case NORMAL -> POSIX_MADV_NORMAL;
       case RANDOM -> POSIX_MADV_RANDOM;
       case SEQUENTIAL -> POSIX_MADV_SEQUENTIAL;
-      case RANDOM_PRELOAD -> POSIX_MADV_NORMAL;
     };
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/ReadAdvice.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ReadAdvice.java
@@ -33,12 +33,5 @@ public enum ReadAdvice {
    * Data is expected to be read sequentially with very little seeking at most. The system may read
    * ahead aggressively and free pages soon after they are accessed.
    */
-  SEQUENTIAL,
-  /**
-   * Data is treated as random-access memory in practice. {@link Directory} implementations may
-   * explicitly load the content of the file in memory, or provide hints to the system so that it
-   * loads the content of the file into the page cache at open time. This should only be used on
-   * very small files that can be expected to fit in RAM with very high confidence.
-   */
-  RANDOM_PRELOAD
+  SEQUENTIAL
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestDefaultCodecParallelizesIO.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDefaultCodecParallelizesIO.java
@@ -16,6 +16,9 @@
  */
 package org.apache.lucene.index;
 
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
 import java.io.IOException;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.store.ByteBuffersDirectory;
@@ -29,9 +32,6 @@ import org.apache.lucene.util.IOBooleanSupplier;
 import org.apache.lucene.util.IOUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
 
 public class TestDefaultCodecParallelizesIO extends LuceneTestCase {
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDefaultCodecParallelizesIO.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDefaultCodecParallelizesIO.java
@@ -30,6 +30,9 @@ import org.apache.lucene.util.IOUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
 public class TestDefaultCodecParallelizesIO extends LuceneTestCase {
 
   private static SerialIOCountingDirectory dir;
@@ -81,10 +84,10 @@ public class TestDefaultCodecParallelizesIO extends LuceneTestCase {
       }
     }
 
-    assertTrue(nonNullIOSuppliers > 0);
+    assertThat(nonNullIOSuppliers, greaterThan(0));
     long newCount = dir.count();
-    assertTrue(newCount - prevCount > 0);
-    assertTrue(newCount - prevCount < nonNullIOSuppliers);
+    assertThat(newCount, greaterThan(prevCount));
+    assertThat(newCount, lessThan(prevCount + nonNullIOSuppliers));
   }
 
   /** Simulate stored fields retrieval. */
@@ -103,7 +106,7 @@ public class TestDefaultCodecParallelizesIO extends LuceneTestCase {
     }
 
     long newCount = dir.count();
-    assertTrue(newCount - prevCount > 0);
-    assertTrue(newCount - prevCount < docs.length);
+    assertThat(newCount, greaterThan(prevCount));
+    assertThat(newCount, lessThan(prevCount + docs.length));
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestDefaultCodecParallelizesIO.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDefaultCodecParallelizesIO.java
@@ -43,8 +43,6 @@ public class TestDefaultCodecParallelizesIO extends LuceneTestCase {
             new IndexWriter(
                 bbDir,
                 new IndexWriterConfig()
-                    // Disable CFS, this test needs to know about files that are open with the
-                    // RANDOM_PRELOAD advice, which CFS doesn't allow us to detect.
                     .setUseCompoundFile(false)
                     .setMergePolicy(newLogMergePolicy(false))
                     .setCodec(TestUtil.getDefaultCodec()))) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
@@ -73,11 +73,6 @@ public class SerialIOCountingDirectory extends FilterDirectory {
   @Override
   public IndexInput openInput(String name, IOContext context) throws IOException {
     ReadAdvice readAdvice = context.readAdvice().orElse(Constants.DEFAULT_READADVICE);
-    if (readAdvice == ReadAdvice.RANDOM_PRELOAD) {
-      // expected to be loaded in memory, only count 1 at open time
-      counter.increment();
-      return super.openInput(name, context);
-    }
     return new SerializedIOCountingIndexInput(super.openInput(name, context), readAdvice);
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
@@ -73,6 +73,11 @@ public class SerialIOCountingDirectory extends FilterDirectory {
   @Override
   public IndexInput openInput(String name, IOContext context) throws IOException {
     ReadAdvice readAdvice = context.readAdvice().orElse(Constants.DEFAULT_READADVICE);
+    if (readAdvice == ReadAdvice.NORMAL) {
+      // expected to be loaded in memory, only count 1 at open time
+      counter.increment();
+      return super.openInput(name, context);
+    }
     return new SerializedIOCountingIndexInput(super.openInput(name, context), readAdvice);
   }
 


### PR DESCRIPTION
`ReadAdvice.RANDOM_PRELOAD` just maps to the same madvise as NORMAL - so remove it completely.