### PR TITLE
Speed up exhaustive execution of TermQuery

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/CompleteBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CompleteBulkScorer.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import org.apache.lucene.util.Bits;
+
+/**
+ * A bulk scorer used when score mode is {@link ScoreMode#COMPLETE} and {@link
+ * Scorer#nextDocsAndScores} has optimizations to run faster than one-by-one iteration.
+ */
+class CompleteBulkScorer extends BulkScorer {
+
+  private final SimpleScorable scorable = new SimpleScorable();
+  private final DocAndScoreBuffer buffer = new DocAndScoreBuffer();
+  private final Scorer scorer;
+
+  CompleteBulkScorer(Scorer scorer) {
+    this.scorer = scorer;
+  }
+
+  @Override
+  public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+    collector.setScorer(scorable);
+    if (scorer.docID() < min) {
+      scorer.iterator().advance(min);
+    }
+    for (scorer.nextDocsAndScores(max, acceptDocs, buffer);
+        buffer.size > 0;
+        scorer.nextDocsAndScores(max, acceptDocs, buffer)) {
+      for (int i = 0, size = buffer.size; i < size; i++) {
+        scorable.score = buffer.scores[i];
+        collector.collect(buffer.docs[i]);
+      }
+    }
+    return scorer.docID();
+  }
+
+  @Override
+  public long cost() {
+    return scorer.iterator().cost();
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/TermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermQuery.java
@@ -173,6 +173,9 @@ public class TermQuery extends Query {
             return ConstantScoreScorerSupplier.fromIterator(iterator, 0f, scoreMode, maxDoc)
                 .bulkScorer();
           }
+          if (scoreMode == ScoreMode.COMPLETE) {
+            return new CompleteBulkScorer(get(Long.MAX_VALUE));
+          }
           return super.bulkScorer();
         }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
@@ -201,7 +201,7 @@ public class TestBooleanScorer extends LuceneTestCase {
     weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE, 1);
     ss = weight.scorerSupplier(ctx);
     scorer = ((BooleanScorerSupplier) ss).booleanScorer();
-    assertThat(scorer, instanceOf(DefaultBulkScorer.class)); // term scorer
+    assertThat(scorer, instanceOf(CompleteBulkScorer.class)); // term scorer
 
     w.close();
     reader.close();


