### PR TITLE
Fix for add char and token filters in Luke Analysis tab

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -116,6 +116,8 @@ Bug Fixes
 * GITHUB#14654: ValueSource.fromDoubleValuesSource(dvs).getSortField() would throw errors when
   used if the DoubleValuesSource needed scores. (David Smiley)
 
+* GITHUB#14682 : Fix for add char and token filters in Luke Analysis tab. (Amir Raza)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to version 3.9.  (Uwe Schindler)

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/ListUtils.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/ListUtils.java
@@ -19,6 +19,7 @@ package org.apache.lucene.luke.app.desktop.util;
 
 import java.util.List;
 import java.util.function.IntFunction;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.swing.JList;
 import javax.swing.ListModel;
@@ -33,7 +34,7 @@ public class ListUtils {
 
   public static <T, R> List<R> getAllItems(JList<T> jlist, IntFunction<R> mapFunc) {
     ListModel<T> model = jlist.getModel();
-    return IntStream.range(0, model.getSize()).mapToObj(mapFunc).toList();
+    return IntStream.range(0, model.getSize()).mapToObj(mapFunc).collect(Collectors.toList());
   }
 
   private ListUtils() {}

--- a/lucene/luke/src/test/org/apache/lucene/luke/app/desktop/util/TestListUtils.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/app/desktop/util/TestListUtils.java
@@ -1,21 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.lucene.luke.app.desktop.util;
 
+import java.util.Arrays;
+import java.util.List;
+import javax.swing.JList;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
-import javax.swing.*;
-import java.util.Arrays;
-import java.util.List;
-
 public class TestListUtils extends LuceneTestCase {
 
-    @Test
-    public void testGetAllItems() {
-        JList<String> list = new JList<>(new String[]{"Item 1", "Item 2"});
-        List<String> items = ListUtils.getAllItems(list);
-        assertEquals(Arrays.asList("Item 1", "Item 2"), items);
-        // test mutability
-        items.add("Item 3");
-        assertEquals(Arrays.asList("Item 1", "Item 2", "Item 3"), items);
-    }
+  @Test
+  public void testGetAllItems() {
+    JList<String> list = new JList<>(new String[] {"Item 1", "Item 2"});
+    List<String> items = ListUtils.getAllItems(list);
+    assertEquals(Arrays.asList("Item 1", "Item 2"), items);
+    // test mutability
+    items.add("Item 3");
+    assertEquals(Arrays.asList("Item 1", "Item 2", "Item 3"), items);
+  }
 }

--- a/lucene/luke/src/test/org/apache/lucene/luke/app/desktop/util/TestListUtils.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/app/desktop/util/TestListUtils.java
@@ -1,0 +1,21 @@
+package org.apache.lucene.luke.app.desktop.util;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.Test;
+
+import javax.swing.*;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestListUtils extends LuceneTestCase {
+
+    @Test
+    public void testGetAllItems() {
+        JList<String> list = new JList<>(new String[]{"Item 1", "Item 2"});
+        List<String> items = ListUtils.getAllItems(list);
+        assertEquals(Arrays.asList("Item 1", "Item 2"), items);
+        // test mutability
+        items.add("Item 3");
+        assertEquals(Arrays.asList("Item 1", "Item 2", "Item 3"), items);
+    }
+}


### PR DESCRIPTION
### Description
Adds a fix for Luke Analysis tab where user weren't able to add char or token filters. 

#### Root Cause:
We have a util method which returns JList's model underlying data, here list of strings representing char filters/token filters. Earlier, the method returned a mutable list which allowed adding new entries to filters. But due to a previous refactoring from `.collect(Collectors.toList()) to .toList()` it returns an immutable list, introduced in https://github.com/apache/lucene/pull/12978. 

#### Fix
Revert from `.toList() to .collect(Collectors.toList())` for **ListUtils** class which is only used in CustomAnalyzerPanelProvider class.

Tested locally

Closes https://github.com/apache/lucene/issues/14649
