### PR TITLE
Added toString() method to BytesRefBuilder

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -49,6 +49,9 @@ Bug Fixes
 
 * GITHUB#14075: Remove duplicate and add missing entry on brazilian portuguese stopwords list. (Arthur Caccavo)
 
+* GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException
+  instead of UnsupportedOperationException when values are out of order. (Shubham Sharma)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -90,6 +90,8 @@ Improvements
 * GITHUB#14602: Refactor the expressions compiler to use official ClassData BSM with indexed lookup
   (Uwe Schindler)
 
+  * GITHUB#14443: Support adaptive refresh in Searcher Managers (Vigya Sharma)
+
 Optimizations
 ---------------------
 * GITHUB#14418: Quick exit on filter query matching no docs when rewriting knn query. (Pan Guixin)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -49,9 +49,6 @@ Bug Fixes
 
 * GITHUB#14075: Remove duplicate and add missing entry on brazilian portuguese stopwords list. (Arthur Caccavo)
 
-* GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException
-  instead of UnsupportedOperationException when values are out of order. (Shubham Sharma)
-
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)
@@ -116,7 +113,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+* GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException
+  instead of UnsupportedOperationException when values are out of order. (Shubham Sharma)
 
 Build
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -90,7 +90,7 @@ Improvements
 * GITHUB#14602: Refactor the expressions compiler to use official ClassData BSM with indexed lookup
   (Uwe Schindler)
 
-  * GITHUB#14443: Support adaptive refresh in Searcher Managers (Vigya Sharma)
+* GITHUB#14443: Support adaptive refresh in Searcher Managers (Vigya Sharma)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefBuilder.java
@@ -174,6 +174,6 @@ public class BytesRefBuilder {
 
   @Override
   public String toString() {
-    return ToStringUtils.bytesRefToString(this);
+    return this.get().toString();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefBuilder.java
@@ -171,4 +171,9 @@ public class BytesRefBuilder {
   public int hashCode() {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public String toString() {
+    return ToStringUtils.bytesRefToString(this);
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
@@ -2599,4 +2599,36 @@ public class TestPointQueries extends LuceneTestCase {
     w.close();
     dir.close();
   }
+
+  public void testOutOfOrderValuesInPointInSetQuery() throws Exception {
+    IllegalArgumentException expected =
+            expectThrows(
+                    IllegalArgumentException.class,
+                    () -> {
+                      new PointInSetQuery(
+                              "foo",
+                              1,
+                              1,
+                              new PointInSetQuery.Stream() {
+                                private final BytesRef[] values = {
+                                        newBytesRef(new byte[]{2}),
+                                        newBytesRef(new byte[]{1})  // out of order
+                                };
+                                int index = 0;
+
+                                @Override
+                                public BytesRef next() {
+                                  return index < values.length ? values[index++] : null;
+                                }
+                              }) {
+                        @Override
+                        protected String toString(byte[] point) {
+                          return Arrays.toString(point);
+                        }
+                      };
+                    });
+    assertEquals(
+            "values are out of order: saw [2] before [1]",
+            expected.getMessage());
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
@@ -2602,33 +2602,30 @@ public class TestPointQueries extends LuceneTestCase {
 
   public void testOutOfOrderValuesInPointInSetQuery() throws Exception {
     IllegalArgumentException expected =
-            expectThrows(
-                    IllegalArgumentException.class,
-                    () -> {
-                      new PointInSetQuery(
-                              "foo",
-                              1,
-                              1,
-                              new PointInSetQuery.Stream() {
-                                private final BytesRef[] values = {
-                                        newBytesRef(new byte[]{2}),
-                                        newBytesRef(new byte[]{1})  // out of order
-                                };
-                                int index = 0;
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+              new PointInSetQuery(
+                  "foo",
+                  1,
+                  1,
+                  new PointInSetQuery.Stream() {
+                    private final BytesRef[] values = {
+                      newBytesRef(new byte[] {2}), newBytesRef(new byte[] {1}) // out of order
+                    };
+                    int index = 0;
 
-                                @Override
-                                public BytesRef next() {
-                                  return index < values.length ? values[index++] : null;
-                                }
-                              }) {
-                        @Override
-                        protected String toString(byte[] point) {
-                          return Arrays.toString(point);
-                        }
-                      };
-                    });
-    assertEquals(
-            "values are out of order: saw [2] before [1]",
-            expected.getMessage());
+                    @Override
+                    public BytesRef next() {
+                      return index < values.length ? values[index++] : null;
+                    }
+                  }) {
+                @Override
+                protected String toString(byte[] point) {
+                  return Arrays.toString(point);
+                }
+              };
+            });
+    assertEquals("values are out of order: saw [2] before [1]", expected.getMessage());
   }
 }


### PR DESCRIPTION
### Description

## Problem
- The BytesRefBuilder was missing toString() override. This was leading to UnsupportedOperationException instead of IllegalArgumentException in PointInSetQuery's constructor as described here - https://github.com/apache/lucene/issues/14161

## Solution
- Added toString() method in BytesRefBuilder.
- Added UT for verifying the IllegalArgumentException exception.