### PR TITLE
Catch and re-throw Throwable rather than using a success boolean

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/SortingStrategy.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/SortingStrategy.java
@@ -120,17 +120,13 @@ public abstract class SortingStrategy {
             var sorter = new OfflineSorter(tempDir, tempFileNamePrefix, BytesRefComparator.NATURAL);
 
             String sorted;
-            boolean success = false;
             try {
               sorted = sorter.sort(output.getName());
-              success = true;
-            } finally {
-              if (success) {
-                tempDir.deleteFile(output.getName());
-              } else {
-                IOUtils.deleteFilesIgnoringExceptions(tempDir, output.getName());
-              }
+            } catch (Throwable t) {
+              IOUtils.deleteFilesSuppressingExceptions(t, tempDir, output.getName());
+              throw t;
             }
+            tempDir.deleteFile(output.getName());
             return sorted;
           }
         };

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene101/Lucene101PostingsFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene101/Lucene101PostingsFormat.java
@@ -389,15 +389,11 @@ public class Lucene101PostingsFormat extends PostingsFormat {
   @Override
   public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
     PostingsReaderBase postingsReader = new Lucene101PostingsReader(state);
-    boolean success = false;
     try {
-      FieldsProducer ret = new Lucene90BlockTreeTermsReader(postingsReader, state);
-      success = true;
-      return ret;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(postingsReader);
-      }
+      return new Lucene90BlockTreeTermsReader(postingsReader, state);
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, postingsReader);
+      throw t;
     }
   }
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsReader.java
@@ -71,7 +71,6 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader implements
   Lucene95HnswVectorsReader(SegmentReadState state) throws IOException {
     this.fieldInfos = state.fieldInfos;
     int versionMeta = readMetadata(state);
-    boolean success = false;
     try {
       vectorData =
           openDataInput(
@@ -85,11 +84,9 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader implements
               versionMeta,
               Lucene95HnswVectorsFormat.VECTOR_INDEX_EXTENSION,
               Lucene95HnswVectorsFormat.VECTOR_INDEX_CODEC_NAME);
-      success = true;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(this);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 
@@ -125,7 +122,6 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader implements
     String fileName =
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
     IndexInput in = state.directory.openInput(fileName, state.context);
-    boolean success = false;
     try {
       int versionVectorData =
           CodecUtil.checkIndexHeader(
@@ -146,12 +142,10 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader implements
             in);
       }
       CodecUtil.retrieveChecksum(in);
-      success = true;
       return in;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(in);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, in);
+      throw t;
     }
   }
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99PostingsFormat.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99PostingsFormat.java
@@ -390,15 +390,11 @@ public class Lucene99PostingsFormat extends PostingsFormat {
   @Override
   public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
     PostingsReaderBase postingsReader = new Lucene99PostingsReader(state);
-    boolean success = false;
     try {
-      FieldsProducer ret = new Lucene90BlockTreeTermsReader(postingsReader, state);
-      success = true;
-      return ret;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(postingsReader);
-      }
+      return new Lucene90BlockTreeTermsReader(postingsReader, state);
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, postingsReader);
+      throw t;
     }
   }
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99PostingsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99PostingsReader.java
@@ -66,7 +66,6 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
 
   /** Sole constructor. */
   public Lucene99PostingsReader(SegmentReadState state) throws IOException {
-    boolean success = false;
     IndexInput docIn = null;
     IndexInput posIn = null;
     IndexInput payIn = null;
@@ -118,11 +117,9 @@ public final class Lucene99PostingsReader extends PostingsReaderBase {
       this.docIn = docIn;
       this.posIn = posIn;
       this.payIn = payIn;
-      success = true;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(docIn, posIn, payIn);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, docIn, posIn, payIn);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
@@ -78,7 +78,6 @@ class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader {
             state.segmentInfo.name,
             state.segmentSuffix,
             Lucene102BinaryQuantizedVectorsFormat.META_EXTENSION);
-    boolean success = false;
     try (ChecksumIndexInput meta = state.directory.openChecksumInput(metaFileName)) {
       Throwable priorE = null;
       try {
@@ -106,11 +105,9 @@ class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader {
               // graph.
               state.context.withHints(
                   FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM));
-      success = true;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(this);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 
@@ -294,7 +291,6 @@ class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader {
     String fileName =
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
     IndexInput in = state.directory.openInput(fileName, context);
-    boolean success = false;
     try {
       int versionVectorData =
           CodecUtil.checkIndexHeader(
@@ -315,12 +311,10 @@ class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader {
             in);
       }
       CodecUtil.retrieveChecksum(in);
-      success = true;
       return in;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(in);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, in);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsFormat.java
@@ -409,32 +409,23 @@ public final class Lucene103PostingsFormat extends PostingsFormat {
   @Override
   public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
     PostingsWriterBase postingsWriter = new Lucene103PostingsWriter(state, version);
-    boolean success = false;
     try {
-      FieldsConsumer ret =
-          new Lucene103BlockTreeTermsWriter(
-              state, postingsWriter, minTermBlockSize, maxTermBlockSize);
-      success = true;
-      return ret;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(postingsWriter);
-      }
+      return new Lucene103BlockTreeTermsWriter(
+          state, postingsWriter, minTermBlockSize, maxTermBlockSize);
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, postingsWriter);
+      throw t;
     }
   }
 
   @Override
   public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
     PostingsReaderBase postingsReader = new Lucene103PostingsReader(state);
-    boolean success = false;
     try {
-      FieldsProducer ret = new Lucene103BlockTreeTermsReader(postingsReader, state);
-      success = true;
-      return ret;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(postingsReader);
-      }
+      return new Lucene103BlockTreeTermsReader(postingsReader, state);
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, postingsReader);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -94,7 +94,6 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
             state.segmentInfo.name, state.segmentSuffix, Lucene103PostingsFormat.META_EXTENSION);
     final long expectedDocFileLength, expectedPosFileLength, expectedPayFileLength;
     ChecksumIndexInput metaIn = null;
-    boolean success = false;
     int version;
     try {
       metaIn = state.directory.openChecksumInput(metaName);
@@ -123,23 +122,21 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
         expectedPayFileLength = -1;
       }
       CodecUtil.checkFooter(metaIn, null);
