### PR TITLE
Improve BytesRef creation from String

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -41,6 +41,7 @@ Optimizations
 ---------------------
 * GITHUB#14011: Reduce allocation rate in HNSW concurrent merge. (Viliam Durina)
 * GITHUB#14022: Optimize DFS marking of connected components in HNSW by reducing stack depth, improving performance and reducing allocations. (Viswanath Kuchibhotla)
+* GITHUB#14678: Optimize BytesRef creation from Strings, improving throughput and reducing allocations. (David Schlosnagle)
 
 Bug Fixes
 ---------------------

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/StemmerOverrideFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/StemmerOverrideFilter.java
@@ -220,7 +220,7 @@ public final class StemmerOverrideFilter extends TokenFilter {
         int id = sort[i];
         BytesRef bytesRef = hash.get(id, spare);
         intsSpare.copyUTF8Bytes(bytesRef);
-        fstCompiler.add(intsSpare.get(), new BytesRef(outputValues.get(id)));
+        fstCompiler.add(intsSpare.get(), BytesRef.of(outputValues.get(id)));
       }
       return new StemmerOverrideMap(
           FST.fromFSTReader(fstCompiler.compile(), fstCompiler.getFSTReader()), ignoreCase);

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BytesRefBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BytesRefBenchmark.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.util.BytesRef;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Thread)
+@Fork(1)
+@Threads(4)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 3)
+public class BytesRefBenchmark {
+
+  @Param({"10", "100", "1000"})
+  private int length;
+
+  @Param({"ASCII", "ISO_8859_1", "UTF_8_BMP", "UTF_16"})
+  private Type type;
+
+  private String string;
+  private CharSequence charSequence;
+
+  @Setup
+  public void before() {
+    string = generateCodepoints(length, type.maxCodePoint);
+    charSequence = string;
+  }
+
+  @Benchmark
+  public BytesRef bytesRefCharSequence() {
+    return new BytesRef(charSequence);
+  }
+
+  @Benchmark
+  public BytesRef bytesRefString() {
+    return new BytesRef(string);
+  }
+
+  private static String generateCodepoints(int size, int maxCodePoint) {
+    Random r = new Random(0);
+    StringBuilder sb = new StringBuilder(size);
+    for (int i = 0; i < size; i++) {
+      sb.appendCodePoint(r.nextInt(maxCodePoint));
+    }
+    return sb.toString();
+  }
+
+  public enum Type {
+    ASCII(128),
+    ISO_8859_1(256),
+    UTF_8_BMP(0xFFFF),
+    UTF_16(0x10FFFF),
+    ;
+
+    private final int maxCodePoint;
+
+    Type(int maxCodepoint) {
+      this.maxCodePoint = maxCodepoint;
+    }
+  }
+
+  public static void main(String[] _args) throws Exception {
+    new Runner(
+            new OptionsBuilder()
+                .include(BytesRefBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build())
+        .run();
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRef.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRef.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /**
@@ -79,6 +80,26 @@ public final class BytesRef implements Comparable<BytesRef>, Cloneable {
   public BytesRef(CharSequence text) {
     this(UnicodeUtil.maxUTF8Length(text.length()));
     length = UnicodeUtil.UTF16toUTF8(text, 0, text.length(), bytes);
+  }
+
+  /**
+   * Initialize the byte[] from the UTF8 bytes for the provided String.
+   *
+   * @param text This must be well-formed unicode text, with no unpaired surrogates.
+   */
+  public BytesRef(String text) {
+    this(text.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * @param text This must be well-formed unicode text, with no unpaired surrogates.
+   * @return BytesRef instance from the provided String.
+   */
+  public static BytesRef of(CharSequence text) {
+    if (text instanceof String string) {
+      return new BytesRef(string);
+    }
+    return new BytesRef(text);
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterUnicode.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterUnicode.java
@@ -178,7 +178,7 @@ public class TestIndexWriterUnicode extends LuceneTestCase {
     for (int iter = 0; iter < num; iter++) {
       boolean hasIllegal = fillUnicode(buffer, expected, 0, 20);
 
-      BytesRef utf8 = new BytesRef(CharBuffer.wrap(buffer, 0, 20));
+      BytesRef utf8 = BytesRef.of(CharBuffer.wrap(buffer, 0, 20));
       if (!hasIllegal) {
         byte[] b = new String(buffer, 0, 20).getBytes(StandardCharsets.UTF_8);
         assertEquals(b.length, utf8.length);
@@ -210,7 +210,7 @@ public class TestIndexWriterUnicode extends LuceneTestCase {
         chars[len++] = (char) (((ch - 0x0010000) & 0x3FFL) + UnicodeUtil.UNI_SUR_LOW_START);
       }
 
-      BytesRef utf8 = new BytesRef(CharBuffer.wrap(chars, 0, len));
+      BytesRef utf8 = BytesRef.of(CharBuffer.wrap(chars, 0, len));
 
       String s1 = new String(chars, 0, len);
       String s2 = new String(utf8.bytes, 0, utf8.length, StandardCharsets.UTF_8);

--- a/lucene/core/src/test/org/apache/lucene/util/TestBytesRef.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestBytesRef.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.util;
 
+import java.nio.CharBuffer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 
@@ -49,6 +50,26 @@ public class TestBytesRef extends LuceneTestCase {
 
     // only for 4.x
     assertEquals("\uFFFF", new BytesRef("\uFFFF").utf8ToString());
+  }
+
+  public void testFromCharSequence() {
+    for (int i = 0; i < 100; i++) {
+      String s = TestUtil.randomUnicodeString(random());
+      String s2 = new BytesRef((CharSequence) s).utf8ToString();
+      String s3 = new BytesRef(s).utf8ToString();
+      String s4 = new BytesRef(CharBuffer.wrap(s)).utf8ToString();
+      String s5 = BytesRef.of(s).utf8ToString();
+      String s6 = BytesRef.of(CharBuffer.wrap(s)).utf8ToString();
+      assertEquals(s, s2);
+      assertEquals(s, s3);
+      assertEquals(s, s4);
+      assertEquals(s, s5);
+      assertEquals(s, s6);
+    }
+
+    // only for 4.x
+    assertEquals("\uFFFF", new BytesRef(CharBuffer.wrap("\uFFFF")).utf8ToString());
+    assertEquals("\uFFFF", BytesRef.of(CharBuffer.wrap("\uFFFF")).utf8ToString());
   }
 
   public void testInvalidDeepCopy() {

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/RegexpQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/RegexpQueryNode.java
@@ -48,7 +48,7 @@ public class RegexpQueryNode extends QueryNodeImpl implements TextableQueryNode,
   }
 
   public BytesRef textToBytesRef() {
-    return new BytesRef(text);
+    return BytesRef.of(text);
   }
 
   @Override

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/AnalyzingSuggester.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/AnalyzingSuggester.java
@@ -690,7 +690,7 @@ public class AnalyzingSuggester extends Lookup {
             "lookup key cannot contain unit separator character U+001F; this character is reserved");
       }
     }
-    final BytesRef utf8Key = new BytesRef(key);
+    final BytesRef utf8Key = BytesRef.of(key);
     try {
       Automaton lookupAutomaton = toLookupAutomaton(key);
 

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
@@ -139,7 +139,7 @@ public class ContextQuery extends CompletionQuery implements Accountable {
       }
     }
     contexts.put(
-        IntsRef.deepCopyOf(Util.toIntsRef(new BytesRef(context), scratch)),
+        IntsRef.deepCopyOf(Util.toIntsRef(BytesRef.of(context), scratch)),
         new ContextMetaData(boost, exact));
     updateRamBytesUsed();
   }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletion.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletion.java
@@ -223,7 +223,7 @@ public class FSTCompletion {
     }
 
     try {
-      return lookupSortedByWeight(new BytesRef(key));
+      return lookupSortedByWeight(BytesRef.of(key));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -399,7 +399,7 @@ public class FSTCompletion {
    * exists.
    */
   public int getBucket(CharSequence key) {
-    return getExactMatchStartingFromRootArc(0, new BytesRef(key));
+    return getExactMatchStartingFromRootArc(0, BytesRef.of(key));
   }
 
   /** Returns the internal automaton. */

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/WFSTCompletionLookup.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/WFSTCompletionLookup.java
@@ -242,7 +242,7 @@ public class WFSTCompletionLookup extends Lookup {
     Arc<Long> arc = new Arc<>();
     Long result = null;
     try {
-      result = lookupPrefix(new BytesRef(key), arc);
+      result = lookupPrefix(BytesRef.of(key), arc);
     } catch (IOException bogus) {
       throw new RuntimeException(bogus);
     }


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

When creating a `BytesRef` from a String, we can leverage `String::getBytes(StandardCharset.UTF_8)` to avoid 3x memory allocation overhead when the `String` is already `UTF-8` and when the [JDK provides compact `String` representation as `byte[]`](https://openjdk.org/jeps/254) this becomes a single array copy rather than more complex
`org.apache.lucene.util.UnicodeUtil#UTF16toUTF8` logic. Benchmark results for the added `BytesRefBenchmark` on MacBookPro M2 Max show specialized `BytesRef(String)` constructor provides 2x to 6x throughput improvement compared to `BytesRef(CharSequence)` constructor, and 3x less allocations for ASCII Strings.

```
# Apple MacBookPro M2 Max
# JMH version: 1.37
# VM version: JDK 24.0.1, OpenJDK 64-Bit Server VM, 24.0.1+9-FR
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-24.jdk/Contents/Home/bin/java
# VM options: -XX:+UseParallelGC -XX:TieredStopAtLevel=1 -XX:ActiveProcessorCount=1 -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 3 iterations, 3 s each
# Measurement: 5 iterations, 3 s each

                                                                         (before)              (after)
                                                                       bytesRefCharSequence   bytesRefString
Benchmark                             (length)      (type)   Mode  Cnt      Score     Error      Score     Error   Units
BytesRefBenchmark                         1000       ASCII  thrpt    5      1.213 ±   0.022      6.090 ±   0.145  ops/us
BytesRefBenchmark:gc.alloc.rate.norm      1000       ASCII  thrpt    5   3040.002 ±   0.001   1040.000 ±   0.001    B/op
BytesRefBenchmark                         1000  ISO_8859_1  thrpt    5      1.123 ±   0.022      3.334 ±   0.116  ops/us
BytesRefBenchmark:gc.alloc.rate.norm      1000  ISO_8859_1  thrpt    5   3040.002 ±   0.001   3552.001 ±   0.001    B/op
BytesRefBenchmark                         1000   UTF_8_BMP  thrpt    5      0.660 ±   0.017      1.548 ±   0.092  ops/us
BytesRefBenchmark:gc.alloc.rate.norm      1000   UTF_8_BMP  thrpt    5   3040.004 ±   0.001   5968.002 ±   0.001    B/op
BytesRefBenchmark                         1000      UTF_16  thrpt    5      0.435 ±   0.009      0.811 ±   0.068  ops/us
BytesRefBenchmark:gc.alloc.rate.norm      1000      UTF_16  thrpt    5   5888.006 ±   0.001   9848.003 ±   0.001    B/op
```
