### PR TITLE
Overrides rewrite in PointRangeQuery to optimize AllDocs/NoDocs cases

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -37,6 +37,8 @@ Optimizations
 ---------------------
 * GITHUB#14011: Reduce allocation rate in HNSW concurrent merge. (Viliam Durina)
 * GITHUB#14022: Optimize DFS marking of connected components in HNSW by reducing stack depth, improving performance and reducing allocations. (Viswanath Kuchibhotla)
+* GITHUB#14609: Optimizes PointRangeQuery by rewriting to MatchAllDocsQuery/FieldExistsQuery/MatchNoDocsQuery if all
+  docs in index are contained or excluded (Elliott Bradshaw)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -22,11 +22,21 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.index.*;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;
-import org.apache.lucene.util.*;
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.ArrayUtil.ByteArrayComparator;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IntsRef;
 
 /**
  * Abstract class for range queries against single or multidimensional points such as {@link

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -614,7 +614,7 @@ public abstract class PointRangeQuery extends Query {
       LeafReader leaf = context.reader();
       PointValues values = leaf.getPointValues(field);
 
-      if (values.getDocCount() != leaf.maxDoc()) {
+      if (values == null || values.getDocCount() != leaf.maxDoc()) {
         return false;
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -548,7 +548,7 @@ public abstract class PointRangeQuery extends Query {
     byte[] globalMaxPacked = PointValues.getMaxPackedValue(reader, getField());
 
     if (globalMinPacked == null || globalMaxPacked == null) {
-      return super.rewrite(searcher);
+      return new MatchNoDocsQuery();
     }
 
     return switch (relate(globalMinPacked, globalMaxPacked)) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -1953,7 +1953,11 @@ public class TestLRUQueryCache extends LuceneTestCase {
     doc2.add(new StringField("name", "alice", Store.YES));
     doc2.add(new LongPoint("age", 20));
     doc2.add(new SortedNumericDocValuesField("age", 20));
-    w.addDocuments(Arrays.asList(doc1, doc2));
+    Document doc3 = new Document();
+    doc3.add(new StringField("name", "steve", Store.YES));
+    doc3.add(new LongPoint("age", 25));
+    doc3.add(new SortedNumericDocValuesField("age", 25));
+    w.addDocuments(Arrays.asList(doc1, doc2, doc3));
     final IndexReader reader = w.getReader();
     final IndexSearcher searcher = newSearcher(reader);
     searcher.setQueryCachingPolicy(ALWAYS_CACHE);
@@ -1964,8 +1968,8 @@ public class TestLRUQueryCache extends LuceneTestCase {
     TermQuery subQuery1 = new TermQuery(new Term("name", "tom"));
     IndexOrDocValuesQuery subQuery2 =
         new IndexOrDocValuesQuery(
-            LongPoint.newRangeQuery("age", 10, 30),
-            SortedNumericDocValuesField.newSlowRangeQuery("age", 10, 30));
+            LongPoint.newRangeQuery("age", 10, 20),
+            SortedNumericDocValuesField.newSlowRangeQuery("age", 10, 20));
     BooleanQuery query = bq.add(subQuery1, Occur.FILTER).add(subQuery2, Occur.FILTER).build();
     Set<Query> cacheSet = new HashSet<>();
 


### PR DESCRIPTION
Overrides rewrite in PointRangeQuery range to handle cases where the query either fully contains or fully excludes all documents within the shard.

Often, particularly when using time based partitioning, range queries may overlap several indexes.  Many of these indexes have timestamp values that are fully contained by the query, in which case the query can be rewritten to a MatchAllDocsQuery or a FieldExistsQuery.  On the other hand, many indexes can be fully excluded if they're outside the requested time range, in which case the query can be rewritten to a MatchNoDocsQuery.

While a similar optimization exists at the leaf level in the createWeight function, rewriting at the shard level enables other optimizations downstream.

Please let me know if this has been ruled out in the past for other reasons or if the implementation misses anything.  Thanks.