-      success = true;
     } catch (Throwable t) {
-      if (metaIn != null) {
-        CodecUtil.checkFooter(metaIn, t);
-        throw new AssertionError("unreachable");
-      } else {
-        throw t;
-      }
-    } finally {
-      if (success) {
-        metaIn.close();
-      } else {
-        IOUtils.closeWhileHandlingException(metaIn);
+      try {
+        if (metaIn != null) {
+          CodecUtil.checkFooter(metaIn, t);
+          throw new AssertionError("unreachable");
+        } else {
+          throw t;
+        }
+      } catch (Throwable ct) {
+        IOUtils.closeWhileSuppressingExceptions(ct, metaIn);
+        throw ct;
       }
     }
+    metaIn.close();
 
-    success = false;
     IndexInput docIn = null;
     IndexInput posIn = null;
     IndexInput payIn = null;
@@ -185,11 +182,9 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
       this.docIn = docIn;
       this.posIn = posIn;
       this.payIn = payIn;
-      success = true;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(docIn, posIn, payIn);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, docIn, posIn, payIn);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -93,49 +93,43 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
         IndexFileNames.segmentFileName(
             state.segmentInfo.name, state.segmentSuffix, Lucene103PostingsFormat.META_EXTENSION);
     final long expectedDocFileLength, expectedPosFileLength, expectedPayFileLength;
-    ChecksumIndexInput metaIn = null;
     int version;
-    try {
-      metaIn = state.directory.openChecksumInput(metaName);
-      version =
-          CodecUtil.checkIndexHeader(
-              metaIn,
-              META_CODEC,
-              VERSION_START,
-              VERSION_CURRENT,
-              state.segmentInfo.getId(),
-              state.segmentSuffix);
-      maxNumImpactsAtLevel0 = metaIn.readInt();
-      maxImpactNumBytesAtLevel0 = metaIn.readInt();
-      maxNumImpactsAtLevel1 = metaIn.readInt();
-      maxImpactNumBytesAtLevel1 = metaIn.readInt();
-      expectedDocFileLength = metaIn.readLong();
-      if (state.fieldInfos.hasProx()) {
-        expectedPosFileLength = metaIn.readLong();
-        if (state.fieldInfos.hasPayloads() || state.fieldInfos.hasOffsets()) {
-          expectedPayFileLength = metaIn.readLong();
+    try (ChecksumIndexInput metaIn = state.directory.openChecksumInput(metaName)) {
+      try {
+        version =
+            CodecUtil.checkIndexHeader(
+                metaIn,
+                META_CODEC,
+                VERSION_START,
+                VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix);
+        maxNumImpactsAtLevel0 = metaIn.readInt();
+        maxImpactNumBytesAtLevel0 = metaIn.readInt();
+        maxNumImpactsAtLevel1 = metaIn.readInt();
+        maxImpactNumBytesAtLevel1 = metaIn.readInt();
+        expectedDocFileLength = metaIn.readLong();
+        if (state.fieldInfos.hasProx()) {
+          expectedPosFileLength = metaIn.readLong();
+          if (state.fieldInfos.hasPayloads() || state.fieldInfos.hasOffsets()) {
+            expectedPayFileLength = metaIn.readLong();
+          } else {
+            expectedPayFileLength = -1;
+          }
         } else {
+          expectedPosFileLength = -1;
           expectedPayFileLength = -1;
         }
-      } else {
-        expectedPosFileLength = -1;
-        expectedPayFileLength = -1;
-      }
-      CodecUtil.checkFooter(metaIn, null);
-    } catch (Throwable t) {
-      try {
+        CodecUtil.checkFooter(metaIn, null);
+      } catch (Throwable t) {
         if (metaIn != null) {
           CodecUtil.checkFooter(metaIn, t);
           throw new AssertionError("unreachable");
         } else {
           throw t;
         }
-      } catch (Throwable ct) {
-        IOUtils.closeWhileSuppressingExceptions(ct, metaIn);
-        throw ct;
       }
     }
-    metaIn.close();
 
     IndexInput docIn = null;
     IndexInput posIn = null;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/Lucene103BlockTreeTermsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/Lucene103BlockTreeTermsReader.java
@@ -106,8 +106,6 @@ public final class Lucene103BlockTreeTermsReader extends FieldsProducer {
   /** Sole constructor. */
   public Lucene103BlockTreeTermsReader(PostingsReaderBase postingsReader, SegmentReadState state)
       throws IOException {
-    boolean success = false;
-
     this.postingsReader = postingsReader;
     this.segment = state.segmentInfo.name;
 
@@ -235,12 +233,9 @@ public final class Lucene103BlockTreeTermsReader extends FieldsProducer {
       fieldInfos = state.fieldInfos;
       this.fieldMap = fieldMap;
       this.fieldList = sortFieldNames(fieldMap, state.fieldInfos);
-      success = true;
-    } finally {
-      if (!success) {
-        // this.close() will close in:
-        IOUtils.closeWhileHandlingException(this);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
@@ -64,7 +64,6 @@ final class Lucene90CompoundReader extends CompoundDirectory {
     String entriesFileName =
         IndexFileNames.segmentFileName(segmentName, "", Lucene90CompoundFormat.ENTRIES_EXTENSION);
     this.entries = readEntries(si.getId(), directory, entriesFileName);
-    boolean success = false;
 
     // find the last FileEntry in the map (largest offset+length) and add length of codec footer:
     final long expectedLength =
@@ -92,12 +91,9 @@ final class Lucene90CompoundReader extends CompoundDirectory {
             "length should be " + expectedLength + " bytes, but is " + handle.length() + " instead",
             handle);
       }
-
-      success = true;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(handle);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, handle);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -78,7 +78,6 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
       String metaExtension)
       throws IOException {
     this.termsDictBuffer = new byte[1 << 14];
-    boolean success = false;
     try {
       String dataName =
           IndexFileNames.segmentFileName(
@@ -102,32 +101,29 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
           state.segmentSuffix);
       maxDoc = state.segmentInfo.maxDoc();
       this.skipIndexIntervalSize = skipIndexIntervalSize;
-      success = true;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(this);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 
   @Override
   public void close() throws IOException {
-    boolean success = false;
     try {
-      if (meta != null) {
-        meta.writeInt(-1); // write EOF marker
-        CodecUtil.writeFooter(meta); // write checksum
+      try {
+        if (meta != null) {
+          meta.writeInt(-1); // write EOF marker
+          CodecUtil.writeFooter(meta); // write checksum
+        }
+        if (data != null) {
+          CodecUtil.writeFooter(data); // write checksum
+        }
+      } catch (Throwable t) {
+        IOUtils.closeWhileSuppressingExceptions(t, data, meta);
+        throw t;
       }
-      if (data != null) {
-        CodecUtil.writeFooter(data); // write checksum
-      }
-      success = true;
+      IOUtils.close(data, meta);
     } finally {
-      if (success) {
-        IOUtils.close(data, meta);
-      } else {
-        IOUtils.closeWhileHandlingException(data, meta);
-      }
       meta = data = null;
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -116,7 +116,6 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, dataExtension);
     // Doc-values have a forward-only access pattern
     this.data = state.directory.openInput(dataName, state.context.withHints(FileTypeHint.DATA));
-    boolean success = false;
     try {
       final int version2 =
           CodecUtil.checkIndexHeader(
@@ -136,12 +135,9 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
       // for FOOTER_MAGIC + algorithmID. This is cheap and can detect some forms of corruption
       // such as file truncation.
       CodecUtil.retrieveChecksum(data);
-
-      success = true;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(this.data);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, data);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
@@ -83,7 +83,6 @@ final class Lucene90NormsProducer extends NormsProducer implements Cloneable {
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, dataExtension);
     // Norms have a forward-only access pattern
     data = state.directory.openInput(dataName, state.context.withHints(FileTypeHint.DATA));
-    boolean success = false;
     try {
       final int version2 =
           CodecUtil.checkIndexHeader(
@@ -103,12 +102,9 @@ final class Lucene90NormsProducer extends NormsProducer implements Cloneable {
       // for FOOTER_MAGIC + algorithmID. This is cheap and can detect some forms of corruption
       // such as file truncation.
       CodecUtil.retrieveChecksum(data);
-
-      success = true;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(this.data);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this.data);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsReader.java
@@ -57,7 +57,6 @@ public class Lucene90PointsReader extends PointsReader {
             readState.segmentSuffix,
             Lucene90PointsFormat.DATA_EXTENSION);
 
-    boolean success = false;
     try {
       indexIn =
           readState.directory.openInput(
@@ -119,11 +118,9 @@ public class Lucene90PointsReader extends PointsReader {
       // know that indexLength and dataLength are very likely correct.
       CodecUtil.retrieveChecksum(indexIn, indexLength);
       CodecUtil.retrieveChecksum(dataIn, dataLength);
-      success = true;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(this);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90PointsWriter.java
@@ -64,7 +64,6 @@ public class Lucene90PointsWriter extends PointsWriter {
             writeState.segmentSuffix,
             Lucene90PointsFormat.DATA_EXTENSION);
     dataOut = writeState.directory.createOutput(dataFileName, writeState.context);
-    boolean success = false;
     try {
       CodecUtil.writeIndexHeader(
           dataOut,
@@ -98,12 +97,9 @@ public class Lucene90PointsWriter extends PointsWriter {
           Lucene90PointsFormat.VERSION_CURRENT,
           writeState.segmentInfo.getId(),
           writeState.segmentSuffix);
-
-      success = true;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(this);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
@@ -229,6 +229,9 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
           throw t;
         }
       }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsWriter.java
@@ -124,7 +124,6 @@ public final class Lucene90CompressingStoredFieldsWriter extends StoredFieldsWri
     this.endOffsets = new int[16];
     this.numBufferedDocs = 0;
 
-    boolean success = false;
     try {
       metaStream =
           directory.createOutput(
@@ -154,12 +153,9 @@ public final class Lucene90CompressingStoredFieldsWriter extends StoredFieldsWri
               context);
 
       metaStream.writeVInt(chunkSize);
-
-      success = true;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(metaStream, fieldsStream, indexWriter);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, metaStream, fieldsStream, indexWriter);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -234,6 +234,9 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
           throw t;
         }
       }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -142,101 +142,105 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
     fieldInfos = fn;
     numDocs = si.maxDoc();
 
-    // Open the data file
-    final String vectorsStreamFN =
-        IndexFileNames.segmentFileName(segment, segmentSuffix, VECTORS_EXTENSION);
-    vectorsStream =
-        d.openInput(
-            vectorsStreamFN,
-            context.withHints(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM));
-    version =
-        CodecUtil.checkIndexHeader(
-            vectorsStream, formatName, VERSION_START, VERSION_CURRENT, si.getId(), segmentSuffix);
-    assert CodecUtil.indexHeaderLength(formatName, segmentSuffix) == vectorsStream.getFilePointer();
+    ChecksumIndexInput metaIn = null;
+    try {
+      // Open the data file
+      final String vectorsStreamFN =
+          IndexFileNames.segmentFileName(segment, segmentSuffix, VECTORS_EXTENSION);
+      vectorsStream =
+          d.openInput(
+              vectorsStreamFN,
+              context.withHints(
+                  FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM));
+      version =
+          CodecUtil.checkIndexHeader(
+              vectorsStream, formatName, VERSION_START, VERSION_CURRENT, si.getId(), segmentSuffix);
+      assert CodecUtil.indexHeaderLength(formatName, segmentSuffix)
+          == vectorsStream.getFilePointer();
 
-    final String metaStreamFN =
-        IndexFileNames.segmentFileName(segment, segmentSuffix, VECTORS_META_EXTENSION);
-    try (ChecksumIndexInput metaIn = d.openChecksumInput(metaStreamFN)) {
+      final String metaStreamFN =
+          IndexFileNames.segmentFileName(segment, segmentSuffix, VECTORS_META_EXTENSION);
+      metaIn = d.openChecksumInput(metaStreamFN);
+      CodecUtil.checkIndexHeader(
+          metaIn,
+          VECTORS_INDEX_CODEC_NAME + "Meta",
+          META_VERSION_START,
+          version,
+          si.getId(),
+          segmentSuffix);
+
+      packedIntsVersion = metaIn.readVInt();
+      chunkSize = metaIn.readVInt();
+
+      // NOTE: data file is too costly to verify checksum against all the bytes on open,
+      // but for now we at least verify proper structure of the checksum footer: which looks
+      // for FOOTER_MAGIC + algorithmID. This is cheap and can detect some forms of corruption
+      // such as file truncation.
+      CodecUtil.retrieveChecksum(vectorsStream);
+
+      FieldsIndexReader fieldsIndexReader =
+          new FieldsIndexReader(
+              d,
+              si.name,
+              segmentSuffix,
+              VECTORS_INDEX_EXTENSION,
+              VECTORS_INDEX_CODEC_NAME,
+              si.getId(),
+              metaIn,
+              context);
+
+      this.indexReader = fieldsIndexReader;
+      this.maxPointer = fieldsIndexReader.getMaxPointer();
+
+      numChunks = metaIn.readVLong();
+      numDirtyChunks = metaIn.readVLong();
+      numDirtyDocs = metaIn.readVLong();
+
+      if (numChunks < numDirtyChunks) {
+        throw new CorruptIndexException(
+            "Cannot have more dirty chunks than chunks: numChunks="
+                + numChunks
+                + ", numDirtyChunks="
+                + numDirtyChunks,
+            metaIn);
+      }
+      if ((numDirtyChunks == 0) != (numDirtyDocs == 0)) {
+        throw new CorruptIndexException(
+            "Cannot have dirty chunks without dirty docs or vice-versa: numDirtyChunks="
+                + numDirtyChunks
+                + ", numDirtyDocs="
+                + numDirtyDocs,
+            metaIn);
+      }
+      if (numDirtyDocs < numDirtyChunks) {
+        throw new CorruptIndexException(
+            "Cannot have more dirty chunks than documents within dirty chunks: numDirtyChunks="
+                + numDirtyChunks
+                + ", numDirtyDocs="
+                + numDirtyDocs,
+            metaIn);
+      }
+
+      decompressor = compressionMode.newDecompressor();
+      this.reader =
+          new BlockPackedReaderIterator(vectorsStream, packedIntsVersion, PACKED_BLOCK_SIZE, 0);
+
+      CodecUtil.checkFooter(metaIn, null);
+      metaIn.close();
+
+      this.prefetchedBlockIDCache = new long[PREFETCH_CACHE_SIZE];
+      Arrays.fill(prefetchedBlockIDCache, -1);
+    } catch (Throwable t) {
       try {
-        CodecUtil.checkIndexHeader(
-            metaIn,
-            VECTORS_INDEX_CODEC_NAME + "Meta",
-            META_VERSION_START,
-            version,
-            si.getId(),
-            segmentSuffix);
-
-        packedIntsVersion = metaIn.readVInt();
-        chunkSize = metaIn.readVInt();
-
-        // NOTE: data file is too costly to verify checksum against all the bytes on open,
-        // but for now we at least verify proper structure of the checksum footer: which looks
-        // for FOOTER_MAGIC + algorithmID. This is cheap and can detect some forms of corruption
-        // such as file truncation.
-        CodecUtil.retrieveChecksum(vectorsStream);
-
-        FieldsIndexReader fieldsIndexReader =
-            new FieldsIndexReader(
-                d,
-                si.name,
-                segmentSuffix,
-                VECTORS_INDEX_EXTENSION,
-                VECTORS_INDEX_CODEC_NAME,
-                si.getId(),
-                metaIn,
-                context);
-
-        this.indexReader = fieldsIndexReader;
-        this.maxPointer = fieldsIndexReader.getMaxPointer();
-
-        numChunks = metaIn.readVLong();
-        numDirtyChunks = metaIn.readVLong();
-        numDirtyDocs = metaIn.readVLong();
-
-        if (numChunks < numDirtyChunks) {
-          throw new CorruptIndexException(
-              "Cannot have more dirty chunks than chunks: numChunks="
-                  + numChunks
-                  + ", numDirtyChunks="
-                  + numDirtyChunks,
-              metaIn);
-        }
-        if ((numDirtyChunks == 0) != (numDirtyDocs == 0)) {
-          throw new CorruptIndexException(
-              "Cannot have dirty chunks without dirty docs or vice-versa: numDirtyChunks="
-                  + numDirtyChunks
-                  + ", numDirtyDocs="
-                  + numDirtyDocs,
-              metaIn);
-        }
-        if (numDirtyDocs < numDirtyChunks) {
-          throw new CorruptIndexException(
-              "Cannot have more dirty chunks than documents within dirty chunks: numDirtyChunks="
-                  + numDirtyChunks
-                  + ", numDirtyDocs="
-                  + numDirtyDocs,
-              metaIn);
-        }
-
-        decompressor = compressionMode.newDecompressor();
-        this.reader =
-            new BlockPackedReaderIterator(vectorsStream, packedIntsVersion, PACKED_BLOCK_SIZE, 0);
-
-        CodecUtil.checkFooter(metaIn, null);
-
-        this.prefetchedBlockIDCache = new long[PREFETCH_CACHE_SIZE];
-        Arrays.fill(prefetchedBlockIDCache, -1);
-      } catch (Throwable t) {
         if (metaIn != null) {
           CodecUtil.checkFooter(metaIn, t);
           throw new AssertionError("unreachable");
         } else {
           throw t;
         }
+      } finally {
+        IOUtils.closeWhileSuppressingExceptions(t, this, metaIn);
       }
-    } catch (Throwable t) {
-      IOUtils.closeWhileSuppressingExceptions(t, this);
-      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -142,105 +142,97 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
     fieldInfos = fn;
     numDocs = si.maxDoc();
 
-    ChecksumIndexInput metaIn = null;
-    try {
-      // Open the data file
-      final String vectorsStreamFN =
-          IndexFileNames.segmentFileName(segment, segmentSuffix, VECTORS_EXTENSION);
-      vectorsStream =
-          d.openInput(
-              vectorsStreamFN,
-              context.withHints(
-                  FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM));
-      version =
-          CodecUtil.checkIndexHeader(
-              vectorsStream, formatName, VERSION_START, VERSION_CURRENT, si.getId(), segmentSuffix);
-      assert CodecUtil.indexHeaderLength(formatName, segmentSuffix)
-          == vectorsStream.getFilePointer();
+    // Open the data file
+    final String vectorsStreamFN =
+        IndexFileNames.segmentFileName(segment, segmentSuffix, VECTORS_EXTENSION);
+    vectorsStream =
+        d.openInput(
+            vectorsStreamFN,
+            context.withHints(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM));
+    version =
+        CodecUtil.checkIndexHeader(
+            vectorsStream, formatName, VERSION_START, VERSION_CURRENT, si.getId(), segmentSuffix);
+    assert CodecUtil.indexHeaderLength(formatName, segmentSuffix) == vectorsStream.getFilePointer();
 
-      final String metaStreamFN =
-          IndexFileNames.segmentFileName(segment, segmentSuffix, VECTORS_META_EXTENSION);
-      metaIn = d.openChecksumInput(metaStreamFN);
-      CodecUtil.checkIndexHeader(
-          metaIn,
-          VECTORS_INDEX_CODEC_NAME + "Meta",
-          META_VERSION_START,
-          version,
-          si.getId(),
-          segmentSuffix);
-
-      packedIntsVersion = metaIn.readVInt();
-      chunkSize = metaIn.readVInt();
-
-      // NOTE: data file is too costly to verify checksum against all the bytes on open,
-      // but for now we at least verify proper structure of the checksum footer: which looks
-      // for FOOTER_MAGIC + algorithmID. This is cheap and can detect some forms of corruption
-      // such as file truncation.
-      CodecUtil.retrieveChecksum(vectorsStream);
-
-      FieldsIndexReader fieldsIndexReader =
-          new FieldsIndexReader(
-              d,
-              si.name,
-              segmentSuffix,
-              VECTORS_INDEX_EXTENSION,
-              VECTORS_INDEX_CODEC_NAME,
-              si.getId(),
-              metaIn,
-              context);
-
-      this.indexReader = fieldsIndexReader;
-      this.maxPointer = fieldsIndexReader.getMaxPointer();
-
-      numChunks = metaIn.readVLong();
-      numDirtyChunks = metaIn.readVLong();
-      numDirtyDocs = metaIn.readVLong();
-
-      if (numChunks < numDirtyChunks) {
-        throw new CorruptIndexException(
-            "Cannot have more dirty chunks than chunks: numChunks="
-                + numChunks
-                + ", numDirtyChunks="
-                + numDirtyChunks,
-            metaIn);
-      }
-      if ((numDirtyChunks == 0) != (numDirtyDocs == 0)) {
-        throw new CorruptIndexException(
-            "Cannot have dirty chunks without dirty docs or vice-versa: numDirtyChunks="
-                + numDirtyChunks
-                + ", numDirtyDocs="
-                + numDirtyDocs,
-            metaIn);
-      }
-      if (numDirtyDocs < numDirtyChunks) {
-        throw new CorruptIndexException(
-            "Cannot have more dirty chunks than documents within dirty chunks: numDirtyChunks="
-                + numDirtyChunks
-                + ", numDirtyDocs="
-                + numDirtyDocs,
-            metaIn);
-      }
-
-      decompressor = compressionMode.newDecompressor();
-      this.reader =
-          new BlockPackedReaderIterator(vectorsStream, packedIntsVersion, PACKED_BLOCK_SIZE, 0);
-
-      CodecUtil.checkFooter(metaIn, null);
-      metaIn.close();
-
-      this.prefetchedBlockIDCache = new long[PREFETCH_CACHE_SIZE];
-      Arrays.fill(prefetchedBlockIDCache, -1);
-    } catch (Throwable t) {
+    final String metaStreamFN =
+        IndexFileNames.segmentFileName(segment, segmentSuffix, VECTORS_META_EXTENSION);
+    try (ChecksumIndexInput metaIn = d.openChecksumInput(metaStreamFN)) {
       try {
+        CodecUtil.checkIndexHeader(
+            metaIn,
+            VECTORS_INDEX_CODEC_NAME + "Meta",
+            META_VERSION_START,
+            version,
+            si.getId(),
+            segmentSuffix);
+
+        packedIntsVersion = metaIn.readVInt();
+        chunkSize = metaIn.readVInt();
+
+        // NOTE: data file is too costly to verify checksum against all the bytes on open,
+        // but for now we at least verify proper structure of the checksum footer: which looks
+        // for FOOTER_MAGIC + algorithmID. This is cheap and can detect some forms of corruption
+        // such as file truncation.
+        CodecUtil.retrieveChecksum(vectorsStream);
+
+        FieldsIndexReader fieldsIndexReader =
+            new FieldsIndexReader(
+                d,
+                si.name,
+                segmentSuffix,
+                VECTORS_INDEX_EXTENSION,
+                VECTORS_INDEX_CODEC_NAME,
+                si.getId(),
+                metaIn,
+                context);
+
+        this.indexReader = fieldsIndexReader;
+        this.maxPointer = fieldsIndexReader.getMaxPointer();
+
+        numChunks = metaIn.readVLong();
+        numDirtyChunks = metaIn.readVLong();
+        numDirtyDocs = metaIn.readVLong();
+
+        if (numChunks < numDirtyChunks) {
+          throw new CorruptIndexException(
+              "Cannot have more dirty chunks than chunks: numChunks="
+                  + numChunks
+                  + ", numDirtyChunks="
+                  + numDirtyChunks,
+              metaIn);
+        }
+        if ((numDirtyChunks == 0) != (numDirtyDocs == 0)) {
+          throw new CorruptIndexException(
+              "Cannot have dirty chunks without dirty docs or vice-versa: numDirtyChunks="
+                  + numDirtyChunks
+                  + ", numDirtyDocs="
+                  + numDirtyDocs,
+              metaIn);
+        }
+        if (numDirtyDocs < numDirtyChunks) {
+          throw new CorruptIndexException(
+              "Cannot have more dirty chunks than documents within dirty chunks: numDirtyChunks="
+                  + numDirtyChunks
+                  + ", numDirtyDocs="
+                  + numDirtyDocs,
+              metaIn);
+        }
+
+        decompressor = compressionMode.newDecompressor();
+        this.reader =
+            new BlockPackedReaderIterator(vectorsStream, packedIntsVersion, PACKED_BLOCK_SIZE, 0);
+
+        CodecUtil.checkFooter(metaIn, null);
+
+        this.prefetchedBlockIDCache = new long[PREFETCH_CACHE_SIZE];
+        Arrays.fill(prefetchedBlockIDCache, -1);
+      } catch (Throwable t) {
         if (metaIn != null) {
           CodecUtil.checkFooter(metaIn, t);
           throw new AssertionError("unreachable");
         } else {
           throw t;
         }
-      } catch (Throwable ct) {
-        IOUtils.closeWhileSuppressingExceptions(ct, metaIn);
-        throw ct;
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -139,7 +139,6 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
       throws IOException {
     this.compressionMode = compressionMode;
     final String segment = si.name;
-    boolean success = false;
     fieldInfos = fn;
     numDocs = si.maxDoc();
 
@@ -231,18 +230,17 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
 
       this.prefetchedBlockIDCache = new long[PREFETCH_CACHE_SIZE];
       Arrays.fill(prefetchedBlockIDCache, -1);
-
-      success = true;
     } catch (Throwable t) {
-      if (metaIn != null) {
-        CodecUtil.checkFooter(metaIn, t);
-        throw new AssertionError("unreachable");
-      } else {
-        throw t;
-      }
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(this, metaIn);
+      try {
+        if (metaIn != null) {
+          CodecUtil.checkFooter(metaIn, t);
+          throw new AssertionError("unreachable");
+        } else {
+          throw t;
+        }
+      } catch (Throwable ct) {
+        IOUtils.closeWhileSuppressingExceptions(ct, metaIn);
+        throw ct;
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsWriter.java
@@ -253,7 +253,6 @@ public final class Lucene90CompressingTermVectorsWriter extends TermVectorsWrite
     payloadBytes = ByteBuffersDataOutput.newResettableInstance();
     lastTerm = new BytesRef(ArrayUtil.oversize(30, 1));
 
-    boolean success = false;
     try {
       metaStream =
           directory.createOutput(
@@ -295,12 +294,10 @@ public final class Lucene90CompressingTermVectorsWriter extends TermVectorsWrite
       startOffsetsBuf = new int[1024];
       lengthsBuf = new int[1024];
       payloadLengthsBuf = new int[1024];
-
-      success = true;
-    } finally {
-      if (!success) {
-        IOUtils.closeWhileHandlingException(metaStream, vectorsStream, indexWriter, indexWriter);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(
+          t, metaStream, vectorsStream, indexWriter, indexWriter);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
@@ -69,7 +69,6 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
     super(scorer);
     int versionMeta = readMetadata(state);
     this.fieldInfos = state.fieldInfos;
-    boolean success = false;
     try {
       vectorData =
           openDataInput(
@@ -81,11 +80,9 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
               // in the HNSW graph.
               state.context.withHints(
                   FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM));
-      success = true;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(this);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 
@@ -125,7 +122,6 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
     String fileName =
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
     IndexInput in = state.directory.openInput(fileName, context);
-    boolean success = false;
     try {
       int versionVectorData =
           CodecUtil.checkIndexHeader(
@@ -146,12 +142,10 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
             in);
       }
       CodecUtil.retrieveChecksum(in);
-      success = true;
       return in;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(in);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, in);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -80,7 +80,6 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
       throws IOException {
     this.fields = new IntObjectHashMap<>();
     this.flatVectorsReader = flatVectorsReader;
-    boolean success = false;
     this.fieldInfos = state.fieldInfos;
     String metaFileName =
         IndexFileNames.segmentFileName(
@@ -111,11 +110,9 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
               Lucene99HnswVectorsFormat.VECTOR_INDEX_CODEC_NAME,
               state.context.withHints(
                   FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM));
-      success = true;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(this);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 
@@ -147,7 +144,6 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
     String fileName =
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
     IndexInput in = state.directory.openInput(fileName, context);
-    boolean success = false;
     try {
       int versionVectorData =
           CodecUtil.checkIndexHeader(
@@ -168,12 +164,10 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
             in);
       }
       CodecUtil.retrieveChecksum(in);
-      success = true;
       return in;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(in);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, in);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
@@ -80,7 +80,6 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
             state.segmentInfo.name,
             state.segmentSuffix,
             Lucene99ScalarQuantizedVectorsFormat.META_EXTENSION);
-    boolean success = false;
     try (ChecksumIndexInput meta = state.directory.openChecksumInput(metaFileName)) {
       Throwable priorE = null;
       try {
@@ -108,11 +107,9 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
               // graph.
               state.context.withHints(
                   FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM));
-      success = true;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(this);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 
@@ -222,7 +219,6 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
     String fileName =
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
     IndexInput in = state.directory.openInput(fileName, context);
-    boolean success = false;
     try {
       int versionVectorData =
           CodecUtil.checkIndexHeader(
@@ -243,12 +239,10 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
             in);
       }
       CodecUtil.retrieveChecksum(in);
-      success = true;
       return in;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(in);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, in);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
@@ -167,7 +167,6 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
             state.segmentSuffix,
             Lucene99ScalarQuantizedVectorsFormat.VECTOR_DATA_EXTENSION);
     this.rawVectorDelegate = rawVectorDelegate;
-    boolean success = false;
     try {
       meta = state.directory.createOutput(metaFileName, state.context);
       quantizedVectorData =
@@ -185,11 +184,9 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
           version,
           state.segmentInfo.getId(),
           state.segmentSuffix);
-      success = true;
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(this);
-      }
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, this);
+      throw t;
     }
   }
 
@@ -480,7 +477,6 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
         segmentWriteState.directory.createTempOutput(
             quantizedVectorData.getName(), "temp", segmentWriteState.context);
     IndexInput quantizationDataInput = null;
-    boolean success = false;
     try {
       MergedQuantizedVectorValues byteVectorValues =
           MergedQuantizedVectorValues.mergeQuantizedByteVectorValues(
@@ -507,8 +503,9 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
           mergedQuantizationState.getLowerQuantile(),
           mergedQuantizationState.getUpperQuantile(),
           docsWithField);
-      success = true;
       final IndexInput finalQuantizationDataInput = quantizationDataInput;
+      quantizationDataInput = null;
+
       return new ScalarQuantizedCloseableRandomVectorScorerSupplier(
           () -> {
             IOUtils.close(finalQuantizationDataInput);
@@ -524,13 +521,12 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
                   compress,
                   fieldInfo.getVectorSimilarityFunction(),
                   vectorsScorer,
-                  quantizationDataInput)));
-    } finally {
-      if (success == false) {
-        IOUtils.closeWhileHandlingException(tempQuantizedVectorData, quantizationDataInput);
-        IOUtils.deleteFilesIgnoringExceptions(
-            segmentWriteState.directory, tempQuantizedVectorData.getName());
-      }
+                  finalQuantizationDataInput)));
+    } catch (Throwable t) {
+      IOUtils.closeWhileSuppressingExceptions(t, tempQuantizedVectorData, quantizationDataInput);
+      IOUtils.deleteFilesSuppressingExceptions(
+          t, segmentWriteState.directory, tempQuantizedVectorData.getName());
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
@@ -281,7 +281,6 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
     public FieldsReader(final SegmentReadState readState) throws IOException {
 
       // Init each unique format:
-      boolean success = false;
       try {
         // Read field name -> format name
         for (FieldInfo fi : readState.fieldInfos) {
@@ -307,11 +306,9 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
             }
           }
         }
-        success = true;
-      } finally {
-        if (!success) {
-          IOUtils.closeWhileHandlingException(formats.values());
-        }
+      } catch (Throwable t) {
+        IOUtils.closeWhileSuppressingExceptions(t, formats.values());
+        throw t;
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
@@ -206,7 +206,6 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
     public FieldsReader(final SegmentReadState readState) throws IOException {
       this.fieldInfos = readState.fieldInfos;
       // Init each unique format:
-      boolean success = false;
       Map<String, KnnVectorsReader> formats = new HashMap<>();
       try {
         // Read field name -> format name
@@ -233,11 +232,9 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
             }
           }
         }
-        success = true;
-      } finally {
-        if (!success) {
-          IOUtils.closeWhileHandlingException(formats.values());
-        }
+      } catch (Throwable t) {
+        IOUtils.closeWhileSuppressingExceptions(t, formats.values());
+        throw t;
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
@@ -143,7 +143,6 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
       Map<PostingsFormat, FieldsGroup> formatToGroups = buildFieldsGroupMapping(fields);
 
       // Write postings
-      boolean success = false;
       try {
         for (Map.Entry<PostingsFormat, FieldsGroup> ent : formatToGroups.entrySet()) {
           PostingsFormat format = ent.getKey();
@@ -162,11 +161,9 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
           toClose.add(consumer);
           consumer.write(maskedFields, norms);
         }
-        success = true;
-      } finally {
-        if (!success) {
-          IOUtils.closeWhileHandlingException(toClose);
-        }
+      } catch (Throwable t) {
+        IOUtils.closeWhileSuppressingExceptions(t, toClose);
+        throw t;
       }
     }
 
@@ -184,7 +181,6 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
       Map<PostingsFormat, FieldsGroup> formatToGroups = buildFieldsGroupMapping(indexedFieldNames);
 
       // Merge postings
-      boolean success = false;
       try {
         for (Map.Entry<PostingsFormat, FieldsGroup> ent : formatToGroups.entrySet()) {
           PostingsFormat format = ent.getKey();
@@ -194,11 +190,9 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
           toClose.add(consumer);
           consumer.merge(PerFieldMergeState.restrictFields(mergeState, group.fields), norms);
         }
-        success = true;
-      } finally {
-        if (!success) {
-          IOUtils.closeWhileHandlingException(toClose);
-        }
+      } catch (Throwable t) {
+        IOUtils.closeWhileSuppressingExceptions(t, toClose);
+        throw t;
       }
     }
 
@@ -297,7 +291,6 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
     public FieldsReader(final SegmentReadState readState) throws IOException {
 
       // Read _X.per and init each format:
-      boolean success = false;
       try {
         // Read field name -> format name
         for (FieldInfo fi : readState.fieldInfos) {
@@ -322,11 +315,9 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
             }
           }
         }
-        success = true;
-      } finally {
-        if (!success) {
-          IOUtils.closeWhileHandlingException(formats.values());
-        }
+      } catch (Throwable t) {
+        IOUtils.closeWhileSuppressingExceptions(t, formats.values());
+        throw t;
       }
 
       this.segment = readState.segmentInfo.name;

--- a/lucene/core/src/java/org/apache/lucene/store/Directory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/Directory.java
@@ -176,15 +176,12 @@ public abstract class Directory implements Closeable {
    */
   public void copyFrom(Directory from, String src, String dest, IOContext context)
       throws IOException {
-    boolean success = false;
     try (IndexInput is = from.openInput(src, IOContext.READONCE);
         IndexOutput os = createOutput(dest, context)) {
       os.copyBytes(is, is.length());
-      success = true;
-    } finally {
-      if (!success) {
-        IOUtils.deleteFilesIgnoringExceptions(this, dest);
-      }
+    } catch (Throwable t) {
+      IOUtils.deleteFilesSuppressingExceptions(t, this, dest);
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
@@ -95,7 +95,37 @@ public final class IOUtils {
   }
 
   /**
-   * Closes all given <code>Closeable</code>s, suppressing all thrown exceptions. Some of the <code>
+   * Closes all given <code>Closeable</code>s, suppressing all thrown Throwables in {@code ex}. Some
+   * of the <code>
+   * Closeable</code>s may be null, they are ignored.
+   *
+   * @param objects objects to call <code>close()</code> on
+   */
+  public static void closeWhileSuppressingExceptions(Throwable ex, Closeable... objects) {
+    closeWhileSuppressingExceptions(ex, Arrays.asList(objects));
+  }
+
+  /**
+   * Closes all given <code>Closeable</code>s, suppressing all thrown Throwables in {@code ex}. Even
+   * if a {@link Error} is thrown all given closeable are closed.
+   *
+   * @see #closeWhileHandlingException(Closeable...)
+   */
+  public static void closeWhileSuppressingExceptions(
+      Throwable ex, Iterable<? extends Closeable> objects) {
+    for (Closeable object : objects) {
+      try {
+        if (object != null) {
+          object.close();
+        }
+      } catch (Throwable e) {
+        ex.addSuppressed(e);
+      }
+    }
+  }
+
+  /**
+   * Closes all given <code>Closeable</code>s, ignoring all thrown exceptions. Some of the <code>
    * Closeable</code>s may be null, they are ignored.
    *
    * @param objects objects to call <code>close()</code> on
@@ -105,7 +135,7 @@ public final class IOUtils {
   }
 
   /**
-   * Closes all given <code>Closeable</code>s, suppressing all thrown non {@link Error} exceptions.
+   * Closes all given <code>Closeable</code>s, ignoring all thrown non {@link Error} exceptions.
    * Even if a {@link Error} is thrown all given closeable are closed.
    *
    * @see #closeWhileHandlingException(Closeable...)
@@ -174,7 +204,7 @@ public final class IOUtils {
   }
 
   /**
-   * Deletes all given files, suppressing all thrown IOExceptions.
+   * Deletes all given files, ignoring all thrown Throwables.
    *
    * <p>Note that the files should not be null.
    */
@@ -190,8 +220,39 @@ public final class IOUtils {
     }
   }
 
+  /**
+   * Deletes all given files, ignoring all thrown Throwables.
+   *
+   * <p>Note that the files should not be null.
+   */
   public static void deleteFilesIgnoringExceptions(Directory dir, String... files) {
     deleteFilesIgnoringExceptions(dir, Arrays.asList(files));
+  }
+
+  /**
+   * Deletes all given files, suppressing all thrown Throwables in {@code ex}.
+   *
+   * <p>Note that the files should not be null.
+   */
+  public static void deleteFilesSuppressingExceptions(
+      Throwable ex, Directory dir, Collection<String> files) {
+    for (String name : files) {
+      try {
+        dir.deleteFile(name);
+      } catch (Throwable d) {
+        ex.addSuppressed(d);
+      }
+    }
+  }
+
+  /**
+   * Deletes all given files, suppressing all thrown Throwables in {@code ex}.
+   *
+   * <p>Note that the files should not be null.
+   */
+  public static void deleteFilesSuppressingExceptions(
+      Throwable ex, Directory dir, String... files) {
+    deleteFilesSuppressingExceptions(ex, dir, Arrays.asList(files));
   }
 
   /**
@@ -220,7 +281,7 @@ public final class IOUtils {
   }
 
   /**
-   * Deletes all given files, suppressing all thrown IOExceptions.
+   * Deletes all given files, ignoring all thrown Throwables.
    *
    * <p>Some of the files may be null, if so they are ignored.
    */
@@ -229,7 +290,7 @@ public final class IOUtils {
   }
 
   /**
-   * Deletes all given files, suppressing all thrown IOExceptions.
+   * Deletes all given files, ignoring all thrown Throwables.
    *
    * <p>Some of the files may be null, if so they are ignored.
    */
@@ -242,6 +303,33 @@ public final class IOUtils {
             @SuppressWarnings("unused")
             Throwable ignored) {
           // ignore
+        }
+      }
+    }
+  }
+
+  /**
+   * Deletes all given files, ignoring all thrown Throwables.
+   *
+   * <p>Some of the files may be null, if so they are ignored.
+   */
+  public static void deleteFilesSuppressingExceptions(Throwable ex, Path... files) {
+    deleteFilesSuppressingExceptions(ex, Arrays.asList(files));
+  }
+
+  /**
+   * Deletes all given files, ignoring all thrown Throwables.
+   *
+   * <p>Some of the files may be null, if so they are ignored.
+   */
+  public static void deleteFilesSuppressingExceptions(
+      Throwable ex, Collection<? extends Path> files) {
+    for (Path name : files) {
+      if (name != null) {
+        try {
+          Files.delete(name);
+        } catch (Throwable d) {
+          ex.addSuppressed(d);
         }
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
@@ -309,7 +309,7 @@ public final class IOUtils {
   }
 
   /**
-   * Deletes all given files, ignoring all thrown Throwables.
+   * Deletes all given files, suppressing all thrown Throwables in {@code ex}.
    *
    * <p>Some of the files may be null, if so they are ignored.
    */
@@ -318,7 +318,7 @@ public final class IOUtils {
   }
 
   /**
-   * Deletes all given files, ignoring all thrown Throwables.
+   * Deletes all given files, suppressing all thrown Throwables in {@code ex}.
    *
    * <p>Some of the files may be null, if so they are ignored.
    */

--- a/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
@@ -113,14 +113,26 @@ public final class IOUtils {
    */
   public static void closeWhileSuppressingExceptions(
       Throwable ex, Iterable<? extends Closeable> objects) {
+    Error firstError = ex instanceof Error err ? err : null;
+
     for (Closeable object : objects) {
       try {
         if (object != null) {
           object.close();
         }
       } catch (Throwable e) {
-        ex.addSuppressed(e);
+        if (firstError == null && e instanceof Error err) {
+          // don't try and suppress it - this Error should be the thing that is thrown
+          firstError = err;
+          firstError.addSuppressed(ex);
+        } else {
+          ex.addSuppressed(e);
+        }
       }
+    }
+
+    if (firstError != null) {
+      throw firstError;
     }
   }
 
@@ -236,12 +248,24 @@ public final class IOUtils {
    */
   public static void deleteFilesSuppressingExceptions(
       Throwable ex, Directory dir, Collection<String> files) {
+    Error firstError = ex instanceof Error err ? err : null;
+
     for (String name : files) {
       try {
         dir.deleteFile(name);
       } catch (Throwable d) {
-        ex.addSuppressed(d);
+        if (firstError == null && d instanceof Error err) {
+          // don't try and suppress it - this Error should be the thing that is thrown
+          firstError = err;
+          firstError.addSuppressed(ex);
+        } else {
+          ex.addSuppressed(d);
+        }
       }
+    }
+
+    if (firstError != null) {
+      throw firstError;
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestIOUtils.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestIOUtils.java
@@ -41,7 +41,6 @@ import java.util.Set;
 import org.apache.lucene.tests.mockfile.FilterFileSystemProvider;
 import org.apache.lucene.tests.mockfile.FilterPath;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.hamcrest.Matchers;
 
 /** Simple test methods for IOUtils */
 public class TestIOUtils extends LuceneTestCase {
@@ -86,7 +85,7 @@ public class TestIOUtils extends LuceneTestCase {
 
     Exception ex = new Exception("Ex");
     IOUtils.closeWhileSuppressingExceptions(ex, exceptionClose);
-    assertThat(ex.getSuppressed(), arrayContaining(Matchers.instanceOf(IOException.class)));
+    assertThat(ex.getSuppressed(), arrayContaining(instanceOf(IOException.class)));
 
     Error topErr = new Error("Err");
     Error thrown =

--- a/lucene/core/src/test/org/apache/lucene/util/TestIOUtils.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestIOUtils.java
@@ -16,6 +16,13 @@
  */
 package org.apache.lucene.util;
 
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.io.Closeable;
+import java.io.IOError;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.channels.FileChannel;
@@ -34,6 +41,7 @@ import java.util.Set;
 import org.apache.lucene.tests.mockfile.FilterFileSystemProvider;
 import org.apache.lucene.tests.mockfile.FilterPath;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.hamcrest.Matchers;
 
 /** Simple test methods for IOUtils */
 public class TestIOUtils extends LuceneTestCase {
@@ -64,6 +72,42 @@ public class TestIOUtils extends LuceneTestCase {
     assertFalse(Files.exists(file2));
     // no exception
     // actually deletes file2
+  }
+
+  public void testCloseExposesErrors() {
+    Closeable exceptionClose =
+        () -> {
+          throw new IOException("IO");
+        };
+    Closeable errorClose =
+        () -> {
+          throw new IOError(new IOException("IOERR"));
+        };
+
+    Exception ex = new Exception("Ex");
+    IOUtils.closeWhileSuppressingExceptions(ex, exceptionClose);
+    assertThat(ex.getSuppressed(), arrayContaining(Matchers.instanceOf(IOException.class)));
+
+    Error topErr = new Error("Err");
+    Error thrown =
+        expectThrows(
+            Error.class,
+            () -> IOUtils.closeWhileSuppressingExceptions(topErr, exceptionClose, errorClose));
+    assertThat(thrown, sameInstance(topErr));
+    assertThat(
+        thrown.getSuppressed(),
+        arrayContainingInAnyOrder(instanceOf(IOException.class), instanceOf(IOError.class)));
+
+    // the IOError takes precedence, and is thrown in preference to the Exception
+    Exception suppressedEx = new Exception("Ex");
+    thrown =
+        expectThrows(
+            IOError.class,
+            () ->
+                IOUtils.closeWhileSuppressingExceptions(suppressedEx, exceptionClose, errorClose));
+    assertThat(thrown.getSuppressed(), arrayContaining(suppressedEx));
+    assertThat(
+        thrown.getSuppressed()[0].getSuppressed(), arrayContaining(instanceOf(IOException.class)));
   }
 
   public void testDeleteFileIfExists() throws Exception {


### PR DESCRIPTION
The use of a boolean `success` parameter is common in the Lucene codebase. This can be replaced with a `catch (Throwable t) {...; throw t}` pattern that means a boolean doesn't need to be used at all, and it generally results in less code. This is helped by some new methods on `IOUtils`.

As a side-effect, any problems that occur whilst closing/deleting during exception handling will now be added to the top-level rethrown exception, rather than being swallowed and disappearing.

I've converted a few here to show the pattern - if this is a direction we want to go in, I can convert more.