### PR TITLE
Use per-segment K in filtered KNN fallback logic (fixes 14671)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -194,19 +194,23 @@ abstract class AbstractKnnVectorQuery extends Query {
     final int cost = acceptDocs.cardinality();
     QueryTimeout queryTimeout = timeLimitingKnnCollectorManager.getQueryTimeout();
 
-    if (cost <= k) {
-      // If there are <= k possible matches, short-circuit and perform exact search, since HNSW
-      // must always visit at least k documents
+    float leafProportion = ctx.reader().maxDoc() / (float) ctx.parent.reader().maxDoc();
+    int perLeafTopK = perLeafTopKCalculation(k, leafProportion);
+
+    if (cost <= perLeafTopK) {
+      // If there are <= perLeafTopK possible matches, short-circuit and perform exact search, since
+      // HNSW must always visit at least perLeafTopK documents
       return exactSearch(ctx, new BitSetIterator(acceptDocs, cost), queryTimeout);
     }
 
     // Perform the approximate kNN search
     // We pass cost + 1 here to account for the edge case when we explore exactly cost vectors
     TopDocs results = approximateSearch(ctx, acceptDocs, cost + 1, timeLimitingKnnCollectorManager);
+
     if ((results.totalHits.relation() == TotalHits.Relation.EQUAL_TO
-            // We know that there are more than `k` available docs, if we didn't even get `k`
-            // something weird happened, and we need to drop to exact search
-            && results.scoreDocs.length >= k)
+            // We know that there are more than `perLeafTopK` available docs, if we didn't even get
+            // `perLeafTopK` something weird happened, and we need to drop to exact search
+            && results.scoreDocs.length >= perLeafTopK)
         // Return partial results only when timeout is met
         || (queryTimeout != null && queryTimeout.shouldExit())) {
       return results;


### PR DESCRIPTION
Originally (before optimistic KNN query):

```
recall  latency(ms)     nDoc  topK  fanout  maxConn  beamWidth  quantized  visited  selectivity   filterType  vec_disk(MB)  vec_RAM(MB)  indexType
 0.693        7.374  1000000   100      50       16         50         no     3753  0.05   pre-filter         0.000        0.000       HNSW
 0.705        7.752  1000000   100     100       16         50         no     4680  0.05   pre-filter         0.000        0.000       HNSW
 0.764       13.086  1000000   100     250       16         50         no     6307  0.05   pre-filter         0.000        0.000       HNSW
```

Mainline (filtering broken):

```
recall  latency(ms)     nDoc  topK  fanout  maxConn  beamWidth  quantized  index(s)  index_docs/s  num_segments  index_size(MB)  vec_disk(MB)  vec_RAM(MB)  indexType
 0.894       31.510  1000000   100      50       16         50         no      0.00      Infinity             0            0.00         0.000        0.000       HNSW
 1.000       46.757  1000000   100     100       16         50         no      0.00      Infinity             0            0.00         0.000        0.000       HNSW
 1.000       52.029  1000000   100     250       16         50         no      0.00      Infinity             0            0.00         0.000        0.000       HNSW
```

With this fix:

```
recall  latency(ms)     nDoc  topK  fanout  maxConn  beamWidth  quantized  visited  selectivity   filterType  vec_disk(MB)  vec_RAM(MB)  indexType
 0.734        9.018  1000000   100      50       16         50         no     8951         0.05   pre-filter         0.000        0.000       HNSW
 0.742       10.259  1000000   100     100       16         50         no     9857         0.05   pre-filter         0.000        0.000       HNSW
 0.771       10.981  1000000   100     250       16         50         no    12117         0.05   pre-filter         0.000        0.000       HNSW
```