### PR DESCRIPTION
This tries to take advantage of the new method `Scorer#nextDocsAndScores` to speed up exhaustive execution of TermQuery.

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                    AndStopWords       13.31      (1.1%)       13.01      (5.1%)   -2.2% (  -8% -    4%) 0.123
                IntervalsOrdered       31.48      (6.5%)       30.87      (5.7%)   -1.9% ( -13% -   10%) 0.418
                          IntNRQ       12.38      (6.0%)       12.20      (5.2%)   -1.5% ( -11% -   10%) 0.510
                     AndHighHigh       18.08      (0.9%)       17.85      (4.4%)   -1.3% (  -6% -    4%) 0.293
                    SloppyPhrase        1.54      (6.8%)        1.53      (8.1%)   -1.2% ( -15% -   14%) 0.686
                        SpanNear       34.44      (3.1%)       34.03      (3.9%)   -1.2% (  -7% -    6%) 0.396
               FilteredOrHighMed       14.78      (1.9%)       14.61      (2.0%)   -1.1% (  -4% -    2%) 0.131
                AndMedOrHighHigh       59.44      (2.6%)       58.82      (2.8%)   -1.0% (  -6% -    4%) 0.324
            FilteredAndStopWords       18.63      (1.0%)       18.44      (2.0%)   -1.0% (  -3% -    1%) 0.105
                    FilteredTerm       61.05      (1.6%)       60.51      (2.4%)   -0.9% (  -4% -    3%) 0.274
             CombinedAndHighHigh        3.89      (1.3%)        3.86      (3.4%)   -0.8% (  -5% -    3%) 0.407
                FilteredOr3Terms       21.40      (3.2%)       21.23      (2.9%)   -0.8% (  -6% -    5%) 0.502
             CountFilteredPhrase       87.15      (2.3%)       86.46      (2.2%)   -0.8% (  -5% -    3%) 0.370
                 FilteredPrefix3       36.35      (1.2%)       36.07      (1.9%)   -0.8% (  -3% -    2%) 0.204
              FilteredOrHighHigh       13.22      (2.5%)       13.12      (2.6%)   -0.8% (  -5% -    4%) 0.457
                 AndHighOrMedMed       43.97      (1.0%)       43.64      (1.9%)   -0.7% (  -3% -    2%) 0.216
             FilteredAndHighHigh       30.83      (1.8%)       30.61      (2.2%)   -0.7% (  -4% -    3%) 0.374
                     CountPhrase        4.02      (2.3%)        4.00      (3.3%)   -0.6% (  -6% -    5%) 0.604
              CombinedAndHighMed       67.11      (2.7%)       66.76      (2.4%)   -0.5% (  -5% -    4%) 0.603
                       And3Terms      195.77      (3.7%)      194.90      (3.2%)   -0.4% (  -7% -    6%) 0.743
             FilteredOrStopWords        9.39      (2.2%)        9.35      (2.6%)   -0.4% (  -5% -    4%) 0.669
      FilteredOr2Terms2StopWords        9.81      (1.5%)        9.77      (2.3%)   -0.4% (  -4% -    3%) 0.613
                          OrMany        0.97      (6.0%)        0.97     (14.6%)   -0.3% ( -19% -   21%) 0.939
             And2Terms2StopWords      294.44      (1.2%)      293.47      (1.6%)   -0.3% (  -3% -    2%) 0.554
                          IntSet      578.19      (2.5%)      576.33      (2.8%)   -0.3% (  -5% -    5%) 0.760
                  FilteredOrMany        2.77      (3.6%)        2.76      (3.1%)   -0.3% (  -6% -    6%) 0.845
                          Phrase       16.37      (1.4%)       16.33      (1.6%)   -0.3% (  -3% -    2%) 0.667
                  FilteredPhrase       12.02      (1.5%)       11.99      (1.3%)   -0.2% (  -3% -    2%) 0.656
     FilteredAnd2Terms2StopWords      354.15      (2.2%)      353.30      (2.3%)   -0.2% (  -4% -    4%) 0.785
              FilteredAndHighMed      104.82      (2.5%)      104.68      (1.7%)   -0.1% (  -4% -    4%) 0.869
                         Respell       71.77      (2.1%)       71.68      (2.2%)   -0.1% (  -4% -    4%) 0.878
          CountFilteredOrHighMed       47.85      (1.0%)       47.82      (0.9%)   -0.1% (  -1% -    1%) 0.871
             CountFilteredIntNRQ       19.76      (0.6%)       19.75      (0.5%)   -0.1% (  -1% -    1%) 0.815
               TermDayOfYearSort      326.81      (1.2%)      326.81      (1.0%)    0.0% (  -2% -    2%) 1.000
                          Fuzzy2       81.44      (2.8%)       81.45      (2.7%)    0.0% (  -5% -    5%) 0.986
                      AndHighMed      114.99      (3.7%)      115.01      (3.4%)    0.0% (  -6% -    7%) 0.985
                      TermDTSort      224.25      (1.5%)      224.32      (1.1%)    0.0% (  -2% -    2%) 0.955
                         Prefix3       21.58      (1.9%)       21.60      (2.9%)    0.1% (  -4% -    4%) 0.933
                    CombinedTerm       28.09      (1.1%)       28.12      (1.4%)    0.1% (  -2% -    2%) 0.839
                        PKLookup      377.96      (2.4%)      378.76      (1.9%)    0.2% (  -4% -    4%) 0.805
         CountFilteredOrHighHigh       41.49      (1.6%)       41.59      (1.1%)    0.2% (  -2% -    3%) 0.650
                  FilteredIntNRQ       18.56      (1.0%)       18.61      (0.9%)    0.3% (  -1% -    2%) 0.488
                        Wildcard       18.78      (1.9%)       18.84      (2.5%)    0.3% (  -4% -    4%) 0.756
               FilteredAnd3Terms      606.79      (4.8%)      609.36      (2.1%)    0.4% (  -6% -    7%) 0.772
                          Fuzzy1       84.06      (2.6%)       84.47      (3.1%)    0.5% (  -5% -    6%) 0.667
                 CountAndHighMed      136.86      (4.9%)      137.58      (3.2%)    0.5% (  -7% -    9%) 0.746
                   TermTitleSort      334.08      (2.5%)      335.99      (1.5%)    0.6% (  -3% -    4%) 0.480
                DismaxOrHighHigh        2.70      (2.3%)        2.71      (2.8%)    0.6% (  -4% -    5%) 0.541
                       CountTerm     9906.18      (6.0%)     9973.27      (8.0%)    0.7% ( -12% -   15%) 0.808
                        Or3Terms       20.95      (4.1%)       21.10     (14.4%)    0.7% ( -17% -   19%) 0.867
                 CountOrHighHigh       77.01      (2.2%)       77.73      (1.7%)    0.9% (  -2% -    4%) 0.228
                 DismaxOrHighMed        7.20      (2.3%)        7.27      (3.6%)    1.0% (  -4% -    7%) 0.421
             CountFilteredOrMany        9.03      (3.7%)        9.12      (2.3%)    1.0% (  -4% -    7%) 0.402
                CountAndHighHigh       92.10      (3.8%)       93.13      (2.1%)    1.1% (  -4% -    7%) 0.361
              Or2Terms2StopWords        2.50      (6.4%)        2.53     (14.2%)    1.5% ( -17% -   23%) 0.720
                  CountOrHighMed      101.42      (4.2%)      103.09      (3.3%)    1.7% (  -5% -    9%) 0.263
                       OrHighMed       30.02      (4.6%)       30.53     (13.9%)    1.7% ( -16% -   21%) 0.674
                      OrHighRare       46.31      (2.3%)       47.10      (2.0%)    1.7% (  -2% -    6%) 0.042
                     OrStopWords        3.34      (6.1%)        3.41     (14.1%)    2.0% ( -17% -   23%) 0.635
                      OrHighHigh        8.30      (5.6%)        8.50     (13.8%)    2.4% ( -16% -   23%) 0.568
                   TermMonthSort     3162.23      (7.1%)     3251.96      (4.3%)    2.8% (  -7% -   15%) 0.215
                     CountOrMany       11.53      (6.7%)       11.87      (4.2%)    3.0% (  -7% -   14%) 0.178
              CombinedOrHighHigh        1.47      (8.9%)        1.51      (8.6%)    3.0% ( -13% -   22%) 0.377
               CombinedOrHighMed        3.97      (8.6%)        4.10      (8.6%)    3.2% ( -12% -   22%) 0.337
                      DismaxTerm       51.75      (3.6%)       67.36     (14.3%)   30.2% (  11% -   49%) 0.000
                            Term       27.45      (5.0%)       40.57     (22.3%)   47.8% (  19% -   79%) 0.000
```