### PR TITLE
Clean up FileTypeHint a bit.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -164,7 +164,7 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
         String proxName =
             IndexFileNames.segmentFileName(
                 state.segmentInfo.name, state.segmentSuffix, Lucene103PostingsFormat.POS_EXTENSION);
-        posIn = state.directory.openInput(proxName, state.context);
+        posIn = state.directory.openInput(proxName, state.context.withHints(FileTypeHint.DATA));
         CodecUtil.checkIndexHeader(
             posIn, POS_CODEC, version, version, state.segmentInfo.getId(), state.segmentSuffix);
         CodecUtil.retrieveChecksum(posIn, expectedPosFileLength);
@@ -175,7 +175,7 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
                   state.segmentInfo.name,
                   state.segmentSuffix,
                   Lucene103PostingsFormat.PAY_EXTENSION);
-          payIn = state.directory.openInput(payName, state.context);
+          payIn = state.directory.openInput(payName, state.context.withHints(FileTypeHint.DATA));
           CodecUtil.checkIndexHeader(
               payIn, PAY_CODEC, version, version, state.segmentInfo.getId(), state.segmentSuffix);
           CodecUtil.retrieveChecksum(payIn, expectedPayFileLength);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/Lucene103BlockTreeTermsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/Lucene103BlockTreeTermsReader.java
@@ -114,7 +114,7 @@ public final class Lucene103BlockTreeTermsReader extends FieldsProducer {
     try {
       String termsName =
           IndexFileNames.segmentFileName(segment, state.segmentSuffix, TERMS_EXTENSION);
-      termsIn = state.directory.openInput(termsName, state.context);
+      termsIn = state.directory.openInput(termsName, state.context.withHints(FileTypeHint.DATA));
       version =
           CodecUtil.checkIndexHeader(
               termsIn,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -58,7 +58,6 @@ import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataAccessHint;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.FileDataHint;
 import org.apache.lucene.store.FileTypeHint;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
@@ -149,10 +148,7 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
       final String vectorsStreamFN =
           IndexFileNames.segmentFileName(segment, segmentSuffix, VECTORS_EXTENSION);
       vectorsStream =
-          d.openInput(
-              vectorsStreamFN,
-              context.withHints(
-                  FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM));
+          d.openInput(vectorsStreamFN, context.withHints(FileTypeHint.DATA, DataAccessHint.RANDOM));
       version =
           CodecUtil.checkIndexHeader(
               vectorsStream, formatName, VERSION_START, VERSION_CURRENT, si.getId(), segmentSuffix);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -111,6 +111,8 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
               Lucene99HnswVectorsFormat.VECTOR_INDEX_EXTENSION,
               Lucene99HnswVectorsFormat.VECTOR_INDEX_CODEC_NAME,
               state.context.withHints(
+                  // Even though this input is referred to an `indexIn`, it doesn't qualify as
+                  // FileTypeHint#INDEX since it's a large file
                   FileTypeHint.DATA,
                   FileDataHint.KNN_VECTORS,
                   DataAccessHint.RANDOM,

--- a/lucene/core/src/java/org/apache/lucene/store/FileTypeHint.java
+++ b/lucene/core/src/java/org/apache/lucene/store/FileTypeHint.java
@@ -16,12 +16,18 @@
  */
 package org.apache.lucene.store;
 
-/** Hints on the type of file being opened */
+/**
+ * Hints on the type of file being opened.
+ *
+ * <p><b>NOTE</b>: There is no constant for metadata files, since metadata files should be opened
+ * with {@link Directory#openChecksumInput(String)}, which doesn't take hints.
+ */
 public enum FileTypeHint implements IOContext.FileOpenHint {
-  /** The file contains metadata */
-  METADATA,
-  /** The file contains field data */
-  DATA,
-  /** The file contains indexes */
-  INDEX
+  /**
+   * The file contains indexes. It is small (~1% or less of the data size) and generally fits in the
+   * page cache.
+   */
+  INDEX,
+  /** The file contains field data. */
+  DATA
 }

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -298,11 +298,6 @@ public class MMapDirectory extends FSDirectory {
       return ReadAdvice.SEQUENTIAL;
     }
 
-    if (context.hints().contains(FileTypeHint.DATA)
-        || context.hints().contains(FileTypeHint.INDEX)) {
-      return ReadAdvice.NORMAL;
-    }
-
     return Constants.DEFAULT_READADVICE;
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
@@ -70,17 +70,10 @@ public class SerialIOCountingDirectory extends FilterDirectory {
     return super.openChecksumInput(name);
   }
 
-  private static boolean defaultDataAccess(IOContext context) {
-    // Data or index file type, and no data access hints
-    return (context.hints().contains(FileTypeHint.DATA)
-            || context.hints().contains(FileTypeHint.INDEX))
-        && context.hints(DataAccessHint.class).findAny().isEmpty();
-  }
-
   @Override
   public IndexInput openInput(String name, IOContext context) throws IOException {
-    if (defaultDataAccess(context)) {
-      // expected to be loaded in memory, only count 1 at open time
+    if (context.hints().contains(FileTypeHint.INDEX)) {
+      // expected to be small and fit in the page cache, only count 1 at open time
       counter.increment();
       return super.openInput(name, context);
     }


### PR DESCRIPTION
 - more javadocs to guide usage of `INDEX` vs. `DATA`,
 - the `METADATA` constant is removed, as metadata files should be opened with `Directory#openChecksumIndexInput`, which doesn't take hints,
 - configure `FileTypeHint` on more files of the default codec,
 - remove checks on `FileTypeHint` from `toReadAdvice` - the default impl should only look at `DataAccessHint` to determine the appropriate read advice.