### PR TITLE
Fix AbstractRangeQueryNode#toQueryString

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -862,7 +862,7 @@ Improvements
 
 * GITHUB#13285: Early terminate graph searches of AbstractVectorSimilarityQuery to follow timeout set from
   IndexSearcher#setTimeout(QueryTimeout). (Kaival Parikh)
-
+  
 * GITHUB#13633: Add ability to read/write knn vector values to a MemoryIndex. (Ben Trent)
 
 * GITHUB#12627: patch HNSW graphs to improve reachability of all nodes from entry points
@@ -1779,7 +1779,7 @@ New Features
   closed while queries are running can no longer crash the JVM. To disable this feature,
   pass the following sysprop on Java command line:
   "-Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false" (Uwe Schindler)
-
+  
 * GITHUB#12252 Add function queries for computing similarity scores between knn vectors. (Elia Porciani, Alessandro Benedetti)
 
 Improvements
@@ -2458,7 +2458,7 @@ New Features
 * LUCENE-10385: Implement Weight#count on IndexSortSortedNumericDocValuesRangeQuery
   to speed up computing the number of hits when possible. (Lu Xugang, Luca Cavanna, Adrien Grand)
 
-* LUCENE-10422: Monitor Improvements: `Monitor` can use a custom `Directory`
+* LUCENE-10422: Monitor Improvements: `Monitor` can use a custom `Directory` 
   implementation. `Monitor` can be created with a readonly `QueryIndex` in order to
   have readonly `Monitor` instances. (Niko Usai)
 
@@ -2517,7 +2517,7 @@ Optimizations
   term of each block as a dictionary when compressing suffixes of the other 63
   terms of the block. (Adrien Grand)
 
-* LUCENE-10411: Add nearest neighbors vectors support to ExitableDirectoryReader.
+* LUCENE-10411: Add nearest neighbors vectors support to ExitableDirectoryReader. 
   (Zach Chen, Adrien Grand, Julie Tibshirani, Tomoko Uchida)
 
 * LUCENE-10542: FieldSource exists implementations can avoid value retrieval (Kevin Risden)
@@ -2682,7 +2682,7 @@ New Features
   points are indexed.
   (Quentin Pradet, Adrien Grand)
 
-* LUCENE-10263: Added Weight#count to NormsFieldExistsQuery to speed up the query if all
+* LUCENE-10263: Added Weight#count to NormsFieldExistsQuery to speed up the query if all 
   documents have the field.. (Alan Woodward)
 
 * LUCENE-10248: Add SpanishPluralStemFilter, for precise stemming of Spanish plurals.
@@ -2708,14 +2708,14 @@ New Features
 
 * LUCENE-10403: Add ArrayUtil#grow(T[]). (Greg Miller)
 
