### PR TITLE
Update the IOContext on IndexInput rather than the ReadAdvice

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
@@ -124,7 +124,7 @@ public abstract class KnnVectorsReader implements Closeable {
    *
    * <p>The default implementation returns {@code this}
    */
-  public KnnVectorsReader getMergeInstance() {
+  public KnnVectorsReader getMergeInstance() throws IOException {
     return this;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
@@ -96,7 +96,7 @@ public abstract class FlatVectorsReader extends KnnVectorsReader implements Acco
    * <p>The default implementation returns {@code this}
    */
   @Override
-  public FlatVectorsReader getMergeInstance() {
+  public FlatVectorsReader getMergeInstance() throws IOException {
     return this;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -131,7 +131,7 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
   }
 
   @Override
-  public KnnVectorsReader getMergeInstance() {
+  public KnnVectorsReader getMergeInstance() throws IOException {
     return new Lucene99HnswVectorsReader(this, this.flatVectorsReader.getMergeInstance());
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
@@ -238,7 +238,7 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
       }
     }
 
-    private FieldsReader(final FieldsReader fieldsReader) {
+    private FieldsReader(final FieldsReader fieldsReader) throws IOException {
       this.fieldInfos = fieldsReader.fieldInfos;
       for (FieldInfo fi : this.fieldInfos) {
         if (fi.hasVectorValues() && fieldsReader.fields.containsKey(fi.number)) {
@@ -248,7 +248,7 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
     }
 
     @Override
-    public KnnVectorsReader getMergeInstance() {
+    public KnnVectorsReader getMergeInstance() throws IOException {
       return new FieldsReader(this);
     }
 

--- a/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
@@ -227,12 +227,12 @@ public abstract class IndexInput extends DataInput implements Closeable {
   public void prefetch(long offset, long length) throws IOException {}
 
   /**
-   * Optional method: Give a hint to this input about the change in read access pattern. IndexInput
+   * Optional method: Updates the {@code IOContext} to specify a new read access pattern. IndexInput
    * implementations may take advantage of this hint to optimize reads from storage.
    *
    * <p>The default implementation is a no-op.
    */
-  public void updateReadAdvice(ReadAdvice readAdvice) throws IOException {}
+  public void updateIOContext(IOContext context) throws IOException {}
 
   /**
    * Returns a hint whether all the contents of this input are resident in physical memory. It's a

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -357,7 +357,11 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
   }
 
   @Override
-  public void updateReadAdvice(ReadAdvice readAdvice) throws IOException {
+  public void updateIOContext(IOContext context) throws IOException {
+    updateReadAdvice(toReadAdvice.apply(context));
+  }
+
+  private void updateReadAdvice(ReadAdvice readAdvice) throws IOException {
     if (NATIVE_ACCESS.isEmpty()) {
       return;
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
@@ -185,7 +185,7 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
     }
 
     @Override
-    public KnnVectorsReader getMergeInstance() {
+    public KnnVectorsReader getMergeInstance() throws IOException {
       assert !mergeInstance;
       var mergeVectorsReader = delegate.getMergeInstance();
       assert mergeVectorsReader != null;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockIndexInputWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockIndexInputWrapper.java
@@ -25,7 +25,6 @@ import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.store.FilterIndexInput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.ReadAdvice;
 
 /**
  * Used by MockDirectoryWrapper to create an input stream that keeps track of when it's been closed.
@@ -186,10 +185,10 @@ public class MockIndexInputWrapper extends FilterIndexInput {
   }
 
   @Override
-  public void updateReadAdvice(ReadAdvice readAdvice) throws IOException {
+  public void updateIOContext(IOContext context) throws IOException {
     ensureOpen();
     ensureAccessible();
-    in.updateReadAdvice(readAdvice);
+    in.updateIOContext(context);
   }
 
   @Override


### PR DESCRIPTION
Update the `IOContext` on `IndexInput` implementations rather than the `ReadAdvice`. This change means that `ReadAdvice` is now only used by `MMapDirectory` and friends. Note that this is a refactoring only, it does not change behaviour.