### PR TITLE
Return MatchNoDocsQuery when IndexOrDocValuesQuery::rewrite does not match

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -116,6 +116,9 @@ Optimizations
 * GITHUB#14679: Optimize exhaustive evaluation of disjunctive queries.
   (Adrien Grand)
 
+* GITHUB#14700: Return MatchNoDocsQuery when IndexOrDocValuesQuery::rewrite does not match
+  (Chris Hegarty)
+
 Bug Fixes
 ---------------------
 * GITHUB#14654: ValueSource.fromDoubleValuesSource(dvs).getSortField() would throw errors when

--- a/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
@@ -117,6 +117,10 @@ public final class IndexOrDocValuesQuery extends Query {
         || dvRewrite.getClass() == MatchAllDocsQuery.class) {
       return new MatchAllDocsQuery();
     }
+    if (indexRewrite.getClass() == MatchNoDocsQuery.class
+        || dvRewrite.getClass() == MatchNoDocsQuery.class) {
+      return new MatchNoDocsQuery();
+    }
     if (indexQuery != indexRewrite || dvQuery != dvRewrite) {
       return new IndexOrDocValuesQuery(indexRewrite, dvRewrite);
     }


### PR DESCRIPTION
In a similar way to how `IndexOrDocValuesQuery` may rewrite to a `MatchAllDocsQuery`, if either of the queries rewrites to match no docs, then return a `MatchNoDocsQuery`.