### PR TITLE
Fix WindowsFS test failure seen on Policeman Jenkins

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -142,9 +142,9 @@ Other
 
 * GITHUB#14516: Move sloppySin into SloppyMath from GeoUtils (Ankit Jain)
 
-* GITHUB#14627, GITHUB#11920: Fix mock filesystem WindowsFS to also work on Windows.
-  This is required to make tests pass on Windows 11 which no longer has
-  all limitations of previous Windows versions.  (Uwe Schindler)
+* GITHUB#14627, GITHUB#11920, GITHUB#14706: Fix mock filesystem WindowsFS to also
+  work on Windows. This is required to make tests pass on Windows 11 which no
+  longer has all limitations of previous Windows versions.  (Uwe Schindler)
 
 
 ======================= Lucene 10.2.1 =======================

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
@@ -197,14 +197,16 @@ public class TestWindowsFS extends MockFileSystemTestCase {
     if (r.nextBoolean()) {
       // We need at least one char after the special char
       // For example, in case of '/' we interpret `foo/` to just be a file `foo` which is valid
+      // We need at least 2 chars before the special character, because resolving a drive
+      // letter (C:) or a path starting with "/" will not fail on real Windows.
       fileName =
-          RandomStrings.randomAsciiLettersOfLength(r, r.nextInt(10))
+          RandomStrings.randomAsciiLettersOfLength(r, r.nextInt(2, 10))
               + reservedCharacters[r.nextInt(reservedCharacters.length)]
               + RandomStrings.randomAsciiLettersOfLength(r, r.nextInt(1, 10));
     } else {
       fileName = reservedNames[r.nextInt(reservedNames.length)];
     }
-    expectThrows(InvalidPathException.class, () -> dir.resolve(fileName));
+    expectThrows(InvalidPathException.class, fileName, () -> dir.resolve(fileName));
 
     // some other basic tests
     expectThrows(InvalidPathException.class, () -> dir.resolve("foo:bar"));


### PR DESCRIPTION
This fixes the following failure seen on Polceman Jenkins:
```
   >     junit.framework.AssertionFailedError: Expected exception InvalidPathException but no exception was thrown
   >         at __randomizedtesting.SeedInfo.seed([B08A8D3F1BDCFB48:200EA110D1BE2403]:0)
   >         at org.apache.lucene.tests.util.LuceneTestCase.expectThrows(LuceneTestCase.java:2910)
   >         at org.apache.lucene.tests.util.LuceneTestCase.expectThrows(LuceneTestCase.java:2896)
   >         at org.apache.lucene.tests.mockfile.TestWindowsFS.testFileName(TestWindowsFS.java:207)
   >         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
   >         at java.base/java.lang.reflect.Method.invoke(Method.java:580)
   >         at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1758)
   >         at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
   >         at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:982)
   >         at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
   >         at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48)
   >         at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
   >         at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
   >         at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
   >         at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
   >         at org.junit.rules.RunRules.evaluate(RunRules.java:20)
   >         at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
   >         at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
   >         at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:843)
   >         at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:490)
   >         at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:955)
   >         at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:840)
   >         at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:891)
   >         at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:902)
   >         at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
   >         at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
   >         at org.apache.lucene.tests.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:38)
   >         at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
   >         at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
   >         at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
   >         at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
   >         at org.apache.lucene.tests.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
   >         at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
   >         at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
   >         at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
   >         at org.apache.lucene.tests.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:47)
   >         at org.junit.rules.RunRules.evaluate(RunRules.java:20)
   >         at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
   >         at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
   >         at com.carrotsearch.randomizedtesting.ThreadLeakControl.lambda$forkTimeoutingTask$0(ThreadLeakControl.java:850)
   >         at java.base/java.lang.Thread.run(Thread.java:1583)
  2> NOTE: reproduce with: gradlew test --tests TestWindowsFS.testFileName -Dtests.seed=B08A8D3F1BDCFB48 -Dtests.locale=ceb-PH -Dtests.timezone=America/Noronha -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```

I added code to print the filename when test fails. What happens here. The test generates the following filename: `m:NfDcLQ`

On Linux this correctly fails the test because the filename triggers our code. But on real WIndows, the resolve call does not fail the test, because "m:" is treated as a drive letter and then it resolves. Our code then does not get triggered, because the filename itsself is not starting with `m:`, it is only `NfDcLQ` (on drive M's CWD).

The same happens when the filename starts with a real slash/backslash. To work asound both cases, trhe file name should have at least 2 random characters before the invalid character. `xy:` is not treated as drive letter and fails correctly also on Windows.