### PR TITLE
An alternate implementation for RerankVectorQuery

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
@@ -36,7 +36,7 @@ import org.apache.lucene.util.VectorUtil;
  */
 public class RerankFloatVectorQuery extends Query {
 
-  private final Query in;
+  private Query in;
   private final String rerankField;
   private final float[] target;
 
@@ -55,8 +55,8 @@ public class RerankFloatVectorQuery extends Query {
 
   @Override
   public Query rewrite(IndexSearcher indexSearcher) throws IOException {
-    Query rewritten = indexSearcher.rewrite(in);
-    return new RerankFloatVectorQuery(rewritten, rerankField, target);
+    in = indexSearcher.rewrite(in);
+    return this;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
@@ -54,8 +54,17 @@ public class RerankFloatVectorQuery extends Query {
   }
 
   @Override
+  public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+    Query rewritten = indexSearcher.rewrite(in);
+    return new RerankFloatVectorQuery(rewritten, rerankField, target);
+  }
+
+  @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
       throws IOException {
+    // knn vector queries generate hits during rewrite. we call it here
+    // to protect against cases where createWeight is called without calling rewrite.
+    // this should be lightweight if this.rewrite() has already been called
     Query rewritten = searcher.rewrite(in);
     Weight preRankWeight = rewritten.createWeight(searcher, scoreMode, boost);
 

--- a/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
@@ -122,7 +122,7 @@ public class RerankFloatVectorQuery extends Query {
     return "RerankFloatVectorQuery:["
         + this.rerankField
         + "]["
-        + target
+        + target[0]
         + ", ...]["
         + in.getClass()
         + "]";

--- a/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
@@ -62,8 +62,8 @@ public class RerankFloatVectorQuery extends Query {
   @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
       throws IOException {
-    // knn vector queries generate hits during rewrite. we call it here
-    // to protect against cases where createWeight is called without calling rewrite.
+    // make sure the wrapped query is rewritten. this is important because
+    // knn vector queries generate hits during rewrite.
     // this should be lightweight if this.rewrite() has already been called
     Query rewritten = searcher.rewrite(in);
     Weight preRankWeight = rewritten.createWeight(searcher, scoreMode, boost);

--- a/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
@@ -26,12 +26,26 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.VectorUtil;
 
+/**
+ * Rerank documents matched by provided query based on similarity to a provided target vector.
+ *
+ * <p>NOTE: this query does not perform knn vector search. It simply re-ranks documents based on their
+ * similarity to a provided target vector. This is useful if you have already performed a vector search
+ * and want to re-rank the results based on a different vector field, or on the same field but with higher
+ * fidelity, like full precision vectors.
+ */
 public class RerankFloatVectorQuery extends Query {
 
   private final Query in;
   private final String rerankField;
   private final float[] target;
 
+  /**
+   * Reranks hits from a given query using vector similarity from provided field.
+   * @param query Query to rerank
+   * @param field Field to use for vector values and vector similarity
+   * @param target Target vector to score against
+   */
   public RerankFloatVectorQuery(Query query, String field, float[] target) {
     this.in = query;
     this.rerankField = field;

--- a/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RerankFloatVectorQuery.java
@@ -29,10 +29,10 @@ import org.apache.lucene.util.VectorUtil;
 /**
  * Rerank documents matched by provided query based on similarity to a provided target vector.
  *
- * <p>NOTE: this query does not perform knn vector search. It simply re-ranks documents based on their
- * similarity to a provided target vector. This is useful if you have already performed a vector search
- * and want to re-rank the results based on a different vector field, or on the same field but with higher
- * fidelity, like full precision vectors.
+ * <p>NOTE: this query does not perform knn vector search. It simply re-ranks documents based on
+ * their similarity to a provided target vector. This is useful if you have already performed a
+ * vector search and want to re-rank the results based on a different vector field, or on the same
+ * field but with higher fidelity, like full precision vectors.
  */
 public class RerankFloatVectorQuery extends Query {
 
@@ -42,6 +42,7 @@ public class RerankFloatVectorQuery extends Query {
 
   /**
    * Reranks hits from a given query using vector similarity from provided field.
+   *
    * @param query Query to rerank
    * @param field Field to use for vector values and vector similarity
    * @param target Target vector to score against

--- a/lucene/core/src/test/org/apache/lucene/search/TestRerankFloatVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRerankFloatVectorQuery.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+// test pulled from https://github.com/apache/lucene/pull/14009
+public class TestRerankFloatVectorQuery extends LuceneTestCase {
+
+  private static final String FIELD = "vector";
+  private static final VectorSimilarityFunction VECTOR_SIMILARITY_FUNCTION =
+      VectorSimilarityFunction.COSINE;
+  private static final int NUM_VECTORS = 1000;
+  private static final int VECTOR_DIMENSION = 128;
+
+  private Directory directory;
+  private IndexWriterConfig config;
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    directory = new ByteBuffersDirectory();
+
+    // Set up the IndexWriterConfig to use quantized vector storage
+    config = new IndexWriterConfig();
+    config.setCodec(
+        TestUtil.alwaysKnnVectorsFormat(new Lucene99HnswScalarQuantizedVectorsFormat()));
+  }
+
+  @Test
+  public void testTwoPhaseKnnVectorQuery() throws Exception {
+    Map<Integer, float[]> vectors = new HashMap<>();
+
+    Random random = random();
+
+    int numVectors = atLeast(NUM_VECTORS);
+    int numSegments = random.nextInt(2, 10);
+
+    // Step 1: Index random vectors in quantized format
+    try (IndexWriter writer = new IndexWriter(directory, config)) {
+      for (int j = 0; j < numSegments; j++) {
+        for (int i = 0; i < numVectors; i++) {
+          float[] vector = randomFloatVector(VECTOR_DIMENSION, random);
+          Document doc = new Document();
+          int id = j * numVectors + i;
+          doc.add(new IntField("id", id, Field.Store.YES));
+          doc.add(new KnnFloatVectorField(FIELD, vector, VECTOR_SIMILARITY_FUNCTION));
+          writer.addDocument(doc);
+          vectors.put(id, vector);
+
+          writer.flush();
+        }
+      }
+    }
+
+    // Step 2: Run TwoPhaseKnnVectorQuery with a random target vector
+    try (IndexReader reader = DirectoryReader.open(directory)) {
+      IndexSearcher searcher = new IndexSearcher(reader);
+      float[] targetVector = randomFloatVector(VECTOR_DIMENSION, random);
+      int k = 10;
+      double oversample = random.nextFloat(1.5f, 3.0f);
+
+      KnnFloatVectorQuery knnQuery =
+          new KnnFloatVectorQuery(FIELD, targetVector, k + (int) (k * oversample));
+      RerankFloatVectorQuery query = new RerankFloatVectorQuery(knnQuery, knnQuery.field, targetVector);
+      TopDocs topDocs = searcher.search(query, k);
+
+      // Step 3: Verify that TopDocs scores match similarity with unquantized vectors
+      for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+        Document retrievedDoc = searcher.storedFields().document(scoreDoc.doc);
+        int id = retrievedDoc.getField("id").numericValue().intValue();
+        float[] docVector = vectors.get(id);
+        assert docVector != null : "Vector for id " + id + " not found";
+        float expectedScore = VECTOR_SIMILARITY_FUNCTION.compare(targetVector, docVector);
+        Assert.assertEquals(
+            "Score does not match expected similarity for doc ord: " + scoreDoc.doc + ", id: " + id,
+            expectedScore,
+            scoreDoc.score,
+            1e-5);
+      }
+    }
+  }
+
+  private float[] randomFloatVector(int dimension, Random random) {
+    float[] vector = new float[dimension];
+    for (int i = 0; i < dimension; i++) {
+      vector[i] = random.nextFloat();
+    }
+    return vector;
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestRerankFloatVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRerankFloatVectorQuery.java
@@ -17,9 +17,7 @@
 package org.apache.lucene.search;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat;
 import org.apache.lucene.document.Document;

--- a/lucene/core/src/test/org/apache/lucene/search/TestRerankFloatVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRerankFloatVectorQuery.java
@@ -96,7 +96,8 @@ public class TestRerankFloatVectorQuery extends LuceneTestCase {
 
       KnnFloatVectorQuery knnQuery =
           new KnnFloatVectorQuery(FIELD, targetVector, k + (int) (k * oversample));
-      RerankFloatVectorQuery query = new RerankFloatVectorQuery(knnQuery, knnQuery.field, targetVector);
+      RerankFloatVectorQuery query =
+          new RerankFloatVectorQuery(knnQuery, knnQuery.field, targetVector);
       TopDocs topDocs = searcher.search(query, k);
 
       // Step 3: Verify that TopDocs scores match similarity with unquantized vectors


### PR DESCRIPTION
This PR presents an alternate to #14009 for `RerankVectorQuery`. It takes an input query, a target vector and a field to use for vector values, and rescores the output of wrapped query with full precision vector values from provided field.

**Main differences with #14009 :**
1. While the primary use case would be to rerank results from a quantized `KnnFloatVectorQuery` against full precision vectors, this implementation has no tight coupling. Users could provide any inner query and rerank against vectors stored in any field.
2. This can, in future, be extended to support reranking using Late Interaction models stored in a different field. We just need to override add some checks to ensure multi-vectors in provided `field` are compatible with provided `target`. This idea has been floated [here](https://github.com/apache/lucene/pull/13525#issuecomment-2445295372) earlier
3. Maintains a regular query flow of keeping heavier computation in Weight and Scorer, instead of keeping heavy matching and scoring logic in rewrite.
4. This should implicitly use any slicing or per leaf parallel execution provided at searchers. We don't need to rewrite logic for per leaf threads.

**Pending Tasks:**
I plan to get some benchmark results next. Would also like to clean up the test and add a few more, if we chose to go this route. Sharing an early impl. to get feedback on the approach.