### PR TITLE
Update ruff rule PATH103 to enforce modern os.makedirs usage

### DIFF
--- a/dev-tools/scripts/addBackcompatIndexes.py
+++ b/dev-tools/scripts/addBackcompatIndexes.py
@@ -22,6 +22,7 @@
 
 import os
 import sys
+from pathlib import Path
 
 sys.path.append(os.path.dirname(__file__))
 import argparse
@@ -188,7 +189,7 @@ http://wiki.apache.org/lucene-java/ReleaseTodo#Generate_Backcompat_Indexes
 def main():
   c = read_config()
   if not os.path.exists(c.temp_dir):
-    os.makedirs(c.temp_dir)
+    Path(c.temp_dir).mkdir(parents=True)
 
   print("\nCreating backwards compatibility indexes")
   source = download_release(c.version, c.temp_dir, c.force)

--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -24,6 +24,7 @@ import textwrap
 import time
 import urllib.request
 import xml.etree.ElementTree as ET
+from pathlib import Path
 from subprocess import TimeoutExpired
 
 import scriptutil
@@ -213,13 +214,13 @@ def normalizeVersion(tup: tuple[str, ...]):
 
 def pushLocal(version: str, root: str, rcNum: int, localDir: str):
   print("Push local [%s]..." % localDir)
-  os.makedirs(localDir)
+  Path(localDir).mkdir(parents=True)
 
   lucene_dist_dir = "%s/lucene/distribution/build/release" % root
   rev = open("%s/lucene/distribution/build/release/.gitrev" % root, encoding="UTF-8").read()
 
   dir = "lucene-%s-RC%d-rev-%s" % (version, rcNum, rev)
-  os.makedirs("%s/%s/lucene" % (localDir, dir))
+  Path("%s/%s/lucene" % (localDir, dir)).mkdir(parents=True)
   print("  Lucene")
   os.chdir(lucene_dist_dir)
   print("    archive...")

