### PR TITLE
Expressions: Avoid creating a dynamic constant with BSM if MethodHandle descriptor can be used

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -33,6 +33,9 @@ Improvements
   This avoids clashes with other ASM versions on classpath because it removes the dependency.
   (Uwe Schindler)
 
+* GITHUB#14642: Expressions: Avoid creating a dynamic constant with BSM if MethodHandle
+  descriptor can be used.  (Uwe Schindler)
+
 * GITHUB#14226: Use optimistic-with-checking KNN Query execution strategy in place of cross-thread
   global queue min-score checking. Improves performance and consistency. (Mike Sokolov, Dzung Bui,
   Ben Trent)

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestCustomFunctions.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestCustomFunctions.java
@@ -198,7 +198,8 @@ public class TestCustomFunctions extends CompilerTestCase {
     assertTrue(expected.getMessage().contains("is not static"));
   }
 
-  static double nonPublicMethod() {
+  @SuppressWarnings("unused")
+  private static double nonPublicMethod() {
     return 7;
   }
 
@@ -209,7 +210,8 @@ public class TestCustomFunctions extends CompilerTestCase {
     assertEquals(7, expr.evaluate(null), DELTA);
   }
 
-  static class NestedNotPublic {
+  @SuppressWarnings("unused")
+  private static class NestedNotPublic {
     public static double method() {
       return 41;
     }


### PR DESCRIPTION
This is an optimization to avoid using a bootstrap when creting the MethodHandle constant. This won't be backported as it's not easy possible to do with ASM.

Basically, if the `MethodHandle` in our function list is a direct one and reachable from system classloader, we push a reference to it directly to stack. This is the common case for static (named) functions and all methods in the default functions. The classfile API makes it easy, because if a `MethodHandle` is direct and reachable by system classloader, it returns a non-empty `describeConstable()`.

This won't improve performance for the execution (as it is a constant before and after), but it should improve startup time.