-* LUCENE-10414: Add fn:fuzzyTerm interval function to flexible query parser (Dawid Weiss,
+* LUCENE-10414: Add fn:fuzzyTerm interval function to flexible query parser (Dawid Weiss, 
   Alan Woodward)
-
+  
 * LUCENE-10378: Implement Weight#count for PointRangeQuery to provide a faster way to calculate
   the number of matching range docs when each doc has at-most one point and the points are 1-dimensional.
   (Gautam Worah, Ignacio Vera, Adrien Grand)
 
-* LUCENE-10415: FunctionScoreQuery and IndexOrDocValuesQuery delegate Weight#count. (Ignacio Vera)
+* LUCENE-10415: FunctionScoreQuery and IndexOrDocValuesQuery delegate Weight#count. (Ignacio Vera)     
 
 * LUCENE-10382: Add support for filtering in KnnVectorQuery. This allows for finding the
   nearest k documents that also match a query. (Julie Tibshirani, Joel Bernstein)
@@ -2732,10 +2732,10 @@ Improvements
 
 * LUCENE-10238: Upgrade icu4j dependency to 70.1. (Dawid Weiss)
 
-* LUCENE-9820: Extract BKD tree interface and move intersecting logic to the
+* LUCENE-9820: Extract BKD tree interface and move intersecting logic to the 
   PointValues abstract class. (Ignacio Vera, Adrien Grand)
-
-* LUCENE-10262: Lift up restrictions for navigating PointValues#PointTree
+  
+* LUCENE-10262: Lift up restrictions for navigating PointValues#PointTree 
   added in LUCENE-9820 (Ignacio Vera)
 
 * LUCENE-9538: Detect polygon self-intersections in the Tessellator. (Ignacio Vera)
@@ -2850,8 +2850,8 @@ Bug Fixes
 
 * LUCENE-10407: Containing intervals could sometimes yield incorrect matches when wrapped
   in a disjunction. (Alan Woodward, Dawid Weiss)
-
-* LUCENE-10405: When using the MemoryIndex, binary and Sorted doc values are stored
+  
+* LUCENE-10405: When using the MemoryIndex, binary and Sorted doc values are stored 
    as BytesRef instead of BytesRefHash so they don't have a limit on size. (Ignacio Vera)
 
 * LUCENE-10428: Queries with a misbehaving score function may no longer cause
@@ -2883,7 +2883,7 @@ Other
 
 * LUCENE-10413: Make Ukrainian default stop words list available as a public getter. (Alan Woodward)
 
-* LUCENE-10437: Polygon tessellator throws a more informative error message when the provided polygon
+* LUCENE-10437: Polygon tessellator throws a more informative error message when the provided polygon 
   does not contain enough no-collinear points. (Ignacio Vera)
 
 ======================= Lucene 9.0.0 =======================
@@ -3002,7 +3002,7 @@ API Changes
   only applicable for fields that are indexed with doc values only. (Mayya Sharipova,
   Adrien Grand, Simon Willnauer)
 
-* LUCENE-9047: Directory API is now little endian. (Ignacio Vera, Adrien Grand)
+* LUCENE-9047: Directory API is now little endian. (Ignacio Vera, Adrien Grand)  
 
 * LUCENE-9948: No longer require the user to specify whether-or-not a field is multi-valued in
   LongValueFacetCounts (detect automatically based on what is indexed). (Greg Miller)
@@ -3215,7 +3215,7 @@ Improvements
   (David Smiley)
 
 * LUCENE-10062: Switch taxonomy faceting to use numeric doc values for storing ordinals instead of binary doc values
-  with its own custom encoding. (Greg Miller)
+  with its own custom encoding. (Greg Miller) 
 
 Bug fixes
 ---------------------
@@ -3338,10 +3338,10 @@ Other
 * LUCENE-9822: Add assertion to PFOR exception encoding, documenting the BLOCK_SIZE assumption. (Greg Miller)
 
 * LUCENE-9883: Turn on ecj missingEnumCaseDespiteDefault setting. (Zach Chen)
-
-* LUCENE-9705: Make new versions of all index formats for the Lucene90 codec and move
-  the existing ones to the backwards codecs. (Julie Tibshirani, Ignacio Vera)
-
+ 
+* LUCENE-9705: Make new versions of all index formats for the Lucene90 codec and move 
+  the existing ones to the backwards codecs. (Julie Tibshirani, Ignacio Vera)  
+  
 * LUCENE-9907: Remove dependency on PackedInts#getReader() from the current codecs and move the
   method to backwards codec. (Ignacio Vera)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -22,6 +22,10 @@ API Changes
 
 * GITHUB#14291: Remove IOException from ScorerSupplier#setTopLevelScoringClause signature (Luca Cavanna)
 
+* GITHUB#7865: Added public CharSequence getTermEscaped(EscapeQuerySyntax)
+  to ValueQueryNode. Made existing implementations public in all classes which
+  implement ValueQueryNode. (Peter Barna, Adam Schwartz)
+
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)
@@ -49,6 +53,10 @@ Bug Fixes
 
 * GITHUB#14075: Remove duplicate and add missing entry on brazilian portuguese stopwords list. (Arthur Caccavo)
 
