### PR TITLE
Refactor KnnVectorReader merging to not need a finishMerge method

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Bits;
 
@@ -120,20 +121,13 @@ public abstract class KnnVectorsReader implements Closeable {
 
   /**
    * Returns an instance optimized for merging. This instance may only be consumed in the thread
-   * that called {@link #getMergeInstance()}.
+   * that called {@link #getMergeInstance(IOContext)}.
    *
    * <p>The default implementation returns {@code this}
    */
-  public KnnVectorsReader getMergeInstance() {
+  public KnnVectorsReader getMergeInstance(IOContext context) throws IOException {
     return this;
   }
-
-  /**
-   * Optional: reset or close merge resources used in the reader
-   *
-   * <p>The default implementation is empty
-   */
-  public void finishMerge() throws IOException {}
 
   /**
    * Returns the desired size of off-heap memory the given field. This size can be used to help

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -109,16 +109,7 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
         }
       }
     }
-    finishMerge(mergeState);
     finish();
-  }
-
-  private void finishMerge(MergeState mergeState) throws IOException {
-    for (KnnVectorsReader reader : mergeState.knnVectorsReaders) {
-      if (reader != null) {
-        reader.finishMerge();
-      }
-    }
   }
 
   /** Tracks state of one sub-reader that we are merging */

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
@@ -20,6 +20,7 @@ package org.apache.lucene.codecs.hnsw;
 import java.io.IOException;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
@@ -91,12 +92,12 @@ public abstract class FlatVectorsReader extends KnnVectorsReader implements Acco
 
   /**
    * Returns an instance optimized for merging. This instance may only be consumed in the thread
-   * that called {@link #getMergeInstance()}.
+   * that called {@link KnnVectorsReader#getMergeInstance(IOContext)}.
    *
    * <p>The default implementation returns {@code this}
    */
   @Override
-  public FlatVectorsReader getMergeInstance() {
+  public FlatVectorsReader getMergeInstance(IOContext context) throws IOException {
     return this;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -128,13 +128,8 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
   }
 
   @Override
-  public KnnVectorsReader getMergeInstance() {
-    return new Lucene99HnswVectorsReader(this, this.flatVectorsReader.getMergeInstance());
-  }
-
-  @Override
-  public void finishMerge() throws IOException {
-    flatVectorsReader.finishMerge();
+  public KnnVectorsReader getMergeInstance(IOContext context) throws IOException {
+    return new Lucene99HnswVectorsReader(this, this.flatVectorsReader.getMergeInstance(context));
   }
 
   private static IndexInput openDataInput(

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -31,6 +31,7 @@ import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.packed.PackedInts;
@@ -96,6 +97,7 @@ public class MergeState {
       List<CodecReader> readers,
       SegmentInfo segmentInfo,
       InfoStream infoStream,
+      IOContext mergeContext,
       Executor intraMergeTaskExecutor)
       throws IOException {
     verifyIndexSort(readers, segmentInfo);
@@ -154,7 +156,7 @@ public class MergeState {
 
       knnVectorsReaders[i] = reader.getVectorReader();
       if (knnVectorsReaders[i] != null) {
-        knnVectorsReaders[i] = knnVectorsReaders[i].getMergeInstance();
+        knnVectorsReaders[i] = knnVectorsReaders[i].getMergeInstance(mergeContext);
       }
 
       numDocs += reader.numDocs();

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentMerger.java
@@ -65,7 +65,7 @@ final class SegmentMerger {
       throw new IllegalArgumentException(
           "IOContext.context should be MERGE; got: " + context.context());
     }
-    mergeState = new MergeState(readers, segmentInfo, infoStream, intraMergeTaskExecutor);
+    mergeState = new MergeState(readers, segmentInfo, infoStream, context, intraMergeTaskExecutor);
     mergeStateCreationThread = Thread.currentThread();
     directory = dir;
     this.codec = segmentInfo.getCodec();

--- a/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
@@ -227,12 +227,12 @@ public abstract class IndexInput extends DataInput implements Closeable {
   public void prefetch(long offset, long length) throws IOException {}
 
   /**
-   * Optional method: Give a hint to this input about the change in read access pattern. IndexInput
+   * Optional method: Give a hint to this input about a change in read context. IndexInput
    * implementations may take advantage of this hint to optimize reads from storage.
    *
    * <p>The default implementation is a no-op.
    */
-  public void updateReadAdvice(ReadAdvice readAdvice) throws IOException {}
+  public void changeContext(IOContext context) throws IOException {}
 
   /**
    * Returns a hint whether all the contents of this input are resident in physical memory. It's a

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -357,7 +357,11 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
   }
 
   @Override
-  public void updateReadAdvice(ReadAdvice readAdvice) throws IOException {
+  public void changeContext(IOContext context) throws IOException {
+    updateReadAdvice(toReadAdvice.apply(context));
+  }
+
+  private void updateReadAdvice(ReadAdvice readAdvice) throws IOException {
     if (NATIVE_ACCESS.isEmpty()) {
       return;
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockIndexInputWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockIndexInputWrapper.java
@@ -25,7 +25,6 @@ import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.store.FilterIndexInput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.ReadAdvice;
 
 /**
  * Used by MockDirectoryWrapper to create an input stream that keeps track of when it's been closed.
@@ -186,10 +185,10 @@ public class MockIndexInputWrapper extends FilterIndexInput {
   }
 
   @Override
-  public void updateReadAdvice(ReadAdvice readAdvice) throws IOException {
+  public void changeContext(IOContext context) throws IOException {
     ensureOpen();
     ensureAccessible();
-    in.updateReadAdvice(readAdvice);
+    in.changeContext(context);
   }
 
   @Override


### PR DESCRIPTION
Use a similar pattern to other `getMergeInstance` methods - clone the input, and set the new context on it, rather than setting & resetting the read advice on the main instance.

This also removed ReadAdvice from IndexInput, which is now only used by `MMapDirectory` and friends.