### PR TITLE
Fix FuzzySet#getEstimatedNumberUniqueValuesAllowingForCollisions to account for hashCount

### DIFF
--- a/lucene/codecs/src/java/org/apache/lucene/codecs/bloom/FuzzySet.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/bloom/FuzzySet.java
@@ -268,18 +268,31 @@ public class FuzzySet implements Accountable {
   }
 
   public int getEstimatedUniqueValues() {
-    return getEstimatedNumberUniqueValuesAllowingForCollisions(bloomSize, filter.cardinality());
+    return getEstimatedNumberUniqueValuesAllowingForCollisions(
+        bloomSize, filter.cardinality(), hashCount);
   }
 
-  // Given a set size and a the number of set bits, produces an estimate of the number of unique
-  // values recorded
+  /**
+   * Given a set size and the number of set bits, produces an estimate of the number of unique
+   * values recorded (assuming a single hash function is used)
+   */
   public static int getEstimatedNumberUniqueValuesAllowingForCollisions(
       int setSize, int numRecordedBits) {
+    return getEstimatedNumberUniqueValuesAllowingForCollisions(setSize, numRecordedBits, 1);
+  }
+
+  /**
+   * Given a set size, the number of set bits and hash function count, produces an estimate of the
+   * number of unique values recorded
+   */
+  public static int getEstimatedNumberUniqueValuesAllowingForCollisions(
+      int setSize, int numRecordedBits, int hashCount) {
     double setSizeAsDouble = setSize;
     double numRecordedBitsAsDouble = numRecordedBits;
+    double hashCountAsDouble = hashCount;
     double saturation = numRecordedBitsAsDouble / setSizeAsDouble;
     double logInverseSaturation = Math.log(1 - saturation) * -1;
-    return (int) (setSizeAsDouble * logInverseSaturation);
+    return (int) (setSizeAsDouble * logInverseSaturation / hashCountAsDouble);
   }
 
   public float getTargetMaxSaturation() {


### PR DESCRIPTION
### Description

Estimating bloom filter cardinality should account for the number of hash functions used. It appears this method assumes one function is used, which isn't correct.

Note: It also looks like the API surface area of `FuzzySet` in general may be due for a cleanup. This method doesn't appear to have any direct usage today, so it's debatable whether-or-not we should deprecate this. I'm in favor of keeping it, but would probably suggest deprecating a few other methods (include the version of this I kept around that assumes one hash function). I'll publish a separate PR where we can discuss this, but I think it's worth fixing this bug for now.

### Testing

I verified that this method dramatically over-estimates bloom filter cardinality in its current state (by a factor approximately equal to the hash count) and verified this change corrects it. This was in ad hoc testing related to something else I'm working on. I notice there are no unit tests for `FuzzySet` so I didn't add any explicit test cases for now. I can create some tests for `FuzzySet` as part of this if folks have a strong opinion on this. I can also add testing as a separate task when looking into cleaning up the API surface area...