### PR TITLE
Apply minimal fix for ruff rule PATH103 using Path.resolve

### DIFF
--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -24,6 +24,7 @@ import textwrap
 import time
 import urllib.request
 import xml.etree.ElementTree as ET
+from pathlib import Path
 from subprocess import TimeoutExpired
 
 import scriptutil
@@ -237,7 +238,7 @@ def pushLocal(version: str, root: str, rcNum: int, localDir: str):
   run("chmod -R a+rX-w .")
 
   print("  done!")
-  return "file://%s/%s" % (os.path.abspath(localDir), dir)
+  return "file://%s/%s" % (Path(localDir).resolve(), dir)
 
 
 def read_version(_path: str):

--- a/dev-tools/scripts/pyproject.toml
+++ b/dev-tools/scripts/pyproject.toml
@@ -95,7 +95,6 @@ ignore = [
   "PLW0602", # using global for variable but no assignment is done
   "PLW0603", # using global statement to update variable is discouraged
   "PLW2901", # loop variable overwritten by assignment target
-  "PTH100",  # os.path.abspath should be replaced by Path.resolve
   "PTH103",  # os.mkdirs should be replaced by Path.mkdir(parents=True)
   "PTH104",  # os.rename should be replaced by Path.rename
   "PTH107",  # os.remove shoudl be replaced by Path.unlink

--- a/dev-tools/scripts/releaseWizard.py
+++ b/dev-tools/scripts/releaseWizard.py
@@ -1352,7 +1352,7 @@ def main():
 
 
 sys.path.append(os.path.dirname(__file__))
-current_git_root = Path(os.path.join(Path(os.path.dirname(__file__)).resolve(), os.path.pardir, os.path.pardir)).resolve()
+current_git_root: str = str(Path(os.path.join(Path(os.path.dirname(__file__)).resolve(), os.path.pardir, os.path.pardir)).resolve())
 
 dry_run = False
 

--- a/dev-tools/scripts/releaseWizard.py
+++ b/dev-tools/scripts/releaseWizard.py
@@ -48,6 +48,7 @@ import urllib.request
 from collections import OrderedDict
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any, Self, TextIO, cast, override
 
 import yaml
@@ -1282,7 +1283,7 @@ def main():
       if root.startswith("~/"):
         release_root = os.path.expanduser(root)
       else:
-        release_root = os.path.abspath(root)
+        release_root = str(Path(root).resolve())
     if not os.path.exists(release_root):
       try:
         print("Creating release root %s" % release_root)
@@ -1305,7 +1306,7 @@ def main():
     y = yaml.load(open(os.path.join(script_path, "releaseWizard.yaml")), Loader=yaml.Loader)
     templates = y.get("templates")
     todo_list = y.get("groups")
-    state = ReleaseState(release_root, release_version, getScriptVersion())
+    state = ReleaseState(str(release_root), release_version, getScriptVersion())
     state.init_todos(bootstrap_todos(todo_list))
     state.load()
   except Exception as e:
@@ -1351,7 +1352,7 @@ def main():
 
 
 sys.path.append(os.path.dirname(__file__))
-current_git_root = os.path.abspath(os.path.join(os.path.abspath(os.path.dirname(__file__)), os.path.pardir, os.path.pardir))
+current_git_root = Path(os.path.join(Path(os.path.dirname(__file__)).resolve(), os.path.pardir, os.path.pardir)).resolve()
 
 dry_run = False
 

--- a/dev-tools/scripts/scriptutil.py
+++ b/dev-tools/scripts/scriptutil.py
@@ -22,6 +22,7 @@ import time
 import urllib.request
 from collections.abc import Callable
 from enum import Enum
+from pathlib import Path
 from re import Match, Pattern
 from typing import Self, override
 
@@ -188,7 +189,7 @@ version_prop_re = re.compile(r'baseVersion\s*=\s*([\'"])(.*)\1')
 
 def find_current_version():
   script_path = os.path.dirname(os.path.realpath(__file__))
-  top_level_dir = os.path.join(os.path.abspath("%s/" % script_path), os.path.pardir, os.path.pardir)
+  top_level_dir = os.path.join(Path("%s/" % script_path).resolve(), os.path.pardir, os.path.pardir)
   match = version_prop_re.search(open("%s/build.gradle" % top_level_dir).read())
   assert match
   return match.group(2).strip()

--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -35,6 +35,7 @@ import xml.etree.ElementTree as ET
 import zipfile
 from collections import namedtuple
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import scriptutil
@@ -446,7 +447,7 @@ def run(command: str, logFile: str):
   if cygwin:
     command = cygwinifyPaths(command)
   if os.system("%s > %s 2>&1" % (command, logFile)):
-    logPath = os.path.abspath(logFile)
+    logPath = Path(logFile).resolve()
     print('\ncommand "%s" failed:' % command)
     printFileContents(logFile)
     raise RuntimeError('command "%s" failed; see log file %s' % (command, logPath))
@@ -1022,7 +1023,7 @@ def parse_config():
   c.java = make_java_config(parser, c.test_alternative_java)
 
   if c.tmp_dir:
-    c.tmp_dir = os.path.abspath(c.tmp_dir)
+    c.tmp_dir = Path(c.tmp_dir).resolve()
   else:
     tmp = "/tmp/smoke_lucene_%s_%s" % (c.version, c.revision)
     c.tmp_dir = tmp

--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -447,7 +447,7 @@ def run(command: str, logFile: str):
   if cygwin:
     command = cygwinifyPaths(command)
   if os.system("%s > %s 2>&1" % (command, logFile)):
-    logPath = Path(logFile).resolve()
+    logPath: str = str(Path(logFile).resolve())
     print('\ncommand "%s" failed:' % command)
     printFileContents(logFile)
     raise RuntimeError('command "%s" failed; see log file %s' % (command, logPath))
@@ -1023,7 +1023,7 @@ def parse_config():
   c.java = make_java_config(parser, c.test_alternative_java)
 
   if c.tmp_dir:
-    c.tmp_dir = Path(c.tmp_dir).resolve()
+    c.tmp_dir = str(Path(c.tmp_dir).resolve())
   else:
     tmp = "/tmp/smoke_lucene_%s_%s" % (c.version, c.revision)
     c.tmp_dir = tmp


### PR DESCRIPTION
### Description

This PR updates the usage of os.path.abspath to Path(...).resolve() in compliance with ruff rule PATH103. Other os.path elements are retained to scope the change narrowly and safely.

### Tested the change locally:
```
version = "0.1.0"
rcNum = 123
rev = "2"
dir = "lucene-%s-RC%d-rev-%s" % (version, rcNum, rev)
localDir = "/some/local/dir"
path_file = "file://%s/%s" % (Path(localDir).resolve(), dir)
print(path_file)
print(type(path_file))

os_file =  "file://%s/%s" % (os.path.abspath(localDir), dir)
print(os_file)
print(type(os_file))
assert path_file == os_file
```
### Results:
```
file:///some/local/dir/lucene-0.1.0-RC123-rev-2
<class 'str'>
file:///some/local/dir/lucene-0.1.0-RC123-rev-2
<class 'str'>
```