+* GITHUB#7865 AbstractRangeQueryNode#toQueryString(EscapeQuerySyntax) now
+  returns a string which can be parsed back into the original node.
+  (Peter Barna, Adam Schwartz)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)
@@ -73,10 +81,6 @@ API Changes
 
 * GITHUB#14426: Support determining desired off-heap memory requirements through
   KnnVectorsReader::getOffHeapByteSize (Chris Hegarty)
-
-* GITHUB#7865: Added public CharSequence getTermEscaped(EscapeQuerySyntax)
-  to ValueQueryNode. Made existing implementations public in all classes which
-  implement ValueQueryNode. (Peter Barna, Adam Schwartz)
 
 New Features
 ---------------------
@@ -126,10 +130,6 @@ Bug Fixes
 
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException
   instead of UnsupportedOperationException when values are out of order. (Shubham Sharma)
-
-* GITHUB#7865 AbstractRangeQueryNode#toQueryString(EscapeQuerySyntax) now
-  returns a string which can be parsed back into the original node.
-  (Peter Barna, Adam Schwartz)
 
 Build
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -74,6 +74,10 @@ API Changes
 * GITHUB#14426: Support determining desired off-heap memory requirements through
   KnnVectorsReader::getOffHeapByteSize (Chris Hegarty)
 
+* GITHUB#7865: Added public CharSequence getTermEscaped(EscapeQuerySyntax)
+  to ValueQueryNode. Made existing implementations public in all classes which
+  implement ValueQueryNode. (Peter Barna, Adam Schwartz)
+
 New Features
 ---------------------
 * GITHUB#14404: Introducing DocValuesMultiRangeQuery.SortedNumericStabbingBuilder into sandbox.
@@ -122,6 +126,10 @@ Bug Fixes
 
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException
   instead of UnsupportedOperationException when values are out of order. (Shubham Sharma)
+
+* GITHUB#7865 AbstractRangeQueryNode#toQueryString(EscapeQuerySyntax) now
+  returns a string which can be parsed back into the original node.
+  (Peter Barna, Adam Schwartz)
 
 Build
 ---------------------
@@ -854,7 +862,7 @@ Improvements
 
 * GITHUB#13285: Early terminate graph searches of AbstractVectorSimilarityQuery to follow timeout set from
   IndexSearcher#setTimeout(QueryTimeout). (Kaival Parikh)
-  
+
 * GITHUB#13633: Add ability to read/write knn vector values to a MemoryIndex. (Ben Trent)
 
 * GITHUB#12627: patch HNSW graphs to improve reachability of all nodes from entry points
@@ -1771,7 +1779,7 @@ New Features
   closed while queries are running can no longer crash the JVM. To disable this feature,
   pass the following sysprop on Java command line:
   "-Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false" (Uwe Schindler)
-  
+
 * GITHUB#12252 Add function queries for computing similarity scores between knn vectors. (Elia Porciani, Alessandro Benedetti)
 
 Improvements
@@ -2450,7 +2458,7 @@ New Features
 * LUCENE-10385: Implement Weight#count on IndexSortSortedNumericDocValuesRangeQuery
   to speed up computing the number of hits when possible. (Lu Xugang, Luca Cavanna, Adrien Grand)
 
-* LUCENE-10422: Monitor Improvements: `Monitor` can use a custom `Directory` 
+* LUCENE-10422: Monitor Improvements: `Monitor` can use a custom `Directory`
   implementation. `Monitor` can be created with a readonly `QueryIndex` in order to
   have readonly `Monitor` instances. (Niko Usai)
 
@@ -2509,7 +2517,7 @@ Optimizations
   term of each block as a dictionary when compressing suffixes of the other 63
   terms of the block. (Adrien Grand)
 
-* LUCENE-10411: Add nearest neighbors vectors support to ExitableDirectoryReader. 
+* LUCENE-10411: Add nearest neighbors vectors support to ExitableDirectoryReader.
   (Zach Chen, Adrien Grand, Julie Tibshirani, Tomoko Uchida)
 
 * LUCENE-10542: FieldSource exists implementations can avoid value retrieval (Kevin Risden)
@@ -2674,7 +2682,7 @@ New Features
   points are indexed.
   (Quentin Pradet, Adrien Grand)
 
