### PR TITLE
Override ValueSource.FromDoubleValuesSource.getSortField

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -113,7 +113,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+* GITHUB#14654: ValueSource.fromDoubleValuesSource(dvs).getSortField() would throw errors when
+  used if the DoubleValuesSource needed scores. (David Smiley)
 
 Build
 ---------------------

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSource.java
@@ -320,6 +320,12 @@ public abstract class ValueSource {
     }
 
     @Override
+    public SortField getSortField(boolean reverse) {
+      // avoids indirection and supports a better needsScores()
+      return in.getSortField(reverse);
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;


### PR DESCRIPTION
Thus reducing indirection and supporting needsScores correctly (fixes a bug).

The added test, without the fix, would throw an assertion inside DoubleValuesSource [here](https://github.com/apache/lucene/blob/304d4e7855deb39b4650d954d027ce8697873056/lucene/core/src/java/org/apache/lucene/search/DoubleValuesSource.java#L329) because the required scores were not provided to the DoubleValuesSource.getValues implementation.