### PR TITLE
Refactor main top-n bulk scorers to evaluate hits in a more term-at-a-time fashion.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -116,6 +116,9 @@ Optimizations
 * GITHUB#14679: Optimize exhaustive evaluation of disjunctive queries.
   (Adrien Grand)
 
+* GITHUB#14701: Optimize top-n bulk scorers by evaluating scoring windows in a
+  term-at-a-time fashion instead of doc-at-a-time. (Adrien Grand)
+
 Bug Fixes
 ---------------------
 * GITHUB#14654: ValueSource.fromDoubleValuesSource(dvs).getSortField() would throw errors when

--- a/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionBulkScorer.java
@@ -22,7 +22,6 @@ import java.util.Comparator;
 import java.util.List;
 import org.apache.lucene.search.Weight.DefaultBulkScorer;
 import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.MathUtil;
 
 /**
  * BulkScorer implementation of {@link BlockMaxConjunctionScorer} that focuses on top-level
@@ -38,11 +37,12 @@ final class BlockMaxConjunctionBulkScorer extends BulkScorer {
   private final Scorer[] scorers;
   private final Scorable[] scorables;
   private final DocIdSetIterator[] iterators;
-  private final DocIdSetIterator lead1, lead2;
-  private final Scorable scorer1, scorer2;
+  private final DocIdSetIterator lead1;
   private final DocAndScore scorable = new DocAndScore();
   private final double[] sumOfOtherClauses;
   private final int maxDoc;
+  private final DocAndScoreBuffer docAndScoreBuffer = new DocAndScoreBuffer();
+  private final DocAndScoreAccBuffer docAndScoreAccBuffer = new DocAndScoreAccBuffer();
 
   BlockMaxConjunctionBulkScorer(int maxDoc, List<Scorer> scorers) throws IOException {
     if (scorers.size() <= 1) {
@@ -55,9 +55,6 @@ final class BlockMaxConjunctionBulkScorer extends BulkScorer {
     this.iterators =
         Arrays.stream(this.scorers).map(Scorer::iterator).toArray(DocIdSetIterator[]::new);
     lead1 = ScorerUtil.likelyImpactsEnum(iterators[0]);
-    lead2 = ScorerUtil.likelyImpactsEnum(iterators[1]);
-    scorer1 = this.scorables[0];
-    scorer2 = this.scorables[1];
     this.sumOfOtherClauses = new double[this.scorers.length];
     for (int i = 0; i < sumOfOtherClauses.length; i++) {
       sumOfOtherClauses[i] = Double.POSITIVE_INFINITY;
@@ -118,98 +115,36 @@ final class BlockMaxConjunctionBulkScorer extends BulkScorer {
       return;
     }
 
-    Scorable scorer1 = this.scorer1;
-    if (scorers[0].getMaxScore(max - 1) == 0f) {
-      // Null out scorer1 if it may only produce 0 scores over this window. In practice, this is
-      // mostly useful because FILTER clauses are pushed as constant-scoring MUST clauses with a
-      // 0 score to this scorer. Setting it to null instead of using a different impl helps
-      // reduce polymorphism of calls to Scorable#score and skip the check of whether the leading
-      // clause produced a high-enough score for the doc to be competitive.
-      scorer1 = null;
+    for (scorers[0].nextDocsAndScores(max, acceptDocs, docAndScoreBuffer);
+        docAndScoreBuffer.size > 0;
+        scorers[0].nextDocsAndScores(max, acceptDocs, docAndScoreBuffer)) {
+
+      docAndScoreAccBuffer.copyFrom(docAndScoreBuffer);
+
+      for (int i = 1; i < scorers.length; ++i) {
+        if (scorable.minCompetitiveScore > 0) {
+          ScorerUtil.filterCompetitiveHits(
+              docAndScoreAccBuffer,
+              sumOfOtherClauses[i],
+              scorable.minCompetitiveScore,
+              scorers.length);
+        }
+
+        ScorerUtil.applyRequiredClause(docAndScoreAccBuffer, iterators[i], scorables[i]);
+      }
+
+      for (int i = 0; i < docAndScoreAccBuffer.size; ++i) {
+        scorable.score = (float) docAndScoreAccBuffer.scores[i];
+        collector.collect(docAndScoreAccBuffer.docs[i]);
+      }
     }
 
-    final double sumOfOtherMaxScoresAt1 = sumOfOtherClauses[1];
-
-    advanceHead:
-    for (int doc = lead1.docID(); doc < max; ) {
-      if (acceptDocs != null && acceptDocs.get(doc) == false) {
-        doc = lead1.nextDoc();
-        continue;
-      }
-
-      // Compute the score as we find more matching clauses, in order to skip advancing other
-      // clauses if the total score has no chance of being competitive. This works well because
-      // computing a score is usually cheaper than decoding a full block of postings and
-      // frequencies.
-      final boolean hasMinCompetitiveScore = scorable.minCompetitiveScore > 0;
-      double currentScore;
-      if (scorer1 != null && hasMinCompetitiveScore) {
-        currentScore = scorer1.score();
-
-        // This is the same logic as in the below for loop, specialized for the 2nd least costly
-        // clause. This seems to help the JVM.
-
-        // First check if we have a chance of having a match based on max scores
-        if ((float) MathUtil.sumUpperBound(currentScore + sumOfOtherMaxScoresAt1, scorers.length)
-            < scorable.minCompetitiveScore) {
-          doc = lead1.nextDoc();
-          continue advanceHead;
-        }
-      } else {
-        currentScore = 0;
-      }
-
-      // NOTE: lead2 may be on `doc` already if we `continue`d on the previous loop iteration.
-      if (lead2.docID() < doc) {
-        int next = lead2.advance(doc);
-        if (next != doc) {
-          doc = lead1.advance(next);
-          continue advanceHead;
-        }
-      }
-      assert lead2.docID() == doc;
-      if (hasMinCompetitiveScore) {
-        currentScore += scorer2.score();
-      }
-
-      for (int i = 2; i < iterators.length; ++i) {
-        // First check if we have a chance of having a match based on max scores
-        if (hasMinCompetitiveScore
-            && (float) MathUtil.sumUpperBound(currentScore + sumOfOtherClauses[i], scorers.length)
-                < scorable.minCompetitiveScore) {
-          doc = lead1.nextDoc();
-          continue advanceHead;
-        }
-
-        // NOTE: these iterators may be on `doc` already if we called `continue advanceHead` on the
-        // previous loop iteration.
-        if (iterators[i].docID() < doc) {
-          int next = iterators[i].advance(doc);
-          if (next != doc) {
-            doc = lead1.advance(next);
-            continue advanceHead;
-          }
-        }
-        assert iterators[i].docID() == doc;
-        if (hasMinCompetitiveScore) {
-          currentScore += scorables[i].score();
-        }
-      }
-
-      if (hasMinCompetitiveScore == false) {
-        for (Scorable scorer : scorables) {
-          currentScore += scorer.score();
-        }
-      }
-      scorable.score = (float) currentScore;
-      collector.collect(doc);
-      // The collect() call may have updated the minimum competitive score.
-      if (maxWindowScore < scorable.minCompetitiveScore) {
-        // no more hits are competitive
-        return;
-      }
-
-      doc = lead1.nextDoc();
+    int maxOtherDoc = -1;
+    for (int i = 0; i < iterators.length; ++i) {
+      maxOtherDoc = Math.max(iterators[i].docID(), maxOtherDoc);
+    }
+    if (lead1.docID() < maxOtherDoc) {
+      lead1.advance(maxOtherDoc);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/DocAndScoreAccBuffer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocAndScoreAccBuffer.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.IntsRef;
+
+/**
+ * Wrapper around parallel arrays storing doc IDs and their corresponding score accumulators.
+ *
+ * @lucene.internal
+ */
+public final class DocAndScoreAccBuffer {
+
+  private static final double[] EMPTY_DOUBLES = new double[0];
+
+  /** Doc IDs */
+  public int[] docs = IntsRef.EMPTY_INTS;
+
+  /** Scores */
+  public double[] scores = EMPTY_DOUBLES;
+
+  /** Number of valid entries in the doc ID and score arrays. */
+  public int size;
+
+  /** Sole constructor. */
+  public DocAndScoreAccBuffer() {}
+
+  /**
+   * Grow both arrays to ensure that they can store at least the given number of entries. Existing
+   * content may be discarded.
+   */
+  public void growNoCopy(int minSize) {
+    if (docs.length < minSize) {
+      docs = ArrayUtil.growNoCopy(docs, minSize);
+      scores = new double[docs.length];
+    }
+  }
+
+  /**
+   * Grow both arrays to ensure that they can store at least the given number of entries. Existing
+   * content is preserved.
+   */
+  public void grow(int minSize) {
+    if (docs.length < minSize) {
+      docs = ArrayUtil.grow(docs, minSize);
+      scores = ArrayUtil.growExact(scores, docs.length);
+    }
+  }
+
+  /** Copy content from the given {@link DocAndScoreBuffer}, expanding float scores to doubles. */
+  public void copyFrom(DocAndScoreBuffer buffer) {
+    growNoCopy(buffer.size);
+    System.arraycopy(buffer.docs, 0, docs, 0, buffer.size);
+    for (int i = 0; i < buffer.size; ++i) {
+      scores[i] = buffer.scores[i];
+    }
+    this.size = buffer.size;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
@@ -371,6 +371,8 @@ final class MaxScoreBulkScorer extends BulkScorer {
 
     for (int i = numNonEssentialClauses - 1; i >= 0; --i) {
       DisiWrapper scorer = allScorers[i];
+      assert minCompetitiveScore > 0
+          : "All clauses are essential if minCompetitiveScore is equal to zero";
       ScorerUtil.filterCompetitiveHits(
           buffer, maxScoreSums[i], minCompetitiveScore, allScorers.length);
       ScorerUtil.applyOptionalClause(buffer, scorer.iterator, scorer.scorable);

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
@@ -48,10 +48,11 @@ final class MaxScoreBulkScorer extends BulkScorer {
   final double[] maxScoreSums;
   private final DisiWrapper filter;
 
-  private final long[] windowMatches = new long[FixedBitSet.bits2words(INNER_WINDOW_SIZE)];
+  private final FixedBitSet windowMatches = new FixedBitSet(INNER_WINDOW_SIZE);
   private final double[] windowScores = new double[INNER_WINDOW_SIZE];
 
   private final DocAndScoreBuffer docAndScoreBuffer = new DocAndScoreBuffer();
+  private final DocAndScoreAccBuffer docAndScoreAccBuffer = new DocAndScoreAccBuffer();
 
   MaxScoreBulkScorer(int maxDoc, List<Scorer> scorers, Scorer filter) throws IOException {
     this.maxDoc = maxDoc;
@@ -182,6 +183,7 @@ final class MaxScoreBulkScorer extends BulkScorer {
     int innerWindowMin = top.doc;
     int innerWindowMax = (int) Math.min(max, (long) innerWindowMin + INNER_WINDOW_SIZE);
 
+    docAndScoreAccBuffer.size = 0;
     while (top.doc < innerWindowMax) {
       assert filter.doc <= top.doc; // invariant
       if (filter.doc < top.doc) {
@@ -208,10 +210,15 @@ final class MaxScoreBulkScorer extends BulkScorer {
         } while (top.doc == doc);
 
         if (match) {
-          scoreNonEssentialClauses(collector, doc, score, firstEssentialScorer);
+          docAndScoreAccBuffer.grow(docAndScoreAccBuffer.size + 1);
+          docAndScoreAccBuffer.docs[docAndScoreAccBuffer.size] = doc;
+          docAndScoreAccBuffer.scores[docAndScoreAccBuffer.size] = score;
+          docAndScoreAccBuffer.size++;
         }
       }
     }
+
+    scoreNonEssentialClauses(collector, docAndScoreAccBuffer, firstEssentialScorer);
   }
 
   private void scoreInnerWindowSingleEssentialClause(
@@ -223,13 +230,9 @@ final class MaxScoreBulkScorer extends BulkScorer {
     for (top.scorer.nextDocsAndScores(upTo, acceptDocs, docAndScoreBuffer);
         docAndScoreBuffer.size > 0;
         top.scorer.nextDocsAndScores(upTo, acceptDocs, docAndScoreBuffer)) {
-      for (int i = 0; i < docAndScoreBuffer.size; ++i) {
-        scoreNonEssentialClauses(
-            collector,
-            docAndScoreBuffer.docs[i],
-            docAndScoreBuffer.scores[i],
-            firstEssentialScorer);
-      }
+
+      docAndScoreAccBuffer.copyFrom(docAndScoreBuffer);
+      scoreNonEssentialClauses(collector, docAndScoreAccBuffer, firstEssentialScorer);
     }
 
     top.doc = top.iterator.docID();
@@ -243,63 +246,29 @@ final class MaxScoreBulkScorer extends BulkScorer {
     DisiWrapper lead1 = allScorers[allScorers.length - 1];
     assert essentialQueue.size() == 1;
     assert lead1 == essentialQueue.top();
-    DisiWrapper lead2 = allScorers[allScorers.length - 2];
-    if (lead1.doc < lead2.doc) {
-      lead1.doc = lead1.iterator.advance(Math.min(lead2.doc, max));
+
+    for (lead1.scorer.nextDocsAndScores(max, acceptDocs, docAndScoreBuffer);
+        docAndScoreBuffer.size > 0;
+        lead1.scorer.nextDocsAndScores(max, acceptDocs, docAndScoreBuffer)) {
+
+      docAndScoreAccBuffer.copyFrom(docAndScoreBuffer);
+
+      for (int i = allScorers.length - 2; i >= firstRequiredScorer; --i) {
+
+        if (minCompetitiveScore > 0) {
+          ScorerUtil.filterCompetitiveHits(
+              docAndScoreAccBuffer, maxScoreSums[i], minCompetitiveScore, allScorers.length);
+        }
+
+        DisiWrapper scorer = allScorers[i];
+        ScorerUtil.applyRequiredClause(docAndScoreAccBuffer, scorer.iterator, scorer.scorable);
+      }
+
+      scoreNonEssentialClauses(collector, docAndScoreAccBuffer, firstRequiredScorer);
     }
-    // maximum score contribution of all scorers but the lead
-    double maxScoreSumAtLead2 = maxScoreSums[allScorers.length - 2];
 
-    outer:
-    while (lead1.doc < max) {
-
-      if (acceptDocs != null && acceptDocs.get(lead1.doc) == false) {
-        lead1.doc = lead1.iterator.nextDoc();
-        continue;
-      }
-
-      double score = lead1.scorable.score();
-
-      // We specialize handling the second best scorer, which seems to help a bit with performance.
-      // But this is the exact same logic as in the below for loop.
-      if ((float) MathUtil.sumUpperBound(score + maxScoreSumAtLead2, allScorers.length)
-          < minCompetitiveScore) {
-        // a competitive match is not possible according to max scores, skip to the next candidate
-        lead1.doc = lead1.iterator.nextDoc();
-        continue;
-      }
-
-      if (lead2.doc < lead1.doc) {
-        lead2.doc = lead2.iterator.advance(lead1.doc);
-      }
-      if (lead2.doc != lead1.doc) {
-        lead1.doc = lead1.iterator.advance(Math.min(lead2.doc, max));
-        continue;
-      }
-
-      score += lead2.scorable.score();
-
-      for (int i = allScorers.length - 3; i >= firstRequiredScorer; --i) {
-        if ((float) MathUtil.sumUpperBound(score + maxScoreSums[i], allScorers.length)
-            < minCompetitiveScore) {
-          // a competitive match is not possible according to max scores, skip to the next candidate
-          lead1.doc = lead1.iterator.nextDoc();
-          continue outer;
-        }
-
-        DisiWrapper w = allScorers[i];
-        if (w.doc < lead1.doc) {
-          w.doc = w.iterator.advance(lead1.doc);
-        }
-        if (w.doc != lead1.doc) {
-          lead1.doc = lead1.iterator.advance(Math.min(w.doc, max));
-          continue outer;
-        }
-        score += w.scorable.score();
-      }
-
-      scoreNonEssentialClauses(collector, lead1.doc, score, firstRequiredScorer);
-      lead1.doc = lead1.iterator.nextDoc();
+    for (int i = allScorers.length - 1; i >= firstRequiredScorer; --i) {
+      allScorers[i].doc = allScorers[i].iterator.docID();
     }
   }
 
@@ -309,6 +278,7 @@ final class MaxScoreBulkScorer extends BulkScorer {
 
     int innerWindowMin = top.doc;
     int innerWindowMax = (int) Math.min(max, (long) innerWindowMin + INNER_WINDOW_SIZE);
+    int innerWindowSize = innerWindowMax - innerWindowMin;
 
     // Collect matches of essential clauses into a bitset
     do {
@@ -319,7 +289,7 @@ final class MaxScoreBulkScorer extends BulkScorer {
           final int doc = docAndScoreBuffer.docs[index];
           final float score = docAndScoreBuffer.scores[index];
           final int i = doc - innerWindowMin;
-          windowMatches[i >>> 6] |= 1L << i;
+          windowMatches.set(i);
           windowScores[i] += score;
         }
       }
@@ -328,20 +298,21 @@ final class MaxScoreBulkScorer extends BulkScorer {
       top = essentialQueue.updateTop();
     } while (top.doc < innerWindowMax);
 
-    for (int wordIndex = 0; wordIndex < windowMatches.length; ++wordIndex) {
-      long bits = windowMatches[wordIndex];
-      windowMatches[wordIndex] = 0L;
-      while (bits != 0L) {
-        int ntz = Long.numberOfTrailingZeros(bits);
-        bits ^= 1L << ntz;
-        int index = wordIndex << 6 | ntz;
-        int doc = innerWindowMin + index;
-        double score = windowScores[index];
-        windowScores[index] = 0d;
+    docAndScoreAccBuffer.growNoCopy(windowMatches.cardinality(0, innerWindowSize));
+    docAndScoreAccBuffer.size = 0;
+    windowMatches.forEach(
+        0,
+        innerWindowSize,
+        0,
+        index -> {
+          docAndScoreAccBuffer.docs[docAndScoreAccBuffer.size] = innerWindowMin + index;
+          docAndScoreAccBuffer.scores[docAndScoreAccBuffer.size] = windowScores[index];
+          docAndScoreAccBuffer.size++;
+          windowScores[index] = 0d;
+        });
+    windowMatches.clear(0, innerWindowSize);
 
-        scoreNonEssentialClauses(collector, doc, score, firstEssentialScorer);
-      }
-    }
+    scoreNonEssentialClauses(collector, docAndScoreAccBuffer, firstEssentialScorer);
   }
 
   private int computeOuterWindowMax(int windowMin) throws IOException {
@@ -394,31 +365,22 @@ final class MaxScoreBulkScorer extends BulkScorer {
   }
 
   private void scoreNonEssentialClauses(
-      LeafCollector collector, int doc, double essentialScore, int numNonEssentialClauses)
+      LeafCollector collector, DocAndScoreAccBuffer buffer, int numNonEssentialClauses)
       throws IOException {
+    numCandidates += buffer.size;
 
-    ++numCandidates;
-
-    double score = essentialScore;
     for (int i = numNonEssentialClauses - 1; i >= 0; --i) {
-      float maxPossibleScore =
-          (float) MathUtil.sumUpperBound(score + maxScoreSums[i], allScorers.length);
-      if (maxPossibleScore < minCompetitiveScore) {
-        // Hit is not competitive.
-        return;
-      }
-
       DisiWrapper scorer = allScorers[i];
-      if (scorer.doc < doc) {
-        scorer.doc = scorer.iterator.advance(doc);
-      }
-      if (scorer.doc == doc) {
-        score += scorer.scorable.score();
-      }
+      ScorerUtil.filterCompetitiveHits(
+          buffer, maxScoreSums[i], minCompetitiveScore, allScorers.length);
+      ScorerUtil.applyOptionalClause(buffer, scorer.iterator, scorer.scorable);
+      scorer.doc = scorer.iterator.docID();
     }
 
-    scorable.score = (float) score;
-    collector.collect(doc);
+    for (int i = 0; i < buffer.size; ++i) {
+      scorable.score = (float) buffer.scores[i];
+      collector.collect(buffer.docs[i]);
+    }
   }
 
   boolean partitionScorers() {

--- a/lucene/core/src/java/org/apache/lucene/search/ScorerUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScorerUtil.java
@@ -16,12 +16,14 @@
  */
 package org.apache.lucene.search;
 
+import java.io.IOException;
 import java.util.stream.LongStream;
 import java.util.stream.StreamSupport;
 import org.apache.lucene.codecs.lucene103.Lucene103PostingsFormat;
 import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.MathUtil;
 import org.apache.lucene.util.PriorityQueue;
 
 /** Util class for Scorer related methods */
@@ -115,6 +117,71 @@ class ScorerUtil {
     @Override
     public int length() {
       return in.length();
+    }
+  }
+
+  static void filterCompetitiveHits(
+      DocAndScoreAccBuffer buffer,
+      double maxRemainingScore,
+      float minCompetitiveScore,
+      int numScorers) {
+    int newSize = 0;
+    for (int i = 0; i < buffer.size; ++i) {
+      float maxPossibleScore =
+          (float) MathUtil.sumUpperBound(buffer.scores[i] + maxRemainingScore, numScorers);
+      if (maxPossibleScore >= minCompetitiveScore) {
+        buffer.docs[newSize] = buffer.docs[i];
+        buffer.scores[newSize] = buffer.scores[i];
+        newSize++;
+      }
+    }
+    buffer.size = newSize;
+  }
+
+  /**
+   * Apply the provided {@link Scorable} as a required clause on the given {@link
+   * DocAndScoreAccBuffer}. This filters out documents from the buffer that do not match, and adds
+   * the scores of this {@link Scorable} to the scores.
+   *
+   * <p><b>NOTE</b>: The provided buffer must contain doc IDs in sorted order, with no duplicates.
+   */
+  static void applyRequiredClause(
+      DocAndScoreAccBuffer buffer, DocIdSetIterator iterator, Scorable scorable)
+      throws IOException {
+    int intersectionSize = 0;
+    int curDoc = iterator.docID();
+    for (int i = 0; i < buffer.size; ++i) {
+      int targetDoc = buffer.docs[i];
+      if (curDoc < targetDoc) {
+        curDoc = iterator.advance(targetDoc);
+      }
+      if (curDoc == targetDoc) {
+        buffer.docs[intersectionSize] = targetDoc;
+        buffer.scores[intersectionSize] = buffer.scores[i] + scorable.score();
+        intersectionSize++;
+      }
+    }
+    buffer.size = intersectionSize;
+  }
+
+  /**
+   * Apply the provided {@link Scorable} as an optional clause on the given {@link
+   * DocAndScoreAccBuffer}. This adds the scores of this {@link Scorer} to the existing scores.
+   *
+   * <p><b>NOTE</b>: The provided buffer must contain doc IDs in sorted order, with no duplicates.
+   */
+  static void applyOptionalClause(
+      DocAndScoreAccBuffer buffer, DocIdSetIterator iterator, Scorable scorable)
+      throws IOException {
+    int curDoc = iterator.docID();
+    for (int i = 0; i < buffer.size; ++i) {
+      int targetDoc = buffer.docs[i];
+      if (curDoc < targetDoc) {
+        curDoc = iterator.advance(targetDoc);
+      }
+      if (curDoc == targetDoc) {
+        buffer.scores[i] += scorable.score();
+      }
     }
   }
 }


### PR DESCRIPTION
`MaxScoreBulkScorer` and `BlockMaxConjunctionBulkScorer` currently evaluate hits in a doc-at-a-time (DAAT) fashion, meaning that they they look at all their clauses to find the next doc and so forth until all docs from the window are evaluated. This changes evaluation to run in a more term-at-a-time fashion (TAAT) within scoring windows, meaning that each clause is fully evaluated within the window before moving on to the next clause.

Note that this isn't completely new, `BooleanScorer` has been doing this to exhaustively evaluate disjunctive queries, by loading their matches into a bit set, one clause at a time. Also note that this is a bit different from traditional TAAT as this is scoped to small-ish windows of doc IDs, not the entire doc ID space.

This in-turn allows these scorers to take advantage of the new `Scorer#nextDocsAndScores` API, and provides a good speedup. A downside is that we may need to perform more memory copying in some cases, and evaluate a bit more documents, but the change still looks like a win in general.