-* LUCENE-10263: Added Weight#count to NormsFieldExistsQuery to speed up the query if all 
+* LUCENE-10263: Added Weight#count to NormsFieldExistsQuery to speed up the query if all
   documents have the field.. (Alan Woodward)
 
 * LUCENE-10248: Add SpanishPluralStemFilter, for precise stemming of Spanish plurals.
@@ -2700,14 +2708,14 @@ New Features
 
 * LUCENE-10403: Add ArrayUtil#grow(T[]). (Greg Miller)
 
-* LUCENE-10414: Add fn:fuzzyTerm interval function to flexible query parser (Dawid Weiss, 
+* LUCENE-10414: Add fn:fuzzyTerm interval function to flexible query parser (Dawid Weiss,
   Alan Woodward)
-  
+
 * LUCENE-10378: Implement Weight#count for PointRangeQuery to provide a faster way to calculate
   the number of matching range docs when each doc has at-most one point and the points are 1-dimensional.
   (Gautam Worah, Ignacio Vera, Adrien Grand)
 
-* LUCENE-10415: FunctionScoreQuery and IndexOrDocValuesQuery delegate Weight#count. (Ignacio Vera)     
+* LUCENE-10415: FunctionScoreQuery and IndexOrDocValuesQuery delegate Weight#count. (Ignacio Vera)
 
 * LUCENE-10382: Add support for filtering in KnnVectorQuery. This allows for finding the
   nearest k documents that also match a query. (Julie Tibshirani, Joel Bernstein)
@@ -2724,10 +2732,10 @@ Improvements
 
 * LUCENE-10238: Upgrade icu4j dependency to 70.1. (Dawid Weiss)
 
-* LUCENE-9820: Extract BKD tree interface and move intersecting logic to the 
+* LUCENE-9820: Extract BKD tree interface and move intersecting logic to the
   PointValues abstract class. (Ignacio Vera, Adrien Grand)
-  
-* LUCENE-10262: Lift up restrictions for navigating PointValues#PointTree 
+
+* LUCENE-10262: Lift up restrictions for navigating PointValues#PointTree
   added in LUCENE-9820 (Ignacio Vera)
 
 * LUCENE-9538: Detect polygon self-intersections in the Tessellator. (Ignacio Vera)
@@ -2842,8 +2850,8 @@ Bug Fixes
 
 * LUCENE-10407: Containing intervals could sometimes yield incorrect matches when wrapped
   in a disjunction. (Alan Woodward, Dawid Weiss)
-  
-* LUCENE-10405: When using the MemoryIndex, binary and Sorted doc values are stored 
+
+* LUCENE-10405: When using the MemoryIndex, binary and Sorted doc values are stored
    as BytesRef instead of BytesRefHash so they don't have a limit on size. (Ignacio Vera)
 
 * LUCENE-10428: Queries with a misbehaving score function may no longer cause
@@ -2875,7 +2883,7 @@ Other
 
 * LUCENE-10413: Make Ukrainian default stop words list available as a public getter. (Alan Woodward)
 
-* LUCENE-10437: Polygon tessellator throws a more informative error message when the provided polygon 
+* LUCENE-10437: Polygon tessellator throws a more informative error message when the provided polygon
   does not contain enough no-collinear points. (Ignacio Vera)
 
 ======================= Lucene 9.0.0 =======================
@@ -2994,7 +3002,7 @@ API Changes
   only applicable for fields that are indexed with doc values only. (Mayya Sharipova,
   Adrien Grand, Simon Willnauer)
 
-* LUCENE-9047: Directory API is now little endian. (Ignacio Vera, Adrien Grand)  
+* LUCENE-9047: Directory API is now little endian. (Ignacio Vera, Adrien Grand)
 
 * LUCENE-9948: No longer require the user to specify whether-or-not a field is multi-valued in
   LongValueFacetCounts (detect automatically based on what is indexed). (Greg Miller)
@@ -3207,7 +3215,7 @@ Improvements
   (David Smiley)
 
 * LUCENE-10062: Switch taxonomy faceting to use numeric doc values for storing ordinals instead of binary doc values
-  with its own custom encoding. (Greg Miller) 
+  with its own custom encoding. (Greg Miller)
 
 Bug fixes
 ---------------------
@@ -3330,10 +3338,10 @@ Other
 * LUCENE-9822: Add assertion to PFOR exception encoding, documenting the BLOCK_SIZE assumption. (Greg Miller)
 
 * LUCENE-9883: Turn on ecj missingEnumCaseDespiteDefault setting. (Zach Chen)
- 
-* LUCENE-9705: Make new versions of all index formats for the Lucene90 codec and move 
-  the existing ones to the backwards codecs. (Julie Tibshirani, Ignacio Vera)  
-  
+
+* LUCENE-9705: Make new versions of all index formats for the Lucene90 codec and move
+  the existing ones to the backwards codecs. (Julie Tibshirani, Ignacio Vera)
+
 * LUCENE-9907: Remove dependency on PackedInts#getReader() from the current codecs and move the
   method to backwards codec. (Ignacio Vera)
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/FieldQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/FieldQueryNode.java
@@ -52,6 +52,7 @@ public class FieldQueryNode extends QueryNodeImpl
     this.setLeaf(true);
   }
 
