### PR TITLE
Clarify filter fields usage in javadocs

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
@@ -57,7 +57,8 @@ import org.apache.lucene.util.BytesRefIterator;
  *
  * <p>Filtering by additional fields can be configured by passing a set of field names. Documents
  * that contain values in those fields will only be checked against {@link MonitorQuery} instances
- * that have the same fieldname-value mapping in their metadata.
+ * that have the same fieldname-value mapping in their metadata. Note that these fields should not
+ * appear in the queries themselves. They should appear only in query metadata and in the documents.
  */
 public class TermFilteredPresearcher extends Presearcher {
 

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/package-info.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/package-info.java
@@ -70,7 +70,8 @@
  * is checked against. For example, you can specify a language that each query should apply to, and
  * documents containing a value in their language field would only be checked against queries that
  * have that same value in their language metadata. Note that when matching documents in batches,
- * all documents in the batch must have the same values in their filter fields.
+ * all documents in the batch must have the same values in their filter fields. Note also that a
+ * filter field should appear only in the query's metadata, not as a field in the query itself.
  *
  * <p>Query analysis uses the {@link org.apache.lucene.search.QueryVisitor} API to extract terms,
  * which will work for all basic term-based queries shipped with Lucene. The analyzer builds a


### PR DESCRIPTION
### Description

To resolve https://github.com/apache/lucene/issues/14427

Update documentation for Lucene Monitor to make clear that filter fields should appear only in the query metadata and incoming documents, and should _not_ appear in the query itself.

### Problem

This is described in more detail in https://github.com/apache/lucene/issues/14427 -- a rough summary is given below:

When `TermFilteredPresearcher` builds a presearcher query, it separates out filter fields into their own clause (with `BooleanClause.Occur.FILTER`), ANDed with a clause for all other terms. If a stored monitor query is a conjunction of fields including the filter field, it's possible that the filter field may be chosen as the indexed field for the document in the monitor's index, in which case the presearcher query will need to search for the filter field in order to match. However, since the filter field is _deliberately omitted_ from the terms clause, the terms clause will never contain that filter field and can never match that stored monitor query. Although the filter clause will match the query, since the two clauses are ANDed together, the stored query doesn't match the presearcher query as a whole, so the stored query is not returned from presearching (and therefore does not match).

Supporting this would potentially cause more queries to run than before, and it's debatable that allowing the filter field to float freely in the stored query (where it could have, for example, a NOT applied to it) would lead to inconsistency.

### Solution

Side-stepping the larger question of whether there is a path forward with filter fields appearing in the query directly, this PR updates the documentation around filter fields to clarify that a user should not have the filter field(s) appear in the stored query itself, only in its metadata.

For reasons described in the linked issue (https://github.com/apache/lucene/issues/14427), I think supporting filter fields in the query would introduce a performance penalty, so it seems preferable to leave that behavior as-is and augment the documentation to help users avoid problems with it.

### Merge Request

If this PR gets merged, can you please use my `bjacobowitz1@bloomberg.net` email address for the squash+merge? Thank you.