### PR TITLE
fix TestSortedDvMultiRangeQuery.testDuelWithStandardDisjunction when …

### DIFF
--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestSortedDvMultiRangeQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestSortedDvMultiRangeQuery.java
@@ -226,6 +226,17 @@ public class TestSortedDvMultiRangeQuery extends LuceneTestCase {
       int lower = ends[pos];
       int upper = ends[pos + 1];
       b.add(lower, upper);
+      for (int repeat = 0; repeat < random().nextInt(3); repeat++) {
+        if (rarely()) {
+          b.add(lower, upper); // plain repeat
+        } else {
+          if (random().nextBoolean()) {
+            b.add(lower, lower); // lower point repeat
+          } else {
+            b.add(upper, upper); // upper point repeat
+          }
+        }
+      }
     }
     return b;
   }


### PR DESCRIPTION
…… (#14632)

* fix TestSortedDvMultiRangeQuery.testDuelWithStandardDisjunction when point occurs in the edge

### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
