### PR TITLE
Update jdk requirements in README to OpenJDK 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ comprehensive documentation, visit:
 
 ### Basic steps:
   
-1. Install OpenJDK 23.
+1. Install [OpenJDK 24](https://jdk.java.net/archive/).
 2. Clone Lucene's git repository (or download the source distribution).
 3. Run gradle launcher script (`gradlew`).
 


### PR DESCRIPTION
Lucene now depends on Java 24.
