### PR TITLE
Fixed incorrect Telugu normalization of vu వు to ma మ (

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/in/IndicNormalizer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/in/IndicNormalizer.java
@@ -176,8 +176,6 @@ class IndicNormalizer {
     {0x33, 0x3C, -1, 0x34, flag(DEVANAGARI)},
     /* malayalam chillu ll */
     {0x33, 0x4D, 0xFF, 0x7E, flag(MALAYALAM)},
-    /* telugu letter MA */
-    {0x35, 0x41, -1, 0x2E, flag(TELUGU)},
     /* devanagari, gujarati vowel sign candra O */
     {0x3E, 0x45, -1, 0x49, flag(DEVANAGARI) | flag(GUJARATI)},
     /* devanagari vowel sign short O */

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/te/TestTeluguAnalyzer.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/te/TestTeluguAnalyzer.java
@@ -38,7 +38,7 @@ public class TestTeluguAnalyzer extends BaseTokenStreamTestCase {
   public void testExclusionSet() throws Exception {
     CharArraySet exclusionSet = new CharArraySet(asSet("వస్తువులు"), false);
     Analyzer a = new TeluguAnalyzer(TeluguAnalyzer.getDefaultStopSet(), exclusionSet);
-    checkOneTerm(a, "వస్తువులు", "వస్తుమలు");
+    checkOneTerm(a, "వస్తువులు", "వస్తువులు");
     a.close();
   }
 

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/te/TestTeluguFilters.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/te/TestTeluguFilters.java
@@ -37,7 +37,7 @@ public class TestTeluguFilters extends BaseTokenStreamFactoryTestCase {
     TokenStream stream = whitespaceMockTokenizer(reader);
     stream = tokenFilterFactory("IndicNormalization").create(stream);
     stream = tokenFilterFactory("TeluguNormalization").create(stream);
-    assertTokenStreamContents(stream, new String[] {"వస్తుమలు"});
+    assertTokenStreamContents(stream, new String[] {"వస్తువులు"});
   }
 
   /** Test TeluguStemFilterFactory */
@@ -47,7 +47,7 @@ public class TestTeluguFilters extends BaseTokenStreamFactoryTestCase {
     stream = tokenFilterFactory("IndicNormalization").create(stream);
     stream = tokenFilterFactory("TeluguNormalization").create(stream);
     stream = tokenFilterFactory("TeluguStem").create(stream);
-    assertTokenStreamContents(stream, new String[] {"వస్తుమ"});
+    assertTokenStreamContents(stream, new String[] {"వస్తువు"});
   }
 
   /** Test that bogus arguments result in exception */

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/te/TestTeluguNormalizer.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/te/TestTeluguNormalizer.java
@@ -39,6 +39,14 @@ public class TestTeluguNormalizer extends BaseTokenStreamTestCase {
     check("ఔఐఆఈఊ", "ఓఏఅఇఉ");
   }
 
+  /** Test that 'vu' and 'ma' are not incorrectly normalized. */
+  public void testVuAndMaNormalization() throws IOException {
+    check("వు", "వు"); // vu
+    check("మ", "మ"); // ma
+    check("వెంకటరావు", "వెంకటరావు"); // VenkataRao (contains vu)
+    check("వెంకటరామ", "వెంకటరామ"); // VenkataRama (contains ma)
+  }
+
   private void check(String input, String output) throws IOException {
     Tokenizer tokenizer = whitespaceMockTokenizer(input);
     TokenFilter tf = new TeluguNormalizationFilter(tokenizer);


### PR DESCRIPTION
Fixes: #14659 

Remove incorrect Telugu వు/మ conflation in Indic Normalization. They look similar, but they are distinct with different meanings. 

Currently "వు" is mapped to "మ" in IndicNormalizer in decompositions. This causes searches for "వెంకటరావు" to include "వెంకటరామ" even though they are different names.

**I am a native speaker of Telugu language.**

