### PR TITLE
Disallow EA versions to run Gradle

### DIFF
--- a/gradle/validation/check-environment.gradle
+++ b/gradle/validation/check-environment.gradle
@@ -37,6 +37,11 @@ configure(rootProject) {
     throw new GradleException("At least Java ${minJavaVersion} is required, you are running Java ${currentJavaVersion} "
         + "[${System.getProperty('java.vm.name')} ${System.getProperty('java.vm.version')}]")
   }
+  if (currentJavaVersion == minJavaVersion && Runtime.version().pre().isPresent()) {
+    throw new GradleException("You are running Gradle with an EA version of Java, this is not supported! "
+        + "To test Lucene compatibility with EA or prerelease versions, use the RUNTIME_JAVA_HOME environment variable. Detected Java version: "
+        + "[${System.getProperty('java.vm.name')} ${System.getProperty('java.vm.version')}]")
+  }
 
   // If we're regenerating the wrapper, skip the check.
   if (!gradle.startParameter.taskNames.contains("wrapper")) {

--- a/gradle/validation/check-environment.gradle
+++ b/gradle/validation/check-environment.gradle
@@ -37,7 +37,7 @@ configure(rootProject) {
     throw new GradleException("At least Java ${minJavaVersion} is required, you are running Java ${currentJavaVersion} "
         + "[${System.getProperty('java.vm.name')} ${System.getProperty('java.vm.version')}]")
   }
-  if (currentJavaVersion == minJavaVersion && Runtime.version().pre().isPresent()) {
+  if (Runtime.version().pre().isPresent()) {
     throw new GradleException("You are running Gradle with an EA version of Java, this is not supported! "
         + "To test Lucene compatibility with EA or prerelease versions, use the RUNTIME_JAVA_HOME environment variable. Detected Java version: "
         + "[${System.getProperty('java.vm.name')} ${System.getProperty('java.vm.version')}]")


### PR DESCRIPTION
This prevents running Gradle with EA versions. This helps to avoid followup errors like recently happening on ASF Jenkins.

I will backport this to 10.x, too (it has nothing to do with Java 24), it is a general safety measure.