+  @Override
   public CharSequence getTermEscaped(EscapeQuerySyntax escaper) {
     return escaper.escape(this.text, Locale.getDefault(), EscapeQuerySyntax.Type.NORMAL);
   }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/FieldQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/FieldQueryNode.java
@@ -52,7 +52,7 @@ public class FieldQueryNode extends QueryNodeImpl
     this.setLeaf(true);
   }
 
-  protected CharSequence getTermEscaped(EscapeQuerySyntax escaper) {
+  public CharSequence getTermEscaped(EscapeQuerySyntax escaper) {
     return escaper.escape(this.text, Locale.getDefault(), EscapeQuerySyntax.Type.NORMAL);
   }
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/ValueQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/ValueQueryNode.java
@@ -16,10 +16,14 @@
  */
 package org.apache.lucene.queryparser.flexible.core.nodes;
 
+import org.apache.lucene.queryparser.flexible.core.parser.EscapeQuerySyntax;
+
 /** This interface should be implemented by {@link QueryNode} that holds an arbitrary value. */
 public interface ValueQueryNode<T extends Object> extends QueryNode {
 
   public void setValue(T value);
 
   public T getValue();
+
+  public CharSequence getTermEscaped(EscapeQuerySyntax escaper);
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/ValueQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/ValueQueryNode.java
@@ -25,5 +25,22 @@ public interface ValueQueryNode<T extends Object> extends QueryNode {
 
   public T getValue();
 
+  /**
+   * This method is used to get the value converted to {@link String} and escaped using the given
+   * {@link EscapeQuerySyntax}. For example:
+   *
+   * <pre>
+   * new FieldQueryNode("FIELD", "(literal parens)", 0, 0).getTermEscaped(escaper);
+   * </pre>
+   *
+   * <p>returns
+   *
+   * <pre>
+   * \(literal\ parens\)
+   * </pre>
+   *
+   * @param escaper the {@link EscapeQuerySyntax} used to escape the value {@link String}
+   * @return the value converted to {@link String} and escaped
+   */
   public CharSequence getTermEscaped(EscapeQuerySyntax escaper);
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/AbstractRangeQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/AbstractRangeQueryNode.java
@@ -169,6 +169,8 @@ public class AbstractRangeQueryNode<T extends FieldValuePairQueryNode<?>> extend
     T lower = getLowerBound();
     T upper = getUpperBound();
 
+    sb.append(getField()).append(":");
+
     if (lowerInclusive) {
       sb.append('[');
 
@@ -177,16 +179,16 @@ public class AbstractRangeQueryNode<T extends FieldValuePairQueryNode<?>> extend
     }
 
     if (lower != null) {
-      sb.append(lower.toQueryString(escapeSyntaxParser));
+      sb.append(lower.getTermEscaped(escapeSyntaxParser));
 
     } else {
       sb.append("...");
     }
 
-    sb.append(' ');
+    sb.append(" TO ");
 
     if (upper != null) {
-      sb.append(upper.toQueryString(escapeSyntaxParser));
+      sb.append(upper.getTermEscaped(escapeSyntaxParser));
 
     } else {
       sb.append("...");

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/PointQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/PointQueryNode.java
@@ -83,6 +83,7 @@ public class PointQueryNode extends QueryNodeImpl implements FieldValuePairQuery
    * @param escaper the {@link EscapeQuerySyntax} used to escape the value {@link String}
    * @return the value converted to {@link String} and escaped
    */
+  @Override
   public CharSequence getTermEscaped(EscapeQuerySyntax escaper) {
     return escaper.escape(numberFormat.format(this.value), Locale.ROOT, Type.NORMAL);
   }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/PointQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/PointQueryNode.java
@@ -76,13 +76,6 @@ public class PointQueryNode extends QueryNodeImpl implements FieldValuePairQuery
     this.field = fieldName;
   }
 
-  /**
-   * This method is used to get the value converted to {@link String} and escaped using the given
-   * {@link EscapeQuerySyntax}.
-   *
-   * @param escaper the {@link EscapeQuerySyntax} used to escape the value {@link String}
-   * @return the value converted to {@link String} and escaped
-   */
   @Override
   public CharSequence getTermEscaped(EscapeQuerySyntax escaper) {
     return escaper.escape(numberFormat.format(this.value), Locale.ROOT, Type.NORMAL);

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/PointQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/PointQueryNode.java
@@ -83,7 +83,7 @@ public class PointQueryNode extends QueryNodeImpl implements FieldValuePairQuery
    * @param escaper the {@link EscapeQuerySyntax} used to escape the value {@link String}
    * @return the value converted to {@link String} and escaped
    */
-  protected CharSequence getTermEscaped(EscapeQuerySyntax escaper) {
+  public CharSequence getTermEscaped(EscapeQuerySyntax escaper) {
     return escaper.escape(numberFormat.format(this.value), Locale.ROOT, Type.NORMAL);
   }
 

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/nodes/TestAbstractRangeQueryNode.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/nodes/TestAbstractRangeQueryNode.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.is;
 
 import java.text.NumberFormat;
 import java.util.Locale;
-import org.apache.lucene.queryparser.flexible.core.QueryNodeException;
 import org.apache.lucene.queryparser.flexible.core.nodes.FieldQueryNode;
 import org.apache.lucene.queryparser.flexible.core.parser.EscapeQuerySyntax;
 import org.apache.lucene.queryparser.flexible.standard.StandardQueryParser;
@@ -52,18 +51,13 @@ public class TestAbstractRangeQueryNode extends LuceneTestCase {
     PointQueryNode lower = new PointQueryNode("FIELD", 1, format);
     PointQueryNode upper = new PointQueryNode("FIELD", 999, format);
 
-    try {
-      PointRangeQueryNode origNode =
-          new PointRangeQueryNode(
-              lower, upper, true, true, new PointsConfig(format, Integer.class));
-      CharSequence queryString = origNode.toQueryString(escaper);
+    PointRangeQueryNode origNode =
+        new PointRangeQueryNode(lower, upper, true, true, new PointsConfig(format, Integer.class));
+    CharSequence queryString = origNode.toQueryString(escaper);
 
-      // query string should have expected format and parse into a valid query
-      assertThat(queryString, is("FIELD:[1 TO 999]"));
-      Query parsedQuery = parser.parse(queryString.toString(), "");
-      assertThat(parsedQuery.toString(), is(queryString));
-    } catch (QueryNodeException e) {
-      fail("testAbstractRangeQueryNode: testNumericRangeQueryNode: \n" + e.getMessage());
-    }
+    // query string should have expected format and parse into a valid query
+    assertThat(queryString, is("FIELD:[1 TO 999]"));
+    Query parsedQuery = parser.parse(queryString.toString(), "");
+    assertThat(parsedQuery.toString(), is(queryString));
   }
 }

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/nodes/TestAbstractRangeQueryNode.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/nodes/TestAbstractRangeQueryNode.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.queryparser.flexible.standard.nodes;
 
 import static org.hamcrest.Matchers.is;

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/nodes/TestAbstractRangeQueryNode.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/nodes/TestAbstractRangeQueryNode.java
@@ -1,0 +1,53 @@
+package org.apache.lucene.queryparser.flexible.standard.nodes;
+
+import static org.hamcrest.Matchers.is;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+import org.apache.lucene.queryparser.flexible.core.QueryNodeException;
+import org.apache.lucene.queryparser.flexible.core.nodes.FieldQueryNode;
+import org.apache.lucene.queryparser.flexible.core.parser.EscapeQuerySyntax;
+import org.apache.lucene.queryparser.flexible.standard.StandardQueryParser;
+import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
+import org.apache.lucene.queryparser.flexible.standard.parser.EscapeQuerySyntaxImpl;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestAbstractRangeQueryNode extends LuceneTestCase {
+  private static final EscapeQuerySyntax escaper = new EscapeQuerySyntaxImpl();
+  private static final StandardQueryParser parser = new StandardQueryParser();
+
+  /* GITHUB#7865 bug in toQueryString() */
+  public void testTermRangeQueryNode() throws Exception {
+    FieldQueryNode lower = new FieldQueryNode("FIELD", "aaa", 0, 0);
+    FieldQueryNode upper = new FieldQueryNode("FIELD", "zzz", 0, 0);
+    TermRangeQueryNode origNode = new TermRangeQueryNode(lower, upper, true, true);
+    CharSequence queryString = origNode.toQueryString(escaper);
+
+    // query string should have expected format and parse into a valid query
+    assertThat(queryString, is("FIELD:[aaa TO zzz]"));
+    Query parsedQuery = parser.parse(queryString.toString(), "");
+    assertThat(parsedQuery.toString(), is(queryString));
+  }
+
+  /* GITHUB#7865 bug in toQueryString() */
+  public void testPointRangeQueryNode() throws Exception {
+    NumberFormat format = NumberFormat.getIntegerInstance(Locale.ROOT);
+    PointQueryNode lower = new PointQueryNode("FIELD", 1, format);
+    PointQueryNode upper = new PointQueryNode("FIELD", 999, format);
+
+    try {
+      PointRangeQueryNode origNode =
+          new PointRangeQueryNode(
+              lower, upper, true, true, new PointsConfig(format, Integer.class));
+      CharSequence queryString = origNode.toQueryString(escaper);
+
+      // query string should have expected format and parse into a valid query
+      assertThat(queryString, is("FIELD:[1 TO 999]"));
+      Query parsedQuery = parser.parse(queryString.toString(), "");
+      assertThat(parsedQuery.toString(), is(queryString));
+    } catch (QueryNodeException e) {
+      fail("testAbstractRangeQueryNode: testNumericRangeQueryNode: \n" + e.getMessage());
+    }
+  }
+}

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/nodes/TestAbstractRangeQueryNode.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/nodes/TestAbstractRangeQueryNode.java
@@ -39,6 +39,8 @@ public class TestAbstractRangeQueryNode extends LuceneTestCase {
     TermRangeQueryNode origNode = new TermRangeQueryNode(lower, upper, true, true);
     CharSequence queryString = origNode.toQueryString(escaper);
 
+    new FieldQueryNode("FIELD", "(literal parens)", 0, 0).getTermEscaped(escaper);
+
     // query string should have expected format and parse into a valid query
     assertThat(queryString, is("FIELD:[aaa TO zzz]"));
     Query parsedQuery = parser.parse(queryString.toString(), "");


### PR DESCRIPTION
Re: #7865 

It now returns a string which is valid Lucene range query syntax and can be parsed back into the original node.

Added public method `getTermEscaped(EscapeQuerySyntax)` to `ValueQueryNode` and made existing methods in `Field/PointQueryNode` public.

Added tests to verify.
