### PR TITLE
Refactor the expressions compiler to use official ClassData BSM with indexed lookup

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -78,6 +78,9 @@ Improvements
 
 * GITHUB#14476: Removing unnecessary splitX in ComponentTree (Ankit Jain)
 
+* GITHUB#14602: Refactor the expressions compiler to use official ClassData BSM with indexed lookup
+  (Uwe Schindler)
+
 Optimizations
 ---------------------
 * GITHUB#14418: Quick exit on filter query matching no docs when rewriting knn query. (Pan Guixin)

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestCustomFunctions.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestCustomFunctions.java
@@ -292,7 +292,7 @@ public class TestCustomFunctions extends CompilerTestCase {
     Expression expr = compile("foo.bar() + bar.foo(7)", functions);
     assertEquals(16, expr.evaluate(null), DELTA);
   }
-  
+
   public void testSameFunctionTwoTimes() throws Exception {
     Expression expr = compile("sqrt(20)+abs(-7)+sqrt(30)");
     assertEquals(Math.sqrt(20) + 7 + Math.sqrt(30), expr.evaluate(null), DELTA);

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestCustomFunctions.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestCustomFunctions.java
@@ -292,6 +292,11 @@ public class TestCustomFunctions extends CompilerTestCase {
     Expression expr = compile("foo.bar() + bar.foo(7)", functions);
     assertEquals(16, expr.evaluate(null), DELTA);
   }
+  
+  public void testSameFunctionTwoTimes() throws Exception {
+    Expression expr = compile("sqrt(20)+abs(-7)+sqrt(30)");
+    assertEquals(Math.sqrt(20) + 7 + Math.sqrt(30), expr.evaluate(null), DELTA);
+  }
 
   public void testLegacyFunctions() throws Exception {
     var functions =


### PR DESCRIPTION
With more review of the code, I thought that it would be better to use one of the default Bootstrap methods available for ClassData. This allows to get rid of our custom BSM method and just use one of the defaults (`MethodHandles#classDataAt()`). By default it is possible to supply a `List` as ClassData and the bootstrap gets the MethodHandle by index. The code for that index was already there and is now reused. Like for the variables, the index is incremented on each new constant (like on each variable) and the index used for lookup.

As this change is simple it can also be backported, in the backport I just need to adapt the ASM 'Handle` to point to the default ClassData bootstrap method.