--- a/dev-tools/scripts/pyproject.toml
+++ b/dev-tools/scripts/pyproject.toml
@@ -96,7 +96,6 @@ ignore = [
   "PLW0603", # using global statement to update variable is discouraged
   "PLW2901", # loop variable overwritten by assignment target
   "PTH100",  # os.path.abspath should be replaced by Path.resolve
-  "PTH103",  # os.mkdirs should be replaced by Path.mkdir(parents=True)
   "PTH104",  # os.rename should be replaced by Path.rename
   "PTH107",  # os.remove shoudl be replaced by Path.unlink
   "PTH109",  # os.getcwd should be replaced by Path.cwd

--- a/dev-tools/scripts/releaseWizard.py
+++ b/dev-tools/scripts/releaseWizard.py
@@ -48,6 +48,7 @@ import urllib.request
 from collections import OrderedDict
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any, Self, TextIO, cast, override
 
 import yaml
@@ -488,7 +489,7 @@ class ReleaseState:
     print("Saving")
     if not os.path.exists(os.path.join(self.config_path, self.release_version)):
       print("Creating folder %s" % os.path.join(self.config_path, self.release_version))
-      os.makedirs(os.path.join(self.config_path, self.release_version))
+      Path(os.path.join(self.config_path, self.release_version)).mkdir(parents=True)
 
     with open(os.path.join(self.config_path, self.release_version, "state.yaml"), "w") as fp:
       yaml.dump(self.to_dict(), fp, sort_keys=False, default_flow_style=False)
@@ -532,14 +533,14 @@ class ReleaseState:
     folder = os.path.join(self.config_path, self.release_version)
     if not os.path.exists(folder):
       print("Creating folder %s" % folder)
-      os.makedirs(folder)
+      Path(folder).mkdir(parents=True)
     return folder
 
   def get_rc_folder(self):
     folder = os.path.join(self.get_release_folder(), "RC%d" % self.rc_number)
     if not os.path.exists(folder):
       print("Creating folder %s" % folder)
-      os.makedirs(folder)
+      Path(folder).mkdir(parents=True)
     return folder
 
   def get_dist_folder(self):
@@ -1286,7 +1287,7 @@ def main():
     if not os.path.exists(release_root):
       try:
         print("Creating release root %s" % release_root)
-        os.makedirs(release_root)
+        Path(release_root).mkdir(parents=True)
       except Exception as e:
         sys.exit("Error while creating %s: %s" % (release_root, e))
     release_version = get_release_version()
@@ -1389,7 +1390,7 @@ def run_with_log_tail(command: str | list[str], cwd: str | None, logfile: str | 
   if logfile:
     logdir = os.path.dirname(logfile)
     if not os.path.exists(logdir):
-      os.makedirs(logdir)
+      Path(logdir).mkdir(parents=True)
     fh = open(logfile, "w")
   rc = run_follow(command, cwd, fh=fh, tee=tee, live=live, shell=shell)
   if logfile:

--- a/dev-tools/scripts/reproduceJenkinsFailures.py
+++ b/dev-tools/scripts/reproduceJenkinsFailures.py
@@ -25,6 +25,7 @@ import time
 import traceback
 import urllib.error
 import urllib.request
+from pathlib import Path
 from textwrap import dedent
 
 # Example: Checking out Revision e441a99009a557f82ea17ee9f9c3e9b89c75cee6 (refs/remotes/origin/master)
@@ -236,7 +237,7 @@ def printAndMoveReports(testIters: int, newSubDir: str, location: str):
                 break
           # have to play nice with 'ant clean'...
           newDirPath = os.path.join("repro-reports", newSubDir, dir)
-          os.makedirs(newDirPath, exist_ok=True)
+          Path(newDirPath).mkdir(exist_ok=True, parents=True)
           os.rename(filePath, os.path.join(newDirPath, file))
   print("[repro] Failures%s:" % location)
   for testcase in sorted(failures, key=lambda t: (failures[t], t)):  # sort by failure count, then by testcase

--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -35,6 +35,7 @@ import xml.etree.ElementTree as ET
 import zipfile
 from collections import namedtuple
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import scriptutil
@@ -262,7 +263,7 @@ def checkSigs(urlString: str, version: str, tmpDir: str, isSigned: bool, keysFil
   gpgHomeDir = "%s/lucene.gpg" % tmpDir
   if os.path.exists(gpgHomeDir):
     shutil.rmtree(gpgHomeDir)
-  os.makedirs(gpgHomeDir, 0o700)
+  Path(gpgHomeDir).mkdir(mode=0o700, parents=True)
   run("gpg --homedir %s --import %s" % (gpgHomeDir, keysFile), "%s/lucene.gpg.import.log" % tmpDir)
 
   if mavenURL is None:
@@ -501,7 +502,7 @@ def unpackAndVerify(java: Any, tmpDir: str, artifact: str, gitRevision: str, ver
   destDir = "%s/unpack" % tmpDir
   if os.path.exists(destDir):
     shutil.rmtree(destDir)
-  os.makedirs(destDir)
+  Path(destDir).mkdir(parents=True)
   os.chdir(destDir)
   print("  unpack %s..." % artifact)
   unpackLogFile = "%s/lucene-unpack-%s.log" % (tmpDir, artifact)
@@ -722,7 +723,7 @@ def checkMaven(baseURL: str, tmpDir: str, gitRevision: str, version: str, isSign
   artifactsURL = "%s/lucene/maven/org/apache/lucene/" % baseURL
   targetDir = "%s/maven/org/apache/lucene" % tmpDir
   if not os.path.exists(targetDir):
-    os.makedirs(targetDir)
+    Path(targetDir).mkdir(parents=True)
   crawl(artifacts, artifactsURL, targetDir)
   print()
   verifyPOMperBinaryArtifact(artifacts, version)
@@ -747,7 +748,7 @@ def getBinaryDistFiles(tmpDir: str, version: str, baseURL: str):
   destDir = "%s/unpack-lucene-getBinaryDistFiles" % tmpDir
   if os.path.exists(destDir):
     shutil.rmtree(destDir)
-  os.makedirs(destDir)
+  Path(destDir).mkdir(parents=True)
   os.chdir(destDir)
   print("    unpack %s..." % distribution)
   unpackLogFile = "%s/unpack-%s-getBinaryDistFiles.log" % (tmpDir, distribution)
@@ -864,7 +865,7 @@ def verifyMavenSigs(tmpDir: str, artifacts: list[str], keysFile: str):
   gpgHomeDir = "%s/lucene.gpg" % tmpDir
   if os.path.exists(gpgHomeDir):
     shutil.rmtree(gpgHomeDir)
-  os.makedirs(gpgHomeDir, 0o700)
+  Path(gpgHomeDir).mkdir(mode=0o700, parents=True)
   run("gpg --homedir %s --import %s" % (gpgHomeDir, keysFile), "%s/lucene.gpg.import.log" % tmpDir)
 
   reArtifacts = re.compile(r"\.(?:pom|[jw]ar)$")
@@ -929,7 +930,7 @@ def crawl(downloadedFiles: list[str], urlString: str, targetDir: str, exclusions
       path = os.path.join(targetDir, text)
       if text.endswith("/"):
         if not os.path.exists(path):
-          os.makedirs(path)
+          Path(path).mkdir(parents=True)
         crawl(downloadedFiles, subURL, path, exclusions)
       else:
         if not os.path.exists(path) or FORCE_CLEAN:
@@ -1162,7 +1163,7 @@ def smokeTest(java: Any, baseURL: str, gitRevision: str, version: str, tmpDir: s
       raise RuntimeError("temp dir %s exists; please remove first" % tmpDir)
 
   if not os.path.exists(tmpDir):
-    os.makedirs(tmpDir)
+    Path(tmpDir).mkdir(parents=True)
 
   lucenePath = None
   print()


### PR DESCRIPTION
### Description

This pull request updates the usage of os.makedirs in accordance with ruff rule PATH103, which encourages the use of pathlib over os.makedirs for cleaner and more modern path handling.