### PR TITLE
Use the preload hint on completion fields and memory terms dictionaries.

### DIFF
--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
@@ -41,6 +41,7 @@ import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.store.FileTypeHint;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.PreloadHint;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
@@ -75,7 +76,8 @@ public class FSTTermsReader extends FieldsProducer {
 
     this.postingsReader = postingsReader;
     this.fstTermsInput =
-        state.directory.openInput(termsFileName, state.context.withHints(FileTypeHint.INDEX));
+        state.directory.openInput(
+            termsFileName, state.context.withHints(FileTypeHint.DATA, PreloadHint.INSTANCE));
 
     IndexInput in = this.fstTermsInput;
 

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionFieldsProducer.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionFieldsProducer.java
@@ -36,7 +36,9 @@ import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.FileTypeHint;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.PreloadHint;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.CollectionUtil;
@@ -77,7 +79,9 @@ final class CompletionFieldsProducer extends FieldsProducer implements Accountab
       String dictFile =
           IndexFileNames.segmentFileName(
               state.segmentInfo.name, state.segmentSuffix, DICT_EXTENSION);
-      dictIn = state.directory.openInput(dictFile, state.context);
+      dictIn =
+          state.directory.openInput(
+              dictFile, state.context.withHints(FileTypeHint.DATA, PreloadHint.INSTANCE));
       CodecUtil.checkIndexHeader(
           dictIn,
           codecName,


### PR DESCRIPTION
This enables the `PreloadHint` introduced in #14604 on completion fields and memory terms dictionaries, which are both expected to fit in the page cache in practice.

I don't have specific interest in these two file formats, I was more interested in having more than one file format that uses `PreloadHint` to make sure it's generally useful and not only to KNN vectors.