### PR TITLE
Don't run changelog verifier on draft PRs

### DIFF
--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -14,6 +14,7 @@ jobs:
   changelog-verifier-and-milestone-setter:
     name: Verify Change Log Entry and Set Milestone
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Noticed the bot was commenting on draft PRs, which is probably not helpful.

Tested [here](https://github.com/stefanvodita/lucene/actions/runs/15116929918/job/42489853486?pr=9).