### PR TITLE
Add assumption to ignore test failures due to disconnected graphs

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
@@ -491,6 +491,7 @@ abstract class BaseVectorSimilarityQueryTestCase<
 
     try (Directory indexStore = getIndexStore(vectors);
         IndexReader reader = DirectoryReader.open(indexStore)) {
+      assumeTrue("graph is fully reachable", HnswUtil.graphIsRooted(reader, vectorField));
       IndexSearcher searcher = newSearcher(reader);
 
       // This query is cacheable, explicitly prevent it
@@ -504,7 +505,6 @@ abstract class BaseVectorSimilarityQueryTestCase<
                   Float.NEGATIVE_INFINITY,
                   Float.NEGATIVE_INFINITY,
                   null));
-
       assertEquals(numDocs, searcher.count(query)); // Expect some results without timeout
 
       searcher.setTimeout(() -> true); // Immediately timeout


### PR DESCRIPTION
We've seen a occasional test failures like this one:

    gradlew test --tests TestFloatVectorSimilarityQuery.testTimeout -Dtests.seed=B1F95AA82C52ACA8 -Dtests.multiplier=3 -Dtests.locale=nl-BE -Dtests.timezone=Atlantic/St_Helena -Dtests.asserts=true -Dtests.file.encoding=UTF-8

which are caused by disconnected graphs. We removed the behavior to connect graphs during merge because it scaled poorly, but I think it should be safe to use in tests with small datasets to make them more reliable. 