### PR TITLE
add comments around how dependencies are used

### DIFF
--- a/dev-tools/scripts/requirements.txt
+++ b/dev-tools/scripts/requirements.txt
@@ -1,9 +1,18 @@
+# jinja template processing of releaseWizard.yaml
 Jinja2==3.1.6
+# parsing and processing of releaseWizard.yaml
 PyYAML==6.0.2
+# international holidays in releaseWizard 
 holidays==0.71
+# calendar processing in releaseWizard
 ics==0.7.2
+# terminal processing in releaseWizard
 console-menu==0.8.0
+# pull request processing in githubPRs
 PyGithub==2.6.1
+# JIRA processing in githubPRs
 jira==3.8.0
+# type-checking in "make lint"
 basedpyright==1.29.1
+# linting in "make lint"
 ruff==0.11.7

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,39 +1,66 @@
 # Run "gradlew writeLocks" and "gradlew updateLicenses" after modifying this file!
 [versions]
+# expressions/ grammars
 antlr = "4.13.2"
+# expressions/ bytecode, gradle extract-jdk-apis
 asm = "9.8"
+# test assertions
 assertj = "3.27.3"
+# analysis/phonetic/ algorithms, gradle build checksums
 commons-codec = "1.18.0"
+# benchmark/ bzip2 compression
 commons-compress = "1.19"
 # @keep This version refers to ECJ batch compiler from p2 repositories ("drops").
 ecjP2Drop = "ecj-4.36M1"
+# java linting
 errorprone = "2.36.0"
+# markdown documentation generation
 flexmark = "0.64.8"
-# @keep This is GJF version for spotless/ tidy.
+# @keep This is GJF version for spotless/ tidy source code formatting
 googleJavaFormat = "1.23.0"
+# gradle build support
 groovy = "4.0.26"
+# test assertions
 hamcrest = "3.0"
+# analysis/icu/, gradle regeneration unicode support
 icu4j = "77.1"
+# queryparsers/ grammars
 javacc = "7.0.13"
+# analysis/ tokenizer grammars
 jflex = "1.8.2"
+# gradle checkWorkingCopy support
 jgit = "7.2.0.202503040940-r"
+# benchmark-jmh/ microbenchmarks
 jmh = "1.37"
+# spatial-extras/ support
 jts = "1.20.0"
+# unit tests
 junit = "4.13.2"
 # @keep Minimum gradle version to run the build
 minGradle = "8.14"
 # @keep This is the minimum required Java version.
 minJava = "24"
+# analysis/morfologik polish support
 morfologik = "2.1.9"
+# analysis/morfologik ukrainian support
 morfologik-ukrainian = "4.9.1"
+# benchmark/ html parsing
 nekohtml = "1.9.22"
+# analysis/opennlp/ support
 opennlp = "2.5.4"
+# distribution.tests/ process management
 procfork = "1.0.6"
+# unit tests
 randomizedtesting = "2.8.3"
+# license checks
 rat = "0.14"
+# spatial-extras/ support
 s2-geometry = "1.0.0"
+# spatial-extras/ support
 spatial4j = "0.8"
+# benchmark/ XML parsing
 xerces = "2.12.2"
+# external datasets decompression
 zstd = "1.5.7-2"
 
 [libraries]


### PR DESCRIPTION
Add one-liner above comments giving a hint how the dependency is used. This can help make the dependencies easier to maintain: it points you in the right direction and will be shown in dependabot diffs.

