### PR TITLE
Optimize AbstractKnnVectorQuery#createBitSet with intoBitset

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -124,6 +124,8 @@ Optimizations
 
 * GITHUB#14709: Speed up TermQuery by Scorer#nextDocsAndScores. (Guo Feng)
 
+* GITHUB#14674: Optimize AbstractKnnVectorQuery#createBitSet with intoBitset. (Guo Feng)
+
 Bug Fixes
 ---------------------
 * GITHUB#14654: ValueSource.fromDoubleValuesSource(dvs).getSortField() would throw errors when


### PR DESCRIPTION
This tries to implement `intoBitset` to speed up the building of BitSet.