### PR TITLE
Use shasum on macosx and avoid checking the checksum if the wrapper file doesn't exist

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -222,7 +222,7 @@ if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
 fi
 
 GRADLE_WRAPPER_JAR="$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
-if [ "$darwin" ]; then
+if "$darwin"; then
     shasumcmd=shasum
 else
     shasumcmd=sha256sum

--- a/gradlew
+++ b/gradlew
@@ -222,7 +222,12 @@ if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
 fi
 
 GRADLE_WRAPPER_JAR="$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
-if ! ( cd "$APP_HOME/gradle/wrapper" && sha256sum --status -c "${GRADLE_WRAPPER_JAR}.sha256" ); then
+if [ "$darwin" ]; then
+    shasumcmd=shasum
+else
+    shasumcmd=sha256sum
+fi
+if ! ( cd "$APP_HOME/gradle/wrapper" && "$shasumcmd" --status -c "${GRADLE_WRAPPER_JAR}.sha256" ); then
     "$JAVACMD" $JAVA_OPTS "$APP_HOME/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java" "$GRADLE_WRAPPER_JAR"
     WRAPPER_STATUS=$?
     if [ "$WRAPPER_STATUS" -eq 1 ]; then

--- a/gradlew
+++ b/gradlew
@@ -227,7 +227,7 @@ if [ "$darwin" ]; then
 else
     shasumcmd=sha256sum
 fi
-if ! ( cd "$APP_HOME/gradle/wrapper" && "$shasumcmd" --status -c "${GRADLE_WRAPPER_JAR}.sha256" ); then
+if [ ! -e "$GRADLE_WRAPPER_JAR" ] || ! ( cd "$APP_HOME/gradle/wrapper" && "$shasumcmd" --status -c "${GRADLE_WRAPPER_JAR}.sha256" ); then
     "$JAVACMD" $JAVA_OPTS "$APP_HOME/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java" "$GRADLE_WRAPPER_JAR"
     WRAPPER_STATUS=$?
     if [ "$WRAPPER_STATUS" -eq 1 ]; then


### PR DESCRIPTION
I just noticed that sha256sum is not present on github's mac vms. 
https://github.com/actions/runner-images/issues/90

This patch switches to using shasum on darwin and adds a pre-check to see if the file exists at all (otherwise shasum emits a warning, regardless of the ```--status``` flag).