### PR TITLE
Update IndicNormalizer.java

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/in/IndicNormalizer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/in/IndicNormalizer.java
@@ -176,8 +176,6 @@ class IndicNormalizer {
     {0x33, 0x3C, -1, 0x34, flag(DEVANAGARI)},
     /* malayalam chillu ll */
     {0x33, 0x4D, 0xFF, 0x7E, flag(MALAYALAM)},
-    /* telugu letter MA */
-    {0x35, 0x41, -1, 0x2E, flag(TELUGU)},
     /* devanagari, gujarati vowel sign candra O */
     {0x3E, 0x45, -1, 0x49, flag(DEVANAGARI) | flag(GUJARATI)},
     /* devanagari vowel sign short O */

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/te/TestTeluguFilters.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/te/TestTeluguFilters.java
@@ -37,7 +37,7 @@ public class TestTeluguFilters extends BaseTokenStreamFactoryTestCase {
     TokenStream stream = whitespaceMockTokenizer(reader);
     stream = tokenFilterFactory("IndicNormalization").create(stream);
     stream = tokenFilterFactory("TeluguNormalization").create(stream);
-    assertTokenStreamContents(stream, new String[] {"వస్తుమలు"});
+    assertTokenStreamContents(stream, new String[] {"వస్తువులు"});
   }
 
   /** Test TeluguStemFilterFactory */
@@ -47,7 +47,7 @@ public class TestTeluguFilters extends BaseTokenStreamFactoryTestCase {
     stream = tokenFilterFactory("IndicNormalization").create(stream);
     stream = tokenFilterFactory("TeluguNormalization").create(stream);
     stream = tokenFilterFactory("TeluguStem").create(stream);
-    assertTokenStreamContents(stream, new String[] {"వస్తుమ"});
+    assertTokenStreamContents(stream, new String[] {"వస్తువు"});
   }
 
   /** Test that bogus arguments result in exception */


### PR DESCRIPTION
Remove Telugu normalization of vu వు to ma మ from IndicNormalizer.

### Description

Telugu vu వు and ma మ are visually similar—akin to English "rn" and "m"—but they should not be conflated. Names like వెంకటరామ (Venkatarama) and వెంకటరావు (Venkatarao) and words like [మండే](https://te.wiktionary.org/wiki/%E0%B0%AE%E0%B0%82%E0%B0%A6%E0%B0%BF) and [వుండే](https://te.wiktionary.org/wiki/%E0%B0%B5%E0%B1%81%E0%B0%82%E0%B0%A6%E0%B0%BF) (links to Telugu Wiktionary) are distinct.

It's like conflating _burn/bum_ and _corn/com._ It could happen when reading quickly or with poor handwriting, but it is not something that should happen for search